### PR TITLE
fix(fuse): live-night seams from the 0825 hunt (F1-F5, F7, D1)

### DIFF
--- a/ConditioningControlPanel/Services/Descent/DescentCountdownService.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentCountdownService.cs
@@ -103,6 +103,24 @@ namespace ConditioningControlPanel.Services.Descent
         internal static readonly TimeSpan VigilAt    = TimeSpan.FromHours(1);
         internal static readonly TimeSpan TerminalAt = TimeSpan.FromMinutes(10);
 
+        /// <summary>
+        /// How late a tick may first notice zero and still count as "live" (0825 F5). A laptop that
+        /// slept from T-2h to T+8h wakes to a tick with <c>remaining &lt;= 0</c>; without this the
+        /// full crack would play eight hours after the night and mint a "you were there" keepsake
+        /// for someone who was not. Past this grace the tick takes the away fork instead — the
+        /// catch-up crack, exactly as if the app had been closed.
+        /// </summary>
+        internal static readonly TimeSpan LateZeroGrace = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// How long step 4 holds after zero before the chrome lets go on its own (0825 F4). Step 4
+        /// deliberately holds THROUGH zero so the room does not brighten while the show opens, and
+        /// a migrated account restores immediately — but a subject who said "Not tonight", or whom
+        /// the server never offered, used to keep a dimmed app until the owner unset the timestamp,
+        /// which the auto-fire contract (§1.4) says never to do. Twelve hours is long past any show.
+        /// </summary>
+        internal static readonly TimeSpan DimHoldPastZero = TimeSpan.FromHours(12);
+
         /// <summary>Coarse cadence. Thirty seconds is invisible on a day counter and costs nothing.</summary>
         private static readonly TimeSpan SlowTick = TimeSpan.FromSeconds(30);
 
@@ -151,6 +169,16 @@ namespace ConditioningControlPanel.Services.Descent
         /// opens its window from here.
         /// </summary>
         public event EventHandler? ZeroReached;
+
+        /// <summary>
+        /// Zero was first noticed more than <see cref="LateZeroGrace"/> after the instant, in a
+        /// process that was open across it (sleep, hibernate, a frozen UI thread). This is the
+        /// in-session twin of <see cref="ZeroPassedWhileAway"/>: by the time it fires that flag is
+        /// already TRUE, so <see cref="ShouldPlayCatchUp"/> answers correctly and the director can
+        /// run the catch-up path it would have run at launch. Never fires on the same night as
+        /// <see cref="ZeroReached"/>.
+        /// </summary>
+        public event EventHandler? ZeroObservedLate;
 
         // ------------------------------------------------------------------
         // State
@@ -332,7 +360,8 @@ namespace ConditioningControlPanel.Services.Descent
                 // server keeps re-sending must not re-log and re-arm on every sync.
                 if (string.Equals(settings.DescentCeremonyAtUtc, incoming, StringComparison.Ordinal)) return;
 
-                var hadFuse = ParseCeremonyAt(settings.DescentCeremonyAtUtc).HasValue;
+                var previousAt = ParseCeremonyAt(settings.DescentCeremonyAtUtc);
+                var hadFuse = previousAt.HasValue;
                 settings.DescentCeremonyAtUtc = incoming;
                 App.Settings?.Save();
 
@@ -357,6 +386,21 @@ namespace ConditioningControlPanel.Services.Descent
                 {
                     _spokenPhases.Clear();
                     _scriptedSilence = false;
+                }
+
+                // A NEW INSTANT IS A NEW ZERO (0825 F3). The owner's one lever on a bad night is
+                // to push the timestamp back an hour — and before this, a process that had already
+                // raised ZeroReached for the old instant (or launched between the old instant and
+                // the postponement and so settled "already passed") could never fire the new one:
+                // _zeroRaised was never reset and the away fork was decided once. Re-settle both
+                // on the same rule Start uses, but only when the instant actually moved — a
+                // formatting-only change (".000Z" vs "Z") is the same fuse.
+                if (_started && hadFuse && previousAt != parsed)
+                {
+                    _zeroRaised = false;
+                    ZeroPassedWhileAway = parsed.Value <= DateTime.UtcNow;
+                    Log.Information("[Fuse] The instant moved ({From:o} -> {To:o}); zero is re-armed{Away}.",
+                        previousAt!.Value, parsed.Value, ZeroPassedWhileAway ? " (already passed)" : "");
                 }
 
                 if (!_started)
@@ -410,7 +454,10 @@ namespace ConditioningControlPanel.Services.Descent
             }
 
             _fastCadence = wantFast;
-            _timer = new DispatcherTimer(DispatcherPriority.Background, dispatcher)
+            // Normal, not Background (0825 F7): a running session's flash bursts and overlays
+            // starve Background ticks, which stutters the one-second readout and lets zero land
+            // seconds late. Normal is what the rest of the app's user-visible timers use.
+            _timer = new DispatcherTimer(DispatcherPriority.Normal, dispatcher)
             {
                 Interval = wantFast ? FastTick : SlowTick
             };
@@ -454,9 +501,24 @@ namespace ConditioningControlPanel.Services.Descent
                 if (!_zeroRaised && remaining <= TimeSpan.Zero && !ZeroPassedWhileAway)
                 {
                     _zeroRaised = true;
-                    Log.Information("[Fuse] Zero, live. Raising ZeroReached.");
-                    try { ZeroReached?.Invoke(this, EventArgs.Empty); }
-                    catch (Exception ex) { Log.Error(ex, "[Fuse] A ZeroReached handler threw."); }
+
+                    if (IsZeroObservedLate(at.Value, DateTime.UtcNow))
+                    {
+                        // The process was open across the instant but nobody was at it (0825 F5).
+                        // Flip to the away fork BEFORE anyone hears about it, so ShouldPlayCatchUp
+                        // and the witness ratchet both read this as a night that was missed.
+                        ZeroPassedWhileAway = true;
+                        Log.Information("[Fuse] Zero noticed {Late:c} late (sleep/resume?) — taking the away fork, not the live show.",
+                            DateTime.UtcNow - at.Value);
+                        try { ZeroObservedLate?.Invoke(this, EventArgs.Empty); }
+                        catch (Exception ex) { Log.Error(ex, "[Fuse] A ZeroObservedLate handler threw."); }
+                    }
+                    else
+                    {
+                        Log.Information("[Fuse] Zero, live. Raising ZeroReached.");
+                        try { ZeroReached?.Invoke(this, EventArgs.Empty); }
+                        catch (Exception ex) { Log.Error(ex, "[Fuse] A ZeroReached handler threw."); }
+                    }
                 }
 
                 // Past zero the clock has nothing left to say; the show owns the moment now.
@@ -861,12 +923,21 @@ namespace ConditioningControlPanel.Services.Descent
 
             var left = ceremonyAtUtc.Value - nowUtc;
             if (left > DimmingAt) return 0;
-            if (left <= TimeSpan.Zero) return 4;
+            // Holds through zero — and lets go on its own once the night is long over
+            // (DimHoldPastZero), so a deferral is not a permanently dimmed app.
+            if (left <= TimeSpan.Zero) return -left > DimHoldPastZero ? 0 : 4;
 
             var elapsed = DimmingAt - left;
             var step = 1 + (int)Math.Floor(elapsed.TotalHours / 6.0);
             return Math.Clamp(step, 1, 4);
         }
+
+        /// <summary>
+        /// Whether a zero first noticed at <paramref name="nowUtc"/> is too late to be the live
+        /// show (0825 F5). Pure; the tick's fork and the tests both read it.
+        /// </summary>
+        internal static bool IsZeroObservedLate(DateTime ceremonyAtUtc, DateTime nowUtc) =>
+            nowUtc - ceremonyAtUtc > LateZeroGrace;
 
         public void Dispose()
         {

--- a/ConditioningControlPanel/Services/Descent/DescentFuseHandoff.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentFuseHandoff.cs
@@ -49,8 +49,14 @@ namespace ConditioningControlPanel.Services.Descent
     /// </summary>
     public sealed class DescentFuseHandoff
     {
-        /// <summary>Give up on the offer after this. §2.3's number.</summary>
-        public const double TimeoutSeconds = 45.0;
+        /// <summary>
+        /// Give up on the offer after this. §2.3 said forty-five; raised to seventy-five on the
+        /// 0825 hunt (D1): with the thirty-second cooldown on BOTH ends, a client that synced in
+        /// the last half-minute before zero cannot land a request before ~T+37s, and one 429 on
+        /// that attempt pushed the next past forty-five — a healthy install missing the happy path
+        /// maybe one time in six. Seventy-five leaves room for two full cooldown windows.
+        /// </summary>
+        public const double TimeoutSeconds = 75.0;
 
         /// <summary>How often to ask for a sync while waiting. See the cooldown note above.</summary>
         public const double ResyncEverySeconds = 8.0;

--- a/ConditioningControlPanel/Services/Descent/DescentPostZeroRetry.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentPostZeroRetry.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    /// <summary>
+    /// THE POST-ZERO RETRY's policy (0825 hunt, F1) — pure, so the tests can pin it.
+    ///
+    /// <para><b>The hole.</b> Profile sync is event-driven: login, level-up, quest, preset, exit.
+    /// The only periodic sync runs during a session and only for OAuth accounts. So when the zero
+    /// show's handoff timed out ("The ceremony awaits.") the app made no further attempt of its
+    /// own — the subject sat in a step-4-dimmed room, spiral fogged, until they happened to level
+    /// up or restart. On a night when the server is slow under everyone syncing at once, that is
+    /// the common case, not the edge.</para>
+    ///
+    /// <para><b>The shape.</b> One sync a minute for a bounded while, and every reason to stop is
+    /// listed here: the ceremony opened (the sync did its job), an offer is in hand (the migration
+    /// service owns it from here), the account is migrated or has a choice pending (nothing to
+    /// ask), the fuse went dark (kill switch), or the budget ran out. ProfileSyncService's own
+    /// thirty-second cooldown and offline guard sit underneath; a refused attempt costs nothing
+    /// and still counts, which is what bounds the loop.</para>
+    /// </summary>
+    internal static class DescentPostZeroRetry
+    {
+        /// <summary>Fifteen minutes of asking, then the standing re-offer contract takes over.</summary>
+        public const int MaxAttempts = 15;
+
+        /// <summary>Well outside the sync cooldown, so every attempt is a real request.</summary>
+        public static readonly TimeSpan Every = TimeSpan.FromSeconds(60);
+
+        /// <summary>Whether attempt number <paramref name="attemptsSoFar"/> + 1 should be made.</summary>
+        public static bool ShouldContinue(
+            int attemptsSoFar,
+            bool fuseArmed,
+            bool ceremonyOpen,
+            bool offerInHand,
+            bool migrationCompleted,
+            bool choicePending)
+        {
+            if (attemptsSoFar >= MaxAttempts) return false;
+            if (!fuseArmed) return false;
+            if (ceremonyOpen) return false;
+            if (offerInHand) return false;
+            if (migrationCompleted) return false;
+            if (choicePending) return false;
+            return true;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Descent/DescentShowDirector.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentShowDirector.cs
@@ -47,6 +47,19 @@ namespace ConditioningControlPanel.Services.Descent
         private bool _catchUpOwed;
         private bool _catchUpHolding;
 
+        /// <summary>
+        /// THE PRE-ZERO HOLD (0825 hunt, F2). Taken while the fuse is lit and zero has not come,
+        /// released only once the live window holds the ceremony itself. Before this, nothing held
+        /// offers before zero at all: the server fires on ITS clock, so a client two minutes slow
+        /// got the ceremony window while its corner clock still read gold — and then the crack
+        /// opened fullscreen over the open ceremony. With the hold, an early offer simply waits
+        /// under the bloom, which is the choreography the contract describes.
+        /// </summary>
+        private bool _preZeroHolding;
+
+        private DispatcherTimer? _retryTimer;
+        private int _retryAttempts;
+
         /// <summary>The heartbeat hook's player, exposed so a teardown can silence it.</summary>
         public DescentHeartbeat Heartbeat => _heartbeat;
 
@@ -70,6 +83,7 @@ namespace ConditioningControlPanel.Services.Descent
                 if (fuse != null)
                 {
                     fuse.ZeroReached += OnZeroReached;
+                    fuse.ZeroObservedLate += OnZeroObservedLate;
                     fuse.PhaseChanged += OnPhaseChanged;
                 }
 
@@ -79,7 +93,11 @@ namespace ConditioningControlPanel.Services.Descent
                 // Settled by Start() before the first tick, and never true at the same time as a
                 // live zero. Read once: the flags behind it are about to be written by the show.
                 _catchUpOwed = fuse?.ShouldPlayCatchUp == true;
-                if (!_catchUpOwed) return;
+                if (!_catchUpOwed)
+                {
+                    EnsurePreZeroHold();
+                    return;
+                }
 
                 Log.Information("[Fuse] The instant passed while the app was closed — the catch-up crack is owed.");
 
@@ -124,17 +142,80 @@ namespace ConditioningControlPanel.Services.Descent
                 // case where Terminal started it and the phase never announced Zero separately.
                 _heartbeat.Stop();
 
+                // NOTHING TO REVEAL (0825 F2, scenario B). An account that already answered — on
+                // this machine before a slow client clock reached zero, or on another device — has
+                // had its first light. Playing the crack again would end in forty-five seconds of
+                // refused resyncs and "The ceremony awaits." said to someone who just finished it.
+                if (AlreadyAnswered() || App.DescentMigration?.IsCeremonyOpen == true)
+                {
+                    Log.Information("[Fuse] Zero, but the question is already answered or on screen — no live show.");
+                    ReleasePreZeroHold();
+                    return;
+                }
+
                 var window = DescentFuseWindow.Open(DescentShowKind.Live);
+
+                // The window took its own hold in its constructor (released at the bloom), so the
+                // pre-zero hold's job is done. Released even when Open() refused — a hold with no
+                // show behind it would keep the ceremony shut for nothing.
+                ReleasePreZeroHold();
                 if (window is null) return;
 
                 window.Closed += (s, _) =>
                 {
                     if (s is DescentFuseWindow w && w.HandedOffToCeremony) FocusCeremony();
+                    else BeginPostZeroRetry("live handoff timed out");
                 };
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "[Fuse] The live zero show could not start.");
+                ReleasePreZeroHold();
+            }
+        }
+
+        /// <summary>
+        /// Zero was noticed late in a process that slept across it (0825 F5). The countdown has
+        /// already flipped itself to the away fork, so this is the launch-time catch-up decision
+        /// taken again, mid-session: play the condensed crack if it is owed, hold the ceremony
+        /// behind it exactly as at launch, and otherwise just make sure the offer conversation
+        /// happens.
+        /// </summary>
+        private void OnZeroObservedLate(object? sender, EventArgs e)
+        {
+            if (_disposed) return;
+            if (Application.Current?.Dispatcher?.HasShutdownStarted != false) return;
+
+            try
+            {
+                _heartbeat.Stop();
+
+                var fuse = App.DescentCountdown;
+                if (fuse?.ShouldPlayCatchUp != true)
+                {
+                    ReleasePreZeroHold();
+                    BeginPostZeroRetry("zero passed during sleep, no crack owed");
+                    return;
+                }
+
+                Log.Information("[Fuse] The instant passed while this session slept — the catch-up crack is owed.");
+
+                // Convert the pre-zero hold into the catch-up hold rather than stacking a second
+                // one: same depth, same release path (the crack's Closed handler).
+                if (_preZeroHolding) _preZeroHolding = false;
+                else App.DescentMigration?.HoldOffers();
+                _catchUpHolding = true;
+                _catchUpOwed = true;
+
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher is null || dispatcher.HasShutdownStarted) { ReleaseCatchUpHold(); return; }
+                _ = dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(PlayCatchUp));
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[Fuse] The late-zero path failed.");
+                ReleasePreZeroHold();
+                ReleaseCatchUpHold();
             }
         }
 
@@ -167,6 +248,10 @@ namespace ConditioningControlPanel.Services.Descent
                     catch (Exception ex) { Log.Debug("[Fuse] Catch-up flag write failed: {Error}", ex.Message); }
 
                     ReleaseCatchUpHold();
+
+                    // The release replays a held offer synchronously; if nothing was in hand the
+                    // startup sync that should have carried it may simply have failed (F1).
+                    if (App.DescentMigration?.IsCeremonyOpen != true) BeginPostZeroRetry("catch-up closed without an offer");
                 };
             }
             catch (Exception ex)
@@ -182,6 +267,123 @@ namespace ConditioningControlPanel.Services.Descent
             _catchUpHolding = false;
             try { App.DescentMigration?.ReleaseOffers(); }
             catch (Exception ex) { Log.Debug("[Fuse] Releasing the offer hold failed: {Error}", ex.Message); }
+        }
+
+        // ------------------------------------------------------------------
+        // The pre-zero hold (0825 F2)
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Hold offers iff the fuse is lit, zero is still ahead, and nothing else is holding. Safe
+        /// to call on every phase change: it only ever takes ONE hold and only ever when the state
+        /// says so. Release is deliberately NOT here — the moment to let go is after the live
+        /// window holds the ceremony itself (see <see cref="OnZeroReached"/>), never on the phase
+        /// change to Zero, which fires on the same tick a few lines BEFORE ZeroReached.
+        /// </summary>
+        private void EnsurePreZeroHold()
+        {
+            if (_disposed || _preZeroHolding || _catchUpHolding) return;
+
+            var fuse = App.DescentCountdown;
+            var migration = App.DescentMigration;
+            if (fuse is null || migration is null) return;
+            if (fuse.CeremonyAtUtc is null) return;
+            if (fuse.ZeroPassedWhileAway) return;
+            if (fuse.Phase >= DescentFusePhase.Zero) return;
+            if (AlreadyAnswered()) return;
+
+            try
+            {
+                migration.HoldOffers();
+                _preZeroHolding = true;
+                Log.Debug("[Fuse] Holding ceremony offers until zero.");
+            }
+            catch (Exception ex) { Log.Debug("[Fuse] Could not take the pre-zero hold: {Error}", ex.Message); }
+        }
+
+        private void ReleasePreZeroHold()
+        {
+            if (!_preZeroHolding) return;
+            _preZeroHolding = false;
+            try { App.DescentMigration?.ReleaseOffers(); }
+            catch (Exception ex) { Log.Debug("[Fuse] Releasing the pre-zero hold failed: {Error}", ex.Message); }
+        }
+
+        private static bool AlreadyAnswered()
+        {
+            var s = App.Settings?.Current;
+            if (s is null) return false;
+            return s.DescentMigrationCompleted || DescentMigrationChoices.IsValid(s.PendingDescentMigrationChoice);
+        }
+
+        // ------------------------------------------------------------------
+        // The post-zero retry (0825 F1)
+        // ------------------------------------------------------------------
+
+        /// <summary>Ask for a sync once a minute, bounded, until the ceremony conversation happens.
+        /// Policy in <see cref="DescentPostZeroRetry"/>. Idempotent: a second call while running
+        /// is a no-op.</summary>
+        private void BeginPostZeroRetry(string why)
+        {
+            if (_disposed || _retryTimer != null) return;
+
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.HasShutdownStarted) return;
+
+            if (!RetryShouldContinue())
+            {
+                Log.Debug("[Fuse] No post-zero retry needed ({Why}).", why);
+                return;
+            }
+
+            Log.Information("[Fuse] Post-zero retry armed ({Why}): one sync a minute, up to {Max}.",
+                why, DescentPostZeroRetry.MaxAttempts);
+
+            _retryAttempts = 0;
+            _retryTimer = new DispatcherTimer(DispatcherPriority.Normal, dispatcher) { Interval = DescentPostZeroRetry.Every };
+            _retryTimer.Tick += OnRetryTick;
+            _retryTimer.Start();
+        }
+
+        private void OnRetryTick(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (_disposed || Application.Current?.Dispatcher?.HasShutdownStarted != false) { StopPostZeroRetry(); return; }
+
+                if (!RetryShouldContinue())
+                {
+                    Log.Information("[Fuse] Post-zero retry done after {N} attempt(s).", _retryAttempts);
+                    StopPostZeroRetry();
+                    return;
+                }
+
+                _retryAttempts++;
+                _ = App.ProfileSync?.SyncProfileAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[Fuse] Post-zero retry tick failed: {Error}", ex.Message);
+            }
+        }
+
+        private bool RetryShouldContinue()
+        {
+            var s = App.Settings?.Current;
+            var migration = App.DescentMigration;
+            return DescentPostZeroRetry.ShouldContinue(
+                _retryAttempts,
+                fuseArmed: App.DescentCountdown?.CeremonyAtUtc != null,
+                ceremonyOpen: migration?.IsCeremonyOpen == true,
+                offerInHand: migration?.LiveOffer != null,
+                migrationCompleted: s?.DescentMigrationCompleted == true,
+                choicePending: s != null && DescentMigrationChoices.IsValid(s.PendingDescentMigrationChoice));
+        }
+
+        private void StopPostZeroRetry()
+        {
+            try { _retryTimer?.Stop(); } catch { }
+            _retryTimer = null;
         }
 
         // ------------------------------------------------------------------
@@ -347,8 +549,16 @@ namespace ConditioningControlPanel.Services.Descent
             {
                 if (e.Current == DescentFusePhase.Terminal) _heartbeat.Start();
                 else _heartbeat.Stop();
+
+                // The hold follows the fuse (F2): kill switch lets go; a re-arm (or the owner
+                // moving the date back ahead of now, F3) takes it again; a date moved into the
+                // past has no live show coming, so nothing to hold for. The transition TO Zero on
+                // a live night is deliberately left alone — ZeroReached handles that hand-over.
+                if (e.Current == DescentFusePhase.Dark) ReleasePreZeroHold();
+                else if (e.Current < DescentFusePhase.Zero) EnsurePreZeroHold();
+                else if (App.DescentCountdown?.ZeroPassedWhileAway == true) ReleasePreZeroHold();
             }
-            catch (Exception ex) { Log.Debug("[Fuse] Heartbeat phase handling failed: {Error}", ex.Message); }
+            catch (Exception ex) { Log.Debug("[Fuse] Phase handling failed: {Error}", ex.Message); }
         }
 
         // ------------------------------------------------------------------
@@ -379,6 +589,7 @@ namespace ConditioningControlPanel.Services.Descent
                 if (fuse != null)
                 {
                     fuse.ZeroReached -= OnZeroReached;
+                    fuse.ZeroObservedLate -= OnZeroObservedLate;
                     fuse.PhaseChanged -= OnPhaseChanged;
                 }
                 var migration = App.DescentMigration;
@@ -386,6 +597,8 @@ namespace ConditioningControlPanel.Services.Descent
             }
             catch { /* teardown races are not worth a log line */ }
 
+            StopPostZeroRetry();
+            ReleasePreZeroHold();
             ReleaseCatchUpHold();
             _heartbeat.Dispose();
         }

--- a/Tests/ConditioningControlPanel.Tests/DescentFuseHandoffTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentFuseHandoffTests.cs
@@ -155,25 +155,38 @@ public class DescentFuseHandoffTests
     // ------------------------------------------------------------ the timeout
 
     /// <summary>
-    /// Forty-five seconds with no offer: say the standing line, hold it four seconds, close. §2.3
-    /// exactly — and note what does NOT happen, which is anything being written or retried forever.
-    /// The re-offer contract takes it from there.
+    /// The timeout with no offer: say the standing line, hold it four seconds, close. §2.3's
+    /// shape — and note what does NOT happen, which is anything being written or retried forever.
+    /// The re-offer contract (and, since 0825, the director's bounded post-zero retry) takes it
+    /// from there.
     /// </summary>
     [Fact]
-    public void NoOfferInFortyFiveSeconds_SaysTheLineThenCloses()
+    public void NoOfferByTheTimeout_SaysTheLineThenCloses()
     {
+        var t = DescentFuseHandoff.TimeoutSeconds;
         var handoff = new DescentFuseHandoff();
-        var actions = Run(handoff, 0, 44.9, ceremonyOpen: false);
+        var actions = Run(handoff, 0, t - 0.1, ceremonyOpen: false);
         Assert.All(actions, a => Assert.Equal(DescentHandoffAction.Resync, a));
 
-        Assert.Equal(DescentHandoffAction.SpeakAwaits, handoff.Advance(45.0, false));
+        Assert.Equal(DescentHandoffAction.SpeakAwaits, handoff.Advance(t, false));
         Assert.True(handoff.IsAnnouncing);
 
         // Held, silently, for the four seconds. No more syncs — the machine has stopped asking.
-        Assert.Empty(Run(handoff, 45.02, 48.9, ceremonyOpen: false));
+        Assert.Empty(Run(handoff, t + 0.02, t + 3.9, ceremonyOpen: false));
 
-        Assert.Equal(DescentHandoffAction.Close, handoff.Advance(49.0, false));
+        Assert.Equal(DescentHandoffAction.Close, handoff.Advance(t + 4.0, false));
         Assert.True(handoff.IsDone);
+    }
+
+    /// <summary>
+    /// 0825 D1: the timeout must clear TWO client-side sync cooldowns (30s each) plus the bloom,
+    /// or a client that synced in the last half-minute before zero, and then ate one 429, misses
+    /// the happy path on a perfectly healthy night.
+    /// </summary>
+    [Fact]
+    public void Timeout_ClearsTwoSyncCooldowns()
+    {
+        Assert.True(DescentFuseHandoff.TimeoutSeconds >= 2 * 30 + 8);
     }
 
     /// <summary>
@@ -184,14 +197,15 @@ public class DescentFuseHandoffTests
     [Fact]
     public void LateOffer_DoesNotStrandTheWindow()
     {
+        var t = DescentFuseHandoff.TimeoutSeconds;
         var handoff = new DescentFuseHandoff();
-        Run(handoff, 0, 44.9, ceremonyOpen: false);
-        Assert.Equal(DescentHandoffAction.SpeakAwaits, handoff.Advance(45.0, false));
+        Run(handoff, 0, t - 0.1, ceremonyOpen: false);
+        Assert.Equal(DescentHandoffAction.SpeakAwaits, handoff.Advance(t, false));
 
-        var late = Run(handoff, 45.02, 48.9, ceremonyOpen: true);
+        var late = Run(handoff, t + 0.02, t + 3.9, ceremonyOpen: true);
         Assert.Empty(late);
 
-        Assert.Equal(DescentHandoffAction.Close, handoff.Advance(49.0, ceremonyOpen: true));
+        Assert.Equal(DescentHandoffAction.Close, handoff.Advance(t + 4.0, ceremonyOpen: true));
         Assert.True(handoff.IsDone);
     }
 

--- a/Tests/ConditioningControlPanel.Tests/DescentFusePhaseMathTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentFusePhaseMathTests.cs
@@ -161,6 +161,42 @@ public class DescentFusePhaseMathTests
     {
         Assert.Equal(4, DescentCountdownService.DimStepFor(At(TimeSpan.Zero), Now));
         Assert.Equal(4, DescentCountdownService.DimStepFor(At(TimeSpan.FromHours(-5)), Now));
+        Assert.Equal(4, DescentCountdownService.DimStepFor(At(-DescentCountdownService.DimHoldPastZero), Now));
+    }
+
+    /// <summary>
+    /// ...but not forever (0825 F4). A "Not tonight", or an account the server never offered,
+    /// used to keep a dimmed app until the owner unset the timestamp — which the auto-fire
+    /// contract says never to do. Once the night is long over the chrome lets go by itself.
+    /// </summary>
+    [Fact]
+    public void DimStepFor_LetsGoLongAfterZero()
+    {
+        var justPast = -DescentCountdownService.DimHoldPastZero - TimeSpan.FromSeconds(1);
+        Assert.Equal(0, DescentCountdownService.DimStepFor(At(justPast), Now));
+        Assert.Equal(0, DescentCountdownService.DimStepFor(At(TimeSpan.FromDays(-3)), Now));
+        // The migrated overload still restores immediately, unchanged.
+        Assert.Equal(0, DescentCountdownService.DimStepFor(At(TimeSpan.FromMinutes(-1)), Now, migrationCompleted: true));
+    }
+
+    // ------------------------------------------------------------ the late zero (0825 F5)
+
+    /// <summary>
+    /// A tick that first notices zero within the grace is the live night; one that notices it
+    /// hours later (sleep, hibernate, a wedged UI thread) is not, and must take the away fork
+    /// rather than play the full crack and mint a "you were there" keepsake.
+    /// </summary>
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(30, false)]
+    [InlineData(299, false)]
+    [InlineData(301, true)]
+    [InlineData(8 * 3600, true)]
+    public void IsZeroObservedLate_GraceIsFiveMinutes(int secondsAfterZero, bool expectedLate)
+    {
+        var zero = Now;
+        Assert.Equal(expectedLate,
+            DescentCountdownService.IsZeroObservedLate(zero, zero + TimeSpan.FromSeconds(secondsAfterZero)));
     }
 
     /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/DescentPostZeroRetryTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentPostZeroRetryTests.cs
@@ -1,0 +1,53 @@
+using ConditioningControlPanel.Services.Descent;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE POST-ZERO RETRY's policy (0825 hunt, F1). The director asks for a sync once a minute after
+/// the zero show ended without a ceremony; every reason to stop is a parameter here, so the whole
+/// loop's termination is pinned without a dispatcher.
+/// </summary>
+public class DescentPostZeroRetryTests
+{
+    private static bool Go(int attempts = 0, bool armed = true, bool open = false, bool offer = false,
+        bool done = false, bool pending = false) =>
+        DescentPostZeroRetry.ShouldContinue(attempts, armed, open, offer, done, pending);
+
+    [Fact]
+    public void FreshAfterATimeout_Continues() => Assert.True(Go());
+
+    [Fact]
+    public void Budget_IsBounded()
+    {
+        Assert.True(Go(attempts: DescentPostZeroRetry.MaxAttempts - 1));
+        Assert.False(Go(attempts: DescentPostZeroRetry.MaxAttempts));
+        Assert.False(Go(attempts: DescentPostZeroRetry.MaxAttempts + 100));
+    }
+
+    /// <summary>Fifteen minutes is the intent: past the herd, short of a nag.</summary>
+    [Fact]
+    public void Budget_IsAboutFifteenMinutes()
+    {
+        var total = DescentPostZeroRetry.Every * DescentPostZeroRetry.MaxAttempts;
+        Assert.InRange(total.TotalMinutes, 10, 20);
+        // Every attempt must land outside ProfileSyncService's 30s cooldown or it is wasted.
+        Assert.True(DescentPostZeroRetry.Every.TotalSeconds > 30);
+    }
+
+    [Fact]
+    public void CeremonyOpen_Stops() => Assert.False(Go(open: true));
+
+    [Fact]
+    public void OfferInHand_Stops() => Assert.False(Go(offer: true));
+
+    [Fact]
+    public void Migrated_Stops() => Assert.False(Go(done: true));
+
+    [Fact]
+    public void ChoicePending_Stops() => Assert.False(Go(pending: true));
+
+    /// <summary>The kill switch ends it too: no fuse, no ceremony to chase.</summary>
+    [Fact]
+    public void FuseDark_Stops() => Assert.False(Go(armed: false));
+}

--- a/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
@@ -162,7 +162,9 @@ public class DescentZeroShowOrderingTests
 
         Assert.Equal(4, DescentCountdownService.DimStepFor(at, at));
         Assert.Equal(4, DescentCountdownService.DimStepFor(at, at.AddHours(6)));
-        Assert.Equal(4, DescentCountdownService.DimStepFor(at, at.AddDays(9)));
+        Assert.Equal(4, DescentCountdownService.DimStepFor(at, at.AddHours(11)));
+        // ...and lets go on its own once the night is long over (0825 F4, DimHoldPastZero).
+        Assert.Equal(0, DescentCountdownService.DimStepFor(at, at.AddDays(9)));
     }
 
     /// <summary>


### PR DESCRIPTION
Desktop half of the Sept 1 ceremony bughunt. All findings are in code the public runs today (v6.8.4); this PR is the patch, the release call stays with the owner.

| # | Sev | Fix |
|---|---|---|
| F1 | HIGH | Bounded post-zero resync (1/min, 15 min) after a timed-out handoff or offer-less catch-up. Policy pure + pinned (`DescentPostZeroRetry`). |
| F2 | HIGH | Pre-zero offer hold in `DescentShowDirector.Arm()`; released once the live window holds. Live show skipped when already answered / ceremony open. |
| F3 | MED | Moving the timestamp re-arms zero (`_zeroRaised` reset, away fork re-settled). |
| F4 | MED | Dim step 4 lets go 12h after zero (`DimHoldPastZero`). |
| F5 | MED | Zero first noticed >5 min late -> `ZeroObservedLate` -> catch-up path, no keepsake. |
| F7 | LOW | Fuse timer at `DispatcherPriority.Normal`. |
| D1 | MED | Handoff timeout 45s -> 75s (two sync cooldowns). |

Not in this PR: web withhold (S8, cclabs-web PR), `NEXT_PUBLIC_CHAPTERS` redeploy (runbook), heartbeat asset (F9, owner call).

Tests: Descent 416/416 · full battery 4012/4012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnpDoiEJVni4xVVFyPRdUL
