### PR TITLE
Deep End: staged merge choreography + tier 5+ video faces on touch

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/engine/ceremonies.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/ceremonies.js
@@ -22,19 +22,28 @@ export function createCeremonies(ctx) {
   let segs = [];
 
   /* ---- stamp ------------------------------------------------------------- */
-  /** opts: { label, tone:'good'|'bad'|'gild', variant, durMs, sfx } */
+  /** opts: { label, tone:'good'|'bad'|'gild', variant, durMs, sfx, dom }
+   *  `dom:false` (2026-08-26, the double-stamp fix): the shell's ceremony
+   *  module renders its own arc-stamp at the caller's target and delegates
+   *  here for the BEAT - the fx event and the cue. Until now both sides
+   *  appended a node, so every delegated stamp rendered twice (once here in
+   *  the fx layer, once at the target). The shell now asks for the beat
+   *  alone; a direct caller that says nothing keeps the node, as ever. */
   function stamp(opts = {}) {
     if (!hasDom()) return null;
     const variant = ctx.variant('stamp', 0.6, opts.variant);
-    const node = document.createElement('div');
-    const tone = opts.tone === 'bad' ? ' ae-stamp-bad' : (opts.tone === 'gild' || variant.name === 'gild' ? ' ae-stamp-gild' : '');
-    node.className = 'ae-stamp' + tone;
-    node.textContent = String(opts.label == null ? '' : opts.label);
-    ctx.layers.front.appendChild(node);
-    ctx.timers.own(node);
+    let node = null;
+    if (opts.dom !== false) {
+      node = document.createElement('div');
+      const tone = opts.tone === 'bad' ? ' ae-stamp-bad' : (opts.tone === 'gild' || variant.name === 'gild' ? ' ae-stamp-gild' : '');
+      node.className = 'ae-stamp' + tone;
+      node.textContent = String(opts.label == null ? '' : opts.label);
+      ctx.layers.front.appendChild(node);
+      ctx.timers.own(node);
+      ctx.timers.after(opts.durMs == null ? 1000 : opts.durMs, () => ctx.timers.release(node));
+    }
     ctx.fx('stamp', variant.name);
     ctx.sfx(opts.sfx || (opts.tone === 'bad' ? 'stamp_bad' : 'stamp'), 0.55, { duck: 'voice' });
-    ctx.timers.after(opts.durMs == null ? 1000 : opts.durMs, () => ctx.timers.release(node));
     return { kind: 'stamp', variant: variant.name, node };
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/index.js
@@ -679,6 +679,17 @@ export function createEngine(options = {}) {
     isPlainBeat: (i01, floor, early) => isPlainBeat(i01, rng(), floor, early),
     cadenceMs,
     rewardRoll: (o = {}) => schedule.roll(Object.assign({ heat }, o)),
+    /** Pre-warm a heavy path in idle time (2026-08-26). 'spiral' (the default
+     *  and only kind) mounts the loom wash canvas + compiles its shader while
+     *  the element sits at opacity 0, so the first jackpot garnish / spiral
+     *  sustain reuses it instead of paying WebGL setup on a reward frame.
+     *  No rng, no fx, nothing visible; safe to skip, safe to repeat. */
+    warm(what) {
+      if (disposed || suspended) return false;
+      if (what != null && what !== 'spiral') return false;
+      ensureLayer();
+      try { return sustained.warmSpiral(); } catch (e) { log('warm refused: ' + ((e && e.message) || e)); return false; }
+    },
     garnish: (o = {}) => applyGarnish(garnishBag.draw(o.avail || ['pink', 'drain', 'spiral', 'sublim']), o.intensity),
     escapeGuard: (o = {}) => createEscapeGuard(Object.assign({ timers }, o)),
     deadBeat,

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -313,6 +313,23 @@ export function createOneshots(ctx) {
       if (Number.isFinite(Number(opts.maxMs))) detail.maxMs = Number(opts.maxMs);
       if (Number.isFinite(Number(opts.fadeMs))) detail.fadeMs = Number(opts.fadeMs);
     }
+    // THE CASCADE (2026-08-26, deep-end choreography): `steps` are follow-up
+    // blips pre-scheduled on the mixer's own timeline INSIDE this one dispatch
+    // ({atMs, name?, pitch?, level?} each) - one graph build for a whole run of
+    // pops instead of one per pop. Every step level is clamped exactly like the
+    // main cue's; the mixer clamps pitch. Pass-through otherwise, like pitch.
+    if (Array.isArray(opts.steps) && opts.steps.length) {
+      const steps = [];
+      for (const s of opts.steps.slice(0, 16)) {
+        if (!s) continue;
+        const st = { atMs: Math.max(0, Number(s.atMs) || 0) };
+        if (s.name != null) st.name = String(s.name);
+        if (s.pitch != null && Number.isFinite(Number(s.pitch))) st.pitch = Number(s.pitch);
+        if (s.level != null) st.level = ctx.magnitude(ctx.pct(s.level) * (0.8 + 0.2 * clamp01(chans.binauralDepth)));
+        steps.push(st);
+      }
+      if (steps.length) detail.steps = steps;
+    }
     if (duckKind && DUCK[duckKind] != null) {
       // depth of the duck is the player's duckDepth channel against the policy
       const policy = DUCK[duckKind];

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -130,6 +130,29 @@ export function createSustained(ctx) {
   }
 
   /**
+   * Pre-warm the spiral wash's live-loom path (2026-08-26, the deep-end merge
+   * choreography). The first jackpot garnish / spiral sustain used to pay
+   * WebGL context creation + two shader compiles + a draw INLINE on a reward
+   * frame. This mounts the loom canvas on the spiral hold NOW - the element
+   * sits at its CSS opacity 0, one frame renders, the rAF loop is idled - so
+   * the first real trigger reuses the same canvas and compiled program.
+   * No rng, no fx event, nothing visible; a gif-path class (no loom wrapper
+   * from the provider) is a no-op, and a hold already live is left alone.
+   * @returns {boolean} true when a canvas was warmed.
+   */
+  function warmSpiral() {
+    if (!hasDom() || typeof ctx.spiralUrl !== 'function') return false;
+    let src = null;
+    try { src = ctx.spiralUrl(); } catch (e) { src = null; }
+    if (!isLoomWrap(src)) return false;
+    const h = ensureWash('spiral');
+    if (!h || h.loom || h.forever) return false;   // live or held: already paid for
+    const took = loomMount(h, src);
+    loomActive(h, false);
+    return took != null;
+  }
+
+  /**
    * wash: snap ON at alpha, then fade after holdMs. A fresh trigger REFRESHES the
    * deadline on the same element (never a second element for the same kind).
    */
@@ -494,7 +517,7 @@ export function createSustained(ctx) {
     for (const [, h] of active) { try { h.retune(); } catch { /* ignore */ } }
   }
 
-  return { sustain, stop, stopAll, retuneAll, live, active, AMBIENT_KINDS };
+  return { sustain, stop, stopAll, retuneAll, warmSpiral, live, active, AMBIENT_KINDS };
 }
 
 export default createSustained;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/casino.js
@@ -97,6 +97,10 @@ export const DE_CASINO = Object.freeze({
   BUB_DEEP: 7,
   BUB_RESURFACE: 14,
   BUB_ROYAL: 24,
+  /** Pass 7: the merge payout fires once per SWIPE (aggregated), and the one
+   *  bubble burst is hard-capped per swipe - fewer minted nodes on a phone. */
+  BUB_SWIPE_CAP: 10,
+  BUB_SWIPE_CAP_TOUCH: 6,
   /** Off-arc pools (teal night): ~1 in 16. */
   OFF_ARC: 0.06,
   /** The journey: 2-4 stops through the caustic families. */
@@ -503,32 +507,42 @@ export function createDeCasino(o) {
     mq.style.setProperty('--g-de-mqa', a.toFixed(2));
   }
 
-  function flashMarquee(strength) {
-    if (!mq || !mq.classList) return;
-    mq.classList.remove('g-de-mq-flash');
-    if (typeof mq.offsetWidth === 'number') void mq.offsetWidth;   // restart the CSS animation
-    mq.style.setProperty('--g-de-mqf', String(Math.max(1, Math.min(2.2, strength))));
-    mq.classList.add('g-de-mq-flash');
-    if (flashTimer) cancel(flashTimer);
-    flashTimer = after(DE_CASINO.FLASH_MS, () => {
-      flashTimer = 0;
-      if (mq && mq.classList) mq.classList.remove('g-de-mq-flash');
-    });
-  }
-
-  /** The water pulses: the flash layer runs its keyframe once. */
-  function pulseWater(strength, deep) {
-    const f = layers.flash;
-    if (!f || !f.classList || reduced) return;
-    f.classList.remove('g-de-on', 'g-de-deep');
-    if (typeof f.offsetWidth === 'number') void f.offsetWidth;
-    setProp('--de-n-pay', clamp01(strength).toFixed(2));
-    f.classList.add(deep ? 'g-de-deep' : 'g-de-on');
-    if (deepTimer) cancel(deepTimer);
-    deepTimer = after(deep ? DE_CASINO.DEEP_MS : DE_CASINO.FLASH_MS, () => {
-      deepTimer = 0;
-      if (f.classList) f.classList.remove('g-de-on', 'g-de-deep');
-    });
+  /**
+   * The payout pair, restarted with ONE forced layout (pass 7, FIX 5): the
+   * marquee flash and the water pulse always fire on the same beat, and each
+   * used its own `void offsetWidth` - two flushes per payout, both landing in
+   * the merge path. Clear both, flush ONCE, re-arm both.
+   * `waterStrength == null` skips the water entirely - on touch the pulse's
+   * keyframe is DEAD by specificity (html.ae-touch .g-de-bd beats
+   * .g-de-bd-flash.g-de-on), so the caller keeps the look and drops the cost.
+   */
+  function restartPayout(mqStrength, waterStrength, deep) {
+    const mqOk = !!(mq && mq.classList);
+    const f = waterStrength == null ? null : layers.flash;
+    const fOk = !!(f && f.classList) && !reduced;
+    if (!mqOk && !fOk) return;
+    if (mqOk) mq.classList.remove('g-de-mq-flash');
+    if (fOk) f.classList.remove('g-de-on', 'g-de-deep');
+    const probe = mqOk ? mq : f;
+    if (typeof probe.offsetWidth === 'number') void probe.offsetWidth;   // the ONE flush
+    if (mqOk) {
+      mq.style.setProperty('--g-de-mqf', String(Math.max(1, Math.min(2.2, mqStrength))));
+      mq.classList.add('g-de-mq-flash');
+      if (flashTimer) cancel(flashTimer);
+      flashTimer = after(DE_CASINO.FLASH_MS, () => {
+        flashTimer = 0;
+        if (mq && mq.classList) mq.classList.remove('g-de-mq-flash');
+      });
+    }
+    if (fOk) {
+      setProp('--de-n-pay', clamp01(waterStrength).toFixed(2));
+      f.classList.add(deep ? 'g-de-deep' : 'g-de-on');
+      if (deepTimer) cancel(deepTimer);
+      deepTimer = after(deep ? DE_CASINO.DEEP_MS : DE_CASINO.FLASH_MS, () => {
+        deepTimer = 0;
+        if (f.classList) f.classList.remove('g-de-on', 'g-de-deep');
+      });
+    }
   }
 
   /* ------------------------------------------------------------- bubbles */
@@ -709,16 +723,24 @@ export function createDeCasino(o) {
       walkJourney(lastHeat);
     },
 
-    /** A merge pays light scaled by its chain link. */
+    /** A merge pays light scaled by its chain link. Pass 7: called ONCE per
+     *  swipe (the cascade's first pop) with the swipe's biggest link/tier and
+     *  the merge count - one marquee flash, one water pulse, one capped
+     *  bubble burst per swipe instead of one of each per merge. */
     merge(m) {
       if (!armed || destroyed || !started) return;
       const info = m || {};
       const link = Math.max(1, Math.min(8, Number(info.link) || 1));
       const tier = Math.max(1, Math.min(11, Number(info.tier) || 1));
-      flashMarquee(1 + 0.12 * link);
-      pulseWater(0.28 + 0.08 * link + (tier >= 6 ? 0.1 : 0), false);
+      const count = Math.max(1, Math.min(8, Number(info.count) || 1));
+      restartPayout(1 + 0.12 * link,
+        touchDev ? null : (0.28 + 0.08 * link + (tier >= 6 ? 0.1 : 0)), false);
       const a = anchorOf(info.tileEl);
-      if (a) bubblesAt(a.x, a.y, DE_CASINO.BUB_MERGE_BASE + Math.min(5, link) + (tier >= 6 ? 2 : 0), tier, a.w * 0.6);
+      if (a) {
+        const want = DE_CASINO.BUB_MERGE_BASE + Math.min(5, link) + (tier >= 6 ? 2 : 0) + Math.min(3, count - 1);
+        const cap = touchDev ? DE_CASINO.BUB_SWIPE_CAP_TOUCH : DE_CASINO.BUB_SWIPE_CAP;
+        bubblesAt(a.x, a.y, Math.min(cap, want), tier, a.w * 0.6);
+      }
     },
 
     /** A new deepest tier: heavier pulse, and the room steps one stop darker. */
@@ -726,8 +748,7 @@ export function createDeCasino(o) {
       if (!armed || destroyed || !started) return;
       const t = Math.max(1, Math.min(11, Number(tier) || 1));
       setProp('--de-n-depth', (t / 11).toFixed(3));
-      flashMarquee(1.6 + t / 22);
-      pulseWater(0.7, true);
+      restartPayout(1.6 + t / 22, touchDev ? null : 0.7, true);
       const a = anchorOf(tileEl);
       if (a) bubblesAt(a.x, a.y, DE_CASINO.BUB_DEEP, t, (a.w || 60) * 0.8);
     },
@@ -857,8 +878,7 @@ export function createDeCasino(o) {
       if (cs && cs.classList) cs.classList.add('g-de-royal');
       if (mq && mq.classList) mq.classList.add('g-de-mq-bell');
       paintMarquee();
-      flashMarquee(2.2);
-      pulseWater(1, true);
+      restartPayout(2.2, touchDev ? null : 1, true);
       const g = geomNow();
       if (g && g.gw) {
         bubblesAt(g.gx + g.gw / 2, g.gy + g.gh * 0.9, DE_CASINO.BUB_ROYAL, 11, g.gw);

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -76,7 +76,8 @@
  * which is NOT a third quality level - it is a hardware ceiling laid over
  * whichever rung the class resolved to, and it applies on FULL too. A coarse
  * pointer (or more than one touch point) puts `.ae-touch` on <html> for the
- * life of the class: four animated tiers instead of six, stills four deep
+ * life of the class: two animated tiers instead of six (pass 8; pass 6 dealt
+ * four, then the touch diet froze them all anyway), stills four deep
  * instead of three, three engine decoration videos instead of six, and
  * engine/style.js drops the backdrop-filter, the full-screen blend surfaces,
  * the scanline re-raster and the filters that sit over a live decode. iOS caps
@@ -96,6 +97,22 @@
  * The staging applies on desktop too (an intended cross-platform feel change);
  * the pure cost cuts riding it (tremor gate, pulseWater skip, the shorter
  * --de-n-depth transition, the bubble caps) are touch-only.
+ *
+ * PASS 8 (owner, 2026-08-25): DEEP TILES BREATHE AGAIN ON TOUCH. The pass-6
+ * diet's blanket `|| touch` still is gone; a phone deals loops from tier 5
+ * (SHALLOW_STILL_MAX_TIER_TOUCH stays 4) but only FACE_CAP_TOUCH = 2 animated
+ * tiers live at once, and the DEEPEST tiers hold those slots: a new deepest
+ * tier arriving past the cap demotes the shallowest animated tier to a fresh
+ * still (touch only, deterministic, re-dressed on the stamp beat - never in
+ * the input task). Face videos are paused for the slide window on touch
+ * (held at Phase 0 where busy arms, released at the land beat - flushChoreo
+ * fast-forward included) and pause everywhere with document.hidden and
+ * instance.pause, mirroring engine/loomWash. The fire-reward current stops
+ * smuggling an uncounted video url past the engine's decoder budget (a
+ * webm/mp4 draw is dropped so the burst routes through budgetedKind), and a
+ * face video that errors or shows no frame within FACE_VIDEO_STALL_MS falls
+ * back to a still for its tier. Desktop is pixel-identical except that
+ * budget accounting (and the invisible hidden/suspend pauses).
  *
  * PASS 4 (the owner's third note): THE PRESSURE - the CCP effects ladder and
  * the Balatro tremor live in pressure.js, DECK III. This file owns none of
@@ -400,6 +417,11 @@ export default {
     const faceUrls = new Map();            // tier -> {url, kind} | {broken:true}, frozen per class
     let faceLogged = false;
     let capLogged = false;
+    /* pass 8 - faces alive on touch */
+    let facesHeld = false;                 // the slide window holds face videos (touch only)
+    let faceVisWired = false;              // one visibilitychange listener per class
+    const faceDemotes = new Set();         // tiers demoted to a still, owed a re-dress at the stamp beat
+    const faceStalls = new Map();          // tile node -> {media, id}: the no-frame watchdog
     let stuckShown = false;
     /* pass 5 - THE PERF LADDER */
     let perfSetting = 'auto';              // de_perf: auto | full | lite
@@ -770,14 +792,24 @@ export default {
           img.setAttribute('playsinline', ''); img.setAttribute('preload', 'auto');
           img.addEventListener('loadeddata', () => {
             if (dead) return;
+            if (mediaOf(node) !== img) return;         // replaced while it was loading
+            const rec = faceStalls.get(node);          // pass 8: the watchdog is answered
+            if (rec && rec.media === img) { clearTimer(rec.id); faceStalls.delete(node); }
             node.classList.add('is-loaded');
+            /* pass 8: never nudge play into a paused window (the slide hold, a
+             * suspend, a hidden tab) - syncFaceVideos replays on release. */
+            if (facePlayBlocked()) return;
             try { const p = img.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch (e) { /* ignore */ }
           });
         } else {
           img.decoding = 'async';
           img.addEventListener('load', () => { if (!dead) node.classList.add('is-loaded'); });
         }
-        img.addEventListener('error', () => { if (!dead) faceBroken(node); });
+        img.addEventListener('error', () => {
+          if (dead) return;
+          if (mediaOf(node) !== img) return;           // a stale, replaced node's error is not this face's
+          if (video) faceVideoFailed(node); else faceBroken(node);
+        });
       } catch (e) { /* the double has no img semantics; fine */ }
     }
     /** The media node that can SHOW this url: the face's <img>, swapped for a
@@ -965,27 +997,20 @@ export default {
          * tiles nobody is looking at. */
         kind = 'still';
       } else if (kind === 'loop' && animatedFaces() >= faceCap()) {
-        kind = 'still';
-        if (!capLogged) { capLogged = true; say('faces: ' + faceCap() + ' animated tiers live - new tiers wear stills'); }
-      }
-      let url = null;
-      try {
-        /* NEVER DEAL A WORN URL while the pool can offer a different one. An
-         * online-only class opens on a remote pool of one or two clips (the
-         * host streams batches late), and a uniform draw handed that same clip
-         * to tier after tier - the complaint is a whole board wearing one
-         * video. Bounded: six draws, and the FIRST stands if every one comes
-         * back worn (a genuinely tiny pool may only have the one clip). */
-        const worn = new Set();
-        for (const f of faceUrls.values()) if (f && f.url) worn.add(f.url);
-        for (let i = 0; i < 6; i += 1) {
-          const got = pool.next(kind);
-          const u = got && got.url ? String(got.url) : null;
-          if (!u) break;
-          if (url == null) url = u;
-          if (!worn.has(u)) { url = u; break; }
+        /* PASS 8 - THE PROMOTION (touch only): the cap is 2 on a phone, and
+         * the DEEPEST tiers must be the ones breathing - without this, tiers
+         * 5+6 would keep the loops forever and every deeper arrival would
+         * freeze. A new tier DEEPER than the shallowest animated tier takes
+         * the loop slot; the shallowest is demoted to a fresh still and its
+         * tiles re-dress on the stamp beat (never in the input task -
+         * faceFor for a merged tier runs in the pop beat). Desktop keeps the
+         * pass-5 behavior byte-identical: first six animated tiers hold. */
+        if (!(touch && promoteLoopTo(tier))) {
+          kind = 'still';
+          if (!capLogged) { capLogged = true; say('faces: ' + faceCap() + ' animated tiers live - new tiers wear stills'); }
         }
-      } catch (e) { url = null; }
+      }
+      const url = dealFaceUrl(kind);
       if (!url) return null;
       const face = { url, kind };
       faceUrls.set(tier, face);
@@ -998,6 +1023,150 @@ export default {
       }
       return face;
     }
+    /** One url off the pool, deduped against every worn face. NEVER DEAL A
+     *  WORN URL while the pool can offer a different one: an online-only class
+     *  opens on a remote pool of one or two clips (the host streams batches
+     *  late), and a uniform draw handed that same clip to tier after tier -
+     *  the complaint is a whole board wearing one video. Bounded: six draws,
+     *  and the FIRST stands if every one comes back worn (a genuinely tiny
+     *  pool may only have the one clip). Shared by faceFor, the pass-8
+     *  promotion and the video-fail fallback - same machinery, no rng. */
+    function dealFaceUrl(kind) {
+      if (!pool || typeof pool.next !== 'function') return null;
+      let url = null;
+      try {
+        const worn = new Set();
+        for (const f of faceUrls.values()) if (f && f.url) worn.add(f.url);
+        for (let i = 0; i < 6; i += 1) {
+          const got = pool.next(kind);
+          const u = got && got.url ? String(got.url) : null;
+          if (!u) break;
+          if (url == null) url = u;
+          if (!worn.has(u)) { url = u; break; }
+        }
+      } catch (e) { url = null; }
+      return url;
+    }
+    /** PASS 8 - THE PROMOTION's demote half (touch only; see faceFor). Hand
+     *  the loop slot to `tier` by demoting the SHALLOWEST animated tier to a
+     *  fresh still. Deterministic: the shallowest is a pure min over the
+     *  frozen map, the still comes off the same worn-dedup deal. Returns true
+     *  when the slot was freed (the caller then deals `tier` its loop). The
+     *  demoted tier's tiles are NOT re-dressed here - the stamp beat owns
+     *  that (faceDemotes), so the swap never lands mid-slide. */
+    function promoteLoopTo(tier) {
+      let shallowest = 0;
+      for (const [tr, f] of faceUrls) {
+        if (!f || f.broken || f.kind !== 'loop') continue;
+        if (!shallowest || tr < shallowest) shallowest = tr;
+      }
+      if (!shallowest || shallowest >= tier) return false;
+      const still = dealFaceUrl('still');
+      if (!still || VIDEO_URL_RE.test(still)) return false;   // no honest still: the newcomer waits
+      faceUrls.set(shallowest, { url: still, kind: 'still' });
+      faceDemotes.add(shallowest);
+      say('faces: tier ' + shallowest + ' hands its loop to tier ' + tier + ' (touch cap ' + faceCap() + ') - re-dress on the stamp beat');
+      return true;
+    }
+    /** Re-dress every live tile of a tier against its (changed) faceUrls
+     *  entry. data-face is cleared first or dressFace would early-return on
+     *  the unchanged tier number. */
+    function redressTier(tier) {
+      for (const tile of board ? board.tiles : []) {
+        if (tile.silt || tile.tier !== tier) continue;
+        const node = tileEls.get(tile.id);
+        if (!node) continue;
+        node.setAttribute('data-face', '');
+        node.classList.remove('is-loaded');
+        dressFace(node, tile);
+      }
+    }
+    /** PASS 8 - the stamp beat's flush: demoted tiers swap video -> still
+     *  here, after the pops have landed, never in the input task. */
+    function flushFaceDemotes() {
+      if (!faceDemotes.size) return;
+      const tiers = [...faceDemotes];
+      faceDemotes.clear();
+      for (const tr of tiers) redressTier(tr);
+    }
+    /** PASS 8 - THE BELT (touch only, like the ceiling it guards): a face
+     *  <video> that errored (or sat frameless past FACE_VIDEO_STALL_MS) does
+     *  not blacklist the tier to plain the way a broken still does - the tier
+     *  falls back to a STILL first, so a phone whose decoder ceiling refused
+     *  the stream still shows media. Only when no honest still can be dealt
+     *  does the old faceBroken path run. Desktop keeps the pass-2 answer
+     *  (faceBroken) byte-identical. */
+    function faceVideoFailed(node) {
+      if (!touch) { faceBroken(node); return; }
+      const tier = Number(node.getAttribute('data-face'));
+      if (!(tier > 0)) return;
+      const f = faceUrls.get(tier);
+      if (!f || f.broken) return;
+      if (f.kind !== 'loop') { faceBroken(node); return; }     // its still failed too: plain
+      const still = dealFaceUrl('still');
+      if (!still || VIDEO_URL_RE.test(still)) { faceBroken(node); return; }
+      faceUrls.set(tier, { url: still, kind: 'still' });
+      say('faces: tier ' + tier + ' video failed or stalled - the tier falls back to a still');
+      redressTier(tier);
+    }
+    /** PASS 8 - arm the no-frame watchdog on a freshly dressed <video> face
+     *  (clears any previous watch for the node; an <img> face just clears).
+     *  TOUCH ONLY - the stall is an iOS decoder-ceiling symptom; desktop keeps
+     *  waiting exactly as before. Rides the class's pause-aware registry, so
+     *  a suspend does not tick. */
+    function armFaceStall(node, media) {
+      const prev = faceStalls.get(node);
+      if (prev) { clearTimer(prev.id); faceStalls.delete(node); }
+      if (!touch) return;
+      if (!media || String(media.tagName || '').toUpperCase() !== 'VIDEO') return;
+      const id = after(PLAYTEST.FACE_VIDEO_STALL_MS, () => {
+        faceStalls.delete(node);
+        if (dead) return;
+        if (mediaOf(node) !== media) return;                   // re-dressed under the timer
+        const tid = Number(node.getAttribute('data-id'));
+        if (tileEls.get(tid) !== node) return;                 // the tile left the board
+        if (node.classList.contains('is-loaded')) return;      // a frame arrived after all
+        faceVideoFailed(node);
+      });
+      faceStalls.set(node, { media, id });
+    }
+    /* ---- pass 8: the face-video pause windows --------------------------- */
+    /** True while face videos must not run: the slide window (touch), a
+     *  suspended class, a hidden tab. */
+    function facePlayBlocked() { return facesHeld || paused || hiddenTab(); }
+    /** Pause or (re)play every live face <video> against facePlayBlocked().
+     *  Cheap: one pass over live tiles, no layout reads; play() promises are
+     *  swallowed (an autoplay refusal is retried by the next sync). */
+    function syncFaceVideos() {
+      const stop = facePlayBlocked();
+      for (const node of tileEls.values()) {
+        const m = mediaOf(node);
+        if (!m || String(m.tagName || '').toUpperCase() !== 'VIDEO') continue;
+        try {
+          if (stop) m.pause();
+          else { const p = m.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); }
+        } catch (e) { /* the double has no video semantics */ }
+      }
+    }
+    /** The slide window opens where busy arms (Phase 0's one DOM-write task).
+     *  TOUCH ONLY: desktop faces never pause mid-slide (pixel parity). */
+    function faceSlideHold() {
+      if (!touch || facesHeld) return;
+      facesHeld = true;
+      syncFaceVideos();
+    }
+    /** ...and closes at the land beat - which also fires inside flushChoreo's
+     *  fast-forward and the reduced/hidden/no-rAF sync collapse, so a face is
+     *  never left paused past its slide. */
+    function faceSlideRelease() {
+      if (!facesHeld) return;
+      facesHeld = false;
+      if (!dead) syncFaceVideos();
+    }
+    /** document.hidden mirror (engine/loomWash's pattern): pause on hide,
+     *  replay on show - unless another window still holds them. */
+    function onFaceVisibility() { if (!dead) syncFaceVideos(); }
+
     /** Dress (or re-dress after a merge) a tile with its tier's face. Never
      *  blocks a draw: the plain body shows until the image has a frame. */
     function dressFace(node, tile) {
@@ -1019,6 +1188,7 @@ export default {
       node.classList.remove('is-loaded');
       const media = mediaNodeFor(node, face.url) || img;
       try { media.src = face.url; } catch (e) { /* ignore */ }
+      armFaceStall(node, media);             // pass 8: a video face owes a frame within the stall window
     }
     /** A url that failed: this tier goes plain for the rest of the class (no retry storm). */
     function faceBroken(node) {
@@ -1073,14 +1243,7 @@ export default {
         worn.add(fresh);
         faceUrls.set(tier, { url: fresh, kind: f.kind });
         healed = true;
-        for (const tile of board ? board.tiles : []) {
-          if (tile.silt || tile.tier !== tier) continue;
-          const node = tileEls.get(tile.id);
-          if (!node) continue;
-          node.setAttribute('data-face', '');
-          node.classList.remove('is-loaded');
-          dressFace(node, tile);
-        }
+        redressTier(tier);
       }
       if (healed) say('faces: duplicate tier clips re-dealt (the pool grew)');
     }
@@ -1396,6 +1559,7 @@ export default {
       clearHint();
       deck('trickster', 'stalled', 0);
       busy = true;
+      faceSlideHold();                      // pass 8 (touch): decoders yield the slide window; no layout read
       const moveMs = reduced ? PLAYTEST.MOVE_MS_REDUCED : PLAYTEST.MOVE_MS;
 
       /* 1. slide: vars only; victims ride to the merge cell and dissolve.
@@ -1656,6 +1820,7 @@ export default {
     /** Slide-end: the spawn's node lands, the chips read true. */
     function landBeat(rec) {
       if (dead) return;
+      faceSlideRelease();                   // pass 8: the slide is on screen - faces breathe again
       if (rec.spawnTile && board && !ended) {
         const tile = board.tiles.find((x) => x.id === rec.spawnTile.id);
         if (tile) tileEl(tile, true);
@@ -1715,6 +1880,7 @@ export default {
       if (dead) return;
       paintChain();
       markDeepest();
+      flushFaceDemotes();                   // pass 8: the demoted tier swaps video -> still on THIS beat
       if (board && !isLocked(board) && !ended) strainCheck();
       const d = rec.newDeepest;
       if (!d) return;
@@ -1864,6 +2030,16 @@ export default {
       } catch (e) { /* the engine picks its own spot */ }
       let url;
       try { if (pool && typeof pool.next === 'function') { const got = pool.next('loop'); url = got && got.url ? got.url : undefined; } } catch (e) { url = undefined; }
+      /* PASS 8 - BUDGET HONESTY: an explicit opts.url BYPASSES the engine's
+       * shared decoder budget (oneshots.js `opts.url ||` - the caller's choice
+       * is never second-guessed), so this burst stacked up to 3 UNCOUNTED
+       * <video> decoders on top of the face videos. A gif/image draw still
+       * rides through (the player's own media, budget-irrelevant); a webm/mp4
+       * draw is dropped so the burst routes through budgetedKind('loop') -
+       * counted, and answered with a still once the (touch) budget is spent.
+       * This accounting applies on desktop too - the one intended
+       * cross-platform behavior change of this pass. */
+      if (url && VIDEO_URL_RE.test(String(url))) url = undefined;
       fireSafe('gif_burst', { count: 3, variant: 'scatter', x, y, url, assetKind: 'loop', holdMs: 900 });
     }
 
@@ -2488,11 +2664,18 @@ export default {
         {
           const want = String(ctx.settings && ctx.settings.de_tile_faces != null ? ctx.settings.de_tile_faces : 'media').trim().toLowerCase();
           facesMode = FACE_MODES.includes(want) ? want : 'media';
-          /* pass 6: `touch` joins the still conditions - from tier 5 a phone
-             could otherwise hold up to 4 concurrent <video> faces, and iOS
-             thrashes past its hardware decode session cap. */
-          faceKind = (reduced || motionLevelOf() <= 1 || facesMode === 'still' || touch) ? 'still' : 'loop';
+          /* pass 8: `touch` LEFT the still conditions (the owner wants the
+             deep tiles breathing on phones again). The iOS decoder ceiling is
+             held by the numbers instead: FACE_CAP_TOUCH 2, the deepest-tier
+             promotion, and the slide-window pause. reduced motion, motionLevel
+             <= 1 and the explicit 'still' setting stay hard stops; lite keeps
+             its own caps through faceCap()/shallowStillMaxTier() (lite never
+             forced stills - it rations them). */
+          faceKind = (reduced || motionLevelOf() <= 1 || facesMode === 'still') ? 'still' : 'loop';
           faceUrls.clear();
+          facesHeld = false;
+          faceDemotes.clear();
+          faceStalls.clear();                // ids died with the registry; the map must not outlive them
         }
         // the plan's own draws do not depend on the budget; a free swim deals the
         // same seeded show a 300s class would (never Infinity into the clamp)
@@ -2514,6 +2697,16 @@ export default {
 
         try { injectDeepEndStyle(); } catch (e) { say('style inject failed (class unaffected): ' + ((e && e.message) || e)); }
         buildDom();
+        /* pass 8: face videos pause with the page (engine/loomWash's pattern).
+         * One listener per class; destroy takes it off. */
+        if (!faceVisWired) {
+          try {
+            if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+              document.addEventListener('visibilitychange', onFaceVisibility);
+              faceVisWired = true;
+            }
+          } catch (e) { /* a double without events; fine */ }
+        }
 
         const capsOk = !(ctx.caps && Number(ctx.caps.bgIntensity) === 0);
         try {
@@ -2637,12 +2830,14 @@ export default {
         clearQueue();
         deck('pressure', 'pause');
         if (stage) stage.classList.add('suspended');
+        syncFaceVideos();                    // pass 8: a frozen class spins no decoders
       },
 
       resume() {
         if (!paused) return;
         paused = false;
         if (stage) stage.classList.remove('suspended');
+        syncFaceVideos();                    // pass 8: faces replay (unless the slide window or a hidden tab still holds them)
         deck('pressure', 'resume');
         lastTick = Date.now();
         const q = deferred.splice(0);
@@ -2665,6 +2860,10 @@ export default {
           grabRaf = 0;
         }
         opened = false;
+        if (faceVisWired) {
+          try { document.removeEventListener('visibilitychange', onFaceVisibility); } catch (e) { /* noop */ }
+          faceVisWired = false;
+        }
         try { if (surfaceBtn) surfaceBtn.removeEventListener('click', onSurface); } catch (e) { /* noop */ }
         surfaceBtn = null;
         stopClock();
@@ -2707,6 +2906,7 @@ export default {
         diveDeepest = boardDeepest(board);
         bestDeepest = Math.max(bestDeepest, diveDeepest);
         markDeepest();
+        flushFaceDemotes();                  // pass 8: a staged deal may have promoted; settle the swap now
         paintHud();
         heat();
       },
@@ -2729,6 +2929,8 @@ export default {
           jackpots, currents, subFlashes, shimmers, strains, stallMs, currentHeat, driftOn,
           endless, surfaced, ceilingCelebrated, surfaceBtn, secLeft: secLeft(), clockTruth: clockText(),
           facesMode, faceKind, faces: faceUrls.size, animatedFaces: animatedFaces(),
+          /* pass 8 - faces alive on touch */
+          facesHeld, faceDemotesPending: faceDemotes.size,
           /* pass 5 - THE PERF LADDER */
           perf, perfReason, perfSetting, perfProbeDone,
           faceCap: faceCap(), shallowStillMaxTier: shallowStillMaxTier(),

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -86,6 +86,17 @@
  * rung in the PROTECTIVE direction (cap = min, still-line = max), so a phone on
  * lite is still lite. It comes off on destroy, exactly like `.ae-lite`.
  *
+ * PASS 7 (the owner's mobile note: "the slide animation starts, then suddenly
+ * everything is merged, I hear and see the stamp and spiral or reward all
+ * happening at once"): DECIDE SYNCHRONOUSLY, PRESENT IN PHASES. The input task
+ * keeps ALL game-state decisions and rng draws in their old order (Law V) and
+ * writes ONLY the slide vars; the merge pops, the stamp and the reward show
+ * play back on a paint-anchored timeline - see THE CHOREOGRAPHER below. A new
+ * press fast-forwards every pending beat, so choreography never rate-limits.
+ * The staging applies on desktop too (an intended cross-platform feel change);
+ * the pure cost cuts riding it (tremor gate, pulseWater skip, the shorter
+ * --de-n-depth transition, the bubble caps) are touch-only.
+ *
  * PASS 4 (the owner's third note): THE PRESSURE - the CCP effects ladder and
  * the Balatro tremor live in pressure.js, DECK III. This file owns none of
  * that look; it owns the WIRING. The deck is built after the casino and the
@@ -1361,6 +1372,11 @@ export default {
         refused();                            // the briefing: nothing to play against yet
         return false;
       }
+      /* FAST-FORWARD (pass 7): a committed press never waits on the last
+       * move's presentation. Every pending beat lands NOW, synchronously and
+       * in order, BEFORE the new board math - so the deck streams replay in
+       * the same per-tag order at any play speed and paint never desyncs. */
+      flushChoreo();
       const result = boardMove(board, dir);
       if (!result.moved) {
         // THE WALL: a swipe that slides nothing. No spawn, no count - but the
@@ -1431,7 +1447,14 @@ export default {
         pitch: 1 - PLAYTEST.SLIDE_PITCH_DROP * depthLineFor(boardDeepest(board)),
       });
 
-      /* 2. merges: score, chain, light, the descending chime.
+      /* 2. merges: score, chain - THE DECIDE/PRESENT SEAM (pass 7, the owner's
+       * mobile note: "the slide starts, then suddenly everything is merged...
+       * all happening at once"). Everything below DECIDES synchronously - the
+       * ledger and every GAME-STATE rng draw (reward roll, spawn, trickster)
+       * in exactly the order they always ran, so a retake replays
+       * byte-identical - but the merge POPS, the stamp and the reward SHOW
+       * are only RECORDED here and play back on the paint-anchored timeline
+       * (scheduleChoreo below).
        * THE CHAIN IS A STREAK, NOT A SNAPSHOT (owner report, 2026-08-24: "I
        * keep merging stuff but the streak disappears"). It used to be
        * RE-ASSIGNED to this one move's merge count, so a swipe that merged a
@@ -1444,7 +1467,7 @@ export default {
        * honestly starts a fresh chain. */
       const burst = result.merges.length;
       chain = burst > 0 ? chain + burst : 0;
-      let deepestMergeEl = null;
+      let deepestMergeId = 0;
       let deepestMergeTier = 0;
       /* Law I is untouched: `score` still moves in ONE place (below, by
        * result.score). This walks the same arithmetic board.js already did -
@@ -1452,59 +1475,75 @@ export default {
        * merge was worth and what the running total will read. The two agree
        * by construction: result.score IS the sum of these. */
       let runScore = score;
+      const pops = [];
       for (const m of result.merges) {
         merges += 1;
         const deltaScore = Math.pow(2, m.tier);
         runScore += deltaScore;
         const tile = board.tiles.find((x) => x.id === m.id);
-        const node = tile ? tileEl(tile, false) : null;
-        if (node) {
-          paintName(node, tile);
-          node.classList.remove('is-new');
-          node.classList.add('is-merged');
-          after(moveMs + 320, () => node.classList.remove('is-merged'));
-        }
-        deck('casino', 'merge', { tier: m.tier, link: m.link, tileEl: node });
-        deck('pressure', 'merge', { tier: m.tier, link: m.link, tileEl: node, deltaScore, score: runScore });
-        // one chime family, a semitone DOWN per link: you hear yourself sinking
-        tick('streak', 0.3 + 0.04 * m.tier, { pitch: Math.pow(2, -m.link / 12) });
-        if (m.tier > deepestMergeTier) { deepestMergeTier = m.tier; deepestMergeEl = node; }
+        pops.push({
+          id: m.id, tier: m.tier, link: m.link, deltaScore, score: runScore,
+          r: tile ? tile.r : 0, c: tile ? tile.c : 0,
+        });
+        if (m.tier > deepestMergeTier) { deepestMergeTier = m.tier; deepestMergeId = m.id; }
       }
+      /* the CASCADE plays along the direction of travel - the tiles nearest
+       * the wall the board slid into pop first. Fixed arithmetic, no rng. */
+      pops.sort((a, b) => (v.x !== 0 ? (b.c - a.c) * v.x : (b.r - a.r) * v.y));
       score += result.score;
       /* chainLinks stays a CASCADE ledger (extra pairs beyond the first in a
        * single swipe) - the report card's "links" must not inflate just
        * because the chip above now remembers across moves. */
       if (burst >= 2) chainLinks += burst - 1;
       maxChain = Math.max(maxChain, chain);
-      paintChain();
 
-      /* 3. a new deepest tier */
+      /* 3. a new deepest tier: the STATE moves now; the show is the beats'. */
       const d = boardDeepest(board);
+      let newDeep = 0;
+      let rewardShow = null;
       if (d > diveDeepest) {
         diveDeepest = d;
         bestDeepest = Math.max(bestDeepest, d);
-        onNewDeepest(d, deepestMergeEl);
+        newDeep = d;
+        if (d < TIER_MAX) {
+          /* the variable-ratio ROLL is decided here - same stream, same order
+           * as it always drew (the engine's, else the seeded |de-vr local) -
+           * and only its spectacle waits for the reward beat. */
+          rewardShow = rewardRollNow();
+          if (rewardShow && rewardShow.jackpot) jackpots += 1;
+        }
       }
-      markDeepest();
-      paintHud();
 
       /* THE CEILING: tier_11 ends a TIMED class, warm - no spawn, the board is
        * done. A FREE SWIM keeps going: the royal fires once per dive and the
-       * move finishes normally (spawn, trickster, heat, lock check). */
+       * move finishes normally (spawn, trickster, heat, lock check). The royal
+       * is the ONE everything-at-once beat left, on purpose: the pops land
+       * inline (the tier-11 tile must wear its face before the gold) and
+       * ceiling() owns the stage from here. */
+      let popsPending = pops;
       if (d >= TIER_MAX) {
+        playChoreoNow({
+          moveMs, pops, stagger: 0, maxTier: deepestMergeTier, maxLink: maxLinkOf(pops),
+          newDeepest: newDeep, lifetimeNew: false, rewardShow: null, deepestMergeId,
+          spawnTile: null, siltMsg: false,
+        });
+        popsPending = [];
+        newDeep = 0;
+        rewardShow = null;
         if (!endless) { ceiling(); return true; }
         if (!ceilingCelebrated) { ceilingCelebrated = true; ceiling(); }
       }
 
-      /* 4. one seeded spawn (the exhale guarantee rides the flag) */
+      /* 4. one seeded spawn (the exhale guarantee rides the flag). The MODEL
+       * spawns now (rng order untouched); its node reveals on the land beat. */
       const sp = boardSpawn(board, {
         table: plan.spawnTable, siltChance: plan.siltChance, siltMax: plan.siltMax,
         airlockChance: plan.airlockChance, exhale: exhalePending,
       });
       if (sp.exhaled) exhalePending = false;
       if (sp.airlock) removeTileEl(sp.airlock.id, moveMs + 200);
-      if (sp.tile) tileEl(sp.tile, true);
-      if (sp.silt && !siltSeen) { siltSeen = true; msg('de_silt_line', DE_LEX.de_silt_line); }
+      let siltMsg = false;
+      if (sp.silt && !siltSeen) { siltSeen = true; siltMsg = true; }
 
       /* 5. the trickster sees the truth AFTER the ledger moved */
       const locked = isLocked(board);
@@ -1515,19 +1554,33 @@ export default {
         locked,
       });
 
-      /* 6. heat, then the board's verdicts */
+      /* 6. heat, then the playback, then the board's verdicts */
       heat();
+      scheduleChoreo({
+        moveMs,
+        pops: popsPending,
+        stagger: staggerOf(popsPending.length),
+        maxTier: deepestMergeTier,
+        maxLink: maxLinkOf(popsPending),
+        newDeepest: newDeep,
+        lifetimeNew: newDeep > lifetimeBefore,
+        rewardShow,
+        deepestMergeId,
+        spawnTile: sp.tile || null,
+        siltMsg,
+      });
       if (locked) {
         after(moveMs + 80, resurface);
         return true;
       }
       if (!exhaleUsed && occupancy(board) >= plan.exhaleAt) startExhale();
-      strainCheck();
       /* The lock comes off at MOVE_MS and nothing extends it: every step
        * above is synchronous, `after` is only scaled by the harness's own
        * timeScale (1 in production), and a merge victim left tileEls the
        * moment it was removed, so a queued move landing here can never
-       * re-slide or resurrect one. */
+       * re-slide or resurrect one. A queued move draining right after the
+       * release fast-forwards the pending beats (flushChoreo above), so the
+       * choreography never rate-limits a fast player. */
       after(moveMs, release);
       return true;
     }
@@ -1564,33 +1617,223 @@ export default {
       for (const c of cellEls) c.classList.remove('is-hint');
     }
 
-    function onNewDeepest(d, node) {
-      deck('casino', 'newDeepest', d, node);
-      deck('pressure', 'newDeepest', d, node);
+    /* ==================================================================== *
+     * THE CHOREOGRAPHER (pass 7) - decide synchronously, present in phases.
+     *
+     * input() computes the whole "what happened" record in its own task (all
+     * game-state rng in its old order - Law V untouched) and hands it here.
+     * The PHASE CLOCK IS ANCHORED TO PAINT, not to the task: the slide's CSS
+     * transition clock starts on the first frame that SEES the new --r/--c,
+     * so two rAFs land just past that frame and the beats then ride the
+     * class's pause-aware timer registry:
+     *   land beat   slide-end       spawn reveal, HUD truth
+     *   pops        slide-end..+~200  is-merged cascade along the swipe,
+     *                               casino payout once, pressure punch per pop
+     *   stamp beat  slide-end +140  chain meter, strain, the depth stamp
+     *   reward beat slide-end +300  the room darkens, the pre-rolled reward
+     * FAST-FORWARD: flushChoreo() lands every unfired beat synchronously, in
+     * order - called before a new move, a resurface, the bell, the ceiling
+     * and the end, so state and paint always converge and a fast player is
+     * never rate-limited by the show. Reduced motion, a hidden tab and a host
+     * with no frame clock (the harness double reads the DOM synchronously)
+     * collapse the whole timeline to "now", which is exactly pass-6 behavior.
+     * ==================================================================== */
+    let choreo = null;                     // the pending playback, or null
+
+    function hiddenTab() {
+      try { return typeof document !== 'undefined' && document.hidden === true; } catch (e) { return false; }
+    }
+    function staggerOf(n) {
+      return n > 1 ? Math.min(PLAYTEST.POP_STAGGER_MS, Math.round(PLAYTEST.POP_CASCADE_MS / n)) : 0;
+    }
+    function maxLinkOf(pops) {
+      let k = 1;
+      for (const p of pops) if (p.link > k) k = p.link;
+      return k;
+    }
+    function nodeOfTile(id) { return id ? (tileEls.get(id) || null) : null; }
+
+    /** Slide-end: the spawn's node lands, the chips read true. */
+    function landBeat(rec) {
+      if (dead) return;
+      if (rec.spawnTile && board && !ended) {
+        const tile = board.tiles.find((x) => x.id === rec.spawnTile.id);
+        if (tile) tileEl(tile, true);
+      }
+      if (rec.siltMsg) msg('de_silt_line', DE_LEX.de_silt_line);
+      paintHud();
+    }
+
+    /** One pop of the cascade: the tile wears its new tier, the decks hit. */
+    function popBeat(rec, pop, i) {
+      if (dead) return;
+      const tile = board ? board.tiles.find((x) => x.id === pop.id) : null;
+      let node = null;
+      if (tile) {
+        node = tileEl(tile, false);        // data-tier + face + numeral, at pop time
+        paintName(node, tile);
+        node.classList.remove('is-new');
+        node.classList.add('is-merged');
+        after(320, () => node.classList.remove('is-merged'));
+      }
+      if (i === 0) {
+        /* the casino payout fires ONCE per swipe, aggregated (marquee flash +
+         * water pulse + one capped bubble burst), and the whole cascade's
+         * audio is ONE graph build: the follow-up pops ride the same dispatch
+         * as pre-scheduled blips (shell/audio.js `steps`). */
+        deck('casino', 'merge', { tier: rec.maxTier, link: rec.maxLink, count: rec.pops.length, tileEl: node });
+        tickCascade(rec);
+      }
+      deck('pressure', 'merge', {
+        tier: pop.tier, link: pop.link, tileEl: node,
+        deltaScore: pop.deltaScore, score: pop.score, chip: i === 0,
+      });
+    }
+
+    /** One chime family, a semitone DOWN per link: you hear yourself sinking.
+     *  First pop = the full streak cue; the rest are light blips scheduled on
+     *  the SAME context timeline in the same dispatch. */
+    function tickCascade(rec) {
+      const pops = rec.pops;
+      if (!pops.length) return;
+      const ceil = plan ? plan.audioCeil : 0.45;
+      const steps = [];
+      for (let i = 1; i < pops.length; i++) {
+        steps.push({
+          atMs: i * rec.stagger,
+          name: 'blip',
+          pitch: Math.pow(2, -pops[i].link / 12),
+          level: Math.min(ceil, 0.2 + 0.03 * pops[i].tier),
+        });
+      }
+      tick('streak', 0.3 + 0.04 * pops[0].tier,
+        Object.assign({ pitch: Math.pow(2, -pops[0].link / 12) }, steps.length ? { steps } : null));
+    }
+
+    /** Slide-end +140ms: the meter, the strain, the depth stamp + its punch. */
+    function stampBeat(rec) {
+      if (dead) return;
+      paintChain();
+      markDeepest();
+      if (board && !isLocked(board) && !ended) strainCheck();
+      const d = rec.newDeepest;
+      if (!d) return;
+      deck('pressure', 'newDeepest', d, nodeOfTile(rec.deepestMergeId));
+      if (d >= TIER_MAX || ended) return;    // the ceiling has its own ceremony
+      if (d >= 3) {
+        try { ctx.ceremonies.stamp({ text: tierName(d), target: bench }); } catch (e) { /* noop */ }
+        msg(rec.lifetimeNew ? 'de_lifetime_new' : 'de_new_depth',
+          rec.lifetimeNew ? DE_LEX.de_lifetime_new : DE_LEX.de_new_depth);
+      }
+    }
+
+    /** Slide-end +300ms: the room steps darker, then the pre-rolled reward. */
+    function rewardShowBeat(rec) {
+      if (dead) return;
+      const d = rec.newDeepest;
+      if (!d) return;
+      deck('casino', 'newDeepest', d, nodeOfTile(rec.deepestMergeId));
       /* EMI COLOR: the mascot leans in as the dive gets real (tier 6) and
        * shivers at the truly deep water (tier 9). Face only; shell-throttled. */
       try {
         if (ctx.mood && d >= 9) ctx.mood.clutch();
         else if (ctx.mood && d >= 6) ctx.mood.tense();
       } catch (e) { /* noop */ }
-      if (d >= TIER_MAX) return;             // the ceiling has its own ceremony
-      if (d >= 3) {
-        try { ctx.ceremonies.stamp({ text: tierName(d), target: bench }); } catch (e) { /* noop */ }
-        msg(d > lifetimeBefore ? 'de_lifetime_new' : 'de_new_depth',
-          d > lifetimeBefore ? DE_LEX.de_lifetime_new : DE_LEX.de_new_depth);
-      }
-      rewardBeat();
+      if (d >= TIER_MAX || ended) return;
+      rewardShowNow(rec.rewardShow);
     }
 
-    /** The variable-ratio canon: the engine's roll, else a seeded local one. */
-    function rewardBeat() {
+    function choreoSteps(rec) {
+      const steps = [];
+      steps.push({ at: 0, fired: false, fn: () => landBeat(rec) });
+      rec.pops.forEach((pop, i) => {
+        steps.push({ at: i * rec.stagger, fired: false, fn: () => popBeat(rec, pop, i) });
+      });
+      steps.push({ at: PLAYTEST.STAMP_BEAT_MS, fired: false, fn: () => stampBeat(rec) });
+      if (rec.newDeepest) steps.push({ at: PLAYTEST.REWARD_BEAT_MS, fired: false, fn: () => rewardShowBeat(rec) });
+      steps.sort((a, b) => a.at - b.at);     // stable: equal `at` keeps land -> pop order
+      return steps;
+    }
+
+    /** The whole record, NOW (the royal's inline path). */
+    function playChoreoNow(rec) {
+      for (const s of choreoSteps(rec)) {
+        try { s.fn(); } catch (e) { say('choreo step failed: ' + ((e && e.message) || e)); }
+      }
+    }
+
+    /** Land every unfired beat synchronously, in order. Idempotent. */
+    function flushChoreo() {
+      const c = choreo;
+      if (!c) return;
+      choreo = null;                         // orphans the pending rAF anchor
+      if (c.safety) { clearTimer(c.safety); c.safety = 0; }
+      for (const id of c.timers) clearTimer(id);
+      c.timers.length = 0;
+      for (const s of c.steps) {
+        if (s.fired) continue;
+        s.fired = true;
+        try { s.fn(); } catch (e) { say('choreo step failed: ' + ((e && e.message) || e)); }
+      }
+    }
+
+    function scheduleChoreo(rec) {
+      const steps = choreoSteps(rec);
+      if (!steps.length) return;
+      const raf = (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function')
+        ? (fn) => window.requestAnimationFrame(fn) : null;
+      if (reduced || !raf || hiddenTab()) {
+        /* reduced motion keeps its everything-now (the slide is 60ms and the
+         * animations are gone - staging classes against no transition is only
+         * lag); a hidden tab must not stack timers; no rAF = the harness. */
+        for (const s of steps) {
+          s.fired = true;
+          try { s.fn(); } catch (e) { say('choreo step failed: ' + ((e && e.message) || e)); }
+        }
+        return;
+      }
+      const c = { steps, timers: [], safety: 0 };
+      choreo = c;
+      raf(() => raf(() => {
+        if (dead || choreo !== c) return;
+        if (hiddenTab()) { flushChoreo(); return; }
+        const base = Math.max(0, rec.moveMs - 16);
+        for (const s of c.steps) {
+          const id = after(base + s.at, () => {
+            if (s.fired) return;
+            s.fired = true;
+            try { s.fn(); } catch (e) { say('choreo step failed: ' + ((e && e.message) || e)); }
+            if (choreo === c && c.steps.every((x) => x.fired)) {
+              choreo = null;
+              if (c.safety) { clearTimer(c.safety); c.safety = 0; }
+            }
+          });
+          c.timers.push(id);
+        }
+      }));
+      /* the net: a tab hidden between the anchor frames (or a starved frame
+       * clock) must not strand the beats. A completed timeline cleared it. */
+      c.safety = after(rec.moveMs + PLAYTEST.CHOREO_SAFETY_MS, () => {
+        c.safety = 0;
+        if (choreo === c) flushChoreo();
+      });
+    }
+
+    /** The variable-ratio canon, SPLIT at the decide/present seam (pass 7):
+     *  the roll draws in the input task - same stream, same order as always
+     *  (the engine's, else the seeded |de-vr fallback) - and only the
+     *  spectacle waits for the reward beat. */
+    function rewardRollNow() {
       let r = null;
       try {
         if (ctx.engine && typeof ctx.engine.rewardRoll === 'function') r = ctx.engine.rewardRoll({ streak: chain, success: true }) || null;
       } catch (e) { r = null; }
       if (!r) r = rollLocal();
+      return r;
+    }
+    function rewardShowNow(r) {
+      if (!r) return;
       if (r.jackpot) {
-        jackpots += 1;
         try { ctx.ceremonies.reward('jackpot', { target: boardEl, text: t('de_jackpot', DE_LEX.de_jackpot) }); } catch (e) { /* noop */ }
         fireSafe('flash_burst', { count: 2, alpha: 0.45 });     // decoration (fireSafe welds it)
         tick('jackpot', 0.7);
@@ -1667,6 +1910,7 @@ export default {
 
     function resurface() {
       if (dead || ended) return;
+      flushChoreo();                      // the locking move's beats land before the drain
       busy = true;
       clearQueue();                       // the dive that press was aimed at is over
       setPhase('resurface');
@@ -1739,6 +1983,7 @@ export default {
      *  dive ends in a resurface like any other, which re-arms the ceremony. */
     function ceiling() {
       if (dead || ended) return;
+      flushChoreo();                      // whatever was mid-show lands before the gold
       clearQueue();                       // the royal owns the board now
       ceilingReached = true;
       survived = true;
@@ -1782,6 +2027,7 @@ export default {
 
     function bell() {
       if (dead || ended) return;
+      flushChoreo();                      // the last move's beats land before the dim-out
       busy = true;
       clearQueue();                       // the water is closed; nothing drains after the bell
       clearGrab();
@@ -1802,6 +2048,7 @@ export default {
      * ==================================================================== */
     function finish(viaCeiling) {
       if (ended) return;
+      flushChoreo();                      // belt: the ledger and the paint converge first
       ended = true;
       busy = true;
       stopClock();
@@ -1995,6 +2242,27 @@ export default {
       });
     }
     function stopClock() { if (clockId) { clearTimer(clockId); clockId = 0; } }
+
+    /** Pass 7, FIX 4: warm the engine's loom-spiral path in IDLE time so the
+     *  first jackpot garnish / rung-6 wheel doesn't create a WebGL context and
+     *  compile shaders on the merge frame. requestIdleCallback when the host
+     *  has one, else a pause-aware timer; the engine's warm() is a no-op on a
+     *  gif-path class, consumes no rng and paints nothing visible. */
+    function armLoomWarm() {
+      const go = () => {
+        if (dead || ended) return;
+        try { if (ctx.engine && typeof ctx.engine.warm === 'function') ctx.engine.warm('spiral'); } catch (e) { /* optional */ }
+      };
+      let ric = null;
+      try {
+        ric = (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function')
+          ? window.requestIdleCallback : null;
+      } catch (e) { ric = null; }
+      if (ric) {
+        try { ric(() => run(go), { timeout: 4000 }); return; } catch (e) { /* fall through */ }
+      }
+      after(1500, go);
+    }
 
     /* ---- assets (never block a draw) ------------------------------------ */
     function claimAssets() {
@@ -2322,6 +2590,7 @@ export default {
           newDive();
           startPerfProbe();                    // the board is dealt: start counting frames
           startClock();
+          armLoomWarm();                       // idle-time shader warm (pass 7, FIX 4)
           stallTimer = every(PLAYTEST.STALL_TICK_MS, () => {
             if (ended || busy) return;
             stallMs += PLAYTEST.STALL_TICK_MS;
@@ -2400,6 +2669,7 @@ export default {
         surfaceBtn = null;
         stopClock();
         clearTimers();
+        choreo = null;                       // its timers just died with the registry
         stopAmbience();
         unbindInput();
         try { if (trickster) trickster.destroy(); } catch (e) { /* noop */ }
@@ -2431,6 +2701,7 @@ export default {
       /** Re-sync every tile element to the model after the harness staged a board. */
       resync() {
         if (!board) return;
+        flushChoreo();                       // a staged board must not race a pending show
         for (const id of Array.from(tileEls.keys())) if (!board.tiles.some((x) => x.id === id)) removeTileEl(id, 0);
         for (const tile of board.tiles) { const node = tileEl(tile, false); paintName(node, tile); }
         diveDeepest = boardDeepest(board);
@@ -2472,6 +2743,8 @@ export default {
           grabX: grab ? grab.gx : 0,
           grabY: grab ? grab.gy : 0,
           queued, drained, opened,
+          /* pass 7 - THE CHOREOGRAPHER: beats still owed by the last move */
+          choreoPending: choreo ? choreo.steps.filter((s) => !s.fired).length : 0,
           elapsedMs, budgetMs, ended, reported, busy, paused, dead,
           phase: stage ? stage.getAttribute('data-phase') : null,
           liveTileEls: tileEls.size,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/pressure.js
@@ -419,13 +419,83 @@ export function createDePressure(o) {
       node.classList.add(name);
     } catch (e) { /* ignore */ }
   }
-  /** A tile's centre as a % of the viewport (the engine layer's own units). */
+  /* ---- board geometry, measured ONCE (pass 7, FIX 1) ----------------------
+   * burstAt used to getBoundingClientRect a MID-TRANSITION tile: a forced
+   * layout inside the merge path AND an interpolated anchor, so the bursts
+   * landed wherever the slide happened to be. Same cure the casino's
+   * anchorOf got (casino.js 2026-08-25): the board rect + grid step are
+   * cached (invalidated by resize/orientation) and a tile's centre is derived
+   * from its honest --r/--c vars - no flush, and the TRUE cell. */
+  let bgeom = null;                 // {left, top, w, h, n, tile, step} viewport px
+  let geomBound = false;
+  const invalidateGeom = () => { bgeom = null; };
+  function measureGeom() {
+    const r = rectOf(opts.board);
+    if (!r || !r.width || !r.height) { bgeom = null; return null; }
+    const g = { left: r.left, top: r.top, w: r.width, h: r.height, n: 0, tile: 0, step: 0 };
+    try {
+      const cells = opts.board && typeof opts.board.querySelectorAll === 'function'
+        ? opts.board.querySelectorAll('.g-de-cell').length : 0;
+      if (cells > 0) g.n = Math.round(Math.sqrt(cells));
+    } catch (e) { /* stays 0 */ }
+    if (g.n > 0) {
+      let gap = 0;
+      try {
+        if (typeof getComputedStyle === 'function') gap = parseFloat(getComputedStyle(opts.board).columnGap) || 0;
+      } catch (e) { gap = 0; }
+      g.tile = (g.w - (g.n - 1) * gap) / g.n;
+      g.step = g.tile + gap;
+    }
+    bgeom = g;
+    return g;
+  }
+  function geomNow() { return bgeom || measureGeom(); }
+  function bindGeom() {
+    if (geomBound || typeof window === 'undefined' || !window.addEventListener) return;
+    try {
+      window.addEventListener('resize', invalidateGeom);
+      window.addEventListener('orientationchange', invalidateGeom);
+      geomBound = true;
+    } catch (e) { /* stays unbound; the first measure keeps standing */ }
+  }
+  function unbindGeom() {
+    if (!geomBound) return;
+    geomBound = false;
+    try {
+      window.removeEventListener('resize', invalidateGeom);
+      window.removeEventListener('orientationchange', invalidateGeom);
+    } catch (e) { /* ignore */ }
+  }
+  /** A tile's honest row/col, read (never written) off its inline --r/--c. */
+  function cellOf(tileEl) {
+    if (!tileEl || !tileEl.style || typeof tileEl.style.getPropertyValue !== 'function') return null;
+    try {
+      const r = parseFloat(tileEl.style.getPropertyValue('--r'));
+      const c = parseFloat(tileEl.style.getPropertyValue('--c'));
+      if (Number.isFinite(r) && Number.isFinite(c)) return { r, c };
+    } catch (e) { /* fall through */ }
+    return null;
+  }
+  /** A tile's centre as a % of the viewport (the engine layer's own units) -
+   *  derived from --r/--c against the cached grid, never a live rect read. */
   function pctOf(tileEl) {
-    const r = rectOf(tileEl);
+    if (!tileEl) return null;
+    const g = geomNow();
     let w = 0; let h = 0;
     try { w = typeof window !== 'undefined' ? Number(window.innerWidth) || 0 : 0; h = typeof window !== 'undefined' ? Number(window.innerHeight) || 0 : 0; } catch (e) { /* none */ }
-    if (!r || !r.width || !w || !h) return null;
-    return { x: Math.round((r.left + r.width / 2) / w * 100), y: Math.round((r.top + r.height / 2) / h * 100), size: Math.round(r.width) };
+    if (!g || !w || !h) return null;
+    const cell = cellOf(tileEl);
+    let cx; let cy; let size;
+    if (cell && g.step > 0) {
+      cx = g.left + cell.c * g.step + g.tile / 2;
+      cy = g.top + cell.r * g.step + g.tile / 2;
+      size = g.tile;
+    } else {
+      cx = g.left + g.w / 2;
+      cy = g.top + g.h / 2;
+      size = g.tile || g.w / 4;
+    }
+    return { x: Math.round((cx / w) * 100), y: Math.round((cy / h) * 100), size: Math.round(size) };
   }
   function nextAsset() {
     const a = opts.assets;
@@ -610,7 +680,11 @@ export function createDePressure(o) {
   /* ------------------------------------------------------------ the rungs */
   function retune() {
     const base = tremorAmpPx(tierNow, heat, reduced) * P.MOTION_MUL[motion] * (exhaleOn ? P.EXHALE_TREMOR_MUL : 1);
-    tremorAmp = (stopped || outOn || !armed()) ? 0 : Math.min(P.TREMOR_CAP_PX, base);
+    /* pass 7, FIX 3: touchDev mirrors punchBoard's gate - the idle tremor is
+     * a board.style.translate write per FRAME from rung 3+, and that restyles
+     * the whole board subtree; the exact cost the punch gate was added to
+     * remove. A phone never arms the tremor loop. Desktop unchanged. */
+    tremorAmp = (stopped || outOn || touchDev || !armed()) ? 0 : Math.min(P.TREMOR_CAP_PX, base);
     if (pin) {
       setVar(pin, '--de-p-pa', lerp(P.PIN_ALPHA, heat).toFixed(2));
       const spin = lerp(P.PIN_SPIN_S, heat) * (has('wheel') ? P.PIN_FAST_MUL : 1) * (exhaleOn ? P.EXHALE_SPIN_MUL : 1);
@@ -801,6 +875,8 @@ export function createDePressure(o) {
       if (!armed()) { say('pressure: caps 0 - the ladder climbs for SOUND only'); return; }
       mount();
       retune();
+      bindGeom();
+      measureGeom();   // one deliberate layout HERE, not in the merge path (FIX 1)
       say('pressure: mounted ' + [pin, ring, glitch].filter(Boolean).length + ' layers, wheel ' + spiral.file);
     },
 
@@ -829,7 +905,11 @@ export function createDePressure(o) {
       if (roll('slide-g') < lerp(P.SLIDE_GLITCH_CHANCE, heat)) benchRoll(P.SLIDE_GLITCH_S);
     },
 
-    /** Every merge, after the ledger: the punch, the juice, the rung's riders. */
+    /** Every merge, after the ledger: the punch, the juice, the rung's riders.
+     *  Pass 7: called per POP of the swipe's cascade; `chip:false` on the
+     *  follow-up pops keeps the chip punch (and its reduced-motion bloom
+     *  restart, a forced layout) to ONE per swipe - the board punch itself is
+     *  extend-not-stack and stays per pop. */
     merge(m) {
       if (!started || stopped || !armed()) return;
       const info = m || {};
@@ -837,8 +917,10 @@ export function createDePressure(o) {
       const tier = Math.max(1, Math.min(11, Number(info.tier) || 1));
       const p = punchFor({ link, tier, deltaScore: info.deltaScore });
       punchBoard(p.px, p.ms);
-      punchChip('score', p.scale, p.ms + 60);
-      if (link > 1) punchChip('chain', 1 + P.CHAIN_SCALE_PER_LINK * Math.min(8, link), 220);
+      if (info.chip !== false) {
+        punchChip('score', p.scale, p.ms + 60);
+        if (link > 1) punchChip('chain', 1 + P.CHAIN_SCALE_PER_LINK * Math.min(8, link), 220);
+      }
       if (has('burst') && roll('burst') < lerp(P.BURST_CHANCE, heat) + 0.05 * Math.min(4, link - 1)) {
         burstAt(info.tileEl, Math.round(lerp(P.BURST_COUNT, heat)) + (link >= 3 ? 1 : 0));
       }
@@ -937,6 +1019,7 @@ export function createDePressure(o) {
       if (destroyed) return;
       api.stop();
       destroyed = true;
+      unbindGeom();
       for (const id of Array.from(live)) cancel(id);
       live.clear();
       haltLoop();

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
@@ -100,14 +100,26 @@ export const PLAYTEST = Object.freeze({
    *  FULL as well as on lite. iOS caps CONCURRENT HARDWARE VIDEO DECODE
    *  SESSIONS (practically three or four before VideoToolbox starts thrashing
    *  and every one of them stutters), and a phone pays several ms a frame for a
-   *  backdrop-filter or a blend surface that a desktop GPU eats for free. So a
-   *  touch device gets four animated tiers and stills five deep no matter what
-   *  rung it is on. It COMPOSES with the rung in the PROTECTIVE direction, so
+   *  backdrop-filter or a blend surface that a desktop GPU eats for free.
+   *  PASS 8 (owner, 2026-08-25) re-opened loops on touch (the pass-6 diet had
+   *  frozen EVERY phone face still) and paid for them by TIGHTENING this cap
+   *  to 2: only the two DEEPEST animated tiers wear video on a phone - that is
+   *  where the eye is - and 2 face tiers + the engine's touch decoration
+   *  budget of 3 (util.js VIDEO_BUDGET_TOUCH, now honestly charged by the
+   *  fire-reward current too) stays at the session ceiling iOS survives. The
+   *  deepest tiers keep the slots via the promotion in faceFor(): a NEW
+   *  deepest tier past the cap demotes the shallowest animated tier to a
+   *  still. It COMPOSES with the rung in the PROTECTIVE direction, so
    *  touch never makes a lite board heavier: the animated-tier cap takes the
    *  MIN (fewer decoders wins) and the still-shallows line takes the MAX (more
    *  stills wins) - see faceCap()/shallowStillMaxTier() in index.js. */
-  FACE_CAP_TOUCH: 4,
+  FACE_CAP_TOUCH: 2,
   SHALLOW_STILL_MAX_TIER_TOUCH: 4,
+  /** PASS 8 - THE BELT: a face <video> with no frame (no loadeddata) this long
+   *  after its url landed is treated as failed - the tier falls back to a
+   *  still via faceVideoFailed instead of holding a decoder session hostage on
+   *  a stream iOS is thrashing on. */
+  FACE_VIDEO_STALL_MS: 4000,
 
   /** PASS 5 - THE AUTO PROBE. After the board is dealt we sample rAF deltas
    *  for PERF_SAMPLE_MS, skipping PERF_WARMUP_MS of first-frame cost (style

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
@@ -156,6 +156,20 @@ export const PLAYTEST = Object.freeze({
   /** Streak meter visible from this chain length; chain links cap here. */
   STREAK_VISIBLE: 2,
   CHAIN_CAP: 8,
+
+  /** Pass 7 - THE CHOREOGRAPHY (owner's mobile note: "the slide starts, then
+   *  suddenly everything is merged... all happening at once"). A move DECIDES
+   *  synchronously and PRESENTS in phases anchored to the first painted frame
+   *  of the slide: the pops cascade along the swipe (stagger = min(
+   *  POP_STAGGER_MS, POP_CASCADE_MS / merges), so the cascade never outstays
+   *  ~POP_CASCADE_MS), the stamp beat lands at slide-end + STAMP_BEAT_MS, the
+   *  reward show at slide-end + REWARD_BEAT_MS. CHOREO_SAFETY_MS is the
+   *  stranded-anchor net (a tab hidden between the anchor frames). */
+  POP_STAGGER_MS: 50,
+  POP_CASCADE_MS: 200,
+  STAMP_BEAT_MS: 140,
+  REWARD_BEAT_MS: 300,
+  CHOREO_SAFETY_MS: 650,
 });
 
 export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
@@ -1003,6 +1003,16 @@ html.ae-touch .g-de-mq.g-de-mq-flash,
 html.ae-touch .g-de-mq.g-de-mq-bell.g-de-mq-flash{animation:g-de-mqflash-t .6s ease-out 1}
 @keyframes g-de-mqflash-t{0%{opacity:1}100%{opacity:var(--g-de-mqa,.26)}}
 html.ae-touch img.g-de-media{animation:none}
+/* pass 7 (the merge choreography): --de-n-depth is a REGISTERED, INHERITING
+   number with a transition on the whole stage, so every new-deepest write is a
+   window of per-frame inherited-value recompute across the stage subtree. On a
+   phone 1.6s of that lands right on the reward beat; .6s keeps the
+   step-darker read and drops the window to a third. The transition list is
+   restated whole (a transition property does not merge). Desktop keeps 1.6s. */
+html.ae-touch .g-de-stage{
+  transition:--de-n-depth .6s ease, --de-n-a-bands 3.2s ease, --de-n-a-rays 3.2s ease,
+    --de-n-a-lens 3.2s ease, --de-n-a-vortex 3.2s ease, --de-n-a-motes 3.2s ease,
+    --de-n-a-veil 3.2s ease, --de-n-tilt 4s ease, --de-n-scale 4s ease}
 /* the OS-level reduced-motion query pins the bench flat at LOWER specificity
    than the touch rule above, so the touch sheet restates it (the class-based
    html.arc-reduced rule below already outranks by order). */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -363,8 +363,10 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
     return noiseBuf;
   }
 
-  function envelope(node, peak, ms, attackFrac) {
-    const t = ac.currentTime;
+  function envelope(node, peak, ms, attackFrac, at) {
+    // `at` (seconds, optional): schedule the whole envelope ahead on the
+    // context timeline - the cascade's follow-up blips ride one dispatch.
+    const t = ac.currentTime + (at > 0 ? at : 0);
     const dur = Math.max(0.02, ms / 1000);
     const atk = Math.max(0.004, dur * (attackFrac == null ? 0.06 : attackFrac));
     const g = node.gain;
@@ -392,16 +394,16 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
    *     the envelope. A static band is a texture; a moving one is a gesture,
    *     and `whoosh` needed to be a gesture.
    * Neither field exists on any older recipe, so nothing above sounds different. */
-  function playRecipe(rec, bus, amp, pitch, depth) {
+  function playRecipe(rec, bus, amp, pitch, depth, at) {
     const p = clampPitch(pitch);
     if (rec.layer && !(depth > 0)) {
-      try { playRecipe(rec.layer, bus, amp, pitch, 1); } catch { /* a layer is a garnish */ }
+      try { playRecipe(rec.layer, bus, amp, pitch, 1, at); } catch { /* a layer is a garnish */ }
     }
     const env = ac.createGain();
     voiceOut(bus, env);
     // Duration is deliberately NOT scaled: a pitch ratchet should climb, not
     // speed up - the cadence belongs to whoever is firing the cues.
-    const { t, dur } = envelope(env, amp * (rec.gain == null ? 0.7 : rec.gain), rec.ms, rec.attack);
+    const { t, dur } = envelope(env, amp * (rec.gain == null ? 0.7 : rec.gain), rec.ms, rec.attack, at);
     const stop = t + dur + 0.02;
 
     if (rec.noise) {
@@ -448,7 +450,7 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
       const f = ac.createBiquadFilter();
       f.type = 'lowpass'; f.frequency.value = hz(420, p);
       const g = ac.createGain();
-      envelope(g, amp * 0.5, Math.min(90, rec.ms));
+      envelope(g, amp * 0.5, Math.min(90, rec.ms), undefined, at);
       n.connect(f); f.connect(g); voiceOut(bus, g);
       n.start(t); n.stop(t + 0.12);
     }
@@ -682,6 +684,24 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
       stats.dropped += 1;
       settle('dropped');
       say('[audio] ' + (name || '?') + ' failed: ' + ((err && err.message) || err));
+    }
+    /* THE CASCADE (2026-08-26, deep-end choreography). `detail.steps` are
+     * follow-up blips pre-scheduled on the SAME context timeline inside this
+     * one dispatch - one graph build for a whole run of merge pops instead of
+     * one per pop. Each step: {atMs, name?, pitch?, level?}; a missing field
+     * inherits the main cue's. Recipes only (a clip cannot be scheduled ahead
+     * without a decoder per step, which is the cost this exists to avoid). */
+    if (ac && Array.isArray(d.steps) && d.steps.length) {
+      for (const s of d.steps.slice(0, 16)) {
+        if (!s) continue;
+        const at = Math.max(0, Math.min(4000, Number(s.atMs) || 0)) / 1000;
+        const sAmp = Math.sqrt(clamp01(s.level == null ? (d.level == null ? 0.5 : d.level) : s.level));
+        if (sAmp <= 0) continue;
+        try {
+          playRecipe(SOUNDS[String(s.name || name)] || SOUNDS.blip, bus, sAmp,
+            clampPitch(s.pitch == null ? pitch : s.pitch), 0, at);
+        } catch { /* a step must never break the bus */ }
+      }
     }
     if (d.duck) duck(d.duck);
   }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/ceremonies.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/ceremonies.js
@@ -105,7 +105,11 @@ export function createCeremonies({ engine, layer, reducedMotion, log } = {}) {
       // rendering BLANK on every delegated beat (W0 audit). Both ride so either
       // reader is served; the engine's own tone names (good/bad/gild) differ
       // from ours ('pink') on purpose - a wrong tone is a default, never a throw.
-      const opts = { text, label: text, tone, target };
+      // `dom:false` (2026-08-26): the delegate carries the BEAT (fx + cue);
+      // the ONE stamp node is built below, at the caller's target. Before
+      // this, every delegated stamp rendered twice - the engine's ae-stamp in
+      // its fx layer AND our arc-stamp here.
+      const opts = { text, label: text, tone, target, dom: false };
       const engineTook = delegate('stamp', opts);
       // The engine path plays its own stamp cue; the floor plays the same one.
       // `pitch` (gradeObject's rank ladder) rides only the floor - the engine's


### PR DESCRIPTION
Owner playtest note: "the slide animation starts, then suddenly everything is merged, I hear and see the stamp and spiral or reward all happening at once."

Root cause: the whole move ran as one synchronous task and the first forced reflow inside it started the 170ms slide clock before first paint, so tiles teleported and every payoff landed on one frame.

**Commit 1 - staged merge choreography (decide synchronously, present in phases)**
- Phase 0 (input task): board math and ALL rng draws in their old order (retakes byte-identical); DOM = slide vars only; zero forced reflows, so the slide clock starts at first paint.
- Phase 1 (slide end, paint-anchored via double rAF): merge pops cascade along the swipe direction (stagger min(50ms, 200/N)); ONE audio graph per swipe with scheduled blips; casino payout fires once per swipe, bubbles capped 10 desktop / 6 touch.
- Phase 2 (+140ms): chain meter, strain, markDeepest, the depth stamp.
- Phase 3 (+300ms): --de-n-depth, deep pulse, the reward SHOW (roll decided in Phase 0).
- Fast-forward: a new press / bell / ceiling / finish flushes every unfired beat synchronously first - fast players are never rate-limited.
- Riding fixes: pressure burstAt anchors from --r/--c (no more mid-transition getBoundingClientRect), double stamp deduped (shell delegates with dom:false), touch tremor gated, WebGL loom pre-warmed at class start so the first jackpot pays no shader compile, marquee+water restarts batched to one flush.
- Touch-only cost cuts stay behind ae-touch/touchDev; the staging itself is an intended cross-platform feel change.

**Commit 2 - tier 5+ video faces return on touch**
- The diet's blanket "all faces still on touch" clause removed; the dormant dials take over: stills through tier 4, loops from tier 5, FACE_CAP_TOUCH tightened 4 -> 2 (iOS decoder ceiling).
- New deepest tier past the cap deterministically evicts the shallowest animated tier (5,6 -> 7 arrives -> 6,7).
- Face videos pause during the slide window and on hidden/suspend; resume on every choreography path incl. fast-forward.
- Budget fix (desktop too, intended): the fire-reward burst no longer bypasses the engine video budget with an explicit video url.
- Defensive belt: a face video that errors or stalls 4s falls back to that tier's still.

**Verified**: eval-import sweep OK on all 13 touched modules; CDP smoke on 390x844 touch + 1600x900 desktop: median merge-pop delay 183ms/198ms after keydown (was same-frame), stamp at +322/375ms, moved tile sampled at 8-16 distinct positions per slide (teleport = 2), identical 7 merges over 14 moves on both platforms (determinism), zero exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVfeMhCj5mqWQ1b3pPAUVN
