### PR TITLE
Arcademy: manifest media warmer + url blacklist; SORT never deals a cold or dead face

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
@@ -180,6 +180,27 @@ export function wrapQuickPool(claimPool) {
     thin(tag) { return seen[tag === 'noise' ? 'noise' : 'target'].size < DECK.PER_SOURCE_MIN; },
     empty(tag) { return served[tag === 'noise' ? 'noise' : 'target'] === 0 && seen[tag === 'noise' ? 'noise' : 'target'].size === 0; },
     prewarm() { /* the claim pool prewarmed itself */ },
+    /* THE MANIFEST SEAM (0825) rides through to the wrapped claim pool, so the
+     * room speaks one media API whichever pool shape stands behind it. Absent
+     * verbs answer the inert thing: nothing warmed, nothing broken, ready NOW
+     * (a pool with no warm rail is the desktop's local disk - already instant). */
+    warmManifest(entries, opts) {
+      try { return p && typeof p.warmManifest === 'function' ? p.warmManifest(entries, opts) : 0; }
+      catch (e) { return 0; }
+    },
+    warmCursor(i) {
+      try { if (p && typeof p.warmCursor === 'function') p.warmCursor(i); } catch (e) { /* noop */ }
+    },
+    ready(url, opts) {
+      try { if (p && typeof p.ready === 'function') return p.ready(url, opts); } catch (e) { /* fall through */ }
+      return Promise.resolve(true);
+    },
+    markBroken(url) {
+      try { if (p && typeof p.markBroken === 'function') p.markBroken(url); } catch (e) { /* noop */ }
+    },
+    isBroken(url) {
+      try { return !!(p && typeof p.isBroken === 'function' && p.isBroken(url)); } catch (e) { return false; }
+    },
     dealt() {
       const rows = [];
       for (const tg of DECK.TAGS) for (const url of seen[tg]) rows.push({ url, tag: tg, src: 'local' });

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -218,19 +218,12 @@ const DECODER_CEILING = 2;
  *  supply figure - six rows in front of a cursor is six rows whether the deck
  *  is 60 long or 120. Stays 6. */
 const PREWARM = 6;
-/** Cards the WARM RAIL pulls bytes for, standing BEHIND the three-deep stack.
- *  Not a supply figure either: PREWARM buys rows (urls), this buys the bytes
- *  behind them. Four was the first guess and a fast swiper beat it (owner
- *  report, 2026-08-24: a sub-second rhythm against multi-megabyte gifs on a
- *  phone link outran the window before the trickle refilled it). Eight is the
- *  same idea sized to the actual burn rate: ~0.5s a card is ~4s of slack,
- *  which is one big gif's worth of download on a bad day. */
-const WARM_AHEAD = 8;
-/** Warms in flight at once. This is a background TRICKLE and it is competing
- *  with the top card's own download, which always wins - but two lanes stalled
- *  behind one slow gif while the swiper burned the window down, so a third
- *  lets small stills slip past a big download instead of queueing behind it. */
-const WARM_INFLIGHT = 3;
+/* (The game-local WARM_AHEAD/WARM_INFLIGHT byte rail moved INTO the provider
+ * as the manifest warmer, 0825: buildDeck knows the whole ordered deck before
+ * the first card shows, so warmDeck() below hands it to pool.warmManifest()
+ * and reseat() walks pool.warmCursor(). Windows and lanes live in
+ * provider/index.js - MANIFEST_AHEAD_IDLE/PLAY, WARM_INFLIGHT - and the
+ * saveData gate rides inside warmUrl(), where it always was.) */
 /** The claim, when the door never resolved one for us (QUICK SORT floor).
  *  Moved 48/32 -> 72/48 with the deck (see claimOpts): a 120-card tier-4 deck
  *  fed by an 80-row claim would be repeats before the bell. */
@@ -811,7 +804,7 @@ export default {
         ring = makeRing();
         if (ring && ring.el) node.appendChild(ring.el);
       }
-      return { node, clip, face, ring, yes, no, card, depth, video: face && face.tagName === 'VIDEO' };
+      return { node, clip, face, ring, yes, no, card, depth, video: face && face.tagName === 'VIDEO', slotFreed: false };
     }
     function stampNode(side, glyph, text) {
       const n = el('div', 'g-sort-stamp ' + side);
@@ -823,10 +816,113 @@ export default {
       setAttr(n, 'aria-hidden', 'true');
       return n;
     }
+    /* ---------------------------------------------------- broken media law */
+    /** The pool's shared url blacklist, guarded: a pool double without the
+     *  seam (the shell's null-assets, an old harness) just answers "fine". */
+    function poolIsBroken(url) {
+      try { const p = S && S.pool; return !!(p && typeof p.isBroken === 'function' && url && p.isBroken(url)); }
+      catch (e) { return false; }
+    }
+    function poolMarkBroken(url) {
+      try { const p = S && S.pool; if (p && typeof p.markBroken === 'function' && url) p.markBroken(url); }
+      catch (e) { /* noop */ }
+    }
+    /**
+     * THE SUBSTITUTE for a card whose url is dead - decided at MINT time, and
+     * the stored deck (the retake cache) is NEVER touched: game state and the
+     * judge keep reading the deck record, the FACE is presentation. Same-tag
+     * by law (the player judges the pixels, the ledger judges card.tag - and
+     * in QUICK SORT same tag IS same kind, so the kind-truth holds too), and
+     * deterministic by construction: candidates walk S.deckRows (the deal
+     * order, identical on a retake) and the pick is pure hashing of
+     * (seed, deck index) - the same blacklist state shows the same substitute
+     * on a retake, and no seeded stream is consumed (determinism law).
+     */
+    function substituteFor(card) {
+      if (!S || !card) return null;
+      const rows = S.deckRows || [];
+      const seen = new Set();
+      const list = [];
+      for (const c of rows) {
+        if (!c || !c.url || c.tag !== card.tag) continue;
+        if (c.url === card.url || seen.has(c.url) || poolIsBroken(c.url)) continue;
+        seen.add(c.url);
+        list.push(c);
+      }
+      if (!list.length) return null;
+      const pick = list[Math.floor(hash01(String(S.seed) + '|sub|' + (card.i | 0)) * list.length)];
+      return pick ? { url: pick.url, mime: pick.mime || '' } : null;
+    }
+    /** What the face actually shows: the card's own url, or its substitute
+     *  when that url is on the blacklist. Null = no healthy media at all -
+     *  the drawn back stands, which is the fair round it always was. */
+    function displaySrcOf(card) {
+      if (!card || !card.url) return null;
+      if (!poolIsBroken(card.url)) return { url: card.url, mime: card.mime || '' };
+      const sub = substituteFor(card);
+      return sub || null;
+    }
+    /** The live entry currently holding this face element, if any. */
+    function liveHolding(face) {
+      if (!S || !face) return null;
+      for (const live of S.live) if (live && live.face === face) return live;
+      return null;
+    }
+    /**
+     * BUG A's fix: the decoder SLOT frees the moment the card LEAVES PLAY
+     * (flyOut / the pass's sink), not when its node is torn down 400ms later -
+     * in that gap the next card's video used to hit the ceiling, mint null,
+     * and top the stack cold. The node keeps playing while it flies (the slot
+     * is a claim on the future, and the brief overlap is the accepted cost);
+     * `slotFreed` makes the free idempotent across flyOut -> dropCard -> error,
+     * and a re-minted face resets it (reseat's grow branch).
+     */
+    function freeSlot(live) {
+      if (!live || !live.video || live.slotFreed) return;
+      live.slotFreed = true;
+      videoCount = Math.max(0, videoCount - 1);
+    }
+    /** Tear a face out of a live card NOW (a dead url): slot freed, element
+     *  silenced and removed, refs cleared so reseat()'s re-mint branch refires. */
+    function killFace(live) {
+      if (!live || !live.face) return;
+      const face = live.face;
+      if (live.video) {
+        freeSlot(live);
+        try { if (face.pause) face.pause(); face.removeAttribute('src'); if (face.load) face.load(); }
+        catch (e) { /* noop */ }
+      }
+      try { if (face.parentNode) face.remove(); } catch (e) { /* noop */ }
+      live.face = null;
+      live.video = false;
+    }
+    /** BUG B's fix, shared by both element kinds: a face that ERRORED is a url
+     *  the whole page should stop dealing. Blacklist it, clear the face so the
+     *  re-mint branch refires, and reseat now - the re-mint swaps in the
+     *  substitute without waiting for the stack to move. */
+    function faceDied(face) {
+      const url = face && face._aeUrl ? String(face._aeUrl) : '';
+      if (url) poolMarkBroken(url);
+      const live = liveHolding(face);
+      if (live) {
+        killFace(live);
+        try { reseat(); } catch (e) { /* noop */ }
+      } else {
+        /* already out of play: its slot was freed when it left (flyOut/pass);
+         * just make sure the element itself lets go */
+        try { if (face && face.pause) face.pause(); } catch (e) { /* noop */ }
+        try { if (face && face.parentNode) face.remove(); } catch (e) { /* noop */ }
+      }
+    }
+
     function mintFace(card, depth) {
       if (!card || !card.url) return null;
       if (depth > 1) return null;                       // the third card is a back
-      const isVid = isVideoUrl(card.url, card.mime);
+      /* a BLACKLISTED url swaps its face for the deterministic substitute
+       * here, at mint time - the deck record itself is never rewritten */
+      const src = displaySrcOf(card);
+      if (!src) return null;                            // nothing healthy: the back stands
+      const isVid = isVideoUrl(src.url, src.mime);
       /* A VIDEO MAY NOW MINT AT DEPTH 1 TOO - warm, not playing. preload=auto
        * with no play() call pulls bytes and readies the first frame while the
        * card is still second, so the promotion's faceReady gate is usually a
@@ -845,17 +941,20 @@ export default {
         try {
           v.setAttribute('muted', ''); v.setAttribute('loop', '');
           v.setAttribute('playsinline', '');
-          v.setAttribute('preload', isTop ? 'metadata' : 'auto');
+          /* preload=auto at EVERY depth: depth 1 is the pre-mint warm, and a
+           * video minting cold AT depth 0 (a substitute, a promoted back) needs
+           * its bytes now, not a metadata probe - the old 'metadata' top-card
+           * branch was for faces play() would drive anyway, and on a cold top
+           * card it sat under the 1s ceiling doing nothing. */
+          v.setAttribute('preload', 'auto');
           v.setAttribute('disablepictureinpicture', '');
         } catch (e) { /* DOM double */ }
         try { v.disableRemotePlayback = true; } catch (e) { /* not everywhere */ }
+        try { v._aeUrl = src.url; } catch (e) { /* noop */ }
         if (typeof v.addEventListener === 'function') {
-          v.addEventListener('error', () => {
-            try { v.removeAttribute('src'); if (v.load) v.load(); } catch (e) { /* ignore */ }
-            try { if (v.parentNode) v.remove(); } catch (e) { /* ignore */ }
-          });
+          v.addEventListener('error', () => faceDied(v));
         }
-        v.src = card.url;
+        v.src = src.url;
         if (isTop && typeof v.play === 'function') {
           try { const p = v.play(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* autoplay policy */ }
         }
@@ -873,16 +972,17 @@ export default {
       img.alt = '';
       try { img.setAttribute('draggable', 'false'); img.setAttribute('decoding', 'async'); }
       catch (e) { /* DOM double */ }
+      try { img._aeUrl = src.url; } catch (e) { /* noop */ }
       if (typeof img.addEventListener === 'function') {
-        img.addEventListener('error', () => { try { if (img.parentNode) img.remove(); } catch (e) { /* ignore */ } });
+        img.addEventListener('error', () => faceDied(img));
       }
-      img.src = card.url;
+      img.src = src.url;
       return img;
     }
     function dropCard(live) {
       if (!live) return;
+      freeSlot(live);
       if (live.video) {
-        videoCount = Math.max(0, videoCount - 1);
         try { const v = live.face; if (v) { if (v.pause) v.pause(); v.removeAttribute('src'); if (v.load) v.load(); } }
         catch (e) { /* noop */ }
       }
@@ -890,144 +990,31 @@ export default {
     }
 
     /* ==================================================================== *
-     * THE WARM RAIL - bytes ahead of the deal, and nothing else.
+     * THE MANIFEST HAND-OFF (0825) - the game-local warm rail, superseded.
      *
-     * A card asks the network for its media only when it is MINTED into the
-     * three-deep stack, and a VIDEO card does not even do that: since the
-     * blank-card fix a video url never rides an <img>, so the card stands as a
-     * drawn back until reseat() grows the real <video> at the moment it
-     * SURFACES. On a phone against a remote CDN that is a guaranteed blank-back
-     * window - the download starts on the card the player is already being
-     * timed on. PREWARM above does not help: it is the provider's ROW
-     * look-ahead, and a row is a url, not a byte.
-     *
-     * So the rail peeks the cards that hold a url and no bytes - the faceless
-     * ones still in the stack, then the few standing behind it - and asks the
-     * browser to put their bytes in the HTTP cache, so that the element minted
-     * later finds them already there. Two rules keep it honest:
-     *
-     *   - a still or a gif is warmed by a DETACHED `new Image()`. It is never
-     *     attached to the document, so nothing composites and nothing is on
-     *     screen; the strong ref in `held` exists only so GC cannot collect the
-     *     request out from under itself mid-flight, and it is dropped the
-     *     moment the card surfaces or the window walks past it.
-     *   - a video url is warmed by `fetch(url, {mode:'no-cors'})` and the
-     *     opaque reply is thrown away unread. It is deliberately NOT a detached
-     *     <video>: trap 36 says the DECODER COUNT is the only lever that
-     *     matters, DECODER_CEILING is 2, and a warm <video> would start a demux
-     *     the instant it had bytes - a third decoder, off screen, that the
-     *     ceiling never counted. A cache entry costs no decoder at all.
-     *
-     * And it is a trickle, not a race: WARM_INFLIGHT at a time, every url at
-     * most once a class, nothing local or blob-backed (already instant), and
-     * under Data Saver the rail is never built in the first place.
+     * buildDeck writes THE WHOLE ordered deck before the first card shows, so
+     * this class does not need to peek a window itself: warmDeck() hands the
+     * full need list to pool.warmManifest() the moment the deal lands - the
+     * door / ghost round / rules sheet then becomes warm time under the
+     * provider's deep IDLE window - and reseat() (the one seam every advance
+     * already rides) walks pool.warmCursor() so the window follows play. The
+     * warm primitives, the inflight trickle, the once-per-url law, the held
+     * bound and the Data Saver gate all live in the provider now (one rail,
+     * not two); trap 36 still holds - a video warms as a no-cors fetch, never
+     * a detached <video>.
      * ==================================================================== */
-    /** Data Saver is the player's word that we do not spend bytes on a guess. */
-    const saveData = (() => {
-      try { return !!(navigator.connection && navigator.connection.saveData === true); }
-      catch (e) { return false; }
-    })();
-
-    function createWarmRail() {
-      const warmed = new Set();     // every url this class has already asked for
-      const held = new Map();       // url -> the detached Image holding it open
-      const queue = [];
-      let flight = 0;
-      let dead = false;
-
-      /** Only bytes that actually travel. A blob:/data:/file: url has no
-       *  network behind it, and same-origin media is the host serving the
-       *  player's own disk - both are instant and warming them is waste. */
-      function warmable(url) {
-        const s = String(url || '');
-        if (!s || warmed.has(s)) return false;
-        try {
-          const u = new URL(s, (typeof location !== 'undefined' && location.href) || undefined);
-          if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
-          if (typeof location !== 'undefined' && u.origin === location.origin) return false;
-        } catch (e) { return false; }
-        return true;
-      }
-      function done() { flight = Math.max(0, flight - 1); if (!dead) pump(); }
-      function pump() {
-        while (!dead && flight < WARM_INFLIGHT && queue.length) {
-          const job = queue.shift();
-          flight += 1;
-          if (job.video) {
-            /* fire and forget, and swallow everything: a rejected warm is a
-             * card that will simply load the ordinary way. */
-            try {
-              const pr = fetch(job.url, { mode: 'no-cors', credentials: 'omit' });
-              if (pr && pr.then) pr.then(done, done); else done();
-            } catch (e) { done(); }
-          } else {
-            let img = null;
-            try { img = new Image(); } catch (e) { img = null; }
-            if (!img) { done(); continue; }
-            held.set(job.url, img);
-            try {
-              img.decoding = 'async';
-              img.src = job.url;
-              /* BYTES ARE HALF THE BILL. A cached gif still pays its DECODE on
-               * first paint, and on a phone that is the visible half of the
-               * stutter the owner reported - so a warm is not done until
-               * decode() says the first frame exists. The decoded frames live
-               * in the browser's image cache keyed by url, which is exactly
-               * where the card's own <img> will look. Fallback for engines
-               * without decode(): the old load/error pair, bytes-only. */
-              if (typeof img.decode === 'function') {
-                img.decode().then(done, () => { held.delete(job.url); done(); });
-              } else {
-                img.onload = done;
-                img.onerror = () => { held.delete(job.url); done(); };
-              }
-            } catch (e) { held.delete(job.url); done(); }
-          }
-        }
-      }
-      return {
-        /** THE WINDOW IS EVERY CARD WITH NO BYTES YET, and it starts INSIDE the
-         *  stack. A minted card is not a loaded one: the third card is a back
-         *  by law, and since the blank-card fix a video card is a back at depth
-         *  1 too - both hold a url and no request. So the faceless live cards
-         *  come first (they surface soonest), then the cards the cursor has not
-         *  dealt. The tail can be short near the end of the deck, which is
-         *  fine: what follows a spent deck is the passes and a reshuffle, urls
-         *  this class has already met and the cache already holds. */
-        refresh() {
-          if (dead || !S || !S.cards || !S.cards.length) return;
-          const ahead = [];
-          for (const live of (S.live || [])) {
-            if (live && !live.face && live.card && live.card.url) ahead.push(live.card);
-          }
-          for (let k = 0; k < WARM_AHEAD; k++) {
-            const card = S.cards[S.cursor + k];
-            if (card && card.url) ahead.push(card);
-          }
-          const window_ = new Set(ahead.map((c) => String(c.url)));
-          for (const url of Array.from(held.keys())) if (!window_.has(url)) held.delete(url);
-          for (const card of ahead) {
-            const url = String(card.url);
-            if (!warmable(url)) continue;
-            warmed.add(url);
-            queue.push({ url, video: isVideoUrl(url, card.mime) });
-          }
-          pump();
-        },
-        destroy() {
-          dead = true;
-          queue.length = 0;
-          for (const img of held.values()) {
-            try { img.onload = null; img.onerror = null; } catch (e) { /* noop */ }
-          }
-          held.clear();
-          warmed.clear();
-          flight = 0;
-        },
-        diagnostics() { return { warmed: warmed.size, held: held.size, queued: queue.length, flight }; },
-      };
+    function warmDeck() {
+      if (!S || !S.pool || typeof S.pool.warmManifest !== 'function') return;
+      try {
+        S.pool.warmManifest(S.cards.map((c) => ({ url: c.url, kind: c.kind, mime: c.mime })));
+      } catch (e) { /* a warm-up never breaks a deal */ }
     }
-    const warmRail = saveData ? null : createWarmRail();
+    function warmFollow() {
+      if (!S || !S.pool || typeof S.pool.warmCursor !== 'function') return;
+      /* the play position in DECK ORDER: the top card's index, i.e. the deal
+       * cursor minus the cards still standing in the stack */
+      try { S.pool.warmCursor(Math.max(0, S.cursor - S.live.length)); } catch (e) { /* noop */ }
+    }
 
     /* ==================================================================== *
      * THE DEAL
@@ -1085,6 +1072,9 @@ export default {
           if (face) {
             live.face = face;
             live.video = face.tagName === 'VIDEO';
+            /* a fresh face is a fresh slot claim: the free that matters is the
+             * one for THIS face (an earlier face's free already happened) */
+            live.slotFreed = false;
             /* seat it where mintCard does: inside the clip layer, over the
              * back. The stamps and the ring are the card node's own children
              * and stay above the clip either way; the insertBefore fallback is
@@ -1113,12 +1103,12 @@ export default {
           if (live.ring && live.ring.el) { try { live.node.appendChild(live.ring.el); } catch (e) { /* noop */ } }
         }
       }
-      /* THE WARM RAIL RIDES THE RESEAT, because this is the ONE function every
-       * advance already goes through: fillStack() ends here after the deal, and
-       * both shifts - a commit and a pass - call it the instant the stack moves,
-       * which is a beat EARLIER than the fill that follows them. One seam, no
-       * new lifecycle. */
-      if (warmRail) warmRail.refresh();
+      /* THE WARM WINDOW RIDES THE RESEAT, because this is the ONE function
+       * every advance already goes through: fillStack() ends here after the
+       * deal, and both shifts - a commit and a pass - call it the instant the
+       * stack moves, which is a beat EARLIER than the fill that follows them.
+       * One seam, no new lifecycle. */
+      warmFollow();
     }
 
     /* ==================================================================== *
@@ -1128,12 +1118,20 @@ export default {
      * THE MEDIA-READY GATE. The ring used to start on a bare timer, so on a
      * slow link the countdown ran against a face still downloading. done()
      * fires exactly ONCE: on a painted first frame (img decode / video
-     * loadeddata), on a broken url (error RESOLVES - the face removes itself
-     * and the drawn back is the fair round), or on READY_FALLBACK_MS,
-     * whichever lands first. The fallback rides the class's own timer
-     * registry, so the bell, a destroy and the fake clock all own it; a card
-     * with no face at all (the drawn back) is ready NOW, which is also what
-     * the DOM double answers - the scratch harness sees no new asynchrony.
+     * loadeddata), on a bare-back card (no face IS ready), or on
+     * READY_FALLBACK_MS, whichever lands first. The fallback rides the class's
+     * own timer registry, so the bell, a destroy and the fake clock all own
+     * it; the DOM double answers now - the scratch harness sees no new
+     * asynchrony.
+     *
+     * A DEAD URL NO LONGER COUNTS AS READY (the old `error -> finish` armed
+     * the ring over a blank back and the url came back next pass, still dead):
+     * the blacklist is consulted FIRST - a url the warm rail already condemned
+     * swaps to its substitute before any waiting starts - and an error while
+     * we wait rides faceDied() (blacklist + re-mint) and then WATCHES THE
+     * SUBSTITUTE, all inside the same 1s ceiling. With the manifest warmer
+     * ahead of play the common case is a warm url whose element check answers
+     * near-synchronously, and the ring arms over a painted face at ~0 wait.
      */
     function faceReady(live, done) {
       let spent = false;
@@ -1144,36 +1142,65 @@ export default {
         timers.cancel(guardId);
         try { done(); } catch (e) { /* noop */ }
       };
-      const face = live ? live.face : null;
-      if (!face) { finish(); return; }                  // the drawn back IS ready
-      let hooked = false;
-      try {
-        if (face.tagName === 'VIDEO') {
-          /* a double without a readyState is not LOADING anything: answer now
-           * rather than parking a suite on the fallback timer */
-          if (typeof face.readyState !== 'number') { finish(); return; }
-          if (Number(face.readyState) >= 2) { finish(); return; }
-          if (typeof face.addEventListener === 'function') {
-            face.addEventListener('loadeddata', finish, { once: true });
-            face.addEventListener('error', finish, { once: true });
-            hooked = true;
-          }
-        } else {
-          /* same law for the img double: no boolean `complete`, no network */
-          if (typeof face.complete !== 'boolean') { finish(); return; }
-          if (face.complete && Number(face.naturalWidth) > 0) { finish(); return; }
-          if (typeof face.decode === 'function') {
-            face.decode().then(finish, finish);
-            hooked = true;
-          } else if (typeof face.addEventListener === 'function') {
-            face.addEventListener('load', finish, { once: true });
-            face.addEventListener('error', finish, { once: true });
-            hooked = true;
-          }
+      if (!live) { finish(); return; }
+      let hops = 0;
+      const failed = () => {
+        if (spent) return;
+        /* the error handler (faceDied) has blacklisted the url, cleared the
+         * face and re-minted the substitute; watch THAT face. Bounded: every
+         * hop condemns one more url, and a deck out of substitutes answers
+         * with no face at all - ready. */
+        if (++hops > 3) { finish(); return; }
+        timers.after(0, () => {
+          if (spent) return;
+          if (!S || destroyed) { finish(); return; }
+          try { reseat(); } catch (e) { /* noop */ }   // idempotent when faceDied already ran it
+          watch();
+        });
+      };
+      const watch = () => {
+        if (spent) return;
+        const face = live.face;
+        if (!face) { finish(); return; }                // the drawn back IS ready
+        /* the blacklist first: a url condemned since the mint (a warm failure
+         * landing in the gap) swaps NOW instead of waiting the ceiling out */
+        const shown = face._aeUrl ? String(face._aeUrl) : '';
+        if (shown && poolIsBroken(shown)) {
+          killFace(live);
+          failed();
+          return;
         }
-      } catch (e) { hooked = false; }
-      if (!hooked) { finish(); return; }                // the DOM double answers now
+        let hooked = false;
+        try {
+          if (face.tagName === 'VIDEO') {
+            /* a double without a readyState is not LOADING anything: answer now
+             * rather than parking a suite on the fallback timer */
+            if (typeof face.readyState !== 'number') { finish(); return; }
+            if (Number(face.readyState) >= 2) { finish(); return; }
+            if (typeof face.addEventListener === 'function') {
+              face.addEventListener('loadeddata', finish, { once: true });
+              face.addEventListener('error', failed, { once: true });
+              hooked = true;
+            }
+          } else {
+            /* same law for the img double: no boolean `complete`, no network */
+            if (typeof face.complete !== 'boolean') { finish(); return; }
+            if (face.complete && Number(face.naturalWidth) > 0) { finish(); return; }
+            if (face.complete) { failed(); return; }    // complete with no pixels: dead
+            if (typeof face.decode === 'function') {
+              face.decode().then(finish, failed);
+              hooked = true;
+            } else if (typeof face.addEventListener === 'function') {
+              face.addEventListener('load', finish, { once: true });
+              face.addEventListener('error', failed, { once: true });
+              hooked = true;
+            }
+          }
+        } catch (e) { hooked = false; }
+        if (!hooked) { finish(); return; }              // the DOM double answers now
+      };
       guardId = timers.after(READY_FALLBACK_MS, finish);
+      watch();
     }
     /**
      * armTop, deferred until the class can honestly take it. A gate (or the
@@ -1312,6 +1339,7 @@ export default {
       /* a sinking card is not the top card either (see flyOut) */
       setAttr(top.node, 'data-depth', 'x');
       setAttr(top.node, 'data-gone', '1');
+      freeSlot(top);      /* Bug A's law again: leaving play frees the slot */
       addCls(top.node, 'is-sink');
       verdictWord(t('sort_pass', 'PASSED'), 'grey');
       cue('whisper', 0.22, { pitch: 0.85 });
@@ -1400,6 +1428,11 @@ export default {
        * the instant it is thrown. */
       setAttr(live.node, 'data-depth', 'x');
       setAttr(live.node, 'data-gone', '1');
+      /* BUG A: the SLOT frees now, at the throw - not at the node teardown
+       * 400ms on. The next card's video mints inside the ceiling instead of
+       * topping the stack cold; the thrown card keeps playing while it flies
+       * (dropCard below still tears it down on the old clock). */
+      freeSlot(live);
       addCls(live.node, 'is-gone');
       if (wrong) addCls(live.node, 'is-wrong');
       delCls(live.node, 'is-held');
@@ -1577,7 +1610,7 @@ export default {
         rngJack: makeRng(seed + '|jack'),
         quick: !!pending.quick,
         pool: pending.pool,
-        cards: [], cursor: 0, dealt: 0, recycles: 0,
+        cards: [], deckRows: [], cursor: 0, dealt: 0, recycles: 0,
         passQueue: [],
         live: [],
         wall: null,
@@ -1674,6 +1707,8 @@ export default {
       if (retake && cacheUsable(meta.deck, S.day, seed)) {
         const built = deckFromRows(meta.deck.rows, !!meta.deck.quick);
         S.cards = built.cards;
+        S.deckRows = built.cards.slice();     // same rows, same order, same substitutes
+        warmDeck();
         say('retake: re-dealing the cached deck of ' + built.cards.length);
         openRoom();
       } else if (S.pool) {
@@ -1705,6 +1740,9 @@ export default {
         rng: makeRng(S.seed + '|deck'),
       });
       S.cards = built.cards;
+      /* the DEAL-ORDER snapshot: substituteFor walks this, never S.cards -
+       * reshuffles and pass returns must not move a substitute pick */
+      S.deckRows = built.cards.slice();
       S.thin = !!built.thin;
       /* THE RETAKE CACHE, written ONCE at the deal. */
       if (S.cards.length) {
@@ -1715,6 +1753,9 @@ export default {
           },
         });
       }
+      /* the deck IS the manifest: hand the whole ordered need list to the
+       * provider's warmer while the player is still at the door / rules sheet */
+      warmDeck();
       say('dealt ' + built.counts.size + ' cards ('
         + built.counts.target + ' target / ' + built.counts.noise + ' noise, '
         + built.counts.loops + ' loops, max run ' + built.counts.maxRun
@@ -2012,7 +2053,6 @@ export default {
         try { if (pending.pool && pending.pool !== (S && S.pool) && typeof pending.pool.dispose === 'function') pending.pool.dispose(); }
         catch (e) { /* noop */ }
         pending = { pool: null, quick: false, hot: false, thin: false, sources: null };
-        if (warmRail) warmRail.destroy();
         videoCount = 0;
         S = null;
       },
@@ -2026,7 +2066,6 @@ export default {
         if (!S) {
           return {
             live: false, timers: timers.size, videoCount,
-            warm: warmRail ? warmRail.diagnostics() : null,
             decks: { casino: dg(decks.casino), pressure: dg(decks.pressure), trickster: dg(decks.trickster) },
           };
         }
@@ -2052,7 +2091,6 @@ export default {
           },
           heat: S.heat, over: S.over, submitted: S.submitted,
           videoCount, timers: timers.size,
-          warm: warmRail ? warmRail.diagnostics() : null,
           wall: S.wall ? S.wall.diagnostics() : null,
           swipe: S.swipe ? S.swipe.diagnostics() : null,
           decks: { casino: dg(decks.casino), pressure: dg(decks.pressure), trickster: dg(decks.trickster) },

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -39,6 +39,11 @@
  *    the player's own disk and warming it is waste (and what keeps the desktop
  *    WebView2 build inert). The draw itself is still decided AT DRAW TIME by
  *    the same seeded logic, so the served sequence never moves.
+ *  - THE MANIFEST SEAM (0825): a game that knows its WHOLE ordered media list
+ *    up front (SORT's deck) hands it to pool.warmManifest(entries) and walks
+ *    pool.warmCursor(i); pool.ready(url) answers when a url's warm landed, and
+ *    pool.markBroken(url)/isBroken(url) drive the shared url blacklist that
+ *    every draw skips. All five verbs live on BOTH pool shapes.
  *
  * LOCAL INVENTORY. A virtual host cannot be enumerated from JS, so SOMETHING has
  * to hand the page the list. Accepted (first non-empty wins, all merged):
@@ -77,6 +82,43 @@ export const WARM_INFLIGHT = 3;   // warms in flight at once - a third lane lets
                                   // stills slip past one slow multi-megabyte download
 const WARM_HELD_MAX = 24;         // decoded detached Images held against GC
 const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+
+/* THE MANIFEST WARMER's windows (0825, SORT). A game that knows its complete
+ * ordered media need list up front (SORT builds the whole deck before the first
+ * card shows) hands the list to pool.warmManifest() and advances
+ * pool.warmCursor() as its own play position moves; the warm window rides the
+ * cursor. IDLE is the door/ghost-round/rules-sheet time - the cursor has never
+ * advanced, the player is reading and the network is otherwise quiet, so the
+ * window is deep. Once the cursor moves the window narrows to a look-ahead a
+ * fast swiper cannot outrun but that still loses to whatever is on screen.
+ * Manifest warms ride the SAME rail as the forecast deck above - one
+ * WARM_INFLIGHT budget, one warm per url per provider, WARM_HELD_MAX held,
+ * nothing at all under Data Saver. */
+export const MANIFEST_AHEAD_IDLE = 24;
+export const MANIFEST_AHEAD_PLAY = 10;
+
+/* THE URL BLACKLIST (0825), module-level so a dead CDN url stays dead across
+ * every pool and every class this page runs (it empties with the page, so a
+ * transient outage is forgiven on the next load). Fed by warm failures - an
+ * Image error, or a no-cors video fetch REJECTING, which is the one video
+ * verdict no-cors can see (an HTTP 404 behind an opaque response never lands
+ * here) - and by games reporting a face that errored via pool.markBroken().
+ * Draws skip it and serve the next eligible row instead; the placeholder floor
+ * stays the final answer. Bounded: the oldest entry is forgotten first. */
+const BROKEN_URL_CAP = 400;
+const brokenUrls = new Set();
+export function markBrokenUrl(url) {
+  const s = String(url || '');
+  if (!s || brokenUrls.has(s)) return false;
+  brokenUrls.add(s);
+  while (brokenUrls.size > BROKEN_URL_CAP) {
+    const oldest = brokenUrls.values().next().value;
+    if (oldest == null) break;
+    brokenUrls.delete(oldest);
+  }
+  return true;
+}
+export function isBrokenUrl(url) { return brokenUrls.has(String(url || '')); }
 
 /** Keys the shell/host might carry the local inventory under. A page cannot
  *  enumerate a virtual host, so SOMETHING has to hand us the list; we accept
@@ -210,6 +252,7 @@ export function createAssets(options = {}) {
   function warmable(url) {
     const s = String(url || '');
     if (!s || prewarmed.has(s)) return false;
+    if (isBrokenUrl(s)) return false;            // a dead url is never re-asked for
     if (isLocalUrl(s)) return false;             // ccp.* / relative / data: / blob:
     if (!/^https?:\/\//i.test(s)) return false;
     try {
@@ -218,20 +261,57 @@ export function createAssets(options = {}) {
     return true;
   }
 
+  /** A url whose warm cannot help: local disk, our own origin, data:/blob:.
+   *  These are ready the instant an element asks - ready() answers true NOW. */
+  function instantUrl(url) {
+    const s = String(url || '');
+    if (!s) return false;
+    if (isLocalUrl(s)) return true;
+    if (!/^https?:\/\//i.test(s)) return true;
+    try {
+      if (typeof location !== 'undefined' && location.origin && new URL(s).origin === location.origin) return true;
+    } catch { /* an unparsable url is not instant */ }
+    return false;
+  }
+
+  /* Warm OUTCOMES, for ready(): which urls finished (bytes + decode for a
+   * still/gif, bytes for a video) and who is waiting to hear. */
+  const warmDoneUrls = new Set();
+  const readyWaiters = new Map();   // url -> Set of resolve callbacks
+
+  function flushReady(url, ok) {
+    const set = readyWaiters.get(url);
+    if (!set) return;
+    readyWaiters.delete(url);
+    for (const fn of [...set]) { try { fn(!!ok); } catch { /* a bad waiter never kills the rail */ } }
+  }
+  /** The instance's blacklist verb: the module Set, plus this instance's
+   *  waiters answered "no" so a gate consulting ready() moves on at once. */
+  function markBroken(url) {
+    const s = String(url || '');
+    if (!s) return;
+    markBrokenUrl(s);
+    flushReady(s, false);
+  }
+
   function warmDone() { warmFlight = Math.max(0, warmFlight - 1); if (!disposed) warmPump(); }
+  function warmOk(url) { warmDoneUrls.add(url); flushReady(url, true); warmDone(); }
   function warmPump() {
     while (!disposed && warmFlight < WARM_INFLIGHT && warmQueue.length) {
       const job = warmQueue.shift();
       warmFlight += 1;
       if (job.video) {
-        /* fire and forget, and swallow everything: a rejected warm is a url
-         * that will simply load the ordinary way at reveal. */
+        /* fire and forget: the opaque reply is thrown away unread. A REJECTED
+         * warm is a NETWORK-level failure (DNS, refused connection) - the only
+         * video verdict no-cors can see - and it feeds the blacklist; an HTTP
+         * error rides an opaque 'ok' we cannot read and resolves as done. */
         try {
           if (typeof fetch !== 'function') { warmDone(); continue; }
           const init = { mode: 'no-cors', credentials: 'omit' };
           if (job.high) init.priority = 'high';       // Fetch Priority API; unknown keys are ignored
           const pr = fetch(job.url, init);
-          if (pr && pr.then) pr.then(warmDone, warmDone); else warmDone();
+          if (pr && pr.then) pr.then(() => warmOk(job.url), () => { markBroken(job.url); warmDone(); });
+          else warmDone();
         } catch { warmDone(); }
       } else {
         let img = null;
@@ -252,24 +332,32 @@ export function createAssets(options = {}) {
            * frame exists. Fallback for engines without decode(): load/error,
            * bytes-only. */
           if (typeof img.decode === 'function') {
-            img.decode().then(warmDone, () => { warmHeld.delete(job.url); warmDone(); });
+            img.decode().then(() => warmOk(job.url), () => {
+              warmHeld.delete(job.url);
+              /* decode() also rejects when a HEALTHY url's decode is aborted
+               * mid-flight; only a url with no pixels at all is actually dead. */
+              if (img.complete && !(Number(img.naturalWidth) > 0)) markBroken(job.url);
+              else flushReady(job.url, false);
+              warmDone();
+            });
           } else {
-            img.onload = warmDone;
-            img.onerror = () => { warmHeld.delete(job.url); warmDone(); };
+            img.onload = () => warmOk(job.url);
+            img.onerror = () => { warmHeld.delete(job.url); markBroken(job.url); warmDone(); };
           }
         } catch { warmHeld.delete(job.url); warmDone(); }
       }
     }
   }
 
-  /** Queue one url for warming. Returns true if it was actually queued. */
-  function warmUrl(url, high) {
+  /** Queue one url for warming. Returns true if it was actually queued.
+   *  `videoHint` overrides the extension sniff when the caller knows the mime. */
+  function warmUrl(url, high, videoHint) {
     if (disposed || saveData) return false;
     if (typeof document === 'undefined') return false;   // node harness: inert
     if (!warmable(url)) return false;
     const s = String(url);
     prewarmed.add(s);
-    warmQueue.push({ url: s, video: VIDEO_URL_RE.test(s), high: !!high });
+    warmQueue.push({ url: s, video: videoHint == null ? VIDEO_URL_RE.test(s) : !!videoHint, high: !!high });
     warmPump();
     return true;
   }
@@ -288,6 +376,106 @@ export function createAssets(options = {}) {
       if (warmUrl(url, n === 0)) n += 1;
     }
   }
+
+  /* ------------------------------------------------------------------------
+   * THE MANIFEST WARMER (0825). warmManifest(entries) declares the ORDERED
+   * media need list a game already knows in full; warmCursor(i) is the game's
+   * play position in it. The warm window is [cursor, cursor + ahead): deep
+   * (MANIFEST_AHEAD_IDLE) while the cursor has never advanced - the door /
+   * intro / rules-sheet time - and a tight look-ahead (MANIFEST_AHEAD_PLAY)
+   * once play starts. One manifest per provider: a game claims one pool at a
+   * time, and a new warmManifest() simply replaces the old list. Everything
+   * funnels through warmUrl(), so remote-only, once per url, WARM_INFLIGHT
+   * shared with the forecast rail, WARM_HELD_MAX held, saveData-inert - all
+   * of it holds here by construction. The 6-deep forecast rail above stays
+   * exactly as it was for games that never call this.
+   * --------------------------------------------------------------------- */
+  let manifest = null;    // { entries: [{url, video}], cursor, moved }
+
+  function normalizeManifestEntries(entries) {
+    const out = [];
+    for (const e of (Array.isArray(entries) ? entries : [])) {
+      const url = typeof e === 'string' ? e : (e && e.url);
+      if (!url || typeof url !== 'string') continue;
+      const mime = (e && typeof e === 'object') ? String(e.mime || '') : '';
+      out.push({ url: String(url), video: /^video\//i.test(mime) || VIDEO_URL_RE.test(url) });
+    }
+    return out;
+  }
+
+  /** Warm the window the cursor currently commands. Returns how many queued. */
+  function pumpManifest() {
+    if (!manifest || disposed) return 0;
+    const ahead = manifest.moved ? MANIFEST_AHEAD_PLAY : MANIFEST_AHEAD_IDLE;
+    const at = Math.max(0, Math.min(manifest.cursor, manifest.entries.length));
+    const end = Math.min(manifest.entries.length, at + ahead);
+    let queued = 0;
+    for (let k = at; k < end; k++) {
+      const e = manifest.entries[k];
+      /* the HEAD of the window is the card the player is (about to be) looking
+       * at - the one warm allowed to ask for priority */
+      if (e && warmUrl(e.url, k === at, e.video)) queued += 1;
+    }
+    return queued;
+  }
+
+  function warmManifest(entries) {
+    manifest = { entries: normalizeManifestEntries(entries), cursor: 0, moved: false };
+    return pumpManifest();
+  }
+
+  function warmCursor(i) {
+    if (!manifest) return;
+    const n = Math.max(0, Math.round(Number(i) || 0));
+    if (n > 0) manifest.moved = true;
+    if (n === manifest.cursor) return;
+    manifest.cursor = n;
+    pumpManifest();
+  }
+
+  /**
+   * ready(url, {timeoutMs}) -> Promise<boolean>. True the moment the url's
+   * warm has completed (immediately if it already has, and immediately for a
+   * local / same-origin url - the host serving the player's own disk cannot be
+   * probed and does not need to be); false on a KNOWN failure (the blacklist)
+   * or when timeoutMs passes first. Never rejects: a media gate that could
+   * throw would be a class that could not start. timeoutMs 0 answers from
+   * what is known right now.
+   */
+  const READY_DEFAULT_MS = 1000;
+  function readyFor(url, opts) {
+    const s = String(url || '');
+    if (!s) return Promise.resolve(false);
+    if (isBrokenUrl(s)) return Promise.resolve(false);
+    if (instantUrl(s)) return Promise.resolve(true);
+    if (warmDoneUrls.has(s)) return Promise.resolve(true);
+    const t = (opts && opts.timeoutMs != null) ? Math.max(0, Number(opts.timeoutMs) || 0) : READY_DEFAULT_MS;
+    /* nothing pending can ever land: disposed, Data Saver (no warm runs), or
+     * a zero timeout - answer with what is known */
+    if (t === 0 || disposed || saveData) return Promise.resolve(false);
+    return new Promise((resolve) => {
+      let set = readyWaiters.get(s);
+      if (!set) { set = new Set(); readyWaiters.set(s, set); }
+      let timer = 0;
+      const fn = (ok) => { try { clearTimeout(timer); } catch { /* noop */ } resolve(!!ok); };
+      set.add(fn);
+      timer = setTimeout(() => {
+        const cur = readyWaiters.get(s);
+        if (cur) { cur.delete(fn); if (!cur.size) readyWaiters.delete(s); }
+        resolve(false);
+      }, t);
+    });
+  }
+
+  /** The media seam every pool shape exposes (claim() below, claimTagged's
+   *  wrapper, and deck-side adapters forward these five verbs verbatim). */
+  const mediaSeam = {
+    warmManifest: (entries, opts) => { void opts; return warmManifest(entries); },
+    warmCursor: (i) => warmCursor(i),
+    ready: (url, opts) => readyFor(url, opts),
+    markBroken: (url) => markBroken(url),
+    isBroken: (url) => isBrokenUrl(url),
+  };
 
   /* ==========================================================================
    * THE DOOR'S SEAM (SORT). Four reads and two writes, all additive.
@@ -522,7 +710,14 @@ export function createAssets(options = {}) {
       // a deterministic walk with a seeded jump keeps repeats far apart without
       // ever risking "the same tile twice in a row" on a tiny local pool
       const jump = list.length > 2 ? Math.floor(take() * (list.length - 1)) : 0;
-      return list[(i + jump) % list.length];
+      /* THE BLACKLIST SKIP consumes no rand: the walk just steps forward to the
+       * next eligible row, so with a clean blacklist (the ordinary day) the
+       * served sequence is byte-identical to the pre-blacklist provider. */
+      for (let step = 0; step < list.length; step++) {
+        const cand = list[(i + jump + step) % list.length];
+        if (cand && !isBrokenUrl(cand)) return cand;
+      }
+      return placeholders[(i + jump) % placeholders.length] || null;   // every row dead: the floor
     }
 
     function computeDraw(k, st, take) {
@@ -536,7 +731,13 @@ export function createAssets(options = {}) {
         const i = st.remoteCursors[remoteKind] % list.length;
         st.remoteCursors[remoteKind] += 1;
         const jump = list.length > 2 ? Math.floor(take() * (list.length - 1)) : 0;
-        const url = list[(i + jump) % list.length];
+        /* the blacklist skip: step to the next eligible row, no rand consumed;
+         * a fully dead remote list falls through to the local side */
+        let url = null;
+        for (let step = 0; step < list.length; step++) {
+          const cand = list[(i + jump + step) % list.length];
+          if (cand && !isBrokenUrl(cand)) { url = cand; break; }
+        }
         if (url && (!canvasSafe || isLocalUrl(url))) return { url, remote: true };
       }
       return { url: computeLocal(k, st, take), remote: false };
@@ -610,6 +811,19 @@ export function createAssets(options = {}) {
         const d = Math.round(Number(n) || 0);
         return d > 0 ? refreshDeck(d) : 0;
       },
+      /**
+       * THE MANIFEST SEAM (0825), same five verbs on every pool shape:
+       *   warmManifest(entries[, opts])  ordered [{url, kind?, mime?}] (or bare
+       *                                  url strings) - the game's full need
+       *   warmCursor(i)                  the game's play position in it
+       *   ready(url, {timeoutMs})       -> Promise<boolean> (see readyFor)
+       *   markBroken(url) / isBroken(url) the shared url blacklist
+       */
+      warmManifest: mediaSeam.warmManifest,
+      warmCursor: mediaSeam.warmCursor,
+      ready: mediaSeam.ready,
+      markBroken: mediaSeam.markBroken,
+      isBroken: mediaSeam.isBroken,
       /** How many candidates the pool can actually serve right now. */
       stats() {
         return {
@@ -656,6 +870,9 @@ export function createAssets(options = {}) {
       platform,
       prewarm,
       log,
+      /* the shared url blacklist: a tagged serve skips a dead row and the
+       * seeded re-serve is its substitute source (see tagged.js nextRow) */
+      broken: isBrokenUrl,
       /* The remote gate is the app's, not the door's: with remote media off (or
        * OfflineMode on) a remote source row simply never asks, the tag lands
        * empty, and the door refuses to start on pool.empty(). A LOCAL row is
@@ -666,6 +883,12 @@ export function createAssets(options = {}) {
         taggedPools.add(pool);
         const dispose = pool.dispose;
         pool.dispose = () => { taggedPools.delete(pool); dispose(); };
+        /* the manifest seam rides BOTH pool shapes (see claim().warmManifest) */
+        pool.warmManifest = mediaSeam.warmManifest;
+        pool.warmCursor = mediaSeam.warmCursor;
+        pool.ready = mediaSeam.ready;
+        pool.markBroken = mediaSeam.markBroken;
+        pool.isBroken = mediaSeam.isBroken;
       }
       return pool;
     });
@@ -777,6 +1000,9 @@ export function createAssets(options = {}) {
       probes.clear();
       libraryCbs.clear();
       channel.dispose();
+      manifest = null;
+      for (const url of [...readyWaiters.keys()]) flushReady(url, false);
+      warmDoneUrls.clear();
       warmQueue.length = 0;
       for (const img of warmHeld.values()) {
         try { img.onload = null; img.onerror = null; } catch { /* noop */ }

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
@@ -109,9 +109,11 @@ export function normalizeSources(list) {
  * @param {Function} o.prewarm   the provider's bounded prewarm(urls)
  * @param {Function} o.log
  * @param {boolean} o.remoteAllowed  remote media gate (local rows ignore it)
+ * @param {Function} [o.broken]  (url) => boolean, the provider's shared url
+ *                               blacklist; a dead row is skipped at serve time
  * @returns {Promise<Object>} the pool (resolves per law 3, never rejects)
  */
-export function createTaggedPool({ spec, channel, platform, prewarm, log, remoteAllowed } = {}) {
+export function createTaggedPool({ spec, channel, platform, prewarm, log, remoteAllowed, broken } = {}) {
   const s = spec || {};
   const say = typeof log === 'function' ? log : () => {};
   const sources = normalizeSources(s.sources);
@@ -283,29 +285,47 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
     tag.cursor = 0;
   }
 
+  const isDead = (url) => { try { return typeof broken === 'function' && !!broken(url); } catch (e) { return false; } };
+
   function nextRow(tagName, opts) {
     const tag = tags[tagName];
     if (!tag || !tag.rows.length) return null;
-    if (tag.cursor >= tag.order.length) reserve(tag);
-    if (!tag.order.length) return null;
     const prefer = opts && (opts.prefer === 'loop' || opts.prefer === 'still') ? opts.prefer : null;
-    if (prefer) {
-      /* PREFERENCE IS A SWAP, NOT A SKIP: the wanted kind is pulled forward into
-       * the cursor's slot and the row it displaced keeps its place in the pass,
-       * so a preference can never starve a kind out of the deck. */
-      for (let i = tag.cursor; i < tag.order.length; i++) {
-        if (tag.order[i].kind === prefer) {
-          if (i !== tag.cursor) {
-            const t = tag.order[i]; tag.order[i] = tag.order[tag.cursor]; tag.order[tag.cursor] = t;
+    /* A BLACKLISTED URL IS SKIPPED and the SEEDED RE-SERVE is the substitute
+     * source: the cursor just walks on (starting the next seeded pass when it
+     * runs off the end), so the replacement for a dead row is the same row a
+     * dry tag would have re-served anyway - deterministic for a given seed and
+     * blacklist state, and with a clean blacklist this loop runs exactly once,
+     * serving the identical sequence it always served. Bounded at two full
+     * passes: a tag whose EVERY url died still answers (law 2 - null means
+     * zero rows, nothing else), and the game's own floor takes it from there. */
+    const cap = Math.max(1, tag.rows.length * 2);
+    let row = null;
+    for (let attempt = 0; attempt <= cap; attempt++) {
+      if (tag.cursor >= tag.order.length) reserve(tag);
+      if (!tag.order.length) return null;
+      if (prefer && attempt === 0) {
+        /* PREFERENCE IS A SWAP, NOT A SKIP: the wanted kind is pulled forward
+         * into the cursor's slot and the row it displaced keeps its place in
+         * the pass, so a preference can never starve a kind out of the deck. */
+        for (let i = tag.cursor; i < tag.order.length; i++) {
+          if (tag.order[i].kind === prefer) {
+            if (i !== tag.cursor) {
+              const t = tag.order[i]; tag.order[i] = tag.order[tag.cursor]; tag.order[tag.cursor] = t;
+            }
+            break;
           }
-          break;
         }
       }
+      const cand = tag.order[tag.cursor];
+      tag.cursor += 1;
+      if (cand && isDead(cand.url) && attempt < cap) continue;
+      row = cand || null;
+      break;
     }
-    const row = tag.order[tag.cursor];
-    tag.cursor += 1;
+    if (!row) return null;
     tag.served += 1;
-    return row || null;
+    return row;
   }
 
   /* ---------------------- the pool object -------------------------------- */


### PR DESCRIPTION
Owner note: "I am sick of having to see gifs not loaded. We need to find a way to solve this once and for all (scrolller) - start from the sorting game... make sure the gif is displayed before we start the circle; waiting kills the flow."

**Manifest media warmer (provider, all pool shapes)**
- pool.warmManifest(entries) takes a game's full ordered media list; pool.warmCursor(i) tracks the play position. Warm window 24 ahead while idle (door / ghost round / rules sheet), 10 in play; rides the existing WARM_INFLIGHT=3 lanes, once per url, remote-only, Data Saver inert, desktop-local inert. CORS law respected: stills warm via detached Image.decode(), videos via no-cors fetch (browser HTTP cache) - never a detached video (trap 36).
- pool.ready(url, {timeoutMs}): resolves true when the warm landed (instantly if already warm / local), false on known failure or timeout. Never rejects.
- First shared per-url failure blacklist in the stack: fed by warm errors and pool.markBroken(url); claim draws and tagged serves step past dead urls with ZERO extra rng consumed (clean blacklist = byte-identical serving); the seeded re-serve is the substitute source.

**SORT integration + three mechanical fixes**
- The whole deck (90-120 urls, built before the first card shows) is handed to the warmer at deal and on retake re-deal; the old 8-ahead game-local rail is deleted.
- faceReady consults the blacklist and the warmer before waiting: a warm face arms the ring at ~0 wait, a condemned url swaps to a deterministic same-tag substitute immediately (retake-stable via pure hashing of seed + deck index; the stored deck / retake cache is never mutated), the 1s ceiling stays as the outer net. An element error mid-wait re-mints and watches the substitute instead of resolving "ready" over a blank back.
- Bug A: the video decoder slot frees when a card leaves play (flyOut/pass), not 400ms later at node teardown - depth-1 videos stop being silently refused and minting cold at the top.
- Bug B: img/video error now clears the face and blacklists the url, so the re-mint branch actually retries - a dead url is no longer a blank card for life.
- Cold top-card videos mint with preload=auto.

**Verified**: eval-import sweep OK on all touched modules; node smoke (15 asserts: seam on all three pool shapes, ready semantics, blacklist skips on claim + tagged draws, clean-blacklist determinism); decoder accounting hand-walked across mint/commit/pass/error/bell/destroy (no leak, no double-release); CDP smoke mobile + desktop: 90-card deal, faces minted and ready, ring fresh, zero errors.

Deep End and Echo keep their ad-hoc per-slot blacklists for now (Deep End was under parallel edit); adopting the seam there is a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVfeMhCj5mqWQ1b3pPAUVN
