### PR TITLE
fix(arcademy): Deja Vu phone fill + faster flips, niche-only Daily Trigger pool, Annex step-back reachable

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/annex/lab.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/annex/lab.css
@@ -90,9 +90,13 @@
 
 /* ------------------------------ back pill ------------------------------- */
 
+/* z 9 is above EVERY overlay this stage mints (paper 6, the OS 7, descent 8):
+   the way out of a close-up may never be painted over by what the close-up
+   opened - the OS layer's own backdrop used to swallow both the pixels and
+   the click. */
 .al-back {
   position: absolute;
-  z-index: 4;
+  z-index: 9;
   left: 16px;
   bottom: 14px;
   padding: 6px 14px;
@@ -233,6 +237,7 @@
   inset: 0;
   z-index: 7;
   background: rgba(4, 7, 8, 0.6);
+  cursor: zoom-out;   /* the painted room around the laptop steps back */
 }
 .al-osframe {
   position: absolute;

--- a/ConditioningControlPanel/Resources/web/arcademy/annex/lab.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/annex/lab.js
@@ -177,7 +177,7 @@ export function createAnnexLab(caps) {
 
     if (name !== 'wide') {
       const back = el('button', 'al-back', '‹ ' + t('annex_back', 'step back'));
-      back.addEventListener('click', () => { sfx('door', 0.3); showView('wide'); });
+      back.addEventListener('click', () => stepBack());
       stage.appendChild(back);
     }
     if (entering) sfx(name === 'wide' ? 'door' : 'paper', name === 'wide' ? 0.3 : 0.2);
@@ -206,6 +206,17 @@ export function createAnnexLab(caps) {
     if (action === 'laptop') { openOs(); return; }
     sfx('blip', 0.16, { pitch: 1.05 });
     showView(action);
+  }
+
+  /** The pill's verb, and the backdrop's. ONE step, and it never folds an OS
+   *  window: escapeStep() walks inward-out (a window at a time), but a player
+   *  who reaches for "step back" is leaving the terminal, not tidying it. So
+   *  the ladder here is paper -> the whole OS -> the close-up itself. */
+  function stepBack() {
+    if (dead) return;
+    if (paperLayer) { closePaper(); return; }
+    if (os) { closeOs(); return; }
+    if (view && view !== 'wide') { sfx('door', 0.3); showView('wide'); }
   }
 
   function requestExit() {
@@ -309,6 +320,18 @@ export function createAnnexLab(caps) {
     osLayer = el('div', 'al-oslayer');
     const frame = el('div', 'al-osframe');
     osLayer.appendChild(frame);
+    /* the painted room around the laptop is a way out (paperShell's pattern),
+     * but ONLY when the press and the release both landed on the backdrop -
+     * a window dragged out of the frame reports the layer as the click target
+     * (the common ancestor of down and up) and must not read as "leave" */
+    let downOnBackdrop = false;
+    osLayer.addEventListener('pointerdown', (e) => { downOnBackdrop = e.target === osLayer; });
+    osLayer.addEventListener('click', (e) => {
+      const clean = downOnBackdrop;
+      downOnBackdrop = false;
+      if (e.target !== osLayer || !clean) return;
+      stepBack();
+    });
     stage.appendChild(osLayer);
 
     /* zoom out of the laptop glass: origin at its center, scale up */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/words-accept.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/words-accept.js
@@ -20,7 +20,7 @@
  * ==========================================================================*/
 
 /** Curated real words, acceptance only. */
-export const ACCEPT = `
+const ACCEPT_BASE = `
 abbey abide abled abort about above abuse abyss acorn acrid acted actor acute adage adapt added
 adept admit adobe adopt adore adult affix afire afoot afoul after again agate agent agile aging
 agony agree ahead aider aimed aired aisle alarm album alder alert algae alias alibi alien align
@@ -274,5 +274,20 @@ wryly xenon xerox xylem yacht yanks yards yarns yawls yawns yeahs yearn yeast ye
 yield yodel yogas yogis yoked yokel yokes yolks young yours youth yowls yucca yucky yummy zebra
 zeros zesty zilch zincs zings zippy zonal zoned zones zooms
 `;
+
+
+/**
+ * NICHE EXTRAS (2026-08-25, with the answers-are-niche-only ruling): on-theme
+ * words a player will actually try - kink / bimbo / school / arcade vocabulary
+ * that the ordinary-English list above never carried. Acceptance only.
+ */
+export const ACCEPT_NICHE = `
+  booty butts boobs busty twerk dildo femme domme roped caged cages melty dopey dazes dozes dulls
+  rerun aches ached burns rides kissy licks bling gaudy girly ditsy lacey panty bangs cuter circe
+  bambi popup lotto dings bytes stuck desks books years tasks dorms dotty kooky emoji chasm
+`;
+
+/** The list the bank reads: the curated base plus the niche extras. */
+export const ACCEPT = ACCEPT_BASE + ' ' + ACCEPT_NICHE;
 
 export default ACCEPT;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/words-answers.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/words-answers.js
@@ -1,68 +1,114 @@
 /* ============================================================================
  * games/daily-trigger/words-answers.js - THE ANSWER POOL (the day's word).
  *
- * Two bands, ONE pool. `THEME` is the conditioning / arcade-flavoured band (the
- * words the metagame is about internalising); `COMMON` is the widened band of
- * ordinary English. The daily draw runs over the UNION, and that union IS the
- * "widened shared pool" SYNTHESIS-NOTES adopted for veterans: a player who has
- * memorised the trigger words still cannot enumerate the board, because half the
- * pool is plain English. The pool is NOT tier-dependent - the day's word must be
- * globally identical (BUILD-CONTRACT #978 rule / the homeroom ruling), so tier
- * may never change which word is drawn.
+ * THE RULING (owner, 2026-08-25): THE ANSWERS ARE NICHE ONLY. The day's word
+ * can never be a random English word - every answer must relate to what this
+ * app is about (trance / conditioning / submission / bimbo + sissy dress-up /
+ * pleasure + denial / the Arcademy's own school-and-arcade framing). The old
+ * "widened shared pool" of plain English (380 words, SYNTHESIS-NOTES' answer
+ * to veterans enumerating the board) is GONE; the defence against enumeration
+ * is now the SIZE of the curated band, not its blandness.
+ *
+ * Two bands, ONE pool, drawn as the UNION. `THEME` is the curated niche band
+ * (the words the metagame is about internalising - `isThemeWord` skins a hit
+ * as "one of your own words"); `COMMON` is a deliberately TINY band of ordinary
+ * campus / sweet-shop / arcade English that still reads on-theme, kept only so
+ * the two-band shape (and that flavour line) survives. It may stay empty.
+ * The pool is NOT tier-dependent - the day's word must be globally identical
+ * (BUILD-CONTRACT #978 rule / the homeroom ruling), so tier may never change
+ * which word is drawn.
+ *
+ * SIZE IS LOAD-BEARING: bank.js's cyclePick() walks ONE shuffled pass of the
+ * whole pool before any word repeats, so the pool length IS the repeat-free
+ * horizon in days (phrase days ~15% and revision days ~4% only stretch it).
+ * Keep the union above ~400 so no word comes round inside a year; it sits at
+ * ~578 as of 2026-08-25 (532 theme + 46 common).
  *
  * FORMAT: whitespace-separated lowercase a-z, EXACTLY five letters. `bank.js`
  * filters, dedupes and sorts on load, so a stray token degrades to "absent"
- * rather than to a broken board. Do not add slurs or anything hateful; the
- * horny-adjacent theme band is deliberate (this is an adult app).
+ * rather than to a broken board. The category groups below are for the human
+ * editing the file - bank.js sees one flat string. Do not add slurs or
+ * anything hateful, nothing implying minors; the horny-adjacent band is
+ * deliberate (this is an adult app). The three mod names (bambi / sissy /
+ * circe) are in on purpose. Every answer is auto-unioned into ACCEPT by
+ * bank.js, so a word here never needs a twin in words-accept.js.
  *
  * PHRASES drive phrase days (~15% of days, all tiers - see bank.js): two groups
  * with a free gap, spaces auto-marked and never guessed, total letters <= 10.
  * ==========================================================================*/
 
-/** The trigger / mantra / arcade band. */
-export const THEME = `
-abyss adore alien arena aroma babes badge below bends bimbo blank blaze blink bliss blitz block
-blond blush board boost boots bossy bound brain brats bunny candy chain chant charm cheat chest
-chime click clock clone cloud coins combo crave crown cuffs curls cutie cycle dazed depth ditzy
-diver dizzy dodge dolls dolly dream drift drill drips droid drone drown eager ember empty extra
-faint faith flame flash float flush focus foggy fuzzy gasps gazes ghost giddy gleam glint gloss
-glows habit halos hazed heads heavy heels honey hypno joker jumps kitty kneel laced laser latex
-learn leash level limbo lines lives loops loopy loose lower loyal lucky lulls magic mazes mecha
-medal melts might minds misty moans molds murky needy ninja obeys ocean order pearl pilot pinky
-pixel plumb plush power prime prism prize pulse puppy purrs quest quiet relax retry robot rocks
-rogue ruled rules runes sated satin scent score serve shake shape shift shine shiny shook shore
-sighs sigil silky sinks sissy skull sleep snaps soaks spark spawn spell spins stare still sugar
-super sways sweet swirl swoon sword tamed tease teddy tempo tempt think throb tiara tides tiles
-timer token tones toyed train trust twirl under urges vapor verse vivid voice watch waves whirl
-woozy words worth yearn yield
-`;
+/** The curated niche band (owner ruling 2026-08-25: the whole answer pool is this). */
+export const THEME = [
+  /* trance / hypnosis (84) */
+  `
+  abyss blank blink dazed dazes depth dozed dozes dream drift drips drone drown empty faint fades
+  faded float focus foggy fuzzy gazed gazes glaze hazed hazes heavy hypno limbo lower lulls melts
+  misty murky sinks sleep slept spell stare still sways swung swirl swoon tides tones trust under
+  whirl woozy yield yearn blurs dulls numbs inert vapor glass gleam glint glows watch clock ticks
+  timed count chime chant verse lines words voice dizzy giddy heady tipsy dopey mushy melty waken
+  woken awake wakes dives
+  `,
+  /* conditioning / training (44) */
+  `
+  train learn drill habit reset prime loops cycle daily rites study teach tutor coach guide shape
+  molds mould wired wires brand stamp carve tuned tunes tweak nudge minds brain patch fixed edits
+  wipes wiped erase clean slate fresh again creed dogma faith obeys rerun
+  `,
+  /* submission / control / femdom (80) */
+  `
+  kneel knelt serve bound leash owned owner rules ruled ruler mercy bends bowed plead pleas chain
+  cuffs binds ropes roped knots caged cages locks keyed leads stays fetch puppy kitty bunny tamed
+  tames domme queen deity crown reign order edict bossy stern harsh grasp grips holds clasp power
+  might force reins yoked sworn swear vowed loyal lowly timid coyly floor boots heels adore idols
+  altar prays thank sorry spank swats sting stung smack slaps scold shame shush quiet muted mutes
+  `,
+  /* pleasure / edging / denial / sensation (79) */
+  `
+  tease taunt toyed edges edged ruins wreck aches ached throb pulse swell needy needs wants crave
+  urges itchy burns ember flame blaze heats sweat flush moans sighs gasps whine mewls purrs yelps
+  pants shake shook quake tense tight grind rides shock jolts vibes wands slick moist soaks juicy
+  sweet honey sugar candy cream peach curvy curve thigh waist belly mouth teeth smile grins pouty
+  pouts kissy licks bites nails claws touch grope pinch peaks crest spill burst sated spent
+  `,
+  /* bimbo / glam / dumb (101) */
+  `
+  bimbo blond gloss ditzy dolly dolls cutie babes pinky pinks blush rouge liner shiny glitz bling
+  sheen shine spark gaudy showy vogue style model poses posed flirt winks girly dummy dunce ditsy
+  silly sassy perky peppy cheer plush fluff frill laced lacey satin silky sheer gauze tulle nylon
+  skirt dress gowns frock tutus panty thong strap latex vinyl charm tiara pearl jewel rings beads
+  curls curly braid bangs roses coral mauve lilac preen primp teeny cuter angel fairy pixie nymph
+  siren vixen foxes vamps lured lures hooks snare traps hexed hexes curse witch magic runes sigil
+  brews circe bambi sissy goons
+  `,
+  /* app features / arcade (102) */
+  `
+  flash video timer level badge quest drain popup panic chaos pause plays press click audio sound
+  sonic noise texts fonts pixel frame blast combo bonus gifts prize medal ranks coins token chips
+  punch cards decks wheel reels spins slots lucky bingo lotto dealt deals games gamer retry round
+  extra lives heart bells dings alarm beats tempo loopy noisy mists smoke cloud twist twirl whorl
+  coils orbit droid robot cyber codes coded input bytes error crash froze stuck stiff stone tiles
+  score cheat mazes arena laser block dodge jumps snaps boost blitz clone ghost halos super shift
+  tempt worth prism ocean waves rocks
+  `,
+  /* school framing (27) */
+  `
+  class grade exams pupil chalk board desks notes books pages paper marks tests essay honor merit
+  award tiers years halls plaid pleat tasks chore tardy later dorms
+  `,
+  /* mind-melt / happy (15) */
+  `
+  vapid inane batty dotty kooky wacky happy laugh merry jolly enjoy bliss elate highs light
+  `,].join(' ');
 
-/** The widened band: ordinary English, guessable, no obscurities. */
+/**
+ * The tiny on-theme "ordinary English" band: campus, sweet shop, arcade cabinet.
+ * Nothing here is a trigger word, everything reads as the school. Keep it small
+ * (it is NOT the old widened pool) and keep it on-theme, or drop it to empty.
+ */
 export const COMMON = `
-about above actor adopt agree amber angel anger angle apple asset audio avoid awake award bench
-berry birth black blade bloom blues blunt boast booth breed brick bride brief bring built bunch
-burst buyer cabin catch cause chair chalk champ chief child chill chirp choir clash clasp class
-clean clear coach coast cobra cocoa color crack craft crane crash crate cross crude cruel crumb
-crush death debut decay delay delta dozen draft drain drama drank dusty dwarf dwell eagle early
-enemy enjoy enter entry equal exile exist fable faced fairy fetch fever fiber field fiery fleet
-flesh flick fling flint forge forth forty forum found fruit fudge fully funny gauge glide globe
-gloom glory glove grape graph grasp grass grave grind groan groom group grove hairy handy happy
-hardy harsh heart hedge hefty hello herbs hover human humid humor hurry irony issue ivory jelly
-jewel knife knock knots known koala layer lease least leave ledge liver llama lobby local lodge
-macro madam major maker mango media medic melon mercy merge minus mixer model money month movie
-muddy mummy mural music niece nifty night ninth noble occur offer often olive onion outer owner
-oxide ozone paint patch patio pause peach pedal piece pinch pitch pivot pizza pluck plume plump
-poach point pride print prior probe prone purse quack quail quake quart quota quote radar radio
-rainy react ready realm rebel refer rifle right rigid rinse risky route royal rugby ruler rumor
-sauce sauna savor scale scalp scrap screw scrub seize sense share shark sharp shave shawl short
-shout shove shrub shrug slack slate sleek sleet slice smash smell smile smirk smoke snore snout
-snowy soapy sober spade spare speak spear speck spire spite split spoil spoke squid stack staff
-stage stain stash state steak steal steam stock stole stone stool stoop strip study stuff stump
-stunt swell swept swift swing syrup tarot taste tasty taunt teach theme there these thick thief
-thumb thump tidal tiger tight topaz topic torch total touch trait tramp trash tread treat truce
-truck truly trump trunk twice twine twist uncle unfit usage usher usual vague valid video vigor
-villa vinyl viola voter vowel wafer wager wagon weigh weird whale wharf wheat whose widen wider
-widow width women woods world worry worse wrote yacht yeast young yours
+  bench chair early night smirk sleek sharp taste smell sense scale share stage staff stash steam
+  sauna spare ready quote print paint piece point music movie media radio jelly fudge syrup cocoa
+  mango berry apple funny nifty handy hello yours drama fable theme topic truly valid
 `;
 
 /**

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/script.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/script.js
@@ -55,13 +55,37 @@ export function scaled(ms) {
 /* ----------------------------------------------------------------------------
  * TIMINGS (dossier core loop) - one table, scaled at use.
  * -------------------------------------------------------------------------- */
+/* THE TURN IS 30% SHORTER (owner pass, 2026-08-25). It was 220/160/250/240 and
+ * every one of those four is now 0.7 of what it was. Two of them are HALF a
+ * number: 'flipMs' and 'flipReducedMs' are each also a CSS transition duration
+ * in style.js ('.g-dv-card' transform .154s, and the reduced-motion pair's
+ * opacity .112s), because index.js sets '.flipping', waits the constant, then
+ * swaps the face and rotates back. Change one side alone and the plate either
+ * snaps mid-turn (JS shorter) or hangs at 62deg (CSS shorter). They move
+ * together, always.
+ *   flipMs        220 -> 154   (style.js  transform .22s -> .154s)
+ *   flipReducedMs 160 -> 112   (style.js  opacity   .16s -> .112s)
+ *   judgeMs       250 -> 175   no CSS pair - '.judge' is an infinite pulse this
+ *                              simply shows less of - but it sits between the
+ *                              reveal and the verdict, so it is the other half
+ *                              of "the flip feels slow"
+ *   previewDownMs 240 -> 168   NOT a difficulty knob (dials.previewMs is the
+ *                              memorise hold, and it is untouched): this is the
+ *                              down-wave's own window, and it rides the SAME
+ *                              '.flipping' transition, so leaving it at 240
+ *                              would have parked the whole board at 62deg for
+ *                              86ms of nothing
+ * 'mismatchHoldMs' is deliberately NOT in that list. It is the peek - a tuned
+ * difficulty knob, not an animation - and it stays at 900.
+ * The face crossfade ('.g-dv-face' opacity .18s -> .126s) keeps the ratio it
+ * always had to the turn. */
 export const TIMING = Object.freeze({
   dealStaggerMs: 120,       // seeded card-toss cascade
-  previewDownMs: 240,       // the single flip-down wave
+  previewDownMs: 168,       // the single flip-down wave (rides .flipping)
   poisonLeadMs: 400,        // sub_flash at preview end -400ms
-  flipMs: 220,              // 3D Y-flip
-  flipReducedMs: 160,       // reduced motion: crossfade
-  judgeMs: 250,             // both loops playing, before the verdict
+  flipMs: 154,              // 3D Y-flip  == style.js transform .154s
+  flipReducedMs: 112,       // reduced motion: crossfade == style.js .112s
+  judgeMs: 175,             // both loops playing, before the verdict
   mismatchHoldMs: 900,      // x DejaVuPeekHold (dv_peek_hold)
   matchLockMs: 520,         // pulse + wax stamp
   tellMs: 600,              // swap telegraph BEFORE the swap

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
@@ -46,6 +46,17 @@ export const STYLE_TEXT = `
 .g-dv-stage{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
   align-items:center;gap:8px;padding:72px 18px 14px;
   --g-dv-gap:14px;
+  /* THE TWO FIT DIALS (mobile fit wave). They live HERE, on the stage, not on
+     .g-dv-grid, because a breakpoint has to be able to move them from ONE
+     place: a custom property declared on the grid itself would out-vote an
+     inherited override every time.
+       --g-dv-fill  how much of the bench WIDTH the board may take, in cqw
+       --g-dv-arn   the plate aspect as a NUMBER (w/h). 4/3 is the lab's
+                    landscape slide; a phone re-shapes it (see the breakpoints)
+                    so the board can actually fill a portrait or a letterbox
+                    frame instead of floating in the middle of it. */
+  --g-dv-fill:94;
+  --g-dv-arn:1.3333;
   background:
     radial-gradient(1000px 560px at 10% -6%, var(--dv-n-glowa, color-mix(in srgb, var(--lav), transparent 80%)), transparent 62%),
     radial-gradient(1000px 560px at 90% -6%, var(--dv-n-glowb, color-mix(in srgb, var(--lav), transparent 83%)), transparent 62%),
@@ -76,16 +87,45 @@ export const STYLE_TEXT = `
 .g-dv-hud .g-dv-meterwrap{display:inline-flex;align-items:center;gap:6px}
 
 /* ---- the bench: the board fills the frame -------------------------------- */
+/* THE BENCH IS THE MEASURE. 'container-type:size' turns the boardwrap into a
+   size query container, so 100cqw/100cqh inside it are the REAL width and
+   height of the space left under the HUD and above the Cram row - measured,
+   not guessed. That is the whole mobile fix: the old rule reserved a flat
+   250px of chrome off 100dvh, which on a 390px-tall landscape phone left 140px
+   for the board and dealt 33x24px cards. Containment is safe here because both
+   axes are decided from OUTSIDE (flex:1 for the height, width:100% for the
+   width), so nothing cycles. */
 .g-dv-boardwrap{position:relative;z-index:1;flex:1;min-height:0;width:100%;
-  display:flex;justify-content:center;align-items:center}
+  display:flex;justify-content:center;align-items:center;
+  /* THE MARQUEE'S OWN BAND. cq units measure the CONTENT box, so this padding
+     is two things at once: the gutter the casino bulb frame (.g-dv-mq, inset
+     6px, 7px bars) lives in, and the ceiling on the fit below. Without it a
+     board that fills the bench edge to edge paints its outer plates under the
+     bulbs. */
+  padding:var(--g-dv-bench-pad,14px);
+  container-type:size}
 .g-dv-grid{position:relative;display:grid;gap:var(--g-dv-gap);perspective:1100px;justify-content:center;
   grid-template-columns:repeat(var(--g-dv-cols,4),1fr);
-  /* height-fit: plates are 4/3 landscape, so width = (rowHeight * 4/3 * cols)
-     + gaps. ~250px of chrome (proctor strip + hud + hint + pads) is reserved. */
+  /* FALLBACK, first, for an engine with no container queries: the old
+     100dvh-minus-chrome guess. A 'cqw' an engine cannot parse invalidates the
+     whole declaration below at PARSE time, so this one survives in the cascade.
+     (The cq units must be written out literally rather than hidden in a var:
+     a var() that fails is invalid at COMPUTED-VALUE time, which resets width to
+     auto instead of falling back to the previous declaration.) */
   width:min(94%, calc(((100dvh - 250px - (var(--g-dv-rows,3) - 1) * var(--g-dv-gap))
-    / var(--g-dv-rows,3)) * 1.3333 * var(--g-dv-cols,4)
-    + (var(--g-dv-cols,4) - 1) * var(--g-dv-gap)))}
-.g-dv-cell{position:relative;aspect-ratio:4/3}
+    / var(--g-dv-rows,3)) * var(--g-dv-arn,1.3333) * var(--g-dv-cols,4)
+    + (var(--g-dv-cols,4) - 1) * var(--g-dv-gap)));
+  /* THE FIT: one cell is the SMALLER of what the width allows and what the
+     height allows, and the board is that cell times the columns plus the gaps.
+     The rows come free - .g-dv-cell carries the aspect - so the board can never
+     be taller than the bench and never needs a scrollbar. */
+  width:calc(min(
+      (var(--g-dv-fill,94) * 1cqw - (var(--g-dv-cols,4) - 1) * var(--g-dv-gap))
+        / var(--g-dv-cols,4),
+      ((100cqh - (var(--g-dv-rows,3) - 1) * var(--g-dv-gap)) / var(--g-dv-rows,3))
+        * var(--g-dv-arn,1.3333)
+    ) * var(--g-dv-cols,4) + (var(--g-dv-cols,4) - 1) * var(--g-dv-gap))}
+.g-dv-cell{position:relative;aspect-ratio:var(--g-dv-arn,1.3333)}
 
 /* ---- specimen slides ------------------------------------------------------ */
 .g-dv-card{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
@@ -95,7 +135,12 @@ export const STYLE_TEXT = `
     linear-gradient(165deg, color-mix(in srgb, var(--panel2), var(--lav) 14%), var(--panel) 58%,
       color-mix(in srgb, var(--panel), black 12%));
   box-shadow:0 10px 26px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.07);
-  transform-style:preserve-3d;transition:transform .22s ease,opacity .2s ease,
+  transform-style:preserve-3d;
+  /* .154s IS 'TIMING.flipMs' 154 (script.js), 30% off the old .22s/220 pair.
+     index.js waits exactly that long before it swaps the face and rotates the
+     card back, so these are ONE number living in two files - move them
+     together or the plate snaps mid-turn. */
+  transition:transform .154s ease,opacity .2s ease,
     box-shadow .2s ease,filter .25s ease;
   cursor:pointer;font:inherit;font-size:clamp(20px,3.2vmin,34px);line-height:1}
 /* glass sheen over everything on the slide */
@@ -131,7 +176,7 @@ export const STYLE_TEXT = `
 
 /* faces: one media node per card, opacity-toggled (never re-created on a flip) */
 .g-dv-face{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;
-  opacity:0;transition:opacity .18s ease;pointer-events:none;background:var(--panel)}
+  opacity:0;transition:opacity .126s ease;pointer-events:none;background:var(--panel)}
 .g-dv-face.g-dv-glyph{display:flex;align-items:center;justify-content:center;
   font-size:clamp(30px,7vmin,76px);line-height:1;
   color:color-mix(in srgb, var(--ground), var(--lav) 34%);
@@ -305,7 +350,7 @@ html.arc-reduced .g-dv-mq{opacity:.16}
 }
 
 /* ---- reduced motion: the mechanic survives, the motion does not --------- */
-html.arc-reduced .g-dv-card{transition:opacity .16s ease}
+html.arc-reduced .g-dv-card{transition:opacity .112s ease}
 html.arc-reduced .g-dv-card.flipping{transform:none;opacity:.45}
 html.arc-reduced .g-dv-card.dealt,
 html.arc-reduced .g-dv-card.judge,
@@ -325,7 +370,7 @@ html.arc-reduced .chip.g-dv-statlie,
 html.arc-reduced .g-dv-kb .g-dv-card.up .g-dv-face:not(.g-dv-glyph),
 html.arc-reduced .g-dv-kb .g-dv-card.locked .g-dv-face:not(.g-dv-glyph){animation:none}
 @media (prefers-reduced-motion: reduce){
-  .g-dv-card{transition:opacity .16s ease}
+  .g-dv-card{transition:opacity .112s ease}
   .g-dv-card.flipping{transform:none;opacity:.45}
   .g-dv-card.dealt,.g-dv-card.judge,.g-dv-card.pulse,.g-dv-card.jiggle{animation:none}
   .g-dv-card.tell{animation:none;border-color:var(--gold);box-shadow:0 0 0 2px rgba(240,194,75,.55)}
@@ -338,14 +383,51 @@ html.arc-reduced .g-dv-kb .g-dv-card.locked .g-dv-face:not(.g-dv-glyph){animatio
   .g-dv-kb .g-dv-card.locked .g-dv-face:not(.g-dv-glyph){animation:none}
 }
 
-/* ---- narrow / touch: >=64px targets, the rack folds away ----------------- */
+/* ---- narrow / touch: the board takes the frame, the rack folds away ------
+   THE RULE THAT USED TO BE HERE THREW THE FIT AWAY. 'width:100%' on the grid
+   overrode the height-fit outright and 'minmax(64px,1fr)' put a hard floor under
+   a column, so a narrow frame got a full-width band of short cards with two
+   thirds of the bench empty under it - and a short frame overflowed instead.
+   Both are gone: the fit above is the only thing that sizes the board now, and
+   it cannot overflow, so the touch floor is kept by giving the board the room
+   rather than by forcing a minimum into a box that has none. */
 @media (max-width:560px){
-  .g-dv-stage{padding:64px 10px 10px}
-  .g-dv-grid{gap:8px;--g-dv-gap:8px;width:100%;
-    grid-template-columns:repeat(var(--g-dv-cols,4),minmax(64px,1fr))}
-  .g-dv-cell{min-height:64px}
+  .g-dv-stage{padding:64px 10px 10px;gap:6px;--g-dv-gap:8px;--g-dv-fill:100;
+    --g-dv-bench-pad:9px}
+  .g-dv-mq{inset:2px}
   .g-dv-rack{display:none}
 }
+/* PORTRAIT: the frame is tall and the board is wide, so the plate turns. At
+   4/3 a 4x3 board is 1.78:1 and can only ever be a band across the middle of a
+   phone; at 0.8 that same board is about 1:1 and every card is half again as
+   big in both directions. It is still a plate - the faces are object-fit:cover
+   and the glyph faces are centred - and no desktop window ever sees this. */
+@media (max-width:560px) and (orientation:portrait){
+  .g-dv-stage{--g-dv-arn:0.8}
+}
+/* SHORT FRAME - a landscape phone, and the one case 'max-width:560px' never
+   matched, because 844x390 is a WIDE viewport. Height is the entire budget
+   here, so every strip of chrome is worth a row of pixels on the cards, and
+   the plate widens: width is the thing there is plenty of. */
+@media (max-height:560px) and (orientation:landscape){
+  .g-dv-stage{gap:4px;--g-dv-gap:7px;--g-dv-fill:100;--g-dv-arn:1.55;
+    --g-dv-bench-pad:9px}
+  .g-dv-mq{inset:2px}
+  .g-dv-hud{font-size:10px;gap:2px 10px;letter-spacing:.1em}
+  .g-dv-hint{font-size:10px;letter-spacing:.12em;min-height:1.1em}
+  .g-dv-cram .arc-peekbtn{padding:5px 12px}
+  .g-dv-rack{display:none}
+}
+/* THE PHONE ITSELF (core/device.js's one decision, 'html.arc-mobile').
+   '.arc-classroot' is ALREADY pushed down by --arc-mobile-chrome-h while a
+   class is up, so the stage's own 64/72px reservation for the proctor strip is
+   counted TWICE on a phone: 64px of dead sky over every board. It goes, and
+   the sides and floor pick up the safe-area insets they never had. */
+html.arc-mobile.arc-class-on .g-dv-stage{
+  padding:8px calc(10px + env(safe-area-inset-right,0px))
+          calc(8px + env(safe-area-inset-bottom,0px))
+          calc(10px + env(safe-area-inset-left,0px));
+  --g-dv-fill:100}
 
 /* ---- THE CLASS RULES SHEET (Deck VI, Law IV: drawn, not told) ------------ */
 /* A lab card over the bench: three vignettes cut from the same slide chrome the


### PR DESCRIPTION
Three unrelated Arcademy fixes from the 0825 queue, all web-tier only (no C#).

## Deja Vu (memory game)
- Board fills the phone screen: grid sizes from the bench box via container queries (cell = min of width/height budget), plain fallback for engines without cq units. New landscape-phone breakpoint (844x390 never matched `max-width:560px`, 8-pair cards were 33x24px). Mobile shell stopped reserving the proctor strip twice.
- Measured (harness DOM): 8-pair portrait cell 87x65 -> 82x103, landscape 33x24 -> 82x53, desktop 203x152 -> 217x163. No overflow on 3/4/5-column boards.
- Reveal after tap 470 -> 329ms (-30%), mismatch flip-down animation 220 -> 154ms; the 900ms peek hold is untouched. `previewDownMs` 240 -> 168 because it shares the same `.flipping` transition.

## Daily Trigger (wordle)
- Owner ruling: answers must be niche words, never random English. THEME curated 213 -> 532, COMMON 380 -> 46 on-theme campus/arcade words, total pool 578 (578-day repeat-free cycle, confirmed by a 730-day sim). 47 niche extras added to ACCEPT.
- Validated through the real `bank.js`: 0 bad tokens, 0 dups, 0 dropped, 28/28 phrases parse. Note: this reshuffles all future daily answers (inherent to the ruling).

## Records Annex lab
- Root cause: `.al-back` was z-index 4 under the OS layer's z 7 full-stage backdrop, which painted over it and swallowed the click. Pill now z 9; new `stepBack()` leaves the terminal outright (paper -> whole OS -> close-up) instead of folding windows one at a time. Esc ladder byte-identical.
- Clicking the painted room around the laptop closes the OS; guarded on pointerdown+click both landing on the backdrop so a window dragged past the frame never triggers it.
- Side effect: with a paper open, "step back" puts the paper down first (matches its own x).

## Testing
- Puppeteer rigs against the real modules for Deja Vu (7 viewport/pair combos) and the lab (before via `git show HEAD:`, after via tree); computed-style audits confirm no dropped declarations.
- Needs an in-app phone play-test on the real shell before release.

Not included: the Annex reading-room rebuild (fake-OS explorer, charts, docs markup) in progress in another session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnpDoiEJVni4xVVFyPRdUL
