### PR TITLE
fix(arcademy): media warm round 3 - proof-only blacklist, warm adoption in every reported game

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/engine/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/index.js
@@ -247,6 +247,11 @@ export const FIRE_KINDS = Object.freeze(['glitch_swap', 'sub_flash', 'flash_burs
 export const SUSTAIN_KINDS = Object.freeze(['row_drift', 'bubble_field', 'wash', 'gif_rain', 'ambient_field', 'crt']);
 export const CEREMONY_KINDS = Object.freeze(['stamp', 'streak_meter', 'jackpot', 'near_miss']);
 
+/** warm('media') asks the pool to byte-warm this many upcoming draws - the
+ *  provider's own DECK_AHEAD (its prewarm clamps to it anyway); kept local so
+ *  the engine never imports the provider. */
+const WARM_MEDIA_AHEAD = 6;
+
 /** Bundled mono-pink placeholder tiles — the floor under every asset draw. */
 const PLACEHOLDERS = ['ae-ph-1.svg', 'ae-ph-2.svg', 'ae-ph-3.svg', 'ae-ph-4.svg', 'ae-ph-5.svg', 'ae-ph-6.svg']
   .map((f) => {
@@ -711,13 +716,22 @@ export function createEngine(options = {}) {
     isPlainBeat: (i01, floor, early) => isPlainBeat(i01, rng(), floor, early),
     cadenceMs,
     rewardRoll: (o = {}) => schedule.roll(Object.assign({ heat }, o)),
-    /** Pre-warm a heavy path in idle time (2026-08-26). 'spiral' (the default
-     *  and only kind) mounts the loom wash canvas + compiles its shader while
-     *  the element sits at opacity 0, so the first jackpot garnish / spiral
-     *  sustain reuses it instead of paying WebGL setup on a reward frame.
+    /** Pre-warm a heavy path in idle time (2026-08-26). 'spiral' (the default)
+     *  mounts the loom wash canvas + compiles its shader while the element sits
+     *  at opacity 0, so the first jackpot garnish / spiral sustain reuses it
+     *  instead of paying WebGL setup on a reward frame.
+     *  'media' (2026-08-25) asks the asset pool to byte-warm the urls its next
+     *  few draws WILL serve (pool.prewarm forecasts over CLONED cursors +
+     *  peekRand, so it consumes NO rng and moves NO draw) - a game calls it a
+     *  beat before a media shower so cold phone fetches land in time.
      *  No rng, no fx, nothing visible; safe to skip, safe to repeat. */
     warm(what) {
       if (disposed || suspended) return false;
+      if (what === 'media') {
+        if (!pool || typeof pool.prewarm !== 'function') return false;
+        try { pool.prewarm(WARM_MEDIA_AHEAD); return true; }
+        catch (e) { log('warm refused: ' + ((e && e.message) || e)); return false; }
+      }
       if (what != null && what !== 'spiral') return false;
       ensureLayer();
       try { return sustained.warmSpiral(); } catch (e) { log('warm refused: ' + ((e && e.message) || e)); return false; }

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -62,7 +62,7 @@ import {
   NODE_CAPS, DUCK, subFlashSpec, glitchSpec, gifBurstSpec,
   burstCountForHeat, burstOpacityForHeat,
 } from './curves.js';
-import { rand, pickFrom, hasDom, mediaEl, budgetedKind } from './util.js';
+import { rand, pickFrom, hasDom, mediaEl, budgetedKind, isVideoUrl } from './util.js';
 import { createEscapeGuard } from './escape.js';
 
 /** The ceiling on a lengthened sub_flash. A word that outlives this stops being
@@ -296,7 +296,22 @@ export function createOneshots(ctx) {
        * same size, the same count and the same hold, it just stops minting a
        * 854x480 decoder per node. An explicit opts.url is the caller's own
        * choice and is never second-guessed. */
-      const url = opts.url || ctx.assetUrlSync(budgetedKind(opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still')));
+      let url = opts.url || null;
+      if (!url) {
+        const drawn = ctx.assetUrlSync(budgetedKind(opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still')));
+        /* WARM-MEDIA SEAM (opt-in, 2026-08-25; twin of gif_rain's): pick() may
+         * substitute a url the game knows is warm, but the original pool draw
+         * above always happens (shared-rng law - pool.next consumes the
+         * provider's own rng) and stands in when pick answers nothing. A picked
+         * VIDEO only rides a slot budgetedKind already granted. An explicit
+         * opts.url still short-circuits everything, exactly as before. */
+        url = drawn;
+        if (typeof opts.pick === 'function') {
+          let picked = null;
+          try { picked = opts.pick() || null; } catch { picked = null; }
+          if (picked && (!isVideoUrl(picked) || isVideoUrl(drawn))) url = picked;
+        }
+      }
       // mediaEl: <img>, or a muted looping <video> when the pool handed us a
       // webm/mp4 loop (the only animated shape a remote provider has)
       const node = (url && mediaEl(url)) || document.createElement('div');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -50,6 +50,12 @@ export const STYLE_TEXT = `
 /* ---- sub_flash ----------------------------------------------------------- */
 .ae-sub{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);opacity:0;
   animation:ae-sub-blip var(--ae-dur,420ms) ease-out forwards;max-width:44vw;max-height:44vh}
+/* HONEST BOX (media variant only - a word box sizes to its text): a cold <img>
+   has intrinsic height 0 and painted NOTHING for its whole blip. An intrinsic
+   square inside the existing 44vw/44vh maxima + the burst's faint tint, so an
+   unloaded card still reads as a card that is filling in. Cross-platform. */
+img.ae-sub{width:min(38vw,38vh);aspect-ratio:1;object-fit:cover;border-radius:10px;
+  background:rgba(255,105,180,.10)}
 .ae-sub-word{font-family:Georgia,'Times New Roman',serif;font-weight:700;letter-spacing:.06em;
   color:var(--ae-ink);text-shadow:0 0 18px var(--ae-pink);font-size:clamp(28px,6vw,64px);white-space:nowrap}
 .ae-sub-scatter{left:var(--ae-x,50%);top:var(--ae-y,50%)}
@@ -58,7 +64,13 @@ export const STYLE_TEXT = `
   22%{opacity:var(--ae-alpha,.6)}70%{opacity:var(--ae-alpha,.6)}100%{opacity:0;transform:translate(-50%,-50%) scale(1.03)}}
 
 /* ---- flash_burst / gif_burst nodes -------------------------------------- */
+/* HONEST BOX: width-only + a cold media node = intrinsic height 0 = an
+   invisible burst for its whole hold (the owner's placeholder-only rain bug,
+   same flaw here). aspect-ratio pins the card's height to its width var so an
+   unloaded node still reads as a card filling in; the tint was already here.
+   Cross-platform by design (A). .ae-burst-cover's explicit height wins over it. */
 .ae-burst{position:absolute;left:var(--ae-x,50%);top:var(--ae-y,50%);width:var(--ae-size,180px);
+  aspect-ratio:1;
   transform:translate(-50%,-50%) rotate(var(--ae-rot,0deg));opacity:0;border-radius:10px;
   box-shadow:0 0 22px rgba(255,105,180,.35);animation:ae-burst-in var(--ae-dur,900ms) ease-out forwards;
   object-fit:cover;background:rgba(255,105,180,.10)}
@@ -77,7 +89,12 @@ export const STYLE_TEXT = `
   100%{opacity:0;transform:translate(-50%,-50%) rotate(var(--ae-rot,0deg)) scale(1.06)}}
 
 /* ---- gif_rain ----------------------------------------------------------- */
+/* HONEST BOX: same law as .ae-burst - width only meant a cold <img>/<video>
+   fell as a 0-height nothing for its whole 2.9-4.3s life (only the 240x240
+   placeholder SVGs ever painted). A square card + a faint pink-violet tint so
+   the fall reads even before the media lands. Cross-platform by design (A). */
 .ae-rain{position:absolute;top:-22vh;left:var(--ae-x,10%);width:var(--ae-size,140px);border-radius:8px;
+  aspect-ratio:1;background:linear-gradient(160deg,rgba(255,105,180,.12),rgba(184,166,232,.10));
   animation:ae-fall var(--ae-fall,3s) linear forwards;opacity:var(--ae-alpha,.8);object-fit:cover}
 @keyframes ae-fall{from{transform:translateY(0) rotate(var(--ae-rot,0deg))}
   to{transform:translateY(128vh) rotate(calc(var(--ae-rot,0deg) * 3))}}

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -41,7 +41,7 @@
 
 import { clamp01 } from '../core/caps.js';
 import { NODE_CAPS, washSpec, gifRainSpec, ambientSpec, driftSpec, bubbleSpec } from './curves.js';
-import { rand, hasDom, mediaEl, budgetedKind } from './util.js';
+import { rand, hasDom, mediaEl, budgetedKind, isVideoUrl } from './util.js';
 import { createEscapeGuard } from './escape.js';
 import { createLoomWash } from './loomWash.js';
 
@@ -412,7 +412,21 @@ export function createSustained(ctx) {
       if (live.rain >= rainCap) return;
       /* THE DECODER BUDGET (util.js): past it a 'loop' request is served a
        * still, so the rain keeps its node count and drops its decode cost. */
-      const url = ctx.assetUrlSync(budgetedKind(opts.assetKind || 'loop'));
+      const drawn = ctx.assetUrlSync(budgetedKind(opts.assetKind || 'loop'));
+      /* WARM-MEDIA SEAM (opt-in, 2026-08-25): `opts.pick()` may answer a url
+       * the game KNOWS is warm (already decoded on its own board). The original
+       * draw above still happens either way - the provider pool consumes its
+       * own shared rng on next(), so the draw may never be skipped (the
+       * shared-rng law); a null/absent pick falls back to it byte-identically.
+       * A picked VIDEO may only ride a slot the decoder budget already granted
+       * (drawn itself a video), so a pick can never upgrade a still draw into
+       * an uncounted decoder session. */
+      let url = drawn;
+      if (typeof opts.pick === 'function') {
+        let picked = null;
+        try { picked = opts.pick() || null; } catch { picked = null; }
+        if (picked && (!isVideoUrl(picked) || isVideoUrl(drawn))) url = picked;
+      }
       const node = (url && mediaEl(url)) || document.createElement('div');   // <video> for a webm/mp4 loop
       node.className = 'ae-rain';
       node.style.setProperty('--ae-x', Math.round(rand(ctx.rng, 2, 88)) + '%');

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
@@ -89,12 +89,32 @@ const GAME_KEY = 'anomaly';
 const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
 const isVideoUrl = (url) => VIDEO_URL_RE.test(String(url || ''));
 
+/** The provider's bundled glyph-floor svg (the L&F redress law, ported). */
+const PLACEHOLDER_RE = /\/ae-ph-\d+\.svg(\?|#|$)/i;
+const wearsPlaceholder = (url) => !url || PLACEHOLDER_RE.test(String(url));
+
+/** A cross-origin http(s) url - the only kind worth waiting on the provider's
+ *  warm rail for; local/same-origin urls paint instantly and gate on nothing
+ *  (pool.ready answers those true at once anyway). */
+function isRemoteUrl(url) {
+  const s = String(url || '');
+  if (!/^https?:\/\//i.test(s)) return false;
+  try {
+    if (typeof location !== 'undefined' && location.origin
+      && s.indexOf(location.origin + '/') === 0) return false;
+  } catch (e) { /* ignore */ }
+  return true;
+}
+
 /** How many draws to spend looking for a tile-able url before giving up on
  *  media entirely (a video-only pool on a 5x5 grid = plain faces, not 25
  *  <video> elements - the L&F 30Hz lock). */
 const MEDIA_TRIES = 5;
 /** A round shorter than this cannot be offered before the bell. */
 const MIN_ROUND_MS = 2600;
+/** The longest a round's deal may hold the verdict beat waiting for the
+ *  provider's warm rail to land the dealt url (0825 media-warming). */
+const READY_GATE_MS = 900;
 /** W3 P0-2: the widest a round countdown may be heard, in ms. */
 const COUNTDOWN_MS = 3000;
 /** The shared ticker. */
@@ -552,8 +572,16 @@ export default {
       const videoOk = n <= PLAYTEST.VIDEO_GRID_MAX && !reduced && !coarse && motionLevelOf(ctx) > 1;
       let firstVideo = null;
       for (let k = 0; k < MEDIA_TRIES; k++) {
+        const kind = reduced || k >= 3 ? 'still' : 'loop';
+        /* TOUCH (0825, orchestrator-ruled): the coarse class claims no loops
+         * (see claimAssets) and can never paint one - videoOk is false for the
+         * whole class - so a loop draw here would burn provider rng forecasting
+         * mp4s the grid cannot wear. Skipped WITHOUT drawing. This moves which
+         * emissions a TOUCH device consumes vs old builds; desktop paths
+         * (reduced, big grid, motion-capped) draw exactly as before. */
+        if (coarse && kind === 'loop') continue;
         let a = null;
-        try { a = pool.next(reduced || k >= 3 ? 'still' : 'loop'); } catch (e) { a = null; }
+        try { a = pool.next(kind); } catch (e) { a = null; }
         const url = a && a.url ? String(a.url) : '';
         if (!url) continue;
         if (isVideoUrl(url)) {
@@ -663,7 +691,34 @@ export default {
         note('an.breather', { kind: 'curiosity', n: breathers });
       }
 
+      /* WARM AHEAD (0825): the provider's look-ahead consumes no rng, and the
+       * verdict beat between rounds is warm time. */
+      warmAhead();
       const url = dealUrl();
+      /* THE READY GATE (0825): a remote url holds the verdict/briefing beat
+       * until the warm rail reports it landed - never longer than
+       * READY_GATE_MS, so a broken network cannot stall the class. `busy` is
+       * still true and `cur` does not exist yet, so the shared ticker credits
+       * this round NOTHING: the round clock never runs against an unpainted
+       * board. Local urls and a poolless class start at once, as before. */
+      if (url && isRemoteUrl(url) && pool && typeof pool.ready === 'function') {
+        const myIdx = roundIdx;
+        let launched = false;
+        const go = () => {
+          if (launched) return;
+          launched = true;
+          run(() => { if (roundIdx === myIdx) beginRound(r, url); });
+        };
+        try { Promise.resolve(pool.ready(url, { timeoutMs: READY_GATE_MS })).then(go, go); }
+        catch (e) { go(); }
+        return;
+      }
+      beginRound(r, url);
+    }
+
+    /** The dealt round proper - everything below the (possibly gated) deal. */
+    function beginRound(r, url) {
+      if (ended || dead || bellOn) return;
       paintGrid(url);
 
       /* THE VIDEO KINDS: the plan always deals an img-safe kind AND, on a small
@@ -1317,19 +1372,64 @@ export default {
        * until GO is pressed. */
       cue('paper', 0.3);
       howtoEl = node;
+      /* sheet-reading time = warm time (0825). Usually a no-op here - the
+       * claim lands async and warms on arrival - but a pool that beat the
+       * sheet up starts filling its rail now. */
+      warmAhead();
     }
 
     /* ==================================================================== *
      * ASSETS
      * ==================================================================== */
+    /** The provider's bounded look-ahead; consumes NO rng (recon-verified),
+     *  so it is free to call anywhere. Null-safe: the claim lands async. */
+    function warmAhead() {
+      try { if (pool && typeof pool.prewarm === 'function') pool.prewarm(6); }
+      catch (e) { /* a warm-up never breaks a class */ }
+    }
+
+    /** UPGRADE-ON-ARRIVAL (0825). A round dealt before media landed is a full
+     *  placeholder board and used to wear it to round end; when the pool now
+     *  serves the needed kind, re-draw and repaint mid-round. Honest here
+     *  because the media is NOISE - the answer lives in the CSS delta on
+     *  .g-an-face, so a mid-round upgrade lies about nothing. DEGRADED PATH
+     *  ONLY: a round wearing real media returns before any draw, so the clean
+     *  path's rng sequence never moves (house law). */
+    function redress() {
+      if (dead || ended || !pool || !cur || cur.done) return;
+      if (!wearsPlaceholder(lastUrl)) return;
+      const u = dealUrl();
+      if (!u || u === lastUrl || wearsPlaceholder(u)) return;
+      paintGrid(u);
+      applyFace(cur.oddIndex);
+    }
+
     function claimAssets() {
+      /* TOUCH-AWARE SPEC (0825, orchestrator-ruled): on a coarse device
+       * dealUrl() can never paint a loop (videoOk is false for the whole
+       * class), so asking for 10 loops wasted the warm budget forecasting
+       * mp4s while the still lane - the one the device lives on - stopped
+       * refilling at 4 rows (provider askRemote = max(4, spec)). Desktop
+       * keeps the manifest spec exactly as-is. */
+      const claimSpec = coarse
+        ? { loops: 0, targets: 0, stills: 12, canvasSafe: false }
+        : { loops: 10, targets: 0, stills: 4, canvasSafe: false };
       Promise.resolve()
-        .then(() => ctx.assets.claim({ loops: 10, targets: 0, stills: 4, canvasSafe: false }))
+        .then(() => ctx.assets.claim(claimSpec))
         .then((p) => {
           if (dead || !p || typeof p.next !== 'function') return;
           pool = p;
-          /* a round already on screen with plain faces gets its media now */
-          if (cur && mediaMode === 'plain') run(() => { const u = dealUrl(); if (u) { paintGrid(u); applyFace(cur.oddIndex); } });
+          /* the rules sheet is usually still up here: reading time = warm time */
+          warmAhead();
+          /* remote batches stream in AFTER the claim resolves (the provider's
+           * ask-again loop): re-dress a placeholder round as each one lands.
+           * The subscription dies with pool.release(). */
+          if (typeof p.onUpdate === 'function') {
+            try { p.onUpdate(() => run(redress)); } catch (e) { /* optional seam */ }
+          }
+          /* a round already on screen with plain/placeholder faces gets its
+           * media now (redress gates itself to that degraded state) */
+          if (cur) run(redress);
         })
         .catch((e) => say('asset claim failed - plain faces: ' + ((e && e.message) || e)));
     }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -104,6 +104,20 @@ const BUMP_MIN_MS = 250;
  *  (WebView2, fine pointer) never enters any of these paths. */
 const TOUCH_PLAY_CAP = 2;
 const TOUCH_PREVIEW_STEP_MS = 1000;
+/** The rotation's floor when a beat sizes its own step off its window (0825):
+ *  below this the cap-of-2 windows churn decoders faster than iOS spins them
+ *  up, and nothing is seen animating at all. */
+const TOUCH_PREVIEW_STEP_MIN_MS = 400;
+
+/** THE PREVIEW MEDIA GATE (0825 media-warming): before the memorize clock
+ *  arms, each of the board's distinct remote faces gets up to
+ *  PREVIEW_GATE_URL_MS on pool.ready(), and the WHOLE gate is capped at
+ *  PREVIEW_GATE_CAP_MS so a broken network can never hang the class. */
+const PREVIEW_GATE_URL_MS = 1200;
+const PREVIEW_GATE_CAP_MS = 1500;
+
+/** The provider's bundled glyph-floor svg (the L&F redress law, ported). */
+const PLACEHOLDER_RE = /\/ae-ph-\d+\.svg(\?|#|$)/i;
 
 /** Diagnostics seam (the engine has one too): the live class, for the scratch
  *  harness and any future "what is the board doing" debug overlay. The shell
@@ -592,16 +606,29 @@ export default {
     let previewTicks = false;    // W3 P0-2: the memorize countdown is armed
     let previewList = null;      // the cells the window rotates over
     let previewCursor = 0;
+    let previewStepMs = TOUCH_PREVIEW_STEP_MS;   // this beat's rotation step
 
     function videoFaces(list) {
       const out = [];
       for (const c of list) if (c && c.face && c.face.tagName === 'VIDEO') out.push(c);
       return out;
     }
-    function playWindowStart(list) {
+    function playWindowStart(list, windowMs) {
       previewList = list;
       previewCursor = 0;
       previewing = true;
+      /* THE ROTATION ARITHMETIC (0825): a fixed 1000ms step never reached
+       * every face inside a shrinking previewMs (tier 3: 10 of 16 faces were
+       * NEVER played during the memorize beat). When the caller knows its
+       * window, the step is sized so ceil(faces / TOUCH_PLAY_CAP) rotations
+       * fit inside it, floored at TOUCH_PREVIEW_STEP_MIN_MS. The cap of 2
+       * PLAYING videos (the iOS decode ceiling) is untouched - the window
+       * just rotates faster. Callers without a window keep the old step. */
+      const vids = videoFaces(list || []);
+      const rotations = Math.max(1, Math.ceil(vids.length / TOUCH_PLAY_CAP));
+      previewStepMs = Number(windowMs) > 0
+        ? Math.max(TOUCH_PREVIEW_STEP_MIN_MS, Math.floor(Number(windowMs) / rotations))
+        : TOUCH_PREVIEW_STEP_MS;
       playWindowStep();
     }
     function playWindowStep() {
@@ -615,7 +642,7 @@ export default {
       }
       previewCursor = (previewCursor + TOUCH_PLAY_CAP) % n;
       // a board with no more videos than the cap has nothing to rotate
-      if (n > TOUCH_PLAY_CAP) after(TOUCH_PREVIEW_STEP_MS, playWindowStep);
+      if (n > TOUCH_PLAY_CAP) after(previewStepMs, playWindowStep);
     }
     function playWindowStop() {
       previewing = false;
@@ -695,6 +722,24 @@ export default {
       pairUrls = [];
       for (let pid = 0; pid < want; pid++) pairUrls[pid] = draw[pid] || null;
       facesDirty = false;
+      /* THE IMMINENT BOARD HEADS THE WARM WINDOW (0825). warmManifest /
+       * warmCursor consume NO rng (recon-verified) - free on every path. */
+      warmBoardFaces();
+    }
+
+    /** Hand THIS board's faces to the provider's manifest warmer, cursor at
+     *  the top, so the deal/preview about to run is what the rail fetches
+     *  first. Replaces the class-wide facePool manifest for the board's
+     *  lifetime (one manifest per provider, by design). */
+    function warmBoardFaces() {
+      if (!pool || typeof pool.warmManifest !== 'function') return;
+      try {
+        const need = [];
+        for (const u of pairUrls) if (u && need.indexOf(u) < 0) need.push(u);
+        if (!need.length) return;
+        pool.warmManifest(need.map((u) => ({ url: u })));
+        if (typeof pool.warmCursor === 'function') pool.warmCursor(0);
+      } catch (e) { /* a warm-up never breaks a deal */ }
     }
 
     /** Mint this board's cells into the (emptied) grid. */
@@ -800,6 +845,41 @@ export default {
     }
 
     function preview() {
+      /* THE MEDIA GATE (0825): the memorize clock must not run against faces
+       * still fetching (<video preload="metadata"> moves no frame bytes until
+       * play(), so a cold preview was a board of black cards). Hold the deal
+       * beat - `busy` is up since startBoard and the "Dealing the board." hint
+       * stays - until every distinct remote face reports pool.ready(), capped
+       * at PREVIEW_GATE_CAP_MS total so a broken network cannot hang the
+       * class. Glyph and placeholder boards gate on nothing and open at once. */
+      const gate = previewGate();
+      if (!gate) { previewShow(); return; }
+      const myBoard = boardNo;
+      gate.then(() => run(() => {
+        if (dead || ended || belled || boardNo !== myBoard) return;
+        previewShow();
+      }));
+    }
+
+    /** The board's distinct real urls -> one settled-fast promise, or null
+     *  when there is nothing to wait on. Never rejects (pool.ready never
+     *  does; the race cap resolves regardless). */
+    function previewGate() {
+      if (!pool || typeof pool.ready !== 'function') return null;
+      const need = [];
+      for (const u of pairUrls) {
+        if (u && !PLACEHOLDER_RE.test(String(u)) && need.indexOf(u) < 0) need.push(u);
+      }
+      if (!need.length) return null;
+      const waits = need.map((u) => {
+        try { return pool.ready(u, { timeoutMs: PREVIEW_GATE_URL_MS }); }
+        catch (e) { return Promise.resolve(false); }
+      });
+      const cap = new Promise((res) => { setTimeout(res, scaled(PREVIEW_GATE_CAP_MS)); });
+      return Promise.race([Promise.all(waits), cap]);
+    }
+
+    function previewShow() {
       /* THE MEMORIZE BEAT IS PER BOARD and it is kept deliberately: it is the
        * whole encoding moment, and it is tier- (and ladder-) dialled, shrinking
        * a notch per cleared board toward tier 4's own floor. It spends bell
@@ -817,8 +897,10 @@ export default {
         if (!touch) playFace(c, true);
       }
       /* On touch the memorize beat plays TOUCH_PLAY_CAP faces at a time and
-       * rotates; on desktop every face plays at once, exactly as before. */
-      if (touch) playWindowStart(cells.slice());
+       * rotates; on desktop every face plays at once, exactly as before. The
+       * window is sized to previewMs so EVERY face gets its animated moment
+       * before the cards go down (0825). */
+      if (touch) playWindowStart(cells.slice(), dials.previewMs);
       /* W3 P1-10: the board coming up is air moving, not a generic sting. */
       tick('whoosh', 0.35);
       /* W3 P0-2: the memorize window is a countdown, so it ticks - one per
@@ -1727,6 +1809,58 @@ export default {
      * plays the leftovers on their glyph faces (always distinct) rather than
      * repeating someone else's clip.
      */
+    /** Draw distinct loop urls into facePool. `clean` additionally refuses the
+     *  provider's bundled placeholder svgs - the RE-draw path must not refill
+     *  with the very floor it is replacing. The first fill keeps the original
+     *  accept-anything semantics (a placeholder pool still deals a board). */
+    function fillFacePool(clean) {
+      if (!pool || typeof pool.next !== 'function') return;
+      for (let n = 0; n < FACE_POOL_WANT * 3 && facePool.length < FACE_POOL_WANT; n++) {
+        const got = pool.next('loop');
+        const u = got && got.url;
+        if (!u) continue;
+        if (clean && PLACEHOLDER_RE.test(String(u))) continue;
+        if (facePool.indexOf(u) < 0) facePool.push(u);
+      }
+    }
+
+    /** The face pool was built cold: short, or wearing the placeholder floor. */
+    function poolDegraded() {
+      if (facePool.length < FACE_POOL_WANT) return true;
+      for (const u of facePool) if (!u || PLACEHOLDER_RE.test(String(u))) return true;
+      return false;
+    }
+
+    /** pool.onUpdate landed: a fresh media batch exists (0825). DEGRADED PATH
+     *  ONLY - a clean, full facePool returns before ANY rng is consumed, so
+     *  the clean path's draw sequence never moves (house law: extra next()
+     *  calls are permitted only where the state already serves degraded
+     *  results). Contents of facePool are unseeded; the board's seeded shuffle
+     *  in dealFaces is untouched, so determinism is safe. */
+    function refaceFromUpdate() {
+      if (dead || ended || belled || !pool) return;
+      if (!poolDegraded()) return;
+      facePool = facePool.filter((u) => u && !PLACEHOLDER_RE.test(String(u)));
+      const before = facePool.length;
+      fillFacePool(true);
+      if (facePool.length === before) return;         // the batch had nothing new
+      say('media batch landed - face pool now ' + facePool.length + ' distinct');
+      /* re-issue the class warm list; dealFaces below narrows it again */
+      try {
+        if (typeof pool.warmManifest === 'function' && facePool.length) {
+          pool.warmManifest(facePool.map((u) => ({ url: u })));
+        }
+      } catch (e) { /* noop */ }
+      /* the same landing law as the first claim: a board the player has
+       * memorised or started is never re-faced - the NEXT board gets it. */
+      if (facesLocked || faceUp.length || matched > 0) {
+        facesDirty = true;
+        return;
+      }
+      dealFaces(boardNo || 1);
+      for (const c of cells) applyMedia(c);
+    }
+
     function claimAssets() {
       // NEVER block a draw: the board is already dealing on glyph faces and the
       // urls drop in when the pool resolves (empty remote -> local, silently).
@@ -1737,13 +1871,21 @@ export default {
         .then((p) => {
           if (dead || !p || typeof p.next !== 'function') return;
           pool = p;
-          for (let n = 0; n < FACE_POOL_WANT * 3 && facePool.length < FACE_POOL_WANT; n++) {
-            const got = p.next('loop');
-            const u = got && got.url;
-            if (u && facePool.indexOf(u) < 0) facePool.push(u);
-          }
+          fillFacePool();
           say('asset pool ready (' + facePool.length + ' distinct loops; a board wears '
             + (dials ? dials.pairs : '?') + ')');
+          /* THE CLASS WARM LIST (0825): facePool is the class's whole media
+           * need, so the how-to sheet becomes the idle warm window. Each
+           * board's dealFaces re-heads the manifest with its own subset. */
+          if (typeof p.warmManifest === 'function' && facePool.length) {
+            try { p.warmManifest(facePool.map((u) => ({ url: u }))); } catch (e) { /* noop */ }
+          }
+          /* THE REVIVED RE-FACE PATH (0825): remote media streams in after the
+           * claim resolves; the old guard below ran once inside this .then()
+           * and never re-fired. The subscription dies with pool.release(). */
+          if (typeof p.onUpdate === 'function') {
+            try { p.onUpdate(() => run(refaceFromUpdate)); } catch (e) { /* optional seam */ }
+          }
           /* THE LATE POOL. If the player is already reading a preview or a live
            * board, re-facing it would be a lie the tell system never promised -
            * so the draw is banked and the NEXT board is the first with media.

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
@@ -180,6 +180,10 @@ export function wrapQuickPool(claimPool) {
     thin(tag) { return seen[tag === 'noise' ? 'noise' : 'target'].size < DECK.PER_SOURCE_MIN; },
     empty(tag) { return served[tag === 'noise' ? 'noise' : 'target'] === 0 && seen[tag === 'noise' ? 'noise' : 'target'].size === 0; },
     prewarm() { /* the claim pool prewarmed itself */ },
+    /** The tagged pool's spare(tag): rows held beyond the deal. The ordinary
+     *  claim pool keeps no tagged reserve, so the honest answer is none - the
+     *  substitute widener just falls back to the deck's own survivors. */
+    spare() { return []; },
     /* THE MANIFEST SEAM (0825) rides through to the wrapped claim pool, so the
      * room speaks one media API whichever pool shape stands behind it. Absent
      * verbs answer the inert thing: nothing warmed, nothing broken, ready NOW

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -936,27 +936,52 @@ export default {
       try { const p = S && S.pool; if (p && typeof p.markBroken === 'function' && url) p.markBroken(url); }
       catch (e) { /* noop */ }
     }
+    /** The pool's spare rows for a tag (tagged pools hold up to TAG_CAP rows
+     *  the frozen deck never dealt), guarded like the verbs above: a pool
+     *  without the accessor - quick sort, an old double - answers none. */
+    function poolSpare(tag) {
+      try {
+        const p = S && S.pool;
+        const rows = p && typeof p.spare === 'function' ? p.spare(tag) : null;
+        return Array.isArray(rows) ? rows : [];
+      } catch (e) { return []; }
+    }
     /**
      * THE SUBSTITUTE for a card whose url is dead - decided at MINT time, and
      * the stored deck (the retake cache) is NEVER touched: game state and the
      * judge keep reading the deck record, the FACE is presentation. Same-tag
      * by law (the player judges the pixels, the ledger judges card.tag - and
      * in QUICK SORT same tag IS same kind, so the kind-truth holds too), and
-     * deterministic by construction: candidates walk S.deckRows (the deal
-     * order, identical on a retake) and the pick is pure hashing of
-     * (seed, deck index) - the same blacklist state shows the same substitute
-     * on a retake, and no seeded stream is consumed (determinism law).
+     * deterministic by construction: the pick is pure hashing of (seed, deck
+     * index) over an order-stable candidate list - the same pool and blacklist
+     * state show the same substitute on a retake, and no seeded stream is
+     * consumed (determinism law). FRESH BLOOD FIRST (0825): the pool's spare
+     * rows - same-tag media it kept absorbing after the deck froze - stand in
+     * before any deck survivor, because a substitute drawn from the deck itself
+     * is by construction a repeat, and a modest blacklist was reading as "the
+     * variety collapsed" in playtest. The deck's own survivors stay the floor.
      */
     function substituteFor(card) {
       if (!S || !card) return null;
       const rows = S.deckRows || [];
+      const inDeck = new Set();
+      for (const c of rows) if (c && c.url) inDeck.add(c.url);
       const seen = new Set();
-      const list = [];
-      for (const c of rows) {
+      const spares = [];
+      for (const c of poolSpare(card.tag)) {
         if (!c || !c.url || c.tag !== card.tag) continue;
-        if (c.url === card.url || seen.has(c.url) || poolIsBroken(c.url)) continue;
+        if (c.url === card.url || inDeck.has(c.url) || seen.has(c.url) || poolIsBroken(c.url)) continue;
         seen.add(c.url);
-        list.push(c);
+        spares.push(c);
+      }
+      const list = spares;
+      if (!list.length) {
+        for (const c of rows) {
+          if (!c || !c.url || c.tag !== card.tag) continue;
+          if (c.url === card.url || seen.has(c.url) || poolIsBroken(c.url)) continue;
+          seen.add(c.url);
+          list.push(c);
+        }
       }
       if (!list.length) return null;
       const pick = list[Math.floor(hash01(String(S.seed) + '|sub|' + (card.i | 0)) * list.length)];
@@ -998,6 +1023,10 @@ export default {
       const face = live.face;
       if (live.video) {
         freeSlot(live);
+        /* the dying flag FIRST: removeAttribute('src') + load() can surface as
+         * an 'error' on some WebKit paths, and a teardown that condemned the
+         * url the player just watched would feed the blacklist a healthy card */
+        try { face._aeDying = true; } catch (e) { /* noop */ }
         try { if (face.pause) face.pause(); face.removeAttribute('src'); if (face.load) face.load(); }
         catch (e) { /* noop */ }
       }
@@ -1005,13 +1034,30 @@ export default {
       live.face = null;
       live.video = false;
     }
-    /** BUG B's fix, shared by both element kinds: a face that ERRORED is a url
-     *  the whole page should stop dealing. Blacklist it, clear the face so the
-     *  re-mint branch refires, and reseat now - the re-mint swaps in the
-     *  substitute without waiting for the stack to move. */
+    /** Which face errors CONVICT the url, and which are the element's own
+     *  weather. iOS fires <video> 'error' on benign decoder-pool exhaustion
+     *  and aborted loads, so a video only condemns on the codes that name the
+     *  URL as the problem: MEDIA_ERR_NETWORK (2) and MEDIA_ERR_SRC_NOT_SUPPORTED
+     *  (4) - ABORTED (1) and DECODE (3) re-mint without a verdict. An <img> is
+     *  guilty only "loaded and has no pixels" (the provider's own image law). */
+    function faceErrorCondemns(face) {
+      if (!face) return false;
+      if (face.tagName === 'VIDEO') {
+        const code = face.error && face.error.code;
+        return code === 2 || code === 4;
+      }
+      return !!(face.complete && !(Number(face.naturalWidth) > 0));
+    }
+    /** BUG B's fix, shared by both element kinds: a face whose error CONVICTS
+     *  its url (faceErrorCondemns) is a url the whole page should stop dealing.
+     *  Blacklist it, clear the face so the re-mint branch refires, and reseat
+     *  now - the re-mint swaps in the substitute without waiting for the stack
+     *  to move. A benign error still kills and re-mints the face, it just
+     *  never condemns the url; our own teardown (the dying flag) is inert. */
     function faceDied(face) {
+      if (face && face._aeDying) return;    // killFace/dropCard letting go, not a death
       const url = face && face._aeUrl ? String(face._aeUrl) : '';
-      if (url) poolMarkBroken(url);
+      if (url && faceErrorCondemns(face)) poolMarkBroken(url);
       const live = liveHolding(face);
       if (live) {
         killFace(live);
@@ -1092,6 +1138,8 @@ export default {
       if (!live) return;
       freeSlot(live);
       if (live.video) {
+        /* dying flag first, same law as killFace: teardown never self-condemns */
+        try { if (live.face) live.face._aeDying = true; } catch (e) { /* noop */ }
         try { const v = live.face; if (v) { if (v.pause) v.pause(); v.removeAttribute('src'); if (v.load) v.load(); } }
         catch (e) { /* noop */ }
       }
@@ -1147,6 +1195,12 @@ export default {
           emiNote('sort.deckRecycle', { kind: 'curiosity', n: S.recycles, left: S.cards.length });
         }
         S.cursor = 0;
+        /* the deck ORDER just changed (passes returned or a reshuffle), so the
+         * manifest the warmer holds is a lie from here on - it would warm the
+         * OLD order for the rest of the class. Re-hand it the new sequence;
+         * warmManifest resets the warm cursor with it, and warmFollow re-walks
+         * it from reseat() exactly as it did on the first pass. */
+        warmDeck();
       }
       const card = S.cards[S.cursor++];
       if (!card) return null;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -168,7 +168,7 @@ import {
 } from './schedule.js';
 import { compositeFor, hardGates, flavorXp } from './grade.js';
 import { DE_LEX } from './lex.js';
-import { makeTaggedRoll } from '../../core/rng.js';
+import { makeTaggedRoll, makeRng } from '../../core/rng.js';
 
 /** A url the <img> element cannot show (a webm/mp4 loop). Mirrors engine/util.js
  *  VIDEO_URL_RE; games never import the engine, so the two-line rule is repeated. */
@@ -434,6 +434,11 @@ export default {
     let faceVisWired = false;              // one visibilitychange listener per class
     const faceDemotes = new Set();         // tiers demoted to a still, owed a re-dress at the stamp beat
     const faceStalls = new Map();          // tile node -> {media, id}: the no-frame watchdog
+    /* R3 - stall mercy: a tier the belt demoted may be re-dealt a video ONCE */
+    const faceStallRetry = new Set();      // tiers demoted for stall/error, still owed their one retry
+    const faceStallRetried = new Set();    // tiers whose one retry is spent
+    /* R3 - the rain picker's own tagged stream (new tag = legal; retakes stable) */
+    let rainPickRng = null;
     let stuckShown = false;
     /* pass 5 - THE PERF LADDER */
     let perfSetting = 'auto';              // de_perf: auto | full | lite
@@ -581,6 +586,12 @@ export default {
       channels: () => {
         try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
         catch (e) { return null; }
+      },
+      /* R3: the engine's idle pre-warm seam ('spiral' | 'media'). No rng, no
+       * visuals - a deck may nudge it, never depend on it. */
+      warm: (what) => {
+        try { return (ctx.engine && typeof ctx.engine.warm === 'function') ? ctx.engine.warm(what) : false; }
+        catch (e) { return false; }
       },
     };
     /** The player's own media, as a deck sees it. The pool lands ASYNC (a
@@ -825,6 +836,16 @@ export default {
         });
       } catch (e) { /* the double has no img semantics; fine */ }
     }
+    /** R3 - DECODER HYGIENE: a face <video> being replaced or discarded used
+     *  to keep its decoder session alive until GC (iOS holds a hardware
+     *  session per attached stream). pause + drop the src + load() releases it
+     *  NOW. Safe on any node; a non-video node is untouched. */
+    function releaseFaceVideo(media) {
+      if (!media || String(media.tagName || '').toUpperCase() !== 'VIDEO') return;
+      try { if (typeof media.pause === 'function') media.pause(); } catch (e) { /* ignore */ }
+      try { if (typeof media.removeAttribute === 'function') media.removeAttribute('src'); } catch (e) { /* ignore */ }
+      try { if (typeof media.load === 'function') media.load(); } catch (e) { /* ignore */ }
+    }
     /** The media node that can SHOW this url: the face's <img>, swapped for a
      *  <video> when the tier's url is a webm/mp4 loop (and back for a still).
      *  Same class, same place in the face; the listeners are re-armed. */
@@ -835,6 +856,7 @@ export default {
       const wantVideo = VIDEO_URL_RE.test(String(url || ''));
       const isVideo = !!(cur && String(cur.tagName || '').toUpperCase() === 'VIDEO');
       if (cur && wantVideo === isVideo) return cur;
+      if (isVideo) releaseFaceVideo(cur);          // R3: free the outgoing decoder session
       const next = el(wantVideo ? 'video' : 'img', 'g-de-media');
       armMedia(next, node, wantVideo);
       try {
@@ -1025,7 +1047,16 @@ export default {
       }
       const url = dealFaceUrl(kind);
       if (!url) return null;
-      const face = { url, kind };
+      /* R3 - KIND TRUTH: record what the url IS, not what was asked. A starved
+       * pool answers a 'loop' ask with a placeholder .svg or a still, and the
+       * old record said kind:'loop' anyway - burning one of the FACE_CAP
+       * animated slots (only 2 on touch) on a frozen image FOREVER
+       * (healDupFaces only re-deals duplicates; two different placeholders
+       * never heal). animatedFaces() now counts honestly; `want` remembers the
+       * degraded ask so healDegradedFaces can upgrade it when the pool grows. */
+      const isVid = VIDEO_URL_RE.test(String(url));
+      const face = { url, kind: isVid ? 'loop' : 'still' };
+      if (kind === 'loop' && !isVid) face.want = 'loop';
       faceUrls.set(tier, face);
       if (!faceLogged) {
         faceLogged = true;
@@ -1101,6 +1132,10 @@ export default {
       const tiers = [...faceDemotes];
       faceDemotes.clear();
       for (const tr of tiers) redressTier(tr);
+      /* R3: a promotion just moved the animated set around - the stamp beat
+       * (never the input task) is the moment a stall-demoted tier may take its
+       * one retry / a degraded deal may upgrade, if a slot is actually free. */
+      healDegradedFaces();
     }
     /** PASS 8 - THE BELT (touch only, like the ceiling it guards): a face
      *  <video> that errored (or sat frameless past FACE_VIDEO_STALL_MS) does
@@ -1119,7 +1154,12 @@ export default {
       const still = dealFaceUrl('still');
       if (!still || VIDEO_URL_RE.test(still)) { faceBroken(node); return; }
       faceUrls.set(tier, { url: still, kind: 'still' });
-      say('faces: tier ' + tier + ' video failed or stalled - the tier falls back to a still');
+      /* R3 - STALL MERCY: the demote stands (the phone gets its media NOW),
+       * but the tier is owed ONE retry at a video - on the next pool batch or
+       * the next promotion flush, never a retry storm (faceStallRetried). */
+      if (!faceStallRetried.has(tier)) faceStallRetry.add(tier);
+      say('faces: tier ' + tier + ' video failed or stalled - the tier falls back to a still'
+        + (faceStallRetried.has(tier) ? ' (retry spent)' : ' (one retry armed)'));
       redressTier(tier);
     }
     /** PASS 8 - arm the no-frame watchdog on a freshly dressed <video> face
@@ -1180,6 +1220,39 @@ export default {
      *  replay on show - unless another window still holds them. */
     function onFaceVisibility() { if (!dead) syncFaceVideos(); }
 
+    /* ---- R3: THE ELEMENT-TRUE FACE BUDGET ------------------------------- *
+     * FACE_CAP_* counts TIERS; every live TILE of an animated tier is its own
+     * decoder session. These count the ELEMENTS and hold them under a real
+     * ceiling (3 on touch - the iOS hardware number - 8 on desktop), with the
+     * excess tiles of a tier wearing the tier's still fallback. The FACE_CAP
+     * tier semantics stay layered on top, untouched. */
+    function faceVideoElCeil() {
+      return touch ? PLAYTEST.FACE_VIDEO_EL_CEIL_TOUCH : PLAYTEST.FACE_VIDEO_EL_CEIL;
+    }
+    /** Live tile nodes currently carrying a face <video> WITH a stream (a
+     *  released video - src stripped by releaseFaceVideo - holds no session
+     *  and must not count against the ceiling). */
+    function faceVideoTiles() {
+      const out = [];
+      for (const n of tileEls.values()) {
+        const m = mediaOf(n);
+        if (!m || String(m.tagName || '').toUpperCase() !== 'VIDEO') continue;
+        try { if (typeof m.getAttribute === 'function' && !m.getAttribute('src') && !m.src) continue; } catch (e) { /* count it */ }
+        out.push(n);
+      }
+      return out;
+    }
+    /** The tier's still fallback for its excess tiles, dealt lazily ONCE and
+     *  cached on the face record. Only ever runs on the overflow path (dirty
+     *  state - the clean path's draw order is untouched). */
+    function tierStillFallback(face) {
+      if (!face) return null;
+      if (face.still) return face.still;
+      const still = dealFaceUrl('still');
+      if (!still || VIDEO_URL_RE.test(still)) return null;
+      face.still = still;
+      return still;
+    }
     /** Dress (or re-dress after a merge) a tile with its tier's face. Never
      *  blocks a draw: the plain body shows until the image has a frame. */
     function dressFace(node, tile) {
@@ -1192,15 +1265,58 @@ export default {
       if (!face) {
         if (node.getAttribute('data-face') != null) {        // it wore an older tier's face; strip it
           node.classList.remove('is-loaded');
+          releaseFaceVideo(img);                             // R3: an outgoing video frees its decoder
           try { if (typeof img.removeAttribute === 'function') img.removeAttribute('src'); } catch (e) { /* ignore */ }
           node.setAttribute('data-face', '');
         }
         return;
       }
+      let url = face.url;
+      /* R3 - the element ceiling. A video url only lands on this tile while
+       * the face <video> element count stays under faceVideoElCeil(). Past it:
+       * a tile of a DEEPER tier takes the video by demoting one element of the
+       * shallowest video-wearing tier to that tier's still fallback (the
+       * deepest keeps the video - that is where the eye is); a same-or-
+       * shallower arrival wears its own tier's still fallback instead. */
+      if (VIDEO_URL_RE.test(String(url))) {
+        const vids = faceVideoTiles().filter((n) => n !== node);
+        if (vids.length >= faceVideoElCeil()) {
+          let victim = null;
+          let victimTier = Infinity;
+          for (const vn of vids) {
+            const vt = Number(vn.getAttribute('data-face'));
+            if (vt > 0 && vt < victimTier) { victim = vn; victimTier = vt; }
+          }
+          let ceded = false;
+          if (victim && victimTier < tier) {
+            const vf = faceUrls.get(victimTier);
+            const vstill = vf && !vf.broken && vf.url ? tierStillFallback(vf) : null;
+            if (vstill) {
+              const vm = mediaNodeFor(victim, vstill);       // mediaNodeFor releases the outgoing decoder
+              if (vm) {
+                victim.classList.remove('is-loaded');
+                try { vm.src = vstill; } catch (e) { /* ignore */ }
+                armFaceStall(victim, vm);
+              }
+              ceded = true;
+            }
+          }
+          if (!ceded) url = tierStillFallback(face);
+        }
+      }
+      if (!url) {
+        /* no honest still to overflow onto: the plain body stands (same shape
+         * as the face-null path; the tier's video tiles are untouched) */
+        node.classList.remove('is-loaded');
+        releaseFaceVideo(img);
+        try { if (typeof img.removeAttribute === 'function') img.removeAttribute('src'); } catch (e) { /* ignore */ }
+        node.setAttribute('data-face', String(tier));
+        return;
+      }
       node.setAttribute('data-face', String(tier));
       node.classList.remove('is-loaded');
-      const media = mediaNodeFor(node, face.url) || img;
-      try { media.src = face.url; } catch (e) { /* ignore */ }
+      const media = mediaNodeFor(node, url) || img;
+      try { media.src = url; } catch (e) { /* ignore */ }
       armFaceStall(node, media);             // pass 8: a video face owes a frame within the stall window
     }
     /** A url that failed: this tier goes plain for the rest of the class (no retry storm). */
@@ -1217,6 +1333,7 @@ export default {
           other.classList.remove('is-loaded');
           other.setAttribute('data-face', '');
           const img = mediaOf(other);
+          releaseFaceVideo(img);                       // R3: free the decoder with the face
           try { if (img && typeof img.removeAttribute === 'function') img.removeAttribute('src'); } catch (e) { /* ignore */ }
         }
       }
@@ -1254,11 +1371,80 @@ export default {
         }
         if (!fresh) continue;
         worn.add(fresh);
-        faceUrls.set(tier, { url: fresh, kind: f.kind });
+        /* R3 kind truth here too: the re-deal records what fresh IS, and a
+         * loop ask served a still stays owed (want) for healDegradedFaces. */
+        const freshVid = VIDEO_URL_RE.test(fresh);
+        const nf = { url: fresh, kind: freshVid ? 'loop' : 'still' };
+        if ((f.kind === 'loop' || f.want === 'loop') && !freshVid) nf.want = 'loop';
+        faceUrls.set(tier, nf);
         healed = true;
         redressTier(tier);
       }
       if (healed) say('faces: duplicate tier clips re-dealt (the pool grew)');
+    }
+    /** R3 - THE DEGRADED-DEAL CURE, healDupFaces's sibling (same trigger:
+     *  pool.onUpdate; plus the stamp beat's demote flush). Two dirty states
+     *  only - the clean path never runs this and moves no draw:
+     *    (a) a tier that ASKED for a loop but was served a placeholder/still
+     *        (face.want === 'loop') - re-deal it a real video;
+     *    (b) a tier the stall belt demoted, owed its ONE retry
+     *        (faceStallRetry) - re-deal it a video once, then never again.
+     *  Same draw discipline as dealFaceUrl (six bounded draws, worn-dedup),
+     *  and the tier caps stand: never past faceCap(), never in the shallows. */
+    function healDegradedFaces() {
+      if (!pool || typeof pool.next !== 'function') return;
+      for (const [tier, f] of [...faceUrls]) {
+        if (!f || f.broken || !f.url) continue;
+        const wantsUpgrade = f.want === 'loop' && f.kind !== 'loop';
+        const stallRetry = faceStallRetry.has(tier) && f.kind !== 'loop';
+        if (!wantsUpgrade && !stallRetry) continue;
+        if (tier <= shallowStillMaxTier()) continue;       // the shallows stay still
+        if (animatedFaces() >= faceCap()) continue;        // the tier cap stands
+        const worn = new Set();
+        for (const w of faceUrls.values()) if (w && w.url) worn.add(w.url);
+        let url = null;
+        try {
+          for (let i = 0; i < 6; i += 1) {
+            let u = null;
+            const got = pool.next('loop');
+            u = got && got.url ? String(got.url) : null;
+            if (!u) break;
+            if (VIDEO_URL_RE.test(u) && !worn.has(u)) { url = u; break; }
+          }
+        } catch (e) { url = null; }
+        if (!url) continue;
+        if (stallRetry) { faceStallRetry.delete(tier); faceStallRetried.add(tier); }
+        faceUrls.set(tier, { url, kind: 'loop' });
+        say('faces: tier ' + tier + (stallRetry ? ' takes its one stall retry' : ' upgrades its degraded deal') + ' - video re-dealt');
+        redressTier(tier);
+      }
+    }
+    /** R3 - THE WARM RAIN PICKER (the engine's opts.pick seam). A rain node
+     *  lives ~3-4s; a cold phone fetch cannot land inside that, so the rain
+     *  rained placeholders/blanks. This answers a url that is ALREADY DECODED
+     *  AND ON SCREEN: a worn face whose tier has at least one live is-loaded
+     *  tile. On touch only non-video urls qualify (reusing an mp4 in a rain
+     *  node mints a NEW decoder session; a cached still is free) - the tier's
+     *  still fallback included. Empty set -> null -> the engine's own draw
+     *  stands, exactly today's behavior. Seeded on its own NEW tagged stream
+     *  ('|de|rain-pick') so a retake picks the same sequence. */
+    function pickRainUrl() {
+      if (!rainPickRng) return null;
+      const cands = [];
+      for (const [tier, f] of faceUrls) {
+        if (!f || f.broken || !f.url) continue;
+        let loaded = false;
+        for (const tile of board ? board.tiles : []) {
+          if (tile.silt || tile.tier !== tier) continue;
+          const n = tileEls.get(tile.id);
+          if (n && n.classList && n.classList.contains('is-loaded')) { loaded = true; break; }
+        }
+        if (!loaded) continue;
+        if (!touch || !VIDEO_URL_RE.test(String(f.url))) cands.push(f.url);
+        if (f.still && f.still !== f.url) cands.push(f.still);
+      }
+      if (!cands.length) return null;
+      return cands[Math.min(cands.length - 1, Math.floor(rainPickRng() * cands.length))] || null;
     }
     function motionLevelOf() {
       try { const v = ctx.motion && ctx.motion.motionLevel; return Number.isFinite(Number(v)) ? Number(v) : 2; } catch (e) { return 2; }
@@ -1284,7 +1470,10 @@ export default {
       // a tile leaving the board carries no live state with it
       node.classList.remove('is-deepest', 'is-strain', 'is-new', 'is-merged', ...SLIDE_CLASSES);
       node.classList.add('is-gone');
-      const drop = () => { try { node.remove(); } catch (e) { /* noop */ } };
+      const drop = () => {
+        releaseFaceVideo(mediaOf(node));               // R3: a leaving tile frees its decoder NOW, not at GC
+        try { node.remove(); } catch (e) { /* noop */ }
+      };
       if (delayMs > 0) after(delayMs, drop); else drop();
     }
     function liveTiles() {
@@ -2531,7 +2720,7 @@ export default {
           pool = p;
           run(dressAllFaces);                     // the tiles already on the board get their faces now
           /* a remote batch landing is the one moment a starved deal can be bettered */
-          if (typeof p.onUpdate === 'function') p.onUpdate(() => { if (!dead && pool === p) run(healDupFaces); });
+          if (typeof p.onUpdate === 'function') p.onUpdate(() => { if (!dead && pool === p) run(() => { healDupFaces(); healDegradedFaces(); }); });
         })
         .catch((e) => say('asset claim failed - plain faces, currents fall back to the engine pool: ' + ((e && e.message) || e)));
     }
@@ -2758,6 +2947,9 @@ export default {
           facesHeld = false;
           faceDemotes.clear();
           faceStalls.clear();                // ids died with the registry; the map must not outlive them
+          faceStallRetry.clear();            // R3: the one-retry ledger is per class
+          faceStallRetried.clear();
+          rainPickRng = makeRng(seed + '|de|rain-pick');   // R3: new tagged stream, retake-stable
         }
         // the plan's own draws do not depend on the budget; a free swim deals the
         // same seeded show a 300s class would (never Infinity into the clamp)
@@ -2848,6 +3040,9 @@ export default {
              * params wrapper or a plain gif url - the deck's pin paints its
              * paintable half and the wheel wash rides the engine provider. */
             classSpiral: (ctx && ctx.classSpiral) || null,
+            /* R3 - the warm rain: the deck's gif_rain rides urls this board has
+             * already decoded (engine pick seam; the pool draw still happens). */
+            pickRainUrl,
             log: say,
           });
         } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/pressure.js
@@ -250,8 +250,10 @@ function cafFn() {
 /**
  * @param {Object} o   see THE INTERFACE in the pass-4 sheet:
  *   seed, gradeTier, reduced, motionLevel, stage, bench, board,
- *   hud:{score,depth,chain,clock}, engine:{fire,sustain,stop,channels},
- *   assets:{next(kind)}, timers:{after,every,clear}, capsOk:()=>bool, log
+ *   hud:{score,depth,chain,clock}, engine:{fire,sustain,stop,channels,warm?},
+ *   assets:{next(kind)}, timers:{after,every,clear}, capsOk:()=>bool, log,
+ *   pickRainUrl? (R3: () => url|null over the game's already-decoded board
+ *   faces - rides the engine's gif_rain opts.pick seam; optional everywhere)
  */
 export function createDePressure(o) {
   const opts = o || {};
@@ -744,8 +746,21 @@ export function createDePressure(o) {
     if (still || !opts.bench) return null;
     return fire('glitch_swap', { targets: opts.bench, variant: 'vhsroll', seconds: seconds || 0.6, onSwap() {}, sfx: false });
   }
+  /** R3 - the warm-media nudge. Zero rng (the pool's prewarm forecasts over
+   *  cloned cursors), zero visuals; a beat of byte-warm lead so the rain's own
+   *  draws are not stone cold on a phone. Optional at every layer. */
+  function warmMedia() {
+    if (!armedBase || destroyed || typeof eng.warm !== 'function') return;
+    try { eng.warm('media'); } catch (e) { /* optional */ }
+  }
   function rain(variant, ms) {
-    return sustain('gif_rain', { variant, durationMs: Math.round(ms), clickSafe: true });
+    const o2 = { variant, durationMs: Math.round(ms), clickSafe: true };
+    /* R3 - the warm-media seam: the game's picker over its own already-decoded
+     * board faces (index.js pickRainUrl). The engine still performs its
+     * original pool draw either way (shared-rng law); an absent/empty picker
+     * is byte-identical to before. */
+    if (typeof opts.pickRainUrl === 'function') o2.pick = opts.pickRainUrl;
+    return sustain('gif_rain', o2);
   }
   function burstAt(tileEl, n) {
     const at = pctOf(tileEl);
@@ -795,6 +810,10 @@ export function createDePressure(o) {
   function enterRung(k) {
     const row = P.LADDER[k];
     if (!row) return;
+    /* R3: one rung BEFORE the rain arms (rung 5), start byte-warming the pool's
+     * next draws - a rain node lives ~3-4s and a cold phone fetch cannot land
+     * inside that. No rng, no visuals. */
+    if (k === 4) warmMedia();
     for (const key of row.adds) {
       if (present.has(key)) continue;
       present.add(key);
@@ -943,6 +962,7 @@ export function createDePressure(o) {
     /** A new deepest tier this dive: the rung climbs NOW, then the heavy hit. */
     newDeepest(tier, tileEl) {
       if (!started || stopped || !armed()) return;
+      warmMedia();                       // R3: the rain below draws in seconds - warm the deck now
       tierNow = Math.max(1, tierOf(tier));
       stepTo(rungFor(tierNow), false);
       punchBoard(Math.min(P.PUNCH_PX_CAP, P.PUNCH_DEEP_PX + P.PUNCH_DEEP_PER_TIER * tierNow), P.PUNCH_DEEP_MS);

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
@@ -118,8 +118,21 @@ export const PLAYTEST = Object.freeze({
   /** PASS 8 - THE BELT: a face <video> with no frame (no loadeddata) this long
    *  after its url landed is treated as failed - the tier falls back to a
    *  still via faceVideoFailed instead of holding a decoder session hostage on
-   *  a stream iOS is thrashing on. */
-  FACE_VIDEO_STALL_MS: 4000,
+   *  a stream iOS is thrashing on. R3 (owner iPhone playtest): 4000 was too
+   *  tight for a cellular cold fetch + the slide-window pause churn - videos
+   *  are always cold at src time (the byte-warm resolves on headers only), so
+   *  the belt gets mercy; a tier demoted by it is also retryable ONCE now
+   *  (see faceVideoFailed / healDegradedFaces in index.js). */
+  FACE_VIDEO_STALL_MS: 9000,
+  /** R3 - THE ELEMENT-TRUE FACE BUDGET. FACE_CAP_* counts TIERS, but every
+   *  live tile of an animated tier is its OWN decoder session (three tier-5
+   *  tiles = three 854x480 decodes), so a phone could hold ~11 concurrent
+   *  sessions against a real iOS ceiling of ~4. This is the ceiling on face
+   *  <video> ELEMENTS: past it the excess tiles of a tier wear the tier's
+   *  still fallback (the deepest/newest tile keeps the video). Composes ON TOP
+   *  of the FACE_CAP_* tier semantics, which are unchanged. */
+  FACE_VIDEO_EL_CEIL: 8,
+  FACE_VIDEO_EL_CEIL_TOUCH: 3,
 
   /** PASS 5 - THE AUTO PROBE. After the board is dealt we sample rAF deltas
    *  for PERF_SAMPLE_MS, skipping PERF_WARMUP_MS of first-frame cost (style

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -80,6 +80,11 @@ const REMOTE_CAP = 80;        // mirrors intake's REMOTE_CAP: a page never hoard
 export const DECK_AHEAD = 6;      // draws forecast (and byte-warmed) ahead, per kind
 export const WARM_INFLIGHT = 3;   // warms in flight at once - a third lane lets small
                                   // stills slip past one slow multi-megabyte download
+const WARM_VIDEO_INFLIGHT = 2;    // of those, at most TWO may be video fetches - a
+                                  // third stalled mp4 would eat into Safari's
+                                  // 6-connections-per-host budget the game plays on
+const WARM_VIDEO_TIMEOUT_MS = 12000;  // a video warm that outlives this is aborted
+                                      // (an abort is a shrug, never a blacklist)
 const WARM_HELD_MAX = 24;         // decoded detached Images held against GC
 const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
 
@@ -98,27 +103,45 @@ export const MANIFEST_AHEAD_IDLE = 24;
 export const MANIFEST_AHEAD_PLAY = 10;
 
 /* THE URL BLACKLIST (0825), module-level so a dead CDN url stays dead across
- * every pool and every class this page runs (it empties with the page, so a
- * transient outage is forgiven on the next load). Fed by warm failures - an
- * Image error, or a no-cors video fetch REJECTING, which is the one video
- * verdict no-cors can see (an HTTP 404 behind an opaque response never lands
- * here) - and by games reporting a face that errored via pool.markBroken().
- * Draws skip it and serve the next eligible row instead; the placeholder floor
- * stays the final answer. Bounded: the oldest entry is forgotten first. */
+ * every pool and every class this page runs (it empties with the page). Fed by
+ * PROOF only: an image warm that completed with zero pixels, and games
+ * reporting a face whose error actually convicts the url via pool.markBroken().
+ * A no-cors video fetch REJECTING is NOT proof and never lands here - CSP
+ * refusal (production's connect-src excludes the media CDNs), a content
+ * blocker, a dropped cellular link and a page-backgrounding abort all reject
+ * exactly the way a dead host does, and treating them as verdicts once
+ * blacklisted the entire loop pool in seconds. Entries FORGIVE: the first
+ * strike heals after BROKEN_TTL_MS (a transient stumble is not a sentence),
+ * a second strike is permanent for the page. Draws skip a broken url and
+ * serve the next eligible row instead; the placeholder floor stays the final
+ * answer. Bounded: the least recently struck entry is forgotten first. */
 const BROKEN_URL_CAP = 400;
-const brokenUrls = new Set();
+const BROKEN_TTL_MS = 45000;      // one strike heals after this; two never do
+const brokenUrls = new Map();     // url -> { at, strikes }
 export function markBrokenUrl(url) {
   const s = String(url || '');
-  if (!s || brokenUrls.has(s)) return false;
-  brokenUrls.add(s);
+  if (!s) return false;
+  const prior = brokenUrls.get(s);
+  if (prior) {
+    /* a repeat offender: bump the strike and re-stamp. delete + set keeps the
+     * Map's insertion order meaning "least recently struck evicts first". */
+    brokenUrls.delete(s);
+    brokenUrls.set(s, { at: Date.now(), strikes: prior.strikes + 1 });
+    return false;
+  }
+  brokenUrls.set(s, { at: Date.now(), strikes: 1 });
   while (brokenUrls.size > BROKEN_URL_CAP) {
-    const oldest = brokenUrls.values().next().value;
+    const oldest = brokenUrls.keys().next().value;
     if (oldest == null) break;
     brokenUrls.delete(oldest);
   }
   return true;
 }
-export function isBrokenUrl(url) { return brokenUrls.has(String(url || '')); }
+export function isBrokenUrl(url) {
+  const rec = brokenUrls.get(String(url || ''));
+  if (!rec) return false;
+  return rec.strikes >= 2 || (Date.now() - rec.at) < BROKEN_TTL_MS;
+}
 
 /** Keys the shell/host might carry the local inventory under. A page cannot
  *  enumerate a virtual host, so SOMETHING has to hand us the list; we accept
@@ -247,6 +270,7 @@ export function createAssets(options = {}) {
   const warmQueue = [];
   const warmHeld = new Map();       // url -> the detached Image holding it open
   let warmFlight = 0;
+  let warmVideoFlight = 0;          // the video lanes within warmFlight (capped)
 
   /** Only bytes that actually travel: remote http(s), not our own origin. */
   function warmable(url) {
@@ -294,25 +318,54 @@ export function createAssets(options = {}) {
     flushReady(s, false);
   }
 
-  function warmDone() { warmFlight = Math.max(0, warmFlight - 1); if (!disposed) warmPump(); }
-  function warmOk(url) { warmDoneUrls.add(url); flushReady(url, true); warmDone(); }
+  function warmDone(video) {
+    warmFlight = Math.max(0, warmFlight - 1);
+    if (video) warmVideoFlight = Math.max(0, warmVideoFlight - 1);
+    if (!disposed) warmPump();
+  }
+  function warmOk(url, video) { warmDoneUrls.add(url); flushReady(url, true); warmDone(video); }
   function warmPump() {
     while (!disposed && warmFlight < WARM_INFLIGHT && warmQueue.length) {
-      const job = warmQueue.shift();
+      /* the video lanes are capped BELOW the rail's: with both spoken for, a
+       * queued image may still overtake, but a third mp4 waits its turn */
+      let at = 0;
+      if (warmVideoFlight >= WARM_VIDEO_INFLIGHT) {
+        at = warmQueue.findIndex((j) => !j.video);
+        if (at < 0) break;                  // only videos queued and both lanes busy
+      }
+      const job = warmQueue.splice(at, 1)[0];
       warmFlight += 1;
       if (job.video) {
-        /* fire and forget: the opaque reply is thrown away unread. A REJECTED
-         * warm is a NETWORK-level failure (DNS, refused connection) - the only
-         * video verdict no-cors can see - and it feeds the blacklist; an HTTP
-         * error rides an opaque 'ok' we cannot read and resolves as done. */
+        /* the opaque reply's body is CANCELLED the moment the headers land:
+         * warmOk was always a headers-level verdict, and an unread multi-MB
+         * mp4 body parked on the socket starves Safari's 6-per-host budget
+         * until later requests time out. A REJECTED warm proves NOTHING about
+         * the url - CSP refusal, content blockers, a dropped link and our own
+         * deadline abort all reject identically - so it NEVER feeds the
+         * blacklist; the waiters just hear "no" and the draw moves on. */
+        warmVideoFlight += 1;
         try {
-          if (typeof fetch !== 'function') { warmDone(); continue; }
+          if (typeof fetch !== 'function') { warmDone(true); continue; }
           const init = { mode: 'no-cors', credentials: 'omit' };
           if (job.high) init.priority = 'high';       // Fetch Priority API; unknown keys are ignored
+          let deadline = 0;
+          try {
+            if (typeof AbortController === 'function') {
+              const ctl = new AbortController();
+              init.signal = ctl.signal;
+              deadline = setTimeout(() => { try { ctl.abort(); } catch { /* noop */ } }, WARM_VIDEO_TIMEOUT_MS);
+            }
+          } catch { /* engines without AbortController warm undeadlined */ }
+          const settle = () => { if (deadline) { try { clearTimeout(deadline); } catch { /* noop */ } } };
           const pr = fetch(job.url, init);
-          if (pr && pr.then) pr.then(() => warmOk(job.url), () => { markBroken(job.url); warmDone(); });
-          else warmDone();
-        } catch { warmDone(); }
+          if (pr && pr.then) pr.then((res) => {
+            settle();
+            /* opaque responses may carry a null body - the cancel is guarded */
+            try { if (res && res.body && typeof res.body.cancel === 'function') res.body.cancel(); } catch { /* noop */ }
+            warmOk(job.url, true);
+          }, () => { settle(); flushReady(job.url, false); warmDone(true); });
+          else { settle(); warmDone(true); }
+        } catch { warmDone(true); }
       } else {
         let img = null;
         try { img = new Image(); } catch { img = null; }
@@ -1009,6 +1062,7 @@ export function createAssets(options = {}) {
       }
       warmHeld.clear();
       warmFlight = 0;
+      warmVideoFlight = 0;
       prewarmed = new Set();
     },
   };

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
@@ -21,7 +21,7 @@
  *   });
  *   pool.next('target', { prefer:'loop' })  -> row | null
  *   pool.counts() / pool.thin(tag) / pool.empty(tag) / pool.prewarm(n)
- *   pool.dealt() / pool.dispose()
+ *   pool.spare(tag) / pool.dealt() / pool.dispose()
  *
  * FIVE LAWS
  *  1. THE TAG IS THE TRUTH. A row keeps the tag of the SOURCE that served it
@@ -363,6 +363,16 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
         total += urls.length;
       }
       return total;
+    },
+
+    /** Every distinct row the pool holds for ONE tag, in ARRIVAL order (stable
+     *  for a given claim, so a pure-hash pick over it repeats on a retake).
+     *  The substitute widener's window onto media the deck froze out: the pool
+     *  keeps filling to targetFor() after the deal, and those late rows never
+     *  reach a frozen deck any other way. */
+    spare(tag) {
+      const x = tags[String(tag || '')];
+      return x ? x.rows.slice() : [];
     },
 
     /** Every DISTINCT row, for the retake cache (a superset of {url,tag,src}). */


### PR DESCRIPTION
## Media round 3: the blacklist was condemning healthy media, and only SORT ever got the warmer

Playtest verdicts addressed: SORT variety collapse, Deep End stills-only tiers + placeholder rain, Anomaly instant-vs-placeholder rounds, Deja Vu preview starting before its cards load.

### Root cause (4-agent recon, converging)
On app.cclabs.app the CSP `connect-src` excluded the Scrolller media CDNs, so **every** no-cors video warm fetch was refused by the browser - and the provider blacklisted a url on ANY warm rejection. Within seconds of class start the entire loop pool was condemned page-wide (the blacklist is module-level and was permanent), so every game served the placeholder/still floor for the rest of the page session. Amplifiers: warm fetches never cancelled their multi-MB bodies (starving Safari's 6-per-host connection budget into more timeouts = more false blacklisting), SORT substitutes drew from the deck itself (every substitution a guaranteed repeat), and `.ae-rain`/`.ae-burst` reserved no height so cold real media fell invisibly - only placeholder SVGs (intrinsic 240x240) ever painted.

### The fixes (one commit per subsystem)
1. **Provider + SORT** - blacklist convicts on proof only (image loaded with zero pixels; MediaError NETWORK/SRC_NOT_SUPPORTED), forgives (45s TTL, permanence needs two strikes); video warms get an abort deadline, cancelled bodies, 2-in-flight cap; SORT substitutes prefer the tagged pool's spare rows over deck repeats; warm manifest re-handed on deck recycle; teardown can never self-condemn.
2. **Deep End + engine** - face kind derived from the served url (a placeholder can no longer squat an animated slot; degraded deals heal when the pool grows); stall belt 4s->9s with one retry; every teardown releases its iOS decoder; face video ELEMENTS budgeted 3 touch / 8 desktop; rain/burst/sub get honest intrinsic boxes (cross-platform); rain/burst gain an opt-in pick() seam and DE rains its own already-decoded board faces (new `seed|de|rain-pick` stream; original pool draw always still performed - shared-rng law).
3. **Anomaly + Deja Vu adopt the warmer** - warm during the how-to sheet, ready-gated round/preview starts (900ms / 1.5s caps - a broken network can never hang a class), upgrade-on-arrival redress, Anomaly's touch claim becomes {loops:0, stills:12}, DV's preview rotation sized so every face plays before cards go down.

### Determinism
Clean-blacklist serving proven byte-identical against HEAD across 3 seeds (150-draw sequences). All new seams (warmManifest/ready/prewarm/onUpdate) consume zero rng. The one authorized shift: Anomaly's coarse-only loop-draw skip moves which emissions a TOUCH device consumes (the sequence was already device-classed; retakes stay byte-identical). Desktop draw order untouched everywhere.

### Verification
- Eval-import sweep: all 13 touched modules OK (run by the orchestrator after all edits).
- Agent suites in scratchpad: 35 (provider/SORT) + 40 (DE/engine) + 8 (Anomaly/DV) assertions green, including full-game headless boots.
- CDP smoke: DE choreography intact (merge pops 184/220ms median mobile/desktop, identical 7 merges both platforms, smooth slide sampling, 0 errors); SORT deals 90 + fresh ring; Anomaly + DV boot and dress on both viewports through the new gates, 0 errors.

**Pairs with cclabs-web PR** (CSP `connect-src` + shim warm re-kick) - that PR is what makes video warming legal on the website; this one makes the page honest when anything still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmpKwL3fLyt7roq9vJ26Fr
