### PR TITLE
perf(arcademy): mobile graphics diet - Echo playable, media on time, no duplicates

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/engine/ceremonies.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/ceremonies.js
@@ -117,13 +117,17 @@ export function createCeremonies(ctx) {
      * sounded like a one-burst one. A chime per burst, rising, capped at four,
      * and reduced motion collapses to the single burst it already draws. */
     const BURST_PITCH = [1, 1.15, 1.3, 1.45];
-    const bursts = Math.min(4, ctx.reduced() ? 1 : spec.bursts);
+    /* The lite fork rides ctx.lite(), the same seam as every node cap - the
+     * rng divergence (5 draws per spark, 2 per burst) is the device class's
+     * own, exactly like flashBurstLite's. */
+    const lite = ctx.lite();
+    const bursts = Math.min(lite ? 2 : 4, ctx.reduced() ? 1 : spec.bursts);
     for (let b = 0; b < bursts; b++) {
       ctx.timers.after(b * 220, () => {
         ctx.sfx('chime', 0.3, { pitch: BURST_PITCH[b] || 1.45 });
         const cx = rand(ctx.rng, 25, 75);
         const cy = rand(ctx.rng, 30, 70);
-        const n = ctx.reduced() ? 4 : spec.particlesPerBurst;
+        const n = ctx.reduced() ? 4 : (lite ? Math.round(spec.particlesPerBurst / 2) : spec.particlesPerBurst);
         for (let p = 0; p < n; p++) {
           const s = document.createElement('div');
           s.className = 'ae-spark';

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/loomWash.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/loomWash.js
@@ -45,7 +45,7 @@
 
 import { createFieldRenderer, normalizeParams2, loopMs2 } from './loom/loomField.js';
 
-const TOUCH_FRAME_MS = 33;     // ~30fps cap under coarse-touch
+const TOUCH_FRAME_MS = 66;     // ~15fps cap under coarse-touch, timeout-paced
 const BACK_LONG = 512;         // desktop backing-store long side
 const BACK_LONG_TOUCH = 320;   // coarse-touch backing-store long side
 
@@ -86,6 +86,7 @@ export function createLoomWash(o = {}) {
   let still = false;          // reduced motion: one frame, no loop
   let touch = false;
   let rafId = 0;
+  let toId = 0;               // touch pacing timeout (skipped-frame re-arm)
   let active = false;         // the caller's on/off (wash opacity > 0)
   let disposed = false;
   let lost = false;           // context lost / WebGL refused - latched
@@ -140,16 +141,24 @@ export function createLoomWash(o = {}) {
   }
   function onResize() { if (!disposed && canvas) sizeBacking(); }
 
-  function halt() { if (rafId) { caf(rafId); rafId = 0; } }
+  function halt() {
+    if (rafId) { caf(rafId); rafId = 0; }
+    if (toId) { clearTimeout(toId); toId = 0; }
+  }
   function arm() {
-    if (disposed || lost || !active || still || hidden() || rafId || !field) return;
+    if (disposed || lost || !active || still || hidden() || rafId || toId || !field) return;
     rafId = raf(frame);
   }
   function frame(now) {
     rafId = 0;
     if (disposed || lost || !active || hidden() || !field) return;
     const t = Number.isFinite(now) ? now : Date.now();
-    if (touch && t - lastAt < TOUCH_FRAME_MS - 1) { rafId = raf(frame); return; }
+    if (touch && t - lastAt < TOUCH_FRAME_MS - 1) {
+      // pace skipped frames through a timeout so the compositor idles between
+      // paints; a bare raf re-arm keeps a display-rate heartbeat alive forever
+      toId = setTimeout(() => { toId = 0; rafId = raf(frame); }, TOUCH_FRAME_MS);
+      return;
+    }
     lastAt = t;
     try {
       field.render(q, (t % loop) / loop);

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -260,6 +260,13 @@ export function createOneshots(ctx) {
      * CCP's "fullscreen GIF", which a width-only burst node cannot be. Opt-in:
      * without the flag nothing about a burst changes, so no other class moves. */
     const fullBleed = opts.fullBleed === true;
+    /* Touch never bleeds a video over the whole stage - a fullscreen decode is
+     * the most expensive node the engine can mint. The kind is pinned BEFORE
+     * budgetedKind/assetUrlSync, so the single pool draw below stands either
+     * way (shared-rng law: the draw count never moves). */
+    const touchStill = fullBleed && (() => {
+      try { return hasDom() && document.documentElement.classList.contains('ae-touch'); } catch { return false; }
+    })();
 
     let count = Number.isFinite(opts.count) ? Math.max(1, opts.count | 0)
       : burstCountForHeat(heat, ctx.rng());
@@ -298,7 +305,8 @@ export function createOneshots(ctx) {
        * choice and is never second-guessed. */
       let url = opts.url || null;
       if (!url) {
-        const drawn = ctx.assetUrlSync(budgetedKind(opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still')));
+        const drawn = ctx.assetUrlSync(budgetedKind(touchStill ? 'still'
+          : (opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still'))));
         /* WARM-MEDIA SEAM (opt-in, 2026-08-25; twin of gif_rain's): pick() may
          * substitute a url the game knows is warm, but the original pool draw
          * above always happens (shared-rng law - pool.next consumes the

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -255,6 +255,20 @@ img.ae-sub{width:min(38vw,38vh);aspect-ratio:1;object-fit:cover;border-radius:10
 .ae-touch .ae-crt-live{animation:none}
 .ae-touch .ae-burst-double{filter:none}
 .ae-touch .ae-glitch-datamosh{filter:none;animation:ae-shudder var(--ae-dur,600ms) steps(2,end) 1}
+/* the mobile graphics diet (2026-08-26), same ceiling:
+     - the spiral holds still exactly as on lite - a held spiral still reads as
+       a wash while parked;
+     - will-change on every wash pre-promotes a DPR-sized layer per held kind
+       even at opacity 0; the .45s opacity transition promotes on demand;
+     - rgbsplit keeps its text-shadow, drops the filter pass;
+     - vhsroll's clip-path is a per-step re-raster of the whole node - it gets
+       the transform-only shudder datamosh already gets;
+     - the burst box-shadow is a blur pass per node per frame of its fade. */
+.ae-touch .ae-wash-spiral{animation:none}
+.ae-touch .ae-wash{will-change:auto}
+.ae-touch .ae-glitch-rgbsplit{filter:none}
+.ae-touch .ae-glitch-vhsroll{animation:ae-shudder var(--ae-dur,600ms) steps(2,end) 1}
+.ae-touch .ae-burst{box-shadow:none}
 /* .ae-mote stays animated on touch ON PURPOSE: ae-float is transform-only
    (compositor-cheap, no re-raster), and the phone cost of the ambient field is
    its NODE COUNT, which the lite ladder now caps (curves.js ambientLite). */

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -60,6 +60,18 @@ const AMBIENT = {
 };
 export const AMBIENT_KINDS = Object.freeze(Object.keys(AMBIENT));
 
+/** The touch rung: html.ae-touch, the same read style.js's rules key off.
+ *  A hardware ceiling, not a quality level - it applies on FULL too. */
+function touchClass() {
+  try { return hasDom() && document.documentElement.classList.contains('ae-touch'); } catch { return false; }
+}
+
+/** Touch holds at most this many wash kinds' elements at once. */
+const WASH_HOLD_CAP_TOUCH = 2;
+/** Touch renewal deadline on a forever hold: the loom rAF stops until the next
+ *  re-trigger (pressure decks re-assert held washes on every repaintHeat). */
+const WASH_FOREVER_RENEW_MS = 20000;
+
 export function createSustained(ctx) {
   /** kind -> handle. sustain() on a live kind RETUNES it instead of stacking. */
   const active = new Map();
@@ -81,13 +93,29 @@ export function createSustained(ctx) {
     if (!hasDom()) return null;
     let h = washHolds.get(washKind);
     if (!h) {
+      /* Touch caps the held-element roster: each kind is a full-screen layer,
+       * and the least-recently-triggered one gives its element back. */
+      if (touchClass() && washHolds.size >= WASH_HOLD_CAP_TOUCH) {
+        let oldKind = null; let oldAt = Infinity;
+        for (const [k, o] of washHolds) {
+          if ((o.lastAt || 0) < oldAt) { oldAt = o.lastAt || 0; oldKind = k; }
+        }
+        if (oldKind != null) {
+          const o = washHolds.get(oldKind);
+          if (o.hideTimer) { ctx.timers.cancel(o.hideTimer); o.hideTimer = 0; }
+          loomDrop(o);
+          ctx.timers.release(o.el);
+          washHolds.delete(oldKind);
+        }
+      }
       const node = document.createElement('div');
       node.className = 'ae-wash ae-wash-' + washKind + (ctx.reduced() ? ' ae-wash-static' : '');
       ctx.layers.back.appendChild(node);
       ctx.timers.own(node);
-      h = { el: node, hideTimer: 0, forever: false, heldAlpha: 0 };
+      h = { el: node, hideTimer: 0, forever: false, heldAlpha: 0, lastAt: 0 };
       washHolds.set(washKind, h);
     }
+    h.lastAt = Date.now();
     return h;
   }
 
@@ -173,7 +201,18 @@ export function createSustained(ctx) {
     const h = ensureWash(washKind);
     if (!h) return null;
     const strength = ctx.ceiling('bgIntensity', opts.strength);
-    if (strength <= 0.001) return null;       // bgIntensity capped off -> no wash
+    if (strength <= 0.001) {
+      /* bgIntensity capped off -> no wash. A HELD wash must release here too:
+       * wash handles never sit in `active`, so nothing else ever ends a forever
+       * hold once its channel gates off - the alpha and loom rAF would outlive
+       * the cap and every later trigger would land on this early return. */
+      if (h.forever) {
+        if (h.hideTimer) { ctx.timers.cancel(h.hideTimer); h.hideTimer = 0; }
+        h.forever = false; h.heldAlpha = 0;
+        h.el.style.opacity = '0'; loomActive(h, false);
+      }
+      return null;
+    }
     const spec = washSpec(washKind === 'drain' || washKind === 'braindrain' ? 'braindrain' : washKind,
       ctx.magnitude(strength), opts.durationMult || 1);
     const alpha = Math.min(spec.alpha, clamp01(opts.alpha == null ? spec.alpha : ctx.pct(opts.alpha))) * (ctx.reduced() ? 0.7 : 1);
@@ -212,7 +251,18 @@ export function createSustained(ctx) {
        fell back to 0 and silently killed the class's wheel. */
     if (opts.sustainForever === true) {
       h.forever = true; h.heldAlpha = alpha;
-    } else if (h.forever && alpha > (h.heldAlpha || 0)) {
+      /* Touch renewal deadline: the pixels stay at heldAlpha, only the loom
+       * rAF stops - every trigger cancels hideTimer above, so the next
+       * re-trigger renews the deadline and wakes the loop. Desktop keeps the
+       * timerless hold. */
+      if (touchClass()) {
+        h.hideTimer = ctx.timers.after(WASH_FOREVER_RENEW_MS, () => { h.hideTimer = 0; loomActive(h, false); });
+      }
+    } else if (h.forever && (h.heldAlpha || 0) > 0.02 && alpha > (h.heldAlpha || 0)) {
+      /* A FLARE only over a held alpha above the whisper floor: heldAlpha can
+       * be scaled under the flat 0.02 whisper (live in sort), and a step-down
+       * mistaken for a flare leaves `forever` set with the loom running
+       * invisibly for the rest of the class. */
       const back = h.heldAlpha;
       h.hideTimer = ctx.timers.after(holdMs, () => { h.el.style.opacity = String(back); h.hideTimer = 0; });
     } else {
@@ -260,7 +310,11 @@ export function createSustained(ctx) {
     const variant = ctx.variant('row_drift', bg, opts.variant);
     const phase = targets.map((_, i) => (opts.stagger === false ? 0 : i * 0.7 + ctx.rng() * 0.3));
 
-    if (ctx.reduced() || ctx.motion() <= 0) {
+    /* Touch rides the breathe degrade too: a per-frame translate3d write on
+     * every row is main-thread layout traffic a phone does not owe. The rng is
+     * safe - phase[] drew per target ABOVE this branch, so both paths consume
+     * identical draws (shared-rng law). */
+    if (ctx.reduced() || ctx.motion() <= 0 || touchClass()) {
       // degrade: slow opacity breathing, no transforms at all
       for (const t of targets) { try { t.classList.add('ae-drift', 'ae-drift-breathe'); } catch { /* ignore */ } }
       ctx.fx('row_drift', 'breathe');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
@@ -47,13 +47,14 @@ export const isVideoUrl = (url) => VIDEO_URL_RE.test(String(url || ''));
  * THE TOUCH RUNG reads `.ae-touch` on <html>, set the same way and by the same
  * kind of caller, and it is a HARDWARE ceiling rather than a quality level: iOS
  * caps concurrent hardware decode SESSIONS (three or four before VideoToolbox
- * thrashes and every stream stutters), so a phone gets 3 even on the FULL rung.
- * The two compose the protective way - fewer decoders always wins - so
- * touch+lite is min(2,3) = 2 and a lite phone is never handed MORE video than a
- * lite desktop. */
+ * thrashes and every stream stutters), and the mobile graphics diet found even
+ * two simultaneous 854x480 decodes fighting the game for the frame - so a
+ * phone gets ONE decoration decoder, on the FULL rung too. The two compose the
+ * protective way - fewer decoders always wins - so touch+lite is min(2,1) = 1
+ * and a lite phone is never handed MORE video than a lite desktop. */
 export const VIDEO_BUDGET = 6;
 export const VIDEO_BUDGET_LITE = 2;
-export const VIDEO_BUDGET_TOUCH = 3;
+export const VIDEO_BUDGET_TOUCH = 1;
 let liveVideos = 0;
 /** How many decoration <video> nodes mediaEl has minted and not yet released. */
 export const liveVideoCount = () => liveVideos;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
@@ -251,6 +251,11 @@ export default {
     let plan = null;
     let reduced = false;
     let coarse = false;
+    /* Does this class have a LOOP LANE at all? Set once, in claimAssets(), from
+     * the same facts dealUrl's `videoOk` runs on (they cannot change mid-class)
+     * plus whether the library holds local loops. False = the class claims no
+     * loops and dealUrl never draws one; see claimAssets for the why. */
+    let loopLane = true;
     let retake = false;
     let budgetMs = 300000;
     let pool = null;
@@ -573,13 +578,14 @@ export default {
       let firstVideo = null;
       for (let k = 0; k < MEDIA_TRIES; k++) {
         const kind = reduced || k >= 3 ? 'still' : 'loop';
-        /* TOUCH (0825, orchestrator-ruled): the coarse class claims no loops
-         * (see claimAssets) and can never paint one - videoOk is false for the
-         * whole class - so a loop draw here would burn provider rng forecasting
-         * mp4s the grid cannot wear. Skipped WITHOUT drawing. This moves which
-         * emissions a TOUCH device consumes vs old builds; desktop paths
-         * (reduced, big grid, motion-capped) draw exactly as before. */
-        if (coarse && kind === 'loop') continue;
+        /* NO LOOP LANE (0825 touch, widened 0826): when the class claims no
+         * loops (see claimAssets) the loop pool is the placeholder floor, so a
+         * loop draw here would either burn provider rng forecasting mp4s the
+         * grid cannot wear or - worse - hand back a bundled SVG and paint the
+         * whole board with it. Skipped WITHOUT drawing. This moves which
+         * emissions such a class consumes vs old builds; a class that KEEPS
+         * its loop lane draws exactly as before. */
+        if (!loopLane && kind === 'loop') continue;
         let a = null;
         try { a = pool.next(kind); } catch (e) { a = null; }
         const url = a && a.url ? String(a.url) : '';
@@ -1404,16 +1410,41 @@ export default {
       applyFace(cur.oddIndex);
     }
 
+    /** Does the library hold LOCAL loop media (gifs on the player's own disk)?
+     *  Deterministic from the host's manifest - no rand, no network. */
+    function haveLocalLoops() {
+      try {
+        const s = ctx.assets && typeof ctx.assets.stats === 'function' ? ctx.assets.stats() : null;
+        return !!(s && s.local && (s.local.loop | 0) > 0);
+      } catch (e) { return false; }
+    }
+
     function claimAssets() {
-      /* TOUCH-AWARE SPEC (0825, orchestrator-ruled): on a coarse device
-       * dealUrl() can never paint a loop (videoOk is false for the whole
-       * class), so asking for 10 loops wasted the warm budget forecasting
-       * mp4s while the still lane - the one the device lives on - stopped
-       * refilling at 4 rows (provider askRemote = max(4, spec)). Desktop
-       * keeps the manifest spec exactly as-is. */
-      const claimSpec = coarse
-        ? { loops: 0, targets: 0, stills: 12, canvasSafe: false }
-        : { loops: 10, targets: 0, stills: 4, canvasSafe: false };
+      /* THE LOOP LANE (0825 touch, widened 0826 desktop). dealUrl() can only
+       * paint a VIDEO url when `videoOk` holds - grid <= VIDEO_GRID_MAX, full
+       * motion, not reduced, not coarse (rounds.js: N playing <video> elements
+       * pin the page to 30Hz) - and that predicate is constant for a whole
+       * class, because the grid size is dealt once with the plan. So from tier
+       * 2 up, where the grid is 4x4 or 5x5, the 10 loops this class used to
+       * claim were UNDRAWABLE: every loop draw returned an mp4 dealUrl threw
+       * away, the warm rail spent its bandwidth on those mp4s, and the still
+       * lane - the only lane that paints - stopped refilling at 4 rows
+       * (askRemote's goal was max(4, spec)). Four stills across ~129 rounds is
+       * the duplicate wall the owner reported.
+       *
+       * A loop draw is still worth making when the pool can answer it with a
+       * GIF, which is an <img> and needs no video at all - so on DESKTOP the
+       * lane closes only when videos are undrawable AND the library has no
+       * local loops. A COARSE device keeps the 0825 ruling unconditionally:
+       * no loop lane at all, gifs included. Deterministic from tier /
+       * settings / the host manifest; no rand. */
+      const videoClass = n <= PLAYTEST.VIDEO_GRID_MAX && !reduced && !coarse && motionLevelOf(ctx) > 1;
+      loopLane = !coarse && (videoClass || haveLocalLoops());
+      const claimSpec = loopLane
+        ? { loops: 10, targets: 0, stills: 4, canvasSafe: false }
+        : { loops: 0, targets: 0, stills: 12, canvasSafe: false };
+      say('media lane: ' + (loopLane ? 'loops + stills' : 'stills only')
+        + ' (grid ' + n + 'x' + n + ', video ' + (videoClass ? 'ok' : 'off') + ')');
       Promise.resolve()
         .then(() => ctx.assets.claim(claimSpec))
         .then((p) => {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/style.js
@@ -403,6 +403,44 @@ html.arc-reduced .g-an-hw-wash,html.arc-reduced .g-an-hw-fig.lie::after{transfor
 .g-an-howto{pointer-events:auto}
 .g-an-hw-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   The shell arms .ae-touch on <html> for coarse-pointer devices at boot. Two
+   blended layers were the cost here: the film grain overlaid the whole room
+   and re-stepped four times a second, and the sheet's LIE wash was a node
+   three viewports wide screening itself across the figure forever. Both stop
+   blending and stop moving - the grain still speckles, and the wash parks
+   mid-sweep at the same 33% html.arc-reduced already uses, so THE LIE still
+   reads as a lie. Every forever-glow (the ignited frame, the bell clock, GO)
+   freezes at its LIT frame, and the cells breathe on opacity instead of a
+   brightness filter. Desktop is untouched.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-an-bd-grain{mix-blend-mode:normal;opacity:.1}
+html.ae-touch .g-an-bd-grain::before{animation:none}
+/* reduced motion still takes the grain all the way out (it says opacity:0
+   earlier in this sheet, and the rule above would otherwise outrank it) */
+html.arc-reduced.ae-touch .g-an-bd-grain{opacity:0}
+@media (prefers-reduced-motion: reduce){html.ae-touch .g-an-bd-grain{opacity:0}}
+html.ae-touch .g-an-hw-wash,html.ae-touch .g-an-hw-fig.lie::after{
+  mix-blend-mode:normal;animation:none;transform:translate3d(33%,0,0);opacity:.8}
+/* the safelight's one-shot sweep: the swing, without the brightness pass */
+html.ae-touch .g-an-bd-lamp.sweep::before{animation:g-an-sweep-t .9s ease-in-out 1}
+@keyframes g-an-sweep-t{0%{transform:rotate(-1.6deg)}50%{transform:rotate(4deg)}
+  100%{transform:rotate(1.6deg)}}
+/* the ignited frame: it stays ignited, it just stops pumping four shadows */
+html.ae-touch .g-an-stage.g-an-lit .g-an-grid,html.ae-touch .g-an-grid.is-lit{animation:none}
+/* the bell / warning clock: frozen at the bright end */
+html.ae-touch .g-an-stage.g-an-bell .g-an-clock,
+html.ae-touch .g-an-stage[data-phase="bell"] .g-an-clock,
+html.ae-touch .g-an-stage[data-warn="1"] .g-an-clock{animation:none;
+  box-shadow:0 0 16px rgba(240,194,75,.7)}
+/* the sheet: nine cells breathing on a brightness filter, in step */
+html.ae-touch .g-an-hw-cell{animation:g-an-hw-step-t 1.6s ease-in-out infinite alternate}
+@keyframes g-an-hw-step-t{from{opacity:.72}to{opacity:1}}
+/* the pointing hand: a drop-shadow re-rastered on every frame of its move */
+html.ae-touch .g-an-hw-tap{filter:none}
+html.ae-touch .g-an-hw-go{animation:none;
+  box-shadow:0 0 34px hsl(var(--an-hue) 90% 60% / .75), 0 4px 0 hsl(var(--an-hue) 70% 30%)}
+
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/trickster.js
@@ -184,6 +184,23 @@ html.arc-reduced .g-an-tk-wax::before,html.arc-reduced .g-an-tk-wax::after{displ
 html.arc-reduced .g-an-tk-outline.on{animation:none;opacity:.9}
 html.arc-reduced .g-an-tk-refund.on{animation:none;opacity:1}
 .g-an-stage.suspended .g-an-tk *{animation-play-state:paused !important}
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   Coarse pointer. The lure ghost pulsed a drop-shadow forever - a filter
+   re-rastered every frame on a node a transition is also moving - and the stat
+   flicker keyframed brightness+contrast. Both keep their beat on opacity
+   instead; the ghost keeps its shape and its colour, it just stops breathing
+   its glow. The chrome still's two static passes (saturate/contrast over a
+   decoded photo) come off too. Nothing here is hidden: it is all read.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-an-tk-ghost{filter:none}
+html.ae-touch .g-an-tk-ghost.lure{animation:g-an-tk-ghostpulse-t 1.5s ease-in-out infinite}
+@keyframes g-an-tk-ghostpulse-t{50%{opacity:.78}}
+html.ae-touch .g-an-tk-flick{animation:g-an-tk-static-t .16s steps(3) 2}
+@keyframes g-an-tk-static-t{0%{opacity:1}40%{opacity:.55}100%{opacity:1}}
+/* the twin is a new name, so the reduced gate has to say its kill again */
+html.arc-reduced.ae-touch .g-an-tk-flick{animation:none}
+@media (prefers-reduced-motion: reduce){html.ae-touch .g-an-tk-flick{animation:none}}
+html.ae-touch .g-an-tk-chrome img{filter:none}
 `;
 
 function ensureStyle() {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
@@ -654,6 +654,57 @@ html.arc-reduced .g-cp-tile.is-hint::after{opacity:1}
 .g-cp-howto{pointer-events:auto}
 .g-cp-hw-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   The shell arms .ae-touch on <html> for coarse-pointer devices at boot. The
+   studio's three blended layers each made the phone read the backdrop back out
+   of the framebuffer, two of them behind a blur as well; the varnish sheen and
+   the mote drift repainted their whole layer every frame; and the deal flash
+   keyframed a filter across the ENTIRE board six or seven times a class. On
+   touch the wash layers paint flat (saturate stays - one shader pass, and it
+   is what made the wash a ghost instead of a picture), the drifts hold still,
+   and every filter/box-shadow loop is either frozen at its LIT frame or given
+   a transform/opacity twin. The hint ring is a READ, so it freezes bright, the
+   way html.arc-reduced already leaves it. Desktop is untouched.
+   -------------------------------------------------------------------------- */
+/* the asset wash on the wall: no backdrop read, no full-stage blur */
+html.ae-touch .g-cp-bd-wall::after{mix-blend-mode:normal;filter:saturate(.2);
+  opacity:calc(var(--cp-n-a-asset,0) * .8)}
+/* the same pool as the end card's paper */
+html.ae-touch .g-cp-end::before{mix-blend-mode:normal;filter:saturate(.1);
+  opacity:calc(var(--cp-n-a-asset,0) * 1.1)}
+/* the sheet's wash veil: blend + blur on a node that pulses forever */
+html.ae-touch .g-cp-hw-wash .g-cp-hw-a{mix-blend-mode:normal;filter:none}
+/* the motes stay in the lamplight, they just stop drifting (a background
+   -position loop repaints the whole masked layer every frame) */
+html.ae-touch .g-cp-bd-motes::before{animation:none}
+/* the varnish sheen runs on EVERY locked face at once; frozen it is gloss */
+html.ae-touch .g-cp-tile.is-locked .g-cp-face::after{animation:none;
+  background-position:60% 0}
+/* THE RESCUE ring: frozen at its bright frame, never dark (arc-reduced twin) */
+html.ae-touch .g-cp-tile.is-hint::after{animation:none;opacity:1;
+  box-shadow:0 0 22px color-mix(in srgb, var(--lav), transparent 30%), inset 0 0 14px color-mix(in srgb, var(--lav), transparent 50%)}
+/* the three forever-glow chips freeze lit */
+html.ae-touch .g-cp-stage.g-cp-bell .g-cp-chip.g-cp-clock{animation:none;
+  box-shadow:0 0 16px rgba(240,194,75,.7)}
+html.ae-touch .g-cp-hud .g-cp-finish{animation:none;
+  box-shadow:0 0 18px color-mix(in srgb, var(--pink), transparent 58%)}
+html.ae-touch .g-cp-hw-go{animation:none;
+  box-shadow:0 0 30px color-mix(in srgb, var(--lav), transparent 30%), 0 3px 0 color-mix(in srgb, var(--lav), black 35%)}
+/* THE DEAL: same beat, on opacity and scale instead of a whole-board filter */
+html.ae-touch .g-cp-stage[data-phase="dealing"] .g-cp-board,
+html.ae-touch .g-cp-board.is-dealing{animation:g-cp-deal-t 640ms cubic-bezier(.2,.7,.3,1) both}
+@keyframes g-cp-deal-t{0%{opacity:.2;transform:scale(1.035)}
+  50%{opacity:1}100%{opacity:1;transform:none}}
+/* the sheet's bank flash: keep the pop, drop the brightness/saturate frame */
+html.ae-touch .g-cp-hw-bank .g-cp-hw-a{animation:g-cp-hwbank-t 3.4s ease-in-out infinite}
+@keyframes g-cp-hwbank-t{0%,22%{opacity:1;transform:scale(1)}
+  34%{opacity:1;transform:scale(1.04)}48%,100%{opacity:0;transform:scale(.92)}}
+/* the sheet's lock snap: transform only, the ring node already draws the land */
+html.ae-touch .g-cp-hw-lock .g-cp-hw-a{animation:g-cp-hwlock-t 2.6s ease-out infinite;
+  box-shadow:0 3px 8px rgba(0,0,0,.6)}
+@keyframes g-cp-hwlock-t{0%,20%{transform:translateX(var(--hw-s))}
+  38%,88%{transform:translateX(0)}100%{transform:translateX(var(--hw-s))}}
+
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
@@ -206,6 +206,23 @@ html.arc-reduced .g-cp-preview .g-cp-pv{animation:none !important;filter:none;bo
   .g-cp-tile.g-cp-melt::after{opacity:0}
   .g-cp-preview .g-cp-pv{animation:none !important;filter:none;box-shadow:none}
 }
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   Coarse pointer. The lie layer is n*n ghost tiles at once, and DATAMOSH gave
+   every one of them a keyframed saturate + hue-rotate + blur - three filter
+   passes per tile per frame, the most expensive thing the trickster owns. On
+   touch that variant degrades to the same plain ghost the reduced-motion gate
+   already ships (the lie still shows; it just does not churn), RGBSPLIT keeps
+   its shudder and its chroma edges but drops its per-tile contrast pass, and
+   the melt keeps its sag on transform alone - the border-radius morph in the
+   loop was repainting a filtered face every frame. Desktop is untouched.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-cp-preview.is-on.g-cp-pv-mosh .g-cp-pv{animation:none;filter:none}
+html.ae-touch .g-cp-preview.is-on.g-cp-pv-rgb .g-cp-pv{filter:none}
+html.ae-touch .g-cp-tile.g-cp-melt .g-cp-face,
+html.ae-touch .g-cp-tile.g-cp-melt::before{animation:g-cp-meltbody-t 2.4s ease-in-out infinite alternate}
+@keyframes g-cp-meltbody-t{from{transform:scaleY(1) skewX(0)}
+  to{transform:scaleY(1.08) skewX(-3deg) translateY(3%)}}
+html.ae-touch .g-cp-tile.g-cp-melt .g-cp-face{filter:saturate(.85)}
 `;
 function ensureStyle() {
   try {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
@@ -434,6 +434,59 @@ html.arc-reduced .g-dt-mq{opacity:.16}
 .g-dt-howto{pointer-events:auto}
 .g-dt-hw-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- THE PHONE CEILING (html.ae-touch) ----------------------------------
+   The shell arms .ae-touch on <html> for coarse-pointer devices at boot. A
+   phone GPU pays for every blurred layer and for every keyframe that repaints
+   a filter, a box-shadow or a text-shadow; the room's two biggest nodes (the
+   lamp at 38vw x 34vh and the neon bleed) were both wearing large blurs. The
+   room keeps its colours - the gradients are the light, the blur only softened
+   the edge - and every animation that carries a read is frozen at its lit
+   state or given a transform/opacity twin, never hidden. Desktop is untouched.
+   ------------------------------------------------------------------------- */
+/* the lamps: the gradient IS the glow. Drop the 46px blur, widen the falloff
+   so the edge stays soft, keep the slow breath (opacity only = compositor). */
+html.ae-touch .g-dt-lamp{filter:none;
+  background:radial-gradient(closest-side,
+    var(--dt-n-lamp, rgba(240,194,75,.22)) 0%,
+    color-mix(in srgb, var(--dt-n-lamp, rgba(240,194,75,.22)), transparent 55%) 42%,
+    transparent 84%)}
+/* the door neon: cheap blur, and the 7s flicker freezes lit (as arc-reduced) */
+html.ae-touch .g-dt-neonbleed{filter:blur(12px);animation:none;opacity:1}
+/* the marquee's gold drop-shadow re-rasterised every frame of the crawl */
+html.ae-touch .g-dt-mq.g-dt-mq-gold{filter:none}
+html.ae-touch .g-dt-mq.g-dt-mq-flash{animation:g-dt-mqflash-t .6s ease-out 1}
+@keyframes g-dt-mqflash-t{0%{opacity:1}100%{opacity:var(--g-dt-mqa,.25)}}
+/* HUD chips: no live blur behind glass, so the glass turns solid instead */
+html.ae-touch .g-dt-hud .chip{backdrop-filter:none;-webkit-backdrop-filter:none;
+  background:color-mix(in srgb, var(--navy,#1A1A2E), transparent 6%)}
+/* the chalk whisper wrote itself in with a blur ramp: opacity-only twin */
+html.ae-touch .g-dt-whisper{animation:g-dt-whisperin-t 3.4s ease-in-out both}
+@keyframes g-dt-whisperin-t{0%{opacity:0}18%{opacity:.85}78%{opacity:.85}100%{opacity:0}}
+/* the certificate word pulsed a 110px text-shadow forever: scale-only twin */
+html.ae-touch .g-dt-cer .g-dt-word{animation:g-dt-pulse-t 1.5s ease-in-out infinite}
+/* the bad certificate keeps ITS loop (letter-spacing + opacity, no shadow) -
+   the touch rule above out-specifies .g-dt-cer.bad, so hand it back by name */
+html.ae-touch .g-dt-cer.bad .g-dt-word{animation:g-dt-invert 1.1s steps(2) infinite}
+@keyframes g-dt-pulse-t{50%{transform:scale(1.06)}}
+/* the rules sheet: two infinite box-shadow loops freeze at their lit frame,
+   and the keycap keeps its press on transform alone */
+html.ae-touch .g-dt-hw-cell.caret{animation:none;
+  box-shadow:inset 0 -3px 0 var(--pink,#FF69B4)}
+html.ae-touch .g-dt-hw-slab.next{animation:none;
+  box-shadow:0 0 10px rgba(255,105,180,.55)}
+html.ae-touch .g-dt-hw-key{animation:g-dt-hw-press-t 3.4s ease-in-out infinite}
+@keyframes g-dt-hw-press-t{0%,84%{transform:translateY(0)}
+  90%{transform:translateY(2px)}100%{transform:translateY(0)}}
+/* reduced motion still wins on touch (the sheet's kills carry !important),
+   but the twins above are new names, so say the freeze once more for them */
+html.arc-reduced.ae-touch .g-dt-cer .g-dt-word,
+html.arc-reduced.ae-touch .g-dt-whisper,
+html.arc-reduced.ae-touch .g-dt-hw-key{animation:none !important}
+@media (prefers-reduced-motion: reduce){
+  html.ae-touch .g-dt-cer .g-dt-word,html.ae-touch .g-dt-whisper,
+  html.ae-touch .g-dt-hw-key{animation:none !important}
+}
+
 `;
 
 /** Inject once per document. No-op headless (and never throws). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
@@ -549,6 +549,43 @@ html.arc-reduced .g-dv-hw-lock{opacity:1}
 .g-dv-howto{pointer-events:auto}
 .g-dv-hw-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   The shell arms .ae-touch on <html> for coarse-pointer devices at boot. The
+   worst thing in this sheet was the tell: a screen-blended scanline plate
+   re-blending itself five and a half times a SECOND for as long as the
+   telegraph runs, over a card that was shuddering a box-shadow at the same
+   time. The tell is a read the whole game rests on, so it keeps its shudder
+   (transform only) and keeps its scanlines - they just paint flat and hold
+   still, the way html.arc-reduced already leaves them, only lit instead of
+   blanked. The other win is invisible: a locked card is a FILTERED card, and
+   the ken-burns drift inside it made the phone re-run that filter every frame
+   for every archived plate on the board. Filed plates now hold still; lit
+   plates still drift. Desktop is untouched.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-dv-card.tell::before{mix-blend-mode:normal;animation:none;opacity:.5}
+html.ae-touch .g-dv-card.tell{animation:g-dv-shudder-t .6s linear infinite}
+@keyframes g-dv-shudder-t{0%,100%{transform:none}20%{transform:translateX(-2px)}
+  45%{transform:translateX(2px)}70%{transform:translateX(-1px)}}
+/* an archived plate is a filtered plate: it stops drifting under the filter */
+html.ae-touch .g-dv-kb .g-dv-card.locked .g-dv-face:not(.g-dv-glyph){animation:none}
+/* THE ALMOST haunted the card through a blur ramp: opacity-only twin */
+html.ae-touch .g-dv-almost{animation:g-dv-almost-t .62s ease-out both}
+@keyframes g-dv-almost-t{0%{opacity:0}30%{opacity:.55}70%{opacity:.5}100%{opacity:0}}
+/* the bell marquee's drop-shadow sat over four crawling bulb bars */
+html.ae-touch .g-dv-mq.g-dv-mq-bell{filter:none}
+html.ae-touch .g-dv-mq.g-dv-mq-flash{animation:g-dv-mqflash-t .6s ease-out 1}
+@keyframes g-dv-mqflash-t{0%{opacity:1}100%{opacity:var(--g-dv-mqa,.26)}}
+/* the twins carry new names, so the reduced gate has to say its kills again */
+html.arc-reduced.ae-touch .g-dv-card.tell{animation:none;border-color:var(--gold);
+  box-shadow:0 0 0 2px rgba(240,194,75,.55)}
+html.arc-reduced.ae-touch .g-dv-card.tell::before{animation:none;background:none}
+html.arc-reduced.ae-touch .g-dv-almost,
+html.arc-reduced.ae-touch .g-dv-mq.g-dv-mq-flash{animation:none}
+@media (prefers-reduced-motion: reduce){
+  html.ae-touch .g-dv-card.tell,html.ae-touch .g-dv-card.tell::before,
+  html.ae-touch .g-dv-almost,html.ae-touch .g-dv-mq.g-dv-mq-flash{animation:none}
+}
+
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/casino.js
@@ -229,6 +229,16 @@ html.arc-reduced .g-ec-cs-pool{animation:none !important;transition:opacity .4s 
 html.arc-reduced .g-ec-cs-pool.hum{animation:none !important;opacity:.8}
 html.arc-reduced .g-ec-cs-glint.on{animation:none;opacity:.7}
 html.arc-reduced .g-ec-cs-word.on{animation:none;opacity:1}
+/* THE PHONE DIET (html.ae-touch, core/device.js): the marquee keeps its chase
+   and the pools keep their blooms, but the blurred bulb shadows, the whole-halo
+   filter pass on a flash and the infinite filter keyframe on the pools stand
+   down - those are per-frame rasters a phone GPU pays for, 24-36 bulbs at a
+   time. Desktop (no ae-touch) is untouched. */
+html.ae-touch .g-ec-mq-bulb{box-shadow:0 0 5px hsl(var(--ec-mq-hue) 95% 70% / .8)}
+html.ae-touch .g-ec-mq.flash .g-ec-mq-bulb{filter:none;animation-duration:var(--ec-mq-t)}
+html.ae-touch .g-ec-cs-pool{animation:none}
+html.ae-touch .g-ec-cs-pool.hum{animation:none;opacity:.8}
+html.ae-touch .g-ec-cs-pool.cold,html.ae-touch .g-ec-cs-pool.warm{filter:none}
 .g-ec-stage.suspended .g-ec-mq-bulb,.g-ec-stage.suspended .g-ec-cs-pool,.g-ec-stage.suspended .g-ec-cs-word,
 .g-ec-stage.suspended .g-ec-cs-glint{animation-play-state:paused !important}
 `;
@@ -310,7 +320,8 @@ function qs(root, sel) {
  * @param {Object} o
  *   seed, tier (1..4), stage (.g-ec-stage), board (.g-ec-ring), hud (the
  *   .g-ec-hud element OR {len, clock, streak, best}), backdrop (.g-ec-backdrop),
- *   timers {after, every?, clear|cancel}, reduced, capsOk (bool or () => bool),
+ *   timers {after, every?, clear|cancel}, reduced, coarse (touch pointer -
+ *   the perf diet), capsOk (bool or () => bool),
  *   t (key, fallback) => string, engine {fire, ceremony?, channels?}, log,
  *   optional: pads () => Element[] (else read off the board), padCount
  */
@@ -320,6 +331,7 @@ export function createEcCasino(o) {
   const say = typeof opts.log === 'function' ? opts.log : () => {};
   const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
   const reduced = !!opts.reduced;
+  const coarse = !!opts.coarse;
   const tier = Math.max(1, Math.min(4, Math.round(Number(opts.tier) || 1)));
   const audioCeil = C.AUDIO_CEIL[tier] || C.AUDIO_CEIL[1];
   const eng = opts.engine || {};
@@ -540,7 +552,11 @@ export function createEcCasino(o) {
   function flashHalo(strength, ms) {
     if (!halo || !armed() || reduced) return;
     setVar(halo, '--ec-mq-f', Math.max(1, Math.min(2.2, Number(strength) || 1)).toFixed(2));
-    restart(halo, 'flash');
+    /* On touch the diet keeps the chase running through a flash (same duration,
+     * no filter), so there is no animation to re-home - the restart()'s forced
+     * reflow would be a payout-priced layout for nothing. */
+    if (coarse) setCls(halo, 'flash', true);
+    else restart(halo, 'flash');
     cancel(flashTimer);
     flashTimer = after(ms || C.MQ_FLASH_MS, () => { flashTimer = 0; setCls(halo, 'flash', false); });
   }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/index.js
@@ -178,8 +178,17 @@ const CLIP_CHANCE = 0.25;
  *  faces, kept plumbed but no longer the look anyone gets by accident. */
 const FACE_MODES = Object.freeze(['words', 'glyphs', 'media']);
 
-/** How often the honest window ring repaints (the trickster polls it). */
+/** How often the honest window ring repaints (the trickster polls it). On a
+ *  touch device the ring repaints at 100ms - the countdown cue keys off the
+ *  SECOND boundary (windowTickSec), never the tick count, so the cue count is
+ *  identical at either cadence. */
 const WINDOW_TICK_MS = 60;
+const WINDOW_TICK_MS_COARSE = 100;
+
+/** The resize -> refit debounce (both platforms; the RESULT is identical, the
+ *  fit just waits for the trailing edge - iOS fires resize continuously while
+ *  the URL bar collapses). */
+const RESIZE_DEBOUNCE_MS = 150;
 
 /* Diagnostics seams (the DV / DE precedent): the live class, the last report,
  * the final snapshot. The shell never reads these; the harness does. */
@@ -311,6 +320,7 @@ export default {
     let seed = '';
     let tier = 1;
     let reduced = false;
+    let coarse = false;                 // touch pointer (the perf diet; set in start)
     let retake = false;
     let audible = true;
     let budgetMs = 120000;
@@ -391,7 +401,10 @@ export default {
     let rulerEl = null;                 // the hidden measuring span (see ruler())
     let tokenW100 = 0;                  // widest dealt word at 100px type
     let fitPending = 0;
+    let fitKey = '';                    // memo: pad width + the dealt hand (see fitWords)
+    let lastFitPadPx = 0;               // the pad width the last fit measured (resize early-out)
     let onResize = null;
+    let resizeDebounce = 0;             // the trailing-edge resize timer
     /* THE CLIP ROLL (CLIP_CHANCE). `clipUntil` is when the airwave frees up. */
     let clipRoll = null;
     let clipBeat = 0;
@@ -407,6 +420,9 @@ export default {
     let stage = null; let backdrop = null; let hud = null; let ring = null;
     let msgEl = null; let well = null; let endEl = null; let howtoEl = null;
     let lenChip = null; let clockChip = null; let streakChip = null; let bestChip = null;
+    /* The streak meter currently MOUNTED in the chip, and the pair that drew it
+     * (see paintStreak). -1 means "nothing mounted, rebuild". */
+    let streakMeterEl = null; let streakMeterLit = -1; let streakMeterGold = false;
     /* THE TURN, drawn twice over so neither the ear nor a still frame can miss
      * it: the BANNER says whose turn it is in words, the STRIP says how far
      * through the sequence we are in dots. Both are attribute+text only, so
@@ -1108,23 +1124,57 @@ export default {
           el.style.fontSize = '100px';
         }
       } catch (e) { /* the CSS floor already dressed it */ }
+      /* ONE LAYOUT, NOT ONE PER TOKEN. Every write lands first - a child span
+       * per token, wearing the ruler's type by inheritance - and every width is
+       * read in a second pass, so the whole hand costs a single forced layout
+       * where the old write/read interleave forced one per token (12-24 a fit).
+       * Same numbers on both platforms: each span is its own inline box and its
+       * rect is the token's advance, exactly what the single-node measure was. */
+      const spans = [];
+      try { el.textContent = ''; } catch (e) { /* noop */ }
       for (let i = 0; i < padWords.length; i++) {
         const parts = String(padWords[i] || '').split(/\s+/);
         for (let k = 0; k < parts.length; k++) {
           if (!parts[k]) continue;
           try {
-            el.textContent = parts[k];
-            const w = el.getBoundingClientRect().width || 0;
-            if (w > tokenW100) tokenW100 = w;
+            const s = document.createElement('span');
+            s.textContent = parts[k];
+            el.appendChild(s);
+            spans.push(s);
           } catch (e) { /* noop */ }
         }
       }
+      for (let i = 0; i < spans.length; i++) {
+        try {
+          const w = spans[i].getBoundingClientRect().width || 0;
+          if (w > tokenW100) tokenW100 = w;
+        } catch (e) { /* noop */ }
+      }
       try { el.textContent = ''; } catch (e) { /* noop */ }
+    }
+    /** The pads the fit actually has to read: pad 0 and the longest phrase.
+     *  Every pad wears the SAME box (one --ec-pad, one --ec-word-px) so the two
+     *  tests below are decided by the phrase alone - the wrap test by the
+     *  longest one, and the no-split test by tokenW100, which measureTokens
+     *  already takes across the WHOLE hand, not per pad. Reading all six was
+     *  six forced layouts per binary-search step for the same verdict. */
+    function fitProbeIdx() {
+      const out = [];
+      if (padWords[0]) out.push(0);
+      let longest = -1;
+      for (let i = 0; i < padEls.length; i++) {
+        if (!padWords[i]) continue;
+        if (longest < 0 || String(padWords[i]).length > String(padWords[longest]).length) longest = i;
+      }
+      if (longest >= 0 && longest !== 0) out.push(longest);
+      return out;
     }
     function ringFitsAt(px) {
       if (!stage) return true;
       try { stage.style.setProperty('--ec-word-px', px + 'px'); } catch (e) { return true; }
-      for (let i = 0; i < padEls.length; i++) {
+      const probes = fitProbeIdx();
+      for (let n = 0; n < probes.length; n++) {
+        const i = probes[n];
         if (!padWords[i]) continue;
         const w = wordNodeOf(padEls[i]);
         if (!w) continue;
@@ -1150,6 +1200,17 @@ export default {
           ? Math.round(padEls[0].getBoundingClientRect().width) : 0;
       } catch (e) { padPx = 0; }
       if (!padPx) return;               // not laid out yet; the next pass gets it
+      lastFitPadPx = padPx;
+      /* THE MEMO. The fitted px is a pure function of the pad's width and the
+       * dealt hand (the word's type never changes inside a class), so the same
+       * key skips the token measure and the whole binary search: the trickster's
+       * label lie and an iOS URL-bar resize both re-ask for a fit that cannot
+       * have changed. Both platforms - a hit repaints the SAME px it computed. */
+      const key = padPx + '|' + padWords.join('');
+      if (key === fitKey && fittedPx > 0) {
+        try { stage.style.setProperty('--ec-word-px', fittedPx + 'px'); } catch (e) { /* noop */ }
+        return;
+      }
       measureTokens();                    // the widest word, once, for every candidate
       const maxPx = Math.max(
         PLAYTEST.FIT_MIN_PX,
@@ -1157,6 +1218,7 @@ export default {
       );
       const px = fitFontPx({ maxPx, minPx: PLAYTEST.FIT_MIN_PX, fits: ringFitsAt });
       try { stage.style.setProperty('--ec-word-px', px + 'px'); } catch (e) { /* noop */ }
+      fitKey = key;
       if (px !== fittedPx) {
         fittedPx = px;
         say('fit: the ring wears ' + px + 'px (pad ' + padPx + 'px, longest "'
@@ -1245,22 +1307,48 @@ export default {
     }
     function paintStreak() {
       if (!streakChip) return;
+      const label = 'x ' + pressStreak;
       if (pressStreak < PLAYTEST.STREAK_VISIBLE) {
         streakChip.hidden = true;
-        streakChip.textContent = 'x ' + pressStreak;
+        streakChip.textContent = label;      // takes the meter with it
+        streakMeterEl = null; streakMeterLit = -1;
         return;
       }
       streakChip.hidden = false;
-      streakChip.textContent = 'x ' + pressStreak;
+      const filled = Math.min(PLAYTEST.STREAK_CAP, pressStreak);
+      const gold = ratchet >= PLAYTEST.RATCHET_CAP;
       /* The meter is the SHELL's primitive (10 segments, always); it rides
-       * inside the chip so the contract's DOM gains no extra node. */
-      try {
-        const meter = ctx.ceremonies.streakMeter({
-          filled: Math.min(PLAYTEST.STREAK_CAP, pressStreak),
-          gold: ratchet >= PLAYTEST.RATCHET_CAP,
-        });
-        if (meter) streakChip.appendChild(meter);
-      } catch (e) { /* a ceremony must never be the thing that fails */ }
+       * inside the chip so the contract's DOM gains no extra node.
+       *
+       * THE CEREMONY IS ASKED EVERY TIME, unconditionally: streakMeter() is
+       * also where the STREAK CHIME lives (ceremonies.js - the chime ladder
+       * rides the call, not the node), so skipping the call would silence a
+       * cue. What is skipped is the MOUNT. Eleven nodes were torn down and
+       * re-inserted on every press, and the meter can only look different on
+       * (filled, gold) - the count is capped, so a streak past the cap draws
+       * the same ten segments - so an unchanged pair keeps the mounted one and
+       * the label goes into the chip's own text node, which writing through
+       * textContent would take the meter with. The parentNode test is the
+       * honest one: anything that rewrote the chip behind our back re-mounts.
+       * TOUCH ONLY, and that is not timidity: a re-mount replays the segment
+       * shimmer (arc-seg, a per-mount animation), so skipping it is a visible
+       * delta. The phone trades that shimmer for eleven fewer nodes a press;
+       * desktop has the frames and keeps the shimmer. */
+      let meter = null;
+      try { meter = ctx.ceremonies.streakMeter({ filled, gold }); }
+      catch (e) { /* a ceremony must never be the thing that fails */ }
+      if (coarse && filled === streakMeterLit && gold === streakMeterGold
+        && streakMeterEl && streakMeterEl.parentNode === streakChip
+        && streakChip.firstChild && streakChip.firstChild.nodeType === 3) {
+        if (streakChip.firstChild.nodeValue !== label) streakChip.firstChild.nodeValue = label;
+        return;
+      }
+      streakChip.textContent = label;
+      streakMeterEl = null; streakMeterLit = -1;
+      if (meter) {
+        streakChip.appendChild(meter);
+        streakMeterEl = meter; streakMeterLit = filled; streakMeterGold = gold;
+      }
     }
 
     /* ==================================================================== *
@@ -1656,7 +1744,8 @@ export default {
     let windowUntil = 0;
     /* W3 P0-2 / P0-15. The countdown's own state: the last whole-seconds figure
      * we sounded, and how many ticks this window has spent. The ring repaints
-     * every 60ms, so the cue rides the SECOND BOUNDARY and nothing else. */
+     * on WINDOW_TICK_MS (100ms on touch), so the cue rides the SECOND BOUNDARY
+     * and nothing else - the cadence cannot move the cue count. */
     let windowTickSec = -1;
     let windowTickN = 0;
     function armInputWindow() {
@@ -1669,7 +1758,7 @@ export default {
         timerEl.hidden = false;
         try { timerEl.style.setProperty('--ec-k', '1'); } catch (e) { /* noop */ }
       }
-      if (!windowTick) windowTick = every(WINDOW_TICK_MS, paintWindow);
+      if (!windowTick) windowTick = every(coarse ? WINDOW_TICK_MS_COARSE : WINDOW_TICK_MS, paintWindow);
       windowTimer = after(round.windowMs, () => {
         windowTimer = 0;
         if (!inputOpen || dead || ended) return;
@@ -2225,6 +2314,10 @@ export default {
         budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
         retake = !!spec.retake;
         reduced = probeReduced(ctx);
+        /* THE PHONE DIET's one signal. The host populates isTouch (desktop
+         * WebView2 answers false), and it gates the JS half of the diet the
+         * same way html.ae-touch gates the CSS half. It NEVER gates a roll. */
+        coarse = !!(ctx.platform && ctx.platform.isTouch);
         audible = ctx.audioAudible !== false;
         attempt = 0;
         encoreArmed = true;
@@ -2236,7 +2329,12 @@ export default {
         stallCued = false;
         faceUrls.clear();
         clipsFired = 0;
-        faceKind = (reduced || motionLevelOf() <= 1) ? 'still' : 'loop';
+        /* MEDIA FACES ARE STILLS ON A PHONE (../CLAUDE.md trap 42): six pads
+         * dealt a loop is six live decodes, and iOS caps hardware video decode
+         * sessions at ~3-4 - the ring would stall on whichever pads lost the
+         * race. Device-classed on purpose; desktop keeps the motionLevel test
+         * byte-identical. The pool draws the same asset either way. */
+        faceKind = (reduced || coarse || motionLevelOf() <= 1) ? 'still' : 'loop';
 
         try {
           lifetimeBefore = Math.max(0, Math.floor(Number((ctx.store.gameMeta(GAME_KEY) || {}).bestLen) || 0));
@@ -2253,6 +2351,8 @@ export default {
         clipsRolledOff = 0;
         clipsSkipped = 0;
         fittedPx = 0;
+        fitKey = '';                    // a new hand invalidates the memo
+        lastFitPadPx = 0;
         rollLocal = (() => {
           const roll = makeTaggedRoll(seed + '|ec-vr');
           return () => {
@@ -2273,7 +2373,7 @@ export default {
         try {
           casino = createEcCasino({
             seed, tier, stage, board: ring, ring, hud, backdrop,
-            timers: deckTimers, reduced, capsOk, t, engine: deckEngine, assets: deckAssets,
+            timers: deckTimers, reduced, coarse, capsOk, t, engine: deckEngine, assets: deckAssets,
             padEl: (i) => padEls[i] || null,
             pads: () => padEls.slice(),
             padCount: PLAYTEST.PADS,
@@ -2285,7 +2385,7 @@ export default {
             seed, tier, timers: deckTimers, reduced, capsOk,
             stage, board: ring, hud, backdrop, engine: deckEngine, assets: deckAssets,
             budgetSec: Math.round(budgetMs / 1000),
-            coarse: !!(ctx.platform && ctx.platform.isTouch),
+            coarse,
             isHalted: () => dead || paused || ended || busy,
             /* READ-ONLY views of the truth. A deck may READ the ledger (the
              * Ghost Cursor lures to a pad ADJACENT to the due one, which is
@@ -2335,6 +2435,7 @@ export default {
             tier,
             reduced,
             motionLevel: motionLevelOf(),
+            coarse,
             stage,
             ring,
             backdrop,
@@ -2358,7 +2459,27 @@ export default {
         after(220, () => scheduleFit());
         try {
           if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
-            onResize = () => scheduleFit();
+            /* THE TRAILING EDGE. iOS fires resize continuously for the whole
+             * URL-bar collapse, and every one of those asked for a fit. One
+             * fit lands, RESIZE_DEBOUNCE_MS after the last event, and it is
+             * skipped outright when the pad has settled back to the width the
+             * last fit already measured - one rect read, against a fit that
+             * measures the hand and walks a binary search. Both platforms; the
+             * same final px, just once instead of per event. */
+            onResize = () => {
+              if (resizeDebounce) clearTimer(resizeDebounce);
+              resizeDebounce = after(RESIZE_DEBOUNCE_MS, () => {
+                resizeDebounce = 0;
+                if (dead) return;
+                let padPx = 0;
+                try {
+                  padPx = (padEls[0] && typeof padEls[0].getBoundingClientRect === 'function')
+                    ? Math.round(padEls[0].getBoundingClientRect().width) : 0;
+                } catch (e) { padPx = 0; }
+                if (padPx && padPx === lastFitPadPx) return;
+                scheduleFit();
+              });
+            };
             window.addEventListener('resize', onResize);
           }
         } catch (e) { onResize = null; }
@@ -2471,6 +2592,8 @@ export default {
         } catch (e) { /* noop */ }
         onResize = null;
         fitPending = 0;
+        resizeDebounce = 0;
+        streakMeterEl = null; streakMeterLit = -1;
         padTimers.clear();
         flashTimers.clear();
         flashOn.clear();

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/pressure.js
@@ -210,7 +210,8 @@ function contains(a, b) {
 
 /**
  * @param {Object} o
- *   seed, gradeTier|tier, reduced, motionLevel, stage, ring, backdrop,
+ *   seed, gradeTier|tier, reduced, motionLevel, coarse (touch pointer - the
+ *   perf diet; every seeded roll is still consumed), stage, ring, backdrop,
  *   chrome:[els] (the tremor rides the top-level ones), hud:{len,clock,streak,best},
  *   engine {fire, sustain, stop, channels}, assets {next}, timers {after,every,clear|cancel},
  *   capsOk (fn or bool), log
@@ -220,6 +221,7 @@ export function createEcPressure(o) {
   const P = EC_PRESSURE;
   const say = typeof opts.log === 'function' ? opts.log : () => {};
   const reduced = !!opts.reduced;
+  const coarse = !!opts.coarse;
   const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
   const still = reduced || motion <= 0;
   const tier = Math.max(1, Math.min(4, Math.round(Number(opts.gradeTier != null ? opts.gradeTier : opts.tier) || 1)));
@@ -455,7 +457,10 @@ export function createEcPressure(o) {
        deadline (never stop('wash'); the core may hold one too) */
     sustain('wash', { variant, alpha: P.WHISPER_ALPHA, holdMs: P.WHISPER_HOLD_MS });
   }
-  function wheel() { sustain('wash', { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true }); }
+  /* On touch the held spiral runs at half strength: a sustained full-screen
+   * wash is the single heaviest thing this ladder holds on a phone. No roll
+   * is consumed here, so the scale is rng-neutral (Law V). */
+  function wheel() { sustain('wash', { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat) * (coarse ? 0.5 : 1), sustainForever: true }); }
   function ambientBack() { sustain('ambient_field', { kind: P.AMBIENT_OF_TIER[tier] || 'specks' }); }
   function veil(variant, seconds) {
     if (still || !opts.backdrop) return null;
@@ -506,25 +511,35 @@ export function createEcPressure(o) {
   function repaintHeat() {
     if (Math.abs(heat - lastPaintHeat) < P.HEAT_REPAINT_STEP) return;
     lastPaintHeat = heat;
-    if (on.has('wheel')) wheel();
+    /* On touch the held spiral is NOT re-mounted on every 0.06 heat move - it
+     * keeps its arm-time alpha. The rung ladder still steps it down through
+     * whisperOut (applyAdd / stop), which never rides this repaint. */
+    if (on.has('wheel') && !coarse) wheel();
     if (on.has('storm')) sustain('ambient_field', { kind: 'embers', density: lerp(P.STORM_EMBERS, heat) });
   }
 
   /* ---- the riders (on a clear) ------------------------------------------ */
   function ridersOnClear(l) {
     if (!armed() || stopped) return;
+    /* THE TOUCH DIET, under Law V: every roll below is consumed exactly as it
+     * always was - compute-then-discard - and only the FIRE is gated or capped,
+     * so a phone and a desktop walk identical rng streams from the same seed. */
     if (on.has('burst') && roll('burst') < lerp(P.BURST_CHANCE, heat)) {
+      const sizePx = Math.round(vmin() * lerp(P.BURST_VMIN, heat));
       fire('gif_burst', {
         count: Math.round(lerp(P.BURST_COUNT, heat)), clickSafe: true,
-        sizePx: Math.round(vmin() * lerp(P.BURST_VMIN, heat)),
+        sizePx: coarse ? Math.min(sizePx, Math.round(vmin() * 0.28)) : sizePx,
         holdMs: Math.round(lerp(P.BURST_HOLD_MS, heat)),
       });
     }
     if (on.has('giant') && roll('giant') < lerp(P.GIANT_CHANCE, heat)) {
-      fire('gif_burst', { count: 1, clickSafe: true, x: 50, y: 50, sizePx: Math.round(vmin() * P.GIANT_VMIN), holdMs: Math.round(lerp(P.GIANT_HOLD_MS, heat)), variant: 'single' });
+      /* a 0.9vmin decode is a whole-screen gif on a phone - the roll spends
+       * its turn and the giant simply does not land there */
+      if (!coarse) fire('gif_burst', { count: 1, clickSafe: true, x: 50, y: 50, sizePx: Math.round(vmin() * P.GIANT_VMIN), holdMs: Math.round(lerp(P.GIANT_HOLD_MS, heat)), variant: 'single' });
     }
     if (on.has('veil') && roll('veil') < lerp(P.VEIL_CHANCE, heat)) {
-      veil(P.VEIL_VARIANTS[Math.floor(roll('veil') * P.VEIL_VARIANTS.length)], lerp(P.VEIL_S, heat));
+      const vIdx = Math.floor(roll('veil') * P.VEIL_VARIANTS.length);   // ALWAYS drawn
+      if (!coarse) veil(P.VEIL_VARIANTS[vIdx], lerp(P.VEIL_S, heat));
     }
     if (on.has('flashes')) fire('flash_burst', { count: P.FLASH_COUNT, clickSafe: true });
     void l;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/style.js
@@ -353,7 +353,7 @@ ${padRules()}
     0 10px 28px rgba(0,0,0,.5),
     inset 0 -10px 22px rgba(0,0,0,.55),
     inset 0 2px 0 hsl(var(--ec-h) 80% 90% / calc(.25 + .5 * var(--ec-lamp))),
-    0 0 calc(10px + 34px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / calc(.15 + .7 * var(--ec-lamp)));
+    0 0 var(--ec-glow-face, calc(10px + 34px * var(--ec-lamp))) hsl(var(--ec-h) 95% 70% / calc(.15 + .7 * var(--ec-lamp)));
   transform:scale(1);
   transition:transform .14s cubic-bezier(.2,1.4,.4,1), box-shadow .16s ease-out, border-color .16s ease-out, filter .3s ease}
 /* the glass highlight: a crescent that brightens with the lamp */
@@ -394,7 +394,7 @@ ${padRules()}
 .g-ec-glyph{position:absolute;left:50%;top:50%;transform:translate(-50%,-52%);pointer-events:none;
   font:400 clamp(20px, calc(var(--ec-pad) * .36), 52px)/1 var(--body,system-ui,sans-serif);
   color:hsl(var(--ec-h) 90% calc(84% + 10% * var(--ec-lamp)));
-  text-shadow:0 0 calc(4px + 14px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / .9), 0 1px 0 rgba(0,0,0,.5);
+  text-shadow:0 0 var(--ec-glow-glyph, calc(4px + 14px * var(--ec-lamp))) hsl(var(--ec-h) 95% 70% / .9), 0 1px 0 rgba(0,0,0,.5);
   transition:transform .3s ease, font-size .3s ease}
 .g-ec-pad[data-face="word"] .g-ec-glyph{top:auto;bottom:9%;transform:translate(-50%,0);
   font-size:clamp(11px, calc(var(--ec-pad) * .12), 20px);opacity:.72}
@@ -416,7 +416,7 @@ ${padRules()}
   letter-spacing:.01em;text-transform:uppercase;text-align:center;
   overflow-wrap:anywhere;overflow:hidden;
   color:hsl(var(--ec-h) 92% calc(88% + 8% * var(--ec-lamp)));
-  text-shadow:0 0 calc(5px + 16px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / .95),
+  text-shadow:0 0 var(--ec-glow-word, calc(5px + 16px * var(--ec-lamp))) hsl(var(--ec-h) 95% 70% / .95),
     0 2px 4px rgba(0,0,0,.85), 0 0 2px rgba(0,0,0,.9);
   transition:color var(--ec-veil,.2s) ease, text-shadow var(--ec-veil,.2s) ease, opacity .3s ease}
 .g-ec-word:empty{opacity:0}
@@ -455,7 +455,7 @@ html:not(.ae-touch) .g-ec-pad:hover .g-ec-word,
 .g-ec-pad:focus .g-ec-word,
 .g-ec-pad:active .g-ec-word,
 .g-ec-pad[data-veil="off"] .g-ec-word{color:hsl(var(--ec-h) 92% calc(88% + 8% * var(--ec-lamp)));
-  text-shadow:0 0 calc(5px + 16px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / .95),
+  text-shadow:0 0 var(--ec-glow-word, calc(5px + 16px * var(--ec-lamp))) hsl(var(--ec-h) 95% 70% / .95),
     0 2px 4px rgba(0,0,0,.85), 0 0 2px rgba(0,0,0,.9)}
 /* THE POP (2026-08-25): a press-flashed word arrives with a small settle -
    transform/opacity only (never a filter over live media - trap 36), and the
@@ -765,6 +765,44 @@ html.arc-reduced .g-ec-howto-art::before,html.arc-reduced .g-ec-howto-art::after
   .g-ec-pad[data-state="reveal"]::before{animation:none !important;opacity:.9;transform:scale(1.16)}
   .g-ec-step[data-fill="on"],.g-ec-step[data-fill="bad"]{transform:none}
 }
+
+/* ---- THE PHONE DIET (html.ae-touch, armed page-wide by core/device.js) --
+   NOT reduced motion: the room still breathes and the lamps still ride
+   --ec-lamp. What stands down is every per-frame raster a phone GPU cannot
+   afford - the lamp-driven BLUR RADII are pinned to a fixed mid value (the
+   colour and alpha still ride the lamp, so the read survives), the decorative
+   filter passes go, the floor loses its perspective re-raster and the dust
+   crawl holds still. Desktop (no ae-touch) is pixel-identical: every pinned
+   radius above falls back to its original calc. */
+html.ae-touch .g-ec-stage{--ec-glow-glyph:12px;--ec-glow-word:13px;--ec-glow-face:30px}
+/* the glass highlight loses its six permanent blur(1px) render surfaces */
+html.ae-touch .g-ec-face::before{filter:none}
+/* the state brighteners: the lamp carries the read (incl. the silent-room tell) */
+html.ae-touch .g-ec-pad[data-state="lit"] .g-ec-face,
+html.ae-touch .g-ec-pad[data-state="pressed"] .g-ec-face{filter:none}
+html.ae-touch .g-ec-stage[data-audible="0"] .g-ec-pad[data-state="lit"] .g-ec-face,
+html.ae-touch .g-ec-stage[data-audible="0"] .g-ec-pad[data-state="pressed"] .g-ec-face{filter:none}
+/* the decoy: the arc-reduced look - cold hue and spill still tell the tale */
+html.ae-touch .g-ec-pad[data-state="decoy"] .g-ec-face{filter:none;animation:none;opacity:.85}
+/* the spill: a smaller falloff, same read */
+html.ae-touch .g-ec-pad::after{width:170%;height:170%}
+/* the media faces: OPT-IN already, so outside data-faces="media" the six
+   elements are six invisible composited layers wearing a blend, a filter and
+   an infinite ken-burns for nothing - they leave the tree entirely. Inside the
+   mode they stay, minus the per-frame passes (the pad already tints the lamp,
+   and index.js caps a touch deal to stills). */
+html.ae-touch .g-ec-stage:not([data-faces="media"]) .g-ec-media{display:none}
+html.ae-touch .g-ec-media{mix-blend-mode:normal;filter:none;animation:none}
+/* the floorboards go flat: no perspective-transformed double gradient */
+html.ae-touch .g-ec-stage::before{transform:none;top:52%;opacity:.16}
+/* the spotlight still breathes, opacity only - the scaleX re-raster goes */
+html.ae-touch .g-ec-backdrop::before{animation:g-ec-breathe-still var(--ec-breath) ease-in-out infinite alternate}
+@keyframes g-ec-breathe-still{from{opacity:calc(var(--ec-n-spot,.7) * .72)}to{opacity:var(--ec-n-spot,.7)}}
+/* the dust in the beam holds still (the engine kills the CRT the same way) */
+html.ae-touch .g-ec-backdrop::after{animation:none}
+/* the rules sheet: the arc-reduced kills, verbatim */
+html.ae-touch .g-ec-howto-go{animation:none !important}
+html.ae-touch .g-ec-howto-art::before,html.ae-touch .g-ec-howto-art::after{animation:none !important}
 
 /* ---- small screens: the ring shrinks, the HUD tightens ------------------ */
 @media (max-width: 560px){

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/trickster.js
@@ -599,7 +599,9 @@ export function createEcTrickster(o) {
        the real chip's honest face steps aside while the twin is up; the real
        chip keeps painting --ec-k, which is the truth the twin bends */
     layer.appendChild(ringEl);
-    ringPoll = every(Math.round(1000 / T.RING_STEPS / 2), tickRing);
+    /* touch: half the poll rate (~83ms) - the bend is a 12-step face, so a
+       slower poll paints the same steps; the poll consumes no rng */
+    ringPoll = every(Math.round(1000 / T.RING_STEPS / (coarse ? 1 : 2)), tickRing);
   }
   function tickRing() {
     if (!ringEl || !ringReal || destroyed || stopped || paused) return;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/trickster.js
@@ -264,6 +264,25 @@ ${ringKeyframes()}
   .g-ic-tk-ghost{display:none}
   .g-ic-score.g-ic-tk-flick{animation:none}
 }
+/* ---- THE PHONE CEILING (html.ae-touch, same rung as style.js's block) -----
+   The tell is the biggest blurred node this deck owns - 130vw by 38vmin - and
+   it breathes its opacity the whole time it is up, so the phone was re-serving
+   a viewport-scale blur every frame of the loop. The gradient is already soft
+   (its stops fade at 17% and 76%); the blur only rounded the lamp bar, and the
+   bar is what makes pink-versus-gold readable, so it stays sharp instead. The
+   ghost and the stat pop keep their beats on opacity. Nothing is hidden here:
+   the tell, the lure and the flicker are all trickster READ.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-ic-tk-tell{filter:none}
+html.ae-touch .g-ic-tk-ghost{filter:none}
+html.ae-touch .g-ic-tk-ghost.lure{animation:g-ic-tk-ghostpulse-t 1.5s ease-in-out infinite}
+@keyframes g-ic-tk-ghostpulse-t{50%{opacity:.78}}
+html.ae-touch .g-ic-score.g-ic-tk-flick{animation:g-ic-tk-static-t .16s steps(3) 2}
+@keyframes g-ic-tk-static-t{0%{opacity:1}40%{opacity:.55}100%{opacity:1}}
+/* the twins carry new names, so the reduced gate has to say its kills again */
+@media (prefers-reduced-motion: reduce){
+  html.ae-touch .g-ic-tk-ghost.lure,html.ae-touch .g-ic-score.g-ic-tk-flick{animation:none}
+}
 `;
 
 /** Inject the deck's sheet once per document (style.js's pattern). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/style.js
@@ -554,6 +554,20 @@ html.arc-reduced .g-ir-payout.is-on{animation:g-ir-payout 450ms ease-out 1 both 
 .g-ir-howto{pointer-events:auto}
 .g-ir-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- THE PHONE CEILING (html.ae-touch, and see the rung at .g-ir-opt-face
+   above) --------------------------------------------------------------------
+   This sheet was already the cheapest of the ten - no blend mode, no filter,
+   no backdrop-filter anywhere, by the payout layer's own law - so the diet
+   finds only two forever-loops that repaint a shadow instead of composing
+   one. Both freeze at their LIT frame, never dark: the answer ring going low
+   is a read (and it still drains its conic face, which is the read that
+   matters), and GO is the only live thing on the rules sheet.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-ir-timer.is-low,html.ae-touch .g-ir-timer[data-low="1"]{
+  animation:none;box-shadow:0 0 22px rgba(255,105,180,.9)}
+html.ae-touch .g-ir-go{animation:none;
+  box-shadow:0 0 34px rgba(255,105,180,.85), 0 6px 16px rgba(0,0,0,.45)}
+
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/trickster.js
@@ -169,6 +169,27 @@ const STYLE_TEXT = `
 html.arc-reduced .g-ir-tk-ring{opacity:0 !important}
 html.arc-reduced .g-ir-timer.g-ir-tk-bent{opacity:1}
 html.arc-reduced .g-ir-tk-ghost{opacity:0 !important;animation:none}
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   Coarse pointer. Three loops here repainted a shadow every frame instead of
+   composing one: the lure ghost breathed a drop-shadow (on a node a
+   transition is also moving), the stat pop keyframed brightness+contrast, and
+   the lying option shivered a text-shadow under a whole sentence of text. All
+   three keep their beat on opacity - the ghost keeps its glow, it just holds
+   it still. Nothing is hidden: every one of these is trickster READ.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-ir-tk-ghost{filter:none}
+html.ae-touch .g-ir-tk-ghost.is-lure{animation:g-ir-tk-ghostpulse-t 1.5s ease-in-out infinite}
+@keyframes g-ir-tk-ghostpulse-t{50%{opacity:.82}}
+html.ae-touch .g-ir-chip.g-ir-tk-flick{animation:g-ir-tk-static-t .16s steps(3) 2}
+@keyframes g-ir-tk-static-t{0%{opacity:1}40%{opacity:.55}100%{opacity:1}}
+html.ae-touch .g-ir-opt.g-ir-tk-lie{animation:g-ir-tk-shiver-t .5s ease-in-out infinite}
+@keyframes g-ir-tk-shiver-t{0%,100%{opacity:1}50%{opacity:.86}}
+/* the twins carry new names, so the reduced gates have to say their kills again */
+html.arc-reduced.ae-touch .g-ir-tk-ghost.is-lure{animation:none}
+@media (prefers-reduced-motion: reduce){
+  html.ae-touch .g-ir-tk-ghost.is-lure,html.ae-touch .g-ir-chip.g-ir-tk-flick,
+  html.ae-touch .g-ir-opt.g-ir-tk-lie{animation:none}
+}
 `;
 
 function ensureStyle() {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -464,6 +464,57 @@ export default {
       }
       return null;
     }
+    /* ------------------------------------------------------------------------
+     * THE SLEEPER LEDGER (0826). ~16 sleeping seats dress themselves off a
+     * still pool that can be six urls deep, and drawSleeper used to exclude
+     * exactly one thing - the target - so the same still landed on three seats
+     * of one wall. The provider's recency ring now spreads the DRAWS; this
+     * spreads what we do with them, and it does it WITHOUT a single extra
+     * pool.next(): the seats are dressed in one pass, so the draws a seat makes
+     * and discards (the target's own url, an animated row when a still was
+     * asked for) are BANKED instead of thrown away, and the next seat that
+     * would otherwise repeat spends a banked url instead. Draw-then-assign, on
+     * draws that already happened.
+     *   used  the urls this dressing pass has already given to sleeper seats
+     *   bank  drawn-but-unspent urls, oldest first
+     * ---------------------------------------------------------------------- */
+    const SLEEPER_BANK_MAX = 8;
+    let sleeperUsed = new Set();
+    const sleeperBank = [];
+    function sleeperReset() {
+      sleeperUsed = new Set();
+      sleeperBank.length = 0;
+    }
+    function sleeperBankPush(got) {
+      if (!got || !got.url || sleeperUsed.has(got.url)) return;
+      if (sleeperBank.some((e) => e.url === got.url)) return;
+      sleeperBank.push(got);
+      while (sleeperBank.length > SLEEPER_BANK_MAX) sleeperBank.shift();
+    }
+    /** A banked url no seat is wearing yet, preferring a real still. */
+    function sleeperBankTake(targetUrl) {
+      let at = -1;
+      for (let i = 0; i < sleeperBank.length; i++) {
+        const e = sleeperBank[i];
+        if (!e || !e.url || sleeperUsed.has(e.url)) continue;
+        if (targetUrl && e.url === targetUrl) continue;
+        if (!isAnimatedUrl(e.url)) { at = i; break; }
+        if (at < 0) at = i;
+      }
+      return at < 0 ? null : sleeperBank.splice(at, 1)[0];
+    }
+    function sleeperTake(got, targetUrl) {
+      if (!got || !got.url) return got;
+      if (!sleeperUsed.has(got.url)) { sleeperUsed.add(got.url); return got; }
+      /* this seat would repeat: spend a banked url if one is free, and bank the
+       * repeat in its place (it may still dress a later seat) */
+      const alt = sleeperBankTake(targetUrl);
+      if (!alt) return got;                       // nothing banked: the repeat stands
+      sleeperBankPush(got);
+      sleeperUsed.add(alt.url);
+      return alt;
+    }
+
     function drawSleeper(targetUrl) {
       if (!pool || typeof pool.next !== 'function') return null;
       // a gifs-only library HAS no stills; six bundled SVGs across 170 seats is
@@ -474,10 +525,14 @@ export default {
         const got = pool.next('still');
         if (!got || !got.url) break;
         if (targetUrl && got.url === targetUrl) continue;
-        if (!isAnimatedUrl(got.url)) return got;  // the still we actually asked for
+        // the still we actually asked for
+        if (!isAnimatedUrl(got.url)) { if (animated) sleeperBankPush(animated); return sleeperTake(got, targetUrl); }
         if (!animated) animated = got;            // a pool that ignores `kind`
+        else sleeperBankPush(got);
       }
-      return parkedUrl(targetUrl) || animated;
+      const parked = parkedUrl(targetUrl);
+      if (parked) { if (animated) sleeperBankPush(animated); return parked; }
+      return animated ? sleeperTake(animated, targetUrl) : null;
     }
 
     /** Redraw for a seat that already exists, keeping it on the same side of
@@ -676,6 +731,10 @@ export default {
     function dressBoard(o) {
       if (!board || !pool) return;
       const onlyBare = !!(o && o.onlyBare);
+      /* a full dressing is a fresh wall: the sleeper ledger starts empty. A
+       * LATE batch keeps it, because the seats it is upgrading around are
+       * exactly the ones the ledger already knows about. */
+      if (!onlyBare) sleeperReset();
       const target = board.targetTile();
       // A pool that lands LATE (slow disk, remote batch mid-class) may still
       // upgrade the decoys, but the target's look is frozen the moment the player

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
@@ -448,6 +448,49 @@ export const CSS = [
   'html.arc-mobile .g-lf-view {',
   '  --g-lf-th:calc((100vh - var(--arc-mobile-chrome-h, 0px) - var(--g-lf-top) - (var(--g-lf-rows,4) + 1) * var(--g-lf-gap)) / var(--g-lf-rows,4));',
   '  --g-lf-th:calc((100dvh - var(--arc-mobile-chrome-h, 0px) - var(--g-lf-top) - (var(--g-lf-rows,4) + 1) * var(--g-lf-gap)) / var(--g-lf-rows,4)); }',
+
+  /* --------------------- THE PHONE CEILING (html.ae-touch) ----------------- */
+  /* The shell arms .ae-touch on <html> for coarse-pointer devices at boot. This
+     wall is the heaviest surface in the school - dozens of live media seats -
+     and it was wearing a hue-rotate filter over every one of them plus four
+     live backdrop blurs and two keyframes that repaint a drop-shadow. The wall
+     itself is the content; the tint, the frosted glass and the glow were the
+     nicety. Nothing here hides a mark, a hint or a control: the dim still dims
+     (opaque paint instead of blur), the lure ghost still pulses (on opacity),
+     the sheet's two hint loops freeze at their LIT frame. Desktop untouched. */
+  /* The hue skin: one filtered render surface per seat, x2-3 wrap clones. */
+  'html.ae-touch .g-lf-skin { filter:none; }',
+  /* Frosted chrome turns solid - a live blur behind glass is the phone tax. */
+  'html.ae-touch .g-lf-hud .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(20,20,43,.94); }',
+  'html.ae-touch .g-lf-foot .arc-peekbtn { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(37,37,66,.97); }',
+  'html.ae-touch .g-lf-foot .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(20,20,43,.94); }',
+  /* The ceremony dim blurred the WHOLE wall behind it; paint carries the dim. */
+  'html.ae-touch .g-lf-dim { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(20,20,43,.78); }',
+  /* The ghost cursor: drop-shadow on a moving node, and the lure keyframed it. */
+  'html.ae-touch .g-lf-ghost { filter:none; }',
+  'html.ae-touch .g-lf-ghost.g-lf-ghost-lure { animation:g-lf-ghostpulse-t 1.6s ease-in-out infinite; }',
+  '@keyframes g-lf-ghostpulse-t { 50% { opacity:.72; } }',
+  /* The bell marquee wore a drop-shadow over four infinitely crawling bars,
+     so every frame of the chase re-rasterised the glow. Gold still reads. */
+  'html.ae-touch .g-lf-mq.g-lf-mq-bell { filter:none; }',
+  'html.ae-touch .g-lf-mq.g-lf-mq-flash { animation:g-lf-mqflash-t .6s ease-out 1; }',
+  '@keyframes g-lf-mqflash-t { 0% { opacity:1; } 100% { opacity:var(--g-lf-mqa,.3); } }',
+  /* The rules sheet: two infinite box-shadow loops freeze lit (as arc-reduced). */
+  'html.ae-touch .g-lf-hw-mark { animation:none;',
+  '  box-shadow:0 0 0 2px var(--pink), 0 0 15px rgba(255,105,180,.95); }',
+  'html.ae-touch .g-lf-hw-slot.next { animation:none; background:var(--pink);',
+  '  border-color:var(--pink); box-shadow:0 0 8px rgba(255,105,180,.8); }',
+  /* Reduced motion outranks by order on desktop; the twins are new names, so
+     say the freeze once more for the two that touch re-armed. */
+  'html.arc-reduced.ae-touch .g-lf-ghost.g-lf-ghost-lure,',
+  'html.arc-reduced.ae-touch .g-lf-mq.g-lf-mq-flash { animation:none !important; }',
+  '@media (prefers-reduced-motion: reduce) {',
+  '  html.ae-touch .g-lf-ghost.g-lf-ghost-lure,',
+  '  html.ae-touch .g-lf-mq.g-lf-mq-flash { animation:none !important; } }',
 ].join('\n');
 
 /** Inject once per document. Idempotent - re-entering the class is free. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/casino.js
@@ -245,6 +245,22 @@ html.arc-reduced .g-md-cs-kb{animation:none !important}
 html.arc-reduced .g-md-cs-ghost.on{animation:none;opacity:.7}
 .g-md-stage.suspended .g-md-mq-bulb,.g-md-stage.suspended .g-md-cs-lamp,.g-md-stage.suspended .g-md-cs-word,
 .g-md-stage.suspended .g-md-cs-ghost,.g-md-stage.suspended .g-md-cs-coin,.g-md-stage.suspended .g-md-cs-kb{animation-play-state:paused !important}
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   Coarse pointer: the house keeps its lights, it just stops making the phone
+   re-blend and re-lay-out the whole overlay for them. The static burst drops
+   the screen blend (its scanlines are white on near-black, so normal blend at
+   a lower alpha reads the same), the flash stops running a filter on every
+   bulb at once, and the lamp stops swaying - the sway animated MARGIN, which
+   is a layout pass per frame on a node 180% of the stage tall. It still hangs
+   where the round put it (left/width are transitions, not the animation).
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-md-cs-static{mix-blend-mode:normal}
+html.ae-touch .g-md-cs-static.on{animation:g-md-cs-static-t .16s steps(3) 1}
+@keyframes g-md-cs-static-t{0%{opacity:.45;transform:translateY(0)}
+  50%{opacity:.26;transform:translateY(-2px)}100%{opacity:0;transform:translateY(1px)}}
+html.ae-touch .g-md-mq.flash .g-md-mq-bulb{filter:none}
+html.ae-touch .g-md-cs-ghost{filter:none}
+html.ae-touch .g-md-cs-lamp{animation:none}
 `;
 
 function ensureStyle() {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/style.js
@@ -456,6 +456,32 @@ html.arc-reduced .g-md-stage{transition:none}
 .g-md-howto{pointer-events:auto}
 .g-md-hw-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- THE PHONE CEILING (html.ae-touch) ------------------------------------
+   The shell arms .ae-touch on <html> for coarse-pointer devices at boot. The
+   lighting rig ran FIVE full-stage weave layers at mix-blend-mode:soft-light,
+   each one also crawling its background-position forever: every frame the
+   phone re-blended the whole table five times over. On touch the weaves stop
+   blending (normal, at half the layer opacity so the white threads read as
+   thread and not as chalk) and stop crawling - the pattern is still on the
+   felt, it just holds still. The felt's own breath and the smoke drift are
+   transform/opacity and stay. The two forever-glow chips freeze LIT, never
+   dark: the bell and the RIDE button are reads, not decoration.
+   -------------------------------------------------------------------------- */
+html.ae-touch .g-md-bd-diamond,html.ae-touch .g-md-bd-herringbone,
+html.ae-touch .g-md-bd-damask,html.ae-touch .g-md-bd-pinstripe,
+html.ae-touch .g-md-bd-lace{mix-blend-mode:normal;opacity:.5}
+html.ae-touch .g-md-bd-diamond::before,html.ae-touch .g-md-bd-herringbone::before,
+html.ae-touch .g-md-bd-damask::before,html.ae-touch .g-md-bd-pinstripe::before,
+html.ae-touch .g-md-bd-lace::before{animation:none}
+/* the bell chip: frozen at the bright end of its breath */
+html.ae-touch .g-md-chip.g-md-bell,html.ae-touch .g-md-stage.g-md-bell .g-md-clock{
+  animation:none;box-shadow:0 0 16px rgba(240,194,75,.7)}
+/* RIDE (and the sheet's GO): frozen lit instead of pumping a box-shadow */
+html.ae-touch .g-md-btn.g-md-ride{animation:none;
+  box-shadow:0 0 20px color-mix(in srgb, var(--pink), transparent 50%)}
+html.ae-touch .g-md-hw-go{animation:none;
+  box-shadow:0 0 20px color-mix(in srgb, var(--pink), transparent 50%)}
+
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -976,12 +976,27 @@ export default {
       }
       const list = spares;
       if (!list.length) {
+        /* THE HOLE THE FALLBACK LEFT (0826): the deck walk checked the card's
+         * own url and the blacklist, but nothing about the cards STANDING NEXT
+         * TO IT - so a substitute was free to mirror the face right beside it,
+         * which reads as the duplicate the spares branch exists to avoid. The
+         * standing urls are collected first and the deck survivors that mirror
+         * one are held BACK, not dropped: if they were all we had, a repeat
+         * beats a drawn back. (Deck rows only - the spares branch above is
+         * already whole-deck exclusive, so it cannot hit this.) */
+        const standing = new Set();
+        for (const live of S.live) {
+          if (live && live.card && live.card.url && live.card.url !== card.url) standing.add(live.card.url);
+        }
+        const mirrors = [];
         for (const c of rows) {
           if (!c || !c.url || c.tag !== card.tag) continue;
           if (c.url === card.url || seen.has(c.url) || poolIsBroken(c.url)) continue;
           seen.add(c.url);
-          list.push(c);
+          if (standing.has(c.url)) mirrors.push(c);
+          else list.push(c);
         }
+        if (!list.length) for (const c of mirrors) list.push(c);
       }
       if (!list.length) return null;
       const pick = list[Math.floor(hash01(String(S.seed) + '|sub|' + (card.i | 0)) * list.length)];
@@ -1190,7 +1205,21 @@ export default {
           const back = S.passQueue.splice(0, S.passQueue.length);
           S.cards = S.cards.concat(back);
         } else {
-          S.cards = shuffled(S.cards, S.rngDeal);
+          /* THE CARDS STILL IN YOUR HAND ARE NOT IN THE DECK (0826). The
+           * reshuffle used to include the two or three cards STANDING in the
+           * stack - they are the last ones the cursor dealt, so a reshuffle
+           * could drop one straight back at index 0 and the player watched the
+           * same face arrive behind itself. They are held out of the shuffle
+           * and appended AFTER it instead: still in the deck, still dealt, but
+           * a whole pass away, which is exactly what a recycle is for.
+           * The INPUT list is filtered rather than the output re-ordered, so
+           * this is the same single shuffled() call on S.rngDeal it always was
+           * (sort's own stream, not the provider's - no shared draw moves). */
+          const standing = new Set();
+          for (const live of S.live) if (live && live.card && live.card.url) standing.add(live.card.url);
+          const held = standing.size ? S.cards.filter((c) => c && standing.has(c.url)) : [];
+          const feed = held.length ? S.cards.filter((c) => !(c && standing.has(c.url))) : S.cards;
+          S.cards = feed.length ? shuffled(feed, S.rngDeal).concat(held) : shuffled(S.cards, S.rngDeal);
           S.recycles += 1;
           emiNote('sort.deckRecycle', { kind: 'curiosity', n: S.recycles, left: S.cards.length });
         }
@@ -1898,6 +1927,13 @@ export default {
       S.wall = createWall({
         mount: nodes.stage, tier: gradeTier, reduced, seed, log: say,
         stageOf: () => stageBox(),
+        /* THE WALL SEES WHAT THE STACK SAW (0826). A tile used to paint the
+         * card's RAW url, so a card whose url was blacklisted - the stack
+         * showed it as a same-tag substitute - landed on the wall as the dead
+         * url, and the wall disagreed with the class the player just played.
+         * One resolver, both surfaces; null means no healthy media at all and
+         * the drawn back stands, exactly as it does in the stack. */
+        resolve: (card) => displaySrcOf(card),
       });
       /* the wall lives BEHIND the playfield: it was appended last, so move it */
       try { if (S.wall.el && nodes.stage.insertBefore) nodes.stage.insertBefore(S.wall.el, nodes.playfield); }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/wall.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/wall.js
@@ -130,6 +130,9 @@ function el(tag, cls) {
  *   reduced   reduced motion
  *   seed      the class seed (the card-back hue for a tile with no still)
  *   stageOf() -> {w, h}
+ *   resolve(card) -> {url, mime} | null   the game's substitute resolution, so
+ *             a tile paints the face the STACK showed and never a dead url
+ *             (optional: without it a tile paints the card's own url)
  *   log
  */
 export function createWall(o = {}) {
@@ -138,6 +141,13 @@ export function createWall(o = {}) {
   const reduced = !!o.reduced;
   const say = typeof o.log === 'function' ? o.log : () => {};
   const stageOf = typeof o.stageOf === 'function' ? o.stageOf : () => ({ w: 1280, h: 720 });
+  /* (card) -> {url, mime} | null, the game's substitute resolution (see paint).
+   * Guarded: a resolver that throws must never cost the wall a tile. */
+  const resolve = (card) => {
+    if (!card) return null;
+    if (typeof o.resolve !== 'function') return { url: card.url, mime: card.mime || '' };
+    try { return o.resolve(card) || null; } catch (e) { return { url: card.url, mime: card.mime || '' }; }
+  };
 
   const root = el('div', 'g-sort-wall');
   const grid = el('div', 'g-sort-wall-grid');
@@ -180,13 +190,22 @@ export function createWall(o = {}) {
 
   function paint(tile, card) {
     if (!tile) return;
+    /* THE SAME FACE THE STACK SHOWED (0826). `resolve` is the game's own
+     * substitute resolution (index.js displaySrcOf): a card whose url is on
+     * the blacklist was played as a same-tag substitute, and painting its raw
+     * url here put a dead url on the wall and made the wall disagree with the
+     * class. Null = no healthy media at all, which is the drawn back - the
+     * same answer the stack gives. A caller that passes no resolver (a suite,
+     * an old double) keeps the raw card. */
+    const src = resolve(card) || null;
+    if (!src || !src.url) return;
     /* A WALL TILE IS NEVER A LIVE DECODE (trap 36). A loop lands as its own
      * url in an <img> - a gif still animates cheaply. A VIDEO url gets no <img>
      * at all (owner 2026-08-24): an mp4 in an <img> paints nothing but still
      * downloads the whole file, so the drawn card back stands for it instead. */
-    const mime = card && card.mime;
+    const mime = src.mime;
     if ((mime && /^video\//i.test(String(mime)))
-      || /\.(mp4|webm|m4v|mov)(\?|#|$)/i.test(String((card && card.url) || ''))) return;
+      || /\.(mp4|webm|m4v|mov)(\?|#|$)/i.test(String(src.url))) return;
     const img = el('img', 'g-sort-wall-face');
     if (!img) return;
     img.alt = '';
@@ -196,7 +215,7 @@ export function createWall(o = {}) {
     if (typeof img.addEventListener === 'function') {
       img.addEventListener('error', () => { try { if (img.parentNode) img.remove(); } catch (e) { /* ignore */ } });
     }
-    img.src = card && card.url ? card.url : '';
+    img.src = src.url;
     tile.appendChild(img);
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
@@ -1305,6 +1305,61 @@ html.arc-reduced .g-de-hw-ladder i{opacity:1}
 .g-de-howto{pointer-events:auto}
 .g-de-hw-go{position:sticky;bottom:0;z-index:3;align-self:stretch;margin-top:14px}
 
+/* ---- pass 6c: THE TOUCH GPU DIET, second sweep (html.ae-touch) ------------
+   Same rung and the same law as passes 5 and 6b above (the device is the
+   setting; desktop is untouched to the byte). 6b took the board's biggest
+   filter loop - g-de-deepbreath - and the seven backdrop layers. This pass
+   takes the ones that were left, all of the same shape: a keyframe that
+   repaints a filter, a box-shadow or a text glow every frame, on nodes there
+   can be sixteen of at once.
+     - the NAME ladder. Tiers 4-6 breathed brightness and tiers 10-11 pulsed
+       it. The neon IS the stacked text-shadow, and it is untouched: 4-6 simply
+       hold their light, and 10-11 keep the pulse on scale alone. The tier-7-9
+       flicker and the 10-11 scan bar were already opacity-only and still run.
+     - the STRAIN glow and the tier-11 ECLIPSE glyph: both froze at their base
+       frame, which is the LIT one - the strain rim and the glyph halo are
+       reads and they stay on the screen, they just stop pumping.
+     - the MELT keyframed border-radius under a filtered body, which is a
+       repaint of a filtered layer per frame. The sag is transform-only now;
+       the sagging ink and the drip were always transform/opacity and stay.
+     - the PRESSURE WHEEL span the board under mix-blend-mode:screen, so every
+       frame was a fresh read-back-and-blend of a board-sized node. Frozen: the
+       wheel still hangs there as light behind the square.
+     - the GLITCH SHUDDER keyframed hue-rotate + saturate on a FULL-STAGE layer
+       at steps(2), forever, on top of the backdrop-filter 6b already took off.
+       The slip stays (transform), the hue churn goes.
+   Reduced motion is unchanged: its animation:none !important kills outrank
+   every twin named here. --------------------------------------------------- */
+/* THE :not() GUARDS ARE LOAD BEARING. These selectors out-specify every rule
+   that hands a name or a glyph a DIFFERENT animation for a moment - the merge
+   pop, the melt's sliding ink, the trickster's lie shiver - and a plain tier
+   override would silently eat all three on touch only. Excluding those states
+   lets them fall through to the cascade they already win on desktop. */
+html.ae-touch .g-de-tile[data-tier="4"]:not(.g-de-melt):not(.is-merged) .g-de-name:not(.g-de-lielabel),
+html.ae-touch .g-de-tile[data-tier="5"]:not(.g-de-melt):not(.is-merged) .g-de-name:not(.g-de-lielabel),
+html.ae-touch .g-de-tile[data-tier="6"]:not(.g-de-melt):not(.is-merged) .g-de-name:not(.g-de-lielabel){animation:none}
+html.ae-touch .g-de-tile[data-tier="10"]:not(.g-de-melt):not(.is-merged) .g-de-name:not(.g-de-lielabel),
+html.ae-touch .g-de-tile[data-tier="11"]:not(.g-de-melt):not(.is-merged) .g-de-name:not(.g-de-lielabel){
+  animation:g-de-namepulse-t 1.6s ease-in-out infinite alternate}
+@keyframes g-de-namepulse-t{from{transform:scale(1)}to{transform:scale(1.05)}}
+html.ae-touch .g-de-tile[data-tier="11"]:not(.g-de-melt):not(.is-merged) .g-de-glyph{animation:none}
+html.ae-touch .g-de-tile.is-strain::before{animation:none}
+html.ae-touch .g-de-tile.g-de-melt::before{animation:g-de-meltbody-t 2.4s ease-in-out infinite alternate}
+@keyframes g-de-meltbody-t{from{transform:scaleY(1) skewX(0)}
+  to{transform:scaleY(1.09) skewX(-3deg) translateY(3%)}}
+/* the two forever-glow chips freeze at their bright frame, never dark */
+html.ae-touch .g-de-chip.g-de-surface{animation:none;
+  box-shadow:0 0 18px color-mix(in srgb, var(--pink), transparent 58%)}
+html.ae-touch .g-de-stage[data-phase="bell"] .g-de-clock{animation:none;
+  box-shadow:0 0 16px rgba(240,194,75,.7)}
+/* the pressure layer */
+html.ae-touch .g-de-p-pin{animation:none}
+html.ae-touch .g-de-p-glitch.is-shudder{animation:g-de-p-shudder-t .16s steps(2) infinite}
+@keyframes g-de-p-shudder-t{0%{transform:translate(0,0)}
+  50%{transform:translate(-1.2%,0)}100%{transform:translate(1.2%,0)}}
+/* the rules sheet: a drop-shadow on the one arrow that moves */
+html.ae-touch .g-de-hw-arrow.right{filter:none}
+
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -12,6 +12,9 @@
  *   pool.next('loop')   -> { url, remote }   NEVER blocks, NEVER null
  *   pool.next('target') -> { url, remote }   the hunt target (its own slot)
  *   pool.release()
+ *   assets.warmPool({loop, still})   the BOOT ASK: start filling the remote
+ *                                    pools at page boot instead of at the first
+ *                                    claim (no pool, no rand - see warmPool)
  *
  * SECOND SHAPE, ADDITIVE (SORT, 2026-08-23): `claimTagged({sources, want,
  * perSourceMin, seed, timeoutMs})` deals TWO PILES whose rows carry the `tag`
@@ -72,6 +75,17 @@ function placeholderUrls() {
 }
 
 const REMOTE_CAP = 80;        // mirrors intake's REMOTE_CAP: a page never hoards media
+const RECENT_MAX = 24;        // recency-ring depth (0826): a draw step-skips the last
+                              // min(L-1, RECENT_MAX) urls its kind SERVED - the skip
+                              // consumes no rand (the blacklist skip's law), it only
+                              // changes which url a given rand maps to.
+                              // 24 = the board that named the bug: a 24-tile board off
+                              // a 24-url pool. Simulated over 200 seeds, the old
+                              // re-rolled jump dressed it in 15.3 distinct urls (8.7
+                              // duplicate tiles); a ring of 20 leaves 1.2 and 24 leaves
+                              // none. Deeper buys nothing a page this size can see, and
+                              // the min(L-1, ...) bound is what keeps a SMALL pool
+                              // legal - it always leaves the walk a row to land on.
 
 /* THE ON-DECK RAIL's dials (0825). SORT's warm rail proved the shape and the
  * numbers' logic (games/sort/index.js WARM_AHEAD/WARM_INFLIGHT header): the
@@ -83,9 +97,24 @@ export const WARM_INFLIGHT = 3;   // warms in flight at once - a third lane lets
 const WARM_VIDEO_INFLIGHT = 2;    // of those, at most TWO may be video fetches - a
                                   // third stalled mp4 would eat into Safari's
                                   // 6-connections-per-host budget the game plays on
-const WARM_VIDEO_TIMEOUT_MS = 12000;  // a video warm that outlives this is aborted
-                                      // (an abort is a shrug, never a blacklist)
+const WARM_VIDEO_TIMEOUT_MS = 20000;  // a video warm that outlives this is aborted
+                                      // (an abort is a shrug, never a blacklist).
+                                      // 12s was a DESKTOP number: at a cellular
+                                      // 3-5s RTT the TLS handshake alone eats a
+                                      // third of it and a multi-megabyte body
+                                      // never lands, so every loop warm on the
+                                      // owner's phone aborted and (before the
+                                      // un-poison below) took the url with it.
+                                      // The video lanes are capped at
+                                      // WARM_VIDEO_INFLIGHT, so a longer
+                                      // deadline costs a fast link nothing.
 const WARM_HELD_MAX = 24;         // decoded detached Images held against GC
+/* A warm that FAILED is not a url that is dead (the blacklist owns that verdict,
+ * and only on proof). It may be re-queued - but never forever: in production
+ * connect-src excludes the media CDNs, so a video warm can reject INSTANTLY and
+ * a re-queue on every draw would be a fetch storm. Three attempts per url per
+ * page, then the url stays warmed-out and draws serve it cold. */
+const WARM_RETRY_MAX = 3;
 const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
 
 /* THE MANIFEST WARMER's windows (0825, SORT). A game that knows its complete
@@ -243,6 +272,67 @@ export function createAssets(options = {}) {
   }
 
   /* ------------------------------------------------------------------------
+   * THE BOOT ASK (0826). The provider used to send its FIRST 'assets-request'
+   * from claim() - i.e. when the player claims a class - so the whole door /
+   * menu / rules-sheet stretch was network dead air. On the owner's cellular
+   * phone that is 10-30 seconds of a warm rail with nothing to warm, and the
+   * first board dresses itself in placeholders while the host is still doing
+   * its round trip. warmPool() runs the SAME ask machinery at boot, mints no
+   * pool, and hands its batches to absorbRemote() - which draws no rand, so
+   * the served sequence for every later claim is byte-identical.
+   *
+   * The web shim already preconnects the Scrolller API and the CDN origins on
+   * its side; this ask is what makes that preconnect pay off - the sockets it
+   * opened get used while the door is still on screen instead of going cold.
+   *
+   * Gated exactly like claim()'s ask: OfflineMode, remote media off, no bridge
+   * or a zero mix ratio all make it a silent no-op, and every reqId rides the
+   * channel's own mailbox, so a later claim()'s asks are untouched by it.
+   * --------------------------------------------------------------------- */
+  const BOOT_RETRY_MS = 1500;      // claim()'s RETRY_MS, backed off by attempt
+  const BOOT_MAX_ASKS = 4;         // half claim()'s budget: this is a head start,
+                                   // not the supply run the class itself makes
+  const bootTimers = new Set();
+  let bootAsked = false;
+
+  function bootAsk(kind, count, attempt) {
+    if (disposed) return;
+    channel.request({
+      kind, count, niches: defaultNiches,
+      onBatch: (entries) => {
+        if (disposed) return;
+        absorbRemote(entries);       // zero rand: no deck to re-deal, no pool yet
+        /* the host's contract is "ask again after every reply" (a cold buffer
+         * answers empty and streams the real batch later) */
+        if ((remotePools[kind] || []).length < count && attempt < BOOT_MAX_ASKS) {
+          const t = setTimeout(() => { bootTimers.delete(t); bootAsk(kind, count, attempt + 1); }, BOOT_RETRY_MS * Math.max(1, attempt));
+          bootTimers.add(t);
+        }
+      },
+    });
+  }
+
+  /**
+   * warmPool({loop, still}) -> boolean. Start filling the remote pools NOW,
+   * before any class is claimed. Once per provider; returns false when the
+   * gates are shut (and when there is nothing to ask over).
+   */
+  function warmPool(spec) {
+    if (disposed || bootAsked) return false;
+    if (!remoteEnabled || offlineMode || !opts.bridge) return false;
+    if (!(remoteRatio > 0)) return false;              // local-only mix: no ask
+    const s = spec || {};
+    const loop = Math.max(0, Math.min(REMOTE_CAP, s.loop | 0));
+    const still = Math.max(0, Math.min(REMOTE_CAP, s.still | 0));
+    if (!loop && !still) return false;
+    bootAsked = true;
+    if (loop) bootAsk('loop', Math.max(4, loop), 1);
+    if (still) bootAsk('still', Math.max(4, still), 1);
+    log('boot ask: loop ' + loop + ' / still ' + still);
+    return true;
+  }
+
+  /* ------------------------------------------------------------------------
    * THE WARM RAIL - bytes AND decode ahead of the deal, and nothing else.
    *
    * The old mechanism was a `link rel=preload` at fetchPriority low: a hint
@@ -271,6 +361,24 @@ export function createAssets(options = {}) {
   const warmHeld = new Map();       // url -> the detached Image holding it open
   let warmFlight = 0;
   let warmVideoFlight = 0;          // the video lanes within warmFlight (capped)
+  let warmFails = new Map();        // url -> attempts that ended in a failure
+
+  /* THE UN-POISON (0826). `prewarmed` is "this url has been asked for", and it
+   * used to be a LIFE SENTENCE: a video warm that hit the abort deadline or an
+   * image whose decode() rejected stayed marked warmed, warmable() refused to
+   * re-queue it, and ready() answered false for the rest of the page. On the
+   * owner's cellular phone that permanently killed every clip that missed once.
+   * A failure now RELEASES the url (bounded by WARM_RETRY_MAX) so the next
+   * forecast may try it again. It does NOT fight the blacklist: a url the
+   * blacklist has convicted is still refused by warmable() below for as long as
+   * the conviction stands, and only a healed one gets its second chance. */
+  function warmFailed(url) {
+    const s = String(url || '');
+    if (!s) return;
+    const n = (warmFails.get(s) | 0) + 1;
+    warmFails.set(s, n);
+    if (n < WARM_RETRY_MAX) prewarmed.delete(s);
+  }
 
   /** Only bytes that actually travel: remote http(s), not our own origin. */
   function warmable(url) {
@@ -363,7 +471,7 @@ export function createAssets(options = {}) {
             /* opaque responses may carry a null body - the cancel is guarded */
             try { if (res && res.body && typeof res.body.cancel === 'function') res.body.cancel(); } catch { /* noop */ }
             warmOk(job.url, true);
-          }, () => { settle(); flushReady(job.url, false); warmDone(true); });
+          }, () => { settle(); warmFailed(job.url); flushReady(job.url, false); warmDone(true); });
           else { settle(); warmDone(true); }
         } catch { warmDone(true); }
       } else {
@@ -388,14 +496,18 @@ export function createAssets(options = {}) {
             img.decode().then(() => warmOk(job.url), () => {
               warmHeld.delete(job.url);
               /* decode() also rejects when a HEALTHY url's decode is aborted
-               * mid-flight; only a url with no pixels at all is actually dead. */
+               * mid-flight; only a url with no pixels at all is actually dead.
+               * Either way the warm did not land, so the url is released for a
+               * later attempt - a conviction keeps warmable() off it until the
+               * blacklist's own TTL forgives, which is the blacklist's call. */
+              warmFailed(job.url);
               if (img.complete && !(Number(img.naturalWidth) > 0)) markBroken(job.url);
               else flushReady(job.url, false);
               warmDone();
             });
           } else {
             img.onload = () => warmOk(job.url);
-            img.onerror = () => { warmHeld.delete(job.url); markBroken(job.url); warmDone(); };
+            img.onerror = () => { warmHeld.delete(job.url); warmFailed(job.url); markBroken(job.url); warmDone(); };
           }
         } catch { warmHeld.delete(job.url); warmDone(); }
       }
@@ -681,6 +793,12 @@ export function createAssets(options = {}) {
      * the local side is the placeholder floor, so EVERY draw is a remote draw
      * and a whole board could dress itself in one clip. */
     const remoteCursors = { loop: 0, still: 0 };
+    /* THE RECENCY RING (0826) - see computeLocal's header. One ring per KIND
+     * BUCKET ('target' shares the still bucket: it draws the same urls out of
+     * the same two lists, and a hunt target that also dresses a decoy is the
+     * one repeat L&F cannot survive). It rides the draw STATE beside the
+     * cursors, so a forecast clones it and mutates nothing serving reads. */
+    const recent = { loop: [], still: [] };
     let released = false;
     let reqIds = [];
 
@@ -713,6 +831,15 @@ export function createAssets(options = {}) {
     }
     function askRemote(kind, count, attempt) {
       if (released || disposed) return;
+      /* KEEP ASKING PAST THE SPEC (0826). The top-up used to stop the moment
+       * the pool covered `count` - the claim spec - so a pool SETTLED at
+       * exactly the ask (Anomaly's desktop still lane: 4 rows for ~129 rounds)
+       * and REMOTE_CAP was never approached. The spec is what a board needs at
+       * once, not what a class needs all hour; doubling it is what turns the
+       * recency ring below from "spread the repeats" into "there are none".
+       * Pool GROWTH is free by law: batches already arrive on network timing,
+       * and absorbRemote draws no rand. */
+      const topUpTo = Math.min(REMOTE_CAP, Math.max(1, count) * 2);
       const id = channel.request({
         kind, count, niches,
         onBatch: (entries) => {
@@ -724,7 +851,7 @@ export function createAssets(options = {}) {
             refreshDeck();
             notifyUpdate();
           }
-          if ((remotePools[kind] || []).length < count && attempt < MAX_ASKS) {
+          if ((remotePools[kind] || []).length < topUpTo && attempt < MAX_ASKS) {
             const t = setTimeout(() => { retryTimers.delete(t); askRemote(kind, count, attempt + 1); }, RETRY_MS * Math.max(1, attempt));
             retryTimers.add(t);
           }
@@ -755,21 +882,74 @@ export function createAssets(options = {}) {
      * is exact until the pool grows; every draw and every absorbed batch
      * re-deals it, so the deck head is always the truth.
      * ==================================================================== */
+    /* THE RECENCY RING's two verbs. `bucket` is 'loop' or 'still' ('target'
+     * draws the still lists), and the ring holds the last urls that bucket
+     * actually SERVED, newest last, capped at RECENT_MAX.
+     *
+     * Only the last min(L-1, RECENT_MAX) entries are ever consulted against a
+     * list of length L, and that bound is load-bearing: it leaves at least one
+     * row of every list outside the ring, so the forward step-skip can never
+     * walk off the end and fall through to the placeholder floor. On a small
+     * list the skip degrades naturally into a plain cursor walk - which is the
+     * without-replacement behaviour the comment below used to claim. */
+    function recentlyServed(ring, url, L) {
+      const depth = Math.min(L - 1, RECENT_MAX);
+      if (!ring || !url || depth <= 0) return false;
+      for (let i = Math.max(0, ring.length - depth); i < ring.length; i++) {
+        if (ring[i] === url) return true;
+      }
+      return false;
+    }
+    function noteServed(ring, url) {
+      if (!ring || !url) return;
+      ring.push(url);
+      while (ring.length > RECENT_MAX) ring.shift();
+    }
+
+    /**
+     * THE FORWARD STEP-SKIP, both lists' one implementation. From the raw index
+     * the rand chose, walk forward to the first row that is neither blacklisted
+     * nor inside this bucket's recency window.
+     *
+     * The SECOND pass is the guarantee that keeps this legal: if the ring
+     * somehow covers every row - a manifest that lists a url twice, a list most
+     * of which the blacklist has taken - the walk falls back to "merely not
+     * blacklisted", i.e. exactly the row the pre-ring provider served. A draw
+     * can therefore never be pushed OFF its list by the ring, which is what
+     * would have moved a take() (the remote list falling through to the local
+     * one costs a second rand). Neither pass consumes rand.
+     */
+    function stepSkip(list, from, ring) {
+      for (let step = 0; step < list.length; step++) {
+        const cand = list[(from + step) % list.length];
+        if (cand && !isBrokenUrl(cand) && !recentlyServed(ring, cand, list.length)) return cand;
+      }
+      for (let step = 0; step < list.length; step++) {
+        const cand = list[(from + step) % list.length];
+        if (cand && !isBrokenUrl(cand)) return cand;
+      }
+      return null;
+    }
+
     function computeLocal(kind, st, take) {
       const list = kind === 'loop' ? localLoops : (kind === 'target' ? localTargets : localStills);
+      const bucket = kind === 'loop' ? 'loop' : 'still';
       if (!list.length) return placeholders[Math.floor(take() * placeholders.length)] || null;
       const i = st.cursors[kind] % list.length;
       st.cursors[kind] += 1;
-      // a deterministic walk with a seeded jump keeps repeats far apart without
-      // ever risking "the same tile twice in a row" on a tiny local pool
+      // a deterministic walk with a seeded jump, re-rolled every draw: on its
+      // own that samples WITH replacement (a 24-tile board over a 24-url pool
+      // shows ~9 duplicate tiles), which is what the skip below exists to fix
       const jump = list.length > 2 ? Math.floor(take() * (list.length - 1)) : 0;
-      /* THE BLACKLIST SKIP consumes no rand: the walk just steps forward to the
-       * next eligible row, so with a clean blacklist (the ordinary day) the
-       * served sequence is byte-identical to the pre-blacklist provider. */
-      for (let step = 0; step < list.length; step++) {
-        const cand = list[(i + jump + step) % list.length];
-        if (cand && !isBrokenUrl(cand)) return cand;
-      }
+      /* THE FORWARD STEP-SKIP consumes no rand: the walk steps to the next
+       * eligible row and the rand that chose the raw index is untouched, so the
+       * COUNT and ORDER of the draws on this path are what they always were.
+       * It skips two things now - a blacklisted url, and one this bucket served
+       * inside its recency window - which together guarantee the board is
+       * dressed WITHOUT replacement for as long as the list can cover it. */
+      const ring = st.recent[bucket];
+      const cand = stepSkip(list, i + jump, ring);
+      if (cand) { noteServed(ring, cand); return cand; }
       return placeholders[(i + jump) % placeholders.length] || null;   // every row dead: the floor
     }
 
@@ -784,24 +964,29 @@ export function createAssets(options = {}) {
         const i = st.remoteCursors[remoteKind] % list.length;
         st.remoteCursors[remoteKind] += 1;
         const jump = list.length > 2 ? Math.floor(take() * (list.length - 1)) : 0;
-        /* the blacklist skip: step to the next eligible row, no rand consumed;
-         * a fully dead remote list falls through to the local side */
-        let url = null;
-        for (let step = 0; step < list.length; step++) {
-          const cand = list[(i + jump + step) % list.length];
-          if (cand && !isBrokenUrl(cand)) { url = cand; break; }
-        }
-        if (url && (!canvasSafe || isLocalUrl(url))) return { url, remote: true };
+        /* the same forward step-skip, and for the same reason: the raw index is
+         * a WITH-REPLACEMENT pick, so on the remote lists - which under an
+         * online-only source dress EVERY tile - it was the whole duplicate bug.
+         * No rand consumed; a fully dead remote list falls through to local. */
+        const ring = st.recent[remoteKind];
+        const url = stepSkip(list, i + jump, ring);
+        if (url && (!canvasSafe || isLocalUrl(url))) { noteServed(ring, url); return { url, remote: true }; }
       }
       return { url: computeLocal(k, st, take), remote: false };
     }
 
-    const liveState = { cursors, remoteCursors };
+    const liveState = { cursors, remoteCursors, recent };
 
     /** The next `depth` draws of one kind, decided EARLY over cloned cursors
-     *  and peeked rand values. Mutates nothing that serving reads. */
+     *  and peeked rand values. Mutates nothing that serving reads - the rings
+     *  are COPIED, so a forecast avoids its own picks exactly the way the real
+     *  draws will and still leaves the live rings alone. */
     function forecast(k, depth) {
-      const st = { cursors: Object.assign({}, cursors), remoteCursors: Object.assign({}, remoteCursors) };
+      const st = {
+        cursors: Object.assign({}, cursors),
+        remoteCursors: Object.assign({}, remoteCursors),
+        recent: { loop: recent.loop.slice(), still: recent.still.slice() },
+      };
       let pi = 0;
       const take = () => peekRand(pi++);
       const out = [];
@@ -819,14 +1004,45 @@ export function createAssets(options = {}) {
     if (want.target) deckKinds.push('target');
     if (!deckKinds.length) deckKinds.push('still');
 
+    /* THE DOMINANT KIND (0826): the one the game asked for most of, and so the
+     * one most of the coming draws will be. Ties keep deckKinds' order. */
+    const dominantKind = deckKinds.reduce(
+      (best, k) => ((want[k] | 0) > (want[best] | 0) ? k : best), deckKinds[0],
+    );
+
+    /**
+     * How deep to forecast each kind for a `d`-slot warm budget.
+     *
+     * THE MIXED-KIND FORECAST (0826). Every kind's forecast restarts peekRand
+     * at 0 - it has to, or a kind's deck HEAD would stop being the url that
+     * kind's next draw serves - which means each kind's forecast assumes the
+     * coming draws are ALL its own. Warming `d` deep for every kind therefore
+     * spent 50-66% of a 2-3-kind claim's warm bandwidth on urls that will
+     * never be served, which on cellular is bandwidth the on-screen board
+     * needed. The real interleave is "a bit of each, mostly the dominant one",
+     * so: the first 2 of EACH kind (the heads are always honest), and every
+     * slot left over goes to the dominant kind's tail. forecast() only PEEKS,
+     * so no scheme here can move the served sequence - the only thing at stake
+     * is which bytes arrive early.
+     */
+    function deckPlan(d) {
+      const head = Math.min(2, d);
+      const plan = Object.create(null);
+      let spent = 0;
+      for (const k of deckKinds) { plan[k] = head; spent += head; }
+      if (spent < d) plan[dominantKind] = Math.min(DECK_AHEAD, plan[dominantKind] + (d - spent));
+      return plan;
+    }
+
     /** Re-deal the deck and warm its remote urls. Returns how many queued. */
     function refreshDeck(depth) {
       if (released || disposed || saveData) return 0;
       if (typeof document === 'undefined') return 0;
       const d = Math.max(1, Math.min(DECK_AHEAD, (depth | 0) || DECK_AHEAD));
+      const plan = deckPlan(d);
       let queued = 0;
       for (const k of deckKinds) {
-        const entries = forecast(k, d);
+        const entries = forecast(k, plan[k]);
         for (let i = 0; i < entries.length; i++) {
           const e = entries[i];
           if (e && e.url && e.remote && warmUrl(e.url, i === 0)) queued += 1;
@@ -897,6 +1113,8 @@ export function createAssets(options = {}) {
         if (released) return;
         released = true;
         reqIds = [];
+        recent.loop.length = 0;        // the recency rings die with the claim
+        recent.still.length = 0;
         updateCbs.clear();
         for (const t of retryTimers) clearTimeout(t);
         retryTimers.clear();
@@ -950,6 +1168,14 @@ export function createAssets(options = {}) {
   return {
     claim,
     claimTagged,
+    /**
+     * warmPool({loop, still}) - the BOOT ASK (see above). The shell calls it
+     * once, right after createAssets, so the door / menu / rules stretch is
+     * spent filling the remote pools instead of waiting on the first claim.
+     * Mints no pool, draws no rand, and is a silent no-op with remote media
+     * off, under OfflineMode, or with no bridge at all.
+     */
+    warmPool: (spec) => warmPool(spec),
     /** The pickable world, as projected on init.settings. Never null fields. */
     catalog() {
       return {
@@ -1043,6 +1269,9 @@ export function createAssets(options = {}) {
     },
     dispose() {
       disposed = true;
+      for (const t of bootTimers) { try { clearTimeout(t); } catch { /* noop */ } }
+      bootTimers.clear();
+      /* every claim's release() empties its own recency rings */
       for (const p of [...claims]) p.release();
       for (const p of [...taggedPools]) { try { p.dispose(); } catch { /* ignore */ } }
       taggedPools.clear();
@@ -1064,6 +1293,7 @@ export function createAssets(options = {}) {
       warmFlight = 0;
       warmVideoFlight = 0;
       prewarmed = new Set();
+      warmFails = new Map();
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
@@ -167,11 +167,19 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
   }
 
   /* ---------------------- the ask ---------------------------------------- */
-  /** How many distinct rows a tag is still worth asking for. */
+  /** How many distinct rows a tag is still worth asking for.
+   *
+   *  LET THE PILE GROW PAST THE SPEC (0826, the claim()-side twin). This is the
+   *  BACKGROUND top-up gate only - `perSourceMin` is still the settle gate the
+   *  door waits on, and raising THAT would just delay the door. What this
+   *  bounds is how long the ask-again loop keeps pulling rows in after the
+   *  class has already started, and stopping it at the deal spec is why a pile
+   *  settled at exactly its ask and every later hand re-served the same faces.
+   *  Both spec-shaped terms are doubled; TAG_CAP is still the ceiling. */
   function targetFor(tag) {
     const rows = sources.filter((x) => x.tag === tag.name).length || 1;
-    const share = Math.ceil((want.loop + want.still) / Math.max(1, tagNames.length));
-    return Math.max(perSourceMin, Math.min(TAGGED.TAG_CAP, share || perSourceMin * 2, rows * 40));
+    const share = Math.ceil((want.loop + want.still) / Math.max(1, tagNames.length)) * 2;
+    return Math.max(perSourceMin, Math.min(TAGGED.TAG_CAP, share || perSourceMin * 2, rows * 80));
   }
 
   function ask(src, kind, attempt) {

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -940,6 +940,21 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     assets = NULL_ASSETS_FACTORY();
   }
 
+  /* THE BOOT ASK (0826). The provider's first 'assets-request' used to leave
+   * the page when a class was CLAIMED, which made the whole door / menu /
+   * rules-sheet stretch network dead air - 10-30 seconds of it on the owner's
+   * cellular phone, after which the first board still dressed itself in
+   * placeholders because the host was only then doing its round trip. This
+   * starts the remote pools filling NOW; the web shim has already preconnected
+   * the Scrolller API and the CDN origins by this point, and this is the ask
+   * that makes that preconnect pay off instead of letting the sockets go cold.
+   * Modest on purpose - a head start, not a supply run; the class's own claim
+   * still asks for what it needs. Mints no pool and draws no rand, so no
+   * class's served media moves, and it is a silent no-op with remote media
+   * off, under OfflineMode, or with no bridge at all. */
+  try { if (assets && typeof assets.warmPool === 'function') assets.warmPool({ loop: 8, still: 8 }); }
+  catch (e) { say('[assets] boot warm refused (' + ((e && e.message) || e) + ')'); }
+
   const ceremonies = createCeremonies({
     engine: null,                  // rebound per class (the engine is per class)
     layer: dom && dom.ceremony,

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -985,6 +985,10 @@ html.arc-reduced .arc-disc-body, html.arc-reduced .arc-disc-chev { transition:no
 }
 @keyframes arc-intro-burst-in { from { opacity:0; } to { opacity:.085; } }
 @keyframes arc-intro-burst-turn { to { transform:rotate(360deg); } }
+/* touch: keep the entrance, drop the infinite turn - an 18s rotate on a
+   150vmax masked conic is a permanent oversized composite a phone pays for
+   from boot onward */
+html.ae-touch .arc-intro-burst { animation:arc-intro-burst-in .6s ease-out .5s both; }
 
 /* ---- the stage: the wordmark + everything that hangs off it -------------- */
 .arc-intro-stage {


### PR DESCRIPTION
Owner verdict after the R3 media wave: *"some games are unplayable, we might wanna go lightweight on the graphics on mobile. Gifs don't load in time, often duplicates, super laggy whenever we use fullscreen spirals and gifs. The worst offender is for sure the echo game."*

R3 fixed media **loading**. This fixes what the phone has to **draw**, and the two media faults R3 left standing.

## The measurement

Echo on the CDP rig, 390x844 touch, 12s of real play, same seed:

| | frames delivered | p50 | p95 | over 32ms |
|---|---|---|---|---|
| before | 538 | 16.7ms | 33.4ms | **173 (32%)** |
| after | 713 | 16.7ms | 16.7ms | **2 (0.3%)** |

Desktop in the same pair: p50 50ms both, identical blend/filter/willChange counts. The Deep End: 16.7ms and zero janky frames before and after, with a lighter FX census.

## What was actually wrong

The lite twins from the last wave were already firing on every phone, so **node counts were never the lag**. The cost was the half nothing device-classed:

- **Echo had no touch diet at all** - one `ae-touch` hit in the whole game, and it was a hover fix. A registered `@property` lamp drove animating *blur radii* on four gradients, four box-shadows and two text-shadows across six pads, all six lit before every input turn. Its word-fit forced ~23 synchronous full-stage layouts per fit, on every re-deal, every trickster lie, and every iOS URL-bar resize.
- **The loom spiral canvas re-armed rAF on skipped frames**, so a phone held a display-rate heartbeat forever while painting at 30fps.
- **Two held-wash bugs**, both unconditional fixes: a wash whose channel gated off kept its alpha and its GPU loop forever with every later trigger hitting an early return; and a step-down under a scaled-down held alpha was misread as a flare, leaving the loom running behind an invisible wash for the rest of the class - **live in SORT today**.
- **Video**: the engine budgeted 3 decoders on touch, iOS thrashes past ~3, and the games mint their own outside the budget entirely.
- **The eight other classes** carried blend surfaces over live media, viewport-scale blurs, and `@keyframes` animating filter/box-shadow - including a lamp animating `margin-left` (a layout pass per frame) and a ken-burns re-running a filter inside every archived plate.

## The two media faults

- **Late**: the first Scrolller ask only left the page when a class was claimed - the whole door/rules stretch was dead air. And a warm that failed once was marked prewarmed **forever**, so media that missed on cellular never got a second chance.
- **Duplicates**: the core draw was sampling *with replacement* while its comment claimed the opposite (the seeded jump was re-rolled every draw). Simulated over 200 seeds, a 24-tile board over a 24-url pool gave 15.3 distinct tiles - the ~9 duplicates the owner saw. Now 24/24 distinct, zero adjacent repeats, via the blacklist's own zero-rand skip. Pools also stopped growing at the claim spec, which left Anomaly's desktop class living on **four stills for ~129 rounds**.

## The laws held

- **Desktop pixel/behaviour identical.** The eight-game sweep has zero deleted lines (purely additive `ae-touch` overrides). Verified in the A/B above. One deliberate exception, marked in code: Echo's streak meter keeps its mount on touch only, because a remount replays the segment shimmer.
- **Shared-RNG law.** No `pool.next()`/`take()`/`roll()` added, removed or moved on any existing path. Where an effect is suppressed on touch the roll that decided it is still consumed - Echo's veil variant index included - so a phone and a desktop walk identical seeded streams. The two rng divergences that exist ride `ctx.lite()`, an existing device class.
- Eval-import sweep run on all 32 touched modules; TRAP 37 checked programmatically (no backticks in template comments).

## Known / not claimed

- The engine wash cap and the loom idle were **not exercised by the smoke** (they arm at tiers the harness does not reach). Their proof is by review, not measurement.
- Three CSS swaps are approximations rather than freezes (daily-trigger's lamp, misdirection's weave tint, composure's washes) - worth a glance on the phone.
- The dedup fix cannot show in the rig (no remote pool offline); its evidence is the simulation plus a live check against the real module.

Needs a phone play-test: Echo above all, then daily-trigger / misdirection / composure for the three approximations.