### PR TITLE
feat(sync): mobile streak parity - last_streak_date, contiguity adoption, deferred shield burn, mobile quest ledger

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
@@ -207,6 +207,12 @@ namespace ConditioningControlPanel
                 s.LastDailyQuestDate = null;
                 s.LastPerfectWeekStreakAwarded = 0;
 
+                // Mobile quest ledger mirror — per-account, server-authoritative; the next
+                // account's sync re-adopts its own figures.
+                s.MobileQuestDailyCompleted = 0;
+                s.MobileQuestWeeklyCompleted = 0;
+                s.MobileQuestXP = 0;
+
                 // Streak shields
                 s.StreakShieldsRemaining = 0;
                 s.LastStreakShieldResetDate = null;

--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
@@ -782,8 +782,10 @@ namespace ConditioningControlPanel
 
                 if (result != MessageBoxResult.Yes) return;
 
-                // Server-side spend only — charges live on the account.
-                var fixDateStr = fixDate.ToString("yyyy-MM-dd");
+                // Server-side spend only — charges live on the account. Invariant: under a
+                // Buddhist/Umm al-Qura system calendar the default format writes year 2569
+                // onto the wire and the server records (or refuses) a garbage fixed day.
+                var fixDateStr = fixDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
                 if (App.ProfileSync == null || string.IsNullOrEmpty(App.Settings?.Current?.UnifiedId))
                 {
                     // No cloud account

--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
@@ -274,10 +274,13 @@ namespace ConditioningControlPanel
                 QuestsTab.BtnRerollWeekly.Content = Loc.Get("btn_completed");
             }
 
-            // Update statistics
-            QuestsTab.TxtTotalDailyCompleted.Text = questService.Progress.TotalDailyQuestsCompleted.ToString();
-            QuestsTab.TxtTotalWeeklyCompleted.Text = questService.Progress.TotalWeeklyQuestsCompleted.ToString();
-            QuestsTab.TxtTotalQuestXP.Text = questService.Progress.TotalXPFromQuests.ToString();
+            // Update statistics. Combined view: local/desktop totals + the server's mobile quest
+            // ledger (adopted read-only into AppSettings on sync). The two live in separate
+            // counters on purpose — only the desktop ones ride the sync push.
+            var mobileLedger = App.Settings?.Current;
+            QuestsTab.TxtTotalDailyCompleted.Text = (questService.Progress.TotalDailyQuestsCompleted + (mobileLedger?.MobileQuestDailyCompleted ?? 0)).ToString();
+            QuestsTab.TxtTotalWeeklyCompleted.Text = (questService.Progress.TotalWeeklyQuestsCompleted + (mobileLedger?.MobileQuestWeeklyCompleted ?? 0)).ToString();
+            QuestsTab.TxtTotalQuestXP.Text = (questService.Progress.TotalXPFromQuests + (mobileLedger?.MobileQuestXP ?? 0)).ToString();
             QuestsTab.TxtStreakFixCharges.Text = (App.Settings?.Current?.StreakFixCharges ?? 0).ToString();
 
             // Update header stats

--- a/ConditioningControlPanel/Models/AchievementProgress.cs
+++ b/ConditioningControlPanel/Models/AchievementProgress.cs
@@ -232,6 +232,17 @@ public class AchievementProgress
     public bool PendingStreakBonus { get; set; }
 
     /// <summary>
+    /// Mobile streak parity: a launch-time gap was detected but the break decision (shield burn /
+    /// Oopsie spend / reset) is DEFERRED until the first V2 sync answers — the phone may have kept
+    /// the streak alive on days this machine never launched, and burning a shield for a gap the
+    /// cloud says never happened wastes a real, finite token. Deliberately NOT persisted: if the
+    /// app dies while pending, <see cref="LastLaunchDate"/> was never stamped, so the next launch
+    /// re-detects the same gap and defers again — no state to migrate, nothing to get stuck.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool PendingStreakBreak { get; private set; }
+
+    /// <summary>
     /// Check and update consecutive days streak.
     /// Integrates streak shields, oopsie insurance, milestone rewards, and CurrentStreak sync.
     /// </summary>
@@ -246,6 +257,11 @@ public class AchievementProgress
 
         var today = DateTime.Today;
         var lastDate = LastLaunchDate.Date;
+
+        // A deferred break decision is in flight (waiting on the first V2 sync / its timeout).
+        // ResolveDeferredStreakBreak owns the next write to LastLaunchDate — running the gap
+        // math again here would burn the shield the deferral exists to protect.
+        if (PendingStreakBreak) return;
 
         // No recorded launch history (LastLaunchDate == default/MinValue). This is either a
         // genuine first run OR a fresh/reset achievements.json after a reinstall, failed update
@@ -282,37 +298,20 @@ public class AchievementProgress
             App.Logger?.Information("Login streak gap detected: {Days} day(s) missed (last launch: {LastDate}, today: {Today}, streak was: {Streak})",
                 daysMissed, lastDate.ToString("yyyy-MM-dd"), today.ToString("yyyy-MM-dd"), ConsecutiveDays);
 
-            // Streak would break - try streak shield first
-            if (App.SkillTree?.UseStreakShield() == true)
+            // Mobile streak parity: a signed-in account may have kept this streak alive on the
+            // phone. Hold the break decision (and the shield/Oopsie tokens) until the first V2
+            // sync merges the cloud's last_streak_date/consecutive_days, or the timeout gives up.
+            // LastLaunchDate is deliberately NOT stamped: the push that races this deferral must
+            // carry the honest pre-gap date, not claim today.
+            if (CanDeferStreakBreakToCloud())
             {
-                // Shield saved the streak! Increment as normal
-                ConsecutiveDays++;
-                App.Logger?.Information("Streak shield protected streak! Now at {Days} days", ConsecutiveDays);
-                PendingStreakBonus = true;
+                PendingStreakBreak = true;
+                App.Logger?.Information("Login streak: break deferred pending cloud answer (mobile may have covered the gap)");
+                ScheduleDeferredStreakBreakTimeout();
+                return;
+            }
 
-                // Record the missed day(s) that were shielded
-                var settings = App.Settings?.Current;
-                if (settings != null)
-                {
-                    for (var d = lastDate.AddDays(1); d < today; d = d.AddDays(1))
-                    {
-                        if (!settings.StreakShieldUsedDates.Contains(d.Date))
-                            settings.StreakShieldUsedDates.Add(d.Date);
-                    }
-                }
-            }
-            else if (App.SkillTree?.UseOopsieInsurance() == true)
-            {
-                // A streak fix charge was spent automatically — keep current streak
-                App.Logger?.Information("Oopsie Insurance auto-spent a streak fix, saving streak at {Days} days", ConsecutiveDays);
-            }
-            else
-            {
-                // Streak broken, reset to 1
-                App.Logger?.Warning("Login streak RESET from {OldStreak} to 1 — gap of {Days} day(s), no shield/insurance available (last launch: {LastDate})",
-                    ConsecutiveDays, daysMissed, lastDate.ToString("yyyy-MM-dd"));
-                ConsecutiveDays = 1;
-            }
+            ResolveStreakGapNow(lastDate, today, daysMissed);
         }
 
         LastLaunchDate = today;
@@ -324,6 +323,201 @@ public class AchievementProgress
         // CurrentStreak because the server-driven season reset can zero CurrentStreak before
         // the recap snapshot runs — the peak must survive that.
         SeasonRecapService.TrackStreakPeak(ConsecutiveDays);
+    }
+
+    /// <summary>
+    /// The actual streak-break spend/reset, extracted so the deferred path and the immediate path
+    /// share one implementation: shield first, then Oopsie Insurance, then reset to 1.
+    /// Mutates ConsecutiveDays/PendingStreakBonus only — the caller stamps LastLaunchDate.
+    /// </summary>
+    private void ResolveStreakGapNow(DateTime lastDate, DateTime today, int daysMissed)
+    {
+        // Streak would break - try streak shield first
+        if (App.SkillTree?.UseStreakShield() == true)
+        {
+            // Shield saved the streak! Increment as normal
+            ConsecutiveDays++;
+            App.Logger?.Information("Streak shield protected streak! Now at {Days} days", ConsecutiveDays);
+            PendingStreakBonus = true;
+
+            // Record the missed day(s) that were shielded
+            var settings = App.Settings?.Current;
+            if (settings != null)
+            {
+                for (var d = lastDate.AddDays(1); d < today; d = d.AddDays(1))
+                {
+                    if (!settings.StreakShieldUsedDates.Contains(d.Date))
+                        settings.StreakShieldUsedDates.Add(d.Date);
+                }
+            }
+        }
+        else if (App.SkillTree?.UseOopsieInsurance() == true)
+        {
+            // A streak fix charge was spent automatically — keep current streak
+            App.Logger?.Information("Oopsie Insurance auto-spent a streak fix, saving streak at {Days} days", ConsecutiveDays);
+        }
+        else
+        {
+            // Streak broken, reset to 1
+            App.Logger?.Warning("Login streak RESET from {OldStreak} to 1 — gap of {Days} day(s), no shield/insurance available (last launch: {LastDate})",
+                ConsecutiveDays, daysMissed, lastDate.ToString("yyyy-MM-dd"));
+            ConsecutiveDays = 1;
+        }
+    }
+
+    /// <summary>
+    /// The deferral only makes sense when a cloud answer can actually arrive: a V2 identity to
+    /// sync with, and sync not deliberately disabled. Everyone else gets the immediate decision.
+    /// </summary>
+    private static bool CanDeferStreakBreakToCloud()
+    {
+        var settings = App.Settings?.Current;
+        return settings != null
+            && !string.IsNullOrEmpty(settings.UnifiedId)
+            && settings.OfflineMode != true;
+    }
+
+    /// <summary>
+    /// Safety net for the deferral: if no sync resolves the pending break (server down, network
+    /// gone, sync never attempted), fall back to the immediate decision after a grace window —
+    /// exactly the behavior a signed-out user gets at launch.
+    /// </summary>
+    private void ScheduleDeferredStreakBreakTimeout()
+    {
+        _ = System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(120)).ContinueWith(_ =>
+        {
+            try
+            {
+                if (System.Windows.Application.Current?.Dispatcher == null) return;
+                ResolveDeferredStreakBreak("cloud answer timeout");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Deferred streak-break timeout failed: {Error}", ex.Message);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Settle a deferred streak break. Called after the first V2 sync of the launch has merged
+    /// the cloud's streak fields (which may have moved <see cref="LastLaunchDate"/> forward over
+    /// mobile-covered days), on sync failure, and by the timeout. Idempotent; safe from any
+    /// thread (marshals itself to the UI dispatcher).
+    /// </summary>
+    public void ResolveDeferredStreakBreak(string reason)
+    {
+        if (!PendingStreakBreak) return;
+
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher != null && !dispatcher.CheckAccess())
+        {
+            dispatcher.BeginInvoke(new Action(() => ResolveDeferredStreakBreak(reason)));
+            return;
+        }
+
+        if (!PendingStreakBreak) return; // re-check after the hop — another caller may have won
+        PendingStreakBreak = false;
+
+        var today = DateTime.Today;
+        var lastDate = LastLaunchDate.Date;
+        App.Logger?.Information("Deferred streak break resolving ({Reason}): last banked {LastDate}, streak {Streak}",
+            reason, lastDate.ToString("yyyy-MM-dd"), ConsecutiveDays);
+
+        if (lastDate == today)
+        {
+            // The cloud merge moved the date all the way to today — the phone already banked this
+            // day (and its streak figure was adopted with it). No increment and no bonus HERE:
+            // paying the launch bonus for a day another device earned would double-pay it.
+        }
+        else if (lastDate == today.AddDays(-1))
+        {
+            // The cloud covered the gap up to yesterday — today is a normal launch increment.
+            ConsecutiveDays++;
+            PendingStreakBonus = true;
+            LastLaunchDate = today;
+        }
+        else
+        {
+            // The gap is real even by the cloud's account — make the decision we deferred.
+            // SkillTree exists by now (sync runs long after startup), so unlike the old
+            // constructor-time path the shield can actually fire here.
+            ResolveStreakGapNow(lastDate, today, (today - lastDate).Days);
+            LastLaunchDate = today;
+        }
+
+        SyncCurrentStreak();
+        SeasonRecapService.TrackStreakPeak(ConsecutiveDays);
+        AwardDeferredStreakBonus();
+        App.Achievements?.Save();
+        App.Settings?.Save();
+    }
+
+    /// <summary>
+    /// Pure merge rule for adopting the cloud's login-streak pair (consecutive_days +
+    /// last_streak_date) into the local one. Mirrors the mobile client's decideLoginStreakAdopt
+    /// (CCPMobile src/lib/sync/contract.ts) so the two clients converge on the same answer:
+    ///  - never lowers the local streak (the server ratchet is preserved deliberately);
+    ///  - a server date exactly one day AFTER the local one means the runs are contiguous — the
+    ///    local run extends it (max(server, local+1)), not just max;
+    ///  - symmetrically, a local date one day after the server's takes max(local, server+1);
+    ///  - a newer server date is adopted (clamped to today so a timezone-skewed phone can never
+    ///    push LastLaunchDate into the future, which would read as a negative gap next launch);
+    ///  - a wide gap in either direction falls back to plain max — the preserved ratchet.
+    /// Returns null when nothing changes. Static and clock-free for testability.
+    /// </summary>
+    public static (int Streak, DateTime LastDate)? DecideLoginStreakAdopt(
+        int localStreak, DateTime localLastDate, int serverStreak, DateTime? serverLastDate, DateTime today)
+    {
+        var local = localLastDate.Date;
+        int nextStreak;
+        DateTime nextDate;
+
+        if (serverLastDate == null || serverLastDate.Value.Date == default)
+        {
+            // No usable server date — date-blind take-higher, the pre-parity behavior.
+            nextStreak = Math.Max(localStreak, serverStreak);
+            nextDate = local;
+        }
+        else
+        {
+            var server = serverLastDate.Value.Date;
+            if (server > today.Date) server = today.Date;
+
+            if (local == default)
+            {
+                nextStreak = Math.Max(localStreak, serverStreak);
+                nextDate = server;
+            }
+            else if (server == local)
+            {
+                nextStreak = Math.Max(localStreak, serverStreak);
+                nextDate = local;
+            }
+            else if (server == local.AddDays(1))
+            {
+                nextStreak = Math.Max(serverStreak, localStreak + 1);
+                nextDate = server;
+            }
+            else if (server > local)
+            {
+                nextStreak = Math.Max(serverStreak, localStreak);
+                nextDate = server;
+            }
+            else if (local == server.AddDays(1))
+            {
+                nextStreak = Math.Max(localStreak, serverStreak + 1);
+                nextDate = local;
+            }
+            else
+            {
+                nextStreak = Math.Max(localStreak, serverStreak);
+                nextDate = local;
+            }
+        }
+
+        if (nextStreak < localStreak) return null;
+        if (nextStreak == localStreak && nextDate == local) return null;
+        return (nextStreak, nextDate);
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Models/AchievementProgress.cs
+++ b/ConditioningControlPanel/Models/AchievementProgress.cs
@@ -408,8 +408,31 @@ public class AchievementProgress
     {
         if (!PendingStreakBreak) return;
 
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher != null && !dispatcher.CheckAccess())
+        // A profile switch / achievements reload can replace App.Achievements.Progress while
+        // the 120s timeout closure still holds THIS instance. Resolving from a stale instance
+        // would spend the shield/Oopsie tokens of whoever is signed in NOW (App.SkillTree is
+        // global) for a gap that belongs to the OLD profile. A superseded instance only clears
+        // its own flag and steps aside — the live instance re-detects its own gap at launch.
+        if (!ReferenceEquals(App.Achievements?.Progress, this))
+        {
+            PendingStreakBreak = false;
+            App.Logger?.Information("Deferred streak break ({Reason}) dropped: progress instance superseded", reason);
+            return;
+        }
+
+        // Shutting down (or no WPF app at all): there is no dispatcher to marshal to and no
+        // point burning tokens into state that may not save. Clear the flag and do nothing —
+        // the next launch re-detects the same gap and defers again, which is the designed
+        // no-state-to-migrate property of this flag.
+        var app = System.Windows.Application.Current;
+        if (app?.Dispatcher == null || app.Dispatcher.HasShutdownStarted)
+        {
+            PendingStreakBreak = false;
+            return;
+        }
+
+        var dispatcher = app.Dispatcher;
+        if (!dispatcher.CheckAccess())
         {
             dispatcher.BeginInvoke(new Action(() => ResolveDeferredStreakBreak(reason)));
             return;
@@ -456,6 +479,8 @@ public class AchievementProgress
     /// Pure merge rule for adopting the cloud's login-streak pair (consecutive_days +
     /// last_streak_date) into the local one. Mirrors the mobile client's decideLoginStreakAdopt
     /// (CCPMobile src/lib/sync/contract.ts) so the two clients converge on the same answer:
+    ///  - a zero/negative server streak carries no run to merge — refuse it outright (both
+    ///    clients), or a degenerate record's DATE alone could move LastLaunchDate forward;
     ///  - never lowers the local streak (the server ratchet is preserved deliberately);
     ///  - a server date exactly one day AFTER the local one means the runs are contiguous — the
     ///    local run extends it (max(server, local+1)), not just max;
@@ -463,11 +488,17 @@ public class AchievementProgress
     ///  - a newer server date is adopted (clamped to today so a timezone-skewed phone can never
     ///    push LastLaunchDate into the future, which would read as a negative gap next launch);
     ///  - a wide gap in either direction falls back to plain max — the preserved ratchet.
+    /// One deliberate divergence from the mobile twin: with NO usable server date the desktop
+    /// still does a date-blind take-higher (the pre-parity behavior, kept for records written
+    /// by servers older than the parity deploy); mobile answers null there and leaves local
+    /// alone, because it has no pre-parity history to stay compatible with.
     /// Returns null when nothing changes. Static and clock-free for testability.
     /// </summary>
     public static (int Streak, DateTime LastDate)? DecideLoginStreakAdopt(
         int localStreak, DateTime localLastDate, int serverStreak, DateTime? serverLastDate, DateTime today)
     {
+        if (serverStreak <= 0) return null;
+
         var local = localLastDate.Date;
         int nextStreak;
         DateTime nextDate;
@@ -515,6 +546,8 @@ public class AchievementProgress
             }
         }
 
+        // Backstop only — every branch above max()es with localStreak, so this cannot fire
+        // today. It stays to keep the "never lowers" contract true against future edits.
         if (nextStreak < localStreak) return null;
         if (nextStreak == localStreak && nextDate == local) return null;
         return (nextStreak, nextDate);

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -630,6 +630,40 @@ namespace ConditioningControlPanel.Models
             set { _lastDailyQuestDate = value; OnPropertyChanged(); }
         }
 
+        private int _mobileQuestDailyCompleted = 0;
+        /// <summary>
+        /// Lifetime daily quests completed on the MOBILE app — a mirror of the server's
+        /// authoritative mobile_stats ledger (/v2/user/quest-complete), adopted verbatim on every
+        /// V2 sync. Display-only: summed with QuestProgress.TotalDailyQuestsCompleted for combined
+        /// totals, and NEVER added into the counters this client pushes (the server's max-merge
+        /// would double-count every mobile quest).
+        /// </summary>
+        public int MobileQuestDailyCompleted
+        {
+            get => _mobileQuestDailyCompleted;
+            set { _mobileQuestDailyCompleted = Math.Max(0, value); OnPropertyChanged(); }
+        }
+
+        private int _mobileQuestWeeklyCompleted = 0;
+        /// <summary>
+        /// Lifetime weekly quests completed on the mobile app. See <see cref="MobileQuestDailyCompleted"/>.
+        /// </summary>
+        public int MobileQuestWeeklyCompleted
+        {
+            get => _mobileQuestWeeklyCompleted;
+            set { _mobileQuestWeeklyCompleted = Math.Max(0, value); OnPropertyChanged(); }
+        }
+
+        private int _mobileQuestXP = 0;
+        /// <summary>
+        /// Lifetime XP from quests completed on the mobile app. See <see cref="MobileQuestDailyCompleted"/>.
+        /// </summary>
+        public int MobileQuestXP
+        {
+            get => _mobileQuestXP;
+            set { _mobileQuestXP = Math.Max(0, value); OnPropertyChanged(); }
+        }
+
         private int _streakShieldsRemaining = 0;
         /// <summary>
         /// Weekly streak shields remaining.

--- a/ConditioningControlPanel/Services/Progression/SkillTreeService.cs
+++ b/ConditioningControlPanel/Services/Progression/SkillTreeService.cs
@@ -490,7 +490,9 @@ public class SkillTreeService : IDisposable
             {
                 try
                 {
-                    var today = DateTime.Today.ToString("yyyy-MM-dd");
+                    // Invariant like every other wire day key — the default format writes the
+                    // Buddhist/Umm al-Qura year under those system calendars.
+                    var today = DateTime.Today.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
                     var (ok, _, _, credits) = await App.ProfileSync.UseOopsieInsuranceAsync(today);
                     var current = App.Settings?.Current;
                     if (ok && credits.HasValue && current != null && current.StreakFixCharges != credits.Value)

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1320,6 +1320,14 @@ namespace ConditioningControlPanel.Services
                             ["highest_streak"] = settings.HighestStreak,
                             ["total_flashes"] = achievementProgress?.TotalFlashImages ?? 0,
                             ["consecutive_days"] = achievementProgress?.ConsecutiveDays ?? 0,
+                            // Mobile streak parity: the day the streak ran through, as a yyyy-MM-dd
+                            // day key — the server take-newers it (20-char cap, longer is silently
+                            // dropped) and the phone uses it to decide contiguity. Empty when no
+                            // launch was ever banked. While a break decision is deferred this is
+                            // the honest PRE-GAP date (UpdateDailyStreak did not stamp today), so
+                            // this push can never teach the server a streak that may be breaking.
+                            ["last_streak_date"] = achievementProgress != null && achievementProgress.LastLaunchDate.Date != default
+                                ? achievementProgress.LastLaunchDate.ToString("yyyy-MM-dd") : "",
                             ["total_bubbles_popped"] = achievementProgress?.TotalBubblesPopped ?? 0,
                             ["total_video_minutes"] = Math.Round(achievementProgress?.TotalVideoMinutes ?? 0, 1),
                             ["total_lock_cards_completed"] = achievementProgress?.TotalLockCardsCompleted ?? 0,
@@ -1327,7 +1335,10 @@ namespace ConditioningControlPanel.Services
                             ["lifetime_points_spent"] = achievementProgress?.LifetimeSkillPointsSpent ?? 0,
                             // Quest streak data
                             ["daily_quest_streak"] = settings.DailyQuestStreak,
-                            ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("o") ?? "",
+                            // Day key, NOT round-trip "o" format: the server's string-stat merge
+                            // caps values at 20 chars and silently dropped the 33-char ISO stamp,
+                            // so this field never actually reached the cloud until v6.8.5.
+                            ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd") ?? "",
                             ["quest_completion_dates"] = questProgress?.DailyQuestCompletionDates?
                                 .Select(d => d.ToString("yyyy-MM-dd")).ToList() ?? new List<string>(),
                             ["total_daily_quests_completed"] = questProgress?.TotalDailyQuestsCompleted ?? 0,
@@ -1716,6 +1727,33 @@ namespace ConditioningControlPanel.Services
                             }
                         }
 
+                        // Mobile streak parity: the server has answered — whatever it said (even
+                        // "no stats"), this is the cloud's word on whether the phone covered the
+                        // gap. Settle a deferred launch-time streak break now; no-op otherwise.
+                        App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync response merged");
+
+                        // Mobile quest ledger totals (server-authoritative, from the phone's
+                        // /v2/user/quest-complete calls). Stored SEPARATELY and only ever summed
+                        // for display: folding them into QuestProgress counters would push them
+                        // back up as desktop totals, and the server's max-merge would then count
+                        // every mobile quest twice.
+                        if (v2Result?.User?.MobileStats is { } mobileStats)
+                        {
+                            var msSettings = App.Settings?.Current;
+                            if (msSettings != null &&
+                                (msSettings.MobileQuestDailyCompleted != mobileStats.TotalDailyQuestsCompleted ||
+                                 msSettings.MobileQuestWeeklyCompleted != mobileStats.TotalWeeklyQuestsCompleted ||
+                                 msSettings.MobileQuestXP != mobileStats.TotalXPFromQuests))
+                            {
+                                msSettings.MobileQuestDailyCompleted = mobileStats.TotalDailyQuestsCompleted;
+                                msSettings.MobileQuestWeeklyCompleted = mobileStats.TotalWeeklyQuestsCompleted;
+                                msSettings.MobileQuestXP = mobileStats.TotalXPFromQuests;
+                                App.Settings?.Save();
+                                App.Logger?.Information("Mobile quest ledger adopted: {Daily} daily / {Weekly} weekly / {Xp} XP",
+                                    mobileStats.TotalDailyQuestsCompleted, mobileStats.TotalWeeklyQuestsCompleted, mobileStats.TotalXPFromQuests);
+                            }
+                        }
+
                         // Merge total conditioning minutes from server (take higher)
                         if (v2Result?.TotalConditioningMinutes.HasValue == true && v2Result.TotalConditioningMinutes.Value > settings.TotalConditioningMinutes)
                         {
@@ -2025,6 +2063,9 @@ namespace ConditioningControlPanel.Services
                         ["highest_streak"] = settings.HighestStreak,
                         ["total_flashes"] = achievementProgress?.TotalFlashImages ?? 0,
                         ["consecutive_days"] = achievementProgress?.ConsecutiveDays ?? 0,
+                        // Mobile streak parity twin of the V2 dict above: day key or empty.
+                        ["last_streak_date"] = achievementProgress != null && achievementProgress.LastLaunchDate.Date != default
+                            ? achievementProgress.LastLaunchDate.ToString("yyyy-MM-dd") : "",
                         ["total_bubbles_popped"] = achievementProgress?.TotalBubblesPopped ?? 0,
                         ["total_video_minutes"] = Math.Round(achievementProgress?.TotalVideoMinutes ?? 0, 1),
                         ["total_lock_cards_completed"] = achievementProgress?.TotalLockCardsCompleted ?? 0,
@@ -2050,7 +2091,8 @@ namespace ConditioningControlPanel.Services
                         ["total_spiral_minutes"] = Math.Round(achievementProgress?.TotalSpiralMinutes ?? 0, 1),
                         // Quest streak data
                         ["daily_quest_streak"] = settings.DailyQuestStreak,
-                        ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("o") ?? "",
+                        // Day key, not "o" — same 20-char server cap as the V2 dict above.
+                        ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd") ?? "",
                         ["quest_completion_dates"] = legacyQuestProgress?.DailyQuestCompletionDates?
                             .Select(d => d.ToString("yyyy-MM-dd")).ToList() ?? new List<string>(),
                         ["total_daily_quests_completed"] = legacyQuestProgress?.TotalDailyQuestsCompleted ?? 0,
@@ -2121,6 +2163,9 @@ namespace ConditioningControlPanel.Services
             {
                 App.Logger?.Error(ex, "Failed to sync profile to cloud");
                 LastSyncError = ex.Message;
+                // Mobile streak parity: the cloud is unreachable, so a deferred streak break
+                // gets the pre-parity behavior now instead of waiting out the full timeout.
+                App.Achievements?.Progress?.ResolveDeferredStreakBreak("sync failed");
                 return false;
             }
             }
@@ -2891,8 +2936,31 @@ namespace ConditioningControlPanel.Services
                 }
                 if (cloudStats.TryGetValue("consecutive_days", out var streak))
                 {
+                    // Mobile streak parity: not a bare take-higher any more. The cloud pair
+                    // (consecutive_days + last_streak_date) may describe a run the PHONE kept
+                    // alive on days this machine never launched; DecideLoginStreakAdopt applies
+                    // the same contiguity rules as the mobile client (extend by one when the two
+                    // dates are adjacent, plain max otherwise, never lower) and moves
+                    // LastLaunchDate forward over mobile-covered days so a deferred break
+                    // resolution — and every later launch — no longer reads them as a gap.
                     var st = Convert.ToInt32(streak);
-                    if (st > progress.ConsecutiveDays) { progress.ConsecutiveDays = st; needsSave = true; }
+                    DateTime? cloudStreakDate = null;
+                    if (cloudStats.TryGetValue("last_streak_date", out var lsdObj))
+                    {
+                        var lsdStr = lsdObj?.ToString();
+                        if (!string.IsNullOrEmpty(lsdStr) && DateTime.TryParse(lsdStr, out var lsdParsed))
+                            cloudStreakDate = lsdParsed.Date;
+                    }
+                    var adopt = Models.AchievementProgress.DecideLoginStreakAdopt(
+                        progress.ConsecutiveDays, progress.LastLaunchDate, st, cloudStreakDate, DateTime.Today);
+                    if (adopt != null)
+                    {
+                        App.Logger?.Information("Login streak sync: adopting cloud streak {Streak} (local was {Local}), run through {Date}",
+                            adopt.Value.Streak, progress.ConsecutiveDays, adopt.Value.LastDate.ToString("yyyy-MM-dd"));
+                        progress.ConsecutiveDays = adopt.Value.Streak;
+                        if (adopt.Value.LastDate != default) progress.LastLaunchDate = adopt.Value.LastDate;
+                        needsSave = true;
+                    }
                 }
                 if (cloudStats.TryGetValue("total_bubbles_popped", out var bubbles))
                 {
@@ -4511,6 +4579,29 @@ namespace ConditioningControlPanel.Services
 
             [JsonProperty("stats")]
             public Dictionary<string, object>? Stats { get; set; }
+
+            /// <summary>
+            /// Server-authoritative ledger of quests completed ON THE PHONE
+            /// (/v2/user/quest-complete). Combined totals for display are
+            /// stats.X + mobile_stats.X; these must NEVER be folded into the
+            /// QuestProgress counters this client pushes, or the server's
+            /// max-merge double-counts every mobile quest. Null on older servers.
+            /// </summary>
+            [JsonProperty("mobile_stats")]
+            public V2MobileStats? MobileStats { get; set; }
+        }
+
+        /// <summary>The slice of the server's mobile quest ledger the desktop displays.</summary>
+        private class V2MobileStats
+        {
+            [JsonProperty("total_daily_quests_completed")]
+            public int TotalDailyQuestsCompleted { get; set; }
+
+            [JsonProperty("total_weekly_quests_completed")]
+            public int TotalWeeklyQuestsCompleted { get; set; }
+
+            [JsonProperty("total_xp_from_quests")]
+            public int TotalXPFromQuests { get; set; }
         }
 
         private class OopsieSuccessResponse

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1442,16 +1442,24 @@ namespace ConditioningControlPanel.Services
                             // whole failed-sync chain below it, and at the default Information
                             // min-level it was invisible in every log a user ever sent in (#920).
                             App.Logger?.Warning("V2 Profile sync rate-limited by server (429), will retry later");
-                            // A deferred streak break must not hang on this exit: no cloud
-                            // answer arrived, so settle it the way the timeout would.
-                            App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync rate-limited (429)");
+                            // A deferred streak break stays deferred here: a 429 means "try again
+                            // shortly", not "no cloud answer exists". Event-driven syncs retry
+                            // well inside the 120s deferral window (the client cooldown is 30s),
+                            // and resolving now would make the break decision with zero cloud
+                            // data — the exact loss the deferral exists to prevent.
                             return false;
                         }
                         await HandleUnauthorizedAsync(v2Response);
                         var error = await v2Response.Content.ReadAsStringAsync();
                         App.Logger?.Warning("V2 Profile sync failed: {Status} - {Error}", v2Response.StatusCode, error);
                         LastSyncError = $"Sync failed: {v2Response.StatusCode}";
-                        App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync rejected");
+                        // Settle a deferred streak break only on a DEFINITIVE rejection (4xx) —
+                        // retrying cannot change those answers. A 5xx is transient like the 429
+                        // above: leave it to the retry/timeout window rather than deciding the
+                        // break with zero cloud data. (On a 401, HandleUnauthorizedAsync may have
+                        // signed out and swapped Progress; the stale-instance guard absorbs it.)
+                        if ((int)v2Response.StatusCode is >= 400 and < 500)
+                            App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync rejected");
                         return false;
                     }
 
@@ -2033,7 +2041,17 @@ namespace ConditioningControlPanel.Services
                     // Belt for the resolve inside the try above: if the response parse threw
                     // before reaching it, the deferred streak break would have hung until the
                     // 120s timeout. Idempotent — a no-op when the merge-site call already ran.
-                    App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync response (parse fallback)");
+                    // Own try/catch: the resolve can run inline on the UI thread and its body
+                    // touches XP/level-up UI and disk saves — a throw there must not turn a
+                    // sync the server already ACCEPTED into a reported failure.
+                    try
+                    {
+                        App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync response (parse fallback)");
+                    }
+                    catch (Exception resolveEx)
+                    {
+                        App.Logger?.Warning("Deferred streak resolve threw after accepted sync: {Error}", resolveEx.Message);
+                    }
 
                     // THE VAT'S ONE UNAVOIDABLE SECOND REQUEST. An accepted sync is the
                     // moment today's XP lands in the server vat, and the sync RESPONSE
@@ -2923,14 +2941,28 @@ namespace ConditioningControlPanel.Services
         /// Strict wire day-key parse ("yyyy-MM-dd", invariant Gregorian). Cloud dates must never
         /// go through culture-sensitive DateTime.TryParse: under a Buddhist or Umm al-Qura system
         /// calendar the same digits mean a different year entirely (th-TH reads "2026-08-26" as
-        /// 1483 CE), and the take-newer merges would latch the misread. Junk that fails the exact
-        /// shape is refused rather than guessed at — the server sanitizes the same way. Same
-        /// reason every push-side day key formats with InvariantCulture.
+        /// 1483 CE), and the take-newer merges would latch the misread. Same reason every
+        /// push-side day key formats with InvariantCulture. Two deliberate loosenings on top of
+        /// the exact shape: an invariant ISO round-trip fallback (pre-parity builds pushed
+        /// last_daily_quest_date as ToString("o"), and /admin/set-streak can echo ISO
+        /// timestamps — refusing those would silently drop an admin correction's date), and a
+        /// beyond-tomorrow refusal (a day key names a day that has happened; tomorrow is legal
+        /// for a device west of the account's furthest clock, but further out is junk, and a
+        /// record poisoned before the server sanitizer landed must not ratchet local dates 500
+        /// years forward — the login pair has DecideLoginStreakAdopt's today-clamp, the quest
+        /// dates had nothing).
         /// </summary>
         private static bool TryParseDayKey(string? s, out DateTime date)
         {
-            return DateTime.TryParseExact(s, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.None, out date);
+            var inv = System.Globalization.CultureInfo.InvariantCulture;
+            if (!DateTime.TryParseExact(s, "yyyy-MM-dd", inv,
+                System.Globalization.DateTimeStyles.None, out date))
+            {
+                if (!DateTime.TryParse(s, inv, System.Globalization.DateTimeStyles.RoundtripKind, out date))
+                    return false;
+            }
+            date = date.Date;
+            return date <= DateTime.Today.AddDays(1);
         }
 
         private bool MergeV2CloudStatsIntoLocalProgress(Dictionary<string, object>? cloudStats, bool forceStreakOverride)
@@ -2957,10 +2989,13 @@ namespace ConditioningControlPanel.Services
                     var f = Convert.ToInt32(flashes);
                     if (f > progress.TotalFlashImages) { progress.TotalFlashImages = f; needsSave = true; }
                 }
-                // Gated on !forceStreakOverride like the quest block below: the override means
-                // "adopt the server's values even if LOWER", and this adoption only ever raises
-                // — running it in the same pass would fight the very correction the admin sent.
-                if (!forceStreakOverride && cloudStats.TryGetValue("consecutive_days", out var streak))
+                // Deliberately NOT gated on forceStreakOverride, unlike the quest block below:
+                // the override payload (V2StreakStats -> ApplyForceStreakOverride) carries only
+                // the QUEST fields, so there is no login-streak correction here to fight — and
+                // skipping this adopt would leave LastLaunchDate pre-gap for the
+                // ResolveDeferredStreakBreak that runs right after the merge, spending a
+                // shield/Oopsie charge for days another device actually covered.
+                if (cloudStats.TryGetValue("consecutive_days", out var streak))
                 {
                     // Mobile streak parity: not a bare take-higher any more. The cloud pair
                     // (consecutive_days + last_streak_date) may describe a run the PHONE kept

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -2943,23 +2943,33 @@ namespace ConditioningControlPanel.Services
         /// calendar the same digits mean a different year entirely (th-TH reads "2026-08-26" as
         /// 1483 CE), and the take-newer merges would latch the misread. Same reason every
         /// push-side day key formats with InvariantCulture. Two deliberate loosenings on top of
-        /// the exact shape: an invariant ISO round-trip fallback (pre-parity builds pushed
-        /// last_daily_quest_date as ToString("o"), and /admin/set-streak can echo ISO
-        /// timestamps — refusing those would silently drop an admin correction's date), and a
-        /// beyond-tomorrow refusal (a day key names a day that has happened; tomorrow is legal
-        /// for a device west of the account's furthest clock, but further out is junk, and a
-        /// record poisoned before the server sanitizer landed must not ratchet local dates 500
-        /// years forward — the login pair has DecideLoginStreakAdopt's today-clamp, the quest
-        /// dates had nothing).
+        /// the exact shape: an ISO-timestamp fallback limited to the "o" round-trip shapes
+        /// (pre-parity builds pushed last_daily_quest_date as ToString("o"), and
+        /// /admin/set-streak can echo ISO timestamps — refusing those would silently drop an
+        /// admin correction's date; parsed via DateTimeOffset so the calendar day is taken AS
+        /// WRITTEN, never converted to this machine's zone, and via exact formats so loose
+        /// invariant shapes like "Aug 26, 2026" stay refused), and a beyond-tomorrow refusal
+        /// (a day key names a day that has happened; tomorrow is legal for a device west of
+        /// the account's furthest clock, but further out is junk, and a record poisoned before
+        /// the server sanitizer landed must not ratchet local dates 500 years forward — the
+        /// login pair has DecideLoginStreakAdopt's today-clamp, the quest dates had nothing).
         /// </summary>
+        private static readonly string[] DayKeyIsoFallbackFormats =
+        {
+            "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+            "yyyy-MM-dd'T'HH:mm:ssK"
+        };
+
         private static bool TryParseDayKey(string? s, out DateTime date)
         {
             var inv = System.Globalization.CultureInfo.InvariantCulture;
             if (!DateTime.TryParseExact(s, "yyyy-MM-dd", inv,
                 System.Globalization.DateTimeStyles.None, out date))
             {
-                if (!DateTime.TryParse(s, inv, System.Globalization.DateTimeStyles.RoundtripKind, out date))
+                if (!DateTimeOffset.TryParseExact(s, DayKeyIsoFallbackFormats, inv,
+                    System.Globalization.DateTimeStyles.AssumeUniversal, out var dto))
                     return false;
+                date = dto.Date;
             }
             date = date.Date;
             return date <= DateTime.Today.AddDays(1);

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1327,7 +1327,7 @@ namespace ConditioningControlPanel.Services
                             // the honest PRE-GAP date (UpdateDailyStreak did not stamp today), so
                             // this push can never teach the server a streak that may be breaking.
                             ["last_streak_date"] = achievementProgress != null && achievementProgress.LastLaunchDate.Date != default
-                                ? achievementProgress.LastLaunchDate.ToString("yyyy-MM-dd") : "",
+                                ? achievementProgress.LastLaunchDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) : "",
                             ["total_bubbles_popped"] = achievementProgress?.TotalBubblesPopped ?? 0,
                             ["total_video_minutes"] = Math.Round(achievementProgress?.TotalVideoMinutes ?? 0, 1),
                             ["total_lock_cards_completed"] = achievementProgress?.TotalLockCardsCompleted ?? 0,
@@ -1338,14 +1338,14 @@ namespace ConditioningControlPanel.Services
                             // Day key, NOT round-trip "o" format: the server's string-stat merge
                             // caps values at 20 chars and silently dropped the 33-char ISO stamp,
                             // so this field never actually reached the cloud until v6.8.5.
-                            ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd") ?? "",
+                            ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? "",
                             ["quest_completion_dates"] = questProgress?.DailyQuestCompletionDates?
-                                .Select(d => d.ToString("yyyy-MM-dd")).ToList() ?? new List<string>(),
+                                .Select(d => d.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)).ToList() ?? new List<string>(),
                             ["total_daily_quests_completed"] = questProgress?.TotalDailyQuestsCompleted ?? 0,
                             ["total_weekly_quests_completed"] = questProgress?.TotalWeeklyQuestsCompleted ?? 0,
                             ["total_xp_from_quests"] = questProgress?.TotalXPFromQuests ?? 0,
                             ["daily_quests_completed_today"] = questProgress?.GetDailyQuestsCompletedToday() ?? 0,
-                            ["daily_completion_reset_date"] = questProgress?.DailyCompletionResetDate?.ToString("yyyy-MM-dd") ?? ""
+                            ["daily_completion_reset_date"] = questProgress?.DailyCompletionResetDate?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? ""
                         },
                         unlocked_skills = settings.UnlockedSkills?.ToList() ?? new List<string>(),
                         skill_points = settings.SkillPoints,
@@ -1442,12 +1442,16 @@ namespace ConditioningControlPanel.Services
                             // whole failed-sync chain below it, and at the default Information
                             // min-level it was invisible in every log a user ever sent in (#920).
                             App.Logger?.Warning("V2 Profile sync rate-limited by server (429), will retry later");
+                            // A deferred streak break must not hang on this exit: no cloud
+                            // answer arrived, so settle it the way the timeout would.
+                            App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync rate-limited (429)");
                             return false;
                         }
                         await HandleUnauthorizedAsync(v2Response);
                         var error = await v2Response.Content.ReadAsStringAsync();
                         App.Logger?.Warning("V2 Profile sync failed: {Status} - {Error}", v2Response.StatusCode, error);
                         LastSyncError = $"Sync failed: {v2Response.StatusCode}";
+                        App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync rejected");
                         return false;
                     }
 
@@ -2026,6 +2030,11 @@ namespace ConditioningControlPanel.Services
                         App.Logger?.Debug("V2 Sync: Could not parse server flags: {Error}", parseEx.Message);
                     }
 
+                    // Belt for the resolve inside the try above: if the response parse threw
+                    // before reaching it, the deferred streak break would have hung until the
+                    // 120s timeout. Idempotent — a no-op when the merge-site call already ran.
+                    App.Achievements?.Progress?.ResolveDeferredStreakBreak("V2 sync response (parse fallback)");
+
                     // THE VAT'S ONE UNAVOIDABLE SECOND REQUEST. An accepted sync is the
                     // moment today's XP lands in the server vat, and the sync RESPONSE
                     // does not carry the `descent` block (attachDescentBlocks is wired
@@ -2065,7 +2074,7 @@ namespace ConditioningControlPanel.Services
                         ["consecutive_days"] = achievementProgress?.ConsecutiveDays ?? 0,
                         // Mobile streak parity twin of the V2 dict above: day key or empty.
                         ["last_streak_date"] = achievementProgress != null && achievementProgress.LastLaunchDate.Date != default
-                            ? achievementProgress.LastLaunchDate.ToString("yyyy-MM-dd") : "",
+                            ? achievementProgress.LastLaunchDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) : "",
                         ["total_bubbles_popped"] = achievementProgress?.TotalBubblesPopped ?? 0,
                         ["total_video_minutes"] = Math.Round(achievementProgress?.TotalVideoMinutes ?? 0, 1),
                         ["total_lock_cards_completed"] = achievementProgress?.TotalLockCardsCompleted ?? 0,
@@ -2092,9 +2101,9 @@ namespace ConditioningControlPanel.Services
                         // Quest streak data
                         ["daily_quest_streak"] = settings.DailyQuestStreak,
                         // Day key, not "o" — same 20-char server cap as the V2 dict above.
-                        ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd") ?? "",
+                        ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? "",
                         ["quest_completion_dates"] = legacyQuestProgress?.DailyQuestCompletionDates?
-                            .Select(d => d.ToString("yyyy-MM-dd")).ToList() ?? new List<string>(),
+                            .Select(d => d.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)).ToList() ?? new List<string>(),
                         ["total_daily_quests_completed"] = legacyQuestProgress?.TotalDailyQuestsCompleted ?? 0,
                         ["total_weekly_quests_completed"] = legacyQuestProgress?.TotalWeeklyQuestsCompleted ?? 0,
                         ["total_xp_from_quests"] = legacyQuestProgress?.TotalXPFromQuests ?? 0
@@ -2619,7 +2628,7 @@ namespace ConditioningControlPanel.Services
                 if (cloudProfile.Stats.TryGetValue("last_daily_quest_date", out var cloudLastDate))
                 {
                     var dateStr = cloudLastDate?.ToString();
-                    if (!string.IsNullOrEmpty(dateStr) && DateTime.TryParse(dateStr, out var cloudDate))
+                    if (!string.IsNullOrEmpty(dateStr) && TryParseDayKey(dateStr, out var cloudDate))
                     {
                         if (!settings.LastDailyQuestDate.HasValue || cloudDate.Date > settings.LastDailyQuestDate.Value.Date)
                         {
@@ -2643,7 +2652,7 @@ namespace ConditioningControlPanel.Services
                             bool datesChanged = false;
                             foreach (var ds in cloudDates)
                             {
-                                if (DateTime.TryParse(ds, out var d) && !localDates.Contains(d.Date))
+                                if (TryParseDayKey(ds, out var d) && !localDates.Contains(d.Date))
                                 {
                                     questProgress.DailyQuestCompletionDates.Add(d.Date);
                                     datesChanged = true;
@@ -2720,7 +2729,7 @@ namespace ConditioningControlPanel.Services
                         bool cloudDateIsToday = false;
                         if (cloudProfile.Stats.TryGetValue("daily_completion_reset_date", out var cloudResetDate))
                         {
-                            if (DateTime.TryParse(cloudResetDate?.ToString(), out var resetDate))
+                            if (TryParseDayKey(cloudResetDate?.ToString(), out var resetDate))
                                 cloudDateIsToday = resetDate.Date == DateTime.Today;
                         }
                         if (cloudDateIsToday && cloudCount > questProgress.GetDailyQuestsCompletedToday())
@@ -2910,6 +2919,20 @@ namespace ConditioningControlPanel.Services
         /// only synced stats UP and never pulled cloud values DOWN.
         /// Returns true if any local data was modified.
         /// </summary>
+        /// <summary>
+        /// Strict wire day-key parse ("yyyy-MM-dd", invariant Gregorian). Cloud dates must never
+        /// go through culture-sensitive DateTime.TryParse: under a Buddhist or Umm al-Qura system
+        /// calendar the same digits mean a different year entirely (th-TH reads "2026-08-26" as
+        /// 1483 CE), and the take-newer merges would latch the misread. Junk that fails the exact
+        /// shape is refused rather than guessed at — the server sanitizes the same way. Same
+        /// reason every push-side day key formats with InvariantCulture.
+        /// </summary>
+        private static bool TryParseDayKey(string? s, out DateTime date)
+        {
+            return DateTime.TryParseExact(s, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out date);
+        }
+
         private bool MergeV2CloudStatsIntoLocalProgress(Dictionary<string, object>? cloudStats, bool forceStreakOverride)
         {
             if (cloudStats == null) return false;
@@ -2934,7 +2957,10 @@ namespace ConditioningControlPanel.Services
                     var f = Convert.ToInt32(flashes);
                     if (f > progress.TotalFlashImages) { progress.TotalFlashImages = f; needsSave = true; }
                 }
-                if (cloudStats.TryGetValue("consecutive_days", out var streak))
+                // Gated on !forceStreakOverride like the quest block below: the override means
+                // "adopt the server's values even if LOWER", and this adoption only ever raises
+                // — running it in the same pass would fight the very correction the admin sent.
+                if (!forceStreakOverride && cloudStats.TryGetValue("consecutive_days", out var streak))
                 {
                     // Mobile streak parity: not a bare take-higher any more. The cloud pair
                     // (consecutive_days + last_streak_date) may describe a run the PHONE kept
@@ -2948,7 +2974,7 @@ namespace ConditioningControlPanel.Services
                     if (cloudStats.TryGetValue("last_streak_date", out var lsdObj))
                     {
                         var lsdStr = lsdObj?.ToString();
-                        if (!string.IsNullOrEmpty(lsdStr) && DateTime.TryParse(lsdStr, out var lsdParsed))
+                        if (!string.IsNullOrEmpty(lsdStr) && TryParseDayKey(lsdStr, out var lsdParsed))
                             cloudStreakDate = lsdParsed.Date;
                     }
                     var adopt = Models.AchievementProgress.DecideLoginStreakAdopt(
@@ -3076,7 +3102,7 @@ namespace ConditioningControlPanel.Services
                 if (cloudStats.TryGetValue("last_daily_quest_date", out var cloudLastDate))
                 {
                     var dateStr = cloudLastDate?.ToString();
-                    if (!string.IsNullOrEmpty(dateStr) && DateTime.TryParse(dateStr, out var cloudDate))
+                    if (!string.IsNullOrEmpty(dateStr) && TryParseDayKey(dateStr, out var cloudDate))
                     {
                         if (!settings.LastDailyQuestDate.HasValue || cloudDate.Date > settings.LastDailyQuestDate.Value.Date)
                         {
@@ -3098,7 +3124,7 @@ namespace ConditioningControlPanel.Services
                             bool datesChanged = false;
                             foreach (var ds in cloudDates)
                             {
-                                if (DateTime.TryParse(ds, out var d) && !localDates.Contains(d.Date))
+                                if (TryParseDayKey(ds, out var d) && !localDates.Contains(d.Date))
                                 {
                                     questProgress.DailyQuestCompletionDates.Add(d.Date);
                                     datesChanged = true;
@@ -3152,7 +3178,7 @@ namespace ConditioningControlPanel.Services
                         bool cloudDateIsToday = false;
                         if (cloudStats.TryGetValue("daily_completion_reset_date", out var cloudResetDate))
                         {
-                            if (DateTime.TryParse(cloudResetDate?.ToString(), out var resetDate))
+                            if (TryParseDayKey(cloudResetDate?.ToString(), out var resetDate))
                                 cloudDateIsToday = resetDate.Date == DateTime.Today;
                         }
                         if (cloudDateIsToday && cloudCount > questProgress.GetDailyQuestsCompletedToday())
@@ -3198,7 +3224,7 @@ namespace ConditioningControlPanel.Services
             settings.DailyQuestStreak = streakStats.DailyQuestStreak;
 
             // Force-set last daily quest date
-            if (!string.IsNullOrEmpty(streakStats.LastDailyQuestDate) && DateTime.TryParse(streakStats.LastDailyQuestDate, out var parsedDate))
+            if (!string.IsNullOrEmpty(streakStats.LastDailyQuestDate) && TryParseDayKey(streakStats.LastDailyQuestDate, out var parsedDate))
             {
                 settings.LastDailyQuestDate = parsedDate.Date;
             }
@@ -3212,7 +3238,7 @@ namespace ConditioningControlPanel.Services
                     questProgress.DailyQuestCompletionDates.Clear();
                     foreach (var ds in streakStats.QuestCompletionDates)
                     {
-                        if (DateTime.TryParse(ds, out var d))
+                        if (TryParseDayKey(ds, out var d))
                             questProgress.DailyQuestCompletionDates.Add(d.Date);
                     }
                 }

--- a/Tests/ConditioningControlPanel.Tests/LoginStreakAdoptTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LoginStreakAdoptTests.cs
@@ -1,0 +1,130 @@
+using System;
+using ConditioningControlPanel.Models;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Pins the login-streak adoption contract (AchievementProgress.DecideLoginStreakAdopt) that the
+/// mobile client mirrors in CCPMobile src/lib/sync/contract.ts (decideLoginStreakAdopt). The two
+/// implementations must keep answering the same on shared inputs — a drift here spends users'
+/// paid shield/Oopsie charges or forks the streak between devices — so every rule the doc
+/// comment states gets a table row: the serverStreak &lt;= 0 refusal, contiguity extension in both
+/// directions, the future-date clamp, the never-lower ratchet, and the ONE deliberate
+/// divergence (dateless server record: desktop take-higher, mobile null).
+/// </summary>
+public class LoginStreakAdoptTests
+{
+    private static readonly DateTime Today = new(2026, 8, 26);
+    private static DateTime D(int day) => new(2026, 8, day);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public void ZeroOrNegativeServerStreakIsRefusedOutright(int serverStreak)
+    {
+        // Even with a perfectly valid, newer server date: a degenerate record's DATE alone
+        // must not move LastLaunchDate forward on the strength of a streak that isn't there.
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(5, D(20), serverStreak, D(25), Today);
+        Assert.Null(adopt);
+    }
+
+    [Fact]
+    public void DatelessServerRecordStillTakesHigher_TheDeliberateMobileDivergence()
+    {
+        // Pre-parity servers wrote consecutive_days without last_streak_date; desktop keeps
+        // the date-blind take-higher for those records (mobile answers null here — it has no
+        // pre-parity history to stay compatible with). The local date must not move.
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(3, D(25), 7, null, Today);
+        Assert.Equal((7, D(25)), adopt);
+
+        // A default server date counts as dateless, not as year-1 "older".
+        adopt = AchievementProgress.DecideLoginStreakAdopt(3, D(25), 7, default(DateTime), Today);
+        Assert.Equal((7, D(25)), adopt);
+
+        // Dateless AND not higher: nothing changes, null.
+        Assert.Null(AchievementProgress.DecideLoginStreakAdopt(7, D(25), 3, null, Today));
+    }
+
+    [Fact]
+    public void SameDayTakesTheHigherStreakAndKeepsTheDate()
+    {
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(3, D(25), 7, D(25), Today);
+        Assert.Equal((7, D(25)), adopt);
+
+        // Same day, server not higher: no change.
+        Assert.Null(AchievementProgress.DecideLoginStreakAdopt(7, D(25), 3, D(25), Today));
+    }
+
+    [Fact]
+    public void ContiguousServerDayExtendsTheLocalRun()
+    {
+        // Server banked the day right after local's: the runs are one run — local+1, and the
+        // date moves forward so the covered day never reads as a gap again.
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(5, D(24), 2, D(25), Today);
+        Assert.Equal((6, D(25)), adopt);
+
+        // When the server's own figure is larger than local+1, the server figure wins.
+        adopt = AchievementProgress.DecideLoginStreakAdopt(5, D(24), 9, D(25), Today);
+        Assert.Equal((9, D(25)), adopt);
+    }
+
+    [Fact]
+    public void ContiguousLocalDayExtendsTheServerRunSymmetrically()
+    {
+        // Local banked the day right after the server's: server+1, local date kept.
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(5, D(25), 9, D(24), Today);
+        Assert.Equal((10, D(25)), adopt);
+    }
+
+    [Fact]
+    public void FutureServerDateIsClampedToToday()
+    {
+        // A timezone-skewed (or poisoned) record must never push LastLaunchDate into the
+        // future — that reads as a negative gap next launch. Clamped to today it lands one
+        // day after local's yesterday, i.e. the contiguous branch.
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(5, D(25), 9, new DateTime(2999, 1, 1), Today);
+        Assert.Equal((9, Today), adopt);
+
+        // Local already at today: clamp makes it same-day, plain max, date unmoved.
+        adopt = AchievementProgress.DecideLoginStreakAdopt(5, Today, 9, new DateTime(2999, 1, 1), Today);
+        Assert.Equal((9, Today), adopt);
+    }
+
+    [Fact]
+    public void FreshInstallAdoptsTheServerPairWholesale()
+    {
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(0, default, 4, D(20), Today);
+        Assert.Equal((4, D(20)), adopt);
+    }
+
+    [Fact]
+    public void WideGapsFallBackToPlainMax_ThePreservedRatchet()
+    {
+        // Server date newer by a wide margin: max streak, newer date adopted.
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(5, D(10), 3, D(25), Today);
+        Assert.Equal((5, D(25)), adopt);
+
+        // Local date newer by a wide margin: max streak, local date kept.
+        adopt = AchievementProgress.DecideLoginStreakAdopt(2, D(25), 9, D(10), Today);
+        Assert.Equal((9, D(25)), adopt);
+    }
+
+    [Theory]
+    [InlineData(5, 5)]  // identical pair
+    [InlineData(9, 3)]  // server lower on an older date
+    public void NeverLowersAndNeverChurnsOnNoChange(int localStreak, int serverStreak)
+    {
+        var adopt = AchievementProgress.DecideLoginStreakAdopt(localStreak, D(25), serverStreak, D(10), Today);
+        if (adopt != null)
+        {
+            Assert.True(adopt.Value.Streak >= localStreak);
+            Assert.True(adopt.Value.LastDate >= D(25));
+        }
+        else
+        {
+            // Null means "nothing changes" — legal only when the merge would not raise.
+            Assert.True(Math.Max(localStreak, serverStreak) == localStreak);
+        }
+    }
+}


### PR DESCRIPTION
Desktop half (Phase 3) of the **mobile streak parity** program. Companions: server CC-Labs-llc/CCP-Server#77 (quest-complete endpoint + stats-merge module), mobile CodeBambi/CCP-Mobile#26 (streak payload + quest report queue).

Goal: the phone can keep BOTH streaks (login + daily quest) alive, mobile quest completions count in lifetime totals, and the desktop adopts all of it without double-counting, gap misreads, or wasted shields.

## Push side (V2 stats dict + V1 twin)

- **New `last_streak_date`** — the day the login streak ran through, as a `yyyy-MM-dd` day key (empty when nothing banked). The server take-newers it; the phone's `decideLoginStreakAdopt` uses it for contiguity.
- **Bug fix: `last_daily_quest_date`** was pushed as round-trip `"o"` format (33 chars). The server's string-stat merge caps at 20 chars and *silently dropped it* — the field never reached the cloud. Now a day key, both dicts.

## Pull side

- `consecutive_days` is no longer a bare take-higher. New pure `AchievementProgress.DecideLoginStreakAdopt` mirrors the mobile contract function:
  - server date == local date + 1 → runs are contiguous → `max(server, local+1)`, adopt server date (symmetric case for local == server + 1);
  - wide gap → plain max (**ratchet preserved as-is**, per survey decision);
  - never lowers; server dates clamped to today (a timezone-skewed phone can't stamp the future and cause a negative-gap misread next launch);
  - moving `LastLaunchDate` forward over mobile-covered days is what makes later launches stop reading those days as gaps.
- **`mobile_stats` ledger adoption**: the sync response's server-authoritative mobile quest totals land verbatim in three new display-only `AppSettings` fields. Quests tab shows desktop + mobile combined. The mirror is **never folded into pushed counters** (server max-merge would double-count every mobile quest). Cleared on logout with the rest of per-account state.

## Deferred shield/Oopsie burn

`UpdateDailyStreak` no longer spends a streak shield / Oopsie charge at launch on a signed-in account. The break decision waits for the first V2 sync:

- phone covered the gap → the merge moved `LastLaunchDate`, no token spent, streak extends normally;
- gap real by the cloud's account → the original shield → insurance → reset chain runs at resolve time. Bonus: at that point `App.SkillTree` actually exists — the old constructor-time path ran before SkillTree init, so the launch-path shield could literally never fire;
- sync failure → resolves immediately with the old behavior; 120s timeout covers sync never running; nothing persisted (a crash while pending re-detects the same gap next launch);
- while pending, the push carries the honest **pre-gap** streak/date, so an unresolved launch can never teach the server a streak that may be breaking.

## Test matrix (conceptual, all through `DecideLoginStreakAdopt` semantics)

- desktop-only regression: no server date → old take-higher, unchanged behavior;
- mobile-only days then desktop return: server (12, yesterday) vs local (10, 5 days ago) → adopt 12@yesterday, resolve extends to 13 today, no shield burned;
- both devices same day: equal dates → plain max, no double increment;
- season rollover: streak fields survive `freshSeasonStats` server-side (server PR), nothing here touches them.

Build: `dotnet build` clean, 0 errors (warnings pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dkWkCs4onKxDtV5HEPmnu
