### PR TITLE
fix(arcademy): T2 tester wave 0826 - session pile on web, switch hitbox, iOS zoom, knock cue, card line

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -253,6 +253,47 @@ function armKnockGate() {
   doc.addEventListener('keydown', onKnock, true);
 }
 
+/* THE SPLASH STOPS PRETENDING TO LOAD (T2 tester report, 2026-08-26: sat on the
+ * splash on a PC waiting for a rail that had already finished, because nothing
+ * on screen changed when the school was ready).
+ *
+ * `dismissLoader` queues on the knock, and until now that queue was INVISIBLE:
+ * the rail kept chasing, the caption kept saying Opening, and the one line that
+ * mattered stayed a 12.5px dim caption at the bottom of the frame. This is the
+ * escalation, and it runs exactly once - on the frame boot is done and the
+ * gesture is the ONLY thing outstanding.
+ *
+ * `is-ready` is the whole visual half (styles.css): the rail lands full and
+ * stops, the caption steps back, and the hint steps up to real size and full
+ * ink with a soft scale pulse - which reduced motion drops while keeping the
+ * size and the contrast, because the READING is the fix and the pulse is only
+ * the seasoning.
+ *
+ * After KNOCK_WAIT_MS with still no gesture the LINE changes rather than
+ * repeating: someone who has not understood "Knock to enter" needs different
+ * words, not the same ones louder. The timer rides `introTimers`, so failBoot
+ * and shutdown sweep it with everything else, and it re-checks the splash on
+ * the way in - a beat can never land on the error card (trap 66's discipline).
+ *
+ * NO SOUND, EVER. The knock IS the autoplay gate: there is no cue this side of
+ * it that any browser would let us play. */
+const KNOCK_WAIT_MS = 4000;
+
+function escalateKnock() {
+  try { if (dom.loader) dom.loader.classList.add('is-ready'); } catch (e) { /* noop */ }
+  if (!knockHint) return;
+  const id = setTimeout(() => {
+    introTimers.delete(id);
+    if (knockDone || !knockHint || !splashIsUp()) return;
+    try {
+      const src = initMsg || {};
+      knockHint.textContent =
+        (src.lexicon && src.lexicon.intro_knock_wait) || 'Tap anywhere to knock';
+    } catch (e) { /* a hint may never cost the boot */ }
+  }, KNOCK_WAIT_MS);
+  introTimers.add(id);
+}
+
 /* ONE AUDIO DOOR (GROUND-RULES §6, shell/ceremonies.js's exact pattern): a cue
  * is a REQUEST on `document`, never a node - shell/audio.js owns the only audio
  * graph on the page (trap 18). A cue path must never be the thing that throws,
@@ -543,8 +584,13 @@ function dismissLoader() {
   const el = dom.loader;
   if (!el || el.hidden) return;
   /* The knock outranks readiness: a booted school still waits for the door.
-   * onKnock re-calls us KNOCK_EXIT_MS after the tap that struck the bed. */
-  if (knockWanted && !knockDone) { knockDismissQueued = true; return; }
+   * onKnock re-calls us KNOCK_EXIT_MS after the tap that struck the bed.
+   * THE FIRST TIME WE QUEUE, THE SPLASH SAYS SO (escalateKnock): this is the
+   * one frame on which the wait stops being a boot and starts being a door. */
+  if (knockWanted && !knockDone) {
+    if (!knockDismissQueued) { knockDismissQueued = true; escalateKnock(); }
+    return;
+  }
   /* And the jingle outranks both: settleBed() re-calls us the moment the bed is
    * over, or the moment the cap says it is (THE SPLASH WAITS FOR THE JINGLE). */
   if (bedHolding) { bedDismissQueued = true; return; }

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -198,6 +198,10 @@ export const DEFAULT_LEXICON = Object.freeze({
      it reads init.lexicon directly with the same English as its own fallback -
      keep the two strings identical when either moves. */
   intro_knock: 'Knock to enter',
+  /* THE SECOND ASKING (boot.js escalateKnock). Four seconds after the school is
+     ready and still nobody has touched anything, the line changes rather than
+     repeating - the first words did not land, so louder is not the answer. */
+  intro_knock_wait: 'Tap anywhere to knock',
   /* --- THE FRONT OFFICE SHEET (shell/settings.js) -----------------------
      Section titles, the two ceilings blurbs (one per host), the web's device
      rows, and the one-line summaries the folded headers wear. `{v}`, `{n}`,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
@@ -544,10 +544,37 @@ export default {
     /* ==================================================================== *
      * MEDIA - one url, every tile. mediaEl semantics, copied not imported.
      * ==================================================================== */
+    /** THE DEAD URL (0826). A url that 404s paints the browser's own broken-image
+     *  glyph into all n^2 tiles - a tester saw exactly that. This class already
+     *  has a floor for "no media": PLAIN faces, which every dealable kind still
+     *  works on (the delta is CSS on .g-an-face, never on the media node), so a
+     *  failure just walks back to it and asks the pool for another url. Convicted
+     *  ONCE per url: every tile wears the same src, so n^2 error events arrive for
+     *  one dead row. pool.markBroken keeps it out of the next draw. */
+    const brokeUrls = new Set();
+    function mediaBroke(url) {
+      const u = String(url || '');
+      if (dead || ended || !u || u !== lastUrl || brokeUrls.has(u)) return;
+      brokeUrls.add(u);
+      try { if (pool && typeof pool.markBroken === 'function') pool.markBroken(u); }
+      catch (e) { /* an optional seam never breaks a class */ }
+      say('media failed, back to plain faces: ' + u);
+      run(() => {
+        paintGrid('');
+        if (cur && !cur.done) applyFace(cur.oddIndex);
+        redress();                     /* the pool skips the url we just convicted */
+      });
+    }
+    /** Rebound on every repaint: a recycled node carries the OLD url's closure. */
+    function bindMediaError(node, url) {
+      try { node.onerror = () => mediaBroke(url); } catch (e) { /* ignore */ }
+    }
+
     function makeMedia(url) {
       const video = isVideoUrl(url);
       const node = document.createElement(video ? 'video' : 'img');
       node.className = 'g-an-media';
+      bindMediaError(node, url);
       if (video) {
         try {
           node.muted = true; node.loop = true; node.autoplay = true; node.playsInline = true;
@@ -617,6 +644,7 @@ export default {
         }
         if (existing && existing.tagName === (want === 'video' ? 'VIDEO' : 'IMG')) {
           try {
+            bindMediaError(existing, url);
             existing.src = url;
             if (want === 'video') {
               existing.playbackRate = 1;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
@@ -227,6 +227,9 @@ html.arc-reduced .g-dt-mq{opacity:.16}
   background:var(--panel2,#2E2E55);border:1px solid #3E3E70;color:var(--ink-dim,#B9B3CE);
   font:600 clamp(13px,1.9vh,17px)/1 var(--body,sans-serif);
   display:inline-flex;align-items:center;justify-content:center;cursor:pointer;
+  /* a keycap is TAPPED, fast: no double-tap zoom, no 300ms wait (styles.css's
+     html/body floor says the same, this is the belt to that pair of braces) */
+  touch-action:manipulation;-webkit-tap-highlight-color:transparent;
   box-shadow:0 3px 0 rgba(0,0,0,.4);position:relative;overflow:hidden;
   transition:transform .08s ease,background .25s ease,color .25s ease}
 .g-dt-key:active,.g-dt-key.down{transform:translateY(2px);box-shadow:none}
@@ -356,7 +359,7 @@ html.arc-reduced .g-dt-mq{opacity:.16}
 .g-dt-hw-key{flex:0 0 auto;min-width:52px;text-align:center;padding:7px 10px;border-radius:7px;
   font-family:var(--mono,monospace);font-size:10px;letter-spacing:.12em;text-transform:uppercase;
   color:var(--ink,#F2EBDD);background:linear-gradient(180deg,var(--panel2,#2E2E55),#1A1A32);
-  border:1px solid var(--line,#3A3A5E);border-bottom-width:3px;
+  border:1px solid var(--line,#3A3A5E);border-bottom-width:3px;touch-action:manipulation;
   box-shadow:0 2px 0 rgba(0,0,0,.45);animation:g-dt-hw-press 3.4s ease-in-out infinite}
 .g-dt-hw-key.wide{min-width:74px}
 @keyframes g-dt-hw-press{0%,84%{transform:translateY(0)}

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/casino.js
@@ -231,12 +231,23 @@ export function createDvCasino(o) {
       const node = el('div', 'g-dv-almost');
       if (!node) return;
       const url = face && face._url;
-      if (url && face.tagName === 'IMG') {
-        const img = el('img');
-        if (img) { img.alt = ''; img.src = url; node.appendChild(img); }
-      } else {
+      const wearGlyph = () => {
         node.textContent = (face && face._glyph) || '◈';
         node.classList.add('glyph');
+      };
+      if (url && face.tagName === 'IMG') {
+        const img = el('img');
+        if (img) {
+          img.alt = '';
+          /* the ghost copies a face that may be dying: index.js drops a dead url
+           * to its glyph pair, and this echo takes the same floor rather than
+           * flashing the browser's broken-image icon over the board */
+          img.onerror = () => { try { img.remove(); } catch (e) { /* noop */ } wearGlyph(); };
+          img.src = url;
+          node.appendChild(img);
+        }
+      } else {
+        wearGlyph();
       }
       host.appendChild(node);
       timers.after(DV_CASINO.ALMOST_MS, () => { try { node.remove(); } catch (e) { /* ignore */ } });

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -555,6 +555,24 @@ export default {
       };
     }
 
+    /** THE DEAD URL (0826). A face whose url 404s paints the browser's own
+     *  broken-image glyph - a tester saw one on this board. The floor is already
+     *  here: a pair with NO url wears its GLYPH face, and a glyph pair plays
+     *  exactly like a media pair. So a broken url is dropped from `pairUrls` and
+     *  BOTH of the pair's cards are re-applied together - a pair whose two halves
+     *  wore different faces would be a worse bug than the one being fixed.
+     *  Convicted once (the twin fires its own error on the same url), and
+     *  pool.markBroken keeps the row out of the next board's draw. */
+    function faceBroke(pairId, url) {
+      const u = String(url || '');
+      if (dead || !u || pairUrls[pairId] !== u) return;    // already dropped, or stale
+      pairUrls[pairId] = null;
+      try { if (pool && typeof pool.markBroken === 'function') pool.markBroken(u); }
+      catch (e) { /* an optional seam never breaks a class */ }
+      say('face failed, glyph pair ' + pairId + ': ' + u);
+      for (const c of cells) if (c && c.pairId === pairId) applyMedia(c);
+    }
+
     /** One media node per card, created once and never re-created on a flip. */
     function applyMedia(cell) {
       const url = pairUrls[cell.pairId];
@@ -572,6 +590,7 @@ export default {
       } else if (url) {
         node = el('img', 'g-dv-face');
         node.setAttribute('alt', '');
+        node.onerror = () => faceBroke(cell.pairId, url);
         node.src = url;
       } else {
         node = el('div', 'g-dv-face g-dv-glyph', glyph);
@@ -1215,6 +1234,14 @@ export default {
       if (url && !isVideoUrl(url)) {
         const img = el('img');
         img.setAttribute('alt', '');
+        /* the same glyph floor the video branch below already takes: a lie that
+         * renders as a broken-image icon is a tell, and a very unfair one */
+        img.onerror = () => {
+          try { img.remove(); } catch (e) { /* noop */ }
+          node.textContent = glyph;
+          node.classList.add('glyph');
+          faceBroke(wearPairId, url);
+        };
         img.src = url;
         node.appendChild(img);
       } else {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/index.js
@@ -641,12 +641,37 @@ export default {
      * the target (hue-rotate + mirror), which is the contract's ruling and
      * costs no canvas pass at all.
      * ==================================================================== */
+    /** THE DEAD URL (0826). A url that 404s paints the browser's broken-image
+     *  glyph on a shell face. The floor is already here - a round with no url at
+     *  all runs BARE (`dressFace`'s `!url` branch, and the claim-failed log says
+     *  so) - but it has to be taken by EVERY shell at once: one bare face while
+     *  the others wear pictures is a tell, and this game's whole contract is
+     *  that a tell is never accidental. So the url is dropped from the class's
+     *  media state, convicted with pool.markBroken, and the board goes bare for
+     *  the rest of the round; the next round's `dealMedia()` (the `!targetUrl ||
+     *  decoyUrls.length < 1` gate) re-dresses from what the pool has left. */
+    function mediaBroke(url) {
+      const u = String(url || '');
+      if (dead || !u) return;
+      let hit = false;
+      if (targetUrl === u) { targetUrl = ''; targetIsVideo = false; hit = true; }
+      const di = decoyUrls.indexOf(u);
+      if (di >= 0) { decoyUrls.splice(di, 1); hit = true; }
+      if (!hit) return;                  // a second shell reporting a url already dropped
+      try { if (pool && typeof pool.markBroken === 'function') pool.markBroken(u); }
+      catch (e) { /* an optional seam never breaks a class */ }
+      say('media failed, shells run bare this round: ' + u);
+      for (const shell of shellEls) clearFace(shell);
+    }
+
     function armMedia(node, video) {
       if (!node) return;
       try {
         node.setAttribute('alt', '');
         node.setAttribute('draggable', 'false');
         node.draggable = false;
+        /* reads the src OFF THE NODE, so one arming survives every re-dress */
+        node.onerror = () => { try { mediaBroke(node.getAttribute('src')); } catch (e) { /* noop */ } };
         if (video) {
           node.muted = true; node.loop = true; node.autoplay = true; node.playsInline = true;
           node.setAttribute('muted', ''); node.setAttribute('loop', '');

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -57,6 +57,18 @@
  *     localManifest / manifest / assets / media
  * Entries may be ccp.assets-relative paths or absolute ccp.* urls. With NO
  * manifest at all the provider still works — on the bundled placeholder tiles.
+ *
+ * THE WEB HAS NO MANIFEST (2026-08-26; MEDIA-CONTRACT §7). A browser cannot
+ * enumerate a folder, so the shim host ships `localAssets` EMPTY and serves the
+ * player's ingested folder/zip/gallery — the SESSION PILE — as blob: rows over
+ * the same `assets` mailbox the remote pool answers on. Two consequences, both
+ * of them live only where `init.settings.localMedia` exists (never on desktop):
+ *   - `absorbLocal()` takes those rows into `localPools`, so a claim already
+ *     dealing re-syncs and re-dresses. They are LOCAL: never remotePools, never
+ *     remoteRatio, never the remote recency ring.
+ *   - `claim()` sends `local-sample-request {local:true}` whenever a pile is
+ *     present, INCLUDING with remote media off — the consent gate is about the
+ *     network, not the player's own disk (remote.js request(), trap 54).
  * ==========================================================================*/
 
 import { buildLocalPools, isLocalUrl, formatOk, kindOf, wantRemote } from './inventory.js';
@@ -75,6 +87,28 @@ function placeholderUrls() {
 }
 
 const REMOTE_CAP = 80;        // mirrors intake's REMOTE_CAP: a page never hoards media
+
+/* THE SESSION PILE (web only, 2026-08-26; MEDIA-CONTRACT §7 in the site repo's
+ * `scripts/arcademy-web-ext`). On the desktop the host hands the player's own
+ * media over as a MANIFEST (`init.settings.localAssets`, trap 16) of absolute
+ * ccp.assets urls, so the provider knows the whole inventory at create time. A
+ * BROWSER has no folder to enumerate: the shim ingests a folder/zip/gallery
+ * into a session pile of object URLs and serves it in FRAMES, the same `assets`
+ * mailbox the remote pool answers on. Those rows are `blob:` (or `data:`), they
+ * are local by origin, and they are the only local media a web player has.
+ *
+ * A pile row is recognised by its SCHEME, never by a marker: a `local-sample`
+ * reply carries `src` only when it was tagged (host provider.js `rows()`), so
+ * the scheme is the one fact always on the wire. Desktop local rows are
+ * `https://ccp.assets/...` and therefore never take this path - which is what
+ * keeps the desktop build byte-identical. */
+const PILE_URL_RE = /^(blob|data):/i;
+const LOCAL_CAP = 240;        // the pile is the player's own disk, so this is far looser
+                              // than REMOTE_CAP - but a 5000-file folder ingest still may
+                              // not grow the page's arrays without end. At the cap the
+                              // pool STOPS taking rows rather than shifting: a live claim
+                              // walks a cursor over its copy of these lists, and evicting
+                              // from under it would move draws for no gain.
 const RECENT_MAX = 24;        // recency-ring depth (0826): a draw step-skips the last
                               // min(L-1, RECENT_MAX) urls its kind SERVED - the skip
                               // consumes no rand (the blacklist skip's law), it only
@@ -216,6 +250,31 @@ export function createAssets(options = {}) {
   const remoteRatio = Number.isFinite(opts.remoteMediaRatio) ? Math.max(0, Math.min(1, opts.remoteMediaRatio)) : 0;
   const defaultNiches = Array.isArray(opts.niches) ? opts.niches.slice() : null;
 
+  /* ------------------------------------------------------------------------
+   * THE SESSION PILE's presence flag. `init.settings.localMedia` is the web
+   * shim's boot shape (always zeros at init - the pile is session-only) and the
+   * `local-media` push carries every later state. The C# host ships NEITHER, so
+   * on desktop `localPile` stays null, `pilePresent()` is false forever, and not
+   * one line below this changes what the desktop provider does.
+   * --------------------------------------------------------------------- */
+  function readPile(v) {
+    if (!v || typeof v !== 'object') return null;
+    if (!('active' in v) && !('images' in v) && !('videos' in v)) return null;
+    return {
+      images: Math.max(0, v.images | 0),
+      videos: Math.max(0, v.videos | 0),
+      active: !!v.active,
+    };
+  }
+  let localPile = readPile(
+    (opts.settings && typeof opts.settings === 'object' ? opts.settings.localMedia : null) || opts.localMedia,
+  );
+  /** "The player has media of their own on this device." `active` is the host's
+   *  own word for it; the counts are the belt to its braces (a host that pushes
+   *  counts without the flag still gets its pile served). */
+  const pilePresent = () => !!localPile && (localPile.active || (localPile.images + localPile.videos) > 0);
+  const pileCbs = new Set();        // live claims waiting for a pile to appear
+
   const placeholders = placeholderUrls();
   const localPools = buildLocalPools(resolveManifest(opts), platform);
   // the placeholder floor: only used when a kind has no real local entries
@@ -227,7 +286,16 @@ export function createAssets(options = {}) {
   // ArcademyHostService answers 'assets-request' with {type:'assets', reqId, urls,
   // done} and may also push an unsolicited batch; bridge.on is multi-subscriber
   // (bridge.js header) so this costs the shell nothing and cannot steal frames.
-  if (remoteEnabled && opts.bridge) { try { channel.listen(); } catch { /* ignore */ } }
+  // ...and the SAME mailbox answers `local-sample-request`, which is not gated on
+  // remote consent (a file on the player's device is not a network call), so a
+  // player with "Pull from online" OFF but a session pile ingested must have the
+  // channel armed too. Arming it twice is a no-op (`listening` latches).
+  const ensureListening = () => {
+    if (!opts.bridge) return;
+    if (!remoteEnabled && !pilePresent()) return;
+    try { channel.listen(); } catch { /* ignore */ }
+  };
+  ensureListening();
   const claims = new Set();
   let prewarmed = new Set();
   let disposed = false;
@@ -272,6 +340,129 @@ export function createAssets(options = {}) {
   }
 
   /* ------------------------------------------------------------------------
+   * THE SESSION PILE's absorb (web only). absorbRemote() drops every row whose
+   * url `isLocalUrl` on the DESKTOP's reasoning - "the host already gives us
+   * locals", i.e. the `localAssets` manifest is the whole local inventory. On
+   * the web there IS no manifest, the pile arrives as blob: rows in the very
+   * same `assets` replies, and that `continue` threw away the player's own
+   * media on every host that has one. This is where those rows land instead.
+   *
+   * A pile row is NEVER remote: it does not enter remotePools, does not count
+   * toward remoteRatio and never touches the remote recency ring. It is local
+   * inventory that arrived late, which is exactly what `localPools` holds.
+   * --------------------------------------------------------------------- */
+  const pileUrls = new Set();          // every url this provider took FROM the pile
+  const localRefreshers = new Set();   // live claims re-syncing their local lists
+
+  /** A pile row's kind, from the fact the host put on the wire. The url cannot
+   *  answer this: a blob: url has no extension for kindOf() to sniff, so every
+   *  pile video would otherwise land in the STILL pool. */
+  function pileKind(row, url) {
+    if (row && typeof row === 'object') {
+      if (row.kind === 'loop' || row.kind === 'still') return row.kind;
+      const mime = String(row.mime || '');
+      if (/^video\//i.test(mime)) return 'loop';
+      if (/^image\/gif$/i.test(mime)) return 'loop';
+      if (/^image\//i.test(mime)) return 'still';
+    }
+    return kindOf(url);
+  }
+
+  /** iOS is mp4-only, local files included (MEDIA-CONTRACT §0). The web shim
+   *  already refuses them at ingest; this is the page's own belt, run off the
+   *  mime for the same reason pileKind is. */
+  function pileFormatOk(row, url) {
+    const mime = (row && typeof row === 'object') ? String(row.mime || '') : '';
+    if (!/^video\//i.test(mime)) return formatOk(url, platform);
+    const sub = mime.slice(6).toLowerCase().split(';')[0].trim();
+    return formatOk('x.' + (sub === 'quicktime' ? 'mov' : sub), platform);
+  }
+
+  /* THE EXTENSION HINT, and it is load-bearing. Every consumer of a pool url -
+   * anomaly, composure, deja-vu, echo, impulse-control, instant-recall, and the
+   * provider's own warm rail - decides `<video>` vs `<img>` by testing the url
+   * against /\.(mp4|webm|m4v)(\?|#|$)/. A blob: url has no extension, so a pile
+   * VIDEO would be mounted in an <img> and show nothing at all. The URL Standard
+   * resolves a blob URL against the store with the fragment EXCLUDED, so a
+   * trailing `#.mp4` is ignored by the fetch and read by every one of those
+   * regexes. Stills and gifs are handed over untouched - an <img> is already
+   * what they want. */
+  function hintedPileUrl(row, url, kind) {
+    if (kind !== 'loop') return url;
+    if (VIDEO_URL_RE.test(url)) return url;
+    const mime = (row && typeof row === 'object') ? String(row.mime || '') : '';
+    if (!/^video\//i.test(mime)) return url;            // a gif wants an <img>
+    const sub = mime.slice(6).toLowerCase().split(';')[0].trim();
+    const ext = sub === 'webm' ? 'webm' : (sub === 'x-m4v' ? 'm4v' : 'mp4');
+    return url + (url.indexOf('#') >= 0 ? '' : '#.' + ext);
+  }
+
+  function absorbLocal(entries) {
+    let added = 0;
+    for (const e of (entries || [])) {
+      const raw = e && (e.url || e);
+      if (!raw || typeof raw !== 'string') continue;
+      if (!PILE_URL_RE.test(raw)) continue;              // desktop rows are ccp.assets urls
+      if (!pileFormatOk(e, raw)) continue;
+      const k = pileKind(e, raw);
+      const url = hintedPileUrl(e, raw, k);
+      const arr = localPools[k] || localPools.still;
+      if (arr.length >= LOCAL_CAP) continue;
+      if (pileUrls.has(url) || arr.includes(url)) continue;
+      pileUrls.add(url);
+      arr.push(url);
+      added += 1;
+    }
+    if (added) {
+      log('pile +' + added + ' (loop ' + localPools.loop.length + ' / still ' + localPools.still.length + ')');
+      /* every live claim re-reads its local lists and re-dresses: a class that
+       * started on the placeholder floor swaps to the player's own media */
+      for (const fn of [...localRefreshers]) { try { fn(); } catch { /* a bad claim never kills the absorb */ } }
+    }
+    return added;
+  }
+
+  /** The host revoked the pile's object URLs (media.clearLocal): every url we
+   *  took from it is dead now, so drop them and let the live claims re-sync. */
+  function dropPile() {
+    if (!pileUrls.size) return 0;
+    let gone = 0;
+    for (const k of ['loop', 'still']) {
+      const arr = localPools[k];
+      if (!arr) continue;
+      for (let i = arr.length - 1; i >= 0; i--) {
+        if (pileUrls.has(arr[i])) { arr.splice(i, 1); gone += 1; }
+      }
+    }
+    pileUrls.clear();
+    if (gone) {
+      log('pile cleared (-' + gone + ')');
+      for (const fn of [...localRefreshers]) { try { fn(); } catch { /* ignore */ } }
+    }
+    return gone;
+  }
+
+  /** The host's `local-media` push (MEDIA-CONTRACT §4). Desktop never sends it. */
+  function onLocalMediaFrame(msg) {
+    const m = (msg && msg.detail) || msg;
+    const next = readPile(m);
+    if (!next) return;
+    const was = pilePresent();
+    const held = localPile ? (localPile.images + localPile.videos) : 0;
+    localPile = next;
+    const now = pilePresent();
+    if (was && !now) { dropPile(); return; }             // a clear, or an ingest of nothing
+    /* A pile that appears (or GROWS - a second ingest on top of a first) MID-CLASS
+     * is still this class's media, so every live claim asks again rather than
+     * waiting for the next one. A push that changes nothing asks nothing: the
+     * host posts one after a CANCELLED picker too (MEDIA-CONTRACT §4). */
+    if (now && (!was || (next.images + next.videos) > held)) {
+      ensureListening();
+      for (const fn of [...pileCbs]) { try { fn(); } catch { /* ignore */ } }
+    }
+  }
+
+  /* ------------------------------------------------------------------------
    * THE BOOT ASK (0826). The provider used to send its FIRST 'assets-request'
    * from claim() - i.e. when the player claims a class - so the whole door /
    * menu / rules-sheet stretch was network dead air. On the owner's cellular
@@ -301,6 +492,10 @@ export function createAssets(options = {}) {
       kind, count, niches: defaultNiches,
       onBatch: (entries) => {
         if (disposed) return;
+        /* on the web an app-wide reply INTERLEAVES the session pile with the
+         * remote pool (MEDIA-CONTRACT §7); absorbRemote drops those blob: rows
+         * on origin, so they are taken here or they are lost */
+        absorbLocal(entries);
         absorbRemote(entries);       // zero rand: no deck to re-deal, no pool yet
         /* the host's contract is "ask again after every reply" (a cold buffer
          * answers empty and streams the real batch later) */
@@ -770,6 +965,10 @@ export function createAssets(options = {}) {
   if (opts.bridge) {
     try { channel.subscribe('library', onLibraryFrame); } catch { /* ignore */ }
     try { channel.subscribe('sub-probe', onSubProbeFrame); } catch { /* ignore */ }
+    /* The web shim's session-pile push. Same loose `bridge.on` seam, which is
+     * multi-subscriber by design (trap 11) - `shell/settings.js` listens for the
+     * very same frame to paint its counts and neither steals the other's. */
+    try { channel.subscribe('local-media', onLocalMediaFrame); } catch { /* ignore */ }
   }
 
   /**
@@ -814,6 +1013,41 @@ export function createAssets(options = {}) {
     //  slice of the local lists, which on the web build were placeholder SVGs
     //  and on desktop are the host's own disk. See refreshDeck().)
 
+    /* THE SESSION PILE's re-sync (web only). The three lists above are SNAPSHOTS
+     * taken at claim time - on the desktop that is the whole truth, because the
+     * `localAssets` manifest is complete before a class is ever claimed. A web
+     * pile arrives in frames AFTER the claim (and may be ingested mid-class), so
+     * its rows have to reach a claim that is already dealing. The lists are
+     * refilled IN PLACE: the cursors index them modulo length and the recency
+     * rings hold urls, so nothing that is serving has to be rebuilt - the pool
+     * simply gets wider, exactly the way an absorbed remote batch widens it.
+     * A claim whose local lists never move (every desktop claim) never runs the
+     * body of this. */
+    function syncLocal() {
+      if (released || disposed) return;
+      const nextLoops = localFor('loop');
+      const nextStills = localFor('still');
+      const same = (a, b) => a.length === b.length && a.every((u, i) => u === b[i]);
+      let moved = false;
+      if (!same(localLoops, nextLoops)) {
+        localLoops.length = 0;
+        for (const u of nextLoops) localLoops.push(u);
+        moved = true;
+      }
+      if (!same(localStills, nextStills)) {
+        localStills.length = 0;
+        for (const u of nextStills) localStills.push(u);
+        const rev = nextStills.slice().reverse();
+        localTargets.length = 0;
+        for (const u of rev) localTargets.push(u);
+        moved = true;
+      }
+      if (!moved) return;
+      refreshDeck();          // the forecast is stale: re-deal it and warm the new tail
+      notifyUpdate();         // and a class already on placeholders re-dresses
+    }
+    localRefreshers.add(syncLocal);
+
     // --- the remote side, if the gate is open ------------------------------
     // The host's contract is "whatever is buffered NOW, and ask again after
     // every reply" (ArcademyHostService assets-request header): a single ask on
@@ -844,6 +1078,14 @@ export function createAssets(options = {}) {
         kind, count, niches,
         onBatch: (entries) => {
           if (released || disposed) return;
+          /* THE INTERLEAVE (web, MEDIA-CONTRACT §7). With both a remote pool and
+           * a session pile alive the host fills a reply batch from BOTH, so an
+           * app-wide reply carries blob: rows beside the http ones. absorbRemote
+           * refuses them on origin - correctly, they are not remote and must
+           * never count toward remoteRatio or the remote ring - so they are
+           * taken as LOCAL first. absorbLocal fires the refreshers itself, which
+           * is what re-deals the deck and re-dresses the board. */
+          absorbLocal(entries);
           if (absorbRemote(entries)) {
             /* The pool just grew, so every forecast is stale: re-deal the deck
              * and warm ITS urls. (The old `slice(-4)` warmed the newest
@@ -867,6 +1109,51 @@ export function createAssets(options = {}) {
     } else if (canvasSafe && remoteEnabled) {
       log('canvasSafe claim: local-only pool (CORS two-pool law)');
     }
+
+    /* =======================================================================
+     * THE SESSION PILE's ask (web only, 2026-08-26).
+     *
+     * The bug two testers hit: with "Pull from online" OFF, `remoteEnabled` is
+     * false, so the block above sends NOTHING - and the player's own uploaded
+     * folder/zip/gallery was therefore never asked for at all. Every class dealt
+     * itself the six bundled placeholder tiles while the pile sat in the host.
+     *
+     * A LOCAL sample is NOT a network call, so it is not the consent gate's
+     * business (`provider/remote.js` request(): `local:true` rides straight past
+     * the enabled/offline check, which is the same door SORT's local piles have
+     * used since 0823). It is also legal for a `canvasSafe` claim: a blob: from
+     * our own origin passes `isLocalUrl`, which is what the two-pool law
+     * actually tests - the pile is the one media a web player can put on a
+     * canvas at all. On the desktop `pilePresent()` is false, so this whole
+     * block is dead code and not one frame leaves the page.
+     * ==================================================================== */
+    const LOCAL_MAX_ASKS = 4;
+    function askLocal(kind, count, attempt) {
+      if (released || disposed) return;
+      const id = channel.request({
+        type: 'local-sample-request', local: true, kind, count,
+        onBatch: (entries) => {
+          if (released || disposed) return;
+          absorbLocal(entries);          // fires the refreshers: re-deal + re-dress
+          /* the host's contract is the same one the remote ask keeps: ask again
+           * after every reply until the pool covers the spec or the budget is
+           * spent. An empty pile answers `{urls:[], done:true}` and this stops. */
+          if ((localPools[kind] || []).length < count && attempt < LOCAL_MAX_ASKS) {
+            const t = setTimeout(() => { retryTimers.delete(t); askLocal(kind, count, attempt + 1); }, RETRY_MS * Math.max(1, attempt));
+            retryTimers.add(t);
+          }
+        },
+      });
+      if (id) reqIds.push(id);
+    }
+    function askPile() {
+      if (released || disposed || !opts.bridge || !pilePresent()) return;
+      if (want.loop) askLocal('loop', Math.min(LOCAL_CAP, Math.max(4, want.loop)), 1);
+      if (want.still + want.target) askLocal('still', Math.min(LOCAL_CAP, Math.max(4, want.still + want.target)), 1);
+    }
+    askPile();
+    /* ...and again if the player ingests one WHILE this class is running. */
+    pileCbs.add(askPile);
 
     /* =======================================================================
      * THE DRAW, parameterized (THE ON-DECK RAIL, 0825).
@@ -1113,6 +1400,8 @@ export function createAssets(options = {}) {
         if (released) return;
         released = true;
         reqIds = [];
+        localRefreshers.delete(syncLocal);   // the pile seam dies with the claim too
+        pileCbs.delete(askPile);
         recent.loop.length = 0;        // the recency rings die with the claim
         recent.still.length = 0;
         updateCbs.clear();
@@ -1256,6 +1545,12 @@ export function createAssets(options = {}) {
         // tile. The shell surfaces this as its one asset-seam diagnostic.
         placeholderFloor: !localPools.loop.length && !localPools.still.length,
         claims: claims.size,
+        /* THE SESSION PILE, the web's only local inventory. `pileRows` counts
+         * what actually reached the pools, which is the one number that tells a
+         * "the pile never arrived" report apart from a "the pile is empty" one.
+         * Both are 0 / false on the desktop, always. */
+        pilePresent: pilePresent(),
+        pileRows: pileUrls.size,
         remoteEnabled, remoteRatio, offlineMode,
         /* the SORT seam, read-only: live tagged pools and the pickable world */
         taggedPools: taggedPools.size,
@@ -1281,6 +1576,9 @@ export function createAssets(options = {}) {
       }
       probes.clear();
       libraryCbs.clear();
+      localRefreshers.clear();
+      pileCbs.clear();
+      pileUrls.clear();
       channel.dispose();
       manifest = null;
       for (const url of [...readyWaiters.keys()]) flushReady(url, false);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -3067,6 +3067,28 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     card.appendChild(el('p', 'arc-note arc-endcard-chip',
       t('rake_retake_chip', 'Free replay. It pays nothing, and today keeps your first grade.')));
 
+    /* --- THE CARD LINE (T2 tester report, 2026-08-26: "card not updating past
+     *     1st game"). A no-op mint still gets NO CEREMONY and never will - a
+     *     beat for a hole that was not punched is the one lie this screen must
+     *     not tell - but silence was being read as a broken stamp card. So the
+     *     card keeps a slot for one quiet sentence, filled only when
+     *     `punchcard-result` comes back having minted nothing, in the same
+     *     voice as the retake chip above. A LINE, NEVER A BEAT: no sound, no
+     *     stamp, no overlay, nothing that claims a hole was punched.
+     *     It sits above the buttons so the fixed exits row never re-flows. --- */
+    let punchNote = null;
+    function setPunchNote(text) {
+      const line = String(text == null ? '' : text);
+      if (!line || !mine()) return false;
+      if (!punchNote) {
+        punchNote = el('p', 'arc-note arc-endcard-chip arc-endcard-punchnote');
+        try { card.insertBefore(punchNote, actions); }
+        catch (e) { card.appendChild(punchNote); }
+      }
+      punchNote.textContent = line;
+      return true;
+    }
+
     /** Enter = one more. Esc is NOT touched: it walks boot.js's ladder exactly
      *  as it did before this card existed. */
     function onKey(e) {
@@ -3102,6 +3124,8 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     endCard = {
       root,
       gameKey,
+      /** The card's one quiet slot - see THE CARD LINE above. */
+      setPunchNote,
       destroy() {
         if (typeof window !== 'undefined' && window.removeEventListener) {
           window.removeEventListener('keydown', onKey);
@@ -4724,10 +4748,31 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       if (m.reason !== 'daily') return;
       disarmPunch();
       // A NO-OP MINT GETS NO CEREMONY. Same local day twice, a full card, a
-      // class the host declined to stamp: nothing was punched, so nothing is
-      // shown. A card beat for a hole that did not happen is the one lie this
+      // class the host declined to stamp: nothing was punched, so no beat is
+      // played. A card beat for a hole that did not happen is the one lie this
       // screen must never tell.
-      if (!m.minted || !norm) return;
+      //
+      // IT DOES GET A LINE, THOUGH (T2 tester report, 2026-08-26: "card not
+      // updating past 1st game"). No ceremony read to the tester as no card, so
+      // the end card says WHY in one quiet sentence - a full card gets the
+      // unlock line it earned, everything else the come-back-tomorrow one. The
+      // frame carries the post-mint card, so the shell is reading the host's
+      // own truth here and still counting nothing of its own.
+      if (!m.minted) {
+        if (endCard && endCard.gameKey === m.gameKey && endCard.setPunchNote) {
+          // The frame names its own cap; `store.holes` is the parachute.
+          const cap = Math.round(Number(m.holes) || Number(store.holes) || 10);
+          const full = !!(norm && (norm.complete || Number(norm.punches) >= cap));
+          try {
+            endCard.setPunchNote(full
+              ? t('punchcard_unlocked_line',
+                'This room is now open even when the course is not in session.')
+              : t('punchcard_next_hole', 'Come back tomorrow for the next stamp.'));
+          } catch (e) { say('punch note failed: ' + ((e && e.message) || e)); }
+        }
+        return;
+      }
+      if (!norm) return;
       try {
         runPunchCeremony({
           gameKey: m.gameKey,

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -161,6 +161,15 @@
 
 html, body { height:100%; }
 
+/* NO DOUBLE-TAP ZOOM. iOS reserves ~300ms after every tap to see whether a
+   second one is coming, and on a fast board (Daily Trigger's keys, an EMI chip
+   strip) it decided the second tap was a zoom instead of a press. `manipulation`
+   drops double-tap-to-zoom and keeps PINCH zoom, so the accessibility gesture
+   survives. Element rules win over this one, so the drag surfaces that declare
+   their own `touch-action:none` (emi/widget.css, composure, sort, L&F,
+   the-deep-end, .arc-peekbtn) keep it - this is the floor, not a ceiling. */
+html, body { touch-action:manipulation; }
+
 body {
   margin:0;
   background:var(--ground);
@@ -770,9 +779,16 @@ html.arc-reduced .arc-disc-body, html.arc-reduced .arc-disc-chev { transition:no
   .arc-disc-body, .arc-disc-chev { transition:none; }
 }
 
-/* switch */
+/* switch
+   THE KNOB IS NOT THE TARGET: the invisible <input> comes FIRST in the DOM
+   (settings.js switchRow, and `input:checked + span` needs that order), so the
+   knob <span> - absolute, inset:0, later sibling - painted over it and ate every
+   press on the switch itself. Only the row label still toggled. z-index:1 lifts
+   the input back to the front WITHOUT reordering the DOM; :hover still reads on
+   the span (it propagates from the input's box) and the sibling selectors are
+   untouched. */
 .arc-switch { position:relative; width:42px; height:22px; flex:0 0 auto; }
-.arc-switch input { position:absolute; opacity:0; width:100%; height:100%; margin:0; cursor:pointer; }
+.arc-switch input { position:absolute; opacity:0; width:100%; height:100%; margin:0; cursor:pointer; z-index:1; }
 .arc-switch span {
   position:absolute; inset:0; border-radius:999px; background:var(--panel2);
   border:var(--hairline); transition:background .15s;
@@ -964,6 +980,37 @@ html.arc-reduced .arc-disc-body, html.arc-reduced .arc-disc-chev { transition:no
 @keyframes arc-knock-breathe { from { opacity:.35; } to { opacity:.9; } }
 @media (prefers-reduced-motion: reduce) {
   .arc-boot-knock { animation:none; opacity:.7; }
+}
+/* THE DOOR IS THE LAST THING WAITING (boot.js escalateKnock, T2 tester report
+   2026-08-26). `is-ready` says the school is BUILT and only the gesture is
+   outstanding, so the splash stops reading as a progress bar: the rail lands
+   full and holds, the Opening caption steps back, and the hint stops being a
+   caption and becomes the instruction. The `:not(.is-heard)` guard is load
+   bearing - is-heard is the fade-out on the tap, and it is the LESS specific
+   selector, so without it a knocked door would keep its sign up.
+   The scale pulse is the only thing added and the only thing reduced motion
+   takes away: the SIZE and the INK are the fix, the pulse is seasoning. */
+.arc-loader.is-ready .arc-intro-rail {
+  transform:scaleX(1) !important;    /* an !important beats a running animation */
+  animation-play-state:paused;       /* ...and the chase stops chasing */
+}
+.arc-loader.is-ready .arc-intro-caption { opacity:.4; transition:opacity .3s ease-out; }
+.arc-loader.is-ready .arc-boot-knock:not(.is-heard) {
+  font-size:16px; letter-spacing:.26em; color:var(--ink); opacity:1;
+  text-shadow:0 0 18px color-mix(in srgb, var(--pink) 55%, transparent);
+  animation:arc-knock-ready 1.6s ease-in-out infinite both;
+}
+@keyframes arc-knock-ready {
+  0%, 100% { opacity:.78; transform:scale(1); }
+  50%      { opacity:1;   transform:scale(1.045); }
+}
+html.arc-reduced .arc-loader.is-ready .arc-boot-knock:not(.is-heard) {
+  animation:none; opacity:1; transform:none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .arc-loader.is-ready .arc-boot-knock:not(.is-heard) {
+    animation:none; opacity:1; transform:none;
+  }
 }
 .arc-loader.is-done .arc-intro-stage {
   animation:none; transform:scale(1.07); transition:transform .3s ease-in;


### PR DESCRIPTION
Fixes from the 26 Aug `#tier-2-subscribers` Arcademy test wave (8 testers).

| # | Report | Reporters | Fix |
|---|--------|-----------|-----|
| 1 | Own media never shows on web (placeholders with local, online, both) | Derhu, Sussex | `provider/index.js`: `absorbLocal()` takes the host's `blob:` pile rows into `localPools`; `claim()` sends `local-sample-request {local:true}` whenever `init.settings.localMedia` reports a pile, regardless of remote consent. Live claims re-sync + re-dress. Desktop untouched (no `localMedia` = dead code). |
| 2 | "Pull from online" knob dead, row label works | Derhu, Sussex | `.arc-switch input { z-index:1 }` |
| 3 | iOS double-tap zoom on Daily Trigger keys / EMI | ashie | `html, body { touch-action: manipulation }` + `.g-dt-key` |
| 4 | "Knock to enter" unnoticed under running loader | Wombatant1 | `boot.js escalateKnock()`: rail lands full, hint 16px full ink + pulse, "Tap anywhere to knock" after 4s |
| 5 | "Card not updating past 1st game" | Sussex | quiet end-card line on a no-op mint (`punchcard_next_hole` / `punchcard_unlocked_line`), no ceremony |
| 6 | Broken-image tile in Deja Vu | Sussex | `<img onerror>` -> game's own placeholder face + `pool.markBroken` in anomaly, deja-vu, misdirection |

Tests: 12/12 pile suite (fake host, desktop init sends zero frames, seeded draw order byte-identical), `node --check` on every touched file.

Web goes live through the vendor-sync Action after merge. Companion PR in cclabs-web (Arcademy manifest + Scrolller debounce/backoff) is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM6CRqKtSMeTtkoXw5UevE
