### PR TITLE
feat(arcademy): Tickets + Tokens economy, Prize Counter, Extra Credit lever

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -371,6 +371,39 @@ shell/annexreveal.js THE NIGHT THE WALL MOVED: the once-ever reveal cinematic
                      over the black for free. Fires on the tenth hole of the
                      LAST card and sets `annexRevealSeen` - the only gate the
                      ajar panel on the records wall reads
+shell/prizecounter.js THE PRIZE COUNTER (economy wave): the two-currency shop, a
+                   SCREEN at depth 1 beside records - tickets (`t`, the nightly
+                   wage) on a timber shelf, tokens (`k`, one a day at best) in a
+                   glass case, so a player can tell what a thing costs from six
+                   feet away without reading a word. Narrow caps, the annex's
+                   law taken to the letter: it imports NO store, NO bridge, NO
+                   lexicon and NO EMI - `catalog()`, `balance()`, `inv()`,
+                   `unlocks()`, `payday()` and `t` all arrive as functions, so
+                   the whole room is importable in bare Node. THE ECHO LAW IS
+                   THE WHOLE DESIGN (trap 1): a Buy press paints a WAITING state
+                   and sends `prize-buy`; nothing about the wallet, the
+                   inventory or the unlocks moves until `settle()` is handed a
+                   `wallet-result` frame by the shell. A 6s watchdog clears the
+                   waiting look and says "the counter has gone quiet" - it does
+                   NOT grant, refund or retry, because a page that guessed at a
+                   purchase is a page that can sell the same token twice. Refusal
+                   reasons (`poor`/`owned`/`full`/`locked`) each have their own
+                   line; an unknown one degrades to a generic. Node-double
+                   convention throughout (findCls by children index, never
+                   querySelector) + prizecounter.css
+shell/lever.js     THE EXTRA CREDIT LEVER, in ONE place: the words, the lock
+                   lines and the rail painting for the three-way wager
+                   (Standard / Extra Credit / Honors). It has TWO hosts - the
+                   campus door card (under Begin) and the room scene's apron
+                   (beside the knobs) - because the room REPLACES the card for
+                   every painted room, so a rail that lived only on the card
+                   would be invisible in nine rooms out of ten. Imports nothing
+                   at all (`t` and the caps arrive as arguments), and A LOCKED
+                   RUNG STAYS ON THE RAIL, DIMMED: what you cannot pull yet is
+                   the whole reason to walk to the counter, so hiding it would
+                   hide the feature. Rebuilt on every pop rather than mutated -
+                   a token spent between doors has to light Honors on the very
+                   next door
 shell/peek.js      the shared hold-to-reveal verb (caps the class at A)
 shell/keybinds.js  manifest-declared verb slots, one blob, PanicKey conflict check
 shell/audio.js     THE consumer of engine 'arcademy-sfx' (WebAudio, procedural)
@@ -2736,6 +2769,63 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     no echo, never `pending` - `shell/settings.js` reaches the controller
     through a getter because the mascot mounts async, and falls back to
     `store.merge('emi', ...)` so the choice lands even when she never did.
+
+120. **A PURCHASE IS AN ECHO, AND THE WATCHDOG NEVER GRANTS** (economy wave,
+    `shell/prizecounter.js`). The counter is trap 1 with money on it, which is
+    the one place the echo law actually has teeth. The press sends `prize-buy`
+    and paints a WAITING state; `settle(frame)` - fed only by the host's
+    `wallet-result` - is the ONLY thing in the page that may move the wallet,
+    the inventory or the lever unlocks. The 6s watchdog clears the waiting look
+    and says the counter has gone quiet; it does **not** grant, refund, retry or
+    re-send, because a page that guessed would sell one token twice. The same
+    rule reaches one rung up in `shell.js`: `walletEcho` is written ONLY by
+    `payout-result` / `wallet-result` and cleared by the next `meta` snapshot, so
+    it is an overlay ON the host's truth and never an optimistic paint. If a
+    balance ever moves without a frame arriving, the bug is a write that skipped
+    `settle()`, not a lost echo.
+
+121. **A GRADE LETTER IS STRING-COMPARED IN FIVE PLACES, AND `S+` BREAKS FOUR OF
+    THEM** (economy wave, `core/grades.js`). Adding the S+ letter is one line in
+    `gradeClass`; making it WORK is a sweep. `/^[sab]$/i` does not match `'S+'`
+    (shell.js's `endMoment` - an honours run would fire EMI's FAIL pool),
+    `g === 's'` does not either (ceremonies' `payoff()` - the jackpot silently
+    demoted to the stamp floor), `GRADE_PITCH['s+']` was undefined (the chime
+    rang at PASS pitch), `.grade.s+` is not a selector CSS honours unescaped
+    (every S+ badge painted bare), and `letter === 'S'` on the student ID did not
+    count the best day the player had ever had. Hence `gradeKey()`: `'S+'` ->
+    `'splus'`, and every class name goes through it. S+ is deliberately NOT in
+    `GRADE_ORDER` and `gradeRank()` answers -1 for it, so the cap ladder
+    (`capAt`, `capsRaised`) is untouched - it is a letter above S, not a new rung
+    in the ceiling.
+
+122. **THE ROOM SCENE REPLACES THE DOOR CARD, SO EVERY CARD CONTROL OWES A
+    SECOND HOME** (economy wave, `shell/lever.js`). Nine of ten rooms are
+    painted now, which means the door card is the EXCEPTION and anything mounted
+    only on the card is invisible to almost everybody. The Extra Credit lever
+    found this the hard way: card-only, it would have shipped as a feature the
+    Prize Counter sells a rung for and the player can never see. The fix is one
+    shared painter with two hosts (card + `room.js` apron), never two copies -
+    two implementations of a three-way switch is two chances for the labels, the
+    lock lines and the unlock rules to drift apart. When you add a control to
+    `popCard()`, ask what the ten painted rooms do with it before you finish.
+
+123. **A LEXICON KEY THE HOST DOES NOT SHIP FAILS SILENTLY, IN ENGLISH** (economy
+    wave integration). `t(key, fallback)` is total: a key with no
+    `NeutralLexicon` row behind it renders the fallback and the room reads
+    perfectly, so a whole screen can ship with nothing a mod or a translation can
+    ever re-voice and no play-test will notice. This wave built both halves at
+    once and they disagreed about eight spellings - `prize_trade` against
+    `prize_buy`, `prize_reason_poor` against `prize_poor`, one `lever_hint`
+    against the three per-rung `lever_*_hint` rows, `grade_s_plus` against
+    `grade_splus` - plus twelve host rows (`tickets`, `token`, `payday` and the
+    rest) that nothing on the page ever asked for. The rule: **the PAGE's call
+    sites are authoritative**, because they are the thing that runs;
+    `core/lexicon.js` mirrors them as the offline fallback, and the host's table
+    is exactly that set plus the per-sku `nameKey`/`blurbKey` rows the catalog
+    projects. Those per-sku rows are the ones no grep of the page can find, since
+    they arrive as `item.nameKey` off the wire and never appear as a literal
+    anywhere. `econtests/test-seam.mjs` reads both sides at once and fails on a
+    drift; run it whenever a key moves.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -686,6 +686,14 @@ bridge.on('payout-result', guard('payout-result', (m) => {
   if (shell) shell.onPayout(m);
   log('payout: ' + m.gameKey + ' +' + Math.round(Number(m.xp) || 0) + 'xp' + (m.levelUp ? ' (level up)' : ''));
 }));
+/* THE PRIZE COUNTER'S ECHO. The host answers every `prize-buy` with exactly one
+ * of these, ok or not, and the Prize Counter paints nothing until it arrives -
+ * so this subscription is not a nicety, it is the other half of the buy. Like
+ * every frame on this deck it REPLAYS if it beat the shell here. */
+bridge.on('wallet-result', guard('wallet-result', (m) => {
+  if (shell && shell.onWalletResult) shell.onWalletResult(m);
+  log('wallet: ' + (m.sku || '?') + ' ' + (m.ok ? 'bought' : 'refused (' + (m.reason || '?') + ')'));
+}));
 /* THE PUNCH CARD (PUNCHCARD.md §2/§4). It lands right behind the meta snapshot
  * on both mint paths, and `bridge.on` REPLAYS anything that arrived before this
  * subscription existed - which is what makes a frame that beats the shell's two

--- a/ConditioningControlPanel/Resources/web/arcademy/core/grades.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/grades.js
@@ -30,7 +30,24 @@ export const GRADE_THRESHOLDS = Object.freeze({
   // below B -> C
 });
 
-/** Best -> worst. Index doubles as the rank (0 = best). */
+/* THE HONORS LETTER (economy wave, 2026-08-26). S+ is the ONE grade a player
+ * can choose to make reachable: it needs the Honors lever pulled AND a composite
+ * at or above SPLUS_THRESHOLD, so it is never handed out by accident and never
+ * appears on a run that did not ask for it. Everything about it is ADDITIVE:
+ *  - the S threshold and every letter below it are byte-for-byte what they were,
+ *    so a class played on Standard grades exactly as it always did;
+ *  - it is NOT in GRADE_ORDER, because that list is the CEILING ladder the caps
+ *    walk (`capAt` indexes it) and no cap may ever raise a letter to S+;
+ *  - `gradeRank` answers -1 for it, one better than S's 0, so every existing
+ *    "lower rank is better" comparison keeps working and S+ simply wins.
+ * The host re-derives the honors flag from the lever it stored at class-started
+ * and degrades a claimed S+ to S when the lever was not Honors - the page may
+ * propose this letter, it may never mint it. */
+export const SPLUS = 'S+';
+export const SPLUS_THRESHOLD = 0.97;
+
+/** Best -> worst. Index doubles as the rank (0 = best). S+ sits ABOVE this list
+ *  (rank -1) on purpose - see the note above. */
 export const GRADE_ORDER = Object.freeze(['S', 'A', 'B', 'C']);
 export const PASS = 'pass';
 
@@ -44,8 +61,9 @@ export const CAP_REASONS = Object.freeze({
   accessibility_aid: 'A', // Misdirection's numbered-shell aid
 });
 
-/** Promotion rule (shell-owned, BUILD-CONTRACT §11): S or A promotes a tier. */
-export const PROMOTING_GRADES = Object.freeze(['S', 'A']);
+/** Promotion rule (shell-owned, BUILD-CONTRACT §11): S or A promotes a tier.
+ *  S+ promotes for the same reason S does - it is an S with the lever pulled. */
+export const PROMOTING_GRADES = Object.freeze([SPLUS, 'S', 'A']);
 
 /* ----------------------------------------------------------------------------
  * SMALL HELPERS
@@ -56,8 +74,16 @@ export function clamp01(n) {
   return v < 0 ? 0 : v > 1 ? 1 : v;
 }
 
-/** 0 = best (S). 'pass' and anything unknown sort last. */
+/** True for the honors letter, however it was cased or spaced. */
+export function isSPlus(grade) {
+  return String(grade == null ? '' : grade).trim().toUpperCase() === SPLUS;
+}
+
+/** 0 = best (S), -1 for S+. 'pass' and anything unknown sort last. Every caller
+ *  compares ranks rather than reading the number, so the one negative rung is
+ *  free: "smaller is better" was always the contract. */
 export function gradeRank(grade) {
+  if (isSPlus(grade)) return -1;
   const i = GRADE_ORDER.indexOf(String(grade || '').toUpperCase());
   return i < 0 ? GRADE_ORDER.length : i;
 }
@@ -80,6 +106,19 @@ export function letterFor(composite) {
   return 'C';
 }
 
+/**
+ * The CSS-SAFE key for a letter. Every badge on the page is styled by
+ * `.grade.<key>`, and 'S+' lowercases to `s+` - which is a class attribute CSS
+ * will not match without an escape, so the honours letter would have painted as
+ * the unstyled default everywhere at once. One helper, so the report card, the
+ * records wall and the campus chip cannot disagree about the answer.
+ * @returns {string} 'splus' | 's' | 'a' | 'b' | 'c' | 'pass' | ''
+ */
+export function gradeKey(grade) {
+  const raw = String(grade == null ? '' : grade).trim().toLowerCase();
+  return raw === 's+' ? 'splus' : raw;
+}
+
 /** True when this grade should promote the player's per-game tier. */
 export function isPromoting(grade) {
   return PROMOTING_GRADES.indexOf(String(grade || '').toUpperCase()) >= 0;
@@ -94,6 +133,7 @@ export function isPromoting(grade) {
  * @property {Object=} hardGates               declared gates, e.g. {sGate:true}. FALSE = failed.
  * @property {boolean=} zen                    zen / untimed class
  * @property {Object=} assists                 {peek, below_par_board, tempo_assist, ...} truthy = used
+ * @property {boolean=} honors                 the Honors lever was pulled for this run
  *
  * @typedef {Object} GradeResult
  * @property {'S'|'A'|'B'|'C'|'pass'} grade
@@ -124,7 +164,13 @@ export function gradeClass(input) {
     };
   }
 
-  const baseGrade = letterFor(composite);
+  /* THE HONORS RUNG. Only ever reached with the lever pulled, and only from a
+   * composite that would already have been an S with room to spare. It is put on
+   * the BASE letter rather than after the caps so a hard gate or an A-cap knocks
+   * it straight down to A like any other top letter - honors buys a ceiling, it
+   * never buys forgiveness. */
+  const baseGrade = (src.honors === true && composite >= SPLUS_THRESHOLD)
+    ? SPLUS : letterFor(composite);
   let grade = baseGrade;
   const capped = [];
   const gatesFailed = [];

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -43,6 +43,8 @@ export const DEFAULT_LEXICON = Object.freeze({
   /* performance */
   grade: 'Grade',
   grade_s: 'S', grade_a: 'A', grade_b: 'B', grade_c: 'C', grade_pass: 'PASS',
+  /* the honors letter - spelled out because 'grade_s+' is not a legal key */
+  grade_splus: 'S+',
   grade_tier: 'Year',
   grade_tier_1: 'Year 1', grade_tier_2: 'Year 2', grade_tier_3: 'Year 3', grade_tier_4: 'Year 4',
   attendance: 'Attendance',
@@ -551,6 +553,58 @@ export const DEFAULT_LEXICON = Object.freeze({
   campus_annex: 'Records Annex',
   campus_annex_status: 'Stairs down',
   campus_desc_annex: 'Under the office. The lights are off down there. The screens are not.',
+
+  /* ------------------------------------------------------------------------
+   * THE PRIZE COUNTER and the two currencies (economy wave, 2026-08-26).
+   * Front-desk voice: warm, a bit scruffy, never a form. Every row here is a
+   * NeutralLexicon candidate and every one of them is under the 96-character
+   * cap a mod needs to be able to re-voice it (trap 26). The prize NAMES and
+   * blurbs are deliberately NOT here - they ride init.economy.catalog from the
+   * host, so the shelf is whatever the host says it is.
+   * ---------------------------------------------------------------------- */
+  campus_room_prizes: 'Prize Counter',
+  campus_prizes_status: 'Open late',
+  campus_desc_prizes: 'Tickets on the shelf, tokens in the case. Somebody is always restocking.',
+  wallet_tickets: 'Tickets',
+  wallet_tokens: 'Tokens',
+  prize_counter_title: 'Prize Counter',
+  prize_counter_sub: 'Tickets on the shelf, tokens in the case',
+  prize_shelf: 'Ticket Shelf',
+  prize_shelf_hint: 'Every graded class pays tickets. This is where they go.',
+  prize_case: 'Token Case',
+  prize_case_hint: 'Tokens only. Your first S of the day drops one in the tray.',
+  prize_you_have: 'On you',
+  prize_owned: 'Yours',
+  prize_held: 'Holding',
+  prize_buy: 'Trade',
+  prize_soon: 'Arriving soon',
+  prize_wait: 'Asking the counter',
+  prize_bought: 'Wrapped up and yours.',
+  prize_poor: 'Not quite enough on you for that one yet.',
+  prize_owned_msg: 'You have that one already.',
+  prize_full: 'Your pockets are full of those. Use one first.',
+  prize_locked_msg: 'That one stays in the case for now.',
+  prize_unknown: 'The counter does not know that one. Odd.',
+  prize_quiet: 'The counter went quiet on that one. Try again in a moment.',
+  prize_empty: 'Shelf is bare tonight. Come back when the truck has been.',
+  prize_payday_label: 'Hot room tonight',
+  prize_payday_2: 'is paying double',
+  prize_payday_5: 'is paying five times over',
+  /* the Extra Credit lever, on the door card and in the painted room */
+  lever_title: 'Extra Credit',
+  lever_standard: 'Standard',
+  lever_extra: 'Extra Credit',
+  lever_honors: 'Honors',
+  lever_standard_hint: 'Play it straight. Tickets pay the usual.',
+  lever_extra_hint: 'Half again the tickets, and it asks more of you.',
+  lever_honors_hint: 'Double tickets, and the only road to an S plus.',
+  lever_extra_locked: 'Earn an A on anything and this one wakes up.',
+  lever_honors_locked: 'The counter sells this one for a token.',
+  free_swim_key_hint: 'Your key opens this one for a practice run. Nothing counts, nothing costs.',
+  /* the payout beat on the report card */
+  payout_tickets: 'Tickets',
+  payout_token_minted: 'A token dropped in the tray. That is your one for today.',
+  late_slip_used: 'A late slip covered you. Your streak never noticed.',
 });
 
 let table = Object.create(null);
@@ -600,10 +654,15 @@ export function tierLabel(tier) {
   return t('grade_tier_' + n, 'Year ' + n);
 }
 
-/** Grade letter display ('S'|'A'|'B'|'C'|'pass'). */
+/** Grade letter display ('S+'|'S'|'A'|'B'|'C'|'pass').
+ *  S+ CANNOT USE THE DERIVED KEY: 'grade_s+' is not a key shape a NeutralLexicon
+ *  row (or a mod table) can carry, so the one letter with punctuation in it is
+ *  spelled out as `grade_splus` here and nowhere else. */
 export function gradeLabel(grade) {
-  const g = String(grade || '').toLowerCase();
-  return t('grade_' + g, g === 'pass' ? 'PASS' : String(grade || '').toUpperCase());
+  const raw = String(grade == null ? '' : grade).trim();
+  if (raw.toUpperCase() === 'S+') return t('grade_splus', 'S+');
+  const g = raw.toLowerCase();
+  return t('grade_' + g, g === 'pass' ? 'PASS' : raw.toUpperCase());
 }
 
 /** Family chip display. */

--- a/ConditioningControlPanel/Resources/web/arcademy/core/store.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/store.js
@@ -66,7 +66,7 @@ export const S_DAY_PUNCHES = 2;
 /** Keys the host mints. The page never writes them (the write would be refused). */
 export const HOST_OWNED_KEYS = Object.freeze([
   'streak', 'perfectAttendance', 'lastAttendanceLocalDate', 'todayClasses', 'xpPaidDays',
-  'punchCards',
+  'punchCards', 'wallet',
 ]);
 const HOST_OWNED = new Set(HOST_OWNED_KEYS);
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
@@ -15,7 +15,7 @@
  *   .g-ic-basin     the reveal surface: THE bubble (the one interactive node)
  *   .g-ic-hud       THE LIT MACHINE, pinned to the bottom edge
  *   .g-ic-howto     the class rules SHEET · .g-ic-break intro card
- *   .g-ic-debrief   the machine TICKET
+ *   .g-ic-debrief   the machine RESULTS SLIP
  *
  * HOUSE RULES WAVE - what this file gained, and why it is here and not in a
  * deck:
@@ -37,7 +37,11 @@
  *     10-segment streak meter is a SHELL primitive (SYNTHESIS #10) that
  *     index.js mounts through ctx.ceremonies.streakMeter. The old private
  *     5-pip meter that used to live here is DELETED - it was a fork.
- *   THE TICKET (Deck V + VI). debrief() prints a receipt: perforated edges, a
+ *   THE RESULTS SLIP (Deck V + VI). "Ticket" is the school's word for MONEY as
+ *     of the economy wave, so this thing is a results slip and the `.g-ic-ticket*`
+ *     class names are the only place the old word survives (renaming them would
+ *     be a stylesheet rewrite for a word nobody reads). debrief() prints a slip:
+ *     perforated edges, a
  *     slow light sweep, the backdrop still breathing behind it, the grade
  *     arriving as an OBJECT in `nodes.ticketStamp` (index.js drops the shell's
  *     stamp ceremony there). Submit is lit, pulsing and pre-focused; recal is a
@@ -58,7 +62,7 @@
  * integrity).
  *
  * NEVER STILL (Law III): the lamps breathe, the thread head pulses, the topline
- * sweeps, the ticket's light crawls. Every one of those is a CSS animation, so
+ * sweeps, the slip's light crawls. Every one of those is a CSS animation, so
  * `.suspended` (animation-play-state:paused, pseudo-elements included) and
  * prefers-reduced-motion both freeze the whole room from the stylesheet, even
  * if a JS path forgets.
@@ -558,11 +562,11 @@ export function createRender(o = {}) {
     if (nodes.card) { try { nodes.card.remove(); } catch (e) { /* noop */ } nodes.card = null; }
   }
 
-  /* THE TICKET (Deck V + Deck VI). Same signature, same fields, plus the two
-     optional flags the casino decides: d.perfect (no X popped, nothing drifted)
-     and d.royal. The grade arrives as an OBJECT: index.js drops the shell's
-     stamp ceremony into nodes.ticketStamp. Nothing here grades anything - every
-     number on this receipt was handed to it. */
+  /* THE RESULTS SLIP (Deck V + Deck VI). Same signature, same fields, plus the
+     two optional flags the casino decides: d.perfect (no X popped, nothing
+     drifted) and d.royal. The grade arrives as an OBJECT: index.js drops the
+     shell's stamp ceremony into nodes.ticketStamp. Nothing here grades anything
+     - every number on this slip was handed to it. */
   function debrief(d, onSubmit, onRecal) {
     clearCard();
     hideHowto();

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -49,6 +49,7 @@ import { createAccountChip } from './accountchip.js';
 import { mountMailChip } from './mailbox.js';
 import { mountBoardProp } from './corkboard.js';
 import { mountBugleProp } from './bugle.js';
+import { paintLever } from './lever.js';
 
 const SVGNS = 'http://www.w3.org/2000/svg';
 
@@ -532,6 +533,15 @@ export const FACILITIES = Object.freeze({
   annex: Object.freeze({
     rect: [1260, 300, 108, 72], side: 'w', door: 336, stop: [1250, 422], rm: '000',
   }),
+  /* THE PRIZE COUNTER (economy wave, 2026-08-26). Third counter down the same
+   * alley, under the Front Office: it belongs with the other two because it IS
+   * the other two - a window with somebody behind it. Same width, same west
+   * door, same three-step walk, and its stop simply continues down the alley
+   * the way the registrar's continues past Records. Nothing about the pathing
+   * is special-cased for it. */
+  prizes: Object.freeze({
+    rect: [1260, 572, 108, 84], side: 'w', door: 614, stop: [1250, 614], rm: '003',
+  }),
 });
 
 /** ROOMS first, the two counters second. Pure; undefined for anything else. */
@@ -770,12 +780,18 @@ function idCrestGlyph() {
  *   shell/seep.js - it asks `beat('door_card')` and paints what it is told,
  *   exactly the way the split-flap board takes `misprintFor`. Absent = a school
  *   that is simply quiet, and the card is what it always was.
+ * @param {Object=} o.economy   THE TWO CURRENCIES, handed down and never read:
+ *   {balance:() => ({t,k}), lever:{positions, get, set, unlocks}}. This file is
+ *   under the header law - it imports no store and no bridge - so the wallet
+ *   chip, the Prize Counter's window and the Extra Credit lever on the door
+ *   card all live entirely on these getters. Absent = none of the three is
+ *   mounted, and the campus is byte-for-byte the campus it was.
  * @param {Function=} o.log
  * @returns {{root, boardMount, footMount, update, closeCard, destroy}}
  */
 export function createCampus({ state, gameName, banner, stats, reducedMotion, on, log,
   dateSeed, attractIdleMs, boardPulse, idCardMode, holdAttract, post, seep, annex,
-  account } = {}) {
+  account, economy } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const handlers = on || {};
   /* THE ACCOUNT CHIP (shell/accountchip.js): a host slot in the top-right
@@ -815,6 +831,22 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   let mailChip = null;
   let boardProp = null;
   let bugleProp = null;
+  /* THE WALLET CHIP's three nodes - null when no `economy` bag arrived. */
+  let walletChip = null;
+  let walletTicketN = null;
+  let walletTokenN = null;
+
+  /** Repaint the wallet chip from the shell's own reader. Guarded end to end:
+   *  a chip is furniture, and furniture may never be the thing that throws. */
+  function paintWallet() {
+    if (!walletChip || !economy || typeof economy.balance !== 'function') return;
+    let b = null;
+    try { b = economy.balance(); } catch (e) { b = null; }
+    const tt = Math.max(0, Math.round(Number(b && b.t) || 0));
+    const kk = Math.max(0, Math.round(Number(b && b.k) || 0));
+    try { if (walletTicketN) walletTicketN.textContent = String(tt); } catch (e) { /* noop */ }
+    try { if (walletTokenN) walletTokenN.textContent = String(kk); } catch (e) { /* noop */ }
+  }
   const holdsAttract = typeof holdAttract === 'function' ? holdAttract : () => false;
   /* The seep director, always ASKED and never held (see the `seep` param). */
   const seepDir = typeof seep === 'function' ? seep : () => null;
@@ -1501,6 +1533,38 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     stag(annexG, 820);
   }
 
+  /* THE PRIZE COUNTER. The post bag's contract for the third time: the campus
+   * mounts the window only when the shell hands an `economy` bag, and the shell
+   * keeps the catalog, the wallet and every byte of it. A host with no economy
+   * projected in `init` gets the campus it always had, with no dark room and no
+   * gap in the alley where a room used to be. */
+  let prizesG = null;
+  if (economy) {
+    prizesG = facility({
+      rect: FACILITIES.prizes.rect, door: FACILITIES.prizes.door,
+      side: FACILITIES.prizes.side, compact: true,
+      neonY: 580, nameY: 618,
+      sign: t('wallet_tickets', 'Tickets'),
+      name: t('campus_room_prizes', 'Prize Counter'),
+      rm: FACILITIES.prizes.rm,
+      onClick: () => { if (handlers.prizes) handlers.prizes(); },
+      tip: () => ({
+        name: t('campus_room_prizes', 'Prize Counter'),
+        status: t('campus_prizes_status', 'Open late'),
+        desc: t('campus_desc_prizes',
+          'Tickets on the shelf, tokens in the case. Somebody is always restocking.'),
+      }),
+    });
+    /* THE LIT WINDOW. Records gets the trophy-case gold through this same one
+     * modifier; the counter takes its own so the stylesheet can warm it without
+     * either of them borrowing the other's rule. */
+    prizesG.setAttribute('class', 'campus-room facility prizes');
+    /* the shelf behind the glass - three parcels in a row on the back wall */
+    [1280, 1304, 1328].forEach((x) => prizesG.appendChild(
+      svg('rect', { x, y: 644, width: 18, height: 13 }, 'campus-furnf')));
+    stag(prizesG, 860);
+  }
+
   /* Entrance hall dressing (notice board, trophy case, admissions desk, crest) */
   const hall = svg('g', null, 'campus-halldress');
   hall.appendChild(svg('circle', { cx: 582, cy: 622, r: 46, 'stroke-dasharray': '4 6' }, 'campus-crestring'));
@@ -1696,6 +1760,35 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     if (mailChip && mailChip.el) {
       try { topCluster.insertBefore(mailChip.el, gear); } catch (e) { /* order is cosmetic */ }
     }
+  }
+  /* THE WALLET, between the envelope and the gear. It is a READING, not a
+   * control: two numbers and the two glyphs, and pressing it walks to the
+   * counter the same way the Records door walks to the office. It repaints on
+   * every campus update() because a payout can land while the board is up and
+   * a chip that lied about your tickets for a whole screen is worse than no
+   * chip at all. */
+  if (economy && typeof economy.balance === 'function') {
+    walletChip = el('button', 'campus-wallet');
+    walletChip.type = 'button';
+    walletChip.setAttribute('aria-label', t('campus_room_prizes', 'Prize Counter'));
+    walletChip.setAttribute('title', t('campus_room_prizes', 'Prize Counter'));
+    const tWrap = el('span');
+    const tIco = el('i', 'arc-tick');
+    tIco.setAttribute('aria-hidden', 'true');
+    tWrap.appendChild(tIco);
+    walletTicketN = el('b', null, '0');
+    tWrap.appendChild(walletTicketN);
+    walletChip.appendChild(tWrap);
+    const kWrap = el('span');
+    const kIco = el('i', 'arc-tok', '◉');
+    kIco.setAttribute('aria-hidden', 'true');
+    kWrap.appendChild(kIco);
+    walletTokenN = el('b', null, '0');
+    kWrap.appendChild(walletTokenN);
+    walletChip.appendChild(kWrap);
+    walletChip.addEventListener('click', () => { if (handlers.prizes) handlers.prizes(); });
+    try { topCluster.insertBefore(walletChip, gear); } catch (e) { topCluster.appendChild(walletChip); }
+    paintWallet();
   }
   /* THE ACCOUNT CHIP, after the gear - the far right, the way the topbar and
    * the main web app both place it. Web host only. */
@@ -2001,6 +2094,23 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   const ccAltHint = el('p', 'cc-althint', '');
   ccAltHint.hidden = true;
   card.appendChild(ccAltHint);
+  /* THE EXTRA CREDIT LEVER, under the two doors. It sits BELOW Begin on purpose:
+   * it is a choice about the run you are about to take, not a way to take it,
+   * and a control above the verb would read as a step you have to complete
+   * first. Three positions on one rail, and a position you have not unlocked is
+   * DIM AND STILL THERE - what you cannot pull yet is the whole reason to walk
+   * down to the counter, so hiding it would hide the feature. Mounted only when
+   * the shell handed an `economy` bag; the card is otherwise unchanged. */
+  const ccLever = el('div', 'arc-lever');
+  ccLever.hidden = true;
+  const ccLeverRail = el('div', 'arc-lever-rail');
+  const ccLeverHint = el('p', 'arc-lever-hint', '');
+  if (economy && economy.lever) {
+    ccLever.appendChild(el('p', 'arc-lever-title', t('lever_title', 'Extra Credit')));
+    ccLever.appendChild(ccLeverRail);
+    ccLever.appendChild(ccLeverHint);
+    card.appendChild(ccLever);
+  }
   scrim.appendChild(card);
   root.appendChild(scrim);
 
@@ -2048,6 +2158,18 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     ccAltHint.textContent = hint;
     ccAltHint.hidden = !hint;
     cardAltAction = () => { if (handlers.freeSwim) handlers.freeSwim(key); };
+  }
+
+  /**
+   * Paint (or retire) the Extra Credit rail. The words, the lock lines and the
+   * painting all live in shell/lever.js, because the room scene's apron shows
+   * the SAME rail and two copies of a three-way switch is two chances to drift.
+   * Rebuilt on every card pop rather than mutated - see paintLever's note.
+   */
+  function setLever(show) {
+    if (show === false || !economy || !economy.lever) { ccLever.hidden = true; return; }
+    ccLever.hidden = false;
+    paintLever({ rail: ccLeverRail, hint: ccLeverHint }, economy.lever, t, () => setLever(true));
   }
 
   function popCard() {
@@ -2215,6 +2337,11 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       try { fireMoment('lockedClick', { what: 'room', gameKey: key }); } catch (e) { /* noop */ }
     }
     setAltButton(key, r);
+    /* THE LEVER rides the class card and only the class card: it is a wager on
+     * a graded run, so a facility door has nothing to wager. Rebuilt here rather
+     * than once at boot so a token spent at the counter lights Honors on the
+     * very next door the player opens. */
+    setLever(true);
     /* THE CHALK GHOST, and it must be asked BEFORE the card pops - see above. */
     chalkGhost(key);
     popCard();
@@ -2242,6 +2369,7 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       cardAction = d.action || null;
     }
     setAltButton(null, null);        // facilities are never swum
+    setLever(false);                 // nor wagered on
     popCard();
   }
 
@@ -2275,6 +2403,10 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     if (mailChip) { try { mailChip.update(); } catch (e) { /* noop */ } }
     if (boardProp) { try { boardProp.refresh(post && post.daySeed); } catch (e) { /* noop */ } }
     if (bugleProp) { try { bugleProp.refresh(); } catch (e) { /* noop */ } }
+    /* ...and so does the wallet, off the same silent-repaint path: a payout
+     * lands while the board is up, and the chip has to have moved by the time
+     * the player looks at it. */
+    paintWallet();
 
     for (const key of Object.keys(roomRefs)) {
       const ref = roomRefs[key];

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/ceremonies.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/ceremonies.js
@@ -65,11 +65,23 @@ function sfx(name, level, extra) {
  * @param {Object=} o.engine        the Distraction Engine facade (may be null)
  * @param {HTMLElement=} o.layer    fixed-position ceremony layer (#arc-ceremony)
  * @param {boolean=} o.reducedMotion
+ * @param {Function=} o.confetti    () -> true when the player owns the Prize
+ *                                  Counter's confetti stamp. A GETTER, not a
+ *                                  flag: the thing can be bought mid-night and
+ *                                  the ceremonies live for the whole class.
  * @param {Function=} o.log
  */
-export function createCeremonies({ engine, layer, reducedMotion, log } = {}) {
+export function createCeremonies({ engine, layer, reducedMotion, confetti, log } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const reduced = !!reducedMotion;
+  /* THE GARNISH. One class on the stamp node, and prizecounter's CSS-free
+   * cousin in styles.css does the rest. It is deliberately not a new ceremony:
+   * a cosmetic that changed the BEAT would be a cosmetic that changed the
+   * game, and the three-tier law says the shop sells looks and nothing else. */
+  const hasConfetti = () => {
+    try { return typeof confetti === 'function' ? !!confetti() : false; }
+    catch (e) { return false; }
+  };
   const timers = new Set();
   let engineWarned = false;
 
@@ -120,7 +132,8 @@ export function createCeremonies({ engine, layer, reducedMotion, log } = {}) {
       const host = target || layer;
       if (!host) return null;
 
-      const node = el('div', 'arc-stamp' + (tone === 'pink' ? ' pink' : '') + (reduced ? '' : ' pop'),
+      const node = el('div', 'arc-stamp' + (tone === 'pink' ? ' pink' : '') + (reduced ? '' : ' pop')
+        + (hasConfetti() && !reduced ? ' arc-stamp-confetti' : ''),
         String(text == null ? '' : text));
       // The fixed layer is pointer-events:none; an in-flow target needs the same
       // promise or a stamp could eat a click on the button underneath it.
@@ -218,7 +231,11 @@ export function createCeremonies({ engine, layer, reducedMotion, log } = {}) {
       // THE GRADE IS RANK-PITCHED (W0): the House Book's reference beat is the
       // punch-card thud and this is its ladder verbatim (punchcard.js
       // 0.78/0.92/1/1.18) - a C lands low, an S rings. PASS sits at 1.
-      const GRADE_PITCH = { c: 0.78, b: 0.92, a: 1, s: 1.18 };
+      // S+ RINGS HIGHER THAN S and it has to be spelled out: the key here is
+      // the LOWERCASED grade, so 'S+' arrives as 's+' and would have fallen
+      // through to the flat 1 a PASS gets. One rung above the S, no further -
+      // the ladder is the punch card's and this is the top of it.
+      const GRADE_PITCH = { c: 0.78, b: 0.92, a: 1, s: 1.18, 's+': 1.28 };
       // 'a' and 'pass' wear the pink seal, everything else the gold one - the
       // stamp primitive's only two tones, unchanged.
       const node = api.stamp({
@@ -254,7 +271,10 @@ export function createCeremonies({ engine, layer, reducedMotion, log } = {}) {
       const capList = Array.isArray(capped) ? capped.map((c) => String(c)) : [];
       const failedGate = !!gated || capList.some((c) => c.indexOf('hard') >= 0);
       const opts = { target, scale: scale == null ? 1 : scale };
-      if (!failedGate && (g === 's' || g === 'a')) {
+      // 's+' is the lowercased honours letter and it is the BEST result the
+      // school hands out, so it takes the jackpot rung it would otherwise have
+      // missed entirely - `g === 's'` is a string compare and 's+' is not 's'.
+      if (!failedGate && (g === 's+' || g === 's' || g === 'a')) {
         api.reward('jackpot', Object.assign({ text: text || 'JACKPOT' }, opts));
         return 'jackpot';
       }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/idcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/idcard.js
@@ -392,6 +392,8 @@ const HOMEROOM_NO = '101';
  *                                            selfId, web}
  * @param {Function} o.stats          () -> {streak, perfect, stamps, stampCap, sDays,
  *                                            termRoman, tier, enrolled, mastered, cards}
+ * @param {Function=} o.frame         () -> 'gold' | 'navy' | '' - a frame bought at
+ *                                    the Prize Counter, worn as a class on the card
  * @param {Function=} o.onChip        the ONE chip verb (the shell posts the frame)
  * @param {Function=} o.onClose       fired on EVERY path out (Esc, the veil, the
  *                                    close button, Open Records, a teardown) -
@@ -407,7 +409,7 @@ const HOMEROOM_NO = '101';
  * @returns {{open, dismiss, isOpen, setProfile, setChipState, photoDay, root}}
  */
 export function createIdSpotlight({ t, reducedMotion, lite, isMobile, profile, stats,
-  onChip, onRecords, onClose, onOpenCount, sfx, log } = {}) {
+  frame, onChip, onRecords, onClose, onOpenCount, sfx, log } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const tr = typeof t === 'function' ? t : (k, fb) => fb;
   const still = typeof reducedMotion === 'function' ? reducedMotion : idReducedMotion;
@@ -469,6 +471,25 @@ export function createIdSpotlight({ t, reducedMotion, lite, isMobile, profile, s
 
   function nameFor(p) { return (p && p.name) ? String(p.name) : tr('student', 'Student'); }
 
+  /** The frames the counter stocks. An unknown word paints nothing rather than
+   *  a broken class, so a catalog that grows a third frame tomorrow cannot make
+   *  the card render as a mystery. */
+  const FRAMES = { gold: 'is-frame-gold', navy: 'is-frame-navy' };
+
+  /** Put the bought frame on the card, or take a sold-back one off. The node
+   *  arrives by hand at build time (`spot` does not exist yet) and is read off
+   *  the live refs on every repaint after that. */
+  function paintFrame(node) {
+    const big = node || (spot && spot.refs ? spot.refs.big : null);
+    if (!big || !big.classList) return;
+    let want = '';
+    try { want = String((typeof frame === 'function' ? frame() : '') || ''); }
+    catch (e) { want = ''; }
+    for (const key of Object.keys(FRAMES)) {
+      try { big.classList.toggle(FRAMES[key], key === want); } catch (e) { /* noop */ }
+    }
+  }
+
   /** Repaint the parts a `profile` frame or a `setting` echo can move. */
   function setProfile() {
     if (!spot) return;
@@ -490,6 +511,9 @@ export function createIdSpotlight({ t, reducedMotion, lite, isMobile, profile, s
     if (r.foilNo) r.foilNo.textContent = num.no;
     paintBarcode(r.barcode, num.no);
     if (r.barcodeNo) r.barcodeNo.textContent = num.no.replace('-', '') + '00';
+    /* A frame bought while the card is up lands on the SAME repaint a profile
+     * echo takes, so the shell never needs a second verb for it. */
+    paintFrame();
   }
 
   /** The shell hands the chip its in-flight looks (`wait` / `pending`). */
@@ -580,6 +604,13 @@ export function createIdSpotlight({ t, reducedMotion, lite, isMobile, profile, s
     big.appendChild(back);
 
     const refs = {};
+    /* THE FRAME the counter sells. A skin on the card the player already has,
+     * never a second card - trap 93's rule is that the `.campus-idcard` node is
+     * never replaced, and the same reasoning holds one rung in: the frame is a
+     * class on `.arc-id-big`, so every ref, every listener and the flip all
+     * survive a purchase that settles while the card is open. */
+    refs.big = big;
+    paintFrame(big);
 
     function band(host, kindText) {
       const b = el('div', 'arc-id-band');

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/lever.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/lever.js
@@ -1,0 +1,134 @@
+/* ============================================================================
+   shell/lever.js - THE EXTRA CREDIT LEVER, in one place.
+
+   The lever is a wager on a graded run: Standard pays the usual, Extra Credit
+   pays half again and asks more, Honors pays double and is the only road to an
+   S plus. It has to be reachable from BOTH doorways into a class - the campus
+   door card and, for the rooms that have a painted set, the room scene's apron
+   - or a player who only ever enters through the painted door would never see
+   it exist.
+
+   Two surfaces, one rail. This module owns the words, the lock lines and the
+   painting; the two callers own only their own nodes and their own placement.
+   It imports NOTHING (not the lexicon, not the store, not the bridge): `t` and
+   the lever caps arrive as arguments, so it is importable in bare Node and it
+   cannot drift from either host.
+
+   It builds nodes with document.createElement and reads nothing back out of the
+   DOM, so the node-double in the test harness carries it fine.
+   ==========================================================================*/
+
+/** The rail's rungs, cheapest wager first. The host is free to hand down a
+ *  shorter list; this is the fallback when it hands down nothing. */
+export const LEVER_POSITIONS = ['standard', 'extra', 'honors'];
+
+/** Per position: [labelKey, labelEn, hintKey, hintEn]. */
+export const LEVER_WORDS = {
+  standard: ['lever_standard', 'Standard', 'lever_standard_hint',
+    'Play it straight. Tickets pay the usual.'],
+  extra: ['lever_extra', 'Extra Credit', 'lever_extra_hint',
+    'Half again the tickets, and it asks more of you.'],
+  honors: ['lever_honors', 'Honors', 'lever_honors_hint',
+    'Double tickets, and the only road to an S plus.'],
+};
+
+/** What a rung says while it is still locked. Standard never locks. */
+export const LEVER_LOCKED = {
+  extra: ['lever_extra_locked', 'Earn an A on anything and this one wakes up.'],
+  honors: ['lever_honors_locked', 'The counter sells this one for a token.'],
+};
+
+/** A locked rung stays ON the rail, dimmed. A player has to be able to see the
+ *  thing they have not got yet, or the counter is selling a rumour. */
+export function isLocked(pos, unlocks) {
+  const un = unlocks || {};
+  if (pos === 'extra') return un.extra !== true;
+  if (pos === 'honors') return un.honors !== true;
+  return false;
+}
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+}
+
+/**
+ * Rebuild a lever rail from scratch.
+ *
+ * Rebuilt rather than mutated on every pop, because the unlocks can have moved
+ * since the last one (the player walked to the counter and bought the Honors
+ * lever between doors) and a rail that remembered which rungs were dim would be
+ * the one place in the school where a purchase does not show until a reload.
+ *
+ * @param {object} nodes  { rail, hint } - both already in the caller's tree.
+ * @param {object} lev    caps: positions[], get(), set(pos), unlocks().
+ * @param {function} t    lexicon lookup (key, fallback).
+ * @param {function} [repaint] called after a successful set(); the caller
+ *                    hands its own setLever back so the rail re-reads the pick.
+ * @returns {string} the position that is currently pulled.
+ */
+export function paintLever(nodes, lev, t, repaint) {
+  const rail = nodes && nodes.rail;
+  const hint = nodes && nodes.hint;
+  const say = typeof t === 'function' ? t : ((k, fb) => fb);
+  if (!rail) return 'standard';
+
+  const positions = (lev && Array.isArray(lev.positions) && lev.positions.length)
+    ? lev.positions : LEVER_POSITIONS;
+  let un = {};
+  try { un = (lev && typeof lev.unlocks === 'function' ? lev.unlocks() : {}) || {}; }
+  catch (e) { un = {}; }
+  let pick = 'standard';
+  try { pick = String((lev && typeof lev.get === 'function' ? lev.get() : 'standard') || 'standard'); }
+  catch (e) { pick = 'standard'; }
+
+  rail.textContent = '';
+  const paintHint = (pos, locked) => {
+    if (!hint) return;
+    const row = locked ? LEVER_LOCKED[pos] : null;
+    if (row) { hint.textContent = say(row[0], row[1]); return; }
+    const w = LEVER_WORDS[pos];
+    hint.textContent = w ? say(w[2], w[3]) : '';
+  };
+
+  for (const pos of positions) {
+    const w = LEVER_WORDS[pos] || [pos, pos, '', ''];
+    const locked = isLocked(pos, un);
+    const btn = el('button', 'arc-lever-pos'
+      + (pos === pick ? ' is-on' : '') + (locked ? ' is-locked' : ''), say(w[0], w[1]));
+    btn.type = 'button';
+    if (locked) btn.setAttribute('aria-disabled', 'true');
+    btn.addEventListener('click', () => {
+      if (locked) { paintHint(pos, true); return; }
+      try { if (lev && typeof lev.set === 'function') lev.set(pos); } catch (e) { /* noop */ }
+      if (typeof repaint === 'function') repaint();
+    });
+    /* Hovering a rung says what it costs BEFORE it is pulled - the one thing a
+     * three-way switch has to do that a two-way one does not. */
+    btn.addEventListener('mouseenter', () => paintHint(pos, locked));
+    rail.appendChild(btn);
+  }
+  paintHint(pick, isLocked(pick, un));
+  return pick;
+}
+
+/**
+ * Build the whole block (title, rail, hint) for a host that has no nodes yet.
+ * The campus card builds its own because its nodes are stitched into a card
+ * that already exists; the room apron takes this.
+ * @returns {{root:HTMLElement, rail:HTMLElement, hint:HTMLElement}}
+ */
+export function buildLever(t, extraClass) {
+  const say = typeof t === 'function' ? t : ((k, fb) => fb);
+  const root = el('div', 'arc-lever' + (extraClass ? ' ' + extraClass : ''));
+  root.appendChild(el('p', 'arc-lever-title', say('lever_title', 'Extra Credit')));
+  const rail = el('div', 'arc-lever-rail');
+  const hint = el('p', 'arc-lever-hint', '');
+  root.appendChild(rail);
+  root.appendChild(hint);
+  return { root, rail, hint };
+}
+
+export default { LEVER_POSITIONS, LEVER_WORDS, LEVER_LOCKED, isLocked, paintLever, buildLever };

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.css
@@ -1,0 +1,288 @@
+/* ============================================================================
+   shell/prizecounter.css - THE PRIZE COUNTER, DRAWN.
+
+   No plate, no crop, no art prep. Every surface in this room is a gradient and
+   a border: the counter's laminate, the shelf timber, the glass over the case,
+   the little price flags stapled to the front rail. The campus draws its whole
+   school this way and it holds up, and it buys the one thing a painted room
+   could not: the shelf is whatever the HOST says it is tonight, and a catalog
+   that grows a row tomorrow needs nobody to repaint anything.
+
+   THE TWO SURFACES READ DIFFERENT ON PURPOSE. The ticket shelf is warm, open,
+   slightly scuffed - timber and a strip light. The token case is cold and
+   sealed - a pane, a rail, a specular sweep across the top of it, and prices in
+   the contract's own ◉N. A player should be able to tell which currency a thing
+   costs from six feet away without reading a word.
+
+   THE LIGHTS: `.is-lite` (performance mode) drops the strip light's breath, the
+   glass sweep and every shadow that costs a layer; `.is-reduced` drops motion
+   only and keeps the paint. Both are set on `.pc-root` by the module, and
+   `html.arc-reduced` is honoured through the module's own reduced() read, so
+   nothing here needs a media query it could get wrong.
+   ==========================================================================*/
+
+.pc-root {
+  position:fixed; inset:0; z-index:10;
+  display:flex; flex-direction:column;
+  gap:clamp(12px, 2.2vh, 22px);
+  padding:clamp(14px, 3vh, 30px) clamp(12px, 3vw, 30px) 0;
+  overflow:auto;
+  color:var(--ink);
+  font-family:var(--body);
+  background:
+    radial-gradient(ellipse at 50% -6%,
+      color-mix(in srgb, var(--panel), var(--gold) 7%), transparent 58%),
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--navy), black 8%),
+      var(--ground) 62%);
+}
+
+/* ---------------------------------------------------------------- the sign */
+
+.pc-marquee {
+  flex:none;
+  display:flex; flex-direction:column; align-items:center; gap:6px;
+  max-width:940px; width:100%; margin:0 auto;
+  padding:clamp(10px, 2vh, 18px) 16px clamp(12px, 2vh, 18px);
+  border:var(--hairline);
+  border-radius:var(--radius);
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--panel2), var(--gold) 6%),
+      color-mix(in srgb, var(--panel), black 10%));
+  box-shadow:inset 0 1px 0 color-mix(in srgb, var(--ink), transparent 84%),
+             0 10px 26px rgba(0,0,0,.42);
+}
+.pc-title {
+  margin:0;
+  font-family:var(--disp); font-size:clamp(21px, 3.4vw, 31px);
+  letter-spacing:.16em; text-transform:uppercase; line-height:1.05;
+  color:var(--gold);
+  text-shadow:0 0 14px color-mix(in srgb, var(--gold), transparent 62%),
+              0 2px 0 rgba(0,0,0,.5);
+}
+.pc-sub {
+  margin:0; font-size:13px; letter-spacing:.03em;
+  color:var(--ink-dim);
+}
+
+/* --------------------------------------------------------------- the purse */
+
+.pc-wallet {
+  display:flex; flex-wrap:wrap; align-items:center; justify-content:center;
+  gap:10px; margin-top:4px;
+}
+.pc-wallet-lbl {
+  font-family:var(--disp); font-size:11px; letter-spacing:.2em;
+  text-transform:uppercase; color:var(--ink-faint);
+}
+.pc-chip {
+  display:inline-flex; align-items:center; gap:7px;
+  padding:6px 12px 6px 9px;
+  border:1px solid color-mix(in srgb, var(--line), var(--ink) 12%);
+  border-radius:999px;
+  background:color-mix(in srgb, var(--navy), black 16%);
+}
+.pc-chip-n { font-family:var(--mono); font-size:16px; line-height:1; }
+.pc-chip-lbl {
+  font-size:11px; letter-spacing:.14em; text-transform:uppercase;
+  color:var(--ink-faint);
+}
+.pc-chip-t .pc-chip-n { color:var(--pink); }
+.pc-chip-k .pc-chip-n { color:var(--gold); }
+
+/* ------------------------------------------------------------- the payday */
+
+.pc-payday {
+  flex:none;
+  display:flex; flex-wrap:wrap; align-items:baseline; justify-content:center;
+  gap:8px; max-width:940px; width:100%; margin:0 auto;
+  padding:8px 14px;
+  border:1px dashed color-mix(in srgb, var(--gold), transparent 52%);
+  border-radius:var(--radius);
+  background:color-mix(in srgb, var(--gold), transparent 92%);
+  font-size:13px;
+}
+.pc-payday-lbl {
+  font-family:var(--disp); font-size:11px; letter-spacing:.2em;
+  text-transform:uppercase; color:var(--gold);
+}
+.pc-payday-name { color:var(--ink); }
+.pc-payday-mult { color:var(--ink-dim); }
+
+/* ---------------------------------------------------------------- the note */
+
+.pc-note {
+  flex:none; max-width:940px; width:100%; margin:0 auto;
+  min-height:1.2em;
+  text-align:center; font-size:13px; color:var(--ink-dim);
+  opacity:0; transition:opacity .18s ease;
+}
+.pc-note.is-on { opacity:1; }
+.pc-root.is-reduced .pc-note { transition:none; }
+
+/* --------------------------------------------------------- the two shelves */
+
+/* `flex:none` like every other child of `.pc-root`, and for a reason a shelf
+   makes vivid: the root is a column flexbox, so a section left at the default
+   `flex-shrink:1` is SHRUNK to fit the viewport instead of overflowing it - and
+   because `.pc-sect-k` carries `overflow:hidden` (the glass sweep), the rows the
+   shrink squeezed out are CLIPPED AWAY rather than scrolled to. On a 1177px-tall
+   window that ate the whole fourth token row, which is the locked Jukebox. With
+   the shrink off, the sections keep their height, `.pc-root`'s `overflow:auto`
+   does its job, and the sticky exit bar rides the scroller as intended. */
+.pc-sect {
+  flex:none;
+  max-width:940px; width:100%; margin:0 auto;
+  padding:clamp(12px, 2vh, 18px) clamp(12px, 2vw, 20px);
+  border-radius:var(--radius);
+  border:var(--hairline);
+}
+.pc-sect-head { margin-bottom:12px; }
+.pc-sect-title {
+  margin:0;
+  font-family:var(--disp); font-size:15px; letter-spacing:.2em;
+  text-transform:uppercase;
+}
+.pc-sect-hint { margin:3px 0 0; font-size:12.5px; color:var(--ink-faint); }
+
+/* THE TICKET SHELF: timber, a strip light along the top rail, scuffs. */
+.pc-sect-t {
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--gold), transparent 90%) 0 3px,
+      transparent 3px),
+    repeating-linear-gradient(90deg,
+      color-mix(in srgb, var(--panel), black 6%) 0 38px,
+      color-mix(in srgb, var(--panel), black 11%) 38px 40px),
+    var(--panel);
+  border-color:color-mix(in srgb, var(--line), var(--gold) 16%);
+  box-shadow:inset 0 6px 18px -12px color-mix(in srgb, var(--gold), transparent 30%);
+}
+.pc-sect-t .pc-sect-title { color:var(--pink); }
+
+/* THE TOKEN CASE: a cold pane over a dark well, with a specular sweep that
+   sits on the glass rather than on the goods. */
+.pc-sect-k {
+  position:relative; overflow:hidden;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--lav), transparent 88%),
+      transparent 34%),
+    linear-gradient(180deg, color-mix(in srgb, var(--navy), black 22%), var(--navy));
+  border-color:color-mix(in srgb, var(--line), var(--lav) 26%);
+  box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--ink), transparent 92%),
+             inset 0 -14px 30px -20px rgba(0,0,0,.9);
+}
+.pc-sect-k .pc-sect-title { color:var(--gold); }
+.pc-sect-k::after {
+  content:''; position:absolute; inset:0; pointer-events:none;
+  background:linear-gradient(104deg,
+    transparent 34%,
+    color-mix(in srgb, var(--ink), transparent 90%) 46%,
+    transparent 58%);
+}
+.pc-root.is-lite .pc-sect-k::after { display:none; }
+
+/* ------------------------------------------------------------- the goods */
+
+.pc-goods {
+  display:grid; gap:10px;
+  grid-template-columns:repeat(auto-fill, minmax(268px, 1fr));
+}
+
+.pc-item {
+  display:flex; align-items:flex-start; gap:11px;
+  padding:11px;
+  border:1px solid color-mix(in srgb, var(--line), var(--ink) 6%);
+  border-radius:10px;
+  background:color-mix(in srgb, var(--panel2), black 14%);
+  box-shadow:0 5px 14px rgba(0,0,0,.32);
+}
+.pc-item.is-owned {
+  border-color:color-mix(in srgb, var(--gold), transparent 52%);
+  background:color-mix(in srgb, var(--panel2), var(--gold) 6%);
+}
+.pc-item.is-locked { opacity:.62; }
+.pc-item.is-poor .pc-price { opacity:.55; }
+.pc-item.is-busy { border-color:color-mix(in srgb, var(--pink), transparent 40%); }
+
+/* The drawn parcel. A box, a lid seam, one glyph. */
+.pc-art {
+  flex:none; width:46px; height:46px;
+  display:flex; align-items:center; justify-content:center;
+  border-radius:7px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--panel2), var(--ink) 10%) 0 9px,
+      color-mix(in srgb, var(--panel2), black 8%) 9px);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.4);
+}
+.pc-glyph { font-size:20px; line-height:1; color:var(--lav); }
+.pc-item-k .pc-glyph { color:var(--gold); }
+
+.pc-body { flex:1 1 auto; min-width:0; }
+.pc-name {
+  margin:0;
+  font-family:var(--disp); font-size:13.5px; letter-spacing:.09em;
+  text-transform:uppercase; line-height:1.25;
+}
+.pc-blurb {
+  margin:4px 0 0; font-size:12.5px; line-height:1.4;
+  color:var(--ink-dim);
+}
+
+.pc-foot {
+  display:flex; flex-wrap:wrap; align-items:center; gap:8px;
+  margin-top:9px;
+}
+.pc-price {
+  display:inline-flex; align-items:center; gap:6px;
+  padding:3px 9px;
+  border-radius:4px;
+  background:color-mix(in srgb, var(--navy), black 22%);
+  box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--line), transparent 30%);
+}
+.pc-price-n { font-family:var(--mono); font-size:14px; line-height:1; }
+.pc-price-t .pc-price-n { color:var(--pink); }
+.pc-price-k .pc-price-n { color:var(--gold); }
+
+.pc-badge {
+  font-family:var(--disp); font-size:10.5px; letter-spacing:.16em;
+  text-transform:uppercase;
+  padding:3px 8px; border-radius:999px;
+}
+.pc-badge-owned {
+  color:var(--gold);
+  background:color-mix(in srgb, var(--gold), transparent 88%);
+}
+.pc-badge-held {
+  color:var(--lav);
+  background:color-mix(in srgb, var(--lav), transparent 88%);
+}
+.pc-badge-soon {
+  color:var(--ink-faint);
+  background:color-mix(in srgb, var(--ink-faint), transparent 90%);
+}
+
+.pc-buy { margin-left:auto; }
+.pc-item.is-busy .pc-buy { animation:pc-wait 1.1s ease-in-out infinite; }
+@keyframes pc-wait { 0%,100% { opacity:1; } 50% { opacity:.55; } }
+.pc-root.is-reduced .pc-item.is-busy .pc-buy,
+.pc-root.is-lite .pc-item.is-busy .pc-buy { animation:none; opacity:.7; }
+
+.pc-bare {
+  max-width:940px; width:100%; margin:0 auto; text-align:center;
+}
+
+/* The sticky way out sits inside the scroller, which is `.pc-root` itself. */
+.pc-root > .arc-exitbar { margin-top:auto; }
+
+/* Phones: the two surfaces stack, the parcel shrinks, the price flag keeps its
+   size because the price is the one thing that must stay legible. */
+@media (max-width:520px) {
+  .pc-goods { grid-template-columns:1fr; }
+  .pc-art { width:38px; height:38px; }
+  .pc-glyph { font-size:17px; }
+  .pc-title { letter-spacing:.1em; }
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
@@ -1,0 +1,629 @@
+/* ============================================================================
+ * shell/prizecounter.js - THE PRIZE COUNTER.
+ *
+ * The one room in the school where the money goes back out. Two surfaces and
+ * nothing else: the SHELF, which takes tickets and is stacked with the sort of
+ * thing a ticket buys, and the CASE, which is glass, which is locked, and which
+ * only opens for a token. Every graded class pays tickets; the first S-rank of
+ * your day drops exactly one token in the tray. So the shelf is where a good
+ * week goes and the case is where a good NIGHT goes, and the room says that by
+ * standing them side by side rather than by explaining it.
+ *
+ * THERE IS NO ART HERE AND THERE WAS NEVER GOING TO BE. The counter, the
+ * shelf timber, the glass, the little price flags: all of it is drawn in
+ * prizecounter.css out of borders and gradients, the way the campus draws its
+ * buildings. That is a feature and not a shortfall - the room has to survive a
+ * catalog the host can change without anybody repainting a plate.
+ *
+ * THE ECHO LAW IS THE WHOLE FILE (trap 1). Pressing Trade does not buy
+ * anything. It sends `prize-buy` up the seam, it puts the row to sleep with a
+ * "asking the counter" label, and then it waits. Nothing on this page moves -
+ * not a balance, not a badge, not a button - until `settle()` is called with
+ * the host's own `wallet-result` frame. If that frame never comes, the row
+ * wakes back up unchanged and the wallet reads exactly what it read before.
+ * The page proposes; the counter disposes. A page that spent its own money
+ * would be a page that can be lied to, and a currency you can lie to is not a
+ * currency.
+ *
+ * NARROW CAPS, THE ANNEX'S LAW. Nothing under this line imports the store, the
+ * bridge or EMI. Every fact about the player - what they hold, what they can
+ * afford, what is already theirs - arrives as a function in `caps`, and every
+ * consequence leaves as a callback. That is what makes the room testable in
+ * bare node against the DOM double, which is also why it walks its own children
+ * BY INDEX (`findCls`) and never touches `querySelector`.
+ * ==========================================================================*/
+
+import { t as lexT } from '../core/lexicon.js';
+import { exitBar, sign as signExit } from './exits.js';
+
+/* ----------------------------------------------------------------------------
+ * THE TABLE
+ * -------------------------------------------------------------------------- */
+
+/** The two shop surfaces, in the order the room reads left to right. */
+export const SURFACES = Object.freeze(['t', 'k']);
+
+/** How long a pressed row waits for the counter before it wakes back up. The
+ *  host answers a prize-buy in the same tick it receives it, so six seconds is
+ *  not a timeout, it is a promise that the room can never wedge. */
+export const ECHO_WAIT_MS = 6000;
+
+/** Every refusal the host can send back, mapped to the line the counter says.
+ *  An unknown reason falls through to the same shrug an unknown sku gets, so a
+ *  host that grows a new reason tomorrow degrades to a sentence instead of to
+ *  an empty toast. */
+export const REFUSALS = Object.freeze({
+  poor: ['prize_poor', 'Not quite enough on you for that one yet.'],
+  owned: ['prize_owned_msg', 'You have that one already.'],
+  full: ['prize_full', 'Your pockets are full of those. Use one first.'],
+  locked: ['prize_locked_msg', 'That one stays in the case for now.'],
+  unknown: ['prize_unknown', 'The counter does not know that one. Odd.'],
+});
+
+/** The glyph each sku wears on its little drawn box. Text, not art: a sku the
+ *  catalog grows before this table does gets the plain parcel and still reads
+ *  as a thing on a shelf. */
+export const GLYPHS = Object.freeze({
+  id_frame_gold: '▧',
+  id_frame_navy: '▨',
+  confetti_stamp: '✶',
+  late_slip: '✉',
+  honors_lever: '⌇',
+  free_swim_key: '⚿',
+  de_5x5: '▦',
+  jukebox: '♪',
+});
+
+/** The token price glyph, straight out of the contract: ◉1 / ◉2 / ◉3. */
+export const TOKEN_MARK = '◉';
+
+/* ----------------------------------------------------------------------------
+ * PLUMBING
+ * -------------------------------------------------------------------------- */
+
+/* ONE AUDIO DOOR (trap 18): shell/audio.js owns the only audio node on the
+ * page, so every sound this room makes is a REQUEST on `document`. Only cue
+ * names that already exist in the SOUNDS table are ever fired (trap 115) - an
+ * invented name degrades to a blip, which is a worse sound than the one you
+ * meant and a much worse bug than no sound at all. */
+function sfx(name, level, extra) {
+  try {
+    if (typeof document === 'undefined' || typeof document.dispatchEvent !== 'function') return;
+    const Ctor = (typeof CustomEvent === 'function') ? CustomEvent : null;
+    if (!Ctor) return;
+    document.dispatchEvent(new Ctor('arcademy-sfx', {
+      detail: Object.assign(
+        { name: String(name || 'blip'), level: Number(level) || 0.5, bus: 'fx' },
+        extra || {}
+      ),
+    }));
+  } catch (e) { /* a cue must never be the thing that throws */ }
+}
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+}
+
+function attr(node, name, value) {
+  try { if (node && typeof node.setAttribute === 'function') node.setAttribute(name, value); }
+  catch (e) { /* the DOM double may not carry attributes - never fatal */ }
+}
+
+function addCls(node, cls) {
+  try { if (node && node.classList && typeof node.classList.add === 'function') node.classList.add(cls); }
+  catch (e) { /* noop */ }
+}
+
+function dropCls(node, cls) {
+  try { if (node && node.classList && typeof node.classList.remove === 'function') node.classList.remove(cls); }
+  catch (e) { /* noop */ }
+}
+
+function urlFor(rel, fallback) {
+  try { return new URL(rel, import.meta.url).href; }
+  catch (e) { return fallback; }
+}
+
+/** prizecounter.css, linked once and lazily - recordsroom.js's pattern. */
+function ensureSheet(doc, log) {
+  try {
+    if (!doc || typeof doc.createElement !== 'function') return null;
+    const had = typeof doc.getElementById === 'function' ? doc.getElementById('pc-styles') : null;
+    if (had) return had;
+    const link = doc.createElement('link');
+    link.id = 'pc-styles';
+    link.rel = 'stylesheet';
+    link.href = urlFor('./prizecounter.css', 'shell/prizecounter.css');
+    const head = doc.head || doc.body || null;
+    if (head && typeof head.appendChild === 'function') head.appendChild(link);
+    return link;
+  } catch (e) {
+    if (typeof log === 'function') log('prize counter stylesheet failed to link');
+    return null;
+  }
+}
+
+function htmlReduced() {
+  try {
+    const de = (typeof document !== 'undefined') ? document.documentElement : null;
+    if (de && de.classList && typeof de.classList.contains === 'function'
+      && de.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* noop */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* noop */ }
+  return false;
+}
+
+/** Walk a subtree for the first node wearing `cls`, BY INDEX and never with a
+ *  selector - `querySelector` does not exist in the node double, and a counter
+ *  that can only find its own shelf in a browser is a counter with no suite. */
+export function findCls(node, cls) {
+  if (!node) return null;
+  try {
+    if (node.classList && typeof node.classList.contains === 'function'
+      && node.classList.contains(cls)) return node;
+  } catch (e) { /* noop */ }
+  const kids = node.children;
+  if (!kids) return null;
+  for (let i = 0; i < kids.length; i += 1) {
+    const hit = findCls(kids[i], cls);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** Every node under `node` wearing `cls`, in document order, by index. */
+export function findAllCls(node, cls, out) {
+  const acc = out || [];
+  if (!node) return acc;
+  try {
+    if (node.classList && typeof node.classList.contains === 'function'
+      && node.classList.contains(cls)) acc.push(node);
+  } catch (e) { /* noop */ }
+  const kids = node.children;
+  if (!kids) return acc;
+  for (let i = 0; i < kids.length; i += 1) findAllCls(kids[i], cls, acc);
+  return acc;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE INVENTORY READER
+ *
+ * The host is allowed to write an inventory row three different ways over the
+ * life of this feature - a bare count, a `{n, at}` bag, a bare `true` for an
+ * unlock - and the room must read all three without ever asking which one it
+ * got. A cosmetic you own once is `1`; a consumable you hold two of is `2`.
+ * -------------------------------------------------------------------------- */
+
+/** How many of `sku` the player is holding, 0 when none. */
+export function heldCount(inv, sku) {
+  if (!inv || typeof inv !== 'object') return 0;
+  const row = inv[sku];
+  if (row == null || row === false) return 0;
+  if (row === true) return 1;
+  if (typeof row === 'number') return Number.isFinite(row) && row > 0 ? Math.floor(row) : 0;
+  if (typeof row === 'object') {
+    const n = Number(row.n);
+    if (Number.isFinite(n)) return n > 0 ? Math.floor(n) : 0;
+    return 1;                      // a bag with no count is still a thing owned
+  }
+  return 0;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE ROOM
+ * -------------------------------------------------------------------------- */
+
+/**
+ * createPrizeCounter(caps) -> the handle, or null with no DOM.
+ *
+ * @param {Object} caps
+ *  mount     - where the counter's root goes (the shell's screen).
+ *  t / log / lite / reduced
+ *  catalog   - () -> [{sku, cur, cost, kind, nameKey, nameEn, blurbKey, blurbEn, locked}]
+ *              exactly as the host projected it through init.economy. The page
+ *              never invents a row and never prices one.
+ *  balance   - () -> {t, k}
+ *  inv       - () -> the wallet's `inv` bag (see heldCount above).
+ *  unlocks   - () -> {extra, honors} (only read for the badge on honors_lever).
+ *  stackMax  - optional (sku) -> how many of a consumable may be held. Purely a
+ *              display cap for the "2 of 3" badge; the host is the one that
+ *              refuses a third with reason "full".
+ *  payday    - optional () -> {gameKey, mult} for tonight's hot room, or null.
+ *  gameName  - optional (key) -> display name for that line.
+ *  onBuy     - (sku) -> the shell's send of `prize-buy`. Fire and forget: the
+ *              answer arrives at settle(), or it never arrives and nothing here
+ *              has changed.
+ *  onBack    - the way out.
+ * @returns {?Object} the handle
+ */
+export function createPrizeCounter(caps) {
+  const c = caps || {};
+  const doc = (typeof document !== 'undefined') ? document : null;
+  if (!doc || typeof doc.createElement !== 'function') return null;
+
+  const t = typeof c.t === 'function' ? c.t : lexT;
+  const log = typeof c.log === 'function' ? c.log : function () {};
+  const reduced = () => !!c.reduced || htmlReduced();
+
+  ensureSheet(doc, log);
+
+  let dead = false;
+  /** The sku whose row is asleep waiting for an echo, or null. ONE at a time:
+   *  a counter clerk serves one customer, and two in-flight buys is two ways to
+   *  read the same balance. */
+  let pending = null;
+  let pendingTimer = null;
+  /** The last line the counter said, kept as a test seam. */
+  let note = '';
+
+  /* The mirrors. Seeded from caps, and thereafter moved ONLY by settle(). */
+  let wallet = readBalance();
+  let inv = readInv();
+  let unlocks = readUnlocks();
+
+  const rows = new Map();          // sku -> the item element currently painted
+
+  function readBalance() {
+    try {
+      const b = (typeof c.balance === 'function') ? c.balance() : null;
+      const tt = Number(b && b.t); const kk = Number(b && b.k);
+      return { t: Number.isFinite(tt) ? tt : 0, k: Number.isFinite(kk) ? kk : 0 };
+    } catch (e) { return { t: 0, k: 0 }; }
+  }
+
+  function readInv() {
+    try {
+      const v = (typeof c.inv === 'function') ? c.inv() : null;
+      return (v && typeof v === 'object') ? v : {};
+    } catch (e) { return {}; }
+  }
+
+  function readUnlocks() {
+    try {
+      const v = (typeof c.unlocks === 'function') ? c.unlocks() : null;
+      return (v && typeof v === 'object') ? v : {};
+    } catch (e) { return {}; }
+  }
+
+  function readCatalog() {
+    try {
+      const v = (typeof c.catalog === 'function') ? c.catalog() : null;
+      return Array.isArray(v) ? v.filter((r) => r && r.sku) : [];
+    } catch (e) { log('prize catalog read threw'); return []; }
+  }
+
+  function stackMaxFor(sku) {
+    try {
+      const n = Number((typeof c.stackMax === 'function') ? c.stackMax(sku) : NaN);
+      return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+    } catch (e) { return 0; }
+  }
+
+  /* --------------------------------------------------------------- the root */
+
+  const root = el('div', 'pc-root');
+  if (c.lite) addCls(root, 'is-lite');
+  if (reduced()) addCls(root, 'is-reduced');
+
+  /* ------------------------------------------------------------ the chrome */
+
+  /**
+   * A currency chip. Tickets get a drawn stub, tokens get the mark, and both
+   * carry the number FIRST because the number is the thing a player came to
+   * read. `cur` is 't' or 'k'.
+   */
+  function chip(cur) {
+    const box = el('span', 'pc-chip pc-chip-' + cur);
+    const ico = el('i', cur === 'k' ? 'arc-tok' : 'arc-tick', cur === 'k' ? TOKEN_MARK : null);
+    attr(ico, 'aria-hidden', 'true');
+    box.appendChild(ico);
+    box.appendChild(el('b', 'pc-chip-n', String(cur === 'k' ? wallet.k : wallet.t)));
+    box.appendChild(el('span', 'pc-chip-lbl', cur === 'k'
+      ? t('wallet_tokens', 'Tokens')
+      : t('wallet_tickets', 'Tickets')));
+    return box;
+  }
+
+  /** The price flag on a row. Tickets read as a plain count beside a stub;
+   *  tokens read as the contract's ◉N, which is short enough to sit on glass. */
+  function priceTag(item) {
+    const flag = el('span', 'pc-price pc-price-' + (item.cur === 'k' ? 'k' : 't'));
+    const cost = Math.max(0, Math.round(Number(item.cost) || 0));
+    if (item.cur === 'k') {
+      flag.appendChild(el('b', 'pc-price-n', TOKEN_MARK + String(cost)));
+    } else {
+      const stub = el('i', 'arc-tick');
+      attr(stub, 'aria-hidden', 'true');
+      flag.appendChild(stub);
+      flag.appendChild(el('b', 'pc-price-n', String(cost)));
+    }
+    return flag;
+  }
+
+  /* -------------------------------------------------------- the note strip */
+
+  const noteStrip = el('p', 'pc-note');
+  attr(noteStrip, 'aria-live', 'polite');
+
+  function say(line) {
+    note = String(line == null ? '' : line);
+    try { noteStrip.textContent = note; } catch (e) { /* noop */ }
+    if (note) addCls(noteStrip, 'is-on'); else dropCls(noteStrip, 'is-on');
+  }
+
+  /* ------------------------------------------------------------- one shelf */
+
+  /**
+   * Is this row already the player's? An unlock or a cosmetic is owned once and
+   * then it is furniture; a consumable is never "owned", it is HELD, and it can
+   * be held again tomorrow.
+   */
+  function isOwned(item) {
+    if (item.kind === 'consumable') return false;
+    if (heldCount(inv, item.sku) > 0) return true;
+    // The two lever unlocks live in `unlocks` as well as in `inv`, because the
+    // lever reads them there. Either witness is proof.
+    if (item.sku === 'honors_lever' && unlocks.honors === true) return true;
+    if (item.sku === 'free_swim_key' && unlocks.freeSwim === true) return true;
+    return false;
+  }
+
+  function itemNode(item) {
+    const owned = isOwned(item);
+    const held = item.kind === 'consumable' ? heldCount(inv, item.sku) : 0;
+    const cap = item.kind === 'consumable' ? stackMaxFor(item.sku) : 0;
+    const locked = item.locked === true;
+    const cost = Math.max(0, Math.round(Number(item.cost) || 0));
+    const purse = item.cur === 'k' ? wallet.k : wallet.t;
+    const poor = !locked && !owned && purse < cost;
+    const full = !!(cap && held >= cap);
+
+    let cls = 'pc-item pc-item-' + (item.cur === 'k' ? 'k' : 't');
+    if (owned) cls += ' is-owned';
+    if (locked) cls += ' is-locked';
+    if (poor) cls += ' is-poor';
+    if (full) cls += ' is-full';
+    if (pending === item.sku) cls += ' is-busy';
+    const box = el('article', cls);
+    attr(box, 'data-sku', item.sku);
+
+    /* The drawn box on the shelf. Decoration, no pointer events, one glyph. */
+    const art = el('div', 'pc-art');
+    attr(art, 'aria-hidden', 'true');
+    art.appendChild(el('span', 'pc-glyph', GLYPHS[item.sku] || '▤'));
+    box.appendChild(art);
+
+    const body = el('div', 'pc-body');
+    body.appendChild(el('h4', 'pc-name', t(item.nameKey || ('prize_name_' + item.sku),
+      item.nameEn || item.sku)));
+    const blurb = item.blurbEn || item.blurbKey
+      ? t(item.blurbKey || ('prize_blurb_' + item.sku), item.blurbEn || '')
+      : '';
+    if (blurb) body.appendChild(el('p', 'pc-blurb', blurb));
+
+    const foot = el('div', 'pc-foot');
+    foot.appendChild(priceTag(item));
+
+    if (owned) {
+      foot.appendChild(el('span', 'pc-badge pc-badge-owned', t('prize_owned', 'Yours')));
+    } else if (locked) {
+      foot.appendChild(el('span', 'pc-badge pc-badge-soon', t('prize_soon', 'Arriving soon')));
+    } else {
+      if (held > 0) {
+        foot.appendChild(el('span', 'pc-badge pc-badge-held',
+          t('prize_held', 'Holding') + ' ' + String(held) + (cap ? '/' + String(cap) : '')));
+      }
+      const btn = el('button', 'btn primary pc-buy',
+        pending === item.sku ? t('prize_wait', 'Asking the counter') : t('prize_buy', 'Trade'));
+      btn.type = 'button';
+      if (pending) attr(btn, 'disabled', 'disabled');
+      btn.addEventListener('click', () => propose(item));
+      foot.appendChild(btn);
+    }
+
+    body.appendChild(foot);
+    box.appendChild(body);
+    rows.set(item.sku, box);
+    return box;
+  }
+
+  function surface(cur, items) {
+    const sect = el('section', 'pc-sect pc-sect-' + cur);
+    const head = el('div', 'pc-sect-head');
+    head.appendChild(el('h3', 'pc-sect-title', cur === 'k'
+      ? t('prize_case', 'Token Case')
+      : t('prize_shelf', 'Ticket Shelf')));
+    head.appendChild(el('p', 'pc-sect-hint', cur === 'k'
+      ? t('prize_case_hint', 'Tokens only. Your first S of the day drops one in the tray.')
+      : t('prize_shelf_hint', 'Every graded class pays tickets. This is where they go.')));
+    sect.appendChild(head);
+
+    const goods = el('div', 'pc-goods');
+    for (const item of items) goods.appendChild(itemNode(item));
+    sect.appendChild(goods);
+    return sect;
+  }
+
+  /* ---------------------------------------------------------- the buy flow */
+
+  /**
+   * THE PROPOSAL. Everything this does is cosmetic and reversible: it names the
+   * sku it is waiting on, repaints so the row reads asleep, and hands the sku
+   * to the shell. It does not touch `wallet`, it does not touch `inv`, and if
+   * the answer never comes the watchdog puts the room back exactly as it was.
+   */
+  function propose(item) {
+    if (dead || pending) return;
+    if (item.locked === true) { say(t('prize_locked_msg', 'That one stays in the case for now.')); sfx('bump', 0.32); return; }
+    pending = item.sku;
+    say(t('prize_wait', 'Asking the counter'));
+    sfx('commit', 0.4);
+    render();
+    pendingTimer = setTimeout(() => {
+      if (dead || pending !== item.sku) return;
+      pending = null; pendingTimer = null;
+      // No echo, so no purchase: the room wakes up owing exactly what it owed.
+      say(t('prize_quiet', 'The counter went quiet on that one. Try again in a moment.'));
+      render();
+    }, ECHO_WAIT_MS);
+    try { if (typeof c.onBuy === 'function') c.onBuy(item.sku); }
+    catch (e) { log('prize buy send threw: ' + ((e && e.message) || e)); }
+  }
+
+  /**
+   * THE ECHO. The host's `wallet-result` frame, and the ONLY thing in this file
+   * allowed to move a balance or a badge.
+   * @param {Object} res {ok, sku, reason, wallet:{t,k}, inv, unlocks}
+   * @returns {boolean} true when the frame was for a row this room was waiting
+   *          on (the shell does not need it, the suite does)
+   */
+  function settle(res) {
+    if (dead) return false;
+    const r = res || {};
+    const was = pending;
+    if (pendingTimer) { try { clearTimeout(pendingTimer); } catch (e) { /* noop */ } pendingTimer = null; }
+    pending = null;
+
+    /* The host's numbers win outright. A missing bag means "unchanged", never
+     * "empty" - a refusal frame is allowed to carry only the reason. */
+    if (r.wallet && typeof r.wallet === 'object') {
+      const tt = Number(r.wallet.t); const kk = Number(r.wallet.k);
+      wallet = {
+        t: Number.isFinite(tt) ? tt : wallet.t,
+        k: Number.isFinite(kk) ? kk : wallet.k,
+      };
+    }
+    if (r.inv && typeof r.inv === 'object') inv = r.inv;
+    if (r.unlocks && typeof r.unlocks === 'object') unlocks = r.unlocks;
+
+    if (r.ok === true) {
+      say(t('prize_bought', 'Wrapped up and yours.'));
+      sfx('chime', 0.55);
+    } else {
+      const row = REFUSALS[String(r.reason || '')] || REFUSALS.unknown;
+      say(t(row[0], row[1]));
+      sfx('bump', 0.34);
+    }
+    render();
+    return !!was && (!r.sku || r.sku === was);
+  }
+
+  /* ------------------------------------------------------------ the render */
+
+  function render() {
+    if (dead) return root;
+    rows.clear();
+    try { root.textContent = ''; } catch (e) { /* noop */ }
+
+    /* THE MARQUEE. The room's own sign, and the wallet reading under it - a
+     * shop tells you what you can spend before it tells you what it sells. */
+    const marquee = el('div', 'pc-marquee');
+    marquee.appendChild(el('h2', 'pc-title', t('prize_counter_title', 'Prize Counter')));
+    marquee.appendChild(el('p', 'pc-sub', t('prize_counter_sub',
+      'Tickets on the shelf, tokens in the case')));
+    const purse = el('div', 'pc-wallet');
+    const label = el('span', 'pc-wallet-lbl', t('prize_you_have', 'On you'));
+    purse.appendChild(label);
+    purse.appendChild(chip('t'));
+    purse.appendChild(chip('k'));
+    marquee.appendChild(purse);
+    root.appendChild(marquee);
+
+    /* TONIGHT'S HOT ROOM. Projected by the host, seeded per UTC day, and shown
+     * because a payday nobody knows about is a payday nobody plays. */
+    const pd = paydayLine();
+    if (pd) root.appendChild(pd);
+
+    root.appendChild(noteStrip);
+
+    const catalog = readCatalog();
+    if (!catalog.length) {
+      root.appendChild(el('p', 'arc-note pc-bare', t('prize_empty',
+        'Shelf is bare tonight. Come back when the truck has been.')));
+    } else {
+      for (const cur of SURFACES) {
+        const items = catalog.filter((r) => (r.cur === 'k' ? 'k' : 't') === cur);
+        if (items.length) root.appendChild(surface(cur, items));
+      }
+    }
+
+    /* THE WAY OUT, and it is sticky (trap 46): the catalog is a scroller and an
+     * exit that scrolls away is not an exit. */
+    const back = el('button', 'btn primary', t('back', 'Back'));
+    back.type = 'button';
+    back.addEventListener('click', () => {
+      try { if (typeof c.onBack === 'function') c.onBack(); }
+      catch (e) { log('prize back threw: ' + ((e && e.message) || e)); }
+    });
+    signExit(back, { dir: 'back' });
+    root.appendChild(exitBar([back]));
+    return root;
+  }
+
+  function paydayLine() {
+    let pd = null;
+    try { pd = (typeof c.payday === 'function') ? c.payday() : null; } catch (e) { pd = null; }
+    if (!pd || !pd.gameKey) return null;
+    const mult = Number(pd.mult) || 0;
+    if (mult <= 1) return null;
+    let name = String(pd.gameKey);
+    try { if (typeof c.gameName === 'function') name = c.gameName(pd.gameKey) || name; }
+    catch (e) { /* the key is a fine last resort */ }
+    const line = el('div', 'pc-payday');
+    line.appendChild(el('span', 'pc-payday-lbl', t('prize_payday_label', 'Hot room tonight')));
+    line.appendChild(el('b', 'pc-payday-name', name));
+    line.appendChild(el('span', 'pc-payday-mult', mult >= 5
+      ? t('prize_payday_5', 'is paying five times over')
+      : t('prize_payday_2', 'is paying double')));
+    return line;
+  }
+
+  /* ------------------------------------------------------------- the mount */
+
+  render();
+  try {
+    if (c.mount && typeof c.mount.appendChild === 'function') c.mount.appendChild(root);
+  } catch (e) { log('prize counter failed to mount'); }
+
+  function destroy() {
+    if (dead) return;
+    dead = true;
+    if (pendingTimer) { try { clearTimeout(pendingTimer); } catch (e) { /* noop */ } pendingTimer = null; }
+    pending = null;
+    rows.clear();
+    try { root.remove(); } catch (e) { /* noop */ }
+  }
+
+  return {
+    root,
+    render,
+    settle,
+    /** Re-read every cap and repaint. The shell calls this when the wallet moved
+     *  for a reason that was not a purchase (a payout, say). */
+    refresh() {
+      wallet = readBalance();
+      inv = readInv();
+      unlocks = readUnlocks();
+      render();
+    },
+    /** The sku this room is waiting on, or null (test seam). */
+    get pending() { return pending; },
+    /** The last line the counter said (test seam). */
+    get note() { return note; },
+    /** What the room believes it can spend (test seam). Never authored here. */
+    get balance() { return { t: wallet.t, k: wallet.k }; },
+    /** One painted row by sku, or null (test seam). */
+    rowFor(sku) { return rows.get(sku) || null; },
+    destroy,
+  };
+}
+
+export default createPrizeCounter;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
@@ -18,6 +18,7 @@
  * ==========================================================================*/
 
 import { t, gradeLabel, tierLabel } from '../core/lexicon.js';
+import { gradeKey } from '../core/grades.js';
 import { exitBar, sign as signExit, campusPillRow } from './exits.js';
 
 /** Mod-anonymous, name-only, no URL. Do not "improve" this. */
@@ -155,6 +156,24 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
   // class names on the rows/grades/share block - only the frame changed.
   const root = el('div', 'arc-reportstage');
 
+  /* EVERY HOLD HAS AN OWNER. The till's count-up is the card's first timer, and
+   * a timer that outlives its paper writes into a node the shell has already
+   * dropped - so they are all swept here, on a repaint AND on destroy. */
+  const timers = new Set();
+  function later(fn, ms) {
+    if (typeof setTimeout !== 'function') { try { fn(); } catch (e) { /* noop */ } return 0; }
+    const id = setTimeout(() => {
+      timers.delete(id);
+      try { fn(); } catch (e) { /* a beat must never be the thing that throws */ }
+    }, Math.max(0, Number(ms) || 0));
+    timers.add(id);
+    return id;
+  }
+  function sweep() {
+    for (const id of Array.from(timers)) { try { clearTimeout(id); } catch (e) { /* noop */ } }
+    timers.clear();
+  }
+
   /**
    * @param {Object} state
    * @param {Object} state.timetable   buildTimetable() result
@@ -173,6 +192,7 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
     const s = state || {};
     const results = s.results || {};
     const classes = (s.timetable && s.timetable.classes) || [];
+    sweep();
     root.textContent = '';
     if (s.arrived) sfx('paper', 0.3);
 
@@ -198,7 +218,11 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
       const r = results[c.gameKey];
       const cell = el('span', 'rcell' + (r ? '' : ' pending'));
       const g = r ? String(r.grade || '') : '';
-      const gk = g.toLowerCase();
+      /* 'S+' LOWERCASES TO A CLASS NOBODY CAN STYLE. `.grade.s+` is not a
+       * selector CSS will honour without escaping, so the honours letter wears
+       * `splus` here and in every other badge on the page - the LABEL is still
+       * the lexicon's own 'S+' one line down. */
+      const gk = gradeKey(g);
       const badge = el('span', 'grade ' + (gk === 'pass' ? 'pass' : gk || 'none'),
         r ? gradeLabel(r.grade) : '--');
       cell.appendChild(badge);
@@ -238,6 +262,88 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
           }
         }
         sfx('pip', 0.3, { bus: 'drops', steps });
+      }
+    }
+
+    /* --- THE TILL (economy wave, 2026-08-26) -------------------------------
+     * The night's tickets, counted out onto the paper, and - on the rare night
+     * that earned one - the token dropping into the tray. Both numbers are the
+     * HOST'S: they arrive on `payout-result` and the shell parks them on the
+     * result row, so nothing here adds anything up that C# has not already
+     * added up. The card only knows how to count TO a number.
+     *
+     * TICKETS ARE THE SMALL BEAT AND THE TOKEN IS THE BIG ONE, on purpose. A
+     * ticket payout happens every single graded class; if it rang like a
+     * jackpot the jackpot would stop meaning anything by Wednesday. So tickets
+     * get the adding machine (the same `pip` ladder the strip above uses, one
+     * bus, one dispatch) and the token gets the actual ceremony.
+     * --------------------------------------------------------------------- */
+    const till = { tickets: 0, token: false };
+    for (const c of classes) {
+      const p = results[c.gameKey] && results[c.gameKey].payout;
+      if (!p) continue;
+      till.tickets += Math.max(0, Math.round(Number(p.tickets) || 0));
+      if (p.token === true) till.token = true;
+    }
+    if (till.tickets > 0 || till.token) {
+      const row = el('div', 'arc-classbar arc-till');
+      const tChip = el('span', 'chip arc-till-t');
+      const tIco = el('i', 'arc-tick');
+      try { tIco.setAttribute('aria-hidden', 'true'); } catch (e) { /* noop */ }
+      tChip.appendChild(tIco);
+      const tNum = el('b', 'arc-till-n', String(s.arrived ? 0 : till.tickets));
+      tChip.appendChild(tNum);
+      tChip.appendChild(el('span', null, ' ' + t('payout_tickets', 'Tickets')));
+      row.appendChild(tChip);
+      put(row);
+
+      if (s.arrived && till.tickets > 0) {
+        /* THE COUNT-UP. Twelve steps and out, eased so the last few land slow -
+         * a counter that ticks evenly reads as a progress bar, and a counter
+         * that slows down reads as money being counted. A repaint (`arrived`
+         * false) skips straight to the total: the number is not news twice. */
+        const STEPS = 12;
+        const dur = 720;
+        for (let i = 1; i <= STEPS; i += 1) {
+          const frac = i / STEPS;
+          const eased = 1 - Math.pow(1 - frac, 2.2);
+          const at = Math.round(dur * frac);
+          const shown = Math.round(till.tickets * eased);
+          later(() => { try { tNum.textContent = String(shown); } catch (e) { /* noop */ } }, at);
+        }
+        sfx('pip', 0.26, {
+          bus: 'drops',
+          steps: [
+            { atMs: 0, pitch: 0.94 }, { atMs: 150, pitch: 1.02 },
+            { atMs: 320, pitch: 1.1 }, { atMs: 520, pitch: 1.18 },
+            { atMs: 700, name: 'chime', level: 0.34, pitch: 1 },
+          ],
+        });
+      }
+
+      if (till.token) {
+        const kChip = el('span', 'chip arc-till-k');
+        const kIco = el('i', 'arc-tok', '◉');
+        try { kIco.setAttribute('aria-hidden', 'true'); } catch (e) { /* noop */ }
+        kChip.appendChild(kIco);
+        kChip.appendChild(el('span', null,
+          t('payout_token_minted', 'A token dropped in the tray. That is your one for today.')));
+        row.appendChild(kChip);
+        /* THE ONE BIG BEAT OF THE NIGHT, and it is borrowed rather than built:
+         * ceremonies.reward('jackpot') is the engine's own jackpot with the CSS
+         * floor behind it, which is exactly what a once-a-day mint should be
+         * spending. It lands AFTER the ticket count-up so the two do not step on
+         * each other - the small number finishes, then the rare thing happens. */
+        if (s.arrived && ceremonies) {
+          later(() => {
+            try {
+              ceremonies.reward('jackpot', {
+                target: kChip,
+                text: t('wallet_tokens', 'Tokens'),
+              });
+            } catch (e) { say('token mint beat failed: ' + ((e && e.message) || e)); }
+          }, till.tickets > 0 ? 820 : 120);
+        }
       }
     }
 
@@ -351,7 +457,7 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
     return root;
   }
 
-  return { root, render, destroy() { root.remove(); } };
+  return { root, render, destroy() { sweep(); root.remove(); } };
 }
 
 export default createReportCard;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
@@ -35,6 +35,7 @@
  * ==========================================================================*/
 
 import { isMobile, orientation } from '../core/device.js';
+import { buildLever, paintLever } from './lever.js';
 
 /** Stage plane the art was authored on (the annex's, promoted). */
 const STAGE_W = 1376;
@@ -285,6 +286,10 @@ function el(tag, cls, text) {
  *  onFreeSwim  - start the class untimed (Free Swim); absent = no second hero
  *                AND no painted freeSwim rect, however the SCENES row reads.
  *  freeSwimLabel - display label for both free-swim surfaces (t('free_swim')).
+ *  lever       - Extra Credit caps { positions, get, set, unlocks }; absent =
+ *                no rail, exactly like an absent onOptions means no cog. The
+ *                door card carries the same rail, so a room that painted over
+ *                the card would otherwise swallow the whole wager.
  *  lite        - performance mode; kills the pulse like reduced motion does.
  *  log         - shell's say.
  */
@@ -450,6 +455,17 @@ export function createRoomScene(opts) {
       try { o.onOptions(); } catch (e) { say('room options threw: ' + ((e && e.message) || e)); }
     });
     barRight.appendChild(cog);
+  }
+  /* THE EXTRA CREDIT RAIL, on the control plate beside the knobs. It is a
+   * choice about the run, not a way to take it, so it stays off the marquee and
+   * out of the hero group - same reasoning as the card, where it sits under
+   * Begin. Absent caps = absent rail; this module decides nothing about who may
+   * pull which rung, it only paints what the shell hands down. */
+  if (o.lever) {
+    const lv = buildLever(t, 'arm-lever');
+    const repaint = () => { if (!destroyed) paintLever(lv, o.lever, t, repaint); };
+    repaint();
+    barRight.appendChild(lv.root);
   }
   bar.appendChild(barRight);
   /* The apron mounts on <body>, NOT inside root: .arm-root is its own

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
@@ -285,7 +285,41 @@
   align-items: center;
   min-width: 0;
 }
-.arm-bar-right { justify-content: flex-end; }
+.arm-bar-right { justify-content: flex-end; gap: 14px; }
+
+/* THE EXTRA CREDIT RAIL on the apron. The block itself is styles.css's
+   `.arc-lever` (the door card wears the same one); all this does is sit it down
+   on a control plate that is only about 90px tall - no top margin, no title
+   line, and the hint clipped to one line so a long sentence cannot shove the
+   knobs off the plate. The rail keeps its full size because it is the thing
+   being pulled. */
+.arm-lever {
+  margin-top: 0;
+  gap: 4px;
+  align-items: flex-end;
+  max-width: 46%;
+}
+.arm-lever .arc-lever-title { display: none; }
+.arm-lever .arc-lever-hint {
+  margin: 0;
+  /* Wide enough for the longest line lever.js can produce (48 chars, the Extra
+     Credit hint). At 26ch EVERY line - all six hints and both lock lines - came
+     out as an ellipsis, so the one place that says WHY a rung is dim never once
+     said it. `nowrap` is what keeps the hint to a single line and the knobs on
+     the plate; the width cap was only ever a second belt, and this one still
+     fits inside the rail's own width, so the block does not grow. */
+  max-width: 50ch;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* Phones stand the apron up on its short edge; the hint is the first thing to
+   go, because the rung labels already say what the three choices are. */
+@media (max-width: 720px), (max-height: 520px) {
+  .arm-lever .arc-lever-hint { display: none; }
+  .arm-lever .arc-lever-pos { padding: 5px 8px; font-size: 10px; }
+}
 
 /* ------------------------------ the hero -------------------------------- */
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -26,11 +26,11 @@
  *   dates  -> UTC seeds content, LOCAL date rolls attendance (regression #978)
  * ==========================================================================*/
 
-import { t, setLexicon, tierLabel } from '../core/lexicon.js';
+import { t, setLexicon, tierLabel, gradeLabel } from '../core/lexicon.js';
 import { makeRng } from '../core/rng.js';
 import { dayVocabulary } from '../core/vocab.js';
 import { buildTimetable, dayAdd } from '../core/timetable.js';
-import { gradeClass, capsRaised } from '../core/grades.js';
+import { gradeClass, capsRaised, isSPlus, gradeKey } from '../core/grades.js';
 import { createStore } from '../core/store.js';
 import {
   loadGames, descriptors, tierFor, tierForPromotions, advance, suspendedStub, MAX_TIER,
@@ -56,6 +56,7 @@ import { createEnrollmentIntro, createPunchCeremony } from './enrollment.js';
  * player's whole experience of this import is one controller that stands down. */
 import { createFirstBell } from '../vn/index.js';
 import { createRecordsRoom } from './recordsroom.js';
+import { createPrizeCounter } from './prizecounter.js';
 import { createIdSpotlight, idReducedMotion } from './idcard.js';
 import { createAccountChip, readAccount } from './accountchip.js';
 import { createAnnexReveal } from './annexreveal.js';
@@ -119,7 +120,7 @@ function sfx(name, level, extra) {
 
 /** Screen depth, so a swap knows which way it went. An ORDER, not a router -
  *  the router is `screen` and it stays exactly where it was. */
-const SCREEN_DEPTH = Object.freeze({ board: 0, room: 1, records: 1, annex: 2, report: 2, settings: 3, class: 4 });
+const SCREEN_DEPTH = Object.freeze({ board: 0, room: 1, records: 1, prizes: 1, annex: 2, report: 2, settings: 3, class: 4 });
 
 /** Walk targets EMI never remarks on arriving at. The three office doors are
  *  voice.js's geofence read from the other end: she is silent on the Records
@@ -767,6 +768,18 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    *  optional here - the scene chassis hangs its apron on <body>, so a cached
    *  handle would leave a band over the next screen. */
   let recordsRoom = null;
+  /** THE PRIZE COUNTER (shell/prizecounter.js). Same lifecycle as the office:
+   *  built fresh per visit, destroyed by clearScreen. The handle is kept while
+   *  it is up for exactly one reason - the `wallet-result` echo has to find the
+   *  live room to settle into, and a purchase settled into a room that is no
+   *  longer on screen is a purchase the player never sees land. */
+  let prizeRoom = null;
+  /** THE LEVER THIS CLASS WAS STARTED ON. Latched at the opening bracket rather
+   *  than read again at the end, so a player who buys the Honors lever DURING a
+   *  run does not retroactively promote the run they are already in - the host
+   *  clamps the same way from its own stored pending lever, and the two answers
+   *  have to agree or an S+ the page painted would be degraded to an S by C#. */
+  let activeLever = 'standard';
   /* ---------------------- THE STUDENT ID (shell/idcard.js) ----------------
    * The card in the corner of the campus is a document you can pick up now.
    * The shell owns three things about it and the card owns none of them: the
@@ -959,6 +972,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     engine: null,                  // rebound per class (the engine is per class)
     layer: dom && dom.ceremony,
     reducedMotion,
+    // The Prize Counter's one cosmetic that shows up mid-play. A getter, so a
+    // stamp bought tonight garnishes the very next one.
+    confetti: () => ownsSku('confetti_stamp'),
     log: say,
   });
 
@@ -1267,6 +1283,16 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       recordsRoom = null;
       try { rr.destroy(); } catch (e) { /* noop */ }
     }
+    /* THE PRIZE COUNTER hangs nothing on <body>, but it DOES hold a watchdog
+     * timer for the buy it is waiting on, and a timer that outlives its room is
+     * a timer that repaints a dead node. destroy() clears it, so the counter is
+     * torn down here for the same reason every other screen is: one funnel, no
+     * survivors. */
+    if (prizeRoom) {
+      const pr = prizeRoom;
+      prizeRoom = null;
+      try { pr.destroy(); } catch (e) { /* noop */ }
+    }
     extrasBox = null;
     /* THE ROTATE GATE BELONGS TO A SCREEN, NOT TO THE PAGE. Every screen change
      * funnels through here, so dropping it here is what stops a gate the campus
@@ -1496,10 +1522,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       strip.appendChild(el('span', 'rlabel', 'Yesterday'));
       for (const key of yClasses.slice(0, 4)) {
         const r = y.classes[key] || {};
-        const g = String(r.grade || '').toLowerCase();
+        const g = gradeKey(r.grade);
         const cell = el('span', 'rcell');
         cell.appendChild(el('span', 'grade ' + (g === 'pass' ? 'pass' : g || 'none'),
-          r.grade ? String(r.grade).toUpperCase() : '--'));
+          r.grade ? gradeLabel(r.grade) : '--'));
         cell.appendChild(el('span', null, gameName(key)));
         strip.appendChild(cell);
       }
@@ -1717,6 +1743,17 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         annex: (annexPeek || (store.get('annexRevealSeen') && (store.get('annex') || {}).visited))
           ? { open: () => walkThen('annex', () => showAnnex()) }
           : null,
+        /* THE ECONOMY, handed down rather than read. campus.js is under the
+         * header law (it imports no store and no bridge), so the wallet chip in
+         * its top-right cluster and the Extra Credit lever on its door card
+         * both live entirely on these two getters. Same bag contract as `post`
+         * and `annex`: the campus draws, the shell keeps every byte of state.
+         * A host with no economy in `init` hands null and the campus is exactly
+         * the campus it was - no chip, no lever, no gap where one used to be. */
+        economy: economyCatalog().length ? {
+          balance: () => walletBalance(),
+          lever: leverCaps(),
+        } : null,
         on: {
           /* THE STUDENT BODY STARTS HERE AND NOWHERE ELSE (PRESENCE §4): after
            * the entry reveal, never during it. The campus fires this once; a
@@ -1756,6 +1793,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
           },
           freeSwim: (gameKey) => walkThen(gameKey, () => startFreeSwim(gameKey)),
           records: () => walkThen('records', () => showRecords()),
+          /* THE PRIZE COUNTER'S DOOR. A walk like the office's, because it is
+           * across the quad like the office is - the wallet chip in the chrome
+           * is the thing you can read without going anywhere. */
+          prizes: () => walkThen('prizes', () => showPrizes()),
           annex: () => walkThen('annex', () => showAnnex()),
           /* THE DOOR walks; THE GEAR does not. campus.js calls `registrarRoom`
            * for the Front Office room and falls back to `registrar` for the
@@ -2099,7 +2140,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       for (const key of Object.keys(days)) {
         const classes = (days[key] && days[key].classes) || {};
         for (const g of Object.keys(classes)) {
-          if (String((classes[g] || {}).grade).toUpperCase() === 'S') { n++; break; }
+          /* An S+ is an S with the lever pulled, and a day the card counts. */
+          const letter = String((classes[g] || {}).grade).toUpperCase();
+          if (letter === 'S' || letter === 'S+') { n++; break; }
         }
       }
     } catch (e) { /* noop */ }
@@ -2119,6 +2162,15 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       // place. The chip's hint has to say which, so it has to know.
       web: src.mediaControls === true,
     };
+  }
+
+  /** The frame the card wears tonight, if one was bought. Gold wins when both
+   *  are owned, because gold is the dearer of the two and nobody buys the dear
+   *  one to be shown the cheap one. */
+  function idFrame() {
+    if (ownsSku('id_frame_gold')) return 'gold';
+    if (ownsSku('id_frame_navy')) return 'navy';
+    return '';
   }
 
   /** What the card says about your ATTENDANCE. Every number is somebody else's
@@ -2240,6 +2292,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
           isMobile,
           profile: idProfile,
           stats: idStats,
+          frame: idFrame,
           onChip: onIdChip,
           onRecords: () => showRecords(),
           onClose: releaseIdCard,
@@ -2286,6 +2339,240 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     try { was = !!idSpotlight.dismiss(silent); } catch (e) { was = false; }
     releaseIdCard();
     return was;
+  }
+
+  /* ============================ THE ECONOMY =============================
+   * TWO CURRENCIES, AND THE PAGE MINTS NEITHER OF THEM. `wallet` is a
+   * HOST-OWNED meta key: the shell reads it and never writes it, the same
+   * arrangement `days`, `streak` and the punch cards have had since day one.
+   * Tickets land on a graded finish, the token lands on the first S-rank of a
+   * local day, and both of those sums are computed in C# where the page cannot
+   * reach them. Everything below is a READER.
+   *
+   * WHY THE SHELL HOLDS THESE AND NOT THE COUNTER. Two surfaces need the same
+   * numbers - the campus chip and the Prize Counter - and one of them (the
+   * campus) is under the header law and may not touch the store at all. One
+   * reader here, handed down as caps to both, is the only arrangement where the
+   * chip and the shelf can never disagree about what you are holding.
+   * ==================================================================== */
+
+  /** THE LAST THING THE HOST SAID ABOUT THE WALLET, laid over the meta snapshot
+   *  until the next `meta` frame replaces it. This is NOT an optimistic paint -
+   *  every byte of it arrived on a host frame (`payout-result`, `wallet-result`)
+   *  and the host had already banked it before it was posted. It exists because
+   *  the meta snapshot is pushed on its own schedule, and a player who watches
+   *  a token drop into the tray and then finds the campus chip still reading
+   *  yesterday's number has been told two different truths. */
+  let walletEcho = null;
+
+  /** Fold a host frame's wallet fields into the echo. Missing means unchanged. */
+  function noteWalletEcho(frame) {
+    const f = frame || {};
+    const next = walletEcho ? Object.assign({}, walletEcho) : {};
+    let moved = false;
+    if (f.wallet && typeof f.wallet === 'object') {
+      const tt = Number(f.wallet.t); const kk = Number(f.wallet.k);
+      if (Number.isFinite(tt)) { next.t = tt; moved = true; }
+      if (Number.isFinite(kk)) { next.k = kk; moved = true; }
+    }
+    if (f.inv && typeof f.inv === 'object') { next.inv = f.inv; moved = true; }
+    if (f.unlocks && typeof f.unlocks === 'object') { next.unlocks = f.unlocks; moved = true; }
+    if (moved) walletEcho = next;
+  }
+
+  /** The wallet blob, shaped. A wallet that has never been written is an empty
+   *  purse and never a throw - a player who has not finished a class yet is the
+   *  ordinary case on a first night. */
+  function walletBag() {
+    let base = {};
+    try {
+      const w = store.get('wallet');
+      if (w && typeof w === 'object') base = w;
+    } catch (e) { base = {}; }
+    return walletEcho ? Object.assign({}, base, walletEcho) : base;
+  }
+
+  /** {t, k}: what is on the player right now. */
+  function walletBalance() {
+    const w = walletBag();
+    const tt = Number(w.t); const kk = Number(w.k);
+    return { t: Number.isFinite(tt) && tt > 0 ? tt : 0, k: Number.isFinite(kk) && kk > 0 ? kk : 0 };
+  }
+
+  function walletInv() {
+    const v = walletBag().inv;
+    return (v && typeof v === 'object') ? v : {};
+  }
+
+  /** The lever's two permanent unlocks, plus anything else the host banked
+   *  there. init.economy.leverUnlocks is the projection at boot; the wallet's
+   *  own copy is what a purchase echo moves, so the wallet WINS where it says
+   *  something - a token spent on the Honors lever lights it that same second. */
+  function walletUnlocks() {
+    const boot = (src.economy && src.economy.leverUnlocks) || {};
+    const live = walletBag().unlocks;
+    const out = { extra: !!boot.extra, honors: !!boot.honors };
+    if (live && typeof live === 'object') {
+      for (const k of Object.keys(live)) out[k] = live[k] === true;
+    }
+    return out;
+  }
+
+  /** The host's catalog, exactly as init projected it. The page never prices a
+   *  row and never invents one: an empty catalog is a bare shelf, which the
+   *  counter has a sentence for. */
+  function economyCatalog() {
+    const rows = src.economy && src.economy.catalog;
+    return Array.isArray(rows) ? rows.filter((r) => r && r.sku) : [];
+  }
+
+  function catalogRow(sku) {
+    for (const r of economyCatalog()) if (r.sku === sku) return r;
+    return null;
+  }
+
+  /** How many of a consumable may be held at once. Display only - the host is
+   *  the one that refuses the third late slip, with reason "full". */
+  function stackMaxFor(sku) {
+    const row = catalogRow(sku);
+    if (!row || row.kind !== 'consumable') return 0;
+    const n = Number(row.max);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 3;
+  }
+
+  /** Tonight's hot room, or null. Seeded per UTC day in C#; the page displays. */
+  function economyPayday() {
+    const pd = src.economy && src.economy.payday;
+    if (!pd || !pd.gameKey) return null;
+    const mult = Number(pd.mult);
+    return Number.isFinite(mult) && mult > 1 ? { gameKey: String(pd.gameKey), mult } : null;
+  }
+
+  /** Does the player own a thing? Unlocks live in two places (see walletUnlocks)
+   *  and either witness counts. */
+  function ownsSku(sku) {
+    const inv = walletInv();
+    const row = inv[sku];
+    if (row === true) return true;
+    if (typeof row === 'number' && row > 0) return true;
+    if (row && typeof row === 'object') {
+      const n = Number(row.n);
+      return Number.isFinite(n) ? n > 0 : true;
+    }
+    const un = walletUnlocks();
+    if (sku === 'honors_lever') return un.honors === true;
+    if (sku === 'free_swim_key') return un.freeSwim === true;
+    return false;
+  }
+
+  /* ---------------------------- THE EXTRA CREDIT LEVER -------------------
+   * ONE pick for the night, not one per door. A player who pulls Honors at the
+   * Music Room has decided how they want to play tonight, and asking them again
+   * at the next door would be a form rather than a lever. It rides the
+   * page-owned meta key `leverPick`, so it survives a screen change and a
+   * reload; the HOST re-clamps it on every class-started anyway (an unlock the
+   * page thinks it has and the host does not simply grades as Standard).
+   * -------------------------------------------------------------------- */
+
+  /** Legal positions, worst to best. Order matters: the lever walks it. */
+  const LEVER_POSITIONS = ['standard', 'extra', 'honors'];
+
+  /** The pick, clamped to what is actually unlocked. Never returns junk. */
+  function leverPick() {
+    let want = 'standard';
+    try { want = String(store.get('leverPick') || 'standard'); } catch (e) { want = 'standard'; }
+    if (LEVER_POSITIONS.indexOf(want) < 0) return 'standard';
+    const un = walletUnlocks();
+    if (want === 'honors' && un.honors !== true) return 'standard';
+    if (want === 'extra' && un.extra !== true) return 'standard';
+    return want;
+  }
+
+  /** Set it, clamped the same way, and answer what actually stuck. */
+  function setLeverPick(pos) {
+    const want = LEVER_POSITIONS.indexOf(String(pos || '')) >= 0 ? String(pos) : 'standard';
+    const un = walletUnlocks();
+    const ok = want === 'standard'
+      || (want === 'extra' && un.extra === true)
+      || (want === 'honors' && un.honors === true);
+    const next = ok ? want : 'standard';
+    try { store.set('leverPick', next); } catch (e) { say('lever pick write failed'); }
+    return next;
+  }
+
+  /** The bag both class-start surfaces hand their lever control. Narrow caps:
+   *  the door card and the room scene draw a lever, they never read a wallet. */
+  function leverCaps() {
+    return {
+      positions: LEVER_POSITIONS.slice(),
+      get: () => leverPick(),
+      set: (pos) => setLeverPick(pos),
+      unlocks: () => walletUnlocks(),
+    };
+  }
+
+  /* ============================ SCREEN: PRIZES ==========================
+   * The counter is a page under the annex's law (shell/prizecounter.js): it
+   * takes readers and callbacks and it imports no store, no bridge and no EMI.
+   * The one thing worth reading twice is `onBuy`: it SENDS and returns. There
+   * is no optimistic paint anywhere in this screen, because the host owns every
+   * balance in it and a page that spent its own money is a page that can be
+   * lied to (trap 1, and the whole reason `wallet` is host-owned).
+   * ==================================================================== */
+
+  function showPrizes() {
+    screen = 'prizes';
+    dismissEndCard();
+    dismissPunchStage();
+    dismissAnnexStage();
+    clearScreen();
+    renderTopbar();
+    prizeRoom = createPrizeCounter({
+      mount: dom && dom.screen,
+      t,
+      log: say,
+      lite: !!src.performanceMode,
+      reduced: reducedMotion,
+      catalog: () => economyCatalog(),
+      balance: () => walletBalance(),
+      inv: () => walletInv(),
+      unlocks: () => walletUnlocks(),
+      stackMax: (sku) => stackMaxFor(sku),
+      payday: () => economyPayday(),
+      gameName,
+      /* THE PROPOSAL, and nothing else. The counter has already put the row to
+       * sleep; the host's `wallet-result` lands at onWalletResult below and
+       * settles it, or it never lands and the row wakes up unchanged. */
+      onBuy: (sku) => {
+        try { bridge.send({ type: 'prize-buy', sku: String(sku) }); }
+        catch (e) { say('prize-buy send failed: ' + ((e && e.message) || e)); }
+      },
+      onBack: () => showBoard(),
+    });
+    setStage('arc-report-on');
+  }
+
+  /**
+   * THE ECHO (host `wallet-result`). Everything a purchase changes is already
+   * in the host's meta by the time this arrives, so the counter is handed the
+   * frame and the rest of the page simply re-reads. When the counter is not up
+   * (a buy answered after the player walked out) the frame is still worth
+   * having: the lever's unlocks may have moved.
+   */
+  function onWalletResult(m) {
+    const frame = m || {};
+    noteWalletEcho(frame);
+    if (prizeRoom && typeof prizeRoom.settle === 'function') {
+      try { prizeRoom.settle(frame); }
+      catch (e) { say('wallet settle threw: ' + ((e && e.message) || e)); }
+    }
+    /* A lever position that was legal a second ago may not be any more (it can
+     * only ever have been WON here, never lost, but re-clamping is free and it
+     * is the one line that stops a stale pick outliving a wallet reset). */
+    setLeverPick(leverPick());
+    if (screen === 'board' && campus) {
+      try { campus.update(buildCampusState(), campusStats()); } catch (e) { /* noop */ }
+    }
   }
 
   /* ============================ SCREEN: RECORDS =========================
@@ -2456,6 +2743,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
        * than anywhere else, so the room lends them its own way back: settings
        * opened from here folds into the room it left, never past it. */
       onOptions: () => showSettings(gameKey, { onClose: () => showRoomScene(gameKey, info) }),
+      /* THE WAGER, on the second surface. The room replaces the door card for
+       * every painted room, and the card is where the Extra Credit rail lives -
+       * so a painted room without this would be a room where the lever does not
+       * exist, which is nine rooms out of ten. Null when the host sent no
+       * catalog: no economy, no rail, exactly like the card. */
+      lever: economyCatalog().length ? leverCaps() : null,
     });
     if (dom && dom.screen) dom.screen.appendChild(roomPage.root);
     setStage('arc-report-on');
@@ -3572,7 +3865,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     const keys = keybinds.runtime(cls.gameKey, window);
     const peek = createPeek({ log: say });
     const classCeremonies = createCeremonies({
-      engine, layer: (dom && dom.ceremony) || null, reducedMotion, log: say,
+      engine, layer: (dom && dom.ceremony) || null, reducedMotion,
+      confetti: () => ownsSku('confetti_stamp'),
+      log: say,
     });
 
     /* --- per-game settings view (never a global) --- */
@@ -3811,9 +4106,16 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     // not know, so `endless` is free to carry: a free swim opens the same
     // bracket and closes it with `class-left` from teardownClass (never with
     // `class-ended`, which is what would credit attendance and pay XP).
+    /* THE LEVER RIDES THE OPENING BRACKET AND NOWHERE ELSE. It is a PROPOSAL:
+     * the host clamps it against the unlocks it holds, stores the clamped value
+     * as this game's pending lever, and applies the multiplier itself at
+     * class-ended. The page never echoes a multiplier back and never sees one -
+     * which is also why a free swim carries the lever and is paid nothing for
+     * it (an endless run ends with `class-left`, and no bracket closes). */
+    activeLever = leverPick();
     bridge.send(endless
-      ? { type: 'class-started', gameKey: cls.gameKey, gradeTier, endless: true }
-      : { type: 'class-started', gameKey: cls.gameKey, gradeTier });
+      ? { type: 'class-started', gameKey: cls.gameKey, gradeTier, endless: true, lever: activeLever }
+      : { type: 'class-started', gameKey: cls.gameKey, gradeTier, lever: activeLever });
 
     /* THE GAME STARTS HERE, AND NOT BEFORE. Everything above is the stage; this
      * is the class. Enrollment (below) delays it by a few cards on a first run
@@ -3930,11 +4232,33 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     if (!entry || !entry.ok) return null;
     const m = entry.mod && entry.mod.manifest;
     const e = m && m.endless;
-    if (!e || typeof e !== 'object') return null;
+    if (!e || typeof e !== 'object') {
+      /* THE FREE SWIM KEY (Prize Counter, 1 token). It does not unlock a room
+       * and it does not unlock a grade: it opens the UNGRADED door on a class
+       * you are enrolled in but whose game never declared one. Enrollment is
+       * the floor on purpose - the key is a way to practise a room you already
+       * go to, never a way to walk into one you have not been let into. Every
+       * downstream reader (the door card's second button, the room scene's
+       * furniture, startFreeSwim's own re-check) rides this one function, so
+       * the key lights all three surfaces at once and none of them had to hear
+       * about it. */
+      if (ownsSku('free_swim_key') && isEnrolled(gameKey)) {
+        return { labelKey: 'free_swim', hintKey: 'free_swim_key_hint' };
+      }
+      return null;
+    }
     return {
       labelKey: typeof e.label_key === 'string' ? e.label_key : '',
       hintKey: typeof e.hint_key === 'string' ? e.hint_key : '',
     };
+  }
+
+  /** Has this room's card ever been opened? The key's floor. */
+  function isEnrolled(gameKey) {
+    try {
+      const card = store.punchCard(gameKey) || {};
+      return typeof card.enrolledAt === 'string' && !!card.enrolledAt;
+    } catch (e) { return false; }
   }
 
   /** gameKey -> endless declaration, for every game that has one. */
@@ -4038,6 +4362,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       hardGates: r.hardGates,
       zen: !!r.zen,
       assists,
+      /* THE HONORS INPUT, and it is exactly one boolean. The rubric does the
+       * rest (core/grades.js): honors plus a composite at or above 0.97 is the
+       * only road to S+, and every cap still bites it the way it bites an S. */
+      honors: activeLever === 'honors',
     };
     const graded = gradeClass(input);
     // The A-caps the rubric RAISED, whether or not they moved the letter. The
@@ -4095,7 +4423,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     /* ASKS: `newBest` is impulse-control's, reported additively on its own
      * endClass frame (trap 54's spirit), and it is what a11's dare resolves
      * against. Every other class simply never carries it. */
-    const endMoment = /^[sab]$/i.test(String(graded.grade)) || graded.grade === 'pass' ? 'win' : 'fail';
+    /* S+ IS A WIN AND THE REGEX DID NOT KNOW IT. `/^[sab]$/` matched exactly one
+     * letter, so the best result in the school would have fired EMI's FAIL pool
+     * - the honours run gets the rage chain. `isSPlus` is the additive answer
+     * and every other branch here is byte-for-byte what it was. */
+    const endMoment = isSPlus(graded.grade) || /^[sab]$/i.test(String(graded.grade))
+      || graded.grade === 'pass' ? 'win' : 'fail';
     const endPayload = {
       grade: graded.grade, streak: store.streak().count,
       gameKey: cls.gameKey, perfect: allDone(),
@@ -4673,17 +5006,53 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         + ': ' + (profile.discordLinked ? 'linked' : 'not linked') + ', ' + profile.presenceShare);
     },
 
-    /** {type:'payout-result'} - the ONLY source of an XP number on this page. */
+    /** {type:'payout-result'} - the ONLY source of an XP number on this page,
+     *  and since the economy wave the only source of a TICKET number too. */
     onPayout(m) {
       if (!m || !m.gameKey) return;
       const r = results[m.gameKey];
       if (r) { r.xp = m.xp; r.levelUp = !!m.levelUp; }
       // The same frame carries the host's authoritative attendance figures.
       try { store.applyPayout(m); } catch (e) { say('applyPayout: ' + ((e && e.message) || e)); }
+      /* THE PAYDAY. Tickets and the token are minted in C# and simply reported
+       * here; the report card draws the beat. Stashing it on the result row is
+       * what lets showReport() repaint the same card without re-firing the
+       * ceremony (the card's own `arrived` gate does the rest). */
+      noteWalletEcho(m);
+      /* AND THE CHIP MOVES WITH IT. A payout normally lands while the report is
+       * up, but an end-run that dropped the player straight back on the board
+       * would otherwise leave the purse reading the number it had before the
+       * class - the same silent repaint `wallet-result` takes. */
+      if (screen === 'board' && campus) {
+        try { campus.update(buildCampusState(), campusStats()); } catch (e) { /* noop */ }
+      }
+      if (r) {
+        const tk = Math.max(0, Math.round(Number(m.tickets) || 0));
+        if (tk > 0 || m.tokenMinted === true) {
+          r.payout = {
+            tickets: tk,
+            base: Math.max(0, Math.round(Number(m.ticketBase) || 0)),
+            mult: Number(m.ticketMult) || 1,
+            token: m.tokenMinted === true,
+            balance: walletBalance(),
+          };
+        }
+      }
+      /* THE LATE SLIP. The host consumed one inside the attendance path, which
+       * is the one purchase a player never sees happen - so it is the one that
+       * has to be said out loud. */
+      if (m.lateSlipUsed === true) {
+        try { shout(t('late_slip_used', 'A late slip covered you. Your streak never noticed.')); }
+        catch (e) { /* a toast may never hold a door */ }
+      }
       if (m.levelUp) shout('Level up');
       renderTopbar();
       if (screen === 'report') showReport();
     },
+
+    /** {type:'wallet-result'} - the answer to a `prize-buy`, and the ONLY thing
+     *  on this page allowed to move a balance, a badge or a lever unlock. */
+    onWalletResult(m) { onWalletResult(m); },
 
     /**
      * {type:'punchcard-result'} - the host's same-frame truth about a card
@@ -4774,7 +5143,17 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     onSuspend(m) { applySuspend(!!(m && m.on), m && m.reason); },
 
     /** {type:'meta'} is consumed by the store; this just repaints the chrome. */
-    onMeta() { renderTopbar(); if (screen === 'board') showBoard({ silent: true }); },
+    /* A fresh meta snapshot IS the wallet now, so the frame-by-frame echo laid
+     * over it has done its job and is dropped - two truths about one purse is
+     * one truth too many. */
+    onMeta() {
+      walletEcho = null;
+      renderTopbar();
+      if (screen === 'board') showBoard({ silent: true });
+      if (prizeRoom && typeof prizeRoom.refresh === 'function') {
+        try { prizeRoom.refresh(); } catch (e) { /* noop */ }
+      }
+    },
 
     /**
      * One rung of the Esc ladder. Returns true when the shell consumed it, so
@@ -4875,6 +5254,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       // A ROOM SCENE is a screen like records: Esc walks back to campus. Its
       // hotspots are buttons, not modals - the room owns no inner rungs.
       if (screen === 'room') { showBoard(); return true; }
+      // THE PRIZE COUNTER is a flat screen like settings: one rung, straight out
+      // to the quad. It owns no modal and no close-up, and a buy that is still
+      // in the air is not a rung either - the frame that answers it lands on a
+      // room that has gone, which is exactly what onWalletResult is written to
+      // survive (the counter is null by then and only the lever re-clamps).
+      if (screen === 'prizes') { showBoard(); return true; }
       // THE ANNEX folds inward-out (trap 48's shape, one ladder both sides of
       // the seam): the lab's own rungs first - paper down, OS window shut,
       // laptop closed, close-up stepped back - then the stairs walk home to

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -323,6 +323,15 @@ kbd {
   color:var(--ground); background:var(--slate);
 }
 .grade.s { background:var(--gS); box-shadow:0 0 10px rgba(240,194,75,.5); }
+/* THE HONOURS LETTER. `splus`, not `s+`, because a class attribute with a plus
+   in it needs escaping to be selected and one unstyled badge is worse than one
+   extra rule. Same gold as the S it is built on, lit harder and with the plus
+   allowed to overhang - it has to read as MORE than an S at badge size. */
+.grade.splus {
+  background:var(--gS); color:var(--ground);
+  padding:0 5px; letter-spacing:-.02em;
+  box-shadow:0 0 14px rgba(240,194,75,.75), inset 0 0 0 1px rgba(255,255,255,.35);
+}
 .grade.a { background:var(--gA); box-shadow:0 0 10px rgba(255,105,180,.4); }
 .grade.b { background:var(--gB); }
 .grade.c { background:var(--gC); }
@@ -519,6 +528,103 @@ html.arc-reduced .arc-endcard-actions .arc-retake { animation:none; box-shadow:0
   padding-top:9px; margin-top:2px;
 }
 
+/* ============================ THE TWO CURRENCIES =========================
+   The ticket stub and the token, drawn once and worn by THREE surfaces: the
+   campus wallet chip, the Prize Counter's shelf, and the report card's till.
+   They live here rather than in prizecounter.css on purpose - that sheet is
+   linked lazily, the first time the counter is opened, so a report card that
+   paid out before the player ever walked to the shop would have rendered two
+   unstyled squares. A currency glyph is a shell primitive.
+
+   THE TICKET is a cream stub with a bite out of each long edge, which is the
+   whole visual idea of a ticket and costs no image. THE TOKEN is a struck
+   coin with its mark centred in it. */
+.arc-tick {
+  flex:none; display:inline-block; width:18px; height:11px;
+  border-radius:2px; font-style:normal;
+  background:
+    radial-gradient(circle at 0 50%, transparent 0 2.5px,
+      color-mix(in srgb, var(--ink), var(--pink) 22%) 2.6px),
+    radial-gradient(circle at 100% 50%, transparent 0 2.5px,
+      color-mix(in srgb, var(--ink), var(--pink) 22%) 2.6px);
+  background-blend-mode:multiply;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.35);
+}
+.arc-tok {
+  flex:none; display:inline-flex; align-items:center; justify-content:center;
+  width:18px; height:18px; border-radius:50%;
+  font-style:normal; font-size:11px; line-height:1;
+  color:color-mix(in srgb, var(--navy), black 30%);
+  background:radial-gradient(circle at 34% 30%,
+    color-mix(in srgb, var(--gold), white 34%), var(--gold) 58%,
+    color-mix(in srgb, var(--gold), black 34%));
+  box-shadow:inset 0 -1px 2px rgba(0,0,0,.45);
+}
+
+/* THE TILL on the report card: the night's tickets counted out, and on a rare
+   night the token beside them. One row, two chips, the shell's chip primitive. */
+.arc-till { gap:10px; flex-wrap:wrap; }
+.arc-till-t { display:inline-flex; align-items:center; gap:6px; }
+.arc-till-n { font-family:var(--mono); font-size:15px; color:var(--pink); }
+.arc-till-k {
+  display:inline-flex; align-items:center; gap:7px;
+  border:1px solid color-mix(in srgb, var(--gold), transparent 58%);
+  background:color-mix(in srgb, var(--gold), transparent 90%);
+}
+
+/* THE CAMPUS WALLET CHIP. It rides the top-right cluster beside the account
+   chip, it is READ-ONLY, and pressing it walks to the Prize Counter. */
+.campus-wallet {
+  display:inline-flex; align-items:center; gap:9px;
+  padding:5px 11px; border-radius:999px;
+  border:1px solid var(--campus-line-dim);
+  background:color-mix(in srgb, var(--campus-hall), black 18%);
+  color:var(--campus-text);
+  font-family:var(--body); font-size:12px; line-height:1;
+  cursor:pointer;
+}
+.campus-wallet:hover, .campus-wallet:focus-visible {
+  border-color:var(--campus-line);
+  color:var(--ink);
+}
+.campus-wallet span { display:inline-flex; align-items:center; gap:5px; }
+.campus-wallet b { font-family:var(--mono); font-size:13px; }
+.campus-wallet .arc-tick + b { color:var(--pink); }
+.campus-wallet .arc-tok + b { color:var(--gold); }
+
+/* ============================ THE EXTRA CREDIT LEVER =====================
+   Three positions on one rail, on the door card and on the room-scene apron.
+   A locked position is DIM AND STILL PRESENT: what you cannot pull yet is the
+   whole reason to walk to the counter, so hiding it would hide the feature. */
+.arc-lever {
+  display:flex; flex-direction:column; gap:6px;
+  margin-top:10px;
+}
+.arc-lever-title {
+  font-family:var(--disp); font-size:10.5px; letter-spacing:.2em;
+  text-transform:uppercase; color:var(--ink-faint);
+}
+.arc-lever-rail {
+  display:inline-flex; align-items:stretch; gap:0;
+  border:1px solid var(--line); border-radius:8px; overflow:hidden;
+}
+.arc-lever-pos {
+  appearance:none; border:0; cursor:pointer;
+  padding:6px 11px;
+  font-family:var(--disp); font-size:11px; letter-spacing:.12em;
+  text-transform:uppercase;
+  color:var(--ink-dim); background:color-mix(in srgb, var(--panel), black 10%);
+  border-right:1px solid var(--line);
+}
+.arc-lever-pos:last-child { border-right:0; }
+.arc-lever-pos.is-on {
+  color:var(--ground); background:var(--gold);
+}
+.arc-lever-pos.is-locked {
+  color:var(--ink-faint); opacity:.6; cursor:default;
+}
+.arc-lever-hint { font-size:11.5px; color:var(--ink-faint); line-height:1.35; }
+
 /* ============================ CEREMONIES ================================= */
 .arc-ceremony { position:fixed; inset:0; z-index:45; pointer-events:none; }
 .arc-stamp {
@@ -533,6 +639,29 @@ html.arc-reduced .arc-endcard-actions .arc-retake { animation:none; box-shadow:0
   0% { transform:rotate(-6deg) scale(2.4); opacity:0; }
   55% { transform:rotate(-6deg) scale(.94); opacity:1; }
   100% { transform:rotate(-6deg) scale(1); opacity:1; }
+}
+/* THE CONFETTI STAMP (Prize Counter, 300 tickets). A GARNISH and nothing else:
+   two rings of paper thrown off the stamp as it lands, drawn on ::before and
+   ::after so the stamp node itself is byte-for-byte the stamp it always was.
+   Never mounted under reduced motion (ceremonies.js gates the class), which is
+   why the rule is free to be pure animation with no still state to design. */
+.arc-stamp-confetti { position:relative; }
+.arc-stamp-confetti::before,
+.arc-stamp-confetti::after {
+  content:''; position:absolute; left:50%; top:50%;
+  width:6px; height:6px; margin:-3px 0 0 -3px; border-radius:1px;
+  pointer-events:none;
+  box-shadow:
+    -34px -18px 0 var(--pink), 30px -22px 0 var(--gold),
+    -22px 20px 0 var(--lav), 26px 16px 0 var(--pink),
+    -44px 4px 0 var(--gold), 42px 0 0 var(--lav);
+  animation:arc-confetti-burst .62s ease-out both;
+}
+.arc-stamp-confetti::after { animation-delay:.09s; filter:hue-rotate(38deg); }
+@keyframes arc-confetti-burst {
+  0% { transform:scale(.2) rotate(0deg); opacity:0; }
+  25% { opacity:1; }
+  100% { transform:scale(1.5) rotate(28deg); opacity:0; }
 }
 
 /* 10-segment streak meter - the shared shell primitive (SYNTHESIS #10). */
@@ -3899,6 +4028,28 @@ html.ae-lite .arc-rs-name .arc-rs-l { animation-play-state:running, paused; }
     inset 0 1px 0 rgba(255,255,255,.08);
 }
 .arc-id-face.is-back { transform:rotateY(180deg); }
+
+/* THE FRAMES THE COUNTER SELLS. Border and glow ONLY - the face keeps its own
+   gradient, its photo, its foil and every inset it had, because a frame is a
+   thing you put a card in, not a different card. Both faces take it so the
+   frame survives the flip, and nothing here touches layout, so a framed card
+   and a bare one are the same card at the same size on the same three-line
+   layout that the 330px note above spent so long earning. */
+.arc-id-big.is-frame-gold .arc-id-face {
+  border-color:color-mix(in srgb, var(--gold), transparent 30%);
+  box-shadow:0 34px 84px rgba(0,0,0,.72),
+    0 0 52px color-mix(in srgb, var(--gold), transparent 70%),
+    inset 0 0 0 2px color-mix(in srgb, var(--gold), transparent 52%),
+    inset 0 1px 0 rgba(255,255,255,.10);
+}
+.arc-id-big.is-frame-navy .arc-id-face {
+  border-color:color-mix(in srgb, var(--lav), transparent 42%);
+  box-shadow:0 34px 84px rgba(0,0,0,.78),
+    0 0 40px color-mix(in srgb, var(--lav), transparent 74%),
+    inset 0 0 0 2px color-mix(in srgb, var(--navy), var(--lav) 34%),
+    inset 0 1px 0 rgba(255,255,255,.06);
+}
+
 /* THE LAMINATE. A specular that follows the pointer by TRANSFORM off the two
    custom properties the tilt handler writes - plain alpha, no blend surface
    (trap 36's first third: a blend must read back what is under it). */

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyEconomy.cs
@@ -1,0 +1,541 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Arcademy;
+
+/// <summary>
+/// THE ARCADEMY'S TILL. Two currencies, all of the arithmetic, and the prize catalog — kept in one
+/// file with NO WPF and NO <see cref="App"/> references so the money can be exercised standalone.
+/// Every number a player earns or spends is decided here and nowhere else; the page reports what
+/// happened and the host decides what it was worth, exactly as the XP table already works.
+///
+/// <para>TICKETS are common and minted on every graded finish. TOKENS are rare: the first S-rank of
+/// the LOCAL day, hard-capped at one, never from a zen pass. The two are independent — a token day
+/// still pays its tickets.</para>
+///
+/// <para>NO LIVE RANDOMNESS ANYWHERE ON THIS PAGE (House Book law). The nightly payday is a pure
+/// function of the UTC date seed and the enrolled roster, so every machine on the same day agrees
+/// about which room is paying and the page only ever displays what <c>init</c> already told it.</para>
+///
+/// <para>The wallet is a plain <see cref="JObject"/> riding the meta blob under one host-owned key,
+/// for the same reason the streak does: a stale or edited page must never be able to mint currency.
+/// Shape (all fields ensured by <see cref="EnsureShape"/>):</para>
+/// <code>
+/// { "t":0, "k":0, "earnedT":0, "earnedK":0,
+///   "tokenDays":["yyyy-MM-dd"],
+///   "payDays":{ "yyyy-MM-dd": { "&lt;gameKey&gt;": 2 } },
+///   "inv":{ "late_slip": { "n":2, "at":"yyyy-MM-dd" } },
+///   "unlocks":{ "extra":false, "honors":false },
+///   "log":[ { "sku":"late_slip", "cur":"t", "cost":250, "at":"yyyy-MM-dd" } ] }
+/// </code>
+/// </summary>
+internal static class ArcademyEconomy
+{
+    // ============================ the money math ============================
+
+    /// <summary>Base tickets by grade. Zen reports <c>pass</c> and pays the bottom row — a quiet
+    /// night is still a night at school, it just is not a graded one.</summary>
+    public static readonly IReadOnlyDictionary<string, int> TicketBase =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["S+"] = 160, ["S"] = 130, ["A"] = 100, ["B"] = 80, ["C"] = 60, ["pass"] = 40,
+        };
+
+    /// <summary>Replay decay by how many graded finishes this room has already paid for TODAY.
+    /// A retake is a supported, deliberately free thing to do (the day's seed makes it the same
+    /// script), so the second run pays a share and the third onward pays a token amount rather
+    /// than nothing — grinding is bounded, not punished.</summary>
+    private static readonly decimal[] DecayLadder = { 1.00m, 0.40m, 0.15m };
+
+    /// <summary>Attendance bonus per streak day, and its ceiling.</summary>
+    private const decimal StreakStep = 0.02m;
+    private const decimal StreakCap = 0.30m;
+
+    /// <summary>Nothing a graded finish pays ever drops under this.</summary>
+    public const int TicketFloor = 10;
+
+    /// <summary>The ordinary payday, and the rare one. <see cref="JackpotOdds"/> is a denominator:
+    /// one night in thirty the lucky room pays five times instead of two.</summary>
+    private const int PaydayMult = 2;
+    private const int JackpotMult = 5;
+    private const int JackpotOdds = 30;
+
+    /// <summary>The Extra Credit lever's three notches. Unknown text is standard; the CALLER is
+    /// what enforces the unlock rungs (see <see cref="ClampLever"/>).</summary>
+    public static double LeverMult(string? lever) => (double)LeverMultDec(lever);
+
+    private static decimal LeverMultDec(string? lever) => lever switch
+    {
+        "extra" => 1.5m,
+        "honors" => 2.0m,
+        _ => 1.0m,
+    };
+
+    /// <summary>The lever the player may actually pull, given what they have unlocked. Extra Credit
+    /// opens on their first A-or-better; Honors is bought at the counter. Anything unrecognised, or
+    /// a notch they have not earned, quietly becomes standard — the page proposes, the host
+    /// disposes, and a forged frame can only ever cost the player money, never make it.</summary>
+    public static string ClampLever(string? lever, bool extraUnlocked, bool honorsUnlocked) => lever switch
+    {
+        "extra" when extraUnlocked => "extra",
+        "honors" when honorsUnlocked => "honors",
+        _ => "standard",
+    };
+
+    /// <summary>What one graded finish is worth, broken out so the debrief can show its working.</summary>
+    /// <param name="Tickets">The minted amount, post-rounding and post-floor.</param>
+    /// <param name="Base">The grade's base row, before any multiplier.</param>
+    /// <param name="Mult">Every multiplier combined, rounded to 2dp for display.</param>
+    public readonly record struct TicketPayout(
+        int Tickets, int Base, double Mult,
+        double Decay, double Streak, int Payday, double Lever);
+
+    /// <summary>
+    /// THE ONE TICKET SUM. Base by grade, then the replay ladder, then the attendance bonus, then
+    /// tonight's payday, then the lever last of all, then round half-up and floor.
+    ///
+    /// <para>Pure: every input is passed in, nothing is read off a clock, and the same arguments
+    /// always produce the same number. That is what makes it testable without a WebView.</para>
+    /// </summary>
+    /// <param name="grade">S+/S/A/B/C/pass. Anything else pays the C row.</param>
+    /// <param name="priorFinishesToday">Graded finishes this room has ALREADY paid for today (0 for
+    /// the first of the day).</param>
+    /// <param name="streak">The attendance streak AFTER today's credit.</param>
+    /// <param name="paydayMult">1 when this room is not tonight's lucky one, otherwise 2 or 5.</param>
+    /// <param name="lever">The clamped lever notch.</param>
+    public static TicketPayout ComputeTickets(string? grade, int priorFinishesToday, int streak,
+        int paydayMult, string? lever)
+    {
+        var baseAmount = TicketBase.TryGetValue(grade ?? "", out var b) ? b : TicketBase["C"];
+
+        var idx = Math.Clamp(priorFinishesToday, 0, DecayLadder.Length - 1);
+        var decay = DecayLadder[idx];
+
+        var streakBonus = 1.0m + Math.Min(Math.Max(streak, 0) * StreakStep, StreakCap);
+
+        var payday = paydayMult is PaydayMult or JackpotMult ? paydayMult : 1;
+        var leverMult = LeverMultDec(lever);
+
+        // DECIMAL, not double, all the way to the rounding. Every rate in the table is a base-10
+        // fraction that binary floating point cannot hold exactly, and the error lands precisely
+        // where it hurts: 0.15 x 1.5 x 100 comes out as 22.499999999999996, so a half-up rounding
+        // that should have paid 23 quietly pays 22. Money rounds in decimal.
+        var mult = decay * streakBonus * payday * leverMult;
+        // Round half-up at the very end (Math.Round is banker's rounding, which would shave a
+        // ticket off every .5 in the table).
+        var tickets = (int)Math.Floor(baseAmount * mult + 0.5m);
+        if (tickets < TicketFloor) tickets = TicketFloor;
+
+        return new TicketPayout(tickets, baseAmount, (double)Math.Round(mult, 2),
+            (double)decay, (double)Math.Round(streakBonus, 2), payday, (double)leverMult);
+    }
+
+    /// <summary>Is this a grade that mints a token? S and S+ only, and never a zen pass.</summary>
+    public static bool IsTokenGrade(string? grade, bool zen) =>
+        !zen && (string.Equals(grade, "S", StringComparison.OrdinalIgnoreCase)
+                 || string.Equals(grade, "S+", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Is this a grade that opens the Extra Credit notch? A or better.</summary>
+    public static bool IsExtraCreditGrade(string? grade) =>
+        string.Equals(grade, "A", StringComparison.OrdinalIgnoreCase) || IsTokenGrade(grade, false);
+
+    // ============================ tonight's payday ============================
+
+    /// <summary>Which room is paying extra tonight, and by how much.</summary>
+    public readonly record struct Payday(string? GameKey, int Mult);
+
+    /// <summary>
+    /// THE NIGHTLY DRAW, school-wide and seeded. Every enrolled room is scored by hashing the UTC
+    /// date seed with its own key and the highest score wins, which makes the answer independent of
+    /// the ORDER the roster arrives in — a caller that sorts and a caller that does not agree, and
+    /// there is no live roll anywhere to drift between machines.
+    ///
+    /// <para>An empty roster has no payday at all (mult 1), which is the honest answer on a save
+    /// where nobody has enrolled in anything yet.</para>
+    /// </summary>
+    public static Payday PickPayday(string? utcDateSeed, IEnumerable<string>? enrolledGameKeys)
+    {
+        if (string.IsNullOrWhiteSpace(utcDateSeed)) return new Payday(null, 1);
+        var keys = (enrolledGameKeys ?? Enumerable.Empty<string>())
+            .Where(k => !string.IsNullOrWhiteSpace(k))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (keys.Count == 0) return new Payday(null, 1);
+
+        string? best = null;
+        uint bestScore = 0;
+        foreach (var k in keys)
+        {
+            var score = Hash("payday|" + utcDateSeed + "|" + k);
+            // Ordinal tie-break so a hash collision cannot make the answer depend on list order.
+            if (best == null || score > bestScore
+                || (score == bestScore && string.CompareOrdinal(k, best) < 0))
+            {
+                best = k;
+                bestScore = score;
+            }
+        }
+
+        var jackpot = Hash("jackpot|" + utcDateSeed) % JackpotOdds == 0;
+        return new Payday(best, jackpot ? JackpotMult : PaydayMult);
+    }
+
+    /// <summary>Tonight's multiplier for ONE room: 1 unless it is the room the draw picked.</summary>
+    public static int PaydayMultFor(Payday payday, string? gameKey) =>
+        payday.GameKey != null && string.Equals(payday.GameKey, gameKey, StringComparison.Ordinal)
+            ? payday.Mult : 1;
+
+    /// <summary>FNV-1a over UTF-16 code units. Small, stable, and identical on every machine — the
+    /// point is reproducibility, not cryptography, and <see cref="string.GetHashCode()"/> is
+    /// explicitly randomised per process, which would break exactly the property we need.</summary>
+    private static uint Hash(string s)
+    {
+        unchecked
+        {
+            uint h = 2166136261;
+            foreach (var ch in s)
+            {
+                h ^= ch;
+                h *= 16777619;
+            }
+            return h;
+        }
+    }
+
+    // ============================ the prize catalog ============================
+
+    /// <summary>One row on the shelf. <c>Cur</c> is "t" (tickets) or "k" (tokens); <c>Kind</c> is
+    /// cosmetic / consumable / unlock / display.</summary>
+    /// <param name="StackMax">Consumables only: how many the player may hold at once.</param>
+    /// <param name="Locked">A case slot that is dressed but not for sale yet.</param>
+    public sealed record CatalogItem(
+        string Sku, string Cur, int Cost, string Kind,
+        string NameKey, string NameEn, string BlurbKey, string BlurbEn,
+        int StackMax = 0, bool Locked = false);
+
+    public const string CurTickets = "t";
+    public const string CurTokens = "k";
+
+    public const string SkuLateSlip = "late_slip";
+    public const string SkuHonorsLever = "honors_lever";
+    public const string SkuFreeSwimKey = "free_swim_key";
+    public const string SkuDeepEndWideBoard = "de_5x5";
+
+    /// <summary>
+    /// THE SHELF. C# is the single source: <c>init</c> projects this and the page only renders it,
+    /// so nothing about a price or an effect can be argued from the page side.
+    ///
+    /// <para>NOTHING ON SAFETY IS EVER FOR SALE (three-tier law) — no intensity ceiling, no consent
+    /// rung, no mute, no panic key. What is here is frames, garnish, a streak insurance slip, and
+    /// three doors that only ever ADD an option.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<CatalogItem> Catalog = new List<CatalogItem>
+    {
+        new("id_frame_gold", CurTickets, 300, "cosmetic",
+            "prize_id_frame_gold", "Gold Pinstripe Frame",
+            "prize_id_frame_gold_blurb",
+            "A thin gold pinstripe around your ID photo, for the student who likes being seen."),
+        new("id_frame_navy", CurTickets, 300, "cosmetic",
+            "prize_id_frame_navy", "Navy Varsity Frame",
+            "prize_id_frame_navy_blurb",
+            "Deep navy with a varsity edge, the kind the old team photos in the hall wear."),
+        new("confetti_stamp", CurTickets, 150, "cosmetic",
+            "prize_confetti_stamp", "Confetti Stamp",
+            "prize_confetti_stamp_blurb",
+            "Your stamp lands in a little burst of paper now, every single time it lands."),
+        new(SkuLateSlip, CurTickets, 250, "consumable",
+            "prize_late_slip", "Late Slip",
+            "prize_late_slip_blurb",
+            "Slide one across the desk and a single missed day never touches your streak.",
+            StackMax: 3),
+        new(SkuHonorsLever, CurTokens, 1, "unlock",
+            "prize_honors_lever", "Honors Lever",
+            "prize_honors_lever_blurb",
+            "Unbolts the third notch on the lever, which is where the S+ nights live."),
+        new(SkuFreeSwimKey, CurTokens, 1, "unlock",
+            "prize_free_swim_key", "Free Swim Key",
+            "prize_free_swim_key_blurb",
+            "Opens Free Swim on every room you are enrolled in, punched card or not."),
+        new(SkuDeepEndWideBoard, CurTokens, 2, "unlock",
+            "prize_de_5x5", "The Wide Board",
+            "prize_de_5x5_blurb",
+            "Adds the roomy 5x5 board to The Deep End, for a longer and gentler soak."),
+        new("jukebox", CurTokens, 3, "display",
+            "prize_jukebox", "Jukebox",
+            "prize_jukebox_blurb",
+            "The slot is dressed and the case is empty. The desk says it is on the truck.",
+            Locked: true),
+    };
+
+    public static CatalogItem? Find(string? sku) =>
+        sku == null ? null : Catalog.FirstOrDefault(c => string.Equals(c.Sku, sku, StringComparison.Ordinal));
+
+    /// <summary>Which unlock flag a token door flips, if any. Kept beside the catalog so a new
+    /// unlock is one row plus one line here rather than a hunt through the host.</summary>
+    private static string? UnlockFlagFor(string sku) => sku switch
+    {
+        SkuHonorsLever => "honors",
+        _ => null,
+    };
+
+    // ============================ wallet ============================
+
+    private const int TokenDayHistory = 14;
+    private const int PayDayHistory = 14;
+    private const int LogHistory = 40;
+
+    /// <summary>Fill in every field the rest of this file assumes, in place. Safe to call on an
+    /// empty object, on a half-written one, and on a wallet whose fields were left the wrong type
+    /// by a hand-edited save — a wrong type is REPLACED rather than trusted, because a wallet that
+    /// throws mid-payout would cost the player the class credit riding the same frame.</summary>
+    public static JObject EnsureShape(JObject? w)
+    {
+        var wallet = w ?? new JObject();
+        EnsureInt(wallet, "t");
+        EnsureInt(wallet, "k");
+        EnsureInt(wallet, "earnedT");
+        EnsureInt(wallet, "earnedK");
+        if (wallet["tokenDays"] is not JArray) wallet["tokenDays"] = new JArray();
+        if (wallet["payDays"] is not JObject) wallet["payDays"] = new JObject();
+        if (wallet["inv"] is not JObject) wallet["inv"] = new JObject();
+        if (wallet["unlocks"] is not JObject) wallet["unlocks"] = new JObject();
+        if (wallet["log"] is not JArray) wallet["log"] = new JArray();
+        var unlocks = (JObject)wallet["unlocks"]!;
+        if (unlocks["extra"] is not JValue { Type: JTokenType.Boolean }) unlocks["extra"] = false;
+        if (unlocks["honors"] is not JValue { Type: JTokenType.Boolean }) unlocks["honors"] = false;
+        return wallet;
+    }
+
+    private static void EnsureInt(JObject w, string key)
+    {
+        var v = w[key] as JValue;
+        if (v is { Type: JTokenType.Integer }) return;
+        int parsed = 0;
+        if (v is { Type: JTokenType.Float }) { try { parsed = Convert.ToInt32((double)v); } catch { parsed = 0; } }
+        w[key] = Math.Max(parsed, 0);
+    }
+
+    public static int Tickets(JObject w) => (int?)EnsureShape(w)["t"] ?? 0;
+    public static int Tokens(JObject w) => (int?)EnsureShape(w)["k"] ?? 0;
+
+    public static bool ExtraUnlocked(JObject w) => (bool?)EnsureShape(w)["unlocks"]?["extra"] ?? false;
+    public static bool HonorsUnlocked(JObject w) => (bool?)EnsureShape(w)["unlocks"]?["honors"] ?? false;
+
+    /// <summary>Does the player hold this sku at all? Cosmetics and unlocks are one-and-done;
+    /// a consumable answers true while any remain.</summary>
+    public static bool Owns(JObject w, string sku) => Held(w, sku) > 0;
+
+    /// <summary>How many of a sku are on hand (1 for an owned one-off, 0 for anything unowned).</summary>
+    public static int Held(JObject w, string sku)
+    {
+        var inv = EnsureShape(w)["inv"] as JObject;
+        if (inv?[sku] is not JObject row) return 0;
+        return Math.Max((int?)row["n"] ?? 0, 0);
+    }
+
+    /// <summary>Credit tickets. Both the balance and the lifetime total move together — the second
+    /// is what the records room reads, and it must never go down when the first is spent.</summary>
+    public static void EarnTickets(JObject w, int amount)
+    {
+        if (amount <= 0) return;
+        var wallet = EnsureShape(w);
+        wallet["t"] = ((int?)wallet["t"] ?? 0) + amount;
+        wallet["earnedT"] = ((int?)wallet["earnedT"] ?? 0) + amount;
+    }
+
+    /// <summary>
+    /// THE ONE TOKEN A DAY. Claimed against the LOCAL date, cloned from the XP ledger's shape: true
+    /// the first time a date is seen and false forever after, so a second S before midnight mints
+    /// nothing no matter how the frame is dressed.
+    /// </summary>
+    /// <returns>True when a token was actually minted.</returns>
+    public static bool TryMintToken(JObject w, string? localDate)
+    {
+        if (string.IsNullOrWhiteSpace(localDate)) return false;
+        var wallet = EnsureShape(w);
+        var days = (JArray)wallet["tokenDays"]!;
+        if (days.Any(d => string.Equals((string?)d, localDate, StringComparison.Ordinal))) return false;
+
+        days.Add(localDate);
+        // Ordinal order IS chronological for yyyy-MM-dd, so the ledger's SkipLast shape works here.
+        var kept = days.Select(d => (string?)d).Where(d => d != null)
+            .OrderBy(d => d, StringComparer.Ordinal)
+            .TakeLast(TokenDayHistory).ToList();
+        if (kept.Count < days.Count)
+        {
+            days.RemoveAll();
+            foreach (var d in kept) days.Add(d);
+        }
+
+        wallet["k"] = ((int?)wallet["k"] ?? 0) + 1;
+        wallet["earnedK"] = ((int?)wallet["earnedK"] ?? 0) + 1;
+        return true;
+    }
+
+    /// <summary>
+    /// Count one paid finish for (day, room) and answer how many came BEFORE it — which is exactly
+    /// the index the decay ladder wants. Called once per graded finish, before the sum.
+    /// </summary>
+    public static int NotePlay(JObject w, string? localDate, string? gameKey)
+    {
+        if (string.IsNullOrWhiteSpace(localDate) || string.IsNullOrWhiteSpace(gameKey)) return 0;
+        var wallet = EnsureShape(w);
+        var days = (JObject)wallet["payDays"]!;
+        if (days[localDate] is not JObject day)
+        {
+            day = new JObject();
+            days[localDate] = day;
+        }
+        var prior = Math.Max((int?)day[gameKey] ?? 0, 0);
+        day[gameKey] = prior + 1;
+
+        foreach (var stale in days.Properties().Select(p => p.Name)
+                     .OrderBy(n => n, StringComparer.Ordinal)
+                     .SkipLast(PayDayHistory).ToList())
+        {
+            days.Remove(stale);
+        }
+        return prior;
+    }
+
+    /// <summary>Open the Extra Credit notch. Idempotent, and only ever opens.</summary>
+    /// <returns>True the once, when it actually flipped.</returns>
+    public static bool TryUnlockExtraCredit(JObject w, string? grade)
+    {
+        if (!IsExtraCreditGrade(grade)) return false;
+        var wallet = EnsureShape(w);
+        var unlocks = (JObject)wallet["unlocks"]!;
+        if ((bool?)unlocks["extra"] == true) return false;
+        unlocks["extra"] = true;
+        return true;
+    }
+
+    /// <summary>
+    /// SPEND A LATE SLIP. Called from the attendance path when the gap is exactly one missed day:
+    /// one slip comes off the stack and the streak carries on as though the player had been there.
+    /// </summary>
+    /// <returns>True when a slip was actually spent.</returns>
+    public static bool ConsumeLateSlip(JObject w)
+    {
+        var wallet = EnsureShape(w);
+        var inv = (JObject)wallet["inv"]!;
+        if (inv[SkuLateSlip] is not JObject row) return false;
+        var n = Math.Max((int?)row["n"] ?? 0, 0);
+        if (n <= 0) return false;
+        if (n == 1) inv.Remove(SkuLateSlip);
+        else row["n"] = n - 1;
+        return true;
+    }
+
+    /// <summary>The outcome of a <c>prize-buy</c>. <c>Reason</c> is one of unknown / poor / owned /
+    /// full / locked, and it is null when the trade went through.</summary>
+    public readonly record struct BuyResult(bool Ok, string? Reason, CatalogItem? Item);
+
+    /// <summary>
+    /// THE COUNTER. Validation is host-side only, in this order: is it a thing, is it for sale, do
+    /// they already have it, is their pocket full, can they afford it. Nothing is deducted until
+    /// every one of those has passed, so a refusal can never leave the wallet half-spent.
+    /// </summary>
+    public static BuyResult Buy(JObject w, string? sku, string? localDate)
+    {
+        var item = Find(sku);
+        if (item == null) return new BuyResult(false, "unknown", null);
+        if (item.Locked) return new BuyResult(false, "locked", item);
+
+        var wallet = EnsureShape(w);
+        var held = Held(wallet, item.Sku);
+        if (item.Kind == "consumable")
+        {
+            if (held >= Math.Max(item.StackMax, 1)) return new BuyResult(false, "full", item);
+        }
+        else if (held > 0) return new BuyResult(false, "owned", item);
+
+        var purse = item.Cur == CurTokens ? "k" : "t";
+        var have = (int?)wallet[purse] ?? 0;
+        if (have < item.Cost) return new BuyResult(false, "poor", item);
+
+        wallet[purse] = have - item.Cost;
+
+        var inv = (JObject)wallet["inv"]!;
+        if (inv[item.Sku] is JObject row) row["n"] = held + 1;
+        else inv[item.Sku] = new JObject { ["n"] = 1 };
+        ((JObject)inv[item.Sku]!)["at"] = localDate ?? "";
+
+        var flag = UnlockFlagFor(item.Sku);
+        if (flag != null) ((JObject)wallet["unlocks"]!)[flag] = true;
+
+        var log = (JArray)wallet["log"]!;
+        log.Add(new JObject
+        {
+            ["sku"] = item.Sku,
+            ["cur"] = item.Cur,
+            ["cost"] = item.Cost,
+            ["at"] = localDate ?? "",
+        });
+        while (log.Count > LogHistory) log.RemoveAt(0);
+
+        return new BuyResult(true, null, item);
+    }
+
+    // ============================ projections ============================
+
+    /// <summary>The catalog as <c>init.economy.catalog</c> — every row, priced, with both the
+    /// lexicon key and the neutral English so a page with a partial table still reads.</summary>
+    public static JArray CatalogJson()
+    {
+        var arr = new JArray();
+        foreach (var c in Catalog)
+        {
+            var row = new JObject
+            {
+                ["sku"] = c.Sku,
+                ["cur"] = c.Cur,
+                ["cost"] = c.Cost,
+                ["kind"] = c.Kind,
+                ["nameKey"] = c.NameKey,
+                ["nameEn"] = c.NameEn,
+                ["blurbKey"] = c.BlurbKey,
+                ["blurbEn"] = c.BlurbEn,
+            };
+            // `max` on the wire, not `stackMax`: the counter reads `row.max` for its "2 of 3"
+            // badge, and the shorter name is the one the page already had. Display only either
+            // way - the host is what refuses the third late slip, with reason "full".
+            if (c.StackMax > 0) row["max"] = c.StackMax;
+            if (c.Locked) row["locked"] = true;
+            arr.Add(row);
+        }
+        return arr;
+    }
+
+    /// <summary>A clone of what the player holds, for the counter's owned badges.</summary>
+    public static JObject InvJson(JObject w) => (JObject)EnsureShape(w)["inv"]!.DeepClone();
+
+    /// <summary>A clone of the two lever rungs.</summary>
+    public static JObject UnlocksJson(JObject w) => (JObject)EnsureShape(w)["unlocks"]!.DeepClone();
+
+    /// <summary>Just the balances — what every reply carries so the page never has to add up.</summary>
+    public static JObject BalanceJson(JObject w)
+    {
+        var wallet = EnsureShape(w);
+        return new JObject { ["t"] = (int?)wallet["t"] ?? 0, ["k"] = (int?)wallet["k"] ?? 0 };
+    }
+
+    // ============================ dates ============================
+
+    /// <summary>Whole days from <paramref name="from"/> to <paramref name="to"/>, or -1 when either
+    /// date is missing or unreadable. Same yyyy-MM-dd invariant shape the rest of the school uses.
+    /// A gap of 1 is an unbroken streak; a gap of 2 is the one a late slip can cover.</summary>
+    public static int DayGap(string? from, string? to)
+    {
+        if (string.IsNullOrWhiteSpace(from) || string.IsNullOrWhiteSpace(to)) return -1;
+        if (!DateTime.TryParseExact(from, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var a)) return -1;
+        if (!DateTime.TryParseExact(to, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var b)) return -1;
+        var days = (b.Date - a.Date).TotalDays;
+        return days is >= 0 and < int.MaxValue ? (int)days : -1;
+    }
+}

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -535,6 +535,10 @@ internal static class ArcademyHostService
                 break;
             case "class-started":
                 _classActive = true;
+                // THE EXTRA CREDIT LEVER, remembered rather than believed. The page says which
+                // notch it thinks it pulled; the host clamps it against what is actually unlocked
+                // and holds the answer until class-ended asks. The page never echoes a multiplier.
+                NotePendingLever((string?)o["gameKey"], (string?)o["lever"]);
                 App.Logger?.Information("ArcademyHost: class started ({Game}, tier {Tier})",
                     (string?)o["gameKey"], (int?)o["gradeTier"] ?? 0);
                 // CAMPUS PRESENCE: a door opened. Best-effort and gated on the share rung inside;
@@ -546,6 +550,9 @@ internal static class ArcademyHostService
                 break;
             case "enrollment-done":
                 OnEnrollmentDone(o);
+                break;
+            case "prize-buy":
+                OnPrizeBuy(o);
                 break;
             case "class-left":
                 // The closing bracket for `class-started`. Leaving a class with Esc ends no class,
@@ -713,7 +720,63 @@ internal static class ArcademyHostService
             // THE STUDENT ID (STUDENT ID contract, "Wire contract"). Who the card is made out to,
             // whether there is a photo on it, and the one consent rung that governs both.
             profile = BuildProfile(s),
+            // THE PRIZE COUNTER. The shelf, tonight's payday and the two lever rungs, all resolved
+            // here - the page renders the catalog it is handed and never prices anything. The
+            // WALLET itself is not here: it rides `meta` above under its own host-owned key, so
+            // there is exactly one copy of the balances on the wire.
+            economy = BuildEconomy(),
         };
+    }
+
+    /// <summary>
+    /// THE PRIZE COUNTER's projection. Wrapped like every other optional block here: a throw would
+    /// kill <c>init</c>, and a page that never gets <c>init</c> never boots. A failure costs the
+    /// shelf its stock for the session, never the Arcademy.
+    ///
+    /// <para><c>payday</c> is the SEEDED nightly draw, computed once here off the UTC date and the
+    /// enrolled roster (<see cref="ArcademyEconomy.PickPayday"/>) so every machine on the same day
+    /// agrees. The page displays it; it never rolls anything.</para>
+    /// </summary>
+    private static object BuildEconomy()
+    {
+        try
+        {
+            var payday = ArcademyEconomy.PickPayday(
+                DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                _meta?.EnrolledGameKeys());
+            var (extra, honors) = _meta?.LeverUnlocks() ?? (false, false);
+            return new
+            {
+                catalog = ArcademyEconomy.CatalogJson(),
+                payday = new { gameKey = payday.GameKey, mult = payday.Mult },
+                leverUnlocks = new { extra, honors },
+                // Which per-game setting VALUES the counter holds the door on. One row today
+                // (The Deep End's wide board); the settings page draws a locked value from this
+                // rather than guessing which enum entry a sku is talking about. The host refuses
+                // the write regardless (PrizeGateAllows), so this is dressing, never the gate.
+                settingUnlocks = new JArray
+                {
+                    new JObject
+                    {
+                        ["key"] = DeepEndBoardSizeKey,
+                        ["value"] = DeepEndWideBoard,
+                        ["sku"] = ArcademyEconomy.SkuDeepEndWideBoard,
+                        ["owned"] = _meta?.WalletOwns(ArcademyEconomy.SkuDeepEndWideBoard) == true,
+                    },
+                },
+            };
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyHost.BuildEconomy: {E}", ex.Message);
+            return new
+            {
+                catalog = new JArray(),
+                payday = new { gameKey = (string?)null, mult = 1 },
+                leverUnlocks = new { extra = false, honors = false },
+                settingUnlocks = new JArray(),
+            };
+        }
     }
 
     /// <summary>
@@ -1402,8 +1465,91 @@ internal static class ArcademyHostService
         ["grade_tier_2"] = "Year 2",
         ["grade_tier_3"] = "Year 3",
         ["grade_tier_4"] = "Year 4",
+        // The one letter with punctuation in it. 'grade_s+' is not a key shape a lexicon row
+        // (or a mod table) can carry, so core/lexicon.js spells it out and so does this.
+        ["grade_splus"] = "S+",
         ["attendance"] = "Attendance",
         ["perfect_attendance"] = "Perfect Attendance",
+        // ---- the Prize Counter (economy, 2026-08-26) -----------------------------------
+        // Every row here is the front desk talking: warm, a bit scruffy, never a form letter.
+        // These keys are the ONES THE PAGE ACTUALLY ASKS FOR: core/lexicon.js carries the same
+        // set as its offline fallback and shell/lever.js + shell/prizecounter.js look them up
+        // by exactly these names. A row nothing calls is a row a mod would re-voice for
+        // nothing, so the list is kept to what is consumed and the harness checks both ways.
+        // ---- the door on the west wall
+        ["campus_room_prizes"] = "Prize Counter",
+        ["campus_prizes_status"] = "Open late",
+        ["campus_desc_prizes"] = "Tickets on the shelf, tokens in the case. Somebody is always restocking.",
+        // ---- the two currencies, as they read on a chip
+        ["wallet_tickets"] = "Tickets",
+        ["wallet_tokens"] = "Tokens",
+        // ---- the counter itself
+        ["prize_counter_title"] = "Prize Counter",
+        ["prize_counter_sub"] = "Tickets on the shelf, tokens in the case",
+        ["prize_shelf"] = "Ticket Shelf",
+        ["prize_shelf_hint"] = "Every graded class pays tickets. This is where they go.",
+        ["prize_case"] = "Token Case",
+        ["prize_case_hint"] = "Tokens only. Your first S of the day drops one in the tray.",
+        ["prize_you_have"] = "On you",
+        ["prize_owned"] = "Yours",
+        ["prize_held"] = "Holding",
+        ["prize_buy"] = "Trade",
+        ["prize_soon"] = "Arriving soon",
+        ["prize_wait"] = "Asking the counter",
+        // What the counter says back. The five refusals line up one for one with the reason
+        // strings on `wallet-result` (unknown / poor / owned / full / locked); the last two are
+        // what the page says on its own when no answer came back at all.
+        ["prize_bought"] = "Wrapped up and yours.",
+        ["prize_poor"] = "Not quite enough on you for that one yet.",
+        ["prize_owned_msg"] = "You have that one already.",
+        ["prize_full"] = "Your pockets are full of those. Use one first.",
+        ["prize_locked_msg"] = "That one stays in the case for now.",
+        ["prize_unknown"] = "The counter does not know that one. Odd.",
+        ["prize_quiet"] = "The counter went quiet on that one. Try again in a moment.",
+        ["prize_empty"] = "Shelf is bare tonight. Come back when the truck has been.",
+        // Tonight's hot room, painted from the seeded draw `init` already handed down.
+        ["prize_payday_label"] = "Hot room tonight",
+        ["prize_payday_2"] = "is paying double",
+        ["prize_payday_5"] = "is paying five times over",
+        // The eight rows on the shelf. Names and blurbs both, so a page with a partial mod
+        // table still reads (the catalog also ships the neutral English on the wire). Keyed
+        // EXACTLY as ArcademyEconomy.Catalog's NameKey/BlurbKey - a missing row here is a blank
+        // label on the shelf, so the harness checks the two lists against each other.
+        ["prize_id_frame_gold"] = "Gold Pinstripe Frame",
+        ["prize_id_frame_gold_blurb"] = "A thin gold pinstripe around your ID photo, for being seen.",
+        ["prize_id_frame_navy"] = "Navy Varsity Frame",
+        ["prize_id_frame_navy_blurb"] = "Deep navy with a varsity edge, like the old team photos.",
+        ["prize_confetti_stamp"] = "Confetti Stamp",
+        ["prize_confetti_stamp_blurb"] = "Your stamp lands in a little burst of paper now, every time.",
+        ["prize_late_slip"] = "Late Slip",
+        ["prize_late_slip_blurb"] = "Slide one over and a single missed day never touches your streak.",
+        ["prize_honors_lever"] = "Honors Lever",
+        ["prize_honors_lever_blurb"] = "Unbolts the third notch, which is where the S+ nights live.",
+        ["prize_free_swim_key"] = "Free Swim Key",
+        ["prize_free_swim_key_blurb"] = "Opens Free Swim on every room you are in, card or no card.",
+        ["prize_de_5x5"] = "The Wide Board",
+        ["prize_de_5x5_blurb"] = "Adds the roomy 5x5 board to The Deep End, for a gentler soak.",
+        ["prize_jukebox"] = "Jukebox",
+        ["prize_jukebox_blurb"] = "The slot is dressed and the case is empty. It is on the truck.",
+        // ---- the Extra Credit lever ----------------------------------------------------
+        // shell/lever.js owns the words on BOTH class-start surfaces (the door card and the
+        // painted room's apron), so every rung is one key and one locked line, no more.
+        ["lever_title"] = "Extra Credit",
+        ["lever_standard"] = "Standard",
+        ["lever_extra"] = "Extra Credit",
+        ["lever_honors"] = "Honors",
+        ["lever_standard_hint"] = "Play it straight. Tickets pay the usual.",
+        ["lever_extra_hint"] = "Half again the tickets, and it asks more of you.",
+        ["lever_honors_hint"] = "Double tickets, and the only road to an S plus.",
+        ["lever_extra_locked"] = "Earn an A on anything and this one wakes up.",
+        ["lever_honors_locked"] = "The counter sells this one for a token.",
+        // ---- the till, as it reads after a class ---------------------------------------
+        // The payday's own words live on the counter (prize_payday_*); what lands here is the
+        // report card's payout beat and the one purchase a player never watches being spent.
+        ["free_swim_key_hint"] = "Your key opens this one for a practice run. Nothing counts, nothing costs.",
+        ["payout_tickets"] = "Tickets",
+        ["payout_token_minted"] = "A token dropped in the tray. That is your one for today.",
+        ["late_slip_used"] = "A late slip covered you. Your streak never noticed.",
         // Reserved vocabulary: designed for, not built in v1 (GROUND-RULES §3).
         ["detention"] = "Detention",
         ["diploma"] = "Diploma",
@@ -2866,8 +3012,50 @@ internal static class ArcademyHostService
         if (Models.AppSettings.DefaultArcademyAudioLevels().ContainsKey(group))
             return SetAudioLevel(s, group, Num(0.5));
 
+        if (!PrizeGateAllows(s, key, value))
+        {
+            // Refused, never wiped: echo what is STORED so the page's pending paint converges on
+            // the truth rather than on the value it asked for (the keybinds precedent above).
+            return (ParseJsonObject(s.ArcademySettingsJson) ?? new JObject())[key];
+        }
         return SetGameSetting(s, key, value);
     }
+
+    /// <summary>
+    /// THE ONE PER-GAME KNOB THE PRIZE COUNTER GUARDS: The Deep End's wide board. The enum itself
+    /// is declared page-side in the game's manifest (a game file, which the economy does not
+    /// touch), so the door is held HERE — a value the player has not bought is refused on the way
+    /// in, and the counter's projection is what tells the page to draw the row as locked.
+    ///
+    /// <para>GRANDFATHERED, deliberately. 5x5 shipped free, so a save that already sits on it keeps
+    /// it: the gate only ever refuses a CHANGE onto the wide board, never yanks a player off one
+    /// they were already using. Nothing anyone already had is taken away.</para>
+    /// </summary>
+    private static bool PrizeGateAllows(Models.AppSettings s, string key, JToken? value)
+    {
+        if (!string.Equals(key, DeepEndBoardSizeKey, StringComparison.Ordinal)) return true;
+        if (!string.Equals((value as JValue)?.Value as string, DeepEndWideBoard, StringComparison.Ordinal))
+            return true;
+        try
+        {
+            var stored = (ParseJsonObject(s.ArcademySettingsJson) ?? new JObject())[key] as JValue;
+            if (string.Equals(stored?.Value as string, DeepEndWideBoard, StringComparison.Ordinal))
+                return true;   // already there before the counter existed - leave them on it
+            if (_meta?.WalletOwns(ArcademyEconomy.SkuDeepEndWideBoard) == true) return true;
+            App.Logger?.Information("ArcademyHost: the wide board is not bought yet - '{Key}' refused", key);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyHost.PrizeGateAllows: {E}", ex.Message);
+            return true;   // a wallet we cannot read never costs the player a setting
+        }
+    }
+
+    /// <summary>The Deep End's board-size knob and its wide value. Mirrors the game manifest's
+    /// <c>de_board_size</c> enum (<c>games/the-deep-end/index.js</c>) - the two must agree.</summary>
+    private const string DeepEndBoardSizeKey = "de_board_size";
+    private const string DeepEndWideBoard = "5x5";
 
     private static double SetAudioLevel(Models.AppSettings s, string group, double raw)
     {
@@ -2954,7 +3142,9 @@ internal static class ArcademyHostService
     /// <summary>Grade multiplier. Zen reports <c>pass</c> and pays the B row (DECISIONS #1).</summary>
     private static readonly Dictionary<string, double> XpGradeMult = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["S"] = 1.5, ["A"] = 1.25, ["B"] = 1.0, ["C"] = 0.6, ["pass"] = 1.0,
+        // S+ is the Honors-only rung (economy, 2026-08-26). It sits in the SAME table so the
+        // existing "unknown grade degrades to C" clamp below recognises it instead of eating it.
+        ["S+"] = 1.6, ["S"] = 1.5, ["A"] = 1.25, ["B"] = 1.0, ["C"] = 0.6, ["pass"] = 1.0,
     };
 
     /// <summary>Ceiling on the per-game flavour bonus, so a game can season its payout without
@@ -2970,6 +3160,52 @@ internal static class ArcademyHostService
     /// the field is free text off a postMessage and it must never be able to widen the table.</summary>
     private static readonly HashSet<string> DareKinds =
         new(StringComparer.Ordinal) { "S", "streak", "fast" };
+
+    // ============================ the Extra Credit lever ============================
+
+    /// <summary>
+    /// THE PENDING LEVER, per game key: what <c>class-started</c> claimed, already clamped against
+    /// what this save has unlocked. Process-lifetime on purpose — a crash mid-class simply means
+    /// the finish pays the standard rate, which is the safe way for this to fail. Persisting it
+    /// would buy nothing and would give a stale file a way to claim a multiplier.
+    /// </summary>
+    private static readonly Dictionary<string, string> _pendingLever = new(StringComparer.Ordinal);
+
+    /// <summary>Remember the clamped notch for <paramref name="gameKey"/>. Unknown text, and any
+    /// notch the player has not unlocked, become "standard".</summary>
+    private static void NotePendingLever(string? gameKey, string? lever)
+    {
+        try
+        {
+            var key = (gameKey ?? "").Trim();
+            if (key.Length == 0 || key.Length > 64) return;
+            var (extra, honors) = _meta?.LeverUnlocks() ?? (false, false);
+            var clamped = ArcademyEconomy.ClampLever(lever?.Trim(), extra, honors);
+            lock (_pendingLever)
+            {
+                // Bounded for the same reason every other page-fed map here is: there are a dozen
+                // rooms, and a frame loop must not be able to grow this without end.
+                if (clamped == "standard") _pendingLever.Remove(key);
+                else if (_pendingLever.Count < 64 || _pendingLever.ContainsKey(key))
+                    _pendingLever[key] = clamped;
+            }
+            if (clamped != "standard")
+                App.Logger?.Information("ArcademyHost: lever '{Lever}' armed for {Game}", clamped, key);
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.NotePendingLever: {E}", ex.Message); }
+    }
+
+    /// <summary>Read and CLEAR the pending notch. Once spent it is gone, so a second
+    /// <c>class-ended</c> for the same room pays the standard rate.</summary>
+    private static string TakePendingLever(string gameKey)
+    {
+        lock (_pendingLever)
+        {
+            if (!_pendingLever.TryGetValue(gameKey, out var lever)) return "standard";
+            _pendingLever.Remove(gameKey);
+            return lever;
+        }
+    }
 
     /// <summary>
     /// <c>class-ended</c> -> the ONE XP table, the attendance/streak write, and the
@@ -2994,6 +3230,20 @@ internal static class ArcademyHostService
             bool zen = ReadBool(o, "zen", false);
             var grade = (ReadString(o, "grade") ?? "").Trim();
             if (zen || !XpGradeMult.ContainsKey(grade)) grade = zen ? "pass" : "C";
+
+            // THE LEVER, read back and spent. Taken here rather than at the payout below because
+            // it also decides whether the S+ the page is claiming is even reachable.
+            var lever = TakePendingLever(gameKey);
+
+            // S+ IS UNREACHABLE OUTSIDE HONORS, so a claimed one that did not start on the Honors
+            // notch is degraded to a plain S rather than refused: the run really did grade at the
+            // top, it simply cannot be worth the Honors row. Never trust the page for a number.
+            if (string.Equals(grade, "S+", StringComparison.OrdinalIgnoreCase) && lever != "honors")
+            {
+                App.Logger?.Warning("ArcademyHost: S+ claimed for {Game} without the Honors lever - graded S",
+                    gameKey);
+                grade = "S";
+            }
             double flavor = Math.Clamp(ReadDouble(o, "flavorXp", 0), 0, FlavorXpCap);
 
             // THE FARM GUARD: one payout per class per UTC day. Replaying a class is a supported,
@@ -3045,7 +3295,14 @@ internal static class ArcademyHostService
             // running it unconditionally is what keeps a retake on a NEW local day (same UTC day,
             // player east of UTC) crediting the streak it has earned.
             var localDate = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-            var (streak, perfect, classesToday) = _meta?.RecordAttendance(localDate, gameKey) ?? (0, 0, 0);
+            var (streak, perfect, classesToday, lateSlipUsed) =
+                _meta?.RecordAttendance(localDate, gameKey) ?? (0, 0, 0, false);
+
+            // ============================ THE TILL ============================
+            // Tickets and tokens, wrapped on their own: the attendance credit above is the thing we
+            // must not lose, and the money must never become a second way to lose it. Everything
+            // here is host-decided - the frame carries a grade and a room, and nothing else.
+            var till = MintCurrency(gameKey, grade, zen, streak, localDate, lever);
 
             // THE PUNCH CARD RIDES THE ATTENDANCE CREDIT (PUNCHCARD §2.1). Same frame, same local
             // date, same idempotence - a graded finish is exactly the event that stamps, so there
@@ -3065,7 +3322,9 @@ internal static class ArcademyHostService
                 // degrade to "pass"/"C"), so this cannot be talked into an S by a junk field, and
                 // the mint's own per-day idempotence means a retake that grades S is still worth
                 // nothing (trap 23).
-                bool gradedS = string.Equals(grade, "S", StringComparison.OrdinalIgnoreCase);
+                // S+ counts as an S day here (economy, 2026-08-26): it is the same night's work
+                // with the lever pushed, and the double hole is the reward for the letter.
+                bool gradedS = ArcademyEconomy.IsTokenGrade(grade, zen: false);
                 punch = _meta?.StampPunchCard(gameKey, localDate, gradedS);
                 // A real punch is worth mirroring; a same-day retake is not. Debounced, so the
                 // enrollment ceremony's second mint rides the same request (PUNCHCARD §5).
@@ -3096,16 +3355,138 @@ internal static class ArcademyHostService
                 // Additive (EMI ASKS): what the dare bonus actually paid, so the page never has
                 // to guess. 0 on every class that carried no dare, and on a retake.
                 dareXp = darePaid ? DareBonusXp : 0,
+                // Additive (economy): the till, already counted. `tickets` is what was minted,
+                // `ticketBase`/`ticketMult` are its working so the debrief can show the lever and
+                // the payday doing their jobs, and `wallet` is the POST-mint balance, so the page
+                // never adds anything up itself.
+                grade,
+                tickets = till.Tickets,
+                ticketBase = till.Base,
+                ticketMult = till.Mult,
+                tokenMinted = till.TokenMinted,
+                payday = till.Payday,
+                lever = till.Lever,
+                lateSlipUsed,
+                wallet = till.Wallet,
             });
             PostPunchCard(gameKey, "daily", punch);
             App.Logger?.Information(
-                "ArcademyHost: class complete ({Game}, tier {Tier}, grade {Grade}) = {Xp:0} XP{Dare}{Retake}, streak {Streak}, {Today}/4 today",
+                "ArcademyHost: class complete ({Game}, tier {Tier}, grade {Grade}) = {Xp:0} XP{Dare}{Retake}, {Tickets} tickets (x{Mult}{Lever}){Token}, streak {Streak}, {Today}/4 today",
                 gameKey, tier, grade, xp,
                 darePaid ? " +" + DareBonusXp.ToString("0", CultureInfo.InvariantCulture) + " dare (" + dareWon + ")" : "",
                 firstToday ? "" : " (retake - already paid for " + dayUtc + ")",
+                till.Tickets, till.Mult.ToString("0.##", CultureInfo.InvariantCulture),
+                lever == "standard" ? "" : ", " + lever,
+                till.TokenMinted ? " +1 TOKEN" : "",
                 streak, classesToday);
         }
         catch (Exception ex) { App.Logger?.Warning("ArcademyHost.OnClassEnded: {E}", ex.Message); }
+    }
+
+    // ============================ the till ============================
+
+    /// <summary>What one finish put in the drawer, ready to ride <c>payout-result</c>.</summary>
+    private readonly record struct TillResult(
+        int Tickets, int Base, double Mult, bool TokenMinted,
+        int Payday, string Lever, JObject Wallet);
+
+    /// <summary>
+    /// TICKETS AND TOKENS for one graded finish. The whole sum lives in
+    /// <see cref="ArcademyEconomy"/>; this only gathers the inputs the store owns (the replay
+    /// counter, tonight's roster) and writes the result back.
+    ///
+    /// <para>Deliberately NOT gated on the XP farm guard. A retake is free XP-wise because the day's
+    /// seed makes it the same script, but it is still a night at the machine — the replay ladder is
+    /// what bounds it, dropping the second run to 40% and everything after to 15%.</para>
+    ///
+    /// <para>Wrapped whole: a wallet that threw would otherwise cost the frame that carries the
+    /// attendance credit, and no amount of money is worth a streak.</para>
+    /// </summary>
+    private static TillResult MintCurrency(string gameKey, string grade, bool zen, int streak,
+        string localDate, string lever)
+    {
+        var empty = new JObject { ["t"] = 0, ["k"] = 0 };
+        if (_meta == null || gameKey.Length == 0)
+            return new TillResult(0, 0, 1.0, false, 1, lever, empty);
+        try
+        {
+            // A first A-or-better is what opens the Extra Credit notch, so it is checked before
+            // anything is paid - the night that earns it does not get to use it, which is right.
+            _meta.TryUnlockExtraCredit(grade);
+
+            var prior = _meta.NoteWalletPlay(localDate, gameKey);
+            var payday = ArcademyEconomy.PickPayday(
+                DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                _meta.EnrolledGameKeys());
+            var paydayMult = ArcademyEconomy.PaydayMultFor(payday, gameKey);
+
+            var sum = ArcademyEconomy.ComputeTickets(grade, prior, streak, paydayMult, lever);
+            _meta.EarnTickets(sum.Tickets);
+
+            // ONE TOKEN A DAY, on the first S-rank of the LOCAL day, never from a zen pass.
+            // Independent of the tickets above: a token night still pays its tickets.
+            bool token = ArcademyEconomy.IsTokenGrade(grade, zen) && _meta.TryClaimTokenDay(localDate);
+
+            var wallet = _meta.WalletSnapshot();
+            return new TillResult(sum.Tickets, sum.Base, sum.Mult, token, paydayMult, lever,
+                ArcademyEconomy.BalanceJson(wallet));
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("ArcademyHost.MintCurrency: {E}", ex.Message);
+            return new TillResult(0, 0, 1.0, false, 1, lever, empty);
+        }
+    }
+
+    /// <summary>
+    /// <c>prize-buy {sku}</c> -> the counter. Validation is entirely host-side
+    /// (<see cref="ArcademyEconomy.Buy"/>): the frame carries a sku and nothing else, so there is
+    /// no price, no currency and no quantity on it to argue with.
+    ///
+    /// <para>The reply is posted on EVERY attempt, refusals included, because the counter settles
+    /// its UI only on the echo (nothing optimistic) — a silent refusal would leave the page holding
+    /// a spinner it could never put down.</para>
+    /// </summary>
+    private static void OnPrizeBuy(JObject o)
+    {
+        try
+        {
+            var sku = (ReadString(o, "sku") ?? "").Trim();
+            if (sku.Length > 64) sku = sku[..64];
+            if (_meta == null)
+            {
+                PostWalletResult(sku, false, "unknown", null);
+                return;
+            }
+
+            var localDate = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var result = _meta.Buy(sku, localDate);
+            if (result.Ok) _host?.Post(_meta.SnapshotMessage());
+            PostWalletResult(sku, result.Ok, result.Reason, _meta.WalletSnapshot());
+        }
+        catch (Exception ex) { App.Logger?.Warning("ArcademyHost.OnPrizeBuy: {E}", ex.Message); }
+    }
+
+    /// <summary>The <c>wallet-result</c> frame: same-frame truth for the counter, on the same
+    /// pattern <see cref="PostPunchCard"/> uses. Carries the post-trade balances, the whole
+    /// inventory and the lever rungs, so the shelf can repaint from one message.</summary>
+    private static void PostWalletResult(string sku, bool ok, string? reason, JObject? wallet)
+    {
+        try
+        {
+            var w = ArcademyEconomy.EnsureShape(wallet);
+            _host?.Post(new
+            {
+                type = "wallet-result",
+                ok,
+                sku,
+                reason,
+                wallet = ArcademyEconomy.BalanceJson(w),
+                inv = ArcademyEconomy.InvJson(w),
+                unlocks = ArcademyEconomy.UnlocksJson(w),
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.PostWalletResult: {E}", ex.Message); }
     }
 
     // ============================ enrollment-done: the first-run punches ============================

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
@@ -52,6 +52,12 @@ internal sealed class ArcademyMetaStore
     /// one. The math itself lives in <see cref="ArcademyPunchCards"/>.</summary>
     public const string PunchCardsKey = "punchCards";
 
+    /// <summary>Host-owned: the two-currency wallet — balances, the one-a-day token ledger, the
+    /// replay counters the decay ladder reads, what the player has bought and the two lever rungs.
+    /// Minted here for the plainest possible reason: it is MONEY, and a page that could write it
+    /// could print it. Shape and every rule about it live in <see cref="ArcademyEconomy"/>.</summary>
+    public const string WalletKey = "wallet";
+
     /// <summary>Classes in a day — the timetable's fixed size (GROUND-RULES §4).</summary>
     private const int ClassesPerDay = 4;
 
@@ -87,7 +93,7 @@ internal sealed class ArcademyMetaStore
     /// <c>class-ended</c>, so a set/merge naming one is dropped (and logged) rather than applied.</summary>
     private static readonly HashSet<string> HostOwnedKeys = new(StringComparer.Ordinal)
     {
-        AttendanceKey, StreakKey, PerfectKey, TodayClassesKey, XpPaidKey, PunchCardsKey,
+        AttendanceKey, StreakKey, PerfectKey, TodayClassesKey, XpPaidKey, PunchCardsKey, WalletKey,
     };
 
     private readonly object _lock = new();
@@ -208,18 +214,33 @@ internal sealed class ArcademyMetaStore
     /// toward perfect attendance. A gap of exactly one day continues the streak, a larger gap
     /// restarts it at 1, and a day already credited leaves the streak alone.</para>
     /// </summary>
-    /// <returns>(streak, perfectAttendance, classesToday) after the write.</returns>
-    public (int Streak, int Perfect, int ClassesToday) RecordAttendance(string localDate, string? gameKey)
+    /// <para>THE LATE SLIP (economy, 2026-08-26). A gap of exactly two days is one missed day, and
+    /// a slip on the shelf covers it: the slip is spent, the streak carries on as though the player
+    /// had been there, and the caller is told so the debrief can say so. Nothing wider than one day
+    /// is coverable, and a player with no slips is exactly where they were before.</para>
+    /// <returns>(streak, perfectAttendance, classesToday, lateSlipUsed) after the write.</returns>
+    public (int Streak, int Perfect, int ClassesToday, bool LateSlipUsed) RecordAttendance(
+        string localDate, string? gameKey)
     {
         lock (_lock)
         {
             var last = (string?)_state[AttendanceKey];
             int streak = (int?)_state[StreakKey] ?? 0;
             int perfect = (int?)_state[PerfectKey] ?? 0;
+            bool lateSlip = false;
 
             if (!string.Equals(last, localDate, StringComparison.Ordinal))
             {
-                streak = IsPreviousDay(last, localDate) ? streak + 1 : 1;
+                if (IsPreviousDay(last, localDate)) streak += 1;
+                else if (ArcademyEconomy.DayGap(last, localDate) == 2
+                         && ArcademyEconomy.ConsumeLateSlip(WalletUnlocked()))
+                {
+                    streak += 1;
+                    lateSlip = true;
+                    App.Logger?.Information(
+                        "ArcademyMetaStore: a late slip covered {Last} - streak carries on at {N}", last, streak);
+                }
+                else streak = 1;
                 _state[AttendanceKey] = localDate;
                 _state[StreakKey] = streak;
                 _state[TodayClassesKey] = new JArray();
@@ -244,7 +265,7 @@ internal sealed class ArcademyMetaStore
             }
 
             Touch();
-            return (streak, perfect, today.Count);
+            return (streak, perfect, today.Count, lateSlip);
         }
     }
 
@@ -406,6 +427,130 @@ internal sealed class ArcademyMetaStore
             }
             Touch();
             return true;
+        }
+    }
+
+    // ============================ the wallet ============================
+
+    /// <summary>The wallet bag, shape-ensured and created when absent. Called under the lock, and
+    /// deliberately NOT public: every mutation below goes through a named method so it can
+    /// <see cref="Touch"/>, exactly the way the punch cards do.</summary>
+    private JObject WalletUnlocked()
+    {
+        var wallet = ArcademyEconomy.EnsureShape(_state[WalletKey] as JObject);
+        if (!ReferenceEquals(_state[WalletKey], wallet)) _state[WalletKey] = wallet;
+        return wallet;
+    }
+
+    /// <summary>A CLONE of the wallet, for a projection or a reply. Never a live handle.</summary>
+    public JObject WalletSnapshot()
+    {
+        lock (_lock) return (JObject)WalletUnlocked().DeepClone();
+    }
+
+    /// <summary>Read one thing off the wallet without cloning the whole bag.</summary>
+    public bool WalletOwns(string sku)
+    {
+        lock (_lock) return ArcademyEconomy.Owns(WalletUnlocked(), sku);
+    }
+
+    /// <summary>(extraUnlocked, honorsUnlocked) — what the lever will actually accept tonight.</summary>
+    public (bool Extra, bool Honors) LeverUnlocks()
+    {
+        lock (_lock)
+        {
+            var w = WalletUnlocked();
+            return (ArcademyEconomy.ExtraUnlocked(w), ArcademyEconomy.HonorsUnlocked(w));
+        }
+    }
+
+    /// <summary>
+    /// Count one paid finish for (local day, game) and answer how many came BEFORE it — the index
+    /// the replay-decay ladder reads. The counters live here rather than page-side for the same
+    /// reason the XP ledger does: they are the only thing standing between a retake and a mint.
+    /// </summary>
+    public int NoteWalletPlay(string localDate, string? gameKey)
+    {
+        lock (_lock)
+        {
+            var prior = ArcademyEconomy.NotePlay(WalletUnlocked(), localDate, gameKey);
+            Touch();
+            return prior;
+        }
+    }
+
+    /// <summary>Credit tickets. Zero and negatives are no-ops and do not even bump the rev.</summary>
+    public void EarnTickets(int amount)
+    {
+        if (amount <= 0) return;
+        lock (_lock)
+        {
+            ArcademyEconomy.EarnTickets(WalletUnlocked(), amount);
+            Touch();
+        }
+    }
+
+    /// <summary>
+    /// Claim the one token <paramref name="localDate"/> is worth. True the first time that date is
+    /// seen and false forever after — the same shape as <see cref="TryClaimXpDay"/>, on its own
+    /// ledger inside the wallet rather than on the XP one, because the two roll on different clocks
+    /// (the token is LOCAL, #978; XP is seeded by the UTC day).
+    /// </summary>
+    public bool TryClaimTokenDay(string? localDate)
+    {
+        if (string.IsNullOrWhiteSpace(localDate)) return false;
+        lock (_lock)
+        {
+            if (!ArcademyEconomy.TryMintToken(WalletUnlocked(), localDate)) return false;
+            Touch();
+            App.Logger?.Information("ArcademyMetaStore: first S of {Date} - a token in the case", localDate);
+            return true;
+        }
+    }
+
+    /// <summary>Open the Extra Credit notch on a first A-or-better. Idempotent.</summary>
+    public bool TryUnlockExtraCredit(string? grade)
+    {
+        lock (_lock)
+        {
+            if (!ArcademyEconomy.TryUnlockExtraCredit(WalletUnlocked(), grade)) return false;
+            Touch();
+            App.Logger?.Information("ArcademyMetaStore: Extra Credit unlocked (first {Grade})", grade);
+            return true;
+        }
+    }
+
+    /// <summary>Spend at the Prize Counter. Every rule is <see cref="ArcademyEconomy.Buy"/>'s;
+    /// this only owns the lock, the rev bump and the log line.</summary>
+    public ArcademyEconomy.BuyResult Buy(string? sku, string localDate)
+    {
+        lock (_lock)
+        {
+            var result = ArcademyEconomy.Buy(WalletUnlocked(), sku, localDate);
+            if (result.Ok)
+            {
+                Touch();
+                App.Logger?.Information("ArcademyMetaStore: bought '{Sku}' for {Cost}{Cur}",
+                    result.Item?.Sku, result.Item?.Cost, result.Item?.Cur);
+            }
+            return result;
+        }
+    }
+
+    /// <summary>The rooms the player is enrolled in, ordinally sorted — the roster the nightly
+    /// payday draw runs over. Enrollment is the punch card's own <c>enrolledAt</c>, so there is no
+    /// second list here to keep in step with it.</summary>
+    public IReadOnlyList<string> EnrolledGameKeys()
+    {
+        lock (_lock)
+        {
+            if (_state[PunchCardsKey] is not JObject cards) return Array.Empty<string>();
+            return cards.Properties()
+                .Where(p => p.Value is JObject c
+                            && c[ArcademyPunchCards.EnrolledAtField] is JValue { Type: JTokenType.String })
+                .Select(p => p.Name)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToList();
         }
     }
 


### PR DESCRIPTION
Phase 1 of the approved meta-progression direction (artifact cfb4f320 take 3): the two-coin economy, the Prize Counter, and the Extra Credit lever. Night Classes stay parked for NG+.

## What ships
- **Wallet** — one new host-owned meta key (`wallet`), minted only in C# from `class-ended`; page can never forge it; survives the corruption salvage path. No server mirror in v1 (offline-first, punchCards-style philosophy).
- **Tickets** — every graded finish pays: S+ 160 / S 130 / A 100 / B 80 / C 60 / zen 40, then replay decay per game per local day (100/40/15%, floor 10 — losses pay scrap, never silence), attendance-streak bonus (+2%/day, cap +30%), and a seeded school-wide **Payday** (one room per UTC day pays x2; ~1/30 days it pays x5). Decimal end-to-end after the harness caught a floating-point rounding underpay.
- **Arcademy Tokens** — first S or S+ of the local day mints exactly one; hard cap 1/day; never from zen.
- **Prize Counter** (campus RM 003, east wall, neon TICKETS sign): shelf = Gold Pinstripe Frame 300 / Navy Varsity Frame 300 / Confetti Stamp 150 / Late Slip 250 (holds 3, auto-covers one missed streak day); token case = Honors Lever ◉1 / Free Swim Key ◉1 / The Wide Board (DE 5x5) ◉2 / Jukebox ◉3 locked "arriving soon". Catalog is C#-authoritative, projected at init; buy settles only on the `wallet-result` echo.
- **Extra Credit lever** on the class-start surfaces (door card + room apron via shared `lever.js`): Standard / Extra Credit x1.5 (wakes after your first A) / Honors x2 — the only road to the new **S+** grade (composite >= 0.97 under Honors). Host clamps lever positions and degrades any S+ claimed outside Honors.
- Payout debrief: ticket count-up + token-mint jackpot moment from existing ceremony/sfx/particle pieces. 58 new lexicon rows, all <= 96 chars, warm desk voice.

## Guardrails honored
- Safety/consent settings not purchasable; XP/stamps/attendance/promotions semantics untouched; Annex unreferenced.
- DE 5x5 was already free in the manifest, so its gate is **grandfathered**: a save already on 5x5 keeps it; the gate only applies forward.
- Impulse Control's debrief "TICKET" vocabulary retired (comments; no user-facing string existed) so Ticket = currency only.

## Verification
- `dotnet build` 0 errors.
- 159 C# assertions (pure money math incl. determinism, trims, refusal paths) + 78 Node assertions (counter, echo law, lever, S+, teardown, new cross-seam suite pinning lexicon coverage and wire-field names) — all green.
- In-app smoke test on a real screen (browse-only, real profile backed up and restored byte-identical): campus door, counter, refusal toast, lever locks all photographed; two CSS bugs found and fixed from it (counter scroll clip hid the jukebox slot; 26ch clamp ellipsised every lever hint).

## Known notes for review
- The door-card lever host is currently unreachable (all ten classes are scene-backed, so the room apron is the lever's live surface); the card wiring stays as future-proofing for scene-less rooms.
- Not exercised live: an actual Honors S+ run + token mint (a graded finish on the test box would have spent the real daily token) — first human play-test covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wjXe2g2jQ9fCo6EkUUFGz