### PR TITLE
fix(intake): boot watchdog - bound indexedDB open so Android Discord no longer sticks on the loader

### DIFF
--- a/ConditioningControlPanel/Resources/web/intake/boot.js
+++ b/ConditioningControlPanel/Resources/web/intake/boot.js
@@ -86,7 +86,13 @@ async function loadOptional(path, factoryName, makeFallback) {
 // takes over) so a missing/malformed bank degrades gracefully instead of wedging.
 async function loadBank(niche) {
   try {
-    const res = await fetch(`./banks/${niche}.json`, { cache: 'no-cache' });
+    // Bounded: a fetch that never settles (a mobile WebView on a bad radio) must
+    // not wedge the loader - past the deadline the placeholder takes over.
+    const ctl = (typeof AbortController === 'function') ? new AbortController() : null;
+    const timer = ctl ? setTimeout(() => ctl.abort(), BANK_FETCH_TIMEOUT_MS) : null;
+    let res;
+    try { res = await fetch(`./banks/${niche}.json`, { cache: 'no-cache', signal: ctl ? ctl.signal : undefined }); }
+    finally { if (timer) clearTimeout(timer); }
     if (!res.ok) { shim.log(`bank ${niche}: HTTP ${res.status} — using placeholder`); return null; }
     const bank = await res.json();
     if (!bank || !Array.isArray(bank.prompts) || !bank.prompts.length) {
@@ -104,6 +110,18 @@ shim.startHeartbeat();
 
 /** Chance, per card resolution, to sprinkle a Bambi-Sparkle giggle cue. */
 const GIGGLE_CHANCE = 0.03;
+
+/**
+ * BOOT WATCHDOG deadlines (ms). Every await between page load and the loader
+ * dropping is bounded, because one that never settles = a page stuck on
+ * "Opening Graded Intake..." with nothing to tell the player why. Seen for real
+ * 2026-08-26: Discord's Android activity WebView left indexedDB.open() pending
+ * forever, so feedForward() never returned (desktop, iPhone and the hosted
+ * mobile app - which skips feedForward - were all fine). core/stats.js now bounds
+ * the open itself; these are the belt to that brace, at the boot level.
+ */
+const BANK_FETCH_TIMEOUT_MS   = 15000;
+const FEED_FORWARD_TIMEOUT_MS = 5000;
 
 /**
  * Deliberate breather (ms) held on the normal answer -> next-card swap, so a
@@ -131,6 +149,7 @@ shim.onBoot(async (config) => {
     // --- build the stack (real module if present, else stub) --------------
     const ai = createAI(config.ai);
 
+    loaderStep('loading the room');
     const createReward = await loadOptional('./core/reward.js', 'createReward', stubReward);
     const createStats  = await loadOptional('./core/stats.js',  'createStats',  stubStats);
     const createBeats  = await loadOptional('./render/beats.js', 'createBeats',  null); // null -> inline stub render
@@ -147,6 +166,7 @@ shim.onBoot(async (config) => {
     const stats    = createStats();
 
     // Bank FIRST — the resolved theme feeds effects/beats and re-tints the page.
+    loaderStep('opening the bank');
     const bank  = config.bank || await loadBank(config.niche);
     const theme = themeOf(bank);
     applyTheme(theme);
@@ -199,9 +219,12 @@ shim.onBoot(async (config) => {
     const subjectId = resolveSubjectId(config);
     let priorRun = config.priorRun || null;
     if (!priorRun && !config.hosted && stats.feedForward) {
-      try { priorRun = await stats.feedForward(); } catch (_e) { /* best-effort */ }
+      loaderStep('consulting the archive');
+      try { priorRun = await bounded(stats.feedForward(), FEED_FORWARD_TIMEOUT_MS, 'feedForward'); }
+      catch (_e) { /* best-effort */ }
     }
 
+    loaderStep('');
     if (dom.loader) dom.loader.hidden = true;
 
     // --- REMOTE MEDIA: stock the pool while the menu is up ------------------
@@ -408,6 +431,37 @@ shim.log('boot: ready posted');
  * SMALL SHELL HELPERS — DOM sugar, pacing, guarded optional calls.
  * -------------------------------------------------------------------------- */
 function sleep(ms) { return new Promise((r) => setTimeout(r, Math.max(0, ms | 0))); }
+
+/**
+ * Await `promise` for at most `ms`; past that, reject (and log) so the boot moves
+ * on. The underlying work is NOT cancelled - it is simply no longer waited for.
+ */
+function bounded(promise, ms, label) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      shim.log(`boot: ${label} still pending after ${ms}ms — continuing without it`);
+      reject(new Error(`${label} timeout`));
+    }, Math.max(0, ms | 0));
+    Promise.resolve(promise).then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}
+
+/**
+ * Small caption under the loader ring naming the boot step in flight, so a
+ * stuck loader at least says WHERE it stuck (there are no devtools on a phone
+ * inside Discord). Created on first use; cleared right before the loader drops.
+ */
+function loaderStep(text) {
+  if (!doc || !dom.loader) return;
+  try {
+    let el = dom.loader.querySelector('.intake-loader-step');
+    if (!el) { el = doc.createElement('small'); el.className = 'intake-loader-step'; dom.loader.appendChild(el); }
+    el.textContent = text || '';
+  } catch (_e) { /* cosmetic */ }
+}
 
 /**
  * Tear down the pause menu from a path that cannot see the beat loop's `pause`

--- a/ConditioningControlPanel/Resources/web/intake/core/stats.js
+++ b/ConditioningControlPanel/Resources/web/intake/core/stats.js
@@ -199,21 +199,47 @@ function localStorageUsable() {
   } catch (_e) { return false; }
 }
 
-/** Open (or create) the IndexedDB database. Rejects on any failure. */
+/**
+ * How long an indexedDB.open() may sit with NO callback before we give up on it.
+ * Some mobile WebViews (Discord's Android activity WebView, 2026-08-26) leave the
+ * request pending forever - not success, not error, not blocked - and because the
+ * backend promise is memoised, every stats await downstream wedged with it: the
+ * boot's feedForward() never returned and the page sat on its "Opening..." loader.
+ * Past the deadline the open is treated exactly like a rejected one, so the
+ * backend chain falls through to localStorage (then memory) as designed.
+ */
+const IDB_OPEN_TIMEOUT_MS = 3000;
+
+/** Open (or create) the IndexedDB database. Rejects on any failure OR on timeout. */
 function openIDB() {
   return new Promise((resolve, reject) => {
     let req;
     try { req = indexedDB.open(IDB_NAME, 1); }
     catch (e) { reject(e); return; }
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error('idb open timeout'));
+    }, IDB_OPEN_TIMEOUT_MS);
+    const finish = (fn) => {
+      if (settled) {
+        // A late success after the timeout: we already fell through, so do not
+        // leave a stray open connection behind.
+        try { if (req.result && typeof req.result.close === 'function') req.result.close(); } catch (_e) { /* ignore */ }
+        return;
+      }
+      settled = true; clearTimeout(timer); fn();
+    };
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(IDB_STORE)) {
         db.createObjectStore(IDB_STORE, { keyPath: 'seq', autoIncrement: true });
       }
     };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error || new Error('idb open error'));
-    req.onblocked = () => reject(new Error('idb blocked'));
+    req.onsuccess = () => finish(() => resolve(req.result));
+    req.onerror = () => finish(() => reject(req.error || new Error('idb open error')));
+    req.onblocked = () => finish(() => reject(new Error('idb blocked')));
   });
 }
 

--- a/ConditioningControlPanel/Resources/web/intake/styles.css
+++ b/ConditioningControlPanel/Resources/web/intake/styles.css
@@ -74,6 +74,11 @@ body::after {
   animation: intake-spin .9s linear infinite;
 }
 @keyframes intake-spin { to { transform: rotate(360deg); } }
+/* Boot-step caption (boot.js loaderStep) — which await the loader is sitting on. */
+.intake-loader-step {
+  margin-top: -8px; font-size: 12px; letter-spacing: .04em;
+  color: var(--intake-dim); opacity: .8;
+}
 
 /* --- Phase-0 stub renderer widgets (replaced by Agent C) ------------------ */
 .intake-beat {


### PR DESCRIPTION
## Why

Mort (Android, UK) after the #93 iframe fix: desktop works start to finish, but on the Discord **mobile** client the activity loads, she picks Bambi, and the game sits on its own **"Opening Graded Intake…"** loader forever. The CCP mobile app runs the same game fine.

That loader is `public/intake/index.html` `#intake-loader`; `boot.js` hides it only after every pre-briefing await resolves. Of those, exactly one runs on the web path and NOT on the hosted (CCP app) path: `stats.feedForward()` (skipped when `config.hosted`). It goes through `core/stats.js` `openIDB()` = `indexedDB.open()` with **no timeout**. If the WebView leaves that request pending with no callback at all (no success / error / blocked), the memoised backend promise never settles, `feedForward` never returns, and the loader never drops. Desktop Chromium/Electron and the hosted app never hit it, which matches the report exactly.

Simulated locally (`indexedDB.open` returning a request that never fires): before, `feedForward()` hangs forever; after, it resolves `null` in 3.0s and `stats.record()` still lands on the fallback backend.

## What

- `core/stats.js`: `openIDB()` is bounded (3s). Past the deadline it rejects like any failed open, so the backend chain falls through to localStorage, then memory, exactly as designed. A late success closes the stray connection.
- `boot.js`: boot watchdog. `feedForward()` bounded at 5s (belt to the brace above); the bank fetch gets an `AbortController` deadline (15s) so a stalled radio can't wedge it either; a tiny caption under the loader ring names the step in flight (`loading the room` / `opening the bank` / `consulting the archive`) so if a phone ever sticks again the report says WHERE.
- `styles.css`: the caption style.

Applied by hand to the vendored copy (same patch as the desktop repo PR in `Conditioning-Control-Panel---CSharp-WPF`, `fix/intake-boot-watchdog`); the next `sync-intake` after both land reconciles cleanly. `#338` (share button) is still open there, so a sync from desktop main right now would drop the share button - hence not re-synced here.

## Test plan

- [ ] `node --check` on both files (done)
- [ ] After prod deploy: Mort retries on Android Discord - expect the briefing within ~3-5s of picking Bambi
- [ ] If it STILL sticks, the caption under the ring tells us which step
- [ ] Desktop/iPhone regression check: run boots as before, archive still records runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM6CRqKtSMeTtkoXw5UevE
