### PR TITLE
fix(intake): bound the three boot awaits #97 left unbounded

### DIFF
--- a/ConditioningControlPanel/Resources/web/intake/boot.js
+++ b/ConditioningControlPanel/Resources/web/intake/boot.js
@@ -69,7 +69,12 @@ if (typeof window !== 'undefined') {
 // Optional-module loader: import a module + factory, or fall back to a stub.
 async function loadOptional(path, factoryName, makeFallback) {
   try {
-    const mod = await import(path);
+    // Bounded: nine of these run back-to-back on the loader-blocking path, and an
+    // import whose fetch never settles is NOT catchable by this try/catch - the
+    // await simply never returns, so the loader sits on "Opening Graded Intake..."
+    // forever with no error to log. Past the deadline we take the fallback, which
+    // is the same degraded-but-alive outcome a 404 has always produced.
+    const mod = await bounded(import(path), MODULE_IMPORT_TIMEOUT_MS, `import ${path}`);
     const f = mod && mod[factoryName];
     if (typeof f === 'function') return f;
     shim.log(`module ${path}: no '${factoryName}' export — using fallback`);
@@ -88,13 +93,21 @@ async function loadBank(niche) {
   try {
     // Bounded: a fetch that never settles (a mobile WebView on a bad radio) must
     // not wedge the loader - past the deadline the placeholder takes over.
+    // The deadline must cover the BODY READ, not just the headers. Headers can
+    // arrive promptly and the body stream then stall forever, and res.json() on a
+    // stalled stream never settles - so clearing the timer before it left the
+    // loader wedged on exactly the bad radio this guard exists for. The banks are
+    // ~245KB, which is a real body to stall in the middle of. Aborting mid-body
+    // rejects res.json(), which the catch below turns into the placeholder.
     const ctl = (typeof AbortController === 'function') ? new AbortController() : null;
     const timer = ctl ? setTimeout(() => ctl.abort(), BANK_FETCH_TIMEOUT_MS) : null;
-    let res;
-    try { res = await fetch(`./banks/${niche}.json`, { cache: 'no-cache', signal: ctl ? ctl.signal : undefined }); }
-    finally { if (timer) clearTimeout(timer); }
-    if (!res.ok) { shim.log(`bank ${niche}: HTTP ${res.status} — using placeholder`); return null; }
-    const bank = await res.json();
+    let bank;
+    try {
+      const res = await fetch(`./banks/${niche}.json`, { cache: 'no-cache', signal: ctl ? ctl.signal : undefined });
+      if (!res.ok) { shim.log(`bank ${niche}: HTTP ${res.status} — using placeholder`); return null; }
+      // Belt to the abort brace: a browser with no AbortController is bounded anyway.
+      bank = await bounded(res.json(), BANK_FETCH_TIMEOUT_MS, `bank ${niche} body`);
+    } finally { if (timer) clearTimeout(timer); }
     if (!bank || !Array.isArray(bank.prompts) || !bank.prompts.length) {
       shim.log(`bank ${niche}: empty/invalid — using placeholder`); return null;
     }
@@ -122,6 +135,14 @@ const GIGGLE_CHANCE = 0.03;
  */
 const BANK_FETCH_TIMEOUT_MS   = 15000;
 const FEED_FORWARD_TIMEOUT_MS = 5000;
+/**
+ * Per-module deadline for the optional-module imports. Generous on purpose: the
+ * biggest of them (render/beats.js) is ~256KB and they are served with a 4h
+ * cache header, so 12s only ever fires on a stalled radio - never on a
+ * slow-but-working one, where tripping this would needlessly downgrade a player
+ * to the stub renderer.
+ */
+const MODULE_IMPORT_TIMEOUT_MS = 12000;
 
 /**
  * Deliberate breather (ms) held on the normal answer -> next-card swap, so a

--- a/ConditioningControlPanel/Resources/web/intake/core/stats.js
+++ b/ConditioningControlPanel/Resources/web/intake/core/stats.js
@@ -210,6 +210,14 @@ function localStorageUsable() {
  */
 const IDB_OPEN_TIMEOUT_MS = 3000;
 
+/**
+ * How long a single IndexedDB transaction request (add/getAll/put/clear) may sit
+ * with no callback before we give up on it. Larger than the open budget because a
+ * real write of a full run record is genuine work on a slow phone, but still small
+ * enough that a player never sits looking at a finished run with no certificate.
+ */
+const IDB_REQUEST_TIMEOUT_MS = 8000;
+
 /** Open (or create) the IndexedDB database. Rejects on any failure OR on timeout. */
 function openIDB() {
   return new Promise((resolve, reject) => {
@@ -245,9 +253,25 @@ function openIDB() {
 
 function idbBackend(db) {
   const tx = (mode) => db.transaction(IDB_STORE, mode).objectStore(IDB_STORE);
+  // Bounded for the same reason openIDB() is. A WebView that can leave an open()
+  // pending forever can leave a transaction request pending forever too, and the
+  // consequence is worse here because it lands at the END of a run: record() is
+  // awaited by the boot before the outro renders, and record()'s own try/catch
+  // cannot save it - a promise that never settles is not an error to catch. The
+  // player finishes every card and then watches nothing happen, with no
+  // certificate and therefore no share button. Past the deadline we reject, which
+  // record() already swallows as "this run loses its archive row" - the correct
+  // degraded outcome, and one the player never has to see.
   const wrap = (request) => new Promise((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error || new Error('idb request error'));
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error('idb request timeout'));
+    }, IDB_REQUEST_TIMEOUT_MS);
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); fn(); };
+    request.onsuccess = () => finish(() => resolve(request.result));
+    request.onerror = () => finish(() => reject(request.error || new Error('idb request error')));
   });
   return {
     kind: 'idb',


### PR DESCRIPTION
#97 bounded `indexedDB.open()`, `feedForward()` and the bank fetch. Three awaits on the loader-blocking path were still unbounded, and a promise that never settles is not an error any `try/catch` can catch.

### 1. `loadBank` - the abort timer did not cover the body read
The timer was cleared in a `finally` **before** `res.json()`, so the 15s budget covered response headers only. The banks are ~245KB, which is a real body to stall in the middle of: a radio that delivers headers and then stalls left `res.json()` pending forever. The timer now spans the body read, and `bounded()` backs it up for browsers with no `AbortController`.

### 2. `loadOptional` - bare dynamic `import()`
Nine of these run back to back before the loader drops. An import whose fetch never settles wedges the boot with nothing logged. Bounded at 12s, falling through to the same stub a 404 has always produced. Generous on purpose: the biggest module is ~256KB and ships with a 4h cache header, so this only fires on a stalled radio, never on a slow-but-working one.

### 3. `idbBackend`'s per-request `wrap()` - only `openIDB()` was bounded
This is the one that costs the most. `record()` is awaited **before the outro renders**, and `record()`'s own catch cannot save a promise that never settles. The player answers every card and then watches nothing happen: no certificate, and therefore no share button, since the share button is mounted onto the certificate. Now rejects at 8s, which `record()` already swallows as "this run loses its archive row".

## Verification
No test suite exists for this module, so this was verified against a real HTTP server that sends headers and then stalls the body forever - the exact shape of the failure:

```
1) stalling bank body   -> returns the placeholder at the deadline (1211ms)
2) healthy bank         -> unchanged, still parses
3) OLD code, same stall -> STILL PENDING after 3s      <- the bug, demonstrated
4) dead idb request     -> record() returns (800ms) instead of wedging the outro
5) healthy idb request  -> still records
ALL GREEN  pass=8 fail=0
```

Case 3 is the point: the pre-fix shape provably hangs under the same conditions, so this was not a theoretical defect.

## Context
Found while diagnosing the first public traffic on the Discord Graded Intake activity (2026-08-26), where 9 of 29 people relaunched within 6 minutes and almost no certificates were shared. Two other candidate explanations were investigated and **ruled out**: the share age-gate fix (CCP-Server #81) was deployed 21s after merge and before the panels went up, and `ratelimit:intake_act_session:*` keys confirm sessions were being minted, so launches did reach the proxy.

The vendored copy that Discord actually serves is patched in cclabs-web by an identical companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdnjK4ZQZ8QqE4VHex3Hv8