### PR TITLE
fix(6.8.5): quest state across logout, FYP volume slider, Sissy pool de-Bambified

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
@@ -1251,6 +1251,26 @@ namespace ConditioningControlPanel
                         .Select(kvp => kvp.Key)
                         .ToList();
 
+                    // Remember phrases the user typed themselves so ModService's cross-mod trigger
+                    // prune never deletes them - a hand-typed trigger can legitimately collide with
+                    // another built-in mod's default (OBEY, KNEEL, DROP...). Mirrors the subliminal
+                    // editor's UserAddedSubliminals bookkeeping in MainWindow.UiUpdates.cs.
+                    var modDefaults = new HashSet<string>(
+                        App.Mods?.GetDefaultCustomTriggers() ?? new List<string>(),
+                        StringComparer.OrdinalIgnoreCase);
+                    var oldTriggers = new HashSet<string>(triggerDict.Keys, StringComparer.OrdinalIgnoreCase);
+                    var newSet = new HashSet<string>(newTriggers, StringComparer.OrdinalIgnoreCase);
+                    foreach (var t in newTriggers)
+                    {
+                        if (!oldTriggers.Contains(t) && !modDefaults.Contains(t))
+                            App.Settings.Current.UserAddedCustomTriggers.Add(t);
+                    }
+                    foreach (var t in oldTriggers)
+                    {
+                        if (!newSet.Contains(t))
+                            App.Settings.Current.UserAddedCustomTriggers.Remove(t);
+                    }
+
                     App.Settings.Current.CustomTriggers = newTriggers;
                     App.Settings.Save();
                     App.Logger?.Information("Updated {Count} custom triggers", newTriggers.Count);

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -3478,6 +3478,17 @@ namespace ConditioningControlPanel.Models
             set { _fypMuted = value; OnPropertyChanged(); }
         }
 
+        private int _fypVolume = 100;
+        /// <summary>Feed playback volume, 0-100. Independent of <see cref="FypMuted"/>: mute is the
+        /// one-key panic switch (M / the speaker button) and must return you to the volume you had,
+        /// so unmuting never rewrites this. 0 is a legal setting and is silence with the speaker
+        /// button still reading "on" - the page's slider label says 0% so it is not a mystery.</summary>
+        public int FypVolume
+        {
+            get => _fypVolume;
+            set { _fypVolume = Math.Clamp(value, 0, 100); OnPropertyChanged(); }
+        }
+
         private double _fypWindowOpacity = 1.0;
         /// <summary>Ghost-mode translucency for the feed (0.01-1.0) - the DWM thumbnail opacity of
         /// the see-through mirror, never the real window's alpha (the WebView2 window must never be

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -1449,6 +1449,37 @@ namespace ConditioningControlPanel.Models
                 : new(value, StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Trigger phrases the user added by hand in the trigger editor. Mirrors
+        /// <see cref="UserAddedSubliminals"/>: protected from ModService's cross-mod trigger
+        /// prune so a typed phrase that happens to match another built-in mod's default
+        /// (OBEY, KNEEL, DROP...) is never silently deleted on startup or a mod switch.
+        /// Case-insensitive to match the prune's comparison.
+        /// </summary>
+        private HashSet<string> _userAddedCustomTriggers = new(StringComparer.OrdinalIgnoreCase);
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public HashSet<string> UserAddedCustomTriggers
+        {
+            get => _userAddedCustomTriggers;
+            set => _userAddedCustomTriggers = value == null
+                ? new(StringComparer.OrdinalIgnoreCase)
+                : new(value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// One-shot marker for the v6.8.5 migration that strips inherited BambiSleep trigger
+        /// phrases out of a saved SissyHypno trigger list (#general 08-22). Set the first time
+        /// the migration actually runs under the Sissy mod, so a user who later re-adds one of
+        /// those phrases keeps it.
+        /// </summary>
+        private bool _sissyBambiTriggerMigrationDone;
+        [JsonProperty("sissy_bambi_trigger_migration_done")]
+        public bool SissyBambiTriggerMigrationDone
+        {
+            get => _sissyBambiTriggerMigrationDone;
+            set { _sissyBambiTriggerMigrationDone = value; OnPropertyChanged(); }
+        }
+
         private string _subBackgroundColor = "#000000";
         public string SubBackgroundColor
         {

--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -491,6 +491,15 @@ namespace ConditioningControlPanel.Models
                     RankSubject = "Babe"
                 },
 
+                // NO BAMBISLEEP TRIGGERS IN HERE. This pool started life as the BambiSleep pool
+                // with the word "BAMBI" find-replaced out, which left nine of that file's named
+                // trigger phrases standing verbatim inside a mod that is not it (reported in
+                // #general 08-22). The replacements are NOT new writing: every one is a line this
+                // same mod already speaks (LockCardPhrases below, or its BubbleCountMercy pool),
+                // so the Sissy mod now conditions on its own vocabulary only. Existing users
+                // migrate for free - a key that is another built-in mod's default and not this
+                // one's is stripped by ModService.PruneCrossModSubliminals on the next mod
+                // restore, and the new keys arrive through that same pass's defaults top-up.
                 SubliminalPool = new Dictionary<string, bool>
                 {
                     { "FREEZE", true },
@@ -498,21 +507,21 @@ namespace ConditioningControlPanel.Models
                     { "DEEP SLEEP", true },
                     { "BIMBO DOLL", true },
                     { "GOOD GIRL", true },
-                    { "DROP FOR COCK", true },
-                    { "SNAP AND FORGET", true },
-                    { "PRIMPED AND PAMPERED", true },
+                    { "GOOD GIRLS OBEY", true },
+                    { "EMPTY AND OBEDIENT", true },
+                    { "SISSY IS LEARNING", true },
                     { "OBEY", true },
                     { "CUM AND COLLAPSE", true },
-                    { "ZAP COCK DRAIN OBEY", true },
-                    { "GIGGLETIME", true },
-                    { "UNIFORM LOCK", true },
-                    { "COCK ZOMBIE NOW", true },
+                    { "I LOVE BEING PROGRAMMED", true },
+                    { "SISSY LOVES BUBBLES", true },
+                    { "SISSY WILL TRY HARDER", true },
+                    { "DUMB DOLLS COUNT SLOWLY", true },
                     { "JUST OBEY", true },
                     { "TURN YOUR BRAIN OFF", true },
                     { "GOOD GIRLS DONT THINK", true },
                     { "DONT THINK SILLY", true },
-                    { "COCK TURNS MY BRAIN OFF", true },
-                    { "I CANT RESIST MY TRIGGERS", true },
+                    { "GOOD GIRLS PAY ATTENTION", true },
+                    { "SISSY NEEDS TO FOCUS", true },
                     { "THERES NO NEED TO THINK", true }
                 },
 

--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -534,6 +534,13 @@ namespace ConditioningControlPanel.Models
                     { "EMPTY AND OBEDIENT", true }
                 },
 
+                // Same story as SubliminalPool above, and the same fix. This list is what the
+                // companion offers as trigger words (AvatarTubeWindow.Speech / .ChatInput), what
+                // the Patreon trigger surface shows, and what KeywordTriggerService imports, so
+                // leaving BambiSleep's corpus here would have kept the reported phrases in front
+                // of a Sissy user through four other surfaces. Twelve inherited entries are gone;
+                // nine slots are refilled with lines this mod already speaks (no new writing) and
+                // the rest are simply dropped.
                 CustomTriggers = new List<string>
                 {
                     "GOOD GIRL",
@@ -541,19 +548,16 @@ namespace ConditioningControlPanel.Models
                     "BIMBO DOLL",
                     "FREEZE",
                     "RESET",
-                    "DROP FOR COCK",
-                    "GIGGLETIME",
-                    "BLONDE MOMENT",
-                    "ZAP COCK DRAIN OBEY",
-                    "SNAP AND FORGET",
-                    "PRIMPED AND PAMPERED",
-                    "SAFE AND SECURE",
-                    "COCK ZOMBIE NOW",
-                    "UNIFORM LOCK",
-                    "AIRHEAD BARBIE",
-                    "BRAINDEAD BOBBLEHEAD",
-                    "COCKBLANK LOVEDOLL",
-                    "CUM AND COLLAPSE"
+                    "CUM AND COLLAPSE",
+                    "GOOD GIRLS OBEY",
+                    "EMPTY AND OBEDIENT",
+                    "SISSY IS LEARNING",
+                    "I LOVE BEING PROGRAMMED",
+                    "SISSY LOVES BUBBLES",
+                    "SISSY WILL TRY HARDER",
+                    "DUMB DOLLS COUNT SLOWLY",
+                    "GOOD GIRLS PAY ATTENTION",
+                    "SISSY NEEDS TO FOCUS"
                 },
 
                 Triggers = new ModTriggers

--- a/ConditioningControlPanel/Models/BuiltInMods.cs
+++ b/ConditioningControlPanel/Models/BuiltInMods.cs
@@ -913,7 +913,29 @@ namespace ConditioningControlPanel.Models
                     { "Bambi", "babe" },
                     { "BAMBI", "SISSY" },
                     { "BambiCloud", "HypnoTube" },
-                    { "BambiSprite", "BimboDoll" }
+                    { "BambiSprite", "BimboDoll" },
+
+                    // The named BambiSleep triggers that carry no "Bambi" in them, so the rules
+                    // above never caught them. The shipped built-in sessions still prescribe these
+                    // as subliminal phrases, and SessionEngine pipes every session phrase through
+                    // MakeModAware (Services/Session/SessionEngine.cs) before it enters the pool -
+                    // so without these rows a Sissy user still met DROP FOR COCK / GIGGLETIME via
+                    // the Sessions tab even after the pool itself was cleaned. Each right-hand side
+                    // is the exact line that replaced it in SubliminalPool above: reused Sissy
+                    // vocabulary, no new writing. "BAMBI UNIFORM LOCK" is listed explicitly because
+                    // replacements run longest-key-first, so the bare "UNIFORM LOCK" rule would
+                    // otherwise fire first and leave a stray "BAMBI" behind for the "BAMBI" rule.
+                    { "I CANT RESIST MY TRIGGERS", "SISSY NEEDS TO FOCUS" },
+                    { "COCK TURNS MY BRAIN OFF", "GOOD GIRLS PAY ATTENTION" },
+                    { "PRIMPED AND PAMPERED", "SISSY IS LEARNING" },
+                    { "ZAP COCK DRAIN OBEY", "I LOVE BEING PROGRAMMED" },
+                    { "BAMBI UNIFORM LOCK", "SISSY WILL TRY HARDER" },
+                    { "COCK ZOMBIE NOW", "DUMB DOLLS COUNT SLOWLY" },
+                    { "SNAP AND FORGET", "EMPTY AND OBEDIENT" },
+                    { "DROP FOR COCK", "GOOD GIRLS OBEY" },
+                    { "UNIFORM LOCK", "SISSY WILL TRY HARDER" },
+                    { "GIGGLETIME", "SISSY LOVES BUBBLES" },
+                    { "Giggletime", "Sissy Loves Bubbles" }
                 }
             };
         }

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -447,9 +447,9 @@ html, body {
   transition: background 150ms ease;
 }
 .mini-btn:hover { background: rgba(255, 105, 180, 0.35); color: #fff; }
-#mosaic-sec, #window-opacity { flex: 1; accent-color: #ff69b4; }
-#mosaic-sec-label, #window-opacity-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
-#window-opacity-label { width: 40px; }
+#mosaic-sec, #window-opacity, #feed-volume { flex: 1; accent-color: #ff69b4; }
+#mosaic-sec-label, #window-opacity-label, #feed-volume-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
+#window-opacity-label, #feed-volume-label { width: 40px; }
 
 .options-footer { font-size: 11px; color: #6a6a88; margin-top: 12px; }
 

--- a/ConditioningControlPanel/Resources/web/fyp/index.html
+++ b/ConditioningControlPanel/Resources/web/fyp/index.html
@@ -89,6 +89,14 @@
           <span id="mosaic-sec-label">10s</span>
         </div>
         <div class="options-divider"></div>
+        <div class="option-row" id="volume-row">
+          <div class="option-text">
+            <div class="option-title">Volume</div>
+            <div class="option-sub">How loud the audible clip plays. The speaker button still mutes.</div>
+          </div>
+          <input id="feed-volume" type="range" min="0" max="100" step="1">
+          <span id="feed-volume-label">100%</span>
+        </div>
         <div class="option-row">
           <div class="option-text">
             <div class="option-title">Highlight audible tile</div>

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -58,6 +58,7 @@ let settings = {
   mosaicChangeSec: 10,
   autoAdvance: false,
   muted: false,
+  volume: 100,             // 0-100; independent of `muted` (mute is the panic switch)
   audioGlow: true,
   windowOpacity: 1,
   eyeControl: false,
@@ -276,6 +277,10 @@ const pageCtx = {
   },
   isAutoAdvance: () => settings.autoAdvance,
   isMuted: () => settings.muted,
+  // 0..1 for the media elements. Every surface reads this through applyAudio, so a
+  // drag on the slider reaches the clip that is currently speaking AND every clip
+  // mounted after it (mount() ends in applyAudio).
+  volume: () => clampVolume(settings.volume) / 100,
   audioGlow: () => settings.audioGlow !== false,
   audioFocus: (compKey) => audioFocus.get(compKey),
   mosaicAutoChange: () => settings.mosaicAutoChange,
@@ -433,6 +438,25 @@ function setMuted(m) {
   pageAt(activeIdx)?.applyAudio();
 }
 
+function clampVolume(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 100;
+  return Math.min(100, Math.max(0, Math.round(n)));
+}
+
+/**
+ * Volume is deliberately NOT coupled to mute. Mute is the one-key panic switch (M, or the
+ * speaker button) and has to give you back exactly the loudness you had, so unmuting never
+ * touches this value and setting a volume never clears the mute. `post` is left to the
+ * caller: a slider drag applies locally on every frame but only persists on release.
+ */
+function setVolume(pct, persist) {
+  settings.volume = clampVolume(pct);
+  if (persist) post({ type: 'settings-changed', key: 'volume', value: settings.volume });
+  $('feed-volume-label').textContent = `${settings.volume}%`;
+  pageAt(activeIdx)?.applyAudio();
+}
+
 function setAutoAdvance(on) {
   settings.autoAdvance = on;
   post({ type: 'settings-changed', key: 'autoAdvance', value: on });
@@ -460,6 +484,8 @@ function updateOptionsUi() {
   $('mosaic-slider-row').classList.toggle('hidden', !settings.mosaicAutoChange);
   $('mosaic-sec').value = String(settings.mosaicChangeSec);
   $('mosaic-sec-label').textContent = `${settings.mosaicChangeSec}s`;
+  $('feed-volume').value = String(clampVolume(settings.volume));
+  $('feed-volume-label').textContent = `${clampVolume(settings.volume)}%`;
   $('toggle-audio-glow').classList.toggle('on', settings.audioGlow !== false);
   const pct = Math.round(clampOpacity(settings.windowOpacity) * 100);
   $('window-opacity').value = String(pct);
@@ -1111,6 +1137,15 @@ function wireChrome() {
     setting('mosaicChangeSec', Math.max(3, Math.min(60, Number($('mosaic-sec').value) || 10)));
     updateOptionsUi();
   });
+  // Drag = hear it now (local only); release = persist. Mirrors the opacity slider's
+  // split, minus the throttle: setting .volume on a handful of elements is free, so the
+  // live half needs no host round trip at all.
+  $('feed-volume').addEventListener('input', () => {
+    setVolume(Number($('feed-volume').value), false);
+  });
+  $('feed-volume').addEventListener('change', () => {
+    setVolume(Number($('feed-volume').value), true);
+  });
   $('toggle-audio-glow').addEventListener('click', () => {
     setting('audioGlow', settings.audioGlow === false);
     updateOptionsUi();
@@ -1242,6 +1277,7 @@ function onHostMessage(data) {
       settings = { ...settings, ...(data.settings || {}) };
       // Host may omit either (older builds) — both default rather than go undefined.
       settings.audioGlow = settings.audioGlow !== false;
+      settings.volume = clampVolume(settings.volume);
       settings.windowOpacity = clampOpacity(settings.windowOpacity);
       onlineCatalog = Array.isArray(data.online?.niches) ? data.online.niches : [];
       customSubs = normalizeLibrary(data.online?.library, data.online?.customSubs);

--- a/ConditioningControlPanel/Resources/web/fyp/surfaces.js
+++ b/ConditioningControlPanel/Resources/web/fyp/surfaces.js
@@ -58,8 +58,15 @@ function dragVelocity(samples, k) {
   return (last[k] - first[k]) / dt;
 }
 
+/** Media elements throw on an out-of-range volume, so every path funnels through this. */
+function clampVolume(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(1, Math.max(0, n));
+}
+
 /**
- * One media surface for a cut. Returns { el, stop(), setMuted(), setAutoAdvance(),
+ * One media surface for a cut. Returns { el, stop(), setMuted(), setVolume(), setAutoAdvance(),
  * setPreview(), failed }. ctx: { onEnded, onError, onAssetMeta,
  * report(segId, dwellMs, clipLenMs), advances, preview }. Born with ctx.preview
  * it loads + seeks but never plays: a paused element showing its window's first
@@ -74,6 +81,9 @@ function createVideoSurface(cut, ctx) {
   video.playsInline = true;
   video.disablePictureInPicture = true;
   video.muted = true; // page audio routing unmutes the one audible tile
+  // Loudness is a page-wide setting, not a per-clip one. Seed it here as well as in
+  // applyAudio so a surface is never briefly full-volume between mount and routing.
+  video.volume = clampVolume(ctx.volume?.());
   // Loop only matters at a natural end (whole-video cuts; windowed cuts are
   // steered by timeupdate before they ever get there).
   video.loop = !(ctx.autoAdvance && ctx.advances);
@@ -186,6 +196,7 @@ function createVideoSurface(cut, ctx) {
     /** A slot promoting a preview checks this to self-heal a dead file (#562). */
     get failed() { return video.error != null; },
     setMuted(m) { video.muted = m; },
+    setVolume(v) { video.volume = clampVolume(v); },
     setAutoAdvance(on) {
       autoAdvance = on;
       video.loop = !(on && ctx.advances);
@@ -277,6 +288,7 @@ function createGifSurface(cut, ctx) {
     cut,
     get failed() { return failed; },
     setMuted() { /* GIFs are silent */ },
+    setVolume() { /* GIFs are silent */ },
     setAutoAdvance(on) { autoAdvance = on; arm(on); },
     setPreview(on) {
       if (on === previewing) return;
@@ -383,6 +395,7 @@ function createTileSlot(page, tileIndex, ctx) {
       },
       onAssetMeta: ctx.onAssetMeta,
       report: ctx.report,
+      volume: ctx.volume,
     };
   }
 
@@ -703,6 +716,7 @@ function createTileSlot(page, tileIndex, ctx) {
  * ctx:
  *   { onAdvance(compKey), onSwap(compKey, i, dir), onPeek(compKey, i, dir),
  *     onTapAudio(compKey, i), onAssetMeta, report, isAutoAdvance(), isMuted(),
+ *     volume() -> 0..1,
  *     audioGlow() -> bool, audioFocus() -> index|null, isPagerBusy() -> bool,
  *     onPageDragMove(compKey, dy), onPageDragEnd(compKey, dy, vy) }
  */
@@ -732,8 +746,10 @@ export function createPage(comp, ctx) {
     // Nothing is audible while muted (or when no tile carries audio at all) —
     // in that case no tile glows either.
     const glow = !muted && ai >= 0 && ctx.audioGlow?.() !== false;
+    const vol = clampVolume(ctx.volume?.() ?? 1);
     slots.forEach((s, i) => {
       s.surface?.setMuted(muted || i !== ai);
+      s.surface?.setVolume?.(vol);
       s.setAudioGlow(glow && i === ai);
     });
   }
@@ -752,6 +768,7 @@ export function createPage(comp, ctx) {
       onAssetMeta: ctx.onAssetMeta,
       onMediaError: ctx.onMediaError,
       report: ctx.report,
+      volume: ctx.volume,
       applyAudio,
     };
   }

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -154,6 +154,7 @@ internal static class FypHostService
                     mosaicChangeSec = s?.FypMosaicChangeSec ?? 10,
                     autoAdvance = s?.FypAutoAdvance ?? false,
                     muted = s?.FypMuted ?? false,
+                    volume = s?.FypVolume ?? 100,
                     windowOpacity = s?.FypWindowOpacity ?? 1.0,
                     audioGlow = s?.FypAudioGlow ?? true,
                     eyeControl = s?.FypEyeControl ?? false,
@@ -332,6 +333,9 @@ internal static class FypHostService
                 case "mosaicChangeSec": s.FypMosaicChangeSec = (int?)value ?? 10; break;
                 case "autoAdvance": s.FypAutoAdvance = (bool?)value ?? false; break;
                 case "muted": s.FypMuted = (bool?)value ?? false; break;
+                // 0-100. Clamped again by the property, so a hand-edited settings file or an
+                // out-of-range page value can never hand a media element an invalid volume.
+                case "volume": s.FypVolume = (int?)value ?? 100; break;
                 // Persist, and push straight onto the ghost mirror when one is up — the mirror
                 // is a plain window, so its constant alpha IS the opacity (see below).
                 case "windowOpacity":

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -2516,20 +2516,26 @@ namespace ConditioningControlPanel.Services
                     ? new List<string>(settings.CustomTriggers)
                     : new List<string>(GetDefaultCustomTriggers());
 
-            // Same cross-mod cleanup the subliminal and lock-card pools get. The Sissy mod's
-            // trigger list shipped as BambiSleep's corpus with the brand filed off (#general
-            // 08-22), so a user who ran Sissy before this build has that corpus saved in their
-            // per-mod backup and would keep meeting it. Only entries that are some OTHER
-            // built-in mod's default and not the active mod's are dropped, and this mod's own
-            // defaults are topped up only when something was actually pruned - a user who never
-            // had the contamination keeps their list exactly as they left it.
-            var prunedTriggers = PruneCrossModCustomTriggers(
-                settings.CustomTriggers, GetDefaultCustomTriggers(), out var removedTriggers);
-            if (removedTriggers.Count > 0)
+            // One-shot cleanup for the actual defect reported in #general 08-22: the Sissy mod's
+            // trigger list shipped as BambiSleep's corpus with the brand filed off, so a user who
+            // ran Sissy before this build has that corpus saved in their per-mod backup and would
+            // keep meeting it. Deliberately NARROW - it only runs under Sissy, only removes
+            // BambiSleep-specific phrases, never touches phrases the user typed, and never adds
+            // anything back (deliberate deletions stay deleted, see MainWindow.Patreon.cs). The
+            // generic vocabulary other mods share (OBEY, DROP, KNEEL...) is left alone, and the
+            // one-shot flag means a Bambi phrase re-added afterwards is kept.
+            if (!settings.SissyBambiTriggerMigrationDone &&
+                string.Equals(modId, Models.BuiltInMods.SissyHypnoId, StringComparison.OrdinalIgnoreCase))
             {
-                settings.CustomTriggers = prunedTriggers;
-                _log?.Information("Pruned {Count} cross-mod custom trigger(s) for mod {ModId}: {Keys}",
-                    removedTriggers.Count, modId, string.Join(", ", removedTriggers));
+                var prunedTriggers = PruneInheritedBambiTriggers(
+                    settings.CustomTriggers, settings.UserAddedCustomTriggers, out var removedTriggers);
+                if (removedTriggers.Count > 0)
+                {
+                    settings.CustomTriggers = prunedTriggers;
+                    _log?.Information("Pruned {Count} inherited BambiSleep trigger(s) from the Sissy list: {Keys}",
+                        removedTriggers.Count, string.Join(", ", removedTriggers));
+                }
+                settings.SissyBambiTriggerMigrationDone = true;
             }
 
             if (settings.BouncingTextPoolByMod?.TryGetValue(modId, out var savedBounce) == true)
@@ -2591,50 +2597,39 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Removes custom triggers that belong to a DIFFERENT built-in mod's default list and are
-        /// not part of the active mod's defaults, then - only when something was removed - tops the
-        /// list up with the active mod's own defaults. Triggers matching no built-in default are
-        /// user-typed and are always kept. Pure so it can be unit tested without app state.
+        /// Removes BambiSleep-specific trigger phrases that were inherited by the SissyHypno
+        /// trigger list before the de-Bambi'd defaults shipped (#general 08-22). Only phrases that
+        /// are a BambiSleep default AND not a SissyHypno default are candidates; phrases the user
+        /// typed themselves (<paramref name="userAdded"/>) are always kept, and nothing is ever
+        /// added back. Pure so it can be unit tested without app state.
         /// </summary>
-        internal static List<string> PruneCrossModCustomTriggers(
-            IEnumerable<string>? current, IEnumerable<string>? activeDefaults, out List<string> removed)
+        internal static List<string> PruneInheritedBambiTriggers(
+            IEnumerable<string>? current, IEnumerable<string>? userAdded, out List<string> removed)
         {
             removed = new List<string>();
             var list = current?.ToList() ?? new List<string>();
-            var active = activeDefaults?.ToList() ?? new List<string>();
             if (list.Count == 0) return list;
 
-            var activeKeys = new HashSet<string>(active, StringComparer.OrdinalIgnoreCase);
-
-            var foreignDefaults = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var allBuiltIn = new[]
-            {
-                Models.BuiltInMods.CCPDefault, Models.BuiltInMods.BambiSleep,
-                Models.BuiltInMods.SissyHypno, Models.BuiltInMods.Dronification,
-                Models.BuiltInMods.Locked
-            };
-            foreach (var m in allBuiltIn)
-                if (m.CustomTriggers != null)
-                    foreach (var t in m.CustomTriggers)
-                        foreignDefaults.Add(t);
+            var sissyDefaults = new HashSet<string>(
+                Models.BuiltInMods.SissyHypno.CustomTriggers ?? new List<string>(),
+                StringComparer.OrdinalIgnoreCase);
+            var bambiOnly = new HashSet<string>(
+                (Models.BuiltInMods.BambiSleep.CustomTriggers ?? new List<string>())
+                    .Where(t => !sissyDefaults.Contains(t)),
+                StringComparer.OrdinalIgnoreCase);
+            var userTyped = new HashSet<string>(
+                userAdded ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
 
             var kept = new List<string>();
             foreach (var t in list)
             {
-                if (!string.IsNullOrWhiteSpace(t) && foreignDefaults.Contains(t) && !activeKeys.Contains(t))
+                if (!string.IsNullOrWhiteSpace(t) && bambiOnly.Contains(t) && !userTyped.Contains(t))
                     removed.Add(t);
                 else
                     kept.Add(t);
             }
 
-            if (removed.Count == 0) return list;
-
-            var present = new HashSet<string>(kept, StringComparer.OrdinalIgnoreCase);
-            foreach (var d in active)
-                if (present.Add(d))
-                    kept.Add(d);
-
-            return kept;
+            return removed.Count == 0 ? list : kept;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -2516,6 +2516,22 @@ namespace ConditioningControlPanel.Services
                     ? new List<string>(settings.CustomTriggers)
                     : new List<string>(GetDefaultCustomTriggers());
 
+            // Same cross-mod cleanup the subliminal and lock-card pools get. The Sissy mod's
+            // trigger list shipped as BambiSleep's corpus with the brand filed off (#general
+            // 08-22), so a user who ran Sissy before this build has that corpus saved in their
+            // per-mod backup and would keep meeting it. Only entries that are some OTHER
+            // built-in mod's default and not the active mod's are dropped, and this mod's own
+            // defaults are topped up only when something was actually pruned - a user who never
+            // had the contamination keeps their list exactly as they left it.
+            var prunedTriggers = PruneCrossModCustomTriggers(
+                settings.CustomTriggers, GetDefaultCustomTriggers(), out var removedTriggers);
+            if (removedTriggers.Count > 0)
+            {
+                settings.CustomTriggers = prunedTriggers;
+                _log?.Information("Pruned {Count} cross-mod custom trigger(s) for mod {ModId}: {Keys}",
+                    removedTriggers.Count, modId, string.Join(", ", removedTriggers));
+            }
+
             if (settings.BouncingTextPoolByMod?.TryGetValue(modId, out var savedBounce) == true)
                 settings.BouncingTextPool = new Dictionary<string, bool>(savedBounce);
             else
@@ -2572,6 +2588,53 @@ namespace ConditioningControlPanel.Services
             if (toRemove.Count > 0)
                 _log?.Information("Pruned {Count} cross-mod subliminal entries from the active pool: {Keys}",
                     toRemove.Count, string.Join(", ", toRemove));
+        }
+
+        /// <summary>
+        /// Removes custom triggers that belong to a DIFFERENT built-in mod's default list and are
+        /// not part of the active mod's defaults, then - only when something was removed - tops the
+        /// list up with the active mod's own defaults. Triggers matching no built-in default are
+        /// user-typed and are always kept. Pure so it can be unit tested without app state.
+        /// </summary>
+        internal static List<string> PruneCrossModCustomTriggers(
+            IEnumerable<string>? current, IEnumerable<string>? activeDefaults, out List<string> removed)
+        {
+            removed = new List<string>();
+            var list = current?.ToList() ?? new List<string>();
+            var active = activeDefaults?.ToList() ?? new List<string>();
+            if (list.Count == 0) return list;
+
+            var activeKeys = new HashSet<string>(active, StringComparer.OrdinalIgnoreCase);
+
+            var foreignDefaults = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var allBuiltIn = new[]
+            {
+                Models.BuiltInMods.CCPDefault, Models.BuiltInMods.BambiSleep,
+                Models.BuiltInMods.SissyHypno, Models.BuiltInMods.Dronification,
+                Models.BuiltInMods.Locked
+            };
+            foreach (var m in allBuiltIn)
+                if (m.CustomTriggers != null)
+                    foreach (var t in m.CustomTriggers)
+                        foreignDefaults.Add(t);
+
+            var kept = new List<string>();
+            foreach (var t in list)
+            {
+                if (!string.IsNullOrWhiteSpace(t) && foreignDefaults.Contains(t) && !activeKeys.Contains(t))
+                    removed.Add(t);
+                else
+                    kept.Add(t);
+            }
+
+            if (removed.Count == 0) return list;
+
+            var present = new HashSet<string>(kept, StringComparer.OrdinalIgnoreCase);
+            foreach (var d in active)
+                if (present.Add(d))
+                    kept.Add(d);
+
+            return kept;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -1220,14 +1220,21 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public string MakeModAware(string text)
         {
-            if (string.IsNullOrEmpty(text)) return text;
+            return ApplyTextReplacements(_activeMod.Manifest.TextReplacements, text);
+        }
 
-            // No replacements registered → nothing to do (mod-agnostic check)
-            var replacements = _activeMod.Manifest.TextReplacements;
+        /// <summary>
+        /// The pure half of <see cref="MakeModAware"/>: applies a manifest's TextReplacements to a
+        /// string, longest key first so a longer phrase always wins over a shorter one it contains
+        /// (this is what keeps "BAMBI UNIFORM LOCK" from being half-rewritten by the "UNIFORM LOCK"
+        /// and "BAMBI" rules in turn). Split out so the mapping can be tested without an App.
+        /// </summary>
+        internal static string ApplyTextReplacements(IDictionary<string, string>? replacements, string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
             if (replacements == null || replacements.Count == 0) return text;
 
             var result = text;
-            // Apply replacements in order — longer strings first to avoid partial matches
             foreach (var kvp in replacements.OrderByDescending(r => r.Key.Length))
             {
                 result = result.Replace(kvp.Key, kvp.Value);
@@ -2524,18 +2531,10 @@ namespace ConditioningControlPanel.Services
             // anything back (deliberate deletions stay deleted, see MainWindow.Patreon.cs). The
             // generic vocabulary other mods share (OBEY, DROP, KNEEL...) is left alone, and the
             // one-shot flag means a Bambi phrase re-added afterwards is kept.
-            if (!settings.SissyBambiTriggerMigrationDone &&
-                string.Equals(modId, Models.BuiltInMods.SissyHypnoId, StringComparison.OrdinalIgnoreCase))
+            if (ApplySissyBambiTriggerMigration(settings, modId, out var removedTriggers))
             {
-                var prunedTriggers = PruneInheritedBambiTriggers(
-                    settings.CustomTriggers, settings.UserAddedCustomTriggers, out var removedTriggers);
-                if (removedTriggers.Count > 0)
-                {
-                    settings.CustomTriggers = prunedTriggers;
-                    _log?.Information("Pruned {Count} inherited BambiSleep trigger(s) from the Sissy list: {Keys}",
-                        removedTriggers.Count, string.Join(", ", removedTriggers));
-                }
-                settings.SissyBambiTriggerMigrationDone = true;
+                _log?.Information("Pruned {Count} inherited BambiSleep trigger(s) from the Sissy list: {Keys}",
+                    removedTriggers.Count, string.Join(", ", removedTriggers));
             }
 
             if (settings.BouncingTextPoolByMod?.TryGetValue(modId, out var savedBounce) == true)
@@ -2603,6 +2602,38 @@ namespace ConditioningControlPanel.Services
         /// typed themselves (<paramref name="userAdded"/>) are always kept, and nothing is ever
         /// added back. Pure so it can be unit tested without app state.
         /// </summary>
+        /// <summary>
+        /// Runs the one-shot Sissy trigger migration over a settings object and reports whether it
+        /// actually removed anything. Kept static and App-free so the persistence half is testable:
+        /// the pruned list is written to the ACTIVE list AND back over the per-mod backup, because
+        /// the backup is what the next launch restores from. Writing only the active list left
+        /// CustomTriggersByMod holding the old corpus, and since the one-shot flag then blocked a
+        /// second prune, the Bambi triggers came back permanently on the very next start (the
+        /// trailing self-heal is TryAdd, so it never overwrites an existing backup).
+        /// </summary>
+        internal static bool ApplySissyBambiTriggerMigration(
+            Models.AppSettings settings, string modId, out List<string> removed)
+        {
+            removed = new List<string>();
+            if (settings == null) return false;
+            if (settings.SissyBambiTriggerMigrationDone) return false;
+            if (!string.Equals(modId, Models.BuiltInMods.SissyHypnoId, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            var pruned = PruneInheritedBambiTriggers(
+                settings.CustomTriggers, settings.UserAddedCustomTriggers, out removed);
+
+            if (removed.Count > 0)
+            {
+                settings.CustomTriggers = pruned;
+                (settings.CustomTriggersByMod ??= new Dictionary<string, List<string>>())[modId] =
+                    new List<string>(pruned);
+            }
+
+            settings.SissyBambiTriggerMigrationDone = true;
+            return removed.Count > 0;
+        }
+
         internal static List<string> PruneInheritedBambiTriggers(
             IEnumerable<string>? current, IEnumerable<string>? userAdded, out List<string> removed)
         {

--- a/ConditioningControlPanel/Services/PhraseBackupService.cs
+++ b/ConditioningControlPanel/Services/PhraseBackupService.cs
@@ -43,7 +43,7 @@ namespace ConditioningControlPanel.Services
             // Mantras
             "MantraPool",
             // Custom triggers
-            "CustomTriggers", "CustomTriggersByMod",
+            "CustomTriggers", "CustomTriggersByMod", "UserAddedCustomTriggers",
             // Custom companion phrases
             "CustomCompanionPhrases",
         };

--- a/ConditioningControlPanel/Services/Program/BuiltInPrograms.Presentation.cs
+++ b/ConditioningControlPanel/Services/Program/BuiltInPrograms.Presentation.cs
@@ -354,19 +354,20 @@ public static partial class BuiltInPrograms
         RewardId = "pr_ch2_banked",
         RewardDescription = "Banked: the full seven-page ledger and a phrase pack, kept locally.",
 
-        // SISSY POOL KEYS, NOT BAMBI ONES. The Sissy manifest is a near-clone of the Bambi one with
-        // the Bambi-prefixed entries renamed - BAMBI SLEEP became DEEP SLEEP, BAMBI FREEZE became
-        // FREEZE, BAMBI UNIFORM LOCK became UNIFORM LOCK - so a pack copy-pasted from the Takeover
-        // file would compile, install, and be six phrases this program's mod has never heard of.
-        // Same warning as PrSoftSubliminals.
+        // SISSY POOL KEYS, NOT BAMBI ONES. The two manifests share a shape, so a pack copy-pasted
+        // from the Takeover file would compile, install, and be six phrases this program's mod has
+        // never heard of. The overlap is now much smaller than it looks: the nine BambiSleep
+        // triggers the Sissy pool used to inherit verbatim were replaced with that mod's own lines
+        // (#general 08-22), so any Bambi phrase here is a bug, not a coincidence. Same warning as
+        // PrSoftSubliminals.
         RewardPhrases = new List<string>
         {
             "GOOD GIRL",
             "BIMBO DOLL",
-            "PRIMPED AND PAMPERED",
-            "UNIFORM LOCK",
+            "SISSY IS LEARNING",
+            "SISSY WILL TRY HARDER",
             "FREEZE",
-            "SNAP AND FORGET"
+            "EMPTY AND OBEDIENT"
         },
         Days = new List<ProgramDay>
         {
@@ -668,15 +669,15 @@ public static partial class BuiltInPrograms
 
     /// <summary>
     /// Subliminals for the passive templates. Every entry is a key of the Sissy Hypno SubliminalPool,
-    /// all 21 of which ship enabled. Note the Sissy pool is a near-clone of the Bambi one with the
-    /// Bambi-prefixed entries renamed - BAMBI SLEEP became DEEP SLEEP, BAMBI FREEZE became FREEZE - so
-    /// a phrase list copy-pasted from the Takeover file would compile, run, and be wrong.
+    /// all 21 of which ship enabled. Note the two manifests share a shape (BAMBI SLEEP is DEEP SLEEP
+    /// here, BAMBI FREEZE is FREEZE), so a phrase list copy-pasted from the Takeover file would
+    /// compile, run, and be wrong.
     /// </summary>
     private static List<string> PrSoftSubliminals() => new()
     {
         "GOOD GIRL",
         "DEEP SLEEP",
-        "PRIMPED AND PAMPERED",
+        "SISSY IS LEARNING",
         "DONT THINK SILLY",
         "THERES NO NEED TO THINK",
         "TURN YOUR BRAIN OFF"
@@ -685,15 +686,15 @@ public static partial class BuiltInPrograms
     /// <summary>
     /// The mirror pool. The manifest has no vocabulary that literally names looking or reflections, so
     /// this is the pool's set of *being looked at* phrases rather than invented ones - BIMBO DOLL,
-    /// PRIMPED AND PAMPERED, GOOD GIRL. Nothing here is authored; every line is a manifest key.
+    /// SISSY IS LEARNING, GOOD GIRL. Nothing here is authored; every line is a manifest key.
     /// </summary>
     private static List<string> PrMirrorSubliminals() => new()
     {
         "GOOD GIRL",
         "BIMBO DOLL",
-        "PRIMPED AND PAMPERED",
+        "SISSY IS LEARNING",
         "DEEP SLEEP",
-        "GIGGLETIME",
+        "SISSY LOVES BUBBLES",
         "JUST OBEY",
         "GOOD GIRLS DONT THINK",
         "DONT THINK SILLY",
@@ -705,38 +706,38 @@ public static partial class BuiltInPrograms
     {
         "GOOD GIRL",
         "BIMBO DOLL",
-        "PRIMPED AND PAMPERED",
-        "UNIFORM LOCK",
+        "SISSY IS LEARNING",
+        "SISSY WILL TRY HARDER",
         "OBEY",
         "JUST OBEY",
         "FREEZE",
-        "SNAP AND FORGET",
-        "GIGGLETIME",
+        "EMPTY AND OBEDIENT",
+        "SISSY LOVES BUBBLES",
         "GOOD GIRLS DONT THINK",
         "TURN YOUR BRAIN OFF",
-        "I CANT RESIST MY TRIGGERS"
+        "SISSY NEEDS TO FOCUS"
     };
 
     private static List<string> PrShowSubliminals() => new()
     {
         "GOOD GIRL",
         "BIMBO DOLL",
-        "PRIMPED AND PAMPERED",
-        "UNIFORM LOCK",
+        "SISSY IS LEARNING",
+        "SISSY WILL TRY HARDER",
         "FREEZE",
         "RESET",
         "DEEP SLEEP",
         "OBEY",
         "JUST OBEY",
-        "SNAP AND FORGET",
-        "DROP FOR COCK",
-        "COCK ZOMBIE NOW",
+        "EMPTY AND OBEDIENT",
+        "GOOD GIRLS OBEY",
+        "DUMB DOLLS COUNT SLOWLY",
         "CUM AND COLLAPSE",
-        "ZAP COCK DRAIN OBEY",
-        "I CANT RESIST MY TRIGGERS",
+        "I LOVE BEING PROGRAMMED",
+        "SISSY NEEDS TO FOCUS",
         "GOOD GIRLS DONT THINK",
         "TURN YOUR BRAIN OFF",
-        "GIGGLETIME"
+        "SISSY LOVES BUBBLES"
     };
 
     /// <summary>

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -533,6 +533,19 @@ public class QuestService : IDisposable
     /// </summary>
     private bool IsEntitlementResolved()
     {
+        // THE SIGNED-OUT WINDOW IS NOT AN ANSWER. quests.json deliberately survives a logout
+        // (BUG-BN8X9B9SZ5 / #1027), stamped with the account that owns it — but the entitlement
+        // providers do not: a logout tears them down, so between the sign-out and the next
+        // sign-in the premium gate reads a flat "no access" that belongs to nobody. Believing it
+        // let the premium-loss rerolls below discard the departed account's untouched quest
+        // purely because the user signed out, which is the same "log out and back in and your
+        // quests are different" complaint the ledger fix was meant to end. Treat the whole window
+        // as unresolved: the decision is deferred (never lost), the refresh tick stays quiet
+        // while nobody is signed in, and the first post-login sync settles it for real.
+        if (IsSignedOutWithOwnedQuests(
+                App.UnifiedUserId ?? App.Settings?.Current?.UnifiedId, Progress?.OwnerUnifiedId))
+            return false;
+
         var patreon = App.Patreon;
         if (patreon == null) return false;
         if (patreon.IsVerifying) return false;
@@ -544,6 +557,14 @@ public class QuestService : IDisposable
         if (App.SubscribeStar?.IsVerifying == true) return false;
         return DateTime.UtcNow - _startedUtc >= EntitlementSettleWindow;
     }
+
+    /// <summary>
+    /// True when nobody is signed in but the local quest ledger belongs to an account that was.
+    /// That is the logout window: the quests are being held for a returning owner whose
+    /// entitlement is currently unknowable. Pure, so it is testable without a live App.
+    /// </summary>
+    internal static bool IsSignedOutWithOwnedQuests(string? currentUnifiedId, string? questOwnerUnifiedId)
+        => string.IsNullOrEmpty(currentUnifiedId) && !string.IsNullOrEmpty(questOwnerUnifiedId);
 
     /// <summary>
     /// Feature level gating has been removed — every quest category is available from level 1.

--- a/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
@@ -170,3 +170,162 @@ public class FypVolumeSettingTests
         Assert.Equal(30, s.FypVolume);
     }
 }
+/// <summary>
+/// The other half of the same report. CustomTriggers is the pool the companion offers as trigger
+/// words (AvatarTubeWindow.Speech / .ChatInput), the Patreon trigger surface renders, and
+/// KeywordTriggerService imports - so a Sissy user met the same BambiSleep phrases here even after
+/// the subliminal pool was cleaned.
+/// </summary>
+public class SissyCustomTriggerTests
+{
+    /// <summary>The twelve BambiSleep-inherited entries that were removed from Sissy.</summary>
+    public static TheoryData<string> RemovedBambiTriggers => new()
+    {
+        "DROP FOR COCK", "GIGGLETIME", "BLONDE MOMENT", "ZAP COCK DRAIN OBEY", "SNAP AND FORGET",
+        "PRIMPED AND PAMPERED", "SAFE AND SECURE", "COCK ZOMBIE NOW", "UNIFORM LOCK",
+        "AIRHEAD BARBIE", "BRAINDEAD BOBBLEHEAD", "COCKBLANK LOVEDOLL",
+    };
+
+    /// <summary>The subset that is still a verbatim BambiSleep default, so the prune can reach it.</summary>
+    public static TheoryData<string> RemovedAndStillBambiDefaults => new()
+    {
+        "DROP FOR COCK", "GIGGLETIME", "BLONDE MOMENT", "ZAP COCK DRAIN OBEY", "SNAP AND FORGET",
+        "PRIMPED AND PAMPERED", "SAFE AND SECURE", "COCK ZOMBIE NOW",
+        "AIRHEAD BARBIE", "BRAINDEAD BOBBLEHEAD", "COCKBLANK LOVEDOLL",
+    };
+
+    /// <summary>Refilled slots: every one is a line the Sissy mod already speaks.</summary>
+    public static TheoryData<string> ReusedReplacements => new()
+    {
+        "GOOD GIRLS OBEY", "EMPTY AND OBEDIENT", "SISSY IS LEARNING", "I LOVE BEING PROGRAMMED",
+        "SISSY LOVES BUBBLES", "SISSY WILL TRY HARDER", "DUMB DOLLS COUNT SLOWLY",
+        "GOOD GIRLS PAY ATTENTION", "SISSY NEEDS TO FOCUS",
+    };
+
+    [Theory]
+    [MemberData(nameof(RemovedBambiTriggers))]
+    public void SissyTriggers_NoLongerCarryTheBambiPhrase(string phrase)
+    {
+        Assert.NotNull(BuiltInMods.SissyHypno.CustomTriggers);
+        Assert.DoesNotContain(phrase, BuiltInMods.SissyHypno.CustomTriggers!);
+    }
+
+    [Theory]
+    [MemberData(nameof(RemovedAndStillBambiDefaults))]
+    public void RemovedTrigger_IsStillABambiDefault_SoSavedListsGetPruned(string phrase)
+        => Assert.Contains(phrase, BuiltInMods.BambiSleep.CustomTriggers!);
+
+    [Fact]
+    public void UniformLock_IsTheOneThePruneCannotReach()
+    {
+        // BAMBI UNIFORM LOCK -> UNIFORM LOCK: the de-prefixed form is nobody's default, so a saved
+        // list keeps it rather than risk deleting a trigger a user typed themselves. Same call as
+        // the subliminal pool's.
+        Assert.DoesNotContain("UNIFORM LOCK", BuiltInMods.BambiSleep.CustomTriggers!);
+        Assert.Contains("BAMBI UNIFORM LOCK", BuiltInMods.BambiSleep.CustomTriggers!);
+    }
+
+    [Theory]
+    [MemberData(nameof(ReusedReplacements))]
+    public void Replacement_IsInTheTriggerListNow(string phrase)
+        => Assert.Contains(phrase, BuiltInMods.SissyHypno.CustomTriggers!);
+
+    [Theory]
+    [MemberData(nameof(ReusedReplacements))]
+    public void Replacement_AlreadyExistedElsewhereInTheSissyMod(string phrase)
+    {
+        var mod = BuiltInMods.SissyHypno;
+        var elsewhere = new List<string>();
+        if (mod.SubliminalPool != null) elsewhere.AddRange(mod.SubliminalPool.Keys);
+        if (mod.LockCardPhrases != null) elsewhere.AddRange(mod.LockCardPhrases.Keys);
+        if (mod.Phrases != null) foreach (var set in mod.Phrases.Values) elsewhere.AddRange(set);
+        Assert.Contains(phrase, elsewhere);
+    }
+
+    [Fact]
+    public void SissyTriggers_KeepTheirStructuralEntries()
+    {
+        // The mod's own Freeze/Reset/CumAndCollapse words must stay offerable.
+        var triggers = BuiltInMods.SissyHypno.CustomTriggers!;
+        Assert.Contains("FREEZE", triggers);
+        Assert.Contains("RESET", triggers);
+        Assert.Contains("CUM AND COLLAPSE", triggers);
+    }
+
+    [Fact]
+    public void NoSissyTrigger_IsANamedBambiTrigger()
+    {
+        var own = new HashSet<string>(BuiltInMods.SissyHypno.CustomTriggers!, StringComparer.OrdinalIgnoreCase);
+        // Anything Sissy still shares with another built-in mod has to be a generic word it also
+        // uses itself (GOOD GIRL), never one of the named BambiSleep triggers this report was about.
+        foreach (var phrase in BambiNamedTriggers)
+            Assert.DoesNotContain(phrase, own);
+    }
+
+    private static readonly string[] BambiNamedTriggers =
+    {
+        "DROP FOR COCK", "GIGGLETIME", "BLONDE MOMENT", "ZAP COCK DRAIN OBEY", "SNAP AND FORGET",
+        "PRIMPED AND PAMPERED", "SAFE AND SECURE", "COCK ZOMBIE NOW", "UNIFORM LOCK",
+        "AIRHEAD BARBIE", "BRAINDEAD BOBBLEHEAD", "COCKBLANK LOVEDOLL",
+        "BAMBI SLEEP", "BAMBI FREEZE", "BAMBI RESET", "BAMBI UNIFORM LOCK",
+    };
+}
+
+/// <summary>
+/// Migration for users who already ran Sissy before the de-Bambi'd defaults shipped: their saved
+/// per-mod trigger backup still holds the old corpus, so ModService prunes it on restore.
+/// </summary>
+public class CrossModCustomTriggerPruneTests
+{
+    private static List<string> Prune(IEnumerable<string> current, IEnumerable<string> active, out List<string> removed)
+        => ModService.PruneCrossModCustomTriggers(current, active, out removed);
+
+    [Fact]
+    public void ContaminatedSissyList_LosesBambiTriggersAndGainsSissyDefaults()
+    {
+        var saved = new List<string>(BuiltInMods.BambiSleep.CustomTriggers!);
+        var result = Prune(saved, BuiltInMods.SissyHypno.CustomTriggers!, out var removed);
+
+        Assert.NotEmpty(removed);
+        Assert.DoesNotContain("DROP FOR COCK", result);
+        Assert.DoesNotContain("COCKBLANK LOVEDOLL", result);
+        // Top-up only fires because something was pruned.
+        Assert.Contains("SISSY NEEDS TO FOCUS", result);
+        Assert.Contains("GOOD GIRLS OBEY", result);
+    }
+
+    [Fact]
+    public void CleanList_IsLeftExactlyAlone()
+    {
+        var saved = new List<string> { "GOOD GIRL", "FREEZE", "MY OWN TRIGGER" };
+        var result = Prune(saved, BuiltInMods.SissyHypno.CustomTriggers!, out var removed);
+
+        Assert.Empty(removed);
+        Assert.Equal(saved, result);
+    }
+
+    [Fact]
+    public void UserTypedTrigger_SurvivesThePrune()
+    {
+        var saved = new List<string> { "GIGGLETIME", "PLEASE REMEMBER THIS ONE" };
+        var result = Prune(saved, BuiltInMods.SissyHypno.CustomTriggers!, out _);
+        Assert.Contains("PLEASE REMEMBER THIS ONE", result);
+    }
+
+    [Fact]
+    public void ActiveModsOwnDefaults_AreNeverPruned()
+    {
+        var saved = new List<string>(BuiltInMods.BambiSleep.CustomTriggers!);
+        var result = Prune(saved, BuiltInMods.BambiSleep.CustomTriggers!, out var removed);
+        Assert.Empty(removed);
+        Assert.Equal(saved, result);
+    }
+
+    [Fact]
+    public void EmptyList_StaysEmpty()
+    {
+        var result = Prune(new List<string>(), BuiltInMods.SissyHypno.CustomTriggers!, out var removed);
+        Assert.Empty(result);
+        Assert.Empty(removed);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
@@ -273,50 +273,76 @@ public class SissyCustomTriggerTests
 
 /// <summary>
 /// Migration for users who already ran Sissy before the de-Bambi'd defaults shipped: their saved
-/// per-mod trigger backup still holds the old corpus, so ModService prunes it on restore.
+/// per-mod trigger backup still holds the old corpus, so ModService strips the Bambi-specific
+/// entries once, under Sissy only, and never adds anything back.
 /// </summary>
-public class CrossModCustomTriggerPruneTests
+public class InheritedBambiTriggerPruneTests
 {
-    private static List<string> Prune(IEnumerable<string> current, IEnumerable<string> active, out List<string> removed)
-        => ModService.PruneCrossModCustomTriggers(current, active, out removed);
+    private static List<string> Prune(IEnumerable<string> current, out List<string> removed)
+        => ModService.PruneInheritedBambiTriggers(current, null, out removed);
 
     [Fact]
-    public void ContaminatedSissyList_LosesBambiTriggersAndGainsSissyDefaults()
+    public void ContaminatedSissyList_LosesBambiSpecificTriggersOnly()
     {
         var saved = new List<string>(BuiltInMods.BambiSleep.CustomTriggers!);
-        var result = Prune(saved, BuiltInMods.SissyHypno.CustomTriggers!, out var removed);
+        var result = Prune(saved, out var removed);
 
         Assert.NotEmpty(removed);
         Assert.DoesNotContain("DROP FOR COCK", result);
         Assert.DoesNotContain("COCKBLANK LOVEDOLL", result);
-        // Top-up only fires because something was pruned.
-        Assert.Contains("SISSY NEEDS TO FOCUS", result);
-        Assert.Contains("GOOD GIRLS OBEY", result);
+        Assert.DoesNotContain("BAMBI SLEEP", result);
+        // Shared with the Sissy defaults, so it stays.
+        Assert.Contains("GOOD GIRL", result);
+        Assert.Contains("BIMBO DOLL", result);
     }
 
     [Fact]
-    public void CleanList_IsLeftExactlyAlone()
+    public void NothingIsEverAddedBack()
     {
-        var saved = new List<string> { "GOOD GIRL", "FREEZE", "MY OWN TRIGGER" };
-        var result = Prune(saved, BuiltInMods.SissyHypno.CustomTriggers!, out var removed);
+        // A curated Sissy list that the user trimmed down keeps exactly what they left, minus
+        // the inherited Bambi entry. Defaults are NOT stamped back over deliberate deletions.
+        var saved = new List<string> { "GOOD GIRL", "GIGGLETIME", "MY OWN TRIGGER" };
+        var result = Prune(saved, out var removed);
+
+        Assert.Equal(new[] { "GIGGLETIME" }, removed);
+        Assert.Equal(new[] { "GOOD GIRL", "MY OWN TRIGGER" }, result);
+        Assert.DoesNotContain("SISSY NEEDS TO FOCUS", result);
+    }
+
+    [Fact]
+    public void GenericVocabularyFromOtherMods_IsNeverTouched()
+    {
+        // The CCPDefault / Locked / Drone words are generic and can be hand-typed by anyone,
+        // so the narrow Bambi-only pass must leave them alone.
+        var saved = new List<string>
+        {
+            "OBEY", "DROP", "FOCUS", "BREATHE", "RELAX", "DEEPER", "TRANCE",
+            "KNEEL", "EMPTY", "STAY", "SINK", "EDGE", "BEG", "HOLD IT", "COLLAPSE",
+            "GOOD BOY", "COMPLY"
+        };
+        var result = Prune(saved, out var removed);
 
         Assert.Empty(removed);
         Assert.Equal(saved, result);
     }
 
     [Fact]
-    public void UserTypedTrigger_SurvivesThePrune()
+    public void UserTypedBambiPhrase_SurvivesWhenTracked()
     {
-        var saved = new List<string> { "GIGGLETIME", "PLEASE REMEMBER THIS ONE" };
-        var result = Prune(saved, BuiltInMods.SissyHypno.CustomTriggers!, out _);
-        Assert.Contains("PLEASE REMEMBER THIS ONE", result);
+        var saved = new List<string> { "GIGGLETIME", "BLONDE MOMENT" };
+        var result = ModService.PruneInheritedBambiTriggers(
+            saved, new[] { "GIGGLETIME" }, out var removed);
+
+        Assert.Equal(new[] { "BLONDE MOMENT" }, removed);
+        Assert.Contains("GIGGLETIME", result);
     }
 
     [Fact]
-    public void ActiveModsOwnDefaults_AreNeverPruned()
+    public void CleanList_IsLeftExactlyAlone()
     {
-        var saved = new List<string>(BuiltInMods.BambiSleep.CustomTriggers!);
-        var result = Prune(saved, BuiltInMods.BambiSleep.CustomTriggers!, out var removed);
+        var saved = new List<string> { "GOOD GIRL", "FREEZE", "MY OWN TRIGGER" };
+        var result = Prune(saved, out var removed);
+
         Assert.Empty(removed);
         Assert.Equal(saved, result);
     }
@@ -324,7 +350,7 @@ public class CrossModCustomTriggerPruneTests
     [Fact]
     public void EmptyList_StaysEmpty()
     {
-        var result = Prune(new List<string>(), BuiltInMods.SissyHypno.CustomTriggers!, out var removed);
+        var result = Prune(new List<string>(), out var removed);
         Assert.Empty(result);
         Assert.Empty(removed);
     }

--- a/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #1027 (BUG-BN8X9B9SZ5), part two. The ledger itself already survives a logout - quests.json is
+/// stamped with its owner instead of wiped - but the ENTITLEMENT providers are torn down by the
+/// same logout, so during the signed-out window the premium gate answers "no access" on behalf of
+/// nobody. The premium-loss reroll believed that answer and swapped the departed account's
+/// untouched premium quest for a free one, which reaches the user as the same "my quests changed
+/// when I signed back in" report. QuestService now treats the whole window as unresolved.
+/// </summary>
+public class QuestSignedOutEntitlementTests
+{
+    [Fact]
+    public void SignedOut_WithOwnedLedger_IsNotAnEntitlementAnswer()
+        => Assert.True(QuestService.IsSignedOutWithOwnedQuests(null, "unified-abc"));
+
+    [Fact]
+    public void SignedOut_WithEmptyStringId_CountsAsSignedOut()
+        => Assert.True(QuestService.IsSignedOutWithOwnedQuests("", "unified-abc"));
+
+    [Fact]
+    public void SignedIn_IsAlwaysAnAnswer()
+        => Assert.False(QuestService.IsSignedOutWithOwnedQuests("unified-abc", "unified-abc"));
+
+    [Fact]
+    public void SignedIn_AsADifferentAccount_IsStillAnAnswer()
+    {
+        // EnsureOwnedBy wipes the foreign ledger on this login; the entitlement read is the
+        // incoming account's own and must not be deferred.
+        Assert.False(QuestService.IsSignedOutWithOwnedQuests("unified-new", "unified-old"));
+    }
+
+    [Fact]
+    public void NeverLoggedIn_IsUnaffected()
+    {
+        // A user who has never signed in has an unstamped ledger. The #889 settle-window
+        // behaviour has to stay exactly as it was for them - no deferral, ever.
+        Assert.False(QuestService.IsSignedOutWithOwnedQuests(null, null));
+        Assert.False(QuestService.IsSignedOutWithOwnedQuests(null, ""));
+    }
+
+    [Fact]
+    public void FreshLedger_IsUnstamped()
+        => Assert.True(string.IsNullOrEmpty(new QuestProgress().OwnerUnifiedId));
+}
+
+/// <summary>
+/// Sarah, #general 08-22 (Mort verified): the Sissy Hypno mod's subliminal pool was still
+/// conditioning on BambiSleep's named triggers. The pool had been produced by find-replacing the
+/// word "BAMBI" out of the BambiSleep pool, which stripped the brand but left the trigger corpus.
+/// </summary>
+public class SissySubliminalPoolTests
+{
+    /// <summary>
+    /// The BambiSleep trigger phrases that were removed. Eight are verbatim BambiSleep defaults;
+    /// UNIFORM LOCK is BAMBI UNIFORM LOCK with the brand filed off, which is why it is listed
+    /// separately below - the automatic migration cannot see that one.
+    /// </summary>
+    public static TheoryData<string> RemovedBambiTriggers => new()
+    {
+        "DROP FOR COCK", "SNAP AND FORGET", "PRIMPED AND PAMPERED", "ZAP COCK DRAIN OBEY",
+        "GIGGLETIME", "UNIFORM LOCK", "COCK ZOMBIE NOW", "COCK TURNS MY BRAIN OFF",
+        "I CANT RESIST MY TRIGGERS",
+    };
+
+    /// <summary>The subset that is still a verbatim BambiSleep default.</summary>
+    public static TheoryData<string> RemovedAndStillBambiDefaults => new()
+    {
+        "DROP FOR COCK", "SNAP AND FORGET", "PRIMPED AND PAMPERED", "ZAP COCK DRAIN OBEY",
+        "GIGGLETIME", "COCK ZOMBIE NOW", "COCK TURNS MY BRAIN OFF", "I CANT RESIST MY TRIGGERS",
+    };
+
+    [Theory]
+    [MemberData(nameof(RemovedBambiTriggers))]
+    public void SissyPool_NoLongerCarriesTheBambiTrigger(string phrase)
+    {
+        Assert.NotNull(BuiltInMods.SissyHypno.SubliminalPool);
+        Assert.DoesNotContain(phrase, BuiltInMods.SissyHypno.SubliminalPool!.Keys);
+    }
+
+    [Theory]
+    [MemberData(nameof(RemovedAndStillBambiDefaults))]
+    public void RemovedPhrase_IsStillABambiDefault_SoExistingPoolsGetPruned(string phrase)
+    {
+        // The migration for users who already have a saved Sissy pool depends on this: prune
+        // only fires for a key that is some OTHER built-in mod's default and not the active
+        // mod's. If BambiSleep ever drops one of these, the stale key would go unpruned.
+        Assert.NotNull(BuiltInMods.BambiSleep.SubliminalPool);
+        Assert.Contains(phrase, BuiltInMods.BambiSleep.SubliminalPool!.Keys);
+    }
+
+    [Fact]
+    public void UniformLock_IsTheOneThePruneCannotReach()
+    {
+        // BAMBI UNIFORM LOCK -> UNIFORM LOCK: the de-prefixed form is nobody's default, so
+        // PruneCrossModSubliminals sees a user-added phrase and leaves it. Documented, not fixed:
+        // stripping it would need a rename list, and one stale key in an already-customised pool
+        // is a smaller harm than a pass that can delete phrases a user typed themselves.
+        Assert.DoesNotContain("UNIFORM LOCK", BuiltInMods.BambiSleep.SubliminalPool!.Keys);
+        Assert.Contains("BAMBI UNIFORM LOCK", BuiltInMods.BambiSleep.SubliminalPool!.Keys);
+    }
+
+    /// <summary>
+    /// The replacements are reused Sissy-mod lines, not new writing. Every one of them must
+    /// already appear somewhere else in the SAME manifest.
+    /// </summary>
+    public static TheoryData<string> ReusedReplacements => new()
+    {
+        "GOOD GIRLS OBEY", "EMPTY AND OBEDIENT", "SISSY IS LEARNING", "I LOVE BEING PROGRAMMED",
+        "SISSY LOVES BUBBLES", "SISSY WILL TRY HARDER", "DUMB DOLLS COUNT SLOWLY",
+        "GOOD GIRLS PAY ATTENTION", "SISSY NEEDS TO FOCUS",
+    };
+
+    [Theory]
+    [MemberData(nameof(ReusedReplacements))]
+    public void Replacement_IsInThePoolNow(string phrase)
+        => Assert.Contains(phrase, BuiltInMods.SissyHypno.SubliminalPool!.Keys);
+
+    [Theory]
+    [MemberData(nameof(ReusedReplacements))]
+    public void Replacement_AlreadyExistedElsewhereInTheSissyMod(string phrase)
+    {
+        var mod = BuiltInMods.SissyHypno;
+        var elsewhere = new List<string>();
+        if (mod.LockCardPhrases != null) elsewhere.AddRange(mod.LockCardPhrases.Keys);
+        if (mod.Phrases != null) foreach (var set in mod.Phrases.Values) elsewhere.AddRange(set);
+        Assert.Contains(phrase, elsewhere);
+    }
+
+    [Fact]
+    public void SissyPool_KeptItsSize()
+    {
+        // Nine out, nine in: the subliminal cadence a user already tuned does not change.
+        Assert.Equal(21, BuiltInMods.SissyHypno.SubliminalPool!.Count);
+    }
+}
+
+/// <summary>
+/// FYP volume (suggestion thread 1539830425948524654). The feed only ever had a binary mute; the
+/// slider persists through the same host bridge every other feed setting uses.
+/// </summary>
+public class FypVolumeSettingTests
+{
+    [Fact]
+    public void DefaultsToFullVolume() => Assert.Equal(100, new AppSettings().FypVolume);
+
+    [Theory]
+    [InlineData(-40, 0)]
+    [InlineData(0, 0)]
+    [InlineData(55, 55)]
+    [InlineData(100, 100)]
+    [InlineData(9999, 100)]
+    public void IsClampedToZeroHundred(int input, int expected)
+        => Assert.Equal(expected, new AppSettings { FypVolume = input }.FypVolume);
+
+    [Fact]
+    public void MuteAndVolumeAreIndependent()
+    {
+        // Mute is the panic switch; unmuting has to give back the loudness you had.
+        var s = new AppSettings { FypVolume = 30, FypMuted = true };
+        s.FypMuted = false;
+        Assert.Equal(30, s.FypVolume);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs
@@ -355,3 +355,203 @@ public class InheritedBambiTriggerPruneTests
         Assert.Empty(removed);
     }
 }
+
+/// <summary>
+/// The persistence half of the same migration. The prune has to reach the PER-MOD BACKUP, not just
+/// the active list: RestorePoolsFromSettings rebuilds CustomTriggers from CustomTriggersByMod on
+/// every launch, and the one-shot flag stops the prune from running a second time. Writing only the
+/// active list meant the next launch restored the stale Bambi corpus over the pruned one and could
+/// never clean it again, so the reported triggers came back permanently for exactly the users the
+/// migration targets.
+/// </summary>
+public class SissyBambiTriggerMigrationPersistenceTests
+{
+    private const string SissyId = BuiltInMods.SissyHypnoId;
+
+    private static AppSettings ContaminatedSissySettings()
+    {
+        var settings = new AppSettings
+        {
+            SissyBambiTriggerMigrationDone = false,
+            CustomTriggersByMod = new Dictionary<string, List<string>>
+            {
+                [SissyId] = new List<string>(BuiltInMods.BambiSleep.CustomTriggers!)
+            }
+        };
+        // What RestorePoolsFromSettings does just before the migration runs.
+        settings.CustomTriggers = new List<string>(settings.CustomTriggersByMod[SissyId]);
+        return settings;
+    }
+
+    [Fact]
+    public void Migration_WritesThePrunedListBackOverThePerModBackup()
+    {
+        var settings = ContaminatedSissySettings();
+
+        Assert.True(ModService.ApplySissyBambiTriggerMigration(settings, SissyId, out var removed));
+
+        Assert.NotEmpty(removed);
+        Assert.DoesNotContain("DROP FOR COCK", settings.CustomTriggers!);
+        Assert.DoesNotContain("DROP FOR COCK", settings.CustomTriggersByMod![SissyId]);
+        Assert.DoesNotContain("COCKBLANK LOVEDOLL", settings.CustomTriggersByMod![SissyId]);
+        Assert.Equal(settings.CustomTriggers, settings.CustomTriggersByMod![SissyId]);
+    }
+
+    [Fact]
+    public void SecondLaunch_StillSeesThePrunedList()
+    {
+        var settings = ContaminatedSissySettings();
+        ModService.ApplySissyBambiTriggerMigration(settings, SissyId, out _);
+
+        // Next launch: the restore reloads the active list from the backup, and the one-shot flag
+        // means the prune does NOT run again. The list must already be clean.
+        Assert.True(settings.SissyBambiTriggerMigrationDone);
+        settings.CustomTriggers = new List<string>(settings.CustomTriggersByMod![SissyId]);
+        Assert.False(ModService.ApplySissyBambiTriggerMigration(settings, SissyId, out var removedAgain));
+
+        Assert.Empty(removedAgain);
+        Assert.DoesNotContain("DROP FOR COCK", settings.CustomTriggers!);
+        Assert.DoesNotContain("GIGGLETIME", settings.CustomTriggers!);
+        Assert.DoesNotContain("ZAP COCK DRAIN OBEY", settings.CustomTriggers!);
+        Assert.Contains("GOOD GIRL", settings.CustomTriggers!);
+    }
+
+    [Fact]
+    public void OtherMods_AreNeverTouchedAndTheFlagStaysUnset()
+    {
+        var settings = ContaminatedSissySettings();
+
+        Assert.False(ModService.ApplySissyBambiTriggerMigration(settings, BuiltInMods.BambiSleepId, out var removed));
+
+        Assert.Empty(removed);
+        Assert.False(settings.SissyBambiTriggerMigrationDone);
+        Assert.Contains("DROP FOR COCK", settings.CustomTriggersByMod![SissyId]);
+    }
+
+    [Fact]
+    public void AlreadyMigrated_IsANoOp()
+    {
+        var settings = ContaminatedSissySettings();
+        settings.SissyBambiTriggerMigrationDone = true;
+
+        Assert.False(ModService.ApplySissyBambiTriggerMigration(settings, SissyId, out var removed));
+
+        Assert.Empty(removed);
+        // A phrase the user deliberately re-added after the migration is kept, as designed.
+        Assert.Contains("DROP FOR COCK", settings.CustomTriggers!);
+    }
+
+    [Fact]
+    public void CleanList_LeavesTheBackupAloneAndStillStampsTheFlag()
+    {
+        var settings = new AppSettings
+        {
+            CustomTriggers = new List<string> { "GOOD GIRL", "MY OWN TRIGGER" },
+            CustomTriggersByMod = new Dictionary<string, List<string>>
+            {
+                [SissyId] = new List<string> { "GOOD GIRL", "MY OWN TRIGGER" }
+            }
+        };
+
+        Assert.False(ModService.ApplySissyBambiTriggerMigration(settings, SissyId, out var removed));
+
+        Assert.Empty(removed);
+        Assert.True(settings.SissyBambiTriggerMigrationDone);
+        Assert.Equal(new[] { "GOOD GIRL", "MY OWN TRIGGER" }, settings.CustomTriggersByMod![SissyId]);
+    }
+
+    [Fact]
+    public void NoBackupYet_IsCreatedByTheMigration()
+    {
+        var settings = new AppSettings
+        {
+            CustomTriggers = new List<string>(BuiltInMods.BambiSleep.CustomTriggers!),
+            CustomTriggersByMod = null
+        };
+
+        Assert.True(ModService.ApplySissyBambiTriggerMigration(settings, SissyId, out _));
+
+        Assert.NotNull(settings.CustomTriggersByMod);
+        Assert.DoesNotContain("GIGGLETIME", settings.CustomTriggersByMod![SissyId]);
+    }
+}
+
+/// <summary>
+/// The other half of the same report: the shipped built-in sessions still prescribe the named
+/// BambiSleep triggers as subliminal phrases, and SessionEngine installs every session phrase into
+/// the live pool through ModService.MakeModAware. Rules for the trigger names that carry no
+/// "Bambi" in them were missing, so a Sissy user still met them through the Sessions tab. Every
+/// replacement is the line that already took that phrase's place in the Sissy pool - no new writing.
+/// </summary>
+public class SissySessionPhraseTranslationTests
+{
+    private static string Sissy(string text)
+        => ModService.ApplyTextReplacements(BuiltInMods.SissyHypno.TextReplacements, text);
+
+    public static TheoryData<string, string> SessionPhrases => new()
+    {
+        { "DROP FOR COCK", "GOOD GIRLS OBEY" },
+        { "SNAP AND FORGET", "EMPTY AND OBEDIENT" },
+        { "PRIMPED AND PAMPERED", "SISSY IS LEARNING" },
+        { "ZAP COCK DRAIN OBEY", "I LOVE BEING PROGRAMMED" },
+        { "GIGGLETIME", "SISSY LOVES BUBBLES" },
+        { "COCK ZOMBIE NOW", "DUMB DOLLS COUNT SLOWLY" },
+        { "COCK TURNS MY BRAIN OFF", "GOOD GIRLS PAY ATTENTION" },
+        { "I CANT RESIST MY TRIGGERS", "SISSY NEEDS TO FOCUS" },
+        { "UNIFORM LOCK", "SISSY WILL TRY HARDER" },
+        { "BAMBI UNIFORM LOCK", "SISSY WILL TRY HARDER" },
+        { "BAMBI SLEEP", "DEEP SLEEP" },
+    };
+
+    [Theory]
+    [MemberData(nameof(SessionPhrases))]
+    public void SessionPhrase_ArrivesAsTheSissyLine(string prescribed, string expected)
+        => Assert.Equal(expected, Sissy(prescribed));
+
+    [Theory]
+    [MemberData(nameof(SessionPhrases))]
+    public void TranslatedPhrase_IsAlreadyPartOfTheSissyMod(string prescribed, string expected)
+    {
+        _ = prescribed;
+        var mod = BuiltInMods.SissyHypno;
+        var own = new List<string>();
+        if (mod.SubliminalPool != null) own.AddRange(mod.SubliminalPool.Keys);
+        if (mod.LockCardPhrases != null) own.AddRange(mod.LockCardPhrases.Keys);
+        if (mod.CustomTriggers != null) own.AddRange(mod.CustomTriggers);
+        if (mod.Phrases != null) foreach (var set in mod.Phrases.Values) own.AddRange(set);
+        Assert.Contains(expected, own);
+    }
+
+    [Fact]
+    public void EveryBuiltInSessionPhrase_LandsCleanOfNamedBambiTriggers()
+    {
+        var named = new[]
+        {
+            "DROP FOR COCK", "GIGGLETIME", "ZAP COCK DRAIN OBEY", "SNAP AND FORGET",
+            "PRIMPED AND PAMPERED", "COCK ZOMBIE NOW", "UNIFORM LOCK", "BAMBI",
+        };
+
+        foreach (var session in new[]
+        {
+            Session.MorningDrift, Session.GamerGirl, Session.DistantDoll, Session.GoodGirlsDontCum,
+        })
+        {
+            foreach (var phrase in session.Settings.SubliminalPhrases)
+            {
+                var landed = Sissy(phrase);
+                foreach (var bad in named)
+                    Assert.DoesNotContain(bad, landed, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    [Fact]
+    public void BambiMod_IsUntouched()
+    {
+        // The base mod registers no replacements, so its own sessions still say their own words.
+        var replacements = BuiltInMods.BambiSleep.TextReplacements;
+        Assert.True(replacements == null || replacements.Count == 0);
+        Assert.Equal("DROP FOR COCK",
+            ModService.ApplyTextReplacements(replacements, "DROP FOR COCK"));
+    }
+}


### PR DESCRIPTION
Three small v6.8.5 items. Build 0 errors, full suite green (4153/4153 as of Round 4).

## 1. #1027 quest progress on logout -> login (BUG-BN8X9B9SZ5), residual half

**What was already fixed on main** (69877ff0d, landed after the v6.8.3 the report was filed
against): the quest LEDGER survives a logout. `ClearAccountData` stamps `quests.json` with the
departing account id instead of wiping it, `ClearProgressionData(preserveQuestProgress: true)`
leaves the file alone, `QuestService.EnsureOwnedBy` wipes it only when a DIFFERENT account signs
in, and a same-account login no longer calls `ClearProgressionData` at all. `IsQuestAvailableForLevel`
was also already reduced to `return true`, so the level-zeroing named in the brief cannot regenerate
anything any more. That part of #1027 needed no further change and is verified below, not re-fixed.

**What was still broken.** The ledger survives a logout but the entitlement providers do not: a
logout tears down Patreon/SubscribeStar. For the whole signed-out window `IsEntitlementResolved()`
answered "resolved, no access" on behalf of nobody, and the premium-loss reroll in
`CheckAndGenerateQuests` acted on it: an untouched premium daily/weekly was discarded and replaced
with a free quest purely because the user signed out. That reaches the user as exactly the reported
"my quests are different after signing back in".

**Fix.** `IsEntitlementResolved()` now returns false while nobody is signed in AND the ledger is
stamped for an owner (`IsSignedOutWithOwnedQuests`, a pure static so it is testable without a live
App). Consequences:

- the reroll defers instead of dropping (the existing `_premiumRecheckPending` machinery already
  guarantees a deferred decision is retried, never lost);
- the once-a-minute refresh tick stays quiet while signed out, because `premiumRecheck` is
  `_premiumRecheckPending && IsEntitlementResolved()`;
- a day rollover while signed out flags the slot `RolledUnresolved`, so it re-rolls against the
  blended pool once the account is back;
- a user who has never signed in has an unstamped ledger, so #889's settle-window behaviour is
  bit-for-bit unchanged for them;
- a DIFFERENT account signing in reads its own entitlement immediately (the guard requires an empty
  current id), and `EnsureOwnedBy` still gives it a clean roll.

`ProfileSyncService` ~:634 (`EnsureOwnedBy` on the load path) and the `ResetDailyQuest` /
`ResetWeeklyQuest` server flags at ~:1479 / ~:2868 were read as instructed; both are deliberate
server-authoritative wipes and are untouched.

## 2. FYP volume slider (suggestion thread 1539830425948524654, 6 upvotes)

- `AppSettings.FypVolume`, int 0-100, default 100, clamped in the setter.
- `FypHostService`: `volume` in the init payload, `case "volume"` in `ApplySetting`.
- `index.html` / `fyp.css`: a "Volume" row in the options popover, styled with the existing
  `#mosaic-sec` / `#window-opacity` slider rules.
- `main.js`: `settings.volume`, `clampVolume`, `setVolume(pct, persist)`, and `volume() -> 0..1`
  on the page ctx. Drag applies locally on every frame, release persists (same split as the
  opacity slider, minus the throttle: setting `.volume` on a few elements costs nothing).
- `surfaces.js`: `setVolume` on the video surface (no-op on the GIF surface), seeded at creation
  and re-applied by `applyAudio`, which every mount already ends in.

Volume and mute stay independent on purpose: mute is the one-key panic switch (M / the speaker
button) and must return you to the loudness you had, so unmuting never rewrites the volume and
setting a volume never clears the mute. 0% is legal and is silence with the speaker button still
reading "on"; the label says 0% so it is not a mystery.

**Property naming:** `FypVolume` has no `[JsonProperty]`, matching every other `Fyp*` setting in
the file (`FypMuted`, `FypAudioGlow`, `FypWindowOpacity` are all plain PascalCase). The brief
suggested snake_case; a single snake_case key among its PascalCase neighbours would have been the
odd one out, so consistency won. Easy to flip if you would rather.

**MIRROR NOTE:** this is the app's embedded copy of the FYP page. The change is confined to
`Resources/web/fyp` + `Services/Fyp` + `AppSettings`, so it can be mirrored to the web repo as-is;
the web copy needs its own persistence shim in place of the host bridge.

## 3. Sissy mod subliminal pool still carried BambiSleep triggers (Sarah, #general 08-22; Mort verified)

The Sissy pool had been produced by find-replacing the word "BAMBI" out of the BambiSleep pool:
that stripped the brand and left the trigger corpus standing verbatim. Nine phrases removed. **No
new lines were written** - every replacement is a line the Sissy mod already speaks, taken from its
own `LockCardPhrases` or its `BubbleCountMercy` bark pool.

| Removed (BambiSleep trigger) | Replaced with (existing Sissy line) | Reused from |
|---|---|---|
| DROP FOR COCK | GOOD GIRLS OBEY | LockCardPhrases |
| SNAP AND FORGET | EMPTY AND OBEDIENT | LockCardPhrases + BubbleCountMercy |
| PRIMPED AND PAMPERED | SISSY IS LEARNING | BubbleCountMercy |
| ZAP COCK DRAIN OBEY | I LOVE BEING PROGRAMMED | LockCardPhrases |
| GIGGLETIME | SISSY LOVES BUBBLES | BubbleCountMercy |
| UNIFORM LOCK | SISSY WILL TRY HARDER | BubbleCountMercy |
| COCK ZOMBIE NOW | DUMB DOLLS COUNT SLOWLY | BubbleCountMercy |
| COCK TURNS MY BRAIN OFF | GOOD GIRLS PAY ATTENTION | BubbleCountMercy |
| I CANT RESIST MY TRIGGERS | SISSY NEEDS TO FOCUS | BubbleCountMercy |

Nine out, nine in, so the pool is still 21 entries and a user's tuned subliminal cadence does not
change.

`BuiltInPrograms.Presentation.cs` (the Sissy mod's own 14-day program) had 19 references to the
removed phrases across its reward pack and its four subliminal packs; those move to the same
replacements, which is what keeps `ProgramPresentationTests` / `ProgramRewardTests` - the existing
"every program phrase must be a key of its own mod's pool" invariants - green.

**Migration for existing users is automatic**: `ModService.PruneCrossModSubliminals` strips a key
that is another built-in mod's default and not the active mod's, and the same pass tops up new
defaults. Eight of the nine are still verbatim BambiSleep defaults, so they are pruned on the next
mod restore.

### NOT done (deliberate)

- **UNIFORM LOCK does not auto-prune.** It is `BAMBI UNIFORM LOCK` with the brand filed off, so it
  is nobody's default and the prune pass reads it as a user-added phrase. It is gone from the
  shipped pool; a pool a user already saved keeps the stale key. Fixing that needs a rename list,
  and one stale key beats a pass that can delete phrases a user typed themselves. Covered by a test
  that documents the gap.
- **`LockCardPhrases` left alone.** Its five Sissy entries are the mod's own (GOOD GIRLS OBEY,
  I LOVE BEING PROGRAMMED, DEEP SLEEP, DROP FOR ME, EMPTY AND OBEDIENT); none is a BambiSleep
  named trigger. `CustomTriggers` is now fixed too - see section 3b below (review follow-up).
- **CUM AND COLLAPSE kept.** It is wired as the Sissy mod's own `Triggers.CumAndCollapse`; removing
  it from the subliminal pool while it remains the mod's trigger would be incoherent.
- **BIMBO DOLL / GOOD GIRL / DEEP SLEEP / FREEZE / RESET / JUST OBEY / GOOD GIRLS DONT THINK /
  DONT THINK SILLY / TURN YOUR BRAIN OFF / THERES NO NEED TO THINK kept.** Generic sissy-hypno
  vocabulary rather than BambiSleep-specific; BIMBO DOLL is literally the mod's companion name and
  GOOD GIRLS DONT THINK is in the mod's own bark pool.

## 3b. Sissy `CustomTriggers` - the other half of the same report (review follow-up)

The first pass cleaned the subliminal pool only, and that was not enough: `CustomTriggers` was
still the BambiSleep corpus verbatim, and it is not a dormant field. It feeds the companion's
trigger offers (`AvatarTube/AvatarTubeWindow.Speech.cs:1762`, `.ChatInput.cs:194`), the Patreon
trigger surface (`MainWindow/MainWindow.Patreon.cs:1233`) and
`KeywordTriggerService.ImportFromCustomTriggers` (`:436`). A Sissy user still met nine of the
phrases just deleted from the subliminal pool, through four other surfaces, so the same report
could have been filed again against the same mod.

Twelve inherited entries are gone. Nine slots are refilled with lines this mod already speaks
(**still no new writing**); three are simply dropped, which needs no writing at all.

| Removed (Bambi-inherited) | Replaced with (existing Sissy line) |
|---|---|
| DROP FOR COCK | GOOD GIRLS OBEY |
| GIGGLETIME | EMPTY AND OBEDIENT |
| BLONDE MOMENT | SISSY IS LEARNING |
| ZAP COCK DRAIN OBEY | I LOVE BEING PROGRAMMED |
| SNAP AND FORGET | SISSY LOVES BUBBLES |
| PRIMPED AND PAMPERED | SISSY WILL TRY HARDER |
| SAFE AND SECURE | DUMB DOLLS COUNT SLOWLY |
| COCK ZOMBIE NOW | GOOD GIRLS PAY ATTENTION |
| UNIFORM LOCK | SISSY NEEDS TO FOCUS |
| AIRHEAD BARBIE | (dropped, no replacement) |
| BRAINDEAD BOBBLEHEAD | (dropped, no replacement) |
| COCKBLANK LOVEDOLL | (dropped, no replacement) |

18 entries become 15. The mod's structural words (GOOD GIRL, DEEP SLEEP, BIMBO DOLL, FREEZE,
RESET, CUM AND COLLAPSE) are untouched - `FREEZE` / `RESET` / `CUM AND COLLAPSE` are wired as the
mod's own `Triggers`, so they have to stay offerable.

**Migration (revised after review).** A user who ran Sissy before this build keeps the old corpus
in `CustomTriggersByMod`, so the restore path needs a one-shot clean-up. The FIRST version of this
PR did it the way subliminals do it - prune anything that is any OTHER built-in mod's default, then
top the list up with the active mod's defaults - and review caught two regressions in that:

1. **It deleted hand-typed triggers.** Unlike subliminals, custom triggers had no user-added
   allowlist, and the vocabulary that collides across mods is generic, not Bambi-specific: OBEY /
   DROP / FOCUS / BREATHE / RELAX / DEEPER / TRANCE (CCPDefault), KNEEL / EMPTY / STAY / SINK /
   EDGE / BEG / HOLD IT / COLLAPSE / GOOD BOY (Locked), COMPLY (Drone). Any of those typed by hand
   was silently dropped on the next launch, on any mod - wider blast radius than the bug being
   fixed.
2. **The top-up resurrected deliberate deletions**, undoing the fix documented at
   `MainWindow.Patreon.cs:1239` ("We no longer auto-populate defaults when empty... This fixes the
   bug where removed triggers would reappear").

The pass is now scoped to the reported defect and nothing else:
`ModService.PruneInheritedBambiTriggers` (pure static, unit tested without app state) runs **only
when the active mod is SissyHypno**, removes **only** phrases that are a BambiSleep default and NOT
a Sissy default (so GOOD GIRL and BIMBO DOLL stay, and the generic cross-mod vocabulary above is
never a candidate), **never adds anything back**, and is one-shot behind the new
`AppSettings.SissyBambiTriggerMigrationDone` flag so a user who later re-adds a Bambi phrase keeps
it. Eleven of the twelve removed defaults are verbatim BambiSleep entries and so are reached;
UNIFORM LOCK is the de-prefixed one and is out of reach, exactly as documented for the subliminal
pool, and is covered by a test that says so.

Belt and braces, mirroring the subliminal bookkeeping: new
`AppSettings.UserAddedCustomTriggers` (case-insensitive `HashSet`, `[JsonProperty]`), populated by
the trigger editor (`MainWindow.Patreon.cs` `BtnEditTriggers_Click`) for any phrase that is not one
of the active mod's defaults and un-tracked when removed, listed in
`PhraseBackupService.PhraseProperties` so an export/import round-trip stays faithful, and consulted
by the prune so a tracked phrase is never a candidate.

## Files

- `ConditioningControlPanel/Services/Progression/QuestService.cs`
- `ConditioningControlPanel/Models/AppSettings.cs`
- `ConditioningControlPanel/Services/Fyp/FypHostService.cs`
- `ConditioningControlPanel/Resources/web/fyp/index.html`, `fyp.css`, `main.js`, `surfaces.js`
- `ConditioningControlPanel/Models/BuiltInMods.cs`
- `ConditioningControlPanel/Services/ModService.cs` (new `PruneInheritedBambiTriggers` + its one-shot call on pool restore)
- `ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs` (trigger editor tracks user-typed phrases)
- `ConditioningControlPanel/Services/PhraseBackupService.cs` (`UserAddedCustomTriggers` in the backup set)
- `ConditioningControlPanel/Services/Program/BuiltInPrograms.Presentation.cs`
- `Tests/ConditioningControlPanel.Tests/SmallBatch685Tests.cs` (new)

## Tests

`dotnet build -c Debug`: 0 errors. `dotnet test`: **4123 passed / 4123**, 0 failed.

New tests in `SmallBatch685Tests.cs`:

- `QuestSignedOutEntitlementTests` - the signed-out truth table, including "never logged in is
  unaffected" and "a different account signing in is still an answer".
- `SissySubliminalPoolTests` - each removed phrase is gone; each removed phrase is still a Bambi
  default so the prune reaches it (with UNIFORM LOCK's gap documented); each replacement is in the
  pool AND already existed elsewhere in the same manifest (this is the "no new writing" guard);
  the pool is still 21 entries.
- `FypVolumeSettingTests` - default 100, clamping, and mute/volume independence.
- `SissyCustomTriggerTests` - each of the twelve removed entries is gone; the eleven that are still
  Bambi defaults are asserted to be so (that is what the migration prune depends on); UNIFORM
  LOCK's gap is documented; each replacement is present AND already existed elsewhere in the same
  manifest; the structural FREEZE / RESET / CUM AND COLLAPSE survive.
- `InheritedBambiTriggerPruneTests` (replaces the first version's `CrossModCustomTriggerPruneTests`)
  - a contaminated saved list loses the Bambi-specific entries while GOOD GIRL / BIMBO DOLL stay;
  the generic cross-mod vocabulary (OBEY, DROP, KNEEL, EMPTY, EDGE, GOOD BOY, COMPLY, ...) is never
  touched; nothing is ever added back, so a curated list keeps its deliberate deletions; a
  hand-typed phrase tracked in `UserAddedCustomTriggers` survives even when it is a Bambi default;
  a clean list is returned untouched; empty stays empty.

No existing test was weakened or deleted.

## Refs

- ccp-bugs #1027 (BUG-BN8X9B9SZ5)
- Discord suggestion thread 1539830425948524654
- Discord #general 08-22 (Sarah, verified by Mort)

## Not done

- No localization keys added: the FYP page is a WebView2 HTML surface with hardcoded English
  strings throughout (Ghost opacity, Auto-change mosaic, ...); the new Volume row follows its
  neighbours. If that page is ever localized it should be one pass.
- No in-app play-test (headless agent). Worth eyes on: the volume slider actually moving the
  audible tile in each layout, and a real logout -> login on the same account confirming the daily
  and weekly counters hold.
- Web-repo mirror of the FYP volume change not performed (see MIRROR NOTE above).
- Bambi-flavoured phrases elsewhere in the app are untouched and out of scope: the app-wide
  defaults in `AppSettings.cs`, the shipped `assets/sessions/*.session.json`, and the BambiSleep
  mod's own programs in `BuiltInPrograms.cs` / `.Takeover.cs` are that mod's or the app default's
  vocabulary, not the Sissy mod's.

---

## Round 4 (final review pass, 9ec526a21)

Three findings came back from the last adversarial verify. Two were real and are fixed here; the
third is a pre-existing test flake that is not this PR's and is not chased.

### R4-1 (blocker, fixed) - the one-shot Sissy trigger migration did not survive a restart

`RestorePoolsFromSettings` rebuilds `settings.CustomTriggers` from
`settings.CustomTriggersByMod[modId]` on every boot. The migration added in section 3b wrote the
pruned list to the ACTIVE list only. Nothing wrote it back to the backup:

- the trailing self-heal at the end of the method is `TryAdd`, which no-ops for any user who has
  run Sissy before, i.e. exactly the affected population;
- the INPC mirror (`CurrentSettings_PropertyChanged` -> `SaveCurrentPoolsToSettings`) is attached
  only AFTER `RestorePoolsFromSettings` in `Initialize`, and is explicitly suppressed on both the
  `ActivateMod` and `ReapplyActiveModPools` paths.

So after the first launch plus any settings save, `settings.json` held
`sissy_bambi_trigger_migration_done=true` next to a stale `CustomTriggersByMod["builtin-sissyhypno"]`
still containing DROP FOR COCK / GIGGLETIME / ZAP COCK DRAIN OBEY / COCKBLANK LOVEDOLL. The next
launch restored that corpus over the pruned list, and the one-shot flag blocked a second prune for
good - the reported triggers came back permanently. (The subliminal prune escapes the same gap only
because it has no one-shot flag and re-runs every launch.)

**Fix.** The migration is now `ModService.ApplySissyBambiTriggerMigration(settings, modId, out removed)`,
a pure static with no `App` dependency. When it removes anything it writes the pruned list to the
active list AND assigns (not `TryAdd`s) it into `CustomTriggersByMod[modId]`, and only then stamps
the flag. `RestorePoolsFromSettings` just calls it and logs.

New `SissyBambiTriggerMigrationPersistenceTests` (6 tests) drive the persistence path the old tests
never touched:

- the pruned list reaches the per-mod backup and matches the active list;
- a simulated SECOND launch reloads from the backup with the flag already set and still sees a
  clean list (this is the regression that shipped);
- a different mod id is a no-op and leaves the flag unset, so a Bambi user is untouched;
- an already-migrated settings object is a no-op, so a phrase the user deliberately re-added is kept;
- a clean list leaves the backup byte-identical and still stamps the flag;
- a null `CustomTriggersByMod` (fresh / cloud-restored profile) gets the backup created pruned.

### R4-2 (minor, fixed) - built-in sessions were still teaching the removed words

The verifier's claim that `MakeModAware` is "never called on SubliminalPhrases" is not accurate -
`Services/Session/SessionEngine.cs:1197-1199` runs every session-prescribed phrase through
`App.Mods.MakeModAware` before it enters the live pool. But the underlying gap was real: the Sissy
manifest's `TextReplacements` only had rules for phrases containing "Bambi", so `BAMBI SLEEP`
became `DEEP SLEEP` while `DROP FOR COCK`, `GIGGLETIME`, `PRIMPED AND PAMPERED`,
`ZAP COCK DRAIN OBEY`, `COCK ZOMBIE NOW`, `SNAP AND FORGET` and `UNIFORM LOCK` passed through
verbatim. A Sissy user running Morning Drift / Gamer Girl / Distant Doll / Good Girls Don't Cum
still met the exact phrases this PR deleted from the pool.

`BuiltInMods.CreateSissyHypno` now maps each of them to the same line that replaced it in the Sissy
subliminal pool. **Still no new writing** - every right-hand side is a line the mod already speaks:

| Session phrase | Arrives under Sissy as |
|---|---|
| DROP FOR COCK | GOOD GIRLS OBEY |
| SNAP AND FORGET | EMPTY AND OBEDIENT |
| PRIMPED AND PAMPERED | SISSY IS LEARNING |
| ZAP COCK DRAIN OBEY | I LOVE BEING PROGRAMMED |
| GIGGLETIME / Giggletime | SISSY LOVES BUBBLES / Sissy Loves Bubbles |
| COCK ZOMBIE NOW | DUMB DOLLS COUNT SLOWLY |
| COCK TURNS MY BRAIN OFF | GOOD GIRLS PAY ATTENTION |
| I CANT RESIST MY TRIGGERS | SISSY NEEDS TO FOCUS |
| UNIFORM LOCK / BAMBI UNIFORM LOCK | SISSY WILL TRY HARDER |

`BAMBI UNIFORM LOCK` needs its own row because replacements are applied longest-key-first: without
it the `UNIFORM LOCK` rule would fire first and the leftover `BAMBI` would then be rewritten by the
`BAMBI` rule, producing a mangled phrase. The mixed-case `Giggletime` row is there because that
spelling appears inside the Morning Drift description in all 9 language files.

`MakeModAware`'s replacement loop is split out unchanged as the static
`ModService.ApplyTextReplacements(replacements, text)` so the mapping is testable without an `App`;
`MakeModAware` is now a one-line call into it.

New `SissySessionPhraseTranslationTests`: every mapping resolves to the expected line; every target
already exists somewhere in the Sissy manifest (the "no new writing" guard); the full
`SubliminalPhrases` list of all four built-in sessions lands free of every named Bambi trigger and
of the word BAMBI; and the BambiSleep mod itself registers no replacements, so its own sessions
still say their own words.

**Adjacent behaviour checked.** Nothing in the Lock Card, Lockdown or Possession paths calls
`MakeModAware` (`grep MakeModAware` over the app returns display names, descriptions, skills,
achievements, presets and the session phrase loop only), so no commitment device is weakened. The
Sissy `LockCardPhrases` contain none of the new keys. Trigger delivery
(`KeywordTriggerService`, the companion's trigger offers) reads `CustomTriggers` directly and is
unaffected. The migration's new backup write happens on the same paths that already wrote pool
backups, so a mod switch mid-session and a session pause/resume behave as before. This item touches
no window, monitor or overlay code, so single-monitor users on default settings are unaffected.

### R4-3 (minor, NOT this PR) - `DescentZeroShowOrderingTests` flake

`DescentZeroShowOrderingTests.AnOfferDuringTheShow_IsHeldNotDropped` fails intermittently in
full-suite runs because of process-wide state shared with other `DescentMigrationService` tests
under xunit's parallel collections. Nothing in this diff touches Descent, and the verifier's own
note says it is not a regression from this PR and should be tracked separately. Fixing it properly
means giving the whole `DescentMigrationService` test family an explicit `[Collection]`, which is a
shared-test-infra change that would collide with the other v6.8.5 lanes on the same file. Left for a
follow-up ticket. It did not fire in this round's run.

### Build and tests after Round 4

`dotnet build ConditioningControlPanel.sln -c Debug`: **0 errors** (CA1416 / xUnit analyzer warnings only).
`dotnet test Tests/ConditioningControlPanel.Tests -c Debug`: **4153 passed / 4153**, 0 failed, 0 skipped.
(The earlier "4122/4122" line at the top of this body was a stale count from the first round; the
suite has grown with each round's tests.)

No existing test was weakened or deleted.

### Still not done after Round 4

- The `DescentZeroShowOrderingTests` collection fix (above) - separate ticket.
- FYP web-repo mirror of the volume slider (see MIRROR NOTE in section 2).
- No localization keys for the FYP volume row: that page is a WebView2 surface with hardcoded
  English strings throughout, and the new row follows its neighbours.
- No in-app play-test (headless agent).
- The app-wide default pools in `AppSettings.cs` and the BambiSleep mod's own content still carry
  that mod's vocabulary, which is correct - only the Sissy surfaces were in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6xJB7QQLacJN9vN3gRAVe



