### PR TITLE
fix(companion): per-mod AI companion content resolver + source logging (Bambi/Sissy personas were silently the default mod's)

### DIFF
--- a/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
@@ -28,32 +28,25 @@ namespace ConditioningControlPanel.Services.Bark
         public static string EmbeddedManifestPath =>
             CompanionPhraseService.ResolveCompanionAudioFile(ManifestFileName);
 
-        /// <summary>Active mod's manifest from its InstalledPath (Locked/Drone-style packaged mods). Null if none.</summary>
+        /// <summary>
+        /// The active mod's overlay manifest, wherever it actually lives: its extracted .ccpmod
+        /// (Locked/Drone), the per-mod folder bundled in the install dir, or that same folder
+        /// delivered by a downloaded content pack (Bambi/Sissy have no .ccpmod at all, so those
+        /// two rungs are the only ones they can ever hit). One ladder, in
+        /// <see cref="Services.Companion.CompanionContentResolver"/>, so the ordering is not
+        /// re-typed slightly differently in every consumer.
+        /// </summary>
+        public static Services.Companion.CompanionContentPick ActiveModManifest =>
+            Services.Companion.ModCompanionContent.ResolveActive(
+                Services.Companion.CompanionChannel.BarkRules);
+
+        /// <summary>Active mod's overlay manifest path, or null when it ships none.</summary>
         public static string? ActiveModManifestPath
         {
             get
             {
-                var modPath = App.Mods?.ActiveMod?.InstalledPath;
-                if (string.IsNullOrEmpty(modPath)) return null;
-                var p = Path.Combine(modPath, "resources", "sounds", "companion_audio", ManifestFileName);
-                return File.Exists(p) ? p : null;
-            }
-        }
-
-        /// <summary>
-        /// Active mod's manifest from the EMBEDDED per-mod folder
-        /// (Resources/sounds/companion_audio/mods/{modId}/). This is how built-in mods that have
-        /// no InstalledPath (Bambi/Sissy) ship their bark content; it also covers Locked/Drone
-        /// uniformly. Null if the active mod has no embedded manifest.
-        /// </summary>
-        public static string? EmbeddedModManifestPath
-        {
-            get
-            {
-                var modId = App.Mods?.ActiveModId;
-                if (string.IsNullOrEmpty(modId)) return null;
-                var p = CompanionPhraseService.ResolveCompanionAudioFile("mods", modId, ManifestFileName);
-                return File.Exists(p) ? p : null;
+                var pick = ActiveModManifest;
+                return pick.Found ? pick.Path : null;
             }
         }
 
@@ -75,10 +68,9 @@ namespace ConditioningControlPanel.Services.Bark
 
             int baseCount = MergeFile(merged, EmbeddedManifestPath, "embedded");
             int modCount = 0;
-            // Prefer a packaged-mod manifest (InstalledPath); otherwise the embedded per-mod folder.
-            var modPath = ActiveModManifestPath ?? EmbeddedModManifestPath;
-            if (modPath != null)
-                modCount = MergeFile(merged, modPath, "mod");
+            var modPick = ActiveModManifest;
+            if (modPick.Found)
+                modCount = MergeFile(merged, modPick.Path!, "mod");
 
             var rules = new List<BarkRule>();
             foreach (var obj in merged.Values)
@@ -98,8 +90,9 @@ namespace ConditioningControlPanel.Services.Bark
             }
 
             App.Logger?.Information(
-                "BarkRuleLoader: loaded {Total} rules ({Base} base, {Mod} mod-overlay; field-level merge)",
-                rules.Count, baseCount, modCount);
+                "BarkRuleLoader: loaded {Total} rules ({Base} base, {Mod} mod-overlay from {Source}; field-level merge)",
+                rules.Count, baseCount, modCount,
+                Services.Companion.CompanionContentResolver.Describe(modPick.Source));
 
             return new BarkRuleSet(rules);
         }

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -6,6 +6,7 @@ using ConditioningControlPanel.Helpers;
 using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services.AIService;
 using ConditioningControlPanel.Services.Bark;
+using ConditioningControlPanel.Services.Companion;
 
 namespace ConditioningControlPanel.Services
 {
@@ -1500,24 +1501,11 @@ namespace ConditioningControlPanel.Services
         {
             if (string.IsNullOrWhiteSpace(file)) return null;
 
-            // 1) packaged mod (InstalledPath)
-            var modPath = App.Mods?.ActiveMod?.InstalledPath;
-            if (!string.IsNullOrEmpty(modPath))
-            {
-                var p = System.IO.Path.Combine(modPath, "resources", "sounds", "companion_audio", file);
-                if (System.IO.File.Exists(p)) return p;
-            }
-            // 2) embedded per-mod folder (Bambi/Sissy and, uniformly, the others) — bundled in the
-            //    install dir on full installs, or under the content root once it ships as a pack.
-            var modId = App.Mods?.ActiveModId;
-            if (!string.IsNullOrEmpty(modId))
-            {
-                var pm = CompanionPhraseService.ResolveCompanionAudioFile("mods", modId, file);
-                if (System.IO.File.Exists(pm)) return pm;
-            }
-            // 3) embedded shared fallback
-            var embedded = CompanionPhraseService.ResolveCompanionAudioFile(file);
-            return System.IO.File.Exists(embedded) ? embedded : null;
+            // The ladder (packaged .ccpmod -> per-mod folder in the install dir -> per-mod folder in
+            // a downloaded content pack -> shared companion_audio) lives in CompanionContentResolver
+            // so bark audio, bark rules and personalities cannot drift apart.
+            var pick = ModCompanionContent.ResolveActive(CompanionChannel.BarkAudio, file);
+            return pick.Found ? pick.Path : null;
         }
 
         private readonly struct GateDecision

--- a/ConditioningControlPanel/Services/Companion/CompanionContentResolver.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionContentResolver.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ConditioningControlPanel.Services.Companion
+{
+    /// <summary>
+    /// Where a companion-content channel was actually resolved from. The distinction matters
+    /// because a built-in mod can carry its content in three very different places:
+    /// an extracted <c>.ccpmod</c> (Drone/Locked), the per-mod folder bundled in the install dir,
+    /// or that same per-mod folder delivered later by a downloaded content pack (Bambi/Sissy).
+    /// </summary>
+    public enum CompanionContentSource
+    {
+        /// <summary>Nothing matched - the caller falls back to its own shared/baseline behaviour.</summary>
+        None = 0,
+        /// <summary>The active mod's extracted .ccpmod folder (<c>ModPackage.InstalledPath</c>).</summary>
+        PackagedMod,
+        /// <summary>Per-mod folder bundled in the install dir (<c>Resources\sounds\companion_audio\mods\id</c>).</summary>
+        ModInstallDir,
+        /// <summary>The same per-mod folder, delivered by a downloaded content pack.</summary>
+        ModContentPack,
+        /// <summary>The shared, mod-independent baseline tree.</summary>
+        Baseline,
+        /// <summary>The in-code <c>ModManifest</c> (personalities only).</summary>
+        BuiltInManifest,
+        /// <summary>The stock personality presets - i.e. the DEFAULT mod's companion voice.</summary>
+        StockPresets
+    }
+
+    /// <summary>One kind of companion content that has to be resolved per mod.</summary>
+    public enum CompanionChannel
+    {
+        /// <summary>The mod's <c>bark_rules.json</c> overlay (merged over the shared base manifest).</summary>
+        BarkRules,
+        /// <summary>The mod's <c>personalities.json</c> - the AI companion's persona presets.</summary>
+        Personalities,
+        /// <summary>The mod's idle voice-line folder (<c>flashes_audio</c>).</summary>
+        VoiceLines,
+        /// <summary>The mod's event-comment audio folder (<c>event_audio</c>).</summary>
+        EventAudio,
+        /// <summary>The mod's <c>mantras.json</c>.</summary>
+        Mantras,
+        /// <summary>The mod's <c>avatar_manifest.json</c>.</summary>
+        AvatarManifest,
+        /// <summary>A single named bark voiceline file.</summary>
+        BarkAudio
+    }
+
+    /// <summary>One place a channel could live, in priority order.</summary>
+    /// <param name="Source">Which root this candidate belongs to.</param>
+    /// <param name="Path">Absolute path to probe.</param>
+    /// <param name="IsDirectory">True when the candidate is a folder rather than a file.</param>
+    public readonly record struct CompanionContentCandidate(
+        CompanionContentSource Source, string Path, bool IsDirectory);
+
+    /// <summary>The winning candidate, or <see cref="CompanionContentSource.None"/>.</summary>
+    /// <param name="Source">Where the content came from.</param>
+    /// <param name="Path">Absolute path, or null when nothing matched.</param>
+    public readonly record struct CompanionContentPick(CompanionContentSource Source, string? Path)
+    {
+        /// <summary>True when a real source was found.</summary>
+        public bool Found => Source != CompanionContentSource.None && !string.IsNullOrEmpty(Path);
+    }
+
+    /// <summary>
+    /// PURE path logic for "where does THIS mod's companion content live?".
+    ///
+    /// Every consumer (bark rules, voice lines, event audio, mantras, avatar manifest,
+    /// personalities) walks the same ladder:
+    ///
+    ///   1. the extracted .ccpmod, when the mod has one (Drone, Locked)
+    ///   2. the per-mod folder in the INSTALL DIR (full installs ship the manifests here)
+    ///   3. the per-mod folder under the DOWNLOADED CONTENT ROOT (modular installs - the
+    ///      bambi / sissy packs land here, docs/CONTENT_PACKS_PLAN.md section 3)
+    ///   4. the shared baseline - which for the AI companion means the DEFAULT mod's voice,
+    ///      and is exactly the silent fallback that made BambiSleep/SissyHypno feel dead.
+    ///
+    /// This class does no I/O: it builds the ladder and picks the first candidate a caller-supplied
+    /// probe accepts, which keeps it unit-testable.
+    ///
+    /// Consumers migrated so far: <see cref="Bark.BarkRuleLoader"/>, <c>BarkService.ResolveBarkAudio</c>
+    /// and <c>PersonalityService</c>. <c>CompanionPhraseService</c>, <c>AvatarPortraitLoader</c> and
+    /// <c>MantraVoiceService</c> still hand-roll the same ladder (they need the two-root UNION for
+    /// enumeration, not a single winner); this type reports on their channels for the activation log
+    /// so the answer is at least visible in one place.
+    /// </summary>
+    public static class CompanionContentResolver
+    {
+        /// <summary>Install-dir-relative anchor of the shared companion-audio tree.</summary>
+        public static readonly string CompanionAudioRelativeDir =
+            Path.Combine("Resources", "sounds", "companion_audio");
+
+        /// <summary>Install-dir-relative anchor of the shared voice-line tree.</summary>
+        public static readonly string VoiceLinesRelativeDir =
+            Path.Combine("Resources", "sounds", "flashes_audio");
+
+        /// <summary>Folder inside a packaged .ccpmod that mirrors the app's own Resources tree.</summary>
+        public const string PackagedResourcesFolder = "resources";
+
+        /// <summary>Bark rule manifest file name.</summary>
+        public const string BarkRulesFileName = "bark_rules.json";
+
+        /// <summary>Mantra pool file name.</summary>
+        public const string MantrasFileName = "mantras.json";
+
+        /// <summary>Avatar portrait manifest file name.</summary>
+        public const string AvatarManifestFileName = "avatar_manifest.json";
+
+        /// <summary>
+        /// Optional per-mod persona file. Same shape as <c>ModManifest.Personalities</c>
+        /// (a JSON array of id / name / description / promptSettings objects), so a mod can ship
+        /// AI personalities as DATA in its content pack without the manifest being repacked.
+        /// </summary>
+        public const string PersonalitiesFileName = "personalities.json";
+
+        /// <summary>Idle voice-line folder name.</summary>
+        public const string VoiceLinesFolderName = "flashes_audio";
+
+        /// <summary>Event-comment audio folder name.</summary>
+        public const string EventAudioFolderName = "event_audio";
+
+        /// <summary>The per-mod folder for <paramref name="modId"/>, relative to a root.</summary>
+        public static string PerModRelativeDir(string modId) =>
+            Path.Combine(CompanionAudioRelativeDir, "mods", modId);
+
+        /// <summary>
+        /// The ordered candidate list for one channel. Roots that are empty (no content root on a
+        /// full install, no InstalledPath on a built-in mod) simply contribute no candidates, so the
+        /// ladder shortens instead of producing bogus paths.
+        /// </summary>
+        /// <param name="channel">Which content channel to resolve.</param>
+        /// <param name="modId">Active mod id (e.g. builtin-bambisleep).</param>
+        /// <param name="installedPath">The mod's extracted .ccpmod folder, or null for a pure built-in.</param>
+        /// <param name="installRoot">Install directory root.</param>
+        /// <param name="contentRoot">Downloaded content-pack root.</param>
+        /// <param name="fileName">Required for <see cref="CompanionChannel.BarkAudio"/>: the voiceline file name.</param>
+        public static IReadOnlyList<CompanionContentCandidate> Candidates(
+            CompanionChannel channel,
+            string? modId,
+            string? installedPath,
+            string? installRoot,
+            string? contentRoot,
+            string? fileName = null)
+        {
+            var list = new List<CompanionContentCandidate>(4);
+
+            // What the channel is called inside a packaged mod / inside the per-mod folder, and
+            // whether it is a file or a folder.
+            string? leaf;
+            bool isDir;
+            switch (channel)
+            {
+                case CompanionChannel.BarkRules: leaf = BarkRulesFileName; isDir = false; break;
+                case CompanionChannel.Mantras: leaf = MantrasFileName; isDir = false; break;
+                case CompanionChannel.AvatarManifest: leaf = AvatarManifestFileName; isDir = false; break;
+                case CompanionChannel.Personalities: leaf = PersonalitiesFileName; isDir = false; break;
+                case CompanionChannel.VoiceLines: leaf = VoiceLinesFolderName; isDir = true; break;
+                case CompanionChannel.EventAudio: leaf = EventAudioFolderName; isDir = true; break;
+                case CompanionChannel.BarkAudio: leaf = fileName; isDir = false; break;
+                default: return list;
+            }
+            if (string.IsNullOrWhiteSpace(leaf)) return list;
+
+            // 1) packaged .ccpmod. Voice lines and event audio live under resources\sounds\ there,
+            //    personalities at the resources root, everything else under
+            //    resources\sounds\companion_audio\.
+            if (!string.IsNullOrWhiteSpace(installedPath))
+            {
+                var packaged = channel switch
+                {
+                    CompanionChannel.VoiceLines or CompanionChannel.EventAudio =>
+                        Path.Combine(installedPath, PackagedResourcesFolder, "sounds", leaf),
+                    CompanionChannel.Personalities =>
+                        Path.Combine(installedPath, PackagedResourcesFolder, leaf),
+                    _ => Path.Combine(installedPath, PackagedResourcesFolder,
+                                      "sounds", "companion_audio", leaf)
+                };
+                list.Add(new CompanionContentCandidate(CompanionContentSource.PackagedMod, packaged, isDir));
+            }
+
+            // 2) + 3) the per-mod folder, install dir first then the downloaded content root.
+            if (!string.IsNullOrWhiteSpace(modId))
+            {
+                var perMod = Path.Combine(PerModRelativeDir(modId), leaf);
+                if (!string.IsNullOrWhiteSpace(installRoot))
+                    list.Add(new CompanionContentCandidate(
+                        CompanionContentSource.ModInstallDir, Path.Combine(installRoot, perMod), isDir));
+                if (!string.IsNullOrWhiteSpace(contentRoot))
+                    list.Add(new CompanionContentCandidate(
+                        CompanionContentSource.ModContentPack, Path.Combine(contentRoot, perMod), isDir));
+            }
+
+            // 4) the shared baseline, for the channels that have one. Bark rules deliberately do NOT
+            //    get one here: the base manifest is always merged UNDER the mod overlay by
+            //    BarkRuleLoader, so listing it as a candidate would report "resolved: baseline" for
+            //    a mod that simply has no overlay of its own.
+            switch (channel)
+            {
+                case CompanionChannel.VoiceLines:
+                    if (!string.IsNullOrWhiteSpace(installRoot))
+                        list.Add(new CompanionContentCandidate(CompanionContentSource.Baseline,
+                            Path.Combine(installRoot, VoiceLinesRelativeDir), true));
+                    if (!string.IsNullOrWhiteSpace(contentRoot))
+                        list.Add(new CompanionContentCandidate(CompanionContentSource.Baseline,
+                            Path.Combine(contentRoot, VoiceLinesRelativeDir), true));
+                    break;
+                case CompanionChannel.BarkAudio:
+                    if (!string.IsNullOrWhiteSpace(installRoot))
+                        list.Add(new CompanionContentCandidate(CompanionContentSource.Baseline,
+                            Path.Combine(installRoot, CompanionAudioRelativeDir, leaf), false));
+                    if (!string.IsNullOrWhiteSpace(contentRoot))
+                        list.Add(new CompanionContentCandidate(CompanionContentSource.Baseline,
+                            Path.Combine(contentRoot, CompanionAudioRelativeDir, leaf), false));
+                    break;
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// First candidate the probe accepts, or <see cref="CompanionContentSource.None"/>.
+        /// A throwing probe is treated as "not there" so one unreadable root can never take the
+        /// companion silent.
+        /// </summary>
+        public static CompanionContentPick Pick(
+            IReadOnlyList<CompanionContentCandidate> candidates,
+            Func<CompanionContentCandidate, bool> probe)
+        {
+            if (candidates == null || probe == null)
+                return new CompanionContentPick(CompanionContentSource.None, null);
+
+            foreach (var c in candidates)
+            {
+                bool hit;
+                try { hit = probe(c); }
+                catch { hit = false; }
+                if (hit) return new CompanionContentPick(c.Source, c.Path);
+            }
+            return new CompanionContentPick(CompanionContentSource.None, null);
+        }
+
+        /// <summary>Convenience overload that builds the ladder and picks in one call.</summary>
+        public static CompanionContentPick Resolve(
+            CompanionChannel channel,
+            string? modId,
+            string? installedPath,
+            string? installRoot,
+            string? contentRoot,
+            Func<CompanionContentCandidate, bool> probe,
+            string? fileName = null)
+            => Pick(Candidates(channel, modId, installedPath, installRoot, contentRoot, fileName), probe);
+
+        /// <summary>
+        /// Which source the AI personalities came from, given what the two non-path rungs hold.
+        /// Kept separate from <see cref="Resolve"/> because two of the three rungs are not files:
+        /// the in-code manifest, and the stock preset list.
+        ///
+        /// <see cref="CompanionContentSource.StockPresets"/> is the answer that means
+        /// "this mod's AI companion is speaking in the DEFAULT mod's voice".
+        /// </summary>
+        public static CompanionContentSource ResolvePersonalitySource(
+            CompanionContentSource fileSource, bool manifestHasPersonalities)
+        {
+            if (fileSource != CompanionContentSource.None) return fileSource;
+            return manifestHasPersonalities
+                ? CompanionContentSource.BuiltInManifest
+                : CompanionContentSource.StockPresets;
+        }
+
+        /// <summary>Short, log-friendly name for a source.</summary>
+        public static string Describe(CompanionContentSource source) => source switch
+        {
+            CompanionContentSource.PackagedMod => "packaged-mod",
+            CompanionContentSource.ModInstallDir => "mod-install-dir",
+            CompanionContentSource.ModContentPack => "mod-content-pack",
+            CompanionContentSource.Baseline => "baseline",
+            CompanionContentSource.BuiltInManifest => "builtin-manifest",
+            CompanionContentSource.StockPresets => "stock-presets",
+            _ => "none"
+        };
+    }
+}

--- a/ConditioningControlPanel/Services/Companion/ModCompanionContent.cs
+++ b/ConditioningControlPanel/Services/Companion/ModCompanionContent.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ConditioningControlPanel.Models;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Companion
+{
+    /// <summary>
+    /// The I/O half of <see cref="CompanionContentResolver"/>: probes the two real roots
+    /// (install dir + downloaded content packs) plus the active mod's extracted .ccpmod, and
+    /// answers "where is this mod's companion content?" for the running app.
+    ///
+    /// Why this exists: only Drone and Locked ship a bundled <c>.ccpmod</c>, so
+    /// <c>ModPackage.InstalledPath</c> is null for BambiSleep and SissyHypno. Every consumer that
+    /// looked ONLY at InstalledPath therefore no-opped for those two and quietly fell through to
+    /// the shared baseline - which, for the AI companion, is the DEFAULT mod's voice. Routing all
+    /// of them through one ladder makes that fallback explicit and, crucially, LOGGED.
+    ///
+    /// Nothing here throws: a probe failure degrades to "not present", exactly as the individual
+    /// call sites already did.
+    /// </summary>
+    public static class ModCompanionContent
+    {
+        /// <summary>Mirrors <c>ModService.ValidateManifest</c>: at most 20 personalities per mod.</summary>
+        public const int MaxPersonalities = 20;
+
+        /// <summary>Mirrors <c>ModService.ValidateManifest</c>: personality name cap.</summary>
+        public const int MaxPersonalityNameLength = 100;
+
+        /// <summary>Mirrors <c>ModService.ValidateManifest</c>: prompt-section cap.</summary>
+        public const int MaxPromptSettingLength = 5000;
+
+        /// <summary>Probe used against the live filesystem.</summary>
+        public static bool Exists(CompanionContentCandidate candidate)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(candidate.Path)) return false;
+                return candidate.IsDirectory
+                    ? Directory.Exists(candidate.Path)
+                    : File.Exists(candidate.Path);
+            }
+            catch { return false; }
+        }
+
+        private static string InstallRoot
+        {
+            get { try { return ContentLocator.InstallRoot; } catch { return string.Empty; } }
+        }
+
+        private static string ContentRoot
+        {
+            get { try { return ContentLocator.ContentRoot; } catch { return string.Empty; } }
+        }
+
+        /// <summary>Resolve a channel for an explicit mod. Never throws.</summary>
+        public static CompanionContentPick Resolve(
+            CompanionChannel channel, string? modId, string? installedPath, string? fileName = null)
+        {
+            try
+            {
+                return CompanionContentResolver.Resolve(
+                    channel, modId, installedPath, InstallRoot, ContentRoot, Exists, fileName);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ModCompanionContent: resolve failed for {Channel}: {Error}", channel, ex.Message);
+                return new CompanionContentPick(CompanionContentSource.None, null);
+            }
+        }
+
+        /// <summary>Resolve a channel for whatever mod is active right now. Never throws.</summary>
+        public static CompanionContentPick ResolveActive(CompanionChannel channel, string? fileName = null)
+        {
+            string? modId = null, installedPath = null;
+            try
+            {
+                modId = App.Mods?.ActiveModId;
+                installedPath = App.Mods?.ActiveMod?.InstalledPath;
+            }
+            catch { /* service not up yet - fall through with nulls */ }
+            return Resolve(channel, modId, installedPath, fileName);
+        }
+
+        #region Personalities
+
+        /// <summary>
+        /// Strip and cap a personality list read from disk. PURE.
+        ///
+        /// A <c>personalities.json</c> can arrive from a downloaded content pack or a user mod
+        /// folder, and its prompt sections land verbatim in the companion's system prompt - so the
+        /// same limits <c>ModService.ValidateManifest</c> enforces on a manifest apply here, and
+        /// entries with no id or no name are dropped rather than half-registered.
+        /// </summary>
+        public static List<ModPersonality> SanitizePersonalities(IEnumerable<ModPersonality?>? defs)
+        {
+            var result = new List<ModPersonality>();
+            if (defs == null) return result;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var d in defs)
+            {
+                if (result.Count >= MaxPersonalities) break;
+                if (d == null) continue;
+                if (string.IsNullOrWhiteSpace(d.Id) || string.IsNullOrWhiteSpace(d.Name)) continue;
+
+                var id = d.Id.Trim();
+                if (!seen.Add(id)) continue;
+
+                var name = d.Name.Trim();
+                if (name.Length > MaxPersonalityNameLength) name = name[..MaxPersonalityNameLength];
+
+                Dictionary<string, string>? prompts = null;
+                if (d.PromptSettings != null)
+                {
+                    prompts = new Dictionary<string, string>(StringComparer.Ordinal);
+                    foreach (var kvp in d.PromptSettings)
+                    {
+                        if (string.IsNullOrWhiteSpace(kvp.Key) || kvp.Value == null) continue;
+                        var v = kvp.Value;
+                        if (v.Length > MaxPromptSettingLength) v = v[..MaxPromptSettingLength];
+                        prompts[kvp.Key] = v;
+                    }
+                }
+
+                result.Add(new ModPersonality
+                {
+                    Id = id,
+                    Name = name,
+                    Description = d.Description,
+                    PromptSettings = prompts
+                });
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Parse a <c>personalities.json</c> body. PURE - no I/O, never throws; a garbled file
+        /// yields an empty list so the caller falls through to the next rung of the ladder.
+        /// </summary>
+        public static List<ModPersonality> ParsePersonalities(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return new List<ModPersonality>();
+            try
+            {
+                var defs = JsonConvert.DeserializeObject<List<ModPersonality?>>(json);
+                return SanitizePersonalities(defs);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("ModCompanionContent: personalities.json is not valid ({Error})", ex.Message);
+                return new List<ModPersonality>();
+            }
+        }
+
+        /// <summary>Cached personality resolution for one mod.</summary>
+        private sealed class PersonalityCacheEntry
+        {
+            public string Key { get; init; } = string.Empty;
+            public CompanionContentSource Source { get; init; }
+            public List<ModPersonality>? Personalities { get; init; }
+        }
+
+        private static readonly object PersonalityGate = new();
+        private static PersonalityCacheEntry? _personalityCache;
+
+        /// <summary>
+        /// The AI personalities for a mod, walking the ladder: per-mod <c>personalities.json</c>
+        /// (packaged mod, install dir, then downloaded content pack) and finally the in-code
+        /// manifest. Returns null when the mod defines none anywhere - the caller then uses the
+        /// stock presets, i.e. the default mod's voice.
+        ///
+        /// Cached on (mod id + installed path + manifest count) so the file is read once per mod,
+        /// not once per prompt build.
+        /// </summary>
+        public static List<ModPersonality>? GetPersonalities(
+            string? modId, string? installedPath, List<ModPersonality>? manifestPersonalities,
+            out CompanionContentSource source)
+        {
+            var key = (modId ?? "none") + "|" + (installedPath ?? "") + "|" + (manifestPersonalities?.Count ?? 0);
+
+            lock (PersonalityGate)
+            {
+                if (_personalityCache != null && _personalityCache.Key == key)
+                {
+                    source = _personalityCache.Source;
+                    return _personalityCache.Personalities;
+                }
+            }
+
+            List<ModPersonality>? resolved = null;
+            var pick = Resolve(CompanionChannel.Personalities, modId, installedPath);
+            var fileSource = CompanionContentSource.None;
+
+            if (pick.Found)
+            {
+                try
+                {
+                    var parsed = ParsePersonalities(File.ReadAllText(pick.Path!));
+                    if (parsed.Count > 0)
+                    {
+                        resolved = parsed;
+                        fileSource = pick.Source;
+                    }
+                    else
+                    {
+                        App.Logger?.Warning(
+                            "ModCompanionContent: {Path} held no usable personalities; falling back", pick.Path);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Warning("ModCompanionContent: failed to read {Path}: {Error}", pick.Path, ex.Message);
+                }
+            }
+
+            if (resolved == null && manifestPersonalities is { Count: > 0 })
+            {
+                var sanitized = SanitizePersonalities(manifestPersonalities);
+                if (sanitized.Count > 0) resolved = sanitized;
+            }
+
+            source = CompanionContentResolver.ResolvePersonalitySource(
+                fileSource, manifestPersonalities is { Count: > 0 });
+
+            var entry = new PersonalityCacheEntry { Key = key, Source = source, Personalities = resolved };
+            lock (PersonalityGate) { _personalityCache = entry; }
+            return resolved;
+        }
+
+        /// <summary>Drop the cached personality resolution (mod switch, tests).</summary>
+        public static void ResetPersonalityCache()
+        {
+            lock (PersonalityGate) { _personalityCache = null; }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// One Information line naming, per channel, where the active mod's companion content
+        /// actually came from. This is the line to read when a user reports "she only says the
+        /// default lines": <c>personalities=stock-presets</c> means the AI persona is the default
+        /// mod's, and <c>barkRules=none</c> means the mod contributed no bark overlay at all.
+        /// Never throws.
+        /// </summary>
+        public static void LogResolvedSources(string? modId, string? installedPath, ModManifest? manifest)
+        {
+            try
+            {
+                var barks = Resolve(CompanionChannel.BarkRules, modId, installedPath);
+                var voice = Resolve(CompanionChannel.VoiceLines, modId, installedPath);
+                var events = Resolve(CompanionChannel.EventAudio, modId, installedPath);
+                var mantras = Resolve(CompanionChannel.Mantras, modId, installedPath);
+                var avatars = Resolve(CompanionChannel.AvatarManifest, modId, installedPath);
+
+                GetPersonalities(modId, installedPath, manifest?.Personalities, out var personalitySource);
+
+                App.Logger?.Information(
+                    "CompanionContent[{ModId}]: personalities={Personalities}, barkRules={BarkRules}, " +
+                    "voiceLines={VoiceLines}, eventAudio={EventAudio}, mantras={Mantras}, avatarManifest={AvatarManifest}",
+                    modId ?? "none",
+                    CompanionContentResolver.Describe(personalitySource),
+                    CompanionContentResolver.Describe(barks.Source),
+                    CompanionContentResolver.Describe(voice.Source),
+                    CompanionContentResolver.Describe(events.Source),
+                    CompanionContentResolver.Describe(mantras.Source),
+                    CompanionContentResolver.Describe(avatars.Source));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ModCompanionContent: source report failed: {Error}", ex.Message);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Companion/PersonalityService.cs
+++ b/ConditioningControlPanel/Services/Companion/PersonalityService.cs
@@ -31,15 +31,22 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Converts the active mod's ModManifest.Personalities into PersonalityPresets, or
-        /// returns null when the active mod defines none. The prompt text is carried in each
-        /// personality's PromptSettings dictionary (key "Personality", plus any optional
-        /// CompanionPromptSettings sections the mod chooses to set).
+        /// Converts the active mod's AI personalities into PersonalityPresets, or returns null when
+        /// the active mod defines none anywhere. The prompt text is carried in each personality's
+        /// PromptSettings dictionary (key "Personality", plus any optional CompanionPromptSettings
+        /// sections the mod chooses to set).
+        ///
+        /// Source ladder (see <see cref="Companion.CompanionContentResolver"/>): a per-mod
+        /// <c>personalities.json</c> from the extracted .ccpmod, the install dir, or a downloaded
+        /// content pack, and only then the in-code <c>ModManifest.Personalities</c>. Built-in mods
+        /// that ship no .ccpmod at all (BambiSleep, SissyHypno) could previously reach NEITHER, so
+        /// they always landed on the stock preset list - i.e. the default mod's companion voice.
         /// </summary>
         private static List<PersonalityPreset>? GetActiveModPersonalities()
         {
-            var manifest = App.Mods?.ActiveMod?.Manifest;
-            var defs = manifest?.Personalities;
+            var mod = App.Mods?.ActiveMod;
+            var defs = Companion.ModCompanionContent.GetPersonalities(
+                mod?.Id, mod?.InstalledPath, mod?.Manifest?.Personalities, out _);
             if (defs == null || defs.Count == 0) return null;
 
             var result = new List<PersonalityPreset>();

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -131,6 +131,13 @@ namespace ConditioningControlPanel.Services
             }
             _log?.Information("ModService initialized — active mod: {ModId} ({ModName})", _activeMod.Id, _activeMod.Name);
 
+            // Say, once per launch, WHERE this mod's companion content resolved from. A user
+            // reporting "she only says the default lines" is answered by this single line:
+            // personalities=stock-presets means the AI persona is the default mod's.
+            Companion.ModCompanionContent.ResetPersonalityCache();
+            Companion.ModCompanionContent.LogResolvedSources(
+                _activeMod.Id, _activeMod.InstalledPath, _activeMod.Manifest);
+
             // Re-derive the active mod's text pools from per-mod storage (or defaults) on every
             // boot. The settings load runs before this service exists, so the active pools held
             // in settings.json may be stale or contaminated by the legacy subliminal merge; this
@@ -823,6 +830,11 @@ namespace ConditioningControlPanel.Services
             // Clear resource cache
             ModResourceResolver.ClearCache();
 
+            // The AI personalities are resolved per mod (personalities.json, else the manifest, else
+            // the stock presets) and cached; drop that before anything reads a prompt for the new mod.
+            try { Companion.ModCompanionContent.ResetPersonalityCache(); }
+            catch (Exception ex) { _log?.Debug("ActivateMod: personality cache clear failed: {E}", ex.Message); }
+
             // Drop the companion's cached system-prompt prefix. Its fingerprint hashes ActiveModId,
             // so a plain switch is already covered — but everything ELSE the mod contributes
             // (GetCompanionName, GetUserTerm, MakeModAware's replacements) is read at build time and
@@ -865,6 +877,7 @@ namespace ConditioningControlPanel.Services
             }
 
             _log?.Information("Mod activated: {ModId} (was {OldModId})", modId, oldModId);
+            Companion.ModCompanionContent.LogResolvedSources(mod.Id, mod.InstalledPath, mod.Manifest);
             ModChanged?.Invoke(this, mod);
         }
 
@@ -2164,6 +2177,15 @@ namespace ConditioningControlPanel.Services
             try { ModResourceResolver.ClearCache(); }
             catch (Exception ex) { _log?.Debug("ModService: resolver cache clear failed: {Error}", ex.Message); }
 
+            // The extraction may have just delivered this mod's personalities.json, so the cached
+            // "no mod personalities, use the stock presets" answer is now wrong.
+            try
+            {
+                Companion.ModCompanionContent.ResetPersonalityCache();
+                Companion.ModCompanionContent.LogResolvedSources(package.Id, package.InstalledPath, package.Manifest);
+            }
+            catch (Exception ex) { _log?.Debug("ModService: personality cache clear failed: {Error}", ex.Message); }
+
             // Before ModChanged fires: AvatarTubeWindow re-evaluates the portrait gate from that
             // event, and the adopted package may have just delivered the portrait PNGs — a stale
             // cached "absent" would park the avatar on the legacy poses for the whole session.
@@ -2311,6 +2333,16 @@ namespace ConditioningControlPanel.Services
                     // would keep resolving to nothing for the rest of the session without this.
                     try { ModResourceResolver.ClearCache(); }
                     catch (Exception ex) { _log?.Debug("ModService: resolver cache clear failed: {Error}", ex.Message); }
+
+                    // Same reason: the pack that just landed can carry a personalities.json for a
+                    // mod that has been running on the stock (default-mod) presets all session.
+                    try
+                    {
+                        Companion.ModCompanionContent.ResetPersonalityCache();
+                        Companion.ModCompanionContent.LogResolvedSources(
+                            _activeMod.Id, _activeMod.InstalledPath, _activeMod.Manifest);
+                    }
+                    catch (Exception ex) { _log?.Debug("ModService: personality cache clear failed: {Error}", ex.Message); }
 
                     // Voice lines are enumerated per call (no list cache), but the §7.2 positional→
                     // filename id migration is deliberately skipped while the folder is empty — this

--- a/Tests/ConditioningControlPanel.Tests/CompanionContentResolverTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionContentResolverTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.Companion;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Only Drone and Locked ship a bundled .ccpmod, so <c>ModPackage.InstalledPath</c> is null for
+/// BambiSleep and SissyHypno. Everything that resolved companion content off InstalledPath alone
+/// therefore no-opped for those two and fell through to the shared baseline - which, for the AI
+/// companion, is the DEFAULT mod's voice.
+///
+/// These pin the ladder that replaces that: packaged .ccpmod, then the per-mod folder in the
+/// install dir, then the same folder delivered by a downloaded content pack, then (only where one
+/// exists) the shared baseline.
+/// </summary>
+public class CompanionContentResolverTests
+{
+    private const string InstallRoot = @"C:\app";
+    private const string ContentRoot = @"C:\data\content";
+    private const string BambiId = "builtin-bambisleep";
+    private const string PackagedPath = @"C:\data\builtin_mods\drone-mode";
+
+    private static string PerMod(string root, string modId, string leaf) =>
+        Path.Combine(root, "Resources", "sounds", "companion_audio", "mods", modId, leaf);
+
+    private static Func<CompanionContentCandidate, bool> ProbeFor(params string[] present)
+    {
+        var set = new HashSet<string>(present, System.StringComparer.OrdinalIgnoreCase);
+        return c => set.Contains(c.Path);
+    }
+
+    // ---------------------------------------------------------------- ladder shape
+
+    [Fact]
+    public void ABuiltInModWithNoCcpmodStillGetsBothPerModRungs()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkRules, BambiId, installedPath: null, InstallRoot, ContentRoot);
+
+        Assert.Equal(
+            new[] { CompanionContentSource.ModInstallDir, CompanionContentSource.ModContentPack },
+            candidates.Select(c => c.Source).ToArray());
+        Assert.Equal(PerMod(InstallRoot, BambiId, "bark_rules.json"), candidates[0].Path);
+        Assert.Equal(PerMod(ContentRoot, BambiId, "bark_rules.json"), candidates[1].Path);
+    }
+
+    [Fact]
+    public void APackagedModIsProbedBeforeEitherPerModFolder()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkRules, "drone-mode", PackagedPath, InstallRoot, ContentRoot);
+
+        Assert.Equal(CompanionContentSource.PackagedMod, candidates[0].Source);
+        Assert.Equal(
+            Path.Combine(PackagedPath, "resources", "sounds", "companion_audio", "bark_rules.json"),
+            candidates[0].Path);
+        Assert.Equal(3, candidates.Count);
+    }
+
+    [Fact]
+    public void BarkRulesHaveNoBaselineRungBecauseTheBaseManifestIsAlwaysMergedUnderneath()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkRules, BambiId, null, InstallRoot, ContentRoot);
+
+        Assert.DoesNotContain(candidates, c => c.Source == CompanionContentSource.Baseline);
+    }
+
+    [Fact]
+    public void NoModAndNoPackageMeansNothingToProbe()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkRules, modId: null, installedPath: null, InstallRoot, ContentRoot);
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void AMissingContentRootJustShortensTheLadder()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkRules, BambiId, null, InstallRoot, contentRoot: null);
+
+        Assert.Single(candidates);
+        Assert.Equal(CompanionContentSource.ModInstallDir, candidates[0].Source);
+    }
+
+    [Fact]
+    public void VoiceLinesFallBackToTheSharedBaselineFolderAndAreProbedAsDirectories()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.VoiceLines, BambiId, null, InstallRoot, ContentRoot);
+
+        Assert.All(candidates, c => Assert.True(c.IsDirectory));
+        Assert.Equal(CompanionContentSource.Baseline, candidates[^1].Source);
+        Assert.Equal(Path.Combine(ContentRoot, "Resources", "sounds", "flashes_audio"), candidates[^1].Path);
+    }
+
+    [Fact]
+    public void BarkAudioFallsBackToTheSharedCompanionAudioRoot()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkAudio, BambiId, null, InstallRoot, ContentRoot, fileName: "giggle_1.mp3");
+
+        Assert.Equal(
+            new[]
+            {
+                CompanionContentSource.ModInstallDir,
+                CompanionContentSource.ModContentPack,
+                CompanionContentSource.Baseline,
+                CompanionContentSource.Baseline
+            },
+            candidates.Select(c => c.Source).ToArray());
+        Assert.Equal(
+            Path.Combine(InstallRoot, "Resources", "sounds", "companion_audio", "giggle_1.mp3"),
+            candidates[2].Path);
+    }
+
+    [Fact]
+    public void BarkAudioWithNoFileNameResolvesToNothing()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.BarkAudio, BambiId, null, InstallRoot, ContentRoot, fileName: null);
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void PersonalitiesSitAtThePackagedModsResourcesRootNotUnderSounds()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.Personalities, "drone-mode", PackagedPath, InstallRoot, ContentRoot);
+
+        Assert.Equal(Path.Combine(PackagedPath, "resources", "personalities.json"), candidates[0].Path);
+    }
+
+    // ---------------------------------------------------------------- picking
+
+    [Fact]
+    public void TheDownloadedPackWinsWhenTheInstallDirCopyWasStrippedOut()
+    {
+        var packPath = PerMod(ContentRoot, BambiId, "bark_rules.json");
+        var pick = CompanionContentResolver.Resolve(
+            CompanionChannel.BarkRules, BambiId, null, InstallRoot, ContentRoot, ProbeFor(packPath));
+
+        Assert.True(pick.Found);
+        Assert.Equal(CompanionContentSource.ModContentPack, pick.Source);
+        Assert.Equal(packPath, pick.Path);
+    }
+
+    [Fact]
+    public void TheInstallDirCopyStillWinsWhenBothRootsHaveIt()
+    {
+        var installPath = PerMod(InstallRoot, BambiId, "bark_rules.json");
+        var packPath = PerMod(ContentRoot, BambiId, "bark_rules.json");
+        var pick = CompanionContentResolver.Resolve(
+            CompanionChannel.BarkRules, BambiId, null, InstallRoot, ContentRoot, ProbeFor(installPath, packPath));
+
+        Assert.Equal(CompanionContentSource.ModInstallDir, pick.Source);
+    }
+
+    [Fact]
+    public void NothingAnywhereIsReportedAsNoneRatherThanAGuessedPath()
+    {
+        var pick = CompanionContentResolver.Resolve(
+            CompanionChannel.BarkRules, BambiId, null, InstallRoot, ContentRoot, _ => false);
+
+        Assert.False(pick.Found);
+        Assert.Equal(CompanionContentSource.None, pick.Source);
+        Assert.Null(pick.Path);
+    }
+
+    [Fact]
+    public void AnUnreadableRootIsSkippedInsteadOfTakingTheCompanionSilent()
+    {
+        var packPath = PerMod(ContentRoot, BambiId, "bark_rules.json");
+        var pick = CompanionContentResolver.Resolve(
+            CompanionChannel.BarkRules, BambiId, null, InstallRoot, ContentRoot,
+            c => c.Source == CompanionContentSource.ModInstallDir
+                ? throw new IOException("drive went away")
+                : c.Path == packPath);
+
+        Assert.Equal(CompanionContentSource.ModContentPack, pick.Source);
+    }
+
+    // ---------------------------------------------------------------- personality source
+
+    [Fact]
+    public void APersonalityFileBeatsTheInCodeManifest()
+    {
+        Assert.Equal(
+            CompanionContentSource.ModContentPack,
+            CompanionContentResolver.ResolvePersonalitySource(
+                CompanionContentSource.ModContentPack, manifestHasPersonalities: true));
+    }
+
+    [Fact]
+    public void TheInCodeManifestIsUsedWhenNoFileShipped()
+    {
+        Assert.Equal(
+            CompanionContentSource.BuiltInManifest,
+            CompanionContentResolver.ResolvePersonalitySource(
+                CompanionContentSource.None, manifestHasPersonalities: true));
+    }
+
+    [Fact]
+    public void NeitherSourceMeansTheAiIsSpeakingInTheDefaultModsVoice()
+    {
+        Assert.Equal(
+            CompanionContentSource.StockPresets,
+            CompanionContentResolver.ResolvePersonalitySource(
+                CompanionContentSource.None, manifestHasPersonalities: false));
+    }
+
+    [Fact]
+    public void EverySourceHasItsOwnLogName()
+    {
+        var names = System.Enum.GetValues<CompanionContentSource>()
+            .Select(CompanionContentResolver.Describe)
+            .ToArray();
+
+        Assert.Equal(names.Length, names.Distinct().Count());
+        Assert.Equal("stock-presets", CompanionContentResolver.Describe(CompanionContentSource.StockPresets));
+    }
+
+    // ---------------------------------------------------------------- personalities.json parsing
+
+    [Fact]
+    public void APersonalityFileParsesIntoTheSameShapeAsAManifest()
+    {
+        var defs = ModCompanionContent.ParsePersonalities(
+            """
+            [
+              { "id": "bambi-bestie", "name": "Bestie", "description": "d",
+                "promptSettings": { "Personality": "be a bestie" } }
+            ]
+            """);
+
+        var one = Assert.Single(defs);
+        Assert.Equal("bambi-bestie", one.Id);
+        Assert.Equal("Bestie", one.Name);
+        Assert.Equal("be a bestie", one.PromptSettings!["Personality"]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json at all")]
+    [InlineData("{ \"id\": \"x\" }")]
+    public void AGarbledPersonalityFileYieldsNothingSoTheNextRungIsUsed(string json)
+    {
+        Assert.Empty(ModCompanionContent.ParsePersonalities(json));
+    }
+
+    [Fact]
+    public void EntriesWithNoIdOrNoNameAreDroppedRatherThanHalfRegistered()
+    {
+        var defs = ModCompanionContent.SanitizePersonalities(new List<ModPersonality?>
+        {
+            new() { Id = "", Name = "nameless id" },
+            new() { Id = "no-name", Name = "  " },
+            null,
+            new() { Id = "keeper", Name = "Keeper" }
+        });
+
+        var one = Assert.Single(defs);
+        Assert.Equal("keeper", one.Id);
+    }
+
+    [Fact]
+    public void ADuplicateIdIsIgnoredSoOneEntryCannotShadowAnother()
+    {
+        var defs = ModCompanionContent.SanitizePersonalities(new List<ModPersonality?>
+        {
+            new() { Id = "dup", Name = "First" },
+            new() { Id = "DUP", Name = "Second" }
+        });
+
+        Assert.Equal("First", Assert.Single(defs).Name);
+    }
+
+    [Fact]
+    public void PromptTextFromAPackIsCappedTheSameWayAManifestIs()
+    {
+        var defs = ModCompanionContent.SanitizePersonalities(new List<ModPersonality?>
+        {
+            new()
+            {
+                Id = "big",
+                Name = new string('n', ModCompanionContent.MaxPersonalityNameLength + 40),
+                PromptSettings = new Dictionary<string, string>
+                {
+                    ["Personality"] = new string('p', ModCompanionContent.MaxPromptSettingLength + 500)
+                }
+            }
+        });
+
+        var one = Assert.Single(defs);
+        Assert.Equal(ModCompanionContent.MaxPersonalityNameLength, one.Name.Length);
+        Assert.Equal(ModCompanionContent.MaxPromptSettingLength, one.PromptSettings!["Personality"].Length);
+    }
+
+    [Fact]
+    public void APackCannotRegisterMorePersonalitiesThanAManifestCould()
+    {
+        var many = Enumerable.Range(0, ModCompanionContent.MaxPersonalities + 15)
+            .Select(i => (ModPersonality?)new ModPersonality { Id = "p" + i, Name = "P" + i })
+            .ToList();
+
+        Assert.Equal(ModCompanionContent.MaxPersonalities,
+            ModCompanionContent.SanitizePersonalities(many).Count);
+    }
+}


### PR DESCRIPTION
## What / why

Three reporters over two months (Sabie, doomie, mailhand) say the **Bambi-mod AI companion is dead while the default mod works** - "she only repeats default phrases".

I verified the standing diagnosis against `origin/main` first. Most of it is **already fixed**: `BarkRuleLoader`, `CompanionPhraseService.ResolveVoiceLineFolder` / `EventAudioFolder`, `BarkService.ResolveBarkAudio` and `AvatarPortraitLoader` all gained per-mod embedded fallbacks in `0066ad42` (2026-06-05) and `05f7714a` (2026-08-03), and the phrase pools were never broken - all 28 phrase categories are present in all five in-code manifests, and `CompanionLinkIndex` fingerprints on `ActiveModId`.

**The hole that is still real is the AI personalities.** `ModManifest.Personalities` is defined by `CreateLocked` **only** (`Models/BuiltInMods.cs:~2047`), and the bundled `DroneMod/drone-mode.ccpmod` does not define them either (I unzipped it and checked). So BambiSleep, SissyHypno, Dronification **and** CCP Default all fall through `PersonalityService.GetBuiltInPresetsForActiveMod()` to `PersonalityPresets.GetAllBuiltIn()` - the stock, Bambi-flavoured preset set. Because only Drone/Locked ship a `.ccpmod`, `ModPackage.InstalledPath` is null for Bambi/Sissy, so there was no second place they could ever have carried personas. Nothing in the log said any of this was happening.

## What this changes

**`Services/Companion/CompanionContentResolver.cs` (new, PURE, no I/O)** - one ladder for every companion channel:

1. the extracted `.ccpmod` (`InstalledPath`) - Drone, Locked
2. the per-mod folder in the **install dir** - `Resources\sounds\companion_audio\mods\<id>\`
3. the same folder delivered by a **downloaded content pack** (`%LOCALAPPDATA%\...\content\`)
4. the shared baseline - which, for the AI companion, means the DEFAULT mod's voice

**`Services/Companion/ModCompanionContent.cs` (new)** - the I/O half. Probes both real roots, parses an optional per-mod `personalities.json` (same shape as `ModManifest.Personalities`, same caps `ModService.ValidateManifest` enforces: 20 entries, 100-char names, 5000-char prompt sections, id+name required, dupe ids dropped), caches per mod, and never throws.

Wired through it: `BarkRuleLoader` (overlay path, plus the source in its log line), `BarkService.ResolveBarkAudio`, `PersonalityService.GetActiveModPersonalities`.

**One Information line per mod**, at startup, at every mod activation, and whenever a pack or `.ccpmod` lands mid-session:

```
CompanionContent[builtin-bambisleep]: personalities=stock-presets, barkRules=mod-install-dir,
voiceLines=baseline, eventAudio=none, mantras=mod-install-dir, avatarManifest=none
```

`personalities=stock-presets` is the answer to "she only says the default lines". That line is now in every user's `crash.log`/Serilog output, so the next report is a five-second triage instead of a two-month one.

**No installer bloat.** `personalities.json` is a few KB and JSON is not in the content-pack strip set, so a mod can carry personas in the install dir or in its pack at zero size cost. I did **not** bundle the 77 MB bambi pack.

## Files

- `ConditioningControlPanel/Services/Companion/CompanionContentResolver.cs` (new, pure)
- `ConditioningControlPanel/Services/Companion/ModCompanionContent.cs` (new)
- `ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs`
- `ConditioningControlPanel/Services/Companion/BarkService.cs`
- `ConditioningControlPanel/Services/Companion/PersonalityService.cs`
- `ConditioningControlPanel/Services/ModService.cs`
- `Tests/ConditioningControlPanel.Tests/CompanionContentResolverTests.cs` (new, 22 tests)

## Tests

`dotnet build ConditioningControlPanel.sln -c Debug` - **0 errors** (CA1416/CS8602 warnings pre-existing).
`dotnet test Tests/ConditioningControlPanel.Tests -c Debug` - **4049 / 4049 pass**.

New tests cover the pure logic only: ladder shape per channel (packaged-mod first, both per-mod rungs present for a mod with no `.ccpmod`, bark rules deliberately have no baseline rung, empty roots shorten the ladder instead of producing bogus paths), pick order (install dir beats pack, pack wins when the install-dir copy was stripped, nothing anywhere reports `None` rather than a guessed path, a throwing probe is skipped not fatal), the personality source ladder, and `personalities.json` parse/sanitise (garbled file yields nothing so the next rung is used; caps and dedupe match `ValidateManifest`).

No localization keys: everything added is log text, no user-visible string.

## Not done

- **No persona text was authored.** Bambi, Sissy and Drone still resolve `personalities=stock-presets`, i.e. the stock Bambi-flavoured preset list, because none of them define personalities anywhere and creative writing is the owner's. The plumbing is now there: dropping a `personalities.json` into `Resources\sounds\companion_audio\mods\builtin-bambisleep\` (or `...\builtin-sissyhypno\`, or into either mod's content pack) is all that is needed - no code change, no repack, no installer growth. Sissy in particular is worth doing: today its AI persona is the Bambi prompt with `MakeModAware`'s blind `"Bambi" -> "babe"` replacement over it.
- **Not play-tested in the app.** Static verification + unit tests only; the log line has not been read out of a real run.
- `CompanionPhraseService`, `AvatarPortraitLoader` and `MantraVoiceService` still hand-roll the same ladder rather than calling the resolver - they need the two-root UNION for enumeration, not a single winner. Left alone deliberately; the resolver reports on their channels for the log line so the answer is visible in one place.
- One thing I noticed and did **not** touch, worth a separate look: the shared base `bark_rules.json` has **86** rules while each per-mod overlay has **~622**, and `drone-mode.ccpmod` ships no bark overlay at all - so Drone and CCP Default run on 86 barks while Bambi/Sissy/Locked run on 622. If the reported symptom is really "barks crowd out the LLM", that asymmetry is where to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6xJB7QQLacJN9vN3gRAVe
