### PR TITLE
fix(deeper): fullscreen stops burying effects, flashes stop with the video, subliminals instant without a toy (#1041 #1045 #1051 #1052)

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosBubbleHostOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosBubbleHostOverlay.cs
@@ -124,6 +124,27 @@ public sealed class ChaosBubbleHostOverlay : Window
     /// <summary>Re-stack the live host above a mandatory video (see ChaosWindowZ). UI thread only.</summary>
     public static void RaiseActive() => ChaosWindowZ.RaiseTopmost(_active);
 
+    /// <summary>
+    /// HWND of the live host when it is on screen and pinned, for OverlayService's attention-layer
+    /// z-order reconciler (#1041). This one window carries solid-mode flashes, hosted subliminal
+    /// cards and shared-host bubbles, none of which own an hwnd - without it those users had no
+    /// recovery at all from a topmost fullscreen browser burying the layer, only the accidental
+    /// self-heal of the next spawn's <see cref="RaiseActive"/>.
+    /// Returns Zero during a Free Desktop run, where the chaos layer is deliberately NOT topmost
+    /// (ChaosWindowZ.PinTopmost) - mirrors Bubble.GetTopmostWindowHandle so the reconciler can never
+    /// drag a deliberately-demoted window back to the front. UI thread only; never throws.
+    /// </summary>
+    public static IntPtr GetActiveHandle()
+    {
+        try
+        {
+            var w = _active;
+            if (w == null || !w.IsVisible || !w.Topmost) return IntPtr.Zero;
+            return new WindowInteropHelper(w).Handle;
+        }
+        catch { return IntPtr.Zero; }
+    }
+
     /// <summary>Release one reference. The hwnd is torn down (run end / shutdown) only when the LAST
     /// owner releases — a chaos run ending must not close a host the ambient game still holds.</summary>
     public static void CloseActive()

--- a/ConditioningControlPanel/Services/AudioSyncService.cs
+++ b/ConditioningControlPanel/Services/AudioSyncService.cs
@@ -211,7 +211,10 @@ namespace ConditioningControlPanel.Services
             {
                 // Normal operation: calculate look-ahead time with latency compensation
                 // Base 300ms for device response + network + processing latency
-                var latencyMs = 300 + _hapticService.SubliminalAnticipationMs + _settings.ManualLatencyOffsetMs;
+                // Transport latency to the toy, NOT the subliminal routing row: ProviderLatencyMs
+                // is the device-only figure (SubliminalAnticipationMs additionally gates on the
+                // Subliminals haptic row, which must not move this track - #1052 review).
+                var latencyMs = 300 + _hapticService.ProviderLatencyMs + _settings.ManualLatencyOffsetMs;
                 lookAheadTime = currentTime + TimeSpan.FromMilliseconds(latencyMs);
             }
 

--- a/ConditioningControlPanel/Services/AutonomyService.VoiceCommands.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.VoiceCommands.cs
@@ -341,7 +341,12 @@ namespace ConditioningControlPanel.Services
             {
                 Name = "spiral_on",
                 Aliases = OnAliases("spiral", "the spiral"),
-                Execute = () => App.Overlay?.ShowOverlaySustained("spiral", 0.5),
+                // The user's OWN spiral, at the opacity they configured. ShowOverlaySustained used to
+                // drop the value entirely for spiral (#1051) so this hard-coded 0.5 never reached the
+                // screen; now that it does, pass the saved setting so "turn on spiral" keeps behaving
+                // exactly as it always has instead of suddenly rendering 5x heavier.
+                Execute = () => App.Overlay?.ShowOverlaySustained("spiral",
+                    (App.Settings?.Current?.SpiralOpacity ?? 10) / 100.0),
                 VoiceRuleId = "voicecmd_spiral_on",
                 Confirm = new()
                 {
@@ -370,7 +375,11 @@ namespace ConditioningControlPanel.Services
                 Name = "pink_on",
                 Aliases = OnAliases("pink filter", "the pink filter", "make it pink", "go pink"),
                 // OverlayService keys this overlay "pink_filter"; "pink" hits the unknown-kind no-op.
-                Execute = () => App.Overlay?.ShowOverlaySustained("pink_filter", 0.4),
+                // 0.4 is this command's own floor (a voice "go pink" should actually read as pink even
+                // for a user whose saved tint is faint) but it must never DIM a stronger live tint,
+                // which it now would - the sustained path applies the opacity it is handed (#1051).
+                Execute = () => App.Overlay?.ShowOverlaySustained("pink_filter",
+                    Math.Max(0.4, (App.Settings?.Current?.PinkFilterOpacity ?? 10) / 100.0)),
                 VoiceRuleId = "voicecmd_pink_on",
                 Confirm = new()
                 {

--- a/ConditioningControlPanel/Services/Browser/BrowserService.cs
+++ b/ConditioningControlPanel/Services/Browser/BrowserService.cs
@@ -552,6 +552,13 @@ namespace ConditioningControlPanel.Services
             {
                 IsFullscreen = _webView.CoreWebView2.ContainsFullScreenElement;
                 App.Logger?.Information("Browser fullscreen changed: {IsFullscreen}", IsFullscreen);
+                // The subscriber answers this by Show()ing a borderless Topmost window (MainWindow
+                // .EnterBrowserFullscreen, and the same in the popout), which lands at the FRONT of
+                // the topmost band and buries every effect with no way back - the flag-only heal in
+                // OverlayService can't see it because our overlays keep WS_EX_TOPMOST. Tell the
+                // reconciler to force every tick while it is up (#1041/#1051/#1052).
+                try { App.Overlay?.SetFullscreenBrowserActive(this, IsFullscreen); }
+                catch (Exception ex) { App.Logger?.Debug("Browser fullscreen z-order notify failed: {Error}", ex.Message); }
                 FullscreenChanged?.Invoke(this, IsFullscreen);
             };
         }
@@ -1456,6 +1463,12 @@ namespace ConditioningControlPanel.Services
         {
             if (_disposed) return;
             _disposed = true;
+
+            // A WebView torn down while the page still holds HTML5 fullscreen never raises the
+            // "exited" event, which would leave the z-order reconciler forcing every tick for the
+            // rest of the run. Release the registration unconditionally (idempotent per owner).
+            try { App.Overlay?.SetFullscreenBrowserActive(this, false); }
+            catch { }
 
             try
             {

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -75,6 +75,32 @@ public class BubbleService : IDisposable
     public int ActiveFreezeBubbles => _bubbles.Count(b => b.Spec?.IsFreeze == true);
 
     /// <summary>
+    /// HWNDs of the live per-window bubbles, for OverlayService's z-order reconciler (#1041). A
+    /// bubble window asserts HWND_TOPMOST on its show edge only, so a topmost fullscreen browser
+    /// window buried the whole layer with no recovery path. Shared-host and compositor-layer
+    /// bubbles have no HWND of their own (the host is already swept), and a Free Desktop chaos
+    /// bubble deliberately born non-topmost is left exactly where it is.
+    /// UI thread only; a reconciler accessor must never throw.
+    /// </summary>
+    internal List<IntPtr> GetBubbleWindowHandles()
+    {
+        var handles = new List<IntPtr>();
+        try
+        {
+            if (System.Windows.Application.Current?.Dispatcher?.CheckAccess() != true) return handles;
+            // Index walk over a defensive count: the animation timer can retire a bubble while we
+            // read, and this must never throw into the reconciler.
+            for (int i = 0; i < _bubbles.Count; i++)
+            {
+                var hwnd = i < _bubbles.Count ? _bubbles[i].GetTopmostWindowHandle() : IntPtr.Zero;
+                if (hwnd != IntPtr.Zero) handles.Add(hwnd);
+            }
+        }
+        catch { /* a diagnostic/reconciler accessor must never throw */ }
+        return handles;
+    }
+
+    /// <summary>
     /// Snapshot of currently-poppable bubbles for Focus Gaze hit-testing.
     /// Caller iterates in reverse for topmost-first selection.
     /// </summary>
@@ -2211,6 +2237,21 @@ internal class Bubble
     }
 
     private readonly Window? _window;   // null in shared-host mode (the grid lives on ChaosBubbleHostOverlay)
+
+    /// <summary>This bubble's own HWND while it is a LIVE, VISIBLE, topmost window - otherwise zero.
+    /// Zero covers shared-host and compositor-layer bubbles (no window at all), pooled shells that
+    /// are hidden between lives, and Free Desktop chaos bubbles deliberately born non-topmost.
+    /// Feeds OverlayService's z-order reconciler; never throws.</summary>
+    internal IntPtr GetTopmostWindowHandle()
+    {
+        try
+        {
+            if (_window == null || !_isAlive || _isDestroyed) return IntPtr.Zero;
+            if (!_window.IsVisible || !_window.Topmost) return IntPtr.Zero;
+            return new System.Windows.Interop.WindowInteropHelper(_window).Handle;
+        }
+        catch { return IntPtr.Zero; }
+    }
     private readonly bool _useHost;     // AppSettings.ChaosBubbleSharedHost && chaos bubble — see the spawn block
     private readonly bool _useLayer;    // UnifiedOverlayHost: render on the compositor BubbleLayer (also window-less)
     private Compositor.BubbleLayer.BubbleItem? _layerItem;   // this bubble's draw-state on the layer (null off-layer)

--- a/ConditioningControlPanel/Services/Deeper/EnhancementEngine.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementEngine.cs
@@ -68,14 +68,23 @@ namespace ConditioningControlPanel.Services.Deeper
         private bool _hapticDispatched;
 
         /// <summary>
-        /// #1045 - true once this run dispatched a POINT-FIRED visual (flash or subliminal). Those
-        /// are not bands, so FlushActiveBands cannot reach them: they run out their own authored
-        /// duration on the flash/subliminal services' clocks, which is routinely longer than what
-        /// is left of the media, and their loaders are <c>async void</c> so one dispatched on the
-        /// last tick materialises AFTER Stop. Mirrors <see cref="_hapticDispatched"/>: if this run
-        /// put any up, Stop() cancels the one-shot layer.
+        /// #1045 - true once this run dispatched a POINT-FIRED visual. Those are not bands, so
+        /// FlushActiveBands cannot reach them: they run out their own authored duration on the
+        /// flash/subliminal services' clocks, which is routinely longer than what is left of the
+        /// media, and their loaders are <c>async void</c> so one dispatched on the last tick
+        /// materialises AFTER Stop. Mirrors <see cref="_hapticDispatched"/>: if this run put any
+        /// up, Stop() cancels that service's one-shot layer.
+        ///
+        /// Tracked per SERVICE, not as one flag: the services' one-shot retirement is service-wide
+        /// (see FlashService.StopOneShotFlashes), so an enhancement that only ever showed subliminal
+        /// or Speak cue cards must not also retire whatever point-fired FLASH some other feature
+        /// (keyword trigger, Autonomy, chaos) happens to have on screen.
         /// </summary>
-        private bool _visualDispatched;
+        private bool _flashDispatched;
+
+        /// <summary><see cref="_flashDispatched"/>'s subliminal half. Speak counts here: its cue and
+        /// feedback cards go out through SubliminalService.FlashSubliminalCustom.</summary>
+        private bool _subliminalDispatched;
 
         // -- Per-play gamification stats (read by the host on PlaybackCompleted) --
         // Webcam trigger type strings, used to flag "webcam-trigger-used".
@@ -401,7 +410,8 @@ namespace ConditioningControlPanel.Services.Deeper
             _completedFired = false;
             _maxPlaybackTime = 0;
             _hapticDispatched = false;
-            _visualDispatched = false;
+            _flashDispatched = false;
+            _subliminalDispatched = false;
             _runCts = new CancellationTokenSource();
 
             // Prime the cursor to the current playback position so events that
@@ -502,6 +512,10 @@ namespace ConditioningControlPanel.Services.Deeper
                 catch (Exception ex) { App.Logger?.Debug("EnhancementEngine stop-haptics: {Error}", ex.Message); }
             }
 
+            // Flip _running first so any in-flight tick / dispatch short-circuits
+            // before we start tearing down subscriptions.
+            _running = false;
+
             // Same story for point-fired VISUALS (#1045): a flash or subliminal fired near the end
             // carries the timeline segment's own duration and keeps rendering long after the video
             // is gone, and the services' loaders are async void, so one dispatched on the last
@@ -510,17 +524,21 @@ namespace ConditioningControlPanel.Services.Deeper
             // and anything a retired generation already put on screen is taken down. The ambient
             // schedulers are untouched, so a user running flashes or subliminals for real keeps
             // their own rhythm either way.
-            if (_visualDispatched)
+            //
+            // This runs AFTER the flag drops, unlike FlushActiveBands: neither call needs the engine
+            // to still be running, and going first left a window in which a PlaybackTimeChanged tick
+            // still passed the _running check and dispatched a flash under the NEW (post-bump)
+            // generation, so it survived the cancel and outlived the media.
+            if (_flashDispatched)
             {
                 try { App.Flash?.StopOneShotFlashes(); }
                 catch (Exception ex) { App.Logger?.Debug("EnhancementEngine stop-flash: {Error}", ex.Message); }
+            }
+            if (_subliminalDispatched)
+            {
                 try { App.Subliminal?.StopOneShotSubliminals(); }
                 catch (Exception ex) { App.Logger?.Debug("EnhancementEngine stop-subliminal: {Error}", ex.Message); }
             }
-
-            // Flip _running first so any in-flight tick / dispatch short-circuits
-            // before we start tearing down subscriptions.
-            _running = false;
 
             try { _source.PlaybackTimeChanged -= OnPlaybackTime; } catch { }
 
@@ -1037,8 +1055,14 @@ namespace ConditioningControlPanel.Services.Deeper
             // Flash and subliminal effects are always POINT-fired: unlike overlay/haptic effects the
             // dispatcher ignores Phase for them and just shows one, so there is no band for
             // FlushActiveBands to close on Stop. Latch either kind, whatever the authored phase.
-            if (action is TriggerEffectAction { EffectType: EffectTypes.Flash or EffectTypes.Subliminal })
-                _visualDispatched = true;
+            // Speak lands on the subliminal side: it IS a band, but its cue and feedback cards go
+            // out through SubliminalService.FlashSubliminalCustom (SpeakPromptSession.FlashCue /
+            // FlashFeedback), so a cue fired on the last tick outlives the media exactly like a
+            // point-fired card unless the subliminal cancel is armed.
+            if (action is TriggerEffectAction { EffectType: EffectTypes.Flash })
+                _flashDispatched = true;
+            else if (action is TriggerEffectAction { EffectType: EffectTypes.Subliminal or EffectTypes.Speak })
+                _subliminalDispatched = true;
 
             try
             {

--- a/ConditioningControlPanel/Services/Deeper/EnhancementEngine.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementEngine.cs
@@ -67,6 +67,16 @@ namespace ConditioningControlPanel.Services.Deeper
         // mixer's own clock and are invisible to the band flush.
         private bool _hapticDispatched;
 
+        /// <summary>
+        /// #1045 - true once this run dispatched a POINT-FIRED visual (flash or subliminal). Those
+        /// are not bands, so FlushActiveBands cannot reach them: they run out their own authored
+        /// duration on the flash/subliminal services' clocks, which is routinely longer than what
+        /// is left of the media, and their loaders are <c>async void</c> so one dispatched on the
+        /// last tick materialises AFTER Stop. Mirrors <see cref="_hapticDispatched"/>: if this run
+        /// put any up, Stop() cancels the one-shot layer.
+        /// </summary>
+        private bool _visualDispatched;
+
         // -- Per-play gamification stats (read by the host on PlaybackCompleted) --
         // Webcam trigger type strings, used to flag "webcam-trigger-used".
         private static readonly HashSet<string> WebcamTriggerTypes = new()
@@ -391,6 +401,7 @@ namespace ConditioningControlPanel.Services.Deeper
             _completedFired = false;
             _maxPlaybackTime = 0;
             _hapticDispatched = false;
+            _visualDispatched = false;
             _runCts = new CancellationTokenSource();
 
             // Prime the cursor to the current playback position so events that
@@ -489,6 +500,20 @@ namespace ConditioningControlPanel.Services.Deeper
             {
                 try { _ = App.Haptics?.StopAsync(); }
                 catch (Exception ex) { App.Logger?.Debug("EnhancementEngine stop-haptics: {Error}", ex.Message); }
+            }
+
+            // Same story for point-fired VISUALS (#1045): a flash or subliminal fired near the end
+            // carries the timeline segment's own duration and keeps rendering long after the video
+            // is gone, and the services' loaders are async void, so one dispatched on the last
+            // tick can materialise after this Stop returns. Both calls drop the one-shot latch,
+            // which is exactly what those loaders re-check before showing anything, and neither
+            // touches the ambient scheduler when the user has that feature running for real.
+            if (_visualDispatched)
+            {
+                try { App.Flash?.StopOneShotFlashes(); }
+                catch (Exception ex) { App.Logger?.Debug("EnhancementEngine stop-flash: {Error}", ex.Message); }
+                try { App.Subliminal?.StopOneShotSubliminals(); }
+                catch (Exception ex) { App.Logger?.Debug("EnhancementEngine stop-subliminal: {Error}", ex.Message); }
             }
 
             // Flip _running first so any in-flight tick / dispatch short-circuits
@@ -1006,6 +1031,12 @@ namespace ConditioningControlPanel.Services.Deeper
 
             if (action is TriggerHapticAction || action is TriggerEffectAction { EffectType: EffectTypes.Haptic })
                 _hapticDispatched = true;
+
+            // Flash and subliminal effects are always POINT-fired: unlike overlay/haptic effects the
+            // dispatcher ignores Phase for them and just shows one, so there is no band for
+            // FlushActiveBands to close on Stop. Latch either kind, whatever the authored phase.
+            if (action is TriggerEffectAction { EffectType: EffectTypes.Flash or EffectTypes.Subliminal })
+                _visualDispatched = true;
 
             try
             {

--- a/ConditioningControlPanel/Services/Deeper/EnhancementEngine.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementEngine.cs
@@ -505,9 +505,11 @@ namespace ConditioningControlPanel.Services.Deeper
             // Same story for point-fired VISUALS (#1045): a flash or subliminal fired near the end
             // carries the timeline segment's own duration and keeps rendering long after the video
             // is gone, and the services' loaders are async void, so one dispatched on the last
-            // tick can materialise after this Stop returns. Both calls drop the one-shot latch,
-            // which is exactly what those loaders re-check before showing anything, and neither
-            // touches the ambient scheduler when the user has that feature running for real.
+            // tick can materialise after this Stop returns. Both calls RETIRE the service's
+            // one-shot generation: a loader that arrives with a stale generation drops its work,
+            // and anything a retired generation already put on screen is taken down. The ambient
+            // schedulers are untouched, so a user running flashes or subliminals for real keeps
+            // their own rhythm either way.
             if (_visualDispatched)
             {
                 try { App.Flash?.StopOneShotFlashes(); }

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -245,6 +245,35 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// HWNDs of the live per-window flashes, for OverlayService's z-order reconciler (#1041).
+        /// A flash asserts HWND_TOPMOST once on its show edge and nothing ever re-raises it, so a
+        /// topmost fullscreen browser window (Deeper's player, the Settings browser popout) buried
+        /// every flash for the rest of the run with no recovery path. Solid-mode and compositor
+        /// flashes have no HWND of their own - the shared host is already in that sweep.
+        /// UI thread only; a reconciler accessor must never throw.
+        /// </summary>
+        internal List<IntPtr> GetFlashWindowHandles()
+        {
+            var handles = new List<IntPtr>();
+            try
+            {
+                if (System.Windows.Application.Current?.Dispatcher?.CheckAccess() != true) return handles;
+                lock (_lockObj)
+                {
+                    foreach (var w in _activeWindows)
+                    {
+                        if (w.UsesHost || w.UsesLayer) continue;
+                        if (!w.IsVisible) continue;
+                        var hwnd = new System.Windows.Interop.WindowInteropHelper(w).Handle;
+                        if (hwnd != IntPtr.Zero) handles.Add(hwnd);
+                    }
+                }
+            }
+            catch { /* a diagnostic/reconciler accessor must never throw */ }
+            return handles;
+        }
+
+        /// <summary>
         /// File paths of images shown by the most recent FlashDisplayed event.
         /// Snapshot is captured immediately before the event fires so subscribers
         /// can read it synchronously. Empty when no flash has displayed yet.
@@ -384,6 +413,34 @@ namespace ConditioningControlPanel.Services
             App.DiscordRpc?.SetIdleActivity();
 
             App.Logger.Information("FlashService stopped");
+        }
+
+        /// <summary>
+        /// Cancel point-fired ("one-shot") flashes: drop any load still in flight and close what
+        /// they put on screen, WITHOUT stopping the ambient scheduler.
+        ///
+        /// #1045: a Deeper enhancement fired a flash on its last tick and the image outlived the
+        /// video. Two reasons, both handled here. TriggerFlashOnce* hand off to an <c>async void</c>
+        /// loader, so a flash dispatched just before the caller stopped materialised afterwards -
+        /// clearing <c>_oneShotActive</c> makes ShowImages bail on arrival, which is the existing
+        /// "delayed callback after Stop" guard. And an authored flash carries the segment's own
+        /// duration, which can be many seconds longer than whatever is left of the media.
+        ///
+        /// When the ambient service IS running, the windows on screen belong to the user's own
+        /// flash rhythm and are indistinguishable from a one-shot at the window level, so only the
+        /// in-flight one-shot is dropped and the ambient heartbeat keeps its windows.
+        /// </summary>
+        public void StopOneShotFlashes()
+        {
+            DispatcherHelper.RunOnUI(() =>
+            {
+                _oneShotActive = false;
+                if (_isRunning) return;   // ambient owns the windows, the heartbeat and _isBusy
+                _isBusy = false;
+                StopCurrentSound();
+                CloseAllWindows();
+                StopHeartbeat();
+            });
         }
 
         public void TriggerFlash()

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -258,7 +258,9 @@ namespace ConditioningControlPanel.Services
         /// A flash asserts HWND_TOPMOST once on its show edge and nothing ever re-raises it, so a
         /// topmost fullscreen browser window (Deeper's player, the Settings browser popout) buried
         /// every flash for the rest of the run with no recovery path. Solid-mode and compositor
-        /// flashes have no HWND of their own - the shared host is already in that sweep.
+        /// flashes have no HWND of their own: the compositor ones ride their CompositorEngine host,
+        /// and the solid-mode ones ride ChaosBubbleHostOverlay, which the same reconcile pass sweeps
+        /// separately (ChaosBubbleHostOverlay.GetActiveHandle).
         /// UI thread only; a reconciler accessor must never throw.
         /// </summary>
         internal List<IntPtr> GetFlashWindowHandles()
@@ -439,6 +441,16 @@ namespace ConditioningControlPanel.Services
         /// scheduler is running, and every window tagged with a retired generation is closed. The
         /// ambient scheduler's own windows carry no generation and are never touched, so a user
         /// running flashes for real keeps their own rhythm.
+        ///
+        /// SCOPE, precisely: the generation is service-WIDE, not per-caller. Every point-fired flash
+        /// shares one entry point (TriggerFlashOnce - Deeper's TriggerFlashOnceWithImage(null, ..)
+        /// falls straight through to it), so a keyword trigger, an Autonomy nudge, a chaos payload or
+        /// a Gaze reward flash dispatched since the last cancel carries the same generation and is
+        /// retired with the Deeper one. In practice that costs at most one already-visible foreign
+        /// one-shot its remaining duration (_isBusy admits only one one-shot family at a time), and
+        /// only when a Deeper enhancement ends within it. Scoping it per dispatcher would mean an
+        /// owner token threaded through every TriggerFlashOnce call site; deliberately not done for
+        /// 6.8.5. Do NOT call this from anything but a point-fired dispatcher's own stop.
         /// </summary>
         public void StopOneShotFlashes()
         {

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -97,6 +97,15 @@ namespace ConditioningControlPanel.Services
         private bool _isBusy;
         private bool _oneShotActive; // For TriggerFlashOnce when service not running
 
+        // #1045 - every point-fired ("one-shot") flash carries the generation that was current when
+        // it was dispatched. StopOneShotFlashes bumps the generation, so a loader still in flight
+        // bails on arrival and the windows a retired generation already put up get closed. The
+        // _oneShotActive latch alone cannot do that job: the arrival guards read
+        // "!_isRunning && !_oneShotActive", so while the ambient scheduler runs the latch is
+        // meaningless and a cancelled Deeper flash would still materialise and then sit there for
+        // the authored segment duration, long after the media it belonged to ended.
+        private int _oneShotGeneration;
+
         // Solid mode: one ref-counted hold on the shared ChaosBubbleHostOverlay for the whole
         // flash session (Start→Stop, or a one-shot burst) — NOT per flash. The host has the same
         // keep-alive contract as every chaos overlay: creating/closing a fullscreen layered window
@@ -417,30 +426,77 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Cancel point-fired ("one-shot") flashes: drop any load still in flight and close what
-        /// they put on screen, WITHOUT stopping the ambient scheduler.
+        /// they already put on screen, WITHOUT stopping the ambient scheduler.
         ///
         /// #1045: a Deeper enhancement fired a flash on its last tick and the image outlived the
         /// video. Two reasons, both handled here. TriggerFlashOnce* hand off to an <c>async void</c>
-        /// loader, so a flash dispatched just before the caller stopped materialised afterwards -
-        /// clearing <c>_oneShotActive</c> makes ShowImages bail on arrival, which is the existing
-        /// "delayed callback after Stop" guard. And an authored flash carries the segment's own
-        /// duration, which can be many seconds longer than whatever is left of the media.
+        /// loader, so a flash dispatched just before the caller stopped materialised afterwards.
+        /// And an authored flash carries the timeline segment's own duration, which can be many
+        /// seconds longer than whatever was left of the media.
         ///
-        /// When the ambient service IS running, the windows on screen belong to the user's own
-        /// flash rhythm and are indistinguishable from a one-shot at the window level, so only the
-        /// in-flight one-shot is dropped and the ambient heartbeat keeps its windows.
+        /// Both are settled by retiring the one-shot GENERATION rather than the _oneShotActive
+        /// latch: a loader that arrives with a stale generation bails whether or not the ambient
+        /// scheduler is running, and every window tagged with a retired generation is closed. The
+        /// ambient scheduler's own windows carry no generation and are never touched, so a user
+        /// running flashes for real keeps their own rhythm.
         /// </summary>
         public void StopOneShotFlashes()
         {
+            // Retire off the UI thread first: the loaders run on the thread pool and re-read the
+            // generation, so they must see the bump immediately even when the dispatcher is busy.
+            Interlocked.Increment(ref _oneShotGeneration);
+
             DispatcherHelper.RunOnUI(() =>
             {
                 _oneShotActive = false;
-                if (_isRunning) return;   // ambient owns the windows, the heartbeat and _isBusy
+                if (_isRunning)
+                {
+                    // Ambient owns the heartbeat, the shared-host reference and _isBusy - close
+                    // only the point-fired windows and leave the rest of the machinery alone.
+                    CloseOneShotWindows();
+                    return;
+                }
                 _isBusy = false;
                 StopCurrentSound();
                 CloseAllWindows();
+                // Mirror Stop(): without these the shared host window stays stranded (the deferred
+                // one-shot completion that normally releases it early-returns on _oneShotActive)
+                // and, with the unified overlay host on, the global click hook survives with a
+                // STALE hit snapshot, so every click inside the dead flash rect is silently eaten.
+                ReleaseHostRef();
+                ReleaseLayerHook();
                 StopHeartbeat();
             });
+        }
+
+        /// <summary>UI thread. Close only the windows a retired one-shot generation put up, leaving
+        /// the ambient scheduler's own windows (which carry no generation) alone.</summary>
+        private void CloseOneShotWindows()
+        {
+            int current = Volatile.Read(ref _oneShotGeneration);
+            var doomed = new List<FlashWindow>();
+            lock (_lockObj)
+            {
+                for (int i = _activeWindows.Count - 1; i >= 0; i--)
+                {
+                    var w = _activeWindows[i];
+                    if (OneShotGate.IsRetired(w.OneShotGeneration, current))
+                    {
+                        doomed.Add(w);
+                        _activeWindows.RemoveAt(i);
+                    }
+                }
+            }
+
+            if (doomed.Count == 0) return;
+
+            foreach (var w in doomed)
+                SafeCloseFlashWindow(w);
+
+            // Refresh the hook-thread hit snapshot now rather than waiting for a heartbeat tick:
+            // until it is rebuilt the hook still hit-tests rects that no longer render anything.
+            RebuildLayerHitSnapshot();
+            App.Overlay?.NotifyTopWindowClosed();
         }
 
         public void TriggerFlash()
@@ -501,7 +557,10 @@ namespace ConditioningControlPanel.Services
             // Start heartbeat timer for animation and fade management
             StartHeartbeat();
 
-            Task.Run(() => LoadAndShowImages(amount, duration, size, suppressHaptic));
+            // #1045: carry the generation this flash was dispatched under, so StopOneShotFlashes
+            // can cancel it on arrival even while the ambient scheduler keeps _isRunning true.
+            int oneShotGen = Volatile.Read(ref _oneShotGeneration);
+            Task.Run(() => LoadAndShowImages(amount, duration, size, suppressHaptic, oneShotGen));
         }
 
         /// <summary>
@@ -543,10 +602,11 @@ namespace ConditioningControlPanel.Services
             _soundPlayingForCurrentFlash = false;
             StartHeartbeat();
 
-            Task.Run(() => LoadAndShowSpecificImage(resolved, durationMs, playSound, suppressHaptic));
+            int oneShotGen = Volatile.Read(ref _oneShotGeneration);
+            Task.Run(() => LoadAndShowSpecificImage(resolved, durationMs, playSound, suppressHaptic, oneShotGen));
         }
 
-        private async void LoadAndShowSpecificImage(string imagePath, int durationMs, bool playSound, bool suppressHaptic = false)
+        private async void LoadAndShowSpecificImage(string imagePath, int durationMs, bool playSound, bool suppressHaptic = false, int? oneShotGen = null)
         {
             try
             {
@@ -568,7 +628,7 @@ namespace ConditioningControlPanel.Services
 
                 await DispatcherHelper.RunOnUIAsync(() =>
                 {
-                    ShowImages(new List<LoadedImageData> { data }, soundPath, false, customDuration: durationMs, suppressHaptic: suppressHaptic);
+                    ShowImages(new List<LoadedImageData> { data }, soundPath, false, customDuration: durationMs, suppressHaptic: suppressHaptic, oneShotGen: oneShotGen);
                 });
             }
             catch (Exception ex)
@@ -649,7 +709,7 @@ namespace ConditioningControlPanel.Services
 
         #region Image Loading
 
-        private async void LoadAndShowImages(int? amount = null, int? duration = null, int? size = null, bool suppressHaptic = false)
+        private async void LoadAndShowImages(int? amount = null, int? duration = null, int? size = null, bool suppressHaptic = false, int? oneShotGen = null)
         {
             try
             {
@@ -704,7 +764,7 @@ namespace ConditioningControlPanel.Services
                 // Show on UI thread - pass sound path only ONCE
                 await DispatcherHelper.RunOnUIAsync(() =>
                 {
-                    ShowImages(loadedImages, soundPath, false, customDuration: duration, suppressHaptic: suppressHaptic);
+                    ShowImages(loadedImages, soundPath, false, customDuration: duration, suppressHaptic: suppressHaptic, oneShotGen: oneShotGen);
                 });
             }
             catch (Exception ex)
@@ -1088,8 +1148,17 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         /// <param name="overrideLifetimeMs">If provided, overrides the calculated lifetime (used for hydra linked timing)~ 🔗</param>
         /// <param name="hydraGeneration">How many hydra hops deep these spawns are (0 = original flash)~ 🐙</param>
-        private void ShowImages(List<LoadedImageData> images, string? soundPath, bool isMultiplication, int? overrideLifetimeMs = null, int hydraGeneration = 0, int? customDuration = null, bool suppressHaptic = false)
+        private void ShowImages(List<LoadedImageData> images, string? soundPath, bool isMultiplication, int? overrideLifetimeMs = null, int hydraGeneration = 0, int? customDuration = null, bool suppressHaptic = false, int? oneShotGen = null)
         {
+            // #1045: this load was dispatched by a point-fired flash that has since been cancelled.
+            // Checked BEFORE the _isRunning/_oneShotActive pair because that pair is inert while the
+            // ambient scheduler runs, which is exactly the case the Deeper report lives in.
+            if (OneShotGate.IsRetired(oneShotGen, Volatile.Read(ref _oneShotGeneration)))
+            {
+                if (!isMultiplication) _isBusy = false;
+                return;
+            }
+
             if (!_isRunning && !_oneShotActive)
             {
                 if (!isMultiplication) _isBusy = false;
@@ -1185,7 +1254,7 @@ namespace ConditioningControlPanel.Services
                 
                 if (delayMs == 0)
                 {
-                    SpawnFlashWindow(imageData, settings, lifetimeMs, hydraGeneration, suppressHaptic);
+                    SpawnFlashWindow(imageData, settings, lifetimeMs, hydraGeneration, suppressHaptic, oneShotGen);
                 }
                 else
                 {
@@ -1193,6 +1262,7 @@ namespace ConditioningControlPanel.Services
                     var capturedLifetime = lifetimeMs;
                     var capturedGeneration = hydraGeneration;
                     var capturedSuppressHaptic = suppressHaptic;
+                    var capturedOneShotGen = oneShotGen;
                     var spawnToken = _cancellationSource?.Token ?? CancellationToken.None;
                     Task.Delay(delayMs, spawnToken).ContinueWith(_ =>
                     {
@@ -1200,8 +1270,11 @@ namespace ConditioningControlPanel.Services
                         {
                             System.Windows.Application.Current?.Dispatcher?.BeginInvoke(() =>
                             {
+                                // #1045: a staggered spawn from a retired one-shot must not land.
+                                if (OneShotGate.IsRetired(capturedOneShotGen, Volatile.Read(ref _oneShotGeneration)))
+                                    return;
                                 if (_isRunning || _oneShotActive)
-                                    SpawnFlashWindow(capturedData, settings, capturedLifetime, capturedGeneration, capturedSuppressHaptic);
+                                    SpawnFlashWindow(capturedData, settings, capturedLifetime, capturedGeneration, capturedSuppressHaptic, capturedOneShotGen);
                             });
                         }
                         catch { }
@@ -1232,8 +1305,10 @@ namespace ConditioningControlPanel.Services
         /// CopilotNotes: Each window gets a CTS that fires after lifetimeMs, triggering independent fade-out.
         /// When hydraGeneration > 0 and independent timing is active, XP is reduced by 25% per generation (floor 10%).
         /// </summary>
-        private void SpawnFlashWindow(LoadedImageData imageData, AppSettings settings, int lifetimeMs, int hydraGeneration = 0, bool suppressHaptic = false)
+        private void SpawnFlashWindow(LoadedImageData imageData, AppSettings settings, int lifetimeMs, int hydraGeneration = 0, bool suppressHaptic = false, int? oneShotGen = null)
         {
+            // #1045: the point-fired flash that asked for this spawn has been cancelled since.
+            if (OneShotGate.IsRetired(oneShotGen, Volatile.Read(ref _oneShotGeneration))) return;
             if (!_isRunning && !_oneShotActive) return;
 
             // Decide the render path up front so the concurrency cap can be mode-aware. Compositor
@@ -1321,6 +1396,9 @@ namespace ConditioningControlPanel.Services
                 window.ExpiresAt = DateTime.Now.AddMilliseconds(lifetimeMs);
                 window.OriginalLifetimeMs = lifetimeMs;
                 window.HydraGeneration = hydraGeneration;
+                // #1045: null for an ambient flash, the dispatch generation for a point-fired one.
+                // Assigned unconditionally because pooled windows are recycled across both kinds.
+                window.OneShotGeneration = oneShotGen;
                 // Capture the monitor on the window so hydra children can inherit
                 // their parent's screen (TriggerMultiplication reads window.Monitor).
                 window.Monitor = monitor;
@@ -2009,7 +2087,7 @@ namespace ConditioningControlPanel.Services
                 {
                     // Calculate remaining lifetime from the clicked window for linked timing~ 🔗
                     var remainingMs = Math.Max(1000, (int)(window.ExpiresAt - DateTime.Now).TotalMilliseconds);
-                    TriggerMultiplication(maxHydra, currentCount, window.OriginalLifetimeMs, remainingMs, window.HydraGeneration, window.Monitor);
+                    TriggerMultiplication(maxHydra, currentCount, window.OriginalLifetimeMs, remainingMs, window.HydraGeneration, window.Monitor, window.OneShotGeneration);
                 }
             }
         }
@@ -2020,10 +2098,13 @@ namespace ConditioningControlPanel.Services
         /// When HydraLinkedTiming is true, children get parentRemainingMs; when false, they get a fresh full lifetime.
         /// parentGeneration is the clicked window's generation — children will be parentGeneration + 1.
         /// </summary>
-        private async void TriggerMultiplication(int maxHydra, int currentCount, int parentLifetimeMs, int parentRemainingMs, int parentGeneration, MonitorInfo? parentMonitor = null)
+        private async void TriggerMultiplication(int maxHydra, int currentCount, int parentLifetimeMs, int parentRemainingMs, int parentGeneration, MonitorInfo? parentMonitor = null, int? oneShotGen = null)
         {
             try
             {
+                // #1045: hydra children of a point-fired flash inherit its one-shot generation, so
+                // cancelling the one-shot takes the whole family with it.
+                if (OneShotGate.IsRetired(oneShotGen, Volatile.Read(ref _oneShotGeneration))) return;
                 if (!_isRunning && !_oneShotActive) return;
 
                 var spaceAvailable = maxHydra - currentCount;
@@ -2073,7 +2154,7 @@ namespace ConditioningControlPanel.Services
                     await DispatcherHelper.RunOnUIAsync(() =>
                     {
                         // Pass null for sound - NO AUDIO FOR HYDRA
-                        ShowImages(loadedImages, null, true, capturedLifetime, capturedGeneration);
+                        ShowImages(loadedImages, null, true, capturedLifetime, capturedGeneration, oneShotGen: oneShotGen);
                     });
                 }
             }
@@ -4046,6 +4127,14 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>Compositor mode only: this flash's layer item (null once torn down).</summary>
         public Services.Compositor.FlashLayer.FlashItem? LayerItem { get; set; }
+
+        /// <summary>
+        /// #1045 - null for a flash the ambient scheduler put up; otherwise the one-shot generation
+        /// that was current when the point-fired flash was dispatched. FlashService.StopOneShotFlashes
+        /// retires a generation and closes every window still tagged with an older one, which is how a
+        /// cancelled Deeper flash is taken off screen without disturbing the user's own flash rhythm.
+        /// </summary>
+        public int? OneShotGeneration { get; set; }
 
         /// <summary>
         /// Compositor mode only: true while the off-thread frame conversion for this spawn is

--- a/ConditioningControlPanel/Services/Haptics/HapticService.cs
+++ b/ConditioningControlPanel/Services/Haptics/HapticService.cs
@@ -95,9 +95,32 @@ namespace ConditioningControlPanel.Services
         internal static int ResolveSubliminalAnticipationMs(bool hapticsEnabled, bool deviceConnected,
             bool subliminalRuleEnabled, bool isButtplugProvider)
         {
-            if (!hapticsEnabled || !deviceConnected || !subliminalRuleEnabled) return 0;
+            if (!subliminalRuleEnabled) return 0;
+            return ResolveProviderLatencyMs(hapticsEnabled, deviceConnected, isButtplugProvider);
+        }
+
+        /// <summary>
+        /// Pure TRANSPORT-latency rule: how far ahead of the moment a command must leave here to
+        /// reach a real motor on time. Buttplug.io round-trips at roughly 1.3s, a direct provider at
+        /// roughly 250ms, and nothing at all is in flight with no device connected.
+        /// This is deliberately independent of any routing row - <see cref="AudioSyncService"/>
+        /// uses it as the look-ahead for the audio/funscript-synced track, which has nothing to do
+        /// with whether the user routes SUBLIMINALS to their toy (the two were briefly conflated
+        /// while fixing #1052).
+        /// </summary>
+        internal static int ResolveProviderLatencyMs(bool hapticsEnabled, bool deviceConnected,
+            bool isButtplugProvider)
+        {
+            if (!hapticsEnabled || !deviceConnected) return 0;
             return isButtplugProvider ? 1300 : 250;
         }
+
+        /// <summary>
+        /// Transport latency to a connected toy, in ms. The look-ahead the audio-synced haptic
+        /// track runs on. 0 when nothing is connected. See <see cref="ResolveProviderLatencyMs"/>.
+        /// </summary>
+        public int ProviderLatencyMs => ResolveProviderLatencyMs(
+            Settings.Enabled, IsConnected, IsButtplugProvider);
 
         /// <summary>
         /// Head start the subliminal visual gives the toy so the pulse and the card land together.

--- a/ConditioningControlPanel/Services/Haptics/HapticService.cs
+++ b/ConditioningControlPanel/Services/Haptics/HapticService.cs
@@ -83,9 +83,30 @@ namespace ConditioningControlPanel.Services
             || Settings.V2.Provider("buttplug").Enabled;
 
         /// <summary>
-        /// Buttplug.io has ~1.3s latency, so we need to trigger haptics earlier
+        /// Pure anticipation rule (#1052). The delay exists ONLY to give a real motor its spin-up
+        /// head start: Buttplug.io round-trips at roughly 1.3s, a direct provider at roughly 250ms,
+        /// and SubliminalService waits it out BEFORE drawing the card so the pulse and the text
+        /// land together. With no toy connected there is nothing to spin up, so every one of those
+        /// milliseconds was pure lag - a subliminal that is instant with haptics OFF arrived 1.3s
+        /// late with haptics merely ENABLED, which is what the lag repro shows.
+        /// Gated on the master toggle, an actually-connected device, AND the subliminal routing row
+        /// (a disabled row means PostEvent returns Completed without touching a motor).
         /// </summary>
-        public int SubliminalAnticipationMs => IsButtplugProvider ? 1300 : 250;
+        internal static int ResolveSubliminalAnticipationMs(bool hapticsEnabled, bool deviceConnected,
+            bool subliminalRuleEnabled, bool isButtplugProvider)
+        {
+            if (!hapticsEnabled || !deviceConnected || !subliminalRuleEnabled) return 0;
+            return isButtplugProvider ? 1300 : 250;
+        }
+
+        /// <summary>
+        /// Head start the subliminal visual gives the toy so the pulse and the card land together.
+        /// 0 unless a device is actually connected and routed - see
+        /// <see cref="ResolveSubliminalAnticipationMs"/>.
+        /// </summary>
+        public int SubliminalAnticipationMs => ResolveSubliminalAnticipationMs(
+            Settings.Enabled, IsConnected,
+            Settings.V2.Rule(HapticEventKind.SubliminalTrigger).Enabled, IsButtplugProvider);
 
         public List<string> ConnectedDevices
         {

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -879,32 +879,58 @@ public class OverlayService : IDisposable
                 if (kind == "pink_filter")
                 {
                     _timedPinkHolds++;
+                    // Take opacity ownership for the life of the hold, capturing whoever had it
+                    // first so the hide timer can hand it straight back (#573). Parking the hold is
+                    // also what keeps the 500ms settings-sync off this effect's opacity.
+                    if (!_bumpPinkActive) { _bumpPinkActive = true; _bumpPrevRampPink = _rampPinkOpacity; }
                     if (PinkShowing)
                     {
                         // #573: show() would early-return on an already-showing overlay, silently
                         // swallowing the boost. Bump the live opacity instead (never downward) and
                         // park it in the ramp hold so the settings-sync can't stomp it; the hide
                         // timer restores the previous owner.
-                        if (!_bumpPinkActive) { _bumpPinkActive = true; _bumpPrevRampPink = _rampPinkOpacity; }
-                        double current = _rampPinkOpacity ?? (App.Settings?.Current?.PinkFilterOpacity ?? 0) / 100.0;
-                        double target = Math.Max(current, opacityPercent / 100.0);
+                        double target = ResolveAdHocOverlayOpacity(true, _rampPinkOpacity,
+                            (App.Settings?.Current?.PinkFilterOpacity ?? 0) / 100.0, opacityPercent / 100.0);
                         _rampPinkOpacity = target;
                         ApplyPinkOpacityDirect(target);
                     }
-                    else show();
+                    else
+                    {
+                        show();
+                        // #1051: a FRESH ad-hoc overlay takes the effect's own opacity exactly. Without
+                        // the hold the settings-sync handed it straight back to the user's saved
+                        // setting, within half a second of the effect starting.
+                        if (PinkShowing)
+                        {
+                            double fresh = ResolveAdHocOverlayOpacity(false, null, 0, opacityPercent / 100.0);
+                            _rampPinkOpacity = fresh;
+                            ApplyPinkOpacityDirect(fresh);
+                        }
+                    }
                 }
                 else if (kind == "spiral")
                 {
                     _timedSpiralHolds++;
+                    if (!_bumpSpiralActive) { _bumpSpiralActive = true; _bumpPrevRampSpiral = _rampSpiralOpacity; }
                     if (SpiralShowing)
                     {
-                        if (!_bumpSpiralActive) { _bumpSpiralActive = true; _bumpPrevRampSpiral = _rampSpiralOpacity; }
-                        double current = _rampSpiralOpacity ?? (App.Settings?.Current?.SpiralOpacity ?? 0) / 100.0;
-                        double target = Math.Max(current, opacityPercent / 100.0);
+                        double target = ResolveAdHocOverlayOpacity(true, _rampSpiralOpacity,
+                            (App.Settings?.Current?.SpiralOpacity ?? 0) / 100.0, opacityPercent / 100.0);
                         _rampSpiralOpacity = target;
                         ApplySpiralOpacityDirect(target);
                     }
-                    else show();
+                    else
+                    {
+                        show();
+                        // #1051: ShowSpiralAdHoc -> StartSpiral paints the user's saved SpiralOpacity,
+                        // so a point-fired spiral effect ignored its authored opacity entirely.
+                        if (SpiralShowing)
+                        {
+                            double fresh = ResolveAdHocOverlayOpacity(false, null, 0, opacityPercent / 100.0);
+                            _rampSpiralOpacity = fresh;
+                            ApplySpiralOpacityDirect(fresh);
+                        }
+                    }
                 }
                 else
                 {
@@ -946,7 +972,10 @@ public class OverlayService : IDisposable
                         if (_bumpPinkActive)
                         {
                             _bumpPinkActive = false;
-                            if (PinkShowing)
+                            // A sustained Deeper band that started while this timed effect was up now
+                            // owns the opacity; restoring the value captured before the band existed
+                            // would hand its tint back to the settings-sync mid-band.
+                            if (PinkShowing && !_sustainedPinkHeld)
                             {
                                 _rampPinkOpacity = _bumpPrevRampPink;
                                 if (_rampPinkOpacity is double prevPink) ApplyPinkOpacityDirect(prevPink);
@@ -956,8 +985,11 @@ public class OverlayService : IDisposable
                         }
                         // Feature ownership requires the engine to be running (see
                         // HideOverlaySustained) — a ticked checkbox with the engine stopped
-                        // has no reconciler to ever tear this down.
-                        if (!(_isRunning && settings.PinkFilterEnabled)) hide();
+                        // has no reconciler to ever tear this down. A live sustained band counts as
+                        // an owner too: without that check a timed effect expiring over a Deeper
+                        // band tore the band's own overlay off screen (braindrain already guarded
+                        // this via ShouldStopHeldOverlay; pink and spiral did not).
+                        if (ShouldStopHeldOverlay(_isRunning && settings.PinkFilterEnabled, _timedPinkHolds, _sustainedPinkHeld)) hide();
                     }
                 }
                 else if (kind == "spiral")
@@ -968,7 +1000,7 @@ public class OverlayService : IDisposable
                         if (_bumpSpiralActive)
                         {
                             _bumpSpiralActive = false;
-                            if (SpiralShowing)
+                            if (SpiralShowing && !_sustainedSpiralHeld)
                             {
                                 _rampSpiralOpacity = _bumpPrevRampSpiral;
                                 if (_rampSpiralOpacity is double prevSpiral) ApplySpiralOpacityDirect(prevSpiral);
@@ -976,7 +1008,7 @@ public class OverlayService : IDisposable
                             }
                             _bumpPrevRampSpiral = null;
                         }
-                        if (!(_isRunning && settings.SpiralEnabled)) hide();
+                        if (ShouldStopHeldOverlay(_isRunning && settings.SpiralEnabled, _timedSpiralHolds, _sustainedSpiralHeld)) hide();
                     }
                 }
                 else // braindrain / braindrain_melt
@@ -1041,8 +1073,14 @@ public class OverlayService : IDisposable
                 // constant-opacity Deeper band back to the user's saved opacity within half a second
                 // (#563 symptom-1). Ramp bands overwrite this each Update tick; HideOverlaySustained
                 // clears it on band exit, so the lifecycle stays symmetric.
-                if (kind == "pink_filter") { _sustainedPinkHeld = PinkShowing; if (PinkShowing) _rampPinkOpacity = opacity; }
-                else if (kind == "spiral") { _sustainedSpiralHeld = SpiralShowing; if (SpiralShowing) _rampSpiralOpacity = opacity; }
+                // #1051: parking the hold only stops the settings-sync from stomping the band - it
+                // never APPLIED the band's opacity. ShowSpiralAdHoc -> StartSpiral paints the user's
+                // saved SpiralOpacity, so a constant-opacity spiral band rendered at the engine
+                // setting, and only a RAMP looked right (every ramp tick reaches ApplySpiralOpacityDirect).
+                // Pink had the same hole whenever the tint was already up, since ShowPinkFilterAdHoc
+                // early-returns then. Apply the band's own opacity here, for both.
+                if (kind == "pink_filter") { _sustainedPinkHeld = PinkShowing; if (PinkShowing) { _rampPinkOpacity = opacity; ApplyPinkOpacityDirect(opacity); } }
+                else if (kind == "spiral") { _sustainedSpiralHeld = SpiralShowing; if (SpiralShowing) { _rampSpiralOpacity = opacity; ApplySpiralOpacityDirect(opacity); } }
                 // braindrain / braindrain_melt share the one hold + ramp (never co-active). Gated on
                 // BrainDrainShowing for the same reason: a show() that no-oped (compositor host gone,
                 // GDI failure) must not leave a stale hold blocking a later legitimate teardown.
@@ -1168,6 +1206,23 @@ public class OverlayService : IDisposable
         _rampBrainDrainOpacity = null;
         _lastAppliedPinkOpacity = -1;
         _lastAppliedSpiralOpacity = -1;
+    }
+
+    /// <summary>
+    /// Opacity (0..1 fraction) a Deeper ad-hoc overlay effect should take.
+    /// A FRESH overlay takes the effect's own opacity exactly - #1051: the spiral show path paints
+    /// the user's saved SpiralOpacity, so an effect's authored opacity was dropped unless a RAMP
+    /// happened to overwrite it every tick. An overlay that is ALREADY up is only ever bumped UP
+    /// (#573), never dimmed, so a timed effect cannot quietly weaken a live band or the user's own
+    /// tint. Pure so the rule can be unit-tested without a window.
+    /// </summary>
+    internal static double ResolveAdHocOverlayOpacity(bool alreadyShowing, double? rampHold,
+        double settingsFraction, double requested)
+    {
+        requested = Math.Clamp(requested, 0, 1);
+        if (!alreadyShowing) return requested;
+        double current = Math.Clamp(rampHold ?? settingsFraction, 0, 1);
+        return Math.Max(current, requested);
     }
 
     private void ApplyPinkOpacityDirect(double opacity)
@@ -1460,8 +1515,12 @@ public class OverlayService : IDisposable
                         && (s.SpiralEnabled || _timedSpiralHolds > 0 || _sustainedSpiralHeld);
                     if (stillWanted && UseCompositor)
                     {
-                        GetSpiralLayer().ShowFrames(frames, delay, (s.SpiralOpacity / 100.0) * 0.1);
-                        _lastAppliedSpiralOpacity = (s.SpiralOpacity / 100.0) * 0.1;
+                        // #1051: a Deeper band/effect that parked the ramp hold owns this overlay's
+                        // opacity. The decode finishes after the show call returned, so read the hold
+                        // here rather than the user's saved setting.
+                        double baseOpacity = _rampSpiralOpacity ?? (s.SpiralOpacity / 100.0);
+                        GetSpiralLayer().ShowFrames(frames, delay, baseOpacity * 0.1);
+                        _lastAppliedSpiralOpacity = baseOpacity * 0.1;
                         App.Logger?.Debug("Spiral started on compositor layer ({Path}, decoded off-thread)", path);
                     }
                 });
@@ -2965,6 +3024,14 @@ public class OverlayService : IDisposable
                 ReassertAttentionOne(hwnd, force, ref attentionRecovered);
             foreach (var hwnd in App.Bubbles?.GetBubbleWindowHandles() ?? EmptyHandleList)
                 ReassertAttentionOne(hwnd, force, ref attentionRecovered);
+            // The shared chaos host carries the window-LESS members of this layer: solid-mode
+            // flashes (AppSettings.FlashSolidMode), hosted subliminal cards and ChaosBubbleSharedHost
+            // bubbles. It is a plain WPF window, NOT a CompositorEngine host, so the host sweep above
+            // never saw it and those users had no reconciler recovery at all. It returns Zero while
+            // the chaos layer is deliberately un-pinned (Free Desktop).
+            var bubbleHost = ChaosBubbleHostOverlay.GetActiveHandle();
+            if (bubbleHost != IntPtr.Zero)
+                ReassertAttentionOne(bubbleHost, force, ref attentionRecovered);
         }
         catch (Exception ex)
         {

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -83,6 +83,74 @@ public class OverlayService : IDisposable
     /// abnormally-ended band (no matching exit) can't leave overlays pinned above later videos.</summary>
     internal void ResetDeeperOverlayBands() => System.Threading.Interlocked.Exchange(ref _deeperOverlayBandDepth, 0);
 
+    // #1041/#1045/#1051/#1052 - HTML5 fullscreen buries every effect.
+    //
+    // Both fullscreen browser paths (the Deeper enhancement player, and the Settings-tab browser
+    // plus its popout) answer an HTML5 fullscreen request by Show()ing a NEW borderless Topmost
+    // window. A freshly shown topmost window lands at the FRONT of the topmost band, above every
+    // effect window - and the #952/#905 "rented Topmost" handlers re-assert the claim on every
+    // activation, so it returns to the front each time the user clicks the video. Nothing on our
+    // side ever re-raised: ReassertOne only acts when a window LOST WS_EX_TOPMOST, which an overlay
+    // buried by a topmost sibling never does, so ResolveZOrderAction returned None forever and the
+    // pink tint / spiral / flashes stayed invisible for the rest of the run.
+    //
+    // While any such window is live, every reconcile tick is treated as a FORCED tick (see
+    // ShouldForceZOrderTick), which re-issues HWND_TOPMOST and puts the effects back on top within
+    // ~500ms of any re-raise. Tracked as a SET of owners rather than a counter so a double enter or
+    // a partially-unwound exit cannot strand the flag on (both exit paths are retryable by design).
+    private readonly HashSet<object> _fullscreenBrowserOwners = new();
+    private readonly object _fullscreenBrowserGate = new();
+    private volatile bool _fullscreenBrowserActive;
+
+    /// <summary>True while at least one topmost fullscreen browser window is on screen.</summary>
+    internal bool TopmostFullscreenBrowserActive => _fullscreenBrowserActive;
+
+    /// <summary>
+    /// Pure tick policy: a reconcile pass must re-issue HWND_TOPMOST unconditionally (rather than
+    /// only healing windows that lost the flag) whenever the caller asked for it OR a topmost
+    /// fullscreen browser window is live. Extracted so the #1041 rule is unit-testable.
+    /// </summary>
+    internal static bool ShouldForceZOrderTick(bool explicitForce, bool fullscreenBrowserActive)
+        => explicitForce || fullscreenBrowserActive;
+
+    /// <summary>
+    /// Register/unregister a live topmost fullscreen browser window and kick an immediate forced
+    /// z-order pass. Idempotent per <paramref name="owner"/> (pass the window, or the service that
+    /// owns it), so a caller may notify twice, or unwind twice, without unbalancing anything.
+    /// </summary>
+    public void SetFullscreenBrowserActive(object? owner, bool active)
+    {
+        if (owner == null) return;
+        lock (_fullscreenBrowserGate)
+        {
+            if (active) _fullscreenBrowserOwners.Add(owner);
+            else _fullscreenBrowserOwners.Remove(owner);
+            _fullscreenBrowserActive = _fullscreenBrowserOwners.Count > 0;
+        }
+        RequestForcedZOrderReassert();
+    }
+
+    /// <summary>
+    /// Queue a forced z-order pass on the UI thread. Public so the fullscreen enter/exit paths (and
+    /// the rented-Topmost activation handlers) can put the effects back on top the moment they move
+    /// a topmost window, instead of waiting out the next reconcile tick.
+    /// </summary>
+    public void RequestForcedZOrderReassert()
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null) return;
+        try
+        {
+            dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (Application.Current?.Dispatcher == null) return;
+                try { if (!_isDisposed) ReassertZOrder(force: true); }
+                catch (Exception ex) { App.Logger?.Debug("RequestForcedZOrderReassert failed: {Error}", ex.Message); }
+            }));
+        }
+        catch { }
+    }
+
     /// <summary>The AppSettings instance our PropertyChanged hook is currently attached to. Tracked
     /// rather than re-read from <c>App.Settings.Current</c>, so the unsubscribe always detaches from
     /// the object we actually attached to. Same pattern as <c>ModService</c>.</summary>
@@ -2812,6 +2880,12 @@ public class OverlayService : IDisposable
         // correct for ambient/session overlays that happen to co-exist with a mandatory video).
         bool aboveVideo = DeeperOverlayBandActive;
 
+        // A live topmost fullscreen browser window (Deeper's enhancement player, the Settings
+        // browser or its popout) re-raises itself to the front of the topmost band on every
+        // activation and never clears OUR WS_EX_TOPMOST bit - so the flag-only heal below can never
+        // notice. Treat every tick as forced while one is up (#1041/#1051/#1052).
+        force = ShouldForceZOrderTick(force, TopmostFullscreenBrowserActive);
+
         foreach (var list in new[] { _pinkFilterWindows, _spiralWindows, _brainDrainBlurWindows })
         {
             foreach (var window in list)
@@ -2863,8 +2937,37 @@ public class OverlayService : IDisposable
         {
             App.Logger?.Debug("ReassertZOrder (compositor hosts) failed: {Error}", ex.Message);
         }
+
+        // The ATTENTION LAYER: flash, subliminal and bubble windows. Each of these asserts
+        // HWND_TOPMOST once, on its own show edge, and nothing ever re-raises it - so a topmost
+        // fullscreen browser window buried every one of them with no recovery path at all (#1041).
+        // They ride the same rules as the corner GIFs: still topmost, but pinned BELOW a playing
+        // mandatory video (#497) and above it while a Deeper band owns the screen.
+        //
+        // Their recoveries deliberately do NOT feed anyRecovered: these windows come and go by the
+        // second (and pooled bubble shells idle hidden), so counting them as "topmost loss" would
+        // drive the 3s RecreateOverlays escalation on perfectly healthy overlays.
+        bool attentionRecovered = false;
+        try
+        {
+            foreach (var hwnd in App.Flash?.GetFlashWindowHandles() ?? EmptyHandleList)
+                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref attentionRecovered);
+            foreach (var hwnd in App.Subliminal?.GetSubliminalWindowHandles() ?? EmptyHandleList)
+                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref attentionRecovered);
+            foreach (var hwnd in App.Bubbles?.GetBubbleWindowHandles() ?? EmptyHandleList)
+                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref attentionRecovered);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ReassertZOrder (attention layer) failed: {Error}", ex.Message);
+        }
+
         return anyRecovered;
     }
+
+    /// <summary>Shared empty result for the attention-layer accessors (no per-tick allocation when
+    /// a service is null). Immutable on purpose - it is handed to a foreach, never appended to.</summary>
+    private static readonly IReadOnlyList<IntPtr> EmptyHandleList = Array.Empty<IntPtr>();
 
     /// <summary>One window's worth of ReassertZOrder. Normally: below the active video (#497), else
     /// topmost. When <paramref name="aboveVideo"/> (a live Deeper overlay band), the overlay is the

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -2941,8 +2941,17 @@ public class OverlayService : IDisposable
         // The ATTENTION LAYER: flash, subliminal and bubble windows. Each of these asserts
         // HWND_TOPMOST once, on its own show edge, and nothing ever re-raises it - so a topmost
         // fullscreen browser window buried every one of them with no recovery path at all (#1041).
-        // They ride the same rules as the corner GIFs: still topmost, but pinned BELOW a playing
-        // mandatory video (#497) and above it while a Deeper band owns the screen.
+        //
+        // They do NOT ride the corner-GIF rules: the #497 below-video pin must never be applied
+        // here. Flashes (and the legacy per-window subliminals, and the bubble minigames) are the
+        // top attention layer BY DESIGN - FlashService force-topmosts each one on its show edge and
+        // ChaosModeService re-raises the whole set ~1/s through RaiseAllToFront, deliberately over
+        // a playing mandatory video. Handing them the below-video pin would bury a point-fired
+        // Deeper/chaos flash under the very video it was authored for (VideoEnhancementBridge runs
+        // an EnhancementEngine on a mandatory video, and a point-fired flash opens no overlay band,
+        // so aboveVideo is false there) within 500ms, and it would ping-pong at 2Hz against
+        // RaiseAllToFront's ~1Hz raise. ReassertAttentionOne therefore only ever heals a LOST
+        // topmost bit or bumps on a forced tick - which is all #1041 ever needed.
         //
         // Their recoveries deliberately do NOT feed anyRecovered: these windows come and go by the
         // second (and pooled bubble shells idle hidden), so counting them as "topmost loss" would
@@ -2951,11 +2960,11 @@ public class OverlayService : IDisposable
         try
         {
             foreach (var hwnd in App.Flash?.GetFlashWindowHandles() ?? EmptyHandleList)
-                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref attentionRecovered);
+                ReassertAttentionOne(hwnd, force, ref attentionRecovered);
             foreach (var hwnd in App.Subliminal?.GetSubliminalWindowHandles() ?? EmptyHandleList)
-                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref attentionRecovered);
+                ReassertAttentionOne(hwnd, force, ref attentionRecovered);
             foreach (var hwnd in App.Bubbles?.GetBubbleWindowHandles() ?? EmptyHandleList)
-                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref attentionRecovered);
+                ReassertAttentionOne(hwnd, force, ref attentionRecovered);
         }
         catch (Exception ex)
         {
@@ -2998,6 +3007,33 @@ public class OverlayService : IDisposable
         if (needsPin || force || aboveVideo)
             return ZOrderAction.PinTopmost;
         return ZOrderAction.None;
+    }
+
+    /// <summary>
+    /// Pure z-order decision for one ATTENTION-LAYER window (flash / legacy subliminal / bubble).
+    /// Deliberately never sees the video handle: these windows are the top attention layer and are
+    /// force-topmosted over a playing mandatory video by FlashService on show and by
+    /// ChaosModeService.RaiseAllToFront ~1/s. So this sweep limits itself to healing a lost
+    /// WS_EX_TOPMOST bit or bumping on a forced tick (a live topmost fullscreen browser, #1041) -
+    /// applying the #497 below-video pin here would bury point-fired Deeper visuals under the
+    /// enhanced video and fight RaiseAllToFront at 2Hz.
+    /// </summary>
+    internal static ZOrderAction ResolveAttentionLayerAction(bool needsPin, bool force) =>
+        ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
+            needsPin: needsPin, force: force);
+
+    /// <summary>One attention-layer window's worth of ReassertZOrder. See
+    /// <see cref="ResolveAttentionLayerAction"/> for why it has no below-video branch.</summary>
+    private static void ReassertAttentionOne(IntPtr hwnd, bool force, ref bool anyRecovered)
+    {
+        int exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+        bool needsPin = (exStyle & WS_EX_TOPMOST) == 0;
+
+        if (ResolveAttentionLayerAction(needsPin, force) != ZOrderAction.PinTopmost) return;
+
+        SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        if (needsPin) anyRecovered = true;
     }
 
     private static void ReassertOne(IntPtr hwnd, IntPtr videoHwnd, bool aboveVideo, bool force, ref bool anyRecovered)

--- a/ConditioningControlPanel/Services/OneShotGate.cs
+++ b/ConditioningControlPanel/Services/OneShotGate.cs
@@ -1,0 +1,41 @@
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// #1045 - the pure decisions behind cancelling point-fired ("one-shot") effects.
+    ///
+    /// A point-fired flash or subliminal (a Deeper timeline effect, a remote-control trigger, an
+    /// Autonomy nudge) is dispatched through an <c>async void</c> loader and then renders for the
+    /// authored segment's own duration, which is routinely longer than what is left of the media
+    /// that asked for it. Cancelling one cannot key off the services' <c>_oneShotActive</c> latch,
+    /// because every arrival guard reads <c>!_isRunning &amp;&amp; !_oneShotActive</c>: while the
+    /// user has the ambient Flashes/Subliminals feature running, <c>_isRunning</c> is true and the
+    /// latch decides nothing at all.
+    ///
+    /// So each point-fired effect carries the one-shot GENERATION that was current when it was
+    /// dispatched. Cancelling bumps the generation; anything still carrying an older one is stale,
+    /// whatever the ambient scheduler is doing. The ambient scheduler's own work carries no
+    /// generation (null) and is therefore never stale.
+    /// </summary>
+    internal static class OneShotGate
+    {
+        /// <summary>
+        /// True when <paramref name="dispatchGeneration"/> belongs to a point-fired effect that has
+        /// since been cancelled. Null (ambient work) is never retired.
+        /// </summary>
+        internal static bool IsRetired(int? dispatchGeneration, int currentGeneration)
+            => dispatchGeneration is int gen && gen != currentGeneration;
+
+        /// <summary>
+        /// Should a cancel take the subliminal card currently on screen down?
+        /// Unlike flashes there is no per-card window to tag: the service reuses one keep-alive
+        /// window per screen, so the caller remembers which generation put the visible card up
+        /// (<paramref name="visibleGeneration"/>, null when the ambient scheduler did).
+        ///
+        /// With the ambient scheduler stopped the only thing on screen can be the one-shot, so
+        /// blank unconditionally. With it running, blank only when the visible card is the very
+        /// generation being retired - anything else belongs to the user's own rhythm.
+        /// </summary>
+        internal static bool ShouldBlankOnCancel(bool ambientRunning, int? visibleGeneration, int retiredGeneration)
+            => !ambientRunning || visibleGeneration == retiredGeneration;
+    }
+}

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -68,6 +68,18 @@ namespace ConditioningControlPanel.Services
 
         private bool _isRunning;
         private bool _oneShotActive; // Allow one-shot display when service not running (remote control)
+
+        // #1045 - the same generation scheme FlashService uses. A point-fired subliminal carries the
+        // generation it was dispatched under; StopOneShotSubliminals retires that generation so a
+        // show still waiting behind the haptic anticipation delay bails on arrival, and a card
+        // already up from a retired generation is blanked. The _oneShotActive latch alone is inert
+        // while the ambient scheduler runs, because the arrival guard reads
+        // "!_isRunning && !_oneShotActive".
+        private int _oneShotGeneration;
+
+        // The generation of the point-fired subliminal currently on screen (null when the visible
+        // card is the ambient scheduler's own). UI thread only.
+        private int? _visibleOneShotGen;
         private bool _disposed;
         private int _subliminalCount;
 
@@ -114,6 +126,7 @@ namespace ConditioningControlPanel.Services
         {
             _isRunning = false;
             _timer.Stop();
+            _visibleOneShotGen = null;
 
             // Blank + hide the keep-alive windows (don't close them — a Stop can land
             // mid-chaos-run, and closing layered windows then is the deadlock trigger).
@@ -146,34 +159,52 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Cancel point-fired ("one-shot") subliminals: drop any show still waiting behind the
-        /// haptic anticipation delay and blank what is on screen, WITHOUT stopping the ambient
-        /// scheduler. Companion of <c>FlashService.StopOneShotFlashes</c> for #1045 - a Deeper
-        /// enhancement's last-tick subliminal used to land after the video had already gone.
-        /// When the ambient service is running its own cards are left alone; only the one-shot
-        /// latch is dropped, which is what ShowSubliminalVisuals checks on arrival.
+        /// haptic anticipation delay and blank a card a retired one-shot already put up, WITHOUT
+        /// stopping the ambient scheduler. Companion of <c>FlashService.StopOneShotFlashes</c> for
+        /// #1045 - a Deeper enhancement's last-tick subliminal used to land after the video had
+        /// already gone, and an authored one carries the timeline segment's own duration.
+        ///
+        /// Retiring the GENERATION (not just the latch) is what makes this work while the user has
+        /// ambient subliminals running: the arrival guard's "!_isRunning && !_oneShotActive" pair
+        /// is meaningless then, but a stale dispatch generation is not. The ambient scheduler's own
+        /// cards carry no generation and are never blanked.
         /// </summary>
         public void StopOneShotSubliminals()
         {
+            // Retire off the UI thread: the anticipation delay is awaited on the thread pool.
+            int retired = Interlocked.Increment(ref _oneShotGeneration) - 1;
+
             DispatcherHelper.RunOnUI(() =>
             {
                 _oneShotActive = false;
-                if (_isRunning) return;   // ambient owns the cards on screen
 
-                foreach (var win in _screenWindows.Values)
-                {
-                    try
-                    {
-                        win.BeginAnimation(Window.OpacityProperty, null);
-                        win.Opacity = 0;
-                        win.Content = null;
-                        win.Hide();
-                    }
-                    catch { }
-                }
-                RemoveHostedCard(_ => true);
-                if (_layer?.IsActive == true) _layer.Clear();
-                StopAudio();
+                // Ambient running: only blank if the card on screen is the point-fired one we just
+                // retired. Anything else belongs to the user's own subliminal rhythm.
+                if (!OneShotGate.ShouldBlankOnCancel(_isRunning, _visibleOneShotGen, retired)) return;
+
+                _visibleOneShotGen = null;
+                BlankCards();
             });
+        }
+
+        /// <summary>UI thread. Take every subliminal surface (per-screen window, hosted card,
+        /// compositor card) off screen and stop the whisper audio.</summary>
+        private void BlankCards()
+        {
+            foreach (var win in _screenWindows.Values)
+            {
+                try
+                {
+                    win.BeginAnimation(Window.OpacityProperty, null);
+                    win.Opacity = 0;
+                    win.Content = null;
+                    win.Hide();
+                }
+                catch { }
+            }
+            RemoveHostedCard(_ => true);
+            if (_layer?.IsActive == true) _layer.Clear();
+            StopAudio();
         }
 
         /// <summary>
@@ -294,7 +325,10 @@ namespace ConditioningControlPanel.Services
             if (text.Length > 200) text = text.Substring(0, 200);
             text = System.Text.RegularExpressions.Regex.Replace(text, "<[^>]*>", "");
             _oneShotActive = true; // Allow display even when service not running (remote control)
-            TriggerSubliminalWithHapticPattern(text, opacity, overrideDurationMs, suppressHaptic);
+            // #1045: tag this point-fired show with the current one-shot generation so
+            // StopOneShotSubliminals can cancel it even while the ambient scheduler runs.
+            TriggerSubliminalWithHapticPattern(text, opacity, overrideDurationMs, suppressHaptic,
+                Volatile.Read(ref _oneShotGeneration));
             App.Progression?.AddXP(10, XPSource.Subliminal);
         }
 
@@ -606,7 +640,7 @@ namespace ConditioningControlPanel.Services
         /// Pattern depends on the trigger text (Cum/Collapse = long, Freeze = short sharp, Sleep = decay, etc.)
         /// Buttplug.io has ~1.3s latency so we trigger haptics earlier for that provider
         /// </summary>
-        private async void TriggerSubliminalWithHapticPattern(string text, int? opacity = null, int? overrideDurationMs = null, bool suppressHaptic = false)
+        private async void TriggerSubliminalWithHapticPattern(string text, int? opacity = null, int? overrideDurationMs = null, bool suppressHaptic = false, int? oneShotGen = null)
         {
             try
             {
@@ -628,7 +662,7 @@ namespace ConditioningControlPanel.Services
                     await Task.Delay(anticipationMs);
 
                 // Now show on UI thread
-                DispatcherHelper.RunOnUI(() => ShowSubliminalVisuals(text, opacity, overrideDurationMs));
+                DispatcherHelper.RunOnUI(() => ShowSubliminalVisuals(text, opacity, overrideDurationMs, oneShotGen));
             }
             catch (Exception ex)
             {
@@ -636,12 +670,20 @@ namespace ConditioningControlPanel.Services
             }
         }
 
-        private void ShowSubliminalVisuals(string text, int? opacity = null, int? overrideDurationMs = null)
+        private void ShowSubliminalVisuals(string text, int? opacity = null, int? overrideDurationMs = null, int? oneShotGen = null)
         {
+            // #1045: this show belongs to a point-fired subliminal that has since been cancelled.
+            // Checked FIRST because the pair below is inert while the ambient scheduler runs.
+            if (OneShotGate.IsRetired(oneShotGen, Volatile.Read(ref _oneShotGeneration))) return;
+
             // Guard against delayed callbacks firing after Stop() — prevents orphaned windows
             // Allow one-shot from remote control even when service not running
             if (!_isRunning && !_oneShotActive) return;
             _oneShotActive = false;
+
+            // Remember whose card is on screen, so a later StopOneShotSubliminals can tell a
+            // point-fired card (blank it) from the ambient scheduler's own (leave it alone).
+            _visibleOneShotGen = oneShotGen;
 
             // Increment counter and fire event
             _subliminalCount++;

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -145,6 +145,38 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Cancel point-fired ("one-shot") subliminals: drop any show still waiting behind the
+        /// haptic anticipation delay and blank what is on screen, WITHOUT stopping the ambient
+        /// scheduler. Companion of <c>FlashService.StopOneShotFlashes</c> for #1045 - a Deeper
+        /// enhancement's last-tick subliminal used to land after the video had already gone.
+        /// When the ambient service is running its own cards are left alone; only the one-shot
+        /// latch is dropped, which is what ShowSubliminalVisuals checks on arrival.
+        /// </summary>
+        public void StopOneShotSubliminals()
+        {
+            DispatcherHelper.RunOnUI(() =>
+            {
+                _oneShotActive = false;
+                if (_isRunning) return;   // ambient owns the cards on screen
+
+                foreach (var win in _screenWindows.Values)
+                {
+                    try
+                    {
+                        win.BeginAnimation(Window.OpacityProperty, null);
+                        win.Opacity = 0;
+                        win.Content = null;
+                        win.Hide();
+                    }
+                    catch { }
+                }
+                RemoveHostedCard(_ => true);
+                if (_layer?.IsActive == true) _layer.Clear();
+                StopAudio();
+            });
+        }
+
+        /// <summary>
         /// Single authority for toggling the subliminal feature from any UI entry point
         /// (the Settings-tab checkbox and the feature popup both route here). Persists the
         /// flag and, when the engine is running, starts/stops the service — but only on an
@@ -581,7 +613,11 @@ namespace ConditioningControlPanel.Services
                 // Get anticipation delay from haptic service (Buttplug needs ~1.3s, Lovense ~250ms).
                 // When the haptic is suppressed (per-effect opt-out), there's nothing to anticipate,
                 // so show the visual immediately.
-                var anticipationMs = suppressHaptic ? 0 : (App.Haptics?.SubliminalAnticipationMs ?? 250);
+                // 0 when the haptic is suppressed per-effect, and 0 when no toy is actually
+                // connected: HapticService.SubliminalAnticipationMs now returns the motor spin-up
+                // head start only when there is a motor to spin up (#1052). Defaulting to 0 when
+                // the service itself is missing, for the same reason.
+                var anticipationMs = suppressHaptic ? 0 : (App.Haptics?.SubliminalAnticipationMs ?? 0);
 
                 // Trigger haptic pattern first (pattern depends on text), unless suppressed.
                 if (!suppressHaptic)
@@ -1061,6 +1097,31 @@ namespace ConditioningControlPanel.Services
         /// Must be called on the UI thread (reads live WPF visual state); consumed by
         /// <see cref="App.GetCcpWindowRectsCached"/>.
         /// </summary>
+        /// <summary>
+        /// HWNDs of the keep-alive subliminal windows that are CURRENTLY showing a card, for
+        /// OverlayService's z-order reconciler (#1041). The window asserts HWND_TOPMOST once at
+        /// creation and nothing re-raises it, so a topmost fullscreen browser window buried every
+        /// subliminal for the rest of the run. Idle (opacity 0) windows are skipped: re-pinning a
+        /// blank keep-alive shell every tick is pure cost. Solid-mode / compositor cards live on the
+        /// shared host, which is already in that sweep. UI thread only; never throws.
+        /// </summary>
+        internal List<IntPtr> GetSubliminalWindowHandles()
+        {
+            var handles = new List<IntPtr>();
+            try
+            {
+                if (System.Windows.Application.Current?.Dispatcher?.CheckAccess() != true) return handles;
+                foreach (var win in _screenWindows.Values)
+                {
+                    if (win == null || !win.IsVisible || win.Opacity <= 0.01) continue;
+                    var hwnd = new System.Windows.Interop.WindowInteropHelper(win).Handle;
+                    if (hwnd != IntPtr.Zero) handles.Add(hwnd);
+                }
+            }
+            catch { /* a diagnostic/reconciler accessor must never throw */ }
+            return handles;
+        }
+
         public System.Drawing.Rectangle[] GetActiveTextScreenRects()
         {
             var rects = new List<System.Drawing.Rectangle>();

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -168,6 +168,12 @@ namespace ConditioningControlPanel.Services
         /// ambient subliminals running: the arrival guard's "!_isRunning && !_oneShotActive" pair
         /// is meaningless then, but a stale dispatch generation is not. The ambient scheduler's own
         /// cards carry no generation and are never blanked.
+        ///
+        /// SCOPE, precisely: like FlashService's, the generation is service-WIDE. FlashSubliminalCustom
+        /// is shared with keyword triggers, Autonomy and the Speak prompt cues, so a card any of those
+        /// put up since the last cancel is retired alongside the Deeper one. Bounded to the one card
+        /// that is actually on screen (ShouldBlankOnCancel checks _visibleOneShotGen), and deliberately
+        /// left unscoped for 6.8.5 - see StopOneShotFlashes for why.
         /// </summary>
         public void StopOneShotSubliminals()
         {
@@ -1139,31 +1145,6 @@ namespace ConditioningControlPanel.Services
         /// Must be called on the UI thread (reads live WPF visual state); consumed by
         /// <see cref="App.GetCcpWindowRectsCached"/>.
         /// </summary>
-        /// <summary>
-        /// HWNDs of the keep-alive subliminal windows that are CURRENTLY showing a card, for
-        /// OverlayService's z-order reconciler (#1041). The window asserts HWND_TOPMOST once at
-        /// creation and nothing re-raises it, so a topmost fullscreen browser window buried every
-        /// subliminal for the rest of the run. Idle (opacity 0) windows are skipped: re-pinning a
-        /// blank keep-alive shell every tick is pure cost. Solid-mode / compositor cards live on the
-        /// shared host, which is already in that sweep. UI thread only; never throws.
-        /// </summary>
-        internal List<IntPtr> GetSubliminalWindowHandles()
-        {
-            var handles = new List<IntPtr>();
-            try
-            {
-                if (System.Windows.Application.Current?.Dispatcher?.CheckAccess() != true) return handles;
-                foreach (var win in _screenWindows.Values)
-                {
-                    if (win == null || !win.IsVisible || win.Opacity <= 0.01) continue;
-                    var hwnd = new System.Windows.Interop.WindowInteropHelper(win).Handle;
-                    if (hwnd != IntPtr.Zero) handles.Add(hwnd);
-                }
-            }
-            catch { /* a diagnostic/reconciler accessor must never throw */ }
-            return handles;
-        }
-
         public System.Drawing.Rectangle[] GetActiveTextScreenRects()
         {
             var rects = new List<System.Drawing.Rectangle>();
@@ -1255,6 +1236,32 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("Subliminal GetActiveTextScreenRects: {E}", ex.Message);
             }
             return rects.Count == 0 ? Array.Empty<System.Drawing.Rectangle>() : rects.ToArray();
+        }
+
+        /// <summary>
+        /// HWNDs of the keep-alive subliminal windows that are CURRENTLY showing a card, for
+        /// OverlayService's z-order reconciler (#1041). The window asserts HWND_TOPMOST once at
+        /// creation and nothing re-raises it, so a topmost fullscreen browser window buried every
+        /// subliminal for the rest of the run. Idle (opacity 0) windows are skipped: re-pinning a
+        /// blank keep-alive shell every tick is pure cost. Hosted / compositor cards own no hwnd and
+        /// ride their host instead - the compositor host and ChaosBubbleHostOverlay are each swept
+        /// separately in the same pass. UI thread only; never throws.
+        /// </summary>
+        internal List<IntPtr> GetSubliminalWindowHandles()
+        {
+            var handles = new List<IntPtr>();
+            try
+            {
+                if (System.Windows.Application.Current?.Dispatcher?.CheckAccess() != true) return handles;
+                foreach (var win in _screenWindows.Values)
+                {
+                    if (win == null || !win.IsVisible || win.Opacity <= 0.01) continue;
+                    var hwnd = new System.Windows.Interop.WindowInteropHelper(win).Handle;
+                    if (hwnd != IntPtr.Zero) handles.Add(hwnd);
+                }
+            }
+            catch { /* a diagnostic/reconciler accessor must never throw */ }
+            return handles;
         }
 
         /// <summary>Center the border/main text blocks for the current content + window size.</summary>

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -1773,6 +1773,12 @@ namespace ConditioningControlPanel.Views.Deeper
                 {
                     try { if (_videoFullscreenWindow != null) _videoFullscreenWindow.Topmost = true; }
                     catch { }
+                    // Re-taking the claim re-raises this window to the FRONT of the topmost band,
+                    // which is exactly what buried the pink tint / spiral / flashes for the rest of
+                    // the run (#1041/#1051/#1052). Put them straight back on top instead of waiting
+                    // out the reconcile tick.
+                    try { App.Overlay?.RequestForcedZOrderReassert(); }
+                    catch { }
                 };
 
                 EventHandler? closedHandler = null;
@@ -1797,6 +1803,11 @@ namespace ConditioningControlPanel.Views.Deeper
                     try { built!.Closed -= closedHandler!; } catch { }
 
                     _videoFullscreenWindow = null;
+                    // Release the z-order registration on the window's OWN teardown too, so a close
+                    // that did not come through ExitVideoFullscreen can't strand the forced-tick
+                    // flag on (SetFullscreenBrowserActive is idempotent per owner).
+                    try { App.Overlay?.SetFullscreenBrowserActive(built, false); }
+                    catch { }
 
                     // After reparent the underlying Chromium HWND is in a state
                     // where the page no longer receives input events (mouse
@@ -1834,6 +1845,11 @@ namespace ConditioningControlPanel.Views.Deeper
 
                 // Commit state only after reparent is fully in place.
                 _isVideoFullscreen = true;
+                // A new Topmost window at the front of the topmost band buries every effect window,
+                // and none of them re-raise themselves: register it so OverlayService forces a
+                // z-order pass on every tick while the fullscreen video is up (#1041/#1051/#1052).
+                try { App.Overlay?.SetFullscreenBrowserActive(built, true); }
+                catch (Exception ex) { App.Logger?.Debug("EnhancementPlayer: fullscreen z-order notify failed: {Error}", ex.Message); }
                 App.Logger?.Information("EnhancementPlayer: entered fullscreen on {Screen}", screen.DeviceName);
             }
             catch (Exception ex)
@@ -1950,9 +1966,16 @@ namespace ConditioningControlPanel.Views.Deeper
                 catch { }
                 if (_videoFullscreenWindow != null)
                 {
+                    try { App.Overlay?.SetFullscreenBrowserActive(_videoFullscreenWindow, false); }
+                    catch { }
                     try { _videoFullscreenWindow.Close(); }
                     catch (Exception ex) { App.Logger?.Debug("EnhancementPlayer: fullscreen window close failed: {Error}", ex.Message); }
                 }
+                // Back to windowed: the effects were pinned to the front of the topmost band while
+                // the fullscreen window was up, so re-seat everything one last time now that the
+                // forced-tick flag is off.
+                try { App.Overlay?.RequestForcedZOrderReassert(); }
+                catch { }
                 App.Logger?.Information("EnhancementPlayer: exited fullscreen");
             }
             catch (Exception ex)

--- a/Tests/ConditioningControlPanel.Tests/AdHocOverlayOpacityTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AdHocOverlayOpacityTests.cs
@@ -1,0 +1,89 @@
+using Xunit;
+using static ConditioningControlPanel.Services.OverlayService;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1051: "in deeper player, spiral overlay effect only follows set effect opacity when
+/// ramp effect is selected. If ramp isn't selected, opacity follows the setting of users engine."
+///
+/// The show path for spiral (ShowSpiralAdHoc -> StartSpiral) paints the user's saved SpiralOpacity
+/// and the Deeper band only PARKED its own opacity in the ramp hold, so nothing ever applied it.
+/// A ramp appeared to work only because each ramp tick reaches ApplySpiralOpacityDirect.
+/// The rule the fix now runs on is pure and locked here: a FRESH ad-hoc overlay takes the effect's
+/// opacity exactly, while one that is ALREADY on screen is only ever bumped UP (#573) so a timed
+/// effect can never quietly dim a live band or the user's own tint.
+/// </summary>
+public class AdHocOverlayOpacityTests
+{
+    [Fact]
+    public void FreshOverlay_TakesTheEffectsOwnOpacity_NotTheUsersSetting()
+    {
+        // The #1051 core: user's engine setting is 80%, the authored effect asks for 20%.
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: false, rampHold: null,
+            settingsFraction: 0.80, requested: 0.20);
+        Assert.Equal(0.20, opacity, 6);
+    }
+
+    [Fact]
+    public void FreshOverlay_IgnoresAStaleRampHold()
+    {
+        // Nothing is on screen, so no previous owner's value may leak into the new effect.
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: false, rampHold: 0.95,
+            settingsFraction: 0.80, requested: 0.10);
+        Assert.Equal(0.10, opacity, 6);
+    }
+
+    [Fact]
+    public void FreshOverlay_TakesAHigherEffectOpacityToo()
+    {
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: false, rampHold: null,
+            settingsFraction: 0.10, requested: 0.90);
+        Assert.Equal(0.90, opacity, 6);
+    }
+
+    [Fact]
+    public void LiveOverlay_IsBumpedUpByAStrongerEffect()
+    {
+        // #573: a timed effect over a live tint boosts it.
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: true, rampHold: null,
+            settingsFraction: 0.30, requested: 0.75);
+        Assert.Equal(0.75, opacity, 6);
+    }
+
+    [Fact]
+    public void LiveOverlay_IsNeverDimmedByAWeakerEffect()
+    {
+        // #573's other half: the user's own tint (or a live band) must not be weakened.
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: true, rampHold: null,
+            settingsFraction: 0.80, requested: 0.20);
+        Assert.Equal(0.80, opacity, 6);
+    }
+
+    [Fact]
+    public void LiveOverlay_PrefersTheRampHoldOverTheUsersSetting()
+    {
+        // A Deeper band owns the opacity while its hold is parked; the saved setting is not the
+        // current owner and must not be what a bump measures against.
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: true, rampHold: 0.60,
+            settingsFraction: 0.05, requested: 0.40);
+        Assert.Equal(0.60, opacity, 6);
+    }
+
+    [Fact]
+    public void RequestedOpacityIsClamped()
+    {
+        Assert.Equal(1.0, ResolveAdHocOverlayOpacity(false, null, 0.5, 4.2), 6);
+        Assert.Equal(0.0, ResolveAdHocOverlayOpacity(false, null, 0.5, -1.0), 6);
+    }
+
+    [Fact]
+    public void ZeroRequestOnAFreshOverlay_IsHonoured_NotSilentlyReplacedByTheSetting()
+    {
+        // An authored 0% effect is a legitimate instruction (a ramp's starting point). It must not
+        // fall back to the user's setting the way the old code did.
+        var opacity = ResolveAdHocOverlayOpacity(alreadyShowing: false, rampHold: null,
+            settingsFraction: 0.70, requested: 0.0);
+        Assert.Equal(0.0, opacity, 6);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/OneShotGateTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/OneShotGateTests.cs
@@ -1,0 +1,98 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #1045 - a Deeper enhancement fired a flash (or subliminal) on its last tick and the visual
+/// outlived the video, running the authored timeline segment's own duration on an empty screen.
+///
+/// The first attempt at the fix cleared the services' <c>_oneShotActive</c> latch. That is inert in
+/// the common case: every arrival guard reads <c>!_isRunning &amp;&amp; !_oneShotActive</c>, so with
+/// the ambient Flashes/Subliminals feature running (a Deeper enhancement bound to a mandatory video
+/// inside a normal session) <c>_isRunning</c> is true and clearing the latch decides nothing.
+///
+/// Point-fired effects therefore carry the one-shot GENERATION they were dispatched under, and
+/// cancelling retires that generation. These cover the pure decisions.
+/// </summary>
+public class OneShotGateTests
+{
+    // ---- IsRetired: does this dispatch still belong to a live one-shot? ----
+
+    [Fact]
+    public void AmbientWork_IsNeverRetired()
+    {
+        // The ambient scheduler's own flashes carry no generation. Cancelling a Deeper effect must
+        // never take the user's own flash rhythm down with it, however many cancels have happened.
+        Assert.False(OneShotGate.IsRetired(null, 0));
+        Assert.False(OneShotGate.IsRetired(null, 7));
+    }
+
+    [Fact]
+    public void CurrentGenerationDispatch_IsNotRetired()
+    {
+        Assert.False(OneShotGate.IsRetired(0, 0));
+        Assert.False(OneShotGate.IsRetired(42, 42));
+    }
+
+    [Fact]
+    public void DispatchFromBeforeTheCancel_IsRetired()
+    {
+        // The #1045 shape: the loader was handed the generation that was current at dispatch, the
+        // engine stopped and bumped it, and the async void loader only now arrives.
+        Assert.True(OneShotGate.IsRetired(0, 1));
+        Assert.True(OneShotGate.IsRetired(3, 4));
+    }
+
+    [Fact]
+    public void RetirementDoesNotDependOnTheAmbientScheduler()
+    {
+        // The whole point of the generation: the decision is the same whether or not the user has
+        // the ambient feature running, which is what the latch could not manage.
+        const int dispatched = 5;
+        Assert.False(OneShotGate.IsRetired(dispatched, dispatched));
+        Assert.True(OneShotGate.IsRetired(dispatched, dispatched + 1));
+    }
+
+    [Fact]
+    public void SeveralCancelsInARow_KeepEarlierDispatchesRetired()
+    {
+        // Two enhancements stopped back to back must not resurrect the first one's flash.
+        Assert.True(OneShotGate.IsRetired(1, 3));
+        Assert.True(OneShotGate.IsRetired(2, 3));
+        Assert.False(OneShotGate.IsRetired(3, 3));
+    }
+
+    // ---- ShouldBlankOnCancel: take the visible subliminal card down, or leave it? ----
+
+    [Fact]
+    public void AmbientStopped_BlanksWhateverIsOnScreen()
+    {
+        // Nothing but the one-shot can be up, so the caller does not need to know whose card it is.
+        Assert.True(OneShotGate.ShouldBlankOnCancel(ambientRunning: false, visibleGeneration: null, retiredGeneration: 0));
+        Assert.True(OneShotGate.ShouldBlankOnCancel(ambientRunning: false, visibleGeneration: 4, retiredGeneration: 9));
+    }
+
+    [Fact]
+    public void AmbientRunning_BlanksTheCardTheCancelledOneShotPutUp()
+    {
+        // The regression #1045 describes: the Deeper card carries the segment duration and would
+        // otherwise sit there after the video ended.
+        Assert.True(OneShotGate.ShouldBlankOnCancel(ambientRunning: true, visibleGeneration: 2, retiredGeneration: 2));
+    }
+
+    [Fact]
+    public void AmbientRunning_LeavesTheUsersOwnCardAlone()
+    {
+        // An ambient card carries no generation; blanking it would interrupt the user's own
+        // subliminal rhythm for a Deeper effect that had already finished.
+        Assert.False(OneShotGate.ShouldBlankOnCancel(ambientRunning: true, visibleGeneration: null, retiredGeneration: 2));
+    }
+
+    [Fact]
+    public void AmbientRunning_LeavesANewerOneShotCardAlone()
+    {
+        // A second enhancement already put its own card up before the first one's Stop landed.
+        Assert.False(OneShotGate.ShouldBlankOnCancel(ambientRunning: true, visibleGeneration: 3, retiredGeneration: 2));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/OverlayZOrderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/OverlayZOrderTests.cs
@@ -147,4 +147,73 @@ public class OverlayZOrderTests
                     ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
                         needsPin: needsPin, force: force, yieldToCompositorHost: true));
     }
+
+    // ---------------------------------------------------------------------------------------
+    // #1041/#1051/#1052 - HTML5 fullscreen buried every effect.
+    //
+    // Both fullscreen browser paths Show() a NEW borderless Topmost window, which lands at the
+    // front of the topmost band above every effect window. Our overlays KEEP their WS_EX_TOPMOST
+    // bit while they are buried, so needsPin stays false and the un-forced tick resolves to None
+    // forever - there was no recovery path at all. The fix is the tick policy below: while such a
+    // window is live, every tick is a forced tick and re-issues HWND_TOPMOST.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void BuriedButStillFlaggedTopmost_IsANoOpWithoutForce_TheBugShape()
+    {
+        // Exactly the #1041 state: nothing lost the flag, so a flag-only heal does nothing.
+        Assert.Equal(ZOrderAction.None,
+            ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
+                needsPin: false, force: false));
+    }
+
+    [Fact]
+    public void FullscreenBrowserLive_ForcesTheTick()
+    {
+        Assert.True(ShouldForceZOrderTick(explicitForce: false, fullscreenBrowserActive: true));
+    }
+
+    [Fact]
+    public void FullscreenBrowserLive_TurnsTheNoOpIntoARaise()
+    {
+        // The two halves together: the forced tick is what rescues the buried-but-flagged overlay.
+        var force = ShouldForceZOrderTick(explicitForce: false, fullscreenBrowserActive: true);
+        Assert.Equal(ZOrderAction.PinTopmost,
+            ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
+                needsPin: false, force: force));
+    }
+
+    [Fact]
+    public void NoFullscreenBrowser_LeavesTheTickPolicyExactlyAsItWas()
+    {
+        Assert.False(ShouldForceZOrderTick(explicitForce: false, fullscreenBrowserActive: false));
+        Assert.True(ShouldForceZOrderTick(explicitForce: true, fullscreenBrowserActive: false));
+    }
+
+    [Fact]
+    public void ExplicitForceStillWins_WhateverTheBrowserState()
+    {
+        foreach (var fullscreen in new[] { false, true })
+            Assert.True(ShouldForceZOrderTick(explicitForce: true, fullscreenBrowserActive: fullscreen));
+    }
+
+    [Fact]
+    public void ForcedTickCannotBuryAPlayingMandatoryVideo()
+    {
+        // The forced tick must not become a back door around #497: an overlay co-existing with a
+        // playing mandatory video still goes BELOW it, fullscreen browser or not.
+        var force = ShouldForceZOrderTick(explicitForce: false, fullscreenBrowserActive: true);
+        Assert.Equal(ZOrderAction.PinBelowVideo,
+            ResolveZOrderAction(hasVideo: true, isVideoWindow: false, aboveVideo: false,
+                needsPin: false, force: force));
+    }
+
+    [Fact]
+    public void ForcedTickStillLetsADeeperBandSitAboveTheVideo()
+    {
+        var force = ShouldForceZOrderTick(explicitForce: false, fullscreenBrowserActive: true);
+        Assert.Equal(ZOrderAction.PinTopmost,
+            ResolveZOrderAction(hasVideo: true, isVideoWindow: false, aboveVideo: true,
+                needsPin: false, force: force));
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/OverlayZOrderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/OverlayZOrderTests.cs
@@ -216,4 +216,46 @@ public class OverlayZOrderTests
             ResolveZOrderAction(hasVideo: true, isVideoWindow: false, aboveVideo: true,
                 needsPin: false, force: force));
     }
+
+    // ---------------------------------------------------------------------------------------
+    // The ATTENTION LAYER (flash / legacy per-window subliminal / bubble) is swept too, but it is
+    // NOT an ambient overlay: FlashService force-topmosts every flash on its show edge and
+    // ChaosModeService.RaiseAllToFront re-raises the live set ~1/s, deliberately over a playing
+    // mandatory video, because flashes are the top attention layer by design. If the sweep handed
+    // these windows the #497 below-video pin, a point-fired Deeper flash over an enhanced
+    // mandatory video (no overlay band -> aboveVideo false) would be shoved under that video
+    // within 500ms for the rest of its authored duration, and the two re-raisers would ping-pong.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void AttentionLayer_IsNeverPinnedBelowAPlayingVideo()
+    {
+        // Every input combination: the below-video pin is simply not reachable for these windows.
+        foreach (var needsPin in new[] { false, true })
+            foreach (var force in new[] { false, true })
+                Assert.NotEqual(ZOrderAction.PinBelowVideo, ResolveAttentionLayerAction(needsPin, force));
+    }
+
+    [Fact]
+    public void AttentionLayer_HealsALostTopmostBit()
+    {
+        Assert.Equal(ZOrderAction.PinTopmost, ResolveAttentionLayerAction(needsPin: true, force: false));
+    }
+
+    [Fact]
+    public void AttentionLayer_IsRaisedOnAForcedTick_TheFullscreenBrowserRescue()
+    {
+        // #1041: the window kept its topmost bit while the fullscreen browser sat above it, so only
+        // the forced tick can rescue it.
+        var force = ShouldForceZOrderTick(explicitForce: false, fullscreenBrowserActive: true);
+        Assert.Equal(ZOrderAction.PinTopmost, ResolveAttentionLayerAction(needsPin: false, force: force));
+    }
+
+    [Fact]
+    public void AttentionLayer_HealthyAndUnforced_IsALeaveItAlone()
+    {
+        // No SetWindowPos at all on an ordinary tick - that is what keeps this sweep from fighting
+        // FlashService.RaiseAllToFront's ~1/s raise at 2Hz.
+        Assert.Equal(ZOrderAction.None, ResolveAttentionLayerAction(needsPin: false, force: false));
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/SubliminalAnticipationGateTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SubliminalAnticipationGateTests.cs
@@ -85,4 +85,59 @@ public class SubliminalAnticipationGateTests
                             Assert.Equal(0, ms);
                     }
     }
+
+    // ---------------------------------------------------------------------------------------
+    // The subliminal gate must NOT leak into the transport-latency figure. AudioSyncService uses
+    // the provider round-trip as the look-ahead for the audio/funscript-synced haptic track; that
+    // has nothing to do with whether the user routes SUBLIMINALS to their toy. Conflating the two
+    // would put audio-synced haptics ~1.3s behind the video for anyone who simply turned the
+    // Subliminals haptic row off.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ProviderLatency_IgnoresTheSubliminalRoutingRow()
+    {
+        // Same connected Buttplug device, subliminal row off: the transport figure does not move.
+        Assert.Equal(Buttplug, HapticService.ResolveProviderLatencyMs(
+            hapticsEnabled: true, deviceConnected: true, isButtplugProvider: true));
+        Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: true, deviceConnected: true, subliminalRuleEnabled: false, isButtplugProvider: true));
+    }
+
+    [Fact]
+    public void ProviderLatency_MatchesTheDeviceRoundTrip()
+    {
+        Assert.Equal(Buttplug, HapticService.ResolveProviderLatencyMs(
+            hapticsEnabled: true, deviceConnected: true, isButtplugProvider: true));
+        Assert.Equal(Direct, HapticService.ResolveProviderLatencyMs(
+            hapticsEnabled: true, deviceConnected: true, isButtplugProvider: false));
+    }
+
+    [Fact]
+    public void ProviderLatency_IsZeroWithNothingToTalkTo()
+    {
+        foreach (var buttplug in new[] { false, true })
+        {
+            Assert.Equal(0, HapticService.ResolveProviderLatencyMs(
+                hapticsEnabled: true, deviceConnected: false, isButtplugProvider: buttplug));
+            Assert.Equal(0, HapticService.ResolveProviderLatencyMs(
+                hapticsEnabled: false, deviceConnected: true, isButtplugProvider: buttplug));
+        }
+    }
+
+    [Fact]
+    public void SubliminalAnticipation_IsTheProviderLatencyPlusTheRoutingGate()
+    {
+        // The two stay in lockstep except for the row gate - the only difference there may ever be.
+        foreach (var enabled in new[] { false, true })
+            foreach (var connected in new[] { false, true })
+                foreach (var buttplug in new[] { false, true })
+                {
+                    var transport = HapticService.ResolveProviderLatencyMs(enabled, connected, buttplug);
+                    Assert.Equal(transport, HapticService.ResolveSubliminalAnticipationMs(
+                        enabled, connected, subliminalRuleEnabled: true, isButtplugProvider: buttplug));
+                    Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+                        enabled, connected, subliminalRuleEnabled: false, isButtplugProvider: buttplug));
+                }
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/SubliminalAnticipationGateTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SubliminalAnticipationGateTests.cs
@@ -1,0 +1,88 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #1052 - subliminals arrived 1.3s late whenever haptics were enabled, instant when they were off.
+///
+/// SubliminalService awaits <c>HapticService.SubliminalAnticipationMs</c> BEFORE drawing the card so
+/// a real toy's motor has time to spin up and the pulse lands with the text. The old rule keyed that
+/// delay off the PROVIDER alone (Buttplug = 1300ms, anything else = 250ms), so a user who had
+/// haptics enabled but no toy connected paid the full latency for a motor that did not exist.
+/// The delay is now spent only when there is actually something to anticipate.
+/// </summary>
+public class SubliminalAnticipationGateTests
+{
+    private const int Buttplug = 1300;
+    private const int Direct = 250;
+
+    [Fact]
+    public void ConnectedButtplugDevice_KeepsTheFullSpinUpHeadStart()
+    {
+        // The reason the delay exists at all - do not regress it away.
+        Assert.Equal(Buttplug, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: true, deviceConnected: true, subliminalRuleEnabled: true, isButtplugProvider: true));
+    }
+
+    [Fact]
+    public void ConnectedDirectDevice_KeepsItsShorterHeadStart()
+    {
+        Assert.Equal(Direct, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: true, deviceConnected: true, subliminalRuleEnabled: true, isButtplugProvider: false));
+    }
+
+    [Fact]
+    public void HapticsEnabledButNothingConnected_IsInstant_TheBugRepro()
+    {
+        // The exact repro: haptics on, Buttplug selected, no toy paired. Used to cost 1.3s.
+        Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: true, deviceConnected: false, subliminalRuleEnabled: true, isButtplugProvider: true));
+        Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: true, deviceConnected: false, subliminalRuleEnabled: true, isButtplugProvider: false));
+    }
+
+    [Fact]
+    public void MasterToggleOff_IsInstantEvenWithADeviceStillPaired()
+    {
+        // Master off means the mixer never posts the pulse, so there is nothing to wait for.
+        Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: false, deviceConnected: true, subliminalRuleEnabled: true, isButtplugProvider: true));
+    }
+
+    [Fact]
+    public void SubliminalRoutingRowOff_IsInstant()
+    {
+        // A disabled routing row makes PostEvent return Completed without touching a motor, so the
+        // head start would be spent on a pulse that is never sent.
+        Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+            hapticsEnabled: true, deviceConnected: true, subliminalRuleEnabled: false, isButtplugProvider: true));
+    }
+
+    [Fact]
+    public void EveryDisconnectedCombination_IsZero()
+    {
+        foreach (var enabled in new[] { false, true })
+            foreach (var rule in new[] { false, true })
+                foreach (var buttplug in new[] { false, true })
+                    Assert.Equal(0, HapticService.ResolveSubliminalAnticipationMs(
+                        hapticsEnabled: enabled, deviceConnected: false,
+                        subliminalRuleEnabled: rule, isButtplugProvider: buttplug));
+    }
+
+    [Fact]
+    public void OnlyTheFullyRoutedConnectedCase_IsEverNonZero()
+    {
+        foreach (var enabled in new[] { false, true })
+            foreach (var connected in new[] { false, true })
+                foreach (var rule in new[] { false, true })
+                    foreach (var buttplug in new[] { false, true })
+                    {
+                        var ms = HapticService.ResolveSubliminalAnticipationMs(enabled, connected, rule, buttplug);
+                        if (enabled && connected && rule)
+                            Assert.Equal(buttplug ? Buttplug : Direct, ms);
+                        else
+                            Assert.Equal(0, ms);
+                    }
+    }
+}


### PR DESCRIPTION
## What / why

Three Deeper reports, all targeted at v6.8.5. Closes ccp-bugs **#1041**, **#1045**, **#1051**, **#1052** (and extends the rented-Topmost work from **#952**/**#905**).

### A) Fullscreen buried every effect, permanently (#1041, #1051, #1052)

Both fullscreen browser paths answer an HTML5 fullscreen request by `Show()`ing a **new borderless `Topmost` window**, which lands at the **front of the topmost band**, above every effect window. The rented-Topmost handlers (#905/#952) re-assert the claim on every activation, so it goes back to the front each time the user clicks the video.

`OverlayService` could never recover from that: `ReassertOne` only acts on a window that **lost** `WS_EX_TOPMOST`, which a buried-but-still-topmost overlay never does, so `ResolveZOrderAction` returned `None` for the rest of the run. Worse, only band effects were ever allowed above a video, and Flash / Subliminal / Bubble windows were not in the sweep at all, so they had **no recovery path whatsoever**.

Fix:
- `OverlayService.SetFullscreenBrowserActive(owner, active)` registers a live topmost fullscreen browser window. Tracked as a **set of owners**, not a counter, so a double enter or a partially-unwound exit cannot strand the flag on (both exit paths are retryable by design).
- New pure `ShouldForceZOrderTick(explicitForce, fullscreenBrowserActive)`: while such a window is live, **every** reconcile tick is a forced tick, which re-issues `HWND_TOPMOST` and puts the effects back on top within ~500ms of any re-raise. `RequestForcedZOrderReassert()` kicks an immediate pass.
- The sweep now covers the **attention layer** too: flash, subliminal and bubble windows, via new never-throwing handle accessors (`GetFlashWindowHandles`, `GetSubliminalWindowHandles`, `GetBubbleWindowHandles`). These do **not** ride the corner-GIF rules - see *Review round 2* below: they go through `ResolveAttentionLayerAction` / `ReassertAttentionOne`, which never sees the video handle and only heals a lost `WS_EX_TOPMOST` bit or bumps on a forced tick. **#497 is untouched** for the ambient overlays, corner GIFs and compositor hosts, which keep the below-video pin. The attention layer's recoveries deliberately do **not** feed `anyRecovered`, so they can't drive the 3s `RecreateOverlays` escalation.
- Hooks: `BrowserService.ContainsFullScreenElementChanged` (covers the Settings browser *and* the popout in one place) plus its `Dispose` (a WebView torn down mid-fullscreen never raises the "exited" event), and the Deeper player's enter / exit / `Closed` handler plus its activation handler. #905's rented Topmost is **extended, not duplicated**.

Skipped windows by design: solid-mode / compositor flashes and subliminals (no HWND of their own; the shared host is already swept), idle subliminal keep-alive shells, pooled hidden bubble shells, and Free Desktop chaos bubbles deliberately born non-topmost.

### B) Flash outlived the video (#1045)

`EnhancementEngine.Stop()` flushed bands and one-shot haptics but nothing point-fired: an authored flash carries the timeline segment's own duration (routinely longer than what is left of the media), and `LoadAndShowSpecificImage` / `TriggerSubliminalWithHapticPattern` are `async void`, so an effect dispatched on the last tick materialised **after** `Stop`.

Mirrors the `_hapticDispatched` pattern with `_visualDispatched`, and adds `FlashService.StopOneShotFlashes()` / `SubliminalService.StopOneShotSubliminals()`.

Cancellation keys off a **one-shot generation**, not a latch - see *Review round 3* below for why the latch could not work. Every point-fired effect carries the generation that was current when it was dispatched; `StopOneShot*` retires that generation, so a loader, a staggered spawn or a hydra hop that arrives stale drops its work whatever the ambient scheduler is doing, and every window a retired generation put up is closed. **The ambient scheduler's own work carries no generation and is never touched**, so a user running flashes or subliminals for real keeps their own rhythm.

### C) Subliminal 1.3s late whenever haptics were enabled (#1052 lag repro)

`SubliminalService` awaits `HapticService.SubliminalAnticipationMs` **before** drawing the card so a real motor's spin-up lands with the text. The old rule keyed that delay off the provider name alone (`IsButtplugProvider ? 1300 : 250`), so a user with haptics enabled but **no toy connected** paid the full 1.3s for a motor that did not exist — instant with haptics off, 1.3s late with them merely enabled.

New pure `ResolveSubliminalAnticipationMs(hapticsEnabled, deviceConnected, subliminalRuleEnabled, isButtplugProvider)`: 0 unless the master toggle is on, a device is actually connected, **and** the subliminal routing row is enabled (a disabled row makes `PostEvent` return without touching a motor). A connected Buttplug device keeps its 1300ms — that is what the delay is for. The device-only half of that rule is now its own property, `ProviderLatencyMs`, so the audio-sync track does not inherit the subliminal routing gate (again, *Review round 2*).

## Files

- `Services/Notifications/OverlayService.cs` — fullscreen-browser registry, `ShouldForceZOrderTick`, `RequestForcedZOrderReassert`, attention-layer sweep
- `Services/OneShotGate.cs` **(new)** — the two pure cancellation decisions, `IsRetired` and `ShouldBlankOnCancel`
- `Services/Flash/FlashService.cs` — `GetFlashWindowHandles`, `StopOneShotFlashes`, `_oneShotGeneration` threaded through the loaders / spawners / hydra, `FlashWindow.OneShotGeneration`, `CloseOneShotWindows`
- `Services/Subliminal/SubliminalService.cs` — `GetSubliminalWindowHandles`, `StopOneShotSubliminals`, `BlankCards`, `_oneShotGeneration` / `_visibleOneShotGen`, anticipation default 0
- `Services/BubbleService.cs` — `GetBubbleWindowHandles`, `Bubble.GetTopmostWindowHandle`
- `Services/Browser/BrowserService.cs` — register/release on fullscreen change + dispose
- `Views/Deeper/EnhancementPlayerWindow.xaml.cs` — register/release on enter/exit/close, forced reassert on activation
- `Services/Deeper/EnhancementEngine.cs` — `_visualDispatched` + point-fired visual stop on `Stop()`
- `Services/Haptics/HapticService.cs` — `ResolveSubliminalAnticipationMs`, `ResolveProviderLatencyMs` / `ProviderLatencyMs`
- `Services/AudioSyncService.cs` — audio-synced look-ahead now uses `ProviderLatencyMs`
- Tests: `OverlayZOrderTests.cs` (+11), `SubliminalAnticipationGateTests.cs` (new, 11), `OneShotGateTests.cs` (new, 9)

## Tests

- `dotnet build ConditioningControlPanel.sln -c Debug` — **0 errors** (CA1416 warnings only)
- `dotnet test Tests/ConditioningControlPanel.Tests -c Debug` — **4054 / 4054 passed**
- 31 new tests: the pure z-order tick policy (including that a forced tick still cannot bury a mandatory video, #497), the attention-layer action (never resolves to `PinBelowVideo`, heals a lost bit, raises on a forced tick, no-ops when healthy), latency gating across every enabled/connected/routed/provider combination plus the independence of the transport figure from the subliminal row, and the one-shot gate (ambient work is never retired, a dispatch from before the cancel is, retirement is independent of the ambient scheduler, back-to-back cancels, and blank-on-cancel hitting only the retired card).

## Not done / notes

- **Not play-tested in the running app.** A) in particular is a live z-order behaviour that wants a real fullscreen pass in the Deeper player and in the Settings browser popout.
- Point-fired **bubble** bursts are not cancelled on engine `Stop()` (only flash + subliminal, per the brief). Ambient bubbles self-expire in a couple of seconds.
- `StopOneShotFlashes` / `StopOneShotSubliminals` intentionally leave the ambient scheduler's own windows alone. That is now a real distinction rather than a hope: ambient work carries no one-shot generation, point-fired work does.
- Subliminal cards cannot be tagged individually (the service reuses one keep-alive window per screen), so with ambient subliminals running the cancel blanks the visible card only when the service recorded that **that** generation put it up. A one-shot card that had already faded, followed by no ambient card, still runs the (harmless) blank.
- No new user-visible strings, so no localization changes.

## Review round 2 (both majors from the adversarial review)

**1. The attention layer must not inherit the #497 below-video pin.** As first written, the sweep passed the video handle for flash / legacy per-window subliminal / bubble windows, so every 500ms tick shoved them under a playing mandatory video. That is a real regression, not just a legacy-mode note: `VideoEnhancementBridge` binds an `EnhancementEngine` to a `VideoService` mandatory video, and a point-fired Deeper flash opens no overlay band, so `aboveVideo` is false there — `FlashService` topmosts the flash on show and the reconciler buried it within half a second for the rest of its authored duration (default `FlashDuration` 5s). Same shape for chaos / keyword / autonomy one-shots, and it set up a `SetWindowPos` ping-pong with `ChaosModeService`'s ~1/s `FlashService.RaiseAllToFront`, which deliberately raises legacy flash windows over a playing video.

These windows are the **top attention layer by design**, so they now go through the new pure `ResolveAttentionLayerAction(needsPin, force)` and `ReassertAttentionOne`, which never see the video handle at all: heal a lost `WS_EX_TOPMOST` bit, or bump on a forced tick (a live topmost fullscreen browser). That is all #1041 ever needed; on an ordinary tick it issues no `SetWindowPos` at all, so nothing fights `RaiseAllToFront`, and a Deeper visual can no longer be buried under the video it was authored for. Ambient overlays, corner GIFs and compositor hosts keep the #497 pin exactly as before.

**2. `SubliminalAnticipationMs` had a second consumer.** `AudioSyncService` computes `300 + latency + ManualLatencyOffsetMs` as the look-ahead for the audio/funscript-synced haptic track. Gating that shared constant on the `SubliminalTrigger` routing row silently moved an unrelated feature: a user with a connected toy who simply turned the **Subliminals** haptic row off would have had audio-synced haptics run ~1.3s behind the video. Transport latency is now its own rule — `ResolveProviderLatencyMs(hapticsEnabled, deviceConnected, isButtplugProvider)` (connected device only; 1300 Buttplug / 250 direct) exposed as `ProviderLatencyMs`, which `AudioSyncService` consumes. `ResolveSubliminalAnticipationMs` is that same figure **plus** the routing-row gate, so the #1052 fix is unchanged, and a test locks the two to be independent.

## Review round 3 (both majors from the second adversarial review)

**1. `StopOneShotFlashes` leaked the shared host and the global click hook.** It tore the one-shot layer down but skipped the two releases `Stop()` performs — `ReleaseHostRef()` and `ReleaseLayerHook()` — while *simultaneously disabling both deferred paths that would otherwise have done them*: clearing `_oneShotActive` makes the one-shot completion continuation early-return before its `ReleaseHostRef`, and `StopHeartbeat()` stops `RebuildLayerHitSnapshot`, the only other caller of `ReleaseLayerHook`. With the unified overlay host promoted for everyone (`MigrateEnableUnifiedOverlayHost`), a cancelled Deeper flash therefore left the `GlobalMouseHook` installed **for the rest of the run** holding a stale `_layerHits` snapshot — `CloseAllWindows` clears `_activeWindows` but never rebuilds it — and `OnLayerFlashLeftDown` swallows a coordinate hit **before** its UI-thread liveness re-check. Every left/right click inside the dead flash's rectangle was silently eaten, and the shared host window was stranded until the next full `Stop`/`Dispose`. `StopOneShotFlashes` now mirrors `Stop()`.

**2. The fix was inert whenever the ambient feature was running — and the doc comment claimed the opposite.** The arrival guards read `!_isRunning && !_oneShotActive`, so with ambient flashes on, `_isRunning` is true and clearing the latch decided nothing: the last-tick Deeper flash still materialised and ran the authored segment duration. Identical shape for subliminals. This is not an edge case — it is the common `VideoEnhancementBridge` path (an `EnhancementEngine` bound to a mandatory video inside a normal session, where ambient flashes are typically running).

Point-fired effects now carry the **one-shot generation** they were dispatched under (`FlashWindow.OneShotGeneration`; hydra children inherit their parent's, so cancelling takes the whole family). `StopOneShot*` bumps the generation off the UI thread first — the loaders run on the thread pool — then closes what a retired generation left on screen. Guards sit at every arrival point: `ShowImages`, the staggered `SpawnFlashWindow` continuation, `SpawnFlashWindow` itself, `TriggerMultiplication`, and `ShowSubliminalVisuals`. Subliminals reuse one keep-alive window per screen and cannot be tagged per card, so the service records which generation put the visible card up and blanks it only when that is the very generation being retired.

The two decisions are pure and live in `Services/OneShotGate.cs`, covered by `OneShotGateTests`. The stale doc comments in `FlashService`, `SubliminalService` and `EnhancementEngine` that claimed the in-flight one-shot was dropped with ambient running are corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6xJB7QQLacJN9vN3gRAVe




## Review round 4 (final adversarial review)

**1. #1051 was claimed closed and was not in the diff (the major).** #1051 is not a z-order report:
"in deeper player, spiral overlay effect only follows set effect opacity, when ramp effect is selected.
If ramp isn't selected, opacity follows the setting of users engine". It is now actually fixed.

`ShowOverlaySustained` and `ShowOverlayTimed` mapped `"spiral"` to `ShowSpiralAdHoc()` and **dropped
`opacityPercent`** (`pink_filter` correctly got `ShowPinkFilterAdHoc(opacityPercent)`), and
`ShowSpiralAdHoc` -> `StartSpiral` paints `AppSettings.SpiralOpacity`. The band then parked
`_rampSpiralOpacity` only so the 500ms settings-sync would stop stomping it - it never **applied** it.
A ramp appeared to work purely because every ramp tick reaches `SetSustainedOverlayOpacity` ->
`ApplySpiralOpacityDirect`. Pink had the same hole whenever the tint was already up, since
`ShowPinkFilterAdHoc` early-returns then.

- New pure `ResolveAdHocOverlayOpacity(alreadyShowing, rampHold, settingsFraction, requested)`: a
  **fresh** ad-hoc overlay takes the effect's opacity exactly; one **already on screen** is only ever
  bumped **up**, so #573's never-dim rule is preserved.
- Both Deeper paths apply it: the sustained (Region-mode band) branch and the timed (point-fired)
  branch, for spiral and pink. The timed fresh path also parks the ramp hold, without which the
  settings-sync handed the effect back to the user's saved opacity within half a second.
- The **off-thread spiral decode** honours a parked hold as well - it completes after the show call
  returned, so it used to repaint the user's saved opacity over the band.
- 8 new pure tests: `AdHocOverlayOpacityTests`.

*Adjacency, so nothing else silently changes:* `ShowOverlaySustained` has two other callers.
The **"turn on spiral" voice command** passed a hard-coded `0.5` that had never reached the screen -
it now passes the user's saved `SpiralOpacity`, so that command behaves exactly as it always has
instead of rendering 5x heavier. **"go pink"** keeps its `0.4` as a *floor* (`Math.Max` with the saved
value) so it cannot dim a stronger live tint. The chaos `OverlayPayload` does gain its scaled opacity
on spiral - that is the payload's documented intent ("pink_filter / spiral take a plain 0..1 opacity"),
and the spiral path's built-in x0.1 keeps it subtle.

Also fixed while in there, because the change made it reachable: the pink/spiral **timed hide** now
uses `ShouldStopHeldOverlay` like braindrain already did. A timed effect expiring over a live
sustained band used to tear the band's own overlay off screen, and would now also have clobbered its
opacity hold.

**2. `EnhancementEngine.Stop()` cancelled visuals before `_running = false`.** A `PlaybackTimeChanged`
tick arriving in that window still passed the `_running` check and dispatched under the **new**
(post-bump) generation, so it survived the cancel and outlived the media - the residual #1045 race.
Unlike `FlushActiveBands`, neither `StopOneShot*` call needs the engine to still be running, so the
block moved below the flag.

**3. `EffectTypes.Speak` is a third point-fired visual path.** `SpeakPromptSession.FlashCue` /
`FlashFeedback` go out through `SubliminalService.FlashSubliminalCustom`, so an enhancement whose only
visuals were Speak cues left the cancel unarmed and a cue fired on the last tick still rendered after
the media ended. Speak now arms the subliminal cancel.

While doing that the dispatch latch was **split per service** (`_flashDispatched` /
`_subliminalDispatched`). The services' retirement is service-wide, so a subliminal-or-Speak-only
enhancement must not also retire point-fired **flash** work belonging to keyword triggers, Autonomy or
chaos.

**4. The shared chaos host was in no sweep, and three comments said it was.**
`ChaosBubbleHostOverlay` carries solid-mode flashes (`AppSettings.FlashSolidMode`), hosted subliminal
cards and `ChaosBubbleSharedHost` bubbles. It is a plain WPF `Window`, **not** a `CompositorEngine`
host, so `GetVisibleHostHandles()` never saw it and those users had no reconciler recovery from the
fullscreen burial at all - only the accidental self-heal of the next spawn's `RaiseActive()`.
New `ChaosBubbleHostOverlay.GetActiveHandle()` joins the attention-layer sweep; it returns `Zero`
while the chaos layer is deliberately un-pinned (**Free Desktop**, `ChaosWindowZ.PinTopmost == false`),
mirroring `Bubble.GetTopmostWindowHandle`, so the reconciler can never drag a deliberately-demoted
window back to the front. The comments in `FlashService`, `SubliminalService` and the PR text above
are corrected.

**5. The one-shot generation's scope is now documented honestly.** It is service-**wide**, not
per-caller: every point-fired flash shares one entry point (`TriggerFlashOnce` - Deeper's
`TriggerFlashOnceWithImage(null, ..)` falls straight through to it), so a keyword-trigger, Autonomy,
chaos or Gaze one-shot dispatched since the last cancel is retired with the Deeper one. In practice
that costs at most one already-visible foreign one-shot its remaining duration (`_isBusy` admits only
one one-shot family at a time), and only when a Deeper enhancement ends inside it. Scoping it per
dispatcher needs an owner token threaded through every `TriggerFlashOnce` call site; deliberately not
done for 6.8.5, and the earlier "unchanged by design" note (which was not accurate) is replaced by
this, in the code doc as well as here.

**6. Doc-comment placement.** `GetSubliminalWindowHandles` had been inserted between
`GetActiveTextScreenRects`' `<summary>` block and its signature, leaving that method undocumented
under a duplicate tag. Moved below it.

### Round 4 verification

- `dotnet build ConditioningControlPanel.sln -c Debug` - **0 errors** (CA1416 + xUnit analyzer warnings only)
- `dotnet test Tests/ConditioningControlPanel.Tests -c Debug` - **4062 / 4062 passed** (the known
  `DescentZeroShowOrderingTests` flake did not reproduce in this run)
- Still **not play-tested in the running app**; the z-order half (A) and the #1051 opacity change both
  want a live pass in the Deeper player.
