### PR TITLE
feat(arcademy): open the Arcademy for Tier 2 (v6.8.5) and close every go-live gap

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2596,8 +2596,29 @@ namespace ConditioningControlPanel
             // The Arcademy, dev shortcut: `--arcademy` opens the mini-game hub straight away,
             // bypassing the Play strip. Launch() applies the same T2 + AudioOnlySession gates the
             // card's click does, so this skips the UI and nothing else.
+            //
+            // The DEV DOOR (LaunchDev) is a different thing from the shortcut: it sets
+            // init.devDoor, which the campus reads as a dev pass - every room becomes playable
+            // out of timetable, still graded and still paying real XP. That must never be
+            // reachable from a shipped build, so it is compiled out of Release and, in a Release
+            // build, only honoured with a debugger attached. Without one, `--arcademy` still
+            // opens the Arcademy, just through the ordinary front door every player uses.
             if (e.Args.Contains("--arcademy"))
+            {
+#if DEBUG
                 Services.Arcademy.ArcademyHostService.LaunchDev();
+#else
+                if (System.Diagnostics.Debugger.IsAttached)
+                {
+                    Services.Arcademy.ArcademyHostService.LaunchDev();
+                }
+                else
+                {
+                    Logger?.Information("--arcademy: dev door ignored in a Release build without a debugger; opening the Arcademy normally");
+                    Services.Arcademy.ArcademyHostService.Launch();
+                }
+#endif
+            }
 
             // Arm the offline mic features (wake word / push-to-talk) at startup if the user left them
             // on. They're decoupled from Takeover ("She's Listening" owns them), so they no longer wait

--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -1030,6 +1030,19 @@ internal sealed class ChaosWebViewHost : IDisposable
         try { _opts.OnProcessFailed?.Invoke(e.ProcessFailedKind); } catch { }
     }
 
+    /// <summary>
+    /// Map a page <c>{type:'log'}</c> envelope's <c>level</c> field onto a Serilog level.
+    /// Only 'error' and 'warn'/'warning' are loud; everything else (including the bridge's 'info'
+    /// default, an absent field and any junk) is Debug. Case- and whitespace-insensitive.
+    /// </summary>
+    internal static Serilog.Events.LogEventLevel PageLogLevel(string? level)
+        => (level ?? string.Empty).Trim().ToLowerInvariant() switch
+        {
+            "error" => Serilog.Events.LogEventLevel.Error,
+            "warn" or "warning" => Serilog.Events.LogEventLevel.Warning,
+            _ => Serilog.Events.LogEventLevel.Debug,
+        };
+
     private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
     {
         try
@@ -1052,9 +1065,14 @@ internal sealed class ChaosWebViewHost : IDisposable
                     if (_opts.HostOwnedFullscreen && _isFullscreen) SetFullscreen(false);
                     break;
                 case "log":
-                    // Information, not Debug: the global logger floor is Information and page
-                    // logs are the only devtools-less window into the hosted page.
-                    App.Logger?.Information("{Tag}[page]: {Msg}", _opts.LogTag, (string?)o["msg"]);
+                    // Honour the page's own `level`. This used to write EVERY page log at
+                    // Information because that was the global logger floor and page logs were the
+                    // only devtools-less window into the page - fine for the tunnel's handful of
+                    // sites, ruinous once the Arcademy landed with ~700 of them and buried the
+                    // real log under class chatter. Errors and warnings still surface; ordinary
+                    // chatter drops to Debug, where a dev build's lower floor picks it up.
+                    App.Logger?.Write(PageLogLevel((string?)o["level"]),
+                        "{Tag}[page]: {Msg}", _opts.LogTag, (string?)o["msg"]);
                     break;
                 default:
                     _opts.OnMessage?.Invoke(o);

--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -1032,16 +1032,31 @@ internal sealed class ChaosWebViewHost : IDisposable
 
     /// <summary>
     /// Map a page <c>{type:'log'}</c> envelope's <c>level</c> field onto a Serilog level.
-    /// Only 'error' and 'warn'/'warning' are loud; everything else (including the bridge's 'info'
-    /// default, an absent field and any junk) is Debug. Case- and whitespace-insensitive.
+    ///
+    /// <para>The distinction that carries the weight here is ABSENT versus DECLARED. The global
+    /// logger floor is Information and it is set unconditionally, in every build (App.OnStartup),
+    /// so a message routed to Debug is not demoted - it is DROPPED, and page logs are the only
+    /// devtools-less window a hosted surface has. Six of the ten bridges (dtrh, m2test, tunnel,
+    /// goon, intake web-shim, player) send no level field at all, so an absent field has to keep
+    /// meaning Information or those surfaces go dark. A page that declares 'debug' is opting out
+    /// on purpose: that is how the Arcademy's chatter goes quiet without silencing anybody
+    /// else.</para>
+    ///
+    /// <para>Case- and whitespace-insensitive. Unknown junk reads as chatter, never as loud.</para>
     /// </summary>
     internal static Serilog.Events.LogEventLevel PageLogLevel(string? level)
-        => (level ?? string.Empty).Trim().ToLowerInvariant() switch
+    {
+        // Absent or blank: the legacy contract, kept verbatim for the bridges that predate the
+        // level field entirely. Never route this to Debug: it is where six live surfaces sit.
+        if (string.IsNullOrWhiteSpace(level)) return Serilog.Events.LogEventLevel.Information;
+        return level.Trim().ToLowerInvariant() switch
         {
-            "error" => Serilog.Events.LogEventLevel.Error,
+            "error" or "fatal" => Serilog.Events.LogEventLevel.Error,
             "warn" or "warning" => Serilog.Events.LogEventLevel.Warning,
+            "info" or "information" => Serilog.Events.LogEventLevel.Information,
             _ => Serilog.Events.LogEventLevel.Debug,
         };
+    }
 
     private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
     {
@@ -1068,9 +1083,10 @@ internal sealed class ChaosWebViewHost : IDisposable
                     // Honour the page's own `level`. This used to write EVERY page log at
                     // Information because that was the global logger floor and page logs were the
                     // only devtools-less window into the page - fine for the tunnel's handful of
-                    // sites, ruinous once the Arcademy landed with ~700 of them and buried the
-                    // real log under class chatter. Errors and warnings still surface; ordinary
-                    // chatter drops to Debug, where a dev build's lower floor picks it up.
+                    // sites, ruinous once the Arcademy landed with 118 of them behind one funnel
+                    // and buried the real log under class chatter. Debug means DROPPED here, not
+                    // demoted (the floor is Information in every build), so the router only
+                    // silences a page that asked for it: say nothing and you are still heard.
                     App.Logger?.Write(PageLogLevel((string?)o["level"]),
                         "{Tag}[page]: {Msg}", _opts.LogTag, (string?)o["msg"]);
                     break;

--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -506,6 +506,22 @@
       $(MSBuildProjectDirectory)\Resources\web\intake\assets\music\**\*.mp3;
       $(MSBuildProjectDirectory)\Resources\web\dtrh\assets\**\*.mp3
     </ContentPackWebExcludeAbs>
+    <!-- The four arcademy *demo.html browser harnesses. Listed once here and referenced by
+         BOTH the <Content> Exclude below AND the CopyContentAfterPublish WebFiles Exclude,
+         which re-globs Resources\web independently - miss the second one and the
+         harness pages come straight back into the publish tree (and so the installer). -->
+    <ArcademyHarnessExclude>
+      Resources\web\arcademy\annex\demo.html;
+      Resources\web\arcademy\vn\demo.html;
+      Resources\web\arcademy\emi\demo.html;
+      Resources\web\arcademy\shell\recordsroom.demo.html
+    </ArcademyHarnessExclude>
+    <ArcademyHarnessExcludeAbs>
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\annex\demo.html;
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\vn\demo.html;
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\emi\demo.html;
+      $(MSBuildProjectDirectory)\Resources\web\arcademy\shell\recordsroom.demo.html
+    </ArcademyHarnessExcludeAbs>
   </PropertyGroup>
 
   <ItemGroup>
@@ -535,8 +551,7 @@
     <None Remove="Resources\web\**\*" />
     <Content Include="Resources\web\**\*"
              Exclude="Resources\web\**\CLAUDE.md;Resources\web\**\CAPTCHA_*.md;Resources\web\**\BUILD_PLAN.md;
-                      Resources\web\arcademy\annex\demo.html;Resources\web\arcademy\vn\demo.html;
-                      Resources\web\arcademy\emi\demo.html;Resources\web\arcademy\shell\recordsroom.demo.html;
+                      $(ArcademyHarnessExclude);
                       $(ContentPackWebExclude)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -600,13 +615,14 @@
   <!-- Ensure all content files are copied during publish -->
   <Target Name="CopyContentAfterPublish" AfterTargets="Publish">
     <ItemGroup>
-      <!-- The two content-pack excludes below MUST mirror the <Content> items above, or this
-           target silently re-copies the stripped audio back into the publish tree.
-           See docs/CONTENT_PACKS_PLAN.md §6. -->
+      <!-- The excludes below MUST mirror the <Content> items above, or this target silently
+           re-copies the stripped audio (and the arcademy harness pages) back into the publish
+           tree. That is why both live in properties. See docs/CONTENT_PACKS_PLAN.md §6. -->
       <SoundFiles Include="$(ProjectDir)Resources\sounds\**\*" Exclude="$(ContentPackSoundsExcludeAbs)" />
       <WebFiles Include="$(ProjectDir)Resources\web\**\*"
                 Exclude="$(ProjectDir)Resources\web\**\CLAUDE.md;$(ProjectDir)Resources\web\**\CAPTCHA_*.md;$(ProjectDir)Resources\web\**\BUILD_PLAN.md;
-                         $(ContentPackWebExcludeAbs)" />
+                         $(ContentPackWebExcludeAbs);
+                         $(ArcademyHarnessExcludeAbs)" />
       <SubAudioFiles Include="$(ProjectDir)Resources\sub_audio\**\*" />
       <AwarenessPresetFiles Include="$(ProjectDir)Resources\AwarenessPresets\**\*" />
       <DeeperDemoFiles Include="$(ProjectDir)Resources\DeeperDemos\**\*" />

--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -526,10 +526,17 @@
          DtRH browser game (Resources\web\dtrh). Served to a WebView2 via virtual hosts, so they
          must live on disk in the output. Remove from the default None glob first so a no-copy
          None item can never suppress the Content copy for new extensions (woff2/json/etc).
-         Audio listed in $(ContentPackWebExclude) ships as a downloadable pack instead. -->
+         Audio listed in $(ContentPackWebExclude) ships as a downloadable pack instead.
+         The four arcademy *demo.html pages are BROWSER HARNESSES - standalone proofs for the
+         annex, the VN layer, EMI and the Records room, opened straight from a checkout during
+         development. Nothing in the app or the page graph links them (only two comments name
+         them), so they are dead weight in the installer and a stray unversioned entry point in
+         the virtual host. Excluded, not deleted: they are how those layers get worked on. -->
     <None Remove="Resources\web\**\*" />
     <Content Include="Resources\web\**\*"
              Exclude="Resources\web\**\CLAUDE.md;Resources\web\**\CAPTCHA_*.md;Resources\web\**\BUILD_PLAN.md;
+                      Resources\web\arcademy\annex\demo.html;Resources\web\arcademy\vn\demo.html;
+                      Resources\web\arcademy\emi\demo.html;Resources\web\arcademy\shell\recordsroom.demo.html;
                       $(ContentPackWebExclude)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -4624,5 +4624,5 @@
   "play_arcademy_tooltip": "der Stundenplan von heute wartet.",
   "arcademy_boot_error_body": "{0} konnte auf diesem Rechner nicht gestartet werden.\n\n{1}",
   "arcademy_open_failed_body": "The Arcademy konnte nicht geöffnet werden:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy konnte in dieser Sitzung schon einmal nicht starten. Starte die App neu und versuche es noch einmal."
+  "arcademy_boot_failed_this_session": "The Arcademy konnte beim letzten Versuch auf diesem Rechner nicht starten.\n\nNoch einmal versuchen?"
 }

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -4614,5 +4614,15 @@
   "lockdown_poss_safety_dose": "Nichts läuft? Lockdown wählt für dich",
   "lockdown_poss_safety_dose_tip": "Ein Lockdown läuft nie leer. Engine aus beim Start: sie wird für dich gestartet. Nichts eingeschaltet (oder du schaltest mittendrin alles aus): die Wärterin schaltet Features ein, jedes Mal eins mehr, und gibt am Ende alles zurück.",
   "st4_braindrain_audio_rate": "Audio-Häufigkeit",
-  "label_braindrain": "Brain Drain"
+  "label_braindrain": "Brain Drain",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "NEU",
+  "play_arcademy_blurb": "drei Kurse pro Tag. kleine, einfache Spiele, die alles andere auf deinem Bildschirm schwer macht. erscheine, lass dich benoten, halte die Serie.",
+  "play_arcademy_cta": "Teilnehmen",
+  "play_arcademy_tooltip": "der Stundenplan von heute wartet.",
+  "arcademy_boot_error_body": "{0} konnte auf diesem Rechner nicht gestartet werden.\n\n{1}",
+  "arcademy_open_failed_body": "The Arcademy konnte nicht geöffnet werden:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy konnte in dieser Sitzung schon einmal nicht starten. Starte die App neu und versuche es noch einmal."
 }

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -5164,5 +5164,15 @@
   "lockdown_poss_safety_dose": "Nothing running? Lockdown picks for you",
   "lockdown_poss_safety_dose_tip": "A lockdown refuses to run empty. Engine off when it starts: the engine is started for you. Nothing switched on (or you switch everything off mid-lockdown): the warden turns features on, one more each time, and gives them all back when the timer ends.",
   "st4_braindrain_audio_rate": "Audio clip rate",
-  "label_braindrain": "Brain Drain"
+  "label_braindrain": "Brain Drain",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "NEW",
+  "play_arcademy_blurb": "three classes a day. simple little games made hard by everything else on your screen. show up, get graded, keep the streak.",
+  "play_arcademy_cta": "Attend",
+  "play_arcademy_tooltip": "today's timetable is waiting.",
+  "arcademy_boot_error_body": "{0} could not start on this machine.\n\n{1}",
+  "arcademy_open_failed_body": "Couldn't open the Arcademy:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy already failed to start on this machine this session. Restart the app to try again."
 }

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -5174,5 +5174,5 @@
   "play_arcademy_tooltip": "today's timetable is waiting.",
   "arcademy_boot_error_body": "{0} could not start on this machine.\n\n{1}",
   "arcademy_open_failed_body": "Couldn't open the Arcademy:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy already failed to start on this machine this session. Restart the app to try again."
+  "arcademy_boot_failed_this_session": "The Arcademy failed to start the last time you tried on this machine.\n\nTry opening it again?"
 }

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -4605,5 +4605,15 @@
   "lockdown_poss_safety_dose": "¿Nada en marcha? El bloqueo elige por ti",
   "lockdown_poss_safety_dose_tip": "Un bloqueo se niega a correr vacío. Motor apagado al empezar: se enciende por ti. Nada activado (o lo apagas todo a mitad): la guardiana activa funciones, una más cada vez, y lo devuelve todo cuando acaba el temporizador.",
   "st4_braindrain_audio_rate": "Frecuencia de audio",
-  "label_braindrain": "Drenaje Cerebral"
+  "label_braindrain": "Drenaje Cerebral",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "NUEVO",
+  "play_arcademy_blurb": "tres clases al día. juegos sencillos que todo lo demás en tu pantalla vuelve difíciles. preséntate, deja que te califiquen, mantén la racha.",
+  "play_arcademy_cta": "Asistir",
+  "play_arcademy_tooltip": "el horario de hoy te espera.",
+  "arcademy_boot_error_body": "{0} no pudo iniciarse en este equipo.\n\n{1}",
+  "arcademy_open_failed_body": "No se pudo abrir The Arcademy:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy ya falló al iniciarse en esta sesión. Reinicia la aplicación e inténtalo de nuevo."
 }

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -4615,5 +4615,5 @@
   "play_arcademy_tooltip": "el horario de hoy te espera.",
   "arcademy_boot_error_body": "{0} no pudo iniciarse en este equipo.\n\n{1}",
   "arcademy_open_failed_body": "No se pudo abrir The Arcademy:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy ya falló al iniciarse en esta sesión. Reinicia la aplicación e inténtalo de nuevo."
+  "arcademy_boot_failed_this_session": "The Arcademy no se pudo iniciar la última vez que lo intentaste en este equipo.\n\n¿Quieres intentarlo de nuevo?"
 }

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -4624,5 +4624,5 @@
   "play_arcademy_tooltip": "l'emploi du temps du jour t'attend.",
   "arcademy_boot_error_body": "{0} n'a pas pu démarrer sur cette machine.\n\n{1}",
   "arcademy_open_failed_body": "Impossible d'ouvrir The Arcademy :\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy n'a déjà pas réussi à démarrer pendant cette session. Redémarre l'application et réessaie."
+  "arcademy_boot_failed_this_session": "The Arcademy n'a pas réussi à démarrer lors de ton dernier essai sur cette machine.\n\nRéessayer ?"
 }

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -4614,5 +4614,15 @@
   "lockdown_poss_safety_dose": "Rien ne tourne ? Le verrouillage choisit pour toi",
   "lockdown_poss_safety_dose_tip": "Un verrouillage refuse de tourner à vide. Moteur éteint au départ : il est lancé pour toi. Rien d'activé (ou tu coupes tout en cours de route) : la gardienne active des fonctions, une de plus à chaque fois, et rend tout à la fin du minuteur.",
   "st4_braindrain_audio_rate": "Fréquence audio",
-  "label_braindrain": "Drainage Cérébral"
+  "label_braindrain": "Drainage Cérébral",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "NOUVEAU",
+  "play_arcademy_blurb": "trois cours par jour. de petits jeux simples que tout le reste de ton écran rend difficiles. présente-toi, fais-toi noter, garde la série.",
+  "play_arcademy_cta": "Assister",
+  "play_arcademy_tooltip": "l'emploi du temps du jour t'attend.",
+  "arcademy_boot_error_body": "{0} n'a pas pu démarrer sur cette machine.\n\n{1}",
+  "arcademy_open_failed_body": "Impossible d'ouvrir The Arcademy :\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy n'a déjà pas réussi à démarrer pendant cette session. Redémarre l'application et réessaie."
 }

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -4605,5 +4605,15 @@
   "lockdown_poss_safety_dose": "何も動いていない？ロックダウンが代わりに選ぶ",
   "lockdown_poss_safety_dose_tip": "ロックダウンは空のままでは動きません。開始時にエンジンが止まっていれば代わりに起動します。何もオンでなければ（途中で全部オフにしても）、看守が機能をオンにし、毎回ひとつずつ増やし、タイマーが終わると全部元に戻します。",
   "st4_braindrain_audio_rate": "音声クリップの頻度",
-  "label_braindrain": "ブレインドレイン"
+  "label_braindrain": "ブレインドレイン",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "新着",
+  "play_arcademy_blurb": "一日に三つの授業。単純な小さいゲームを、画面の上のほかのすべてが難しくします。出席して、採点されて、連続記録を守りましょう。",
+  "play_arcademy_cta": "出席する",
+  "play_arcademy_tooltip": "今日の時間割が待っています。",
+  "arcademy_boot_error_body": "{0} はこのパソコンで起動できませんでした。\n\n{1}",
+  "arcademy_open_failed_body": "The Arcademy を開けませんでした:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy はこのセッションで一度起動に失敗しています。アプリを再起動してからもう一度お試しください。"
 }

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -4615,5 +4615,5 @@
   "play_arcademy_tooltip": "今日の時間割が待っています。",
   "arcademy_boot_error_body": "{0} はこのパソコンで起動できませんでした。\n\n{1}",
   "arcademy_open_failed_body": "The Arcademy を開けませんでした:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy はこのセッションで一度起動に失敗しています。アプリを再起動してからもう一度お試しください。"
+  "arcademy_boot_failed_this_session": "The Arcademy はこのパソコンで前回の起動に失敗しました。\n\nもう一度開いてみますか？"
 }

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -4612,5 +4612,15 @@
   "lockdown_poss_safety_dose": "아무것도 안 켜져 있나요? 락다운이 대신 고릅니다",
   "lockdown_poss_safety_dose_tip": "락다운은 비어 있는 채로 돌아가지 않습니다. 시작할 때 엔진이 꺼져 있으면 대신 켜 줍니다. 아무 기능도 켜져 있지 않으면(도중에 전부 끄더라도) 간수가 기능을 켜고, 매번 하나씩 더 켜며, 타이머가 끝나면 전부 원래대로 돌려놓습니다.",
   "st4_braindrain_audio_rate": "오디오 클립 빈도",
-  "label_braindrain": "브레인 드레인"
+  "label_braindrain": "브레인 드레인",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "신규",
+  "play_arcademy_blurb": "하루에 세 과목. 화면 위의 다른 모든 것이 단순한 게임을 어렵게 만듭니다. 출석하고, 성적을 받고, 연속 기록을 지키세요.",
+  "play_arcademy_cta": "출석하기",
+  "play_arcademy_tooltip": "오늘의 시간표가 기다리고 있습니다.",
+  "arcademy_boot_error_body": "{0}을(를) 이 컴퓨터에서 시작할 수 없습니다.\n\n{1}",
+  "arcademy_open_failed_body": "The Arcademy를 열 수 없습니다:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy가 이번 세션에서 이미 시작에 실패했습니다. 앱을 다시 시작한 뒤 다시 시도하세요."
 }

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -4622,5 +4622,5 @@
   "play_arcademy_tooltip": "오늘의 시간표가 기다리고 있습니다.",
   "arcademy_boot_error_body": "{0}을(를) 이 컴퓨터에서 시작할 수 없습니다.\n\n{1}",
   "arcademy_open_failed_body": "The Arcademy를 열 수 없습니다:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy가 이번 세션에서 이미 시작에 실패했습니다. 앱을 다시 시작한 뒤 다시 시도하세요."
+  "arcademy_boot_failed_this_session": "The Arcademy가 이 컴퓨터에서 지난번 시도에 시작하지 못했습니다.\n\n다시 열어 볼까요?"
 }

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -4613,5 +4613,15 @@
   "lockdown_poss_safety_dose": "Nada rodando? O Lockdown escolhe por você",
   "lockdown_poss_safety_dose_tip": "Um lockdown se recusa a rodar vazio. Motor desligado no início: ele é ligado por você. Nada ativado (ou você desliga tudo no meio): a guardiã liga recursos, um a mais a cada vez, e devolve tudo quando o tempo acaba.",
   "st4_braindrain_audio_rate": "Frequência do áudio",
-  "label_braindrain": "Drenagem Cerebral"
+  "label_braindrain": "Drenagem Cerebral",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "NOVO",
+  "play_arcademy_blurb": "três aulas por dia. joguinhos simples que tudo o mais na sua tela deixa difícil. apareça, seja avaliada, mantenha a sequência.",
+  "play_arcademy_cta": "Comparecer",
+  "play_arcademy_tooltip": "o horário de hoje está esperando.",
+  "arcademy_boot_error_body": "{0} não conseguiu iniciar nesta máquina.\n\n{1}",
+  "arcademy_open_failed_body": "Não foi possível abrir The Arcademy:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy já falhou ao iniciar nesta sessão. Reinicie o aplicativo e tente de novo."
 }

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -4623,5 +4623,5 @@
   "play_arcademy_tooltip": "o horário de hoje está esperando.",
   "arcademy_boot_error_body": "{0} não conseguiu iniciar nesta máquina.\n\n{1}",
   "arcademy_open_failed_body": "Não foi possível abrir The Arcademy:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy já falhou ao iniciar nesta sessão. Reinicie o aplicativo e tente de novo."
+  "arcademy_boot_failed_this_session": "The Arcademy não conseguiu iniciar na última tentativa neste computador.\n\nQuer tentar de novo?"
 }

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -4612,5 +4612,15 @@
   "lockdown_poss_safety_dose": "Ничего не запущено? Локдаун выберет за тебя",
   "lockdown_poss_safety_dose_tip": "Локдаун не работает вхолостую. Движок выключен при старте: его запустят за тебя. Ничего не включено (или ты выключишь всё посреди локдауна): надзирательница включит функции, каждый раз на одну больше, и вернёт всё обратно, когда таймер закончится.",
   "st4_braindrain_audio_rate": "Частота аудиоклипов",
-  "label_braindrain": "Промывка мозгов"
+  "label_braindrain": "Промывка мозгов",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "НОВОЕ",
+  "play_arcademy_blurb": "три занятия в день. простые маленькие игры, которые всё остальное на экране делает сложными. приходи, получай оценку, держи серию.",
+  "play_arcademy_cta": "Прийти",
+  "play_arcademy_tooltip": "сегодняшнее расписание ждёт.",
+  "arcademy_boot_error_body": "Не удалось запустить {0} на этом компьютере.\n\n{1}",
+  "arcademy_open_failed_body": "Не удалось открыть The Arcademy:\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy уже не смогла запуститься в этой сессии. Перезапусти приложение и попробуй снова."
 }

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -4622,5 +4622,5 @@
   "play_arcademy_tooltip": "сегодняшнее расписание ждёт.",
   "arcademy_boot_error_body": "Не удалось запустить {0} на этом компьютере.\n\n{1}",
   "arcademy_open_failed_body": "Не удалось открыть The Arcademy:\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy уже не смогла запуститься в этой сессии. Перезапусти приложение и попробуй снова."
+  "arcademy_boot_failed_this_session": "The Arcademy не смогла запуститься в прошлый раз на этом компьютере.\n\nПопробовать открыть снова?"
 }

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -5082,5 +5082,5 @@
   "play_arcademy_tooltip": "今天的课表已经排好了。",
   "arcademy_boot_error_body": "{0} 无法在这台电脑上启动。\n\n{1}",
   "arcademy_open_failed_body": "无法打开 The Arcademy：\n\n{0}",
-  "arcademy_boot_failed_this_session": "The Arcademy 在本次会话中已经启动失败过一次。请重启应用后再试。"
+  "arcademy_boot_failed_this_session": "The Arcademy 上次在这台电脑上启动失败了。\n\n要再打开一次吗？"
 }

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -5072,5 +5072,15 @@
   "lockdown_poss_safety_dose": "什么都没开？封锁替你选",
   "lockdown_poss_safety_dose_tip": "封锁不会空转。开始时引擎没开：替你启动。什么功能都没开（或你中途全部关掉）：看守会替你打开功能，每次多一个，计时结束时全部还原。",
   "st4_braindrain_audio_rate": "音频片段频率",
-  "label_braindrain": "脑力流失"
+  "label_braindrain": "脑力流失",
+
+  "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
+  "play_arcademy_title": "The Arcademy",
+  "play_arcademy_new": "新",
+  "play_arcademy_blurb": "每天三节课。简单的小游戏，被屏幕上的其他一切变得不简单。来上课，接受评分，保持连续出勤。",
+  "play_arcademy_cta": "上课",
+  "play_arcademy_tooltip": "今天的课表已经排好了。",
+  "arcademy_boot_error_body": "{0} 无法在这台电脑上启动。\n\n{1}",
+  "arcademy_open_failed_body": "无法打开 The Arcademy：\n\n{0}",
+  "arcademy_boot_failed_this_session": "The Arcademy 在本次会话中已经启动失败过一次。请重启应用后再试。"
 }

--- a/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
@@ -352,18 +352,24 @@ namespace ConditioningControlPanel
         {
             try
             {
-                // The page already reported boot-error once this app session (WebView2 runtime
-                // missing, WebGL refused, the shell never answered its deadline). DtRH consumes its
-                // own BootFailedThisSession the same way at BtnStartChaos_Click - there it picks the
-                // native fallback, and here, where there is no fallback to pick, it stops us walking
-                // the user back into the identical black window. Relaunching the app clears the
-                // flag, which is exactly the advice the message gives.
+                // The page's LAST attempt failed (WebView2 runtime missing, WebGL refused, or the
+                // shell never answered its 45s progress deadline). DtRH consumes its own
+                // BootFailedThisSession at BtnStartChaos_Click, but there the flag DEGRADES to the
+                // native game, so the user still gets a feature. Here there is nothing to degrade
+                // to, and half of what sets the flag is transient (a cold WebView2 start, a machine
+                // under load, a stalled driver), so refusing outright would cost a paying user the
+                // headline feature over a stall that a second click would very likely clear.
+                // So: warn, and let them choose. Saying yes is the old behaviour, saying no spares
+                // them a second black window. A boot that succeeds clears the flag in OnPageReady.
                 if (Services.Arcademy.ArcademyHostService.BootFailedThisSession
                     && !Services.Arcademy.ArcademyHostService.IsActive)
                 {
-                    MessageBox.Show(Loc.Get("arcademy_boot_failed_this_session"),
-                        Services.Arcademy.ArcademyHostService.ProductName, MessageBoxButton.OK, MessageBoxImage.Warning);
-                    return;
+                    var again = MessageBox.Show(Loc.Get("arcademy_boot_failed_this_session"),
+                        Services.Arcademy.ArcademyHostService.ProductName,
+                        MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                    App.Logger?.Information("Arcademy: previous boot failed; user chose {Choice}",
+                        again == MessageBoxResult.Yes ? "retry" : "not now");
+                    if (again != MessageBoxResult.Yes) return;
                 }
 
                 Services.Arcademy.ArcademyHostService.Launch();

--- a/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
@@ -352,12 +352,26 @@ namespace ConditioningControlPanel
         {
             try
             {
+                // The page already reported boot-error once this app session (WebView2 runtime
+                // missing, WebGL refused, the shell never answered its deadline). DtRH consumes its
+                // own BootFailedThisSession the same way at BtnStartChaos_Click - there it picks the
+                // native fallback, and here, where there is no fallback to pick, it stops us walking
+                // the user back into the identical black window. Relaunching the app clears the
+                // flag, which is exactly the advice the message gives.
+                if (Services.Arcademy.ArcademyHostService.BootFailedThisSession
+                    && !Services.Arcademy.ArcademyHostService.IsActive)
+                {
+                    MessageBox.Show(Loc.Get("arcademy_boot_failed_this_session"),
+                        Services.Arcademy.ArcademyHostService.ProductName, MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
                 Services.Arcademy.ArcademyHostService.Launch();
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "BtnStartArcademy_Click failed");
-                MessageBox.Show("Couldn't open the Arcademy:\n\n" + ex.Message,
+                MessageBox.Show(Loc.GetF("arcademy_open_failed_body", ex.Message),
                     Services.Arcademy.ArcademyHostService.ProductName, MessageBoxButton.OK, MessageBoxImage.Warning);
             }
         }

--- a/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
@@ -191,6 +191,21 @@ namespace ConditioningControlPanel
                     App.Logger?.Information("Entitlement lapsed: Haptics switched off");
                 }
 
+                // The Arcademy. Not a setting at all - a live T2 window with its own WebView2, its
+                // own XP payouts and its own progression writes, which the veil pass cannot cover
+                // because it is not on a tab. So this rung closes the WINDOW instead of clearing a
+                // flag, and does not touch `changed`: nothing was persisted. HasLabAccess is the
+                // one truth for the T2 bar (tier >= 2, whitelist, and the 14-day offline grace),
+                // exactly as the launch gate reads it, so a subscriber whose validation is still
+                // in flight is never thrown out of a class. CloseActive is idempotent and asks the
+                // page to wind down first, so an in-progress class saves its meta on the way out.
+                if (App.Patreon?.HasLabAccess != true
+                    && Services.Arcademy.ArcademyHostService.IsActive)
+                {
+                    Services.Arcademy.ArcademyHostService.CloseActive();
+                    App.Logger?.Information("Entitlement lapsed: the Arcademy was closed");
+                }
+
                 if (changed)
                 {
                     App.Settings?.Save();

--- a/ConditioningControlPanel/Resources/web/arcademy/annex/lab.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/annex/lab.js
@@ -171,7 +171,7 @@ export function createAnnexLab(caps) {
   function save(patch) {
     Object.assign(st, patch);
     try { if (typeof c.saveAnnex === 'function') c.saveAnnex(patch); }
-    catch (e) { log('annex save failed'); }
+    catch (e) { log('annex save failed', 'warn'); }
   }
 
   /* THE READ SET IS SHARED, THE COUNTER IS NOT. `read` carries the OS's 26
@@ -230,7 +230,7 @@ export function createAnnexLab(caps) {
       link.rel = 'stylesheet';
       link.href = new URL(rel, import.meta.url).href;
       doc.head.appendChild(link);
-    } catch (e) { log('annex sheet failed: ' + rel); }
+    } catch (e) { log('annex sheet failed: ' + rel, 'warn'); }
   }
   ensureSheet('arc-annex-lab-css', './lab.css');
   ensureSheet('arc-annex-os-css', './os.css');
@@ -361,7 +361,7 @@ export function createAnnexLab(caps) {
         quads = j && j[FEED_KEY] ? j[FEED_KEY] : null;
         if (view === 'monitors') { mountFeeds(); mountLaptopHotspot(); }
       })
-      .catch(() => { quads = null; log('annex quads failed'); });
+      .catch(() => { quads = null; log('annex quads failed', 'warn'); });
   }
 
   function mountFeeds() {
@@ -416,11 +416,11 @@ export function createAnnexLab(caps) {
         feeds.style.webkitMaskImage = 'url(' + url + ')';
         feeds.style.maskSize = '100% 100%';
         feeds.style.webkitMaskSize = '100% 100%';
-      } catch (e) { log('annex mask failed'); }
+      } catch (e) { log('annex mask failed', 'warn'); }
       feeds.classList.remove('is-waiting');
       if (wall) wall.start();
     };
-    mask.onerror = () => { if (!dead) { feeds.remove(); log('annex mask missing'); } };
+    mask.onerror = () => { if (!dead) { feeds.remove(); log('annex mask missing', 'warn'); } };
     mask.src = ART_BASE + MASK_FILE;
   }
 
@@ -613,7 +613,7 @@ export function createAnnexLab(caps) {
       try { sil = fallback(); } catch (e) { sil = null; }
       if (sil) host.insertBefore(sil, img);
       img.remove();
-      log('annex case photo missing: ' + file);
+      log('annex case photo missing: ' + file, 'warn');
     });
     img.src = ART_BASE + file;
     return img;
@@ -718,7 +718,7 @@ export function createAnnexLab(caps) {
   function liveStrip(att) {
     let rows = null;
     try { rows = typeof c.attendance === 'function' ? c.attendance() : null; }
-    catch (e) { rows = null; log('annex attendance threw'); }
+    catch (e) { rows = null; log('annex attendance threw', 'warn'); }
     if (!Array.isArray(rows) || !rows.length) return null;
     const x = [];
     const y = [];

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -62,7 +62,11 @@ let pendingSuspend = null;    // a suspend frame that arrived before the shell e
 /* ----------------------------------------------------------------------------
  * DIAGNOSTICS - the only channel without devtools.
  * -------------------------------------------------------------------------- */
-function log(msg) { bridge.log('info', msg); }
+// `log` is the funnel EVERY room reaches through `caps.log`/`say`, so its default level sets the
+// volume of the whole campus. Quiet by default ('debug' is below the host's Information floor and
+// is therefore dropped, not filed); pass a level as the second argument for anything a triage
+// reader needs to see - `log(msg, 'warn')` for a degraded room, `'error'` for a broken one.
+function log(msg, level) { bridge.log(level || 'debug', msg); }
 function warn(msg) { bridge.log('warning', msg); }
 
 if (win) {

--- a/ConditioningControlPanel/Resources/web/arcademy/bridge.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/bridge.js
@@ -130,9 +130,16 @@ export function markInitialized() {
 
 export function isInitialized() { return initialized; }
 
-/** Serilog passthrough. `level` is optional and defaults to 'info'. */
+/**
+ * Serilog passthrough. `level` is optional and defaults to 'debug'.
+ *
+ * The default is deliberately the QUIET one. The host's logger floor is Information, so 'debug'
+ * frames are dropped rather than filed, and a campus with this many call sites would otherwise
+ * bury every real report in class chatter. Anything worth a triage read has to say so: 'warn' for
+ * a degraded room, 'error' for a broken one.
+ */
 export function log(level, msg) {
-  if (msg === undefined) { msg = level; level = 'info'; }
+  if (msg === undefined) { msg = level; level = 'debug'; }
   send({ type: 'log', level: String(level), msg: String(msg).slice(0, 400) });
 }
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -14,6 +14,7 @@ using System.Windows.Threading;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Services.Chaos;
 using ConditioningControlPanel.Services.Fyp.Online;
 
@@ -106,18 +107,18 @@ internal static class ArcademyHostService
     /// opens the Arcademy asks this - the Play card's visibility in
     /// <c>MainWindow.RefreshPlayCards</c> and the refusal at the top of <see cref="Launch"/>.
     ///
-    /// <para><c>false</c> because the Arcademy is BUILT but not launched: Semester 1 landed on
-    /// main (PR #241) ahead of its public reveal, and 6.8.4 is an auth/stability patch that must
-    /// ship those fixes without also shipping an unannounced feature. A HIDE, not a lockband, for
-    /// the same reason Just Drop hides: a lockband advertises something the account could buy,
-    /// and a door we have not opened yet is not for sale.</para>
+    /// <para><c>true</c> since v6.8.5 "First Bell": the Arcademy is open. Semester 1 landed on
+    /// main (PR #241) ahead of its public reveal and stayed hidden through 6.8.4; this is the
+    /// release that reveals it. Flipping this back to <c>false</c> is still the whole hide - a
+    /// HIDE, not a lockband, for the same reason Just Drop hides: a lockband advertises something
+    /// the account could buy, and a door we have not opened is not for sale.</para>
     ///
-    /// <para>Flip to <c>true</c> to reveal it - that is the whole reveal. The T2 bar and the
-    /// AudioOnlySession rule below are untouched and still apply underneath it.</para>
+    /// <para>The T2 bar and the AudioOnlySession rule below are untouched and still apply
+    /// underneath it.</para>
     /// </summary>
     /// <remarks>static readonly, not const: a const would make the guard in <see cref="Launch"/>
     /// compile-time unreachable (CS0162), exactly as JustDropService.Withheld documents.</remarks>
-    public static readonly bool DoorAvailable = false;
+    public static readonly bool DoorAvailable = true;
     /// <summary>Whether the live instance was opened through the dev switch (recovery relaunch keeps it).</summary>
     private static bool _devDoor;
 
@@ -152,7 +153,7 @@ internal static class ArcademyHostService
         //    no announced feature to explain a refusal about yet.
         if (!DoorAvailable && !devDoor)
         {
-            App.Logger?.Information("ArcademyHost.Launch refused: the Arcademy door is not open yet (unreleased)");
+            App.Logger?.Information("ArcademyHost.Launch refused: the Arcademy door is closed in this build");
             return;
         }
 
@@ -5078,7 +5079,7 @@ internal static class ArcademyHostService
             try
             {
                 MessageBox.Show(
-                    $"{ProductName} could not start on this machine.\n\n{msg}",
+                    Loc.GetF("arcademy_boot_error_body", ProductName, msg ?? string.Empty),
                     ProductName, MessageBoxButton.OK, MessageBoxImage.Warning);
             }
             catch { }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -95,9 +95,15 @@ internal static class ArcademyHostService
 
     public static bool IsActive => _host != null;
 
-    /// <summary>The page reported <c>boot-error</c> this app session (or the host's own deadline
-    /// fired). Entry points can read this to stop sending someone back through a door that has
-    /// already failed on this machine.</summary>
+    /// <summary>The page's LAST boot attempt failed: it reported <c>boot-error</c>, or the host's
+    /// own progress deadline fired. Entry points read this to warn before sending someone back
+    /// through a door that just failed on this machine.
+    ///
+    /// <para>It is a LAST-attempt flag, not a session tombstone. <see cref="OnPageReady"/> clears
+    /// it, because most of what sets it is transient - a cold WebView2 runtime, a machine under
+    /// load, a stalled GPU driver, all of which the 45s <c>BootDeadline</c> reads as failure. The
+    /// entry point offers a retry rather than refusing outright; only a session where the campus
+    /// has never once come up stays latched.</para></summary>
     public static bool BootFailedThisSession { get; private set; }
 
     // ============================== the gate ==============================
@@ -458,6 +464,11 @@ internal static class ArcademyHostService
         {
             _lastHeartbeatUtc = DateTime.UtcNow;
             CancelBootDeadline();
+            // The campus is up, so whatever failed last time did not stick. Clearing here (and only
+            // here) is what keeps BootFailedThisSession a statement about the LAST attempt: a cold
+            // runtime start that blew the 45s deadline must not cost the user the feature for the
+            // rest of the app's life.
+            BootFailedThisSession = false;
             // Keyboard focus does not land in the WebView2 child until a click on a fresh launch -
             // claim it now so the Esc ladder works from the first frame.
             _host?.FocusWeb();

--- a/ConditioningControlPanel/Services/Awareness/AwarenessProbes.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessProbes.cs
@@ -469,14 +469,16 @@ namespace ConditioningControlPanel.Services.Awareness
         }
 
         /// <summary>
-        /// The CCP surfaces awareness must not talk over: a mandatory video, a lock card, or a live
-        /// DtRH run. Each already has authored lines of its own.
+        /// The CCP surfaces awareness must not talk over: a mandatory video, a lock card, a live
+        /// DtRH run, or a class in the Arcademy. Each already has authored lines of its own - and
+        /// the Arcademy in particular has EMI, whose whole job is to be the voice in that window.
         /// </summary>
         private static bool IsBlockingSurfaceActive()
         {
             try { if (App.Video?.IsPlaying == true) return true; } catch { }
             try { if (ConditioningControlPanel.LockCardWindow.IsAnyOpen()) return true; } catch { }
             try { if (Services.Chaos.DtrhHostService.IsActive) return true; } catch { }
+            try { if (Services.Arcademy.ArcademyHostService.IsActive) return true; } catch { }
             return false;
         }
 

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -795,6 +795,13 @@ namespace ConditioningControlPanel.Services
             try { if (Chaos.DtrhHostService.IsActive) Chaos.DtrhHostService.CloseActive(); }
             catch (Exception ex) { _log?.Debug("ActivateMod: DTRH close failed: {E}", ex.Message); }
 
+            // The Arcademy snapshots the active mod the same way DTRH does - its mod root (the
+            // virtual-host mapping for skinned art) and its whole lexicon are resolved once at
+            // launch - so a mid-session switch would leave the campus wearing the old mod's name
+            // for every room. Same cure, same shape.
+            try { if (Arcademy.ArcademyHostService.IsActive) Arcademy.ArcademyHostService.CloseActive(); }
+            catch (Exception ex) { _log?.Debug("ActivateMod: Arcademy close failed: {E}", ex.Message); }
+
             // Save current pool customizations before switching
             SaveCurrentPoolsToSettings(oldModId);
 

--- a/ConditioningControlPanel/Services/SettingsPaletteIndex.cs
+++ b/ConditioningControlPanel/Services/SettingsPaletteIndex.cs
@@ -275,6 +275,25 @@ namespace ConditioningControlPanel.Services
             // in the aliases so the palette finds a feature by name, not just by room.
             Tab("play", "nav_door_play", "🕹️", "play",
                 "play lab games experiments rabbit hole dtrh descent goon gaze focus bureau mantra loom showcase tier 2");
+            // THE ARCADEMY. Not a tab and not a door - a launcher card on the Play wall - so this
+            // row navigates to the wall and highlights the card, which is the same journey the
+            // rail offers. Hand-written rather than a Tab() call for the two things Tab() cannot
+            // express: the ElementNames highlight, and the second IsAvailable predicate in this
+            // index. The gate is the same one the card's own visibility reads, so the palette can
+            // never be the place that admits to a door the Play wall is hiding; and because the
+            // row stays in All either way, the parity tests still see it while the door is shut.
+            list.Add(new SettingsPaletteEntry
+            {
+                Id = "card.arcademy",
+                LabelKey = "play_arcademy_title",
+                Glyph = "🎓",
+                TabKey = "play",
+                ElementNames = new[] { "BtnPlayArcademy", "SlotArcademy" },
+                ContextKeys = new[] { GroupNav, "nav_door_play" },
+                Aliases = "arcademy academy class classes school timetable homeroom mini games "
+                          + "daily trigger lost and found deja vu impulse control grades attendance",
+                IsAvailable = () => Arcademy.ArcademyHostService.DoorAvailable,
+            });
             Tab("deeper", "tab_deeper", "🌊", "deeper", "deeper files audio video");
             Tab("exclusives", "tab_exclusives", "⭐", "exclusives", "premium exclusives velvet vault showcase");
             Tab("gradedintake", "tab_gradedintake", "📝", "gradedintake", "intake quiz graded pass");

--- a/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
@@ -1305,10 +1305,11 @@
                      Same launch posture as the DtRH hero: the band below is decoration and
                      ArcademyHostService.Launch does the refusing (the door, T2, AudioOnlySession).
 
-                     Visibility=Collapsed by DEFAULT, exactly like SlotJustDrop above: Semester 1
-                     is merged but unannounced, so 6.8.4 ships it dark. RefreshPlayCards re-asserts
-                     this from ArcademyHostService.DoorAvailable on every repaint; the default here
-                     is what keeps the card hidden in the frames before that first runs. -->
+                     Visibility=Collapsed by DEFAULT, exactly like SlotJustDrop above - the card
+                     is never shown by the markup, only by code. RefreshPlayCards asserts it from
+                     ArcademyHostService.DoorAvailable on every repaint (true since v6.8.5); the
+                     default here is what keeps the card hidden in the frames before that first
+                     runs, and what makes closing the door again a one-line change. -->
                 <Grid x:Name="SlotArcademy" x:FieldModifier="internal" Margin="0,0,0,10" Visibility="Collapsed">
                     <Border Style="{StaticResource PlayCardT2}" Padding="0" MinHeight="118">
                         <Grid>
@@ -1323,12 +1324,12 @@
                                         <Border Style="{StaticResource PlayTitleGlyphPlate}">
                                             <Image Width="18" Height="18" Source="{Binding Source='🎓', Converter={StaticResource EmojiToImageSource}}"/>
                                         </Border>
-                                        <TextBlock Text="The Arcademy" Style="{StaticResource PlayCardTitle}"/>
+                                        <TextBlock Text="{loc:Str play_arcademy_title}" Style="{StaticResource PlayCardTitle}"/>
                                         <Border Style="{StaticResource PlayBadgePill}" Margin="12,2,0,0" Padding="7,2">
-                                            <TextBlock Text="NEW" Style="{StaticResource PlayBadgePillText}" FontSize="10"/>
+                                            <TextBlock Text="{loc:Str play_arcademy_new}" Style="{StaticResource PlayBadgePillText}" FontSize="10"/>
                                         </Border>
                                     </StackPanel>
-                                    <TextBlock Text="three classes a day. simple little games made hard by everything else on your screen. show up, get graded, keep the streak."
+                                    <TextBlock Text="{loc:Str play_arcademy_blurb}"
                                                Style="{StaticResource PlayCardBlurb}" MaxWidth="560" HorizontalAlignment="Left"/>
                                 </StackPanel>
                                 <!-- PRIME SUBJECT sign in its OWN COLUMN, not as a corner overlay.
@@ -1351,11 +1352,11 @@
                                               Tier="2" VerticalAlignment="Center"
                                               Margin="0,0,18,0" Panel.ZIndex="9"/>
                                 <Button Grid.Column="2" x:Name="BtnPlayArcademy" x:FieldModifier="internal"
-                                        Content="Attend" Cursor="Hand"
+                                        Content="{loc:Str play_arcademy_cta}" Cursor="Hand"
                                         VerticalAlignment="Center" Margin="0,0,24,0" Padding="24,10"
                                         Background="{DynamicResource PinkBrush}" Foreground="White"
                                         BorderThickness="0" FontWeight="Bold" FontSize="14"
-                                        ToolTip="today's timetable is waiting."
+                                        ToolTip="{loc:Str play_arcademy_tooltip}"
                                         Click="BtnStartArcademy_Click">
                                     <Button.Resources>
                                         <Style TargetType="Border"><Setter Property="CornerRadius" Value="10"/></Style>

--- a/Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs
@@ -15,7 +15,7 @@ namespace ConditioningControlPanel.Tests;
 ///
 /// <para>Opening a door that has been dark since PR #241 is one boolean, and every gap the flip
 /// exposes is somewhere else: a dev switch that shipped unguarded, an entitlement enforcer with no
-/// rung for a window that is not a tab, a log bridge that wrote ~700 page sites at Information, a
+/// rung for a window that is not a tab, a log bridge that wrote every page site at Information, a
 /// card built out of raw English, and four browser harnesses riding along in the installer. None of
 /// those fail a compile and none of them fail a play-test - which is exactly why they need standing
 /// tests rather than a review pass.</para>
@@ -111,15 +111,34 @@ public class ArcademyDoorOpenTests
         => Assert.Equal(LogEventLevel.Warning, ChaosWebViewHost.PageLogLevel(level));
 
     [Theory]
-    [InlineData("info")]          // the arcademy bridge's own default
-    [InlineData("INFO")]
-    [InlineData("debug")]
+    [InlineData("fatal")]
+    [InlineData("FATAL")]
+    public void PageFatalsAreErrors(string level)
+        => Assert.Equal(LogEventLevel.Error, ChaosWebViewHost.PageLogLevel(level));
+
+    [Theory]
+    [InlineData(null)]            // THE ONE THAT MATTERS: a page that sends no level field at all
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData(null)]            // a page that sends no level field at all
-    [InlineData("chatter")]
-    [InlineData("fatal")]         // nothing sends it; unknown reads as chatter, never as loud
-    public void EverythingElseDropsToDebug(string? level)
+    [InlineData("info")]
+    [InlineData("INFO")]
+    [InlineData("information")]
+    public void AnAbsentOrPlainLevelStaysAudible(string? level)
+    {
+        // The app's logger floor is Information in EVERY build (App.OnStartup, unconditional), so
+        // Debug here is not "quieter", it is GONE. Six live bridges - dtrh, m2test, tunnel, goon,
+        // the intake web-shim and player - send no level at all, and emergency-exit's bridge clamps
+        // its own to info|warn on the panic surface. If this theory ever goes red, those surfaces
+        // have just lost their only devtools-less channel and nobody will notice until triage.
+        Assert.Equal(LogEventLevel.Information, ChaosWebViewHost.PageLogLevel(level));
+    }
+
+    [Theory]
+    [InlineData("debug")]         // the arcademy's own default: opted out, on purpose
+    [InlineData("DEBUG")]
+    [InlineData("trace")]
+    [InlineData("chatter")]       // unknown junk reads as chatter, never as loud
+    public void ADeclaredDebugOrJunkLevelGoesQuiet(string level)
         => Assert.Equal(LogEventLevel.Debug, ChaosWebViewHost.PageLogLevel(level));
 
     [Fact]
@@ -137,12 +156,46 @@ public class ArcademyDoorOpenTests
     [Fact]
     public void TheArcademyBridgeStillSendsALevelField()
     {
-        // PageLogLevel reads o["level"]. If the page ever stops sending one the router still works
-        // (absent reads as Debug) but the page loses the ability to be loud, which is the half that
-        // matters for boot failures.
+        // PageLogLevel reads o["level"]. If the page ever stops sending one it falls back to the
+        // legacy Information contract, which means the whole campus goes loud again - the noise the
+        // router exists to cure.
         var bridge = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", "arcademy", "bridge.js"));
         Assert.True(Mentions(bridge, "type: 'log', level:"),
             "arcademy bridge.js no longer sends a level with its log frames");
+    }
+
+    [Fact]
+    public void TheArcademyOptsOutLoudlyRatherThanBeingSilencedFromTheHost()
+    {
+        // The noise cure is the PAGE declaring 'debug', not the host demoting everyone. Two places
+        // have to agree: bridge.log's own one-argument default, and boot.js's `log`, which is the
+        // funnel every room reaches through caps.log/say (118 call sites, ~110 of them levelless).
+        var bridge = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", "arcademy", "bridge.js"));
+        Assert.True(Mentions(bridge, "level = 'debug';"),
+            "arcademy bridge.js log() no longer defaults to the quiet level");
+
+        var boot = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", "arcademy", "boot.js"));
+        Assert.True(Mentions(boot, "function log(msg, level) { bridge.log(level || 'debug', msg); }"),
+            "the arcademy boot.js log funnel no longer defaults to the quiet level");
+        Assert.True(Mentions(boot, "function warn(msg) { bridge.log('warning', msg); }"),
+            "the arcademy boot.js warn funnel stopped being loud");
+    }
+
+    [Fact]
+    public void TheAnnexStillReportsItsOwnFailuresOutLoud()
+    {
+        // The annex's degradations are the campus's most useful triage line and they ride the same
+        // funnel as the chatter, so each one has to carry its own level or the quiet default eats
+        // it. Sampled, not exhaustive: enough to fail if someone strips the argument wholesale.
+        var lab = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", "arcademy", "annex", "lab.js"));
+        foreach (var site in new[]
+        {
+            "log('annex save failed', 'warn')",
+            "log('annex sheet failed: ' + rel, 'warn')",
+            "log('annex quads failed', 'warn')",
+            "log('annex attendance threw', 'warn')",
+        })
+            Assert.True(Mentions(lab, site), "annex/lab.js failure report went quiet: " + site);
     }
 
     // =====================================================================================
@@ -250,6 +303,38 @@ public class ArcademyDoorOpenTests
             "BtnStartArcademy_Click still ignores BootFailedThisSession");
         Assert.True(Mentions(src, "Loc.Get(\"arcademy_boot_failed_this_session\")"),
             "the repeat-failure path does not tell the user anything");
+    }
+
+    [Fact]
+    public void ABootFailureWarnsButDoesNotBarTheDoor()
+    {
+        // The flag is set by the 45s no-progress deadline as well as by a page boot-error, and that
+        // deadline fires on transient things: a cold WebView2 runtime, a loaded machine, a stalled
+        // GPU driver. DTRH can afford to latch because it DEGRADES to the native game; the Arcademy
+        // has nothing to degrade to, so a hard refusal would cost a paying T2 user the release's
+        // headline feature over a stall a second click would clear. Warn, then obey the answer.
+        var src = ReadSource("MainWindow", "MainWindow.Lab.cs");
+        Assert.True(Mentions(src, "MessageBoxButton.YesNo"),
+            "the repeat-failure prompt is not a question, so the user cannot retry");
+        Assert.True(Mentions(src, "if (again != MessageBoxResult.Yes) return;"),
+            "the repeat-failure prompt does not act on the answer");
+        Assert.False(Mentions(src,
+            "MessageBox.Show(Loc.Get(\"arcademy_boot_failed_this_session\"), "
+            + "Services.Arcademy.ArcademyHostService.ProductName, MessageBoxButton.OK"),
+            "the terminal OK-only refusal is back");
+    }
+
+    [Fact]
+    public void ASuccessfulBootClearsTheFailureLatch()
+    {
+        // Without this the flag is a session tombstone: nothing anywhere else in the codebase
+        // resets it, so one transient stall would follow the user until they restart the app.
+        var src = ReadSource("Services", "Arcademy", "ArcademyHostService.cs");
+        var ready = src.IndexOf("private static void OnPageReady()", StringComparison.Ordinal);
+        Assert.True(ready > 0, "OnPageReady is gone");
+        var body = src.Substring(ready, Math.Min(1400, src.Length - ready));
+        Assert.True(Mentions(body, "BootFailedThisSession = false;"),
+            "a successful boot no longer clears BootFailedThisSession");
     }
 
     // =====================================================================================
@@ -370,11 +455,14 @@ public class ArcademyDoorOpenTests
             // "The Arcademy" is a proper noun and stays untranslated everywhere.
             Assert.Equal("The Arcademy", root.GetProperty("play_arcademy_title").GetString());
 
-            // Only the two dialog bodies are allowed to carry a line break, and only an escaped one.
+            // Only the three dialog bodies are allowed to carry a line break, and only an escaped
+            // one (the strict parse above is what proves it is escaped). A break inside a card
+            // label or a tooltip is a translation accident, not a choice.
             foreach (var key in NewLocKeys)
             {
                 var s = root.GetProperty(key).GetString() ?? string.Empty;
-                var allowed = key is "arcademy_boot_error_body" or "arcademy_open_failed_body";
+                var allowed = key is "arcademy_boot_error_body" or "arcademy_open_failed_body"
+                                  or "arcademy_boot_failed_this_session";
                 if (!allowed)
                     Assert.False(s.Contains('\n') || s.Contains('\r'),
                         $"{lang}.json {key} contains a line break");

--- a/Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs
@@ -1,0 +1,511 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services;
+using Serilog.Events;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Arcademy go-live guards (v6.8.5 "First Bell").
+///
+/// <para>Opening a door that has been dark since PR #241 is one boolean, and every gap the flip
+/// exposes is somewhere else: a dev switch that shipped unguarded, an entitlement enforcer with no
+/// rung for a window that is not a tab, a log bridge that wrote ~700 page sites at Information, a
+/// card built out of raw English, and four browser harnesses riding along in the installer. None of
+/// those fail a compile and none of them fail a play-test - which is exactly why they need standing
+/// tests rather than a review pass.</para>
+///
+/// <para>Split between real behaviour (the log-level router and the palette row are pure statics,
+/// so they run for real) and source-text tripwires for the WPF-bound halves, in the same shape
+/// <see cref="PaletteDoorParityTests"/> uses.</para>
+/// </summary>
+public class ArcademyDoorOpenTests
+{
+    // =====================================================================================
+    //  helpers
+    // =====================================================================================
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string AppDir() => Path.Combine(RepoRoot(), "ConditioningControlPanel");
+
+    private static string ReadSource(params string[] parts) =>
+        File.ReadAllText(Path.Combine(new[] { AppDir() }.Concat(parts).ToArray()));
+
+    /// <summary>Whitespace-insensitive contains, so a reflow of the source never fails a tripwire.</summary>
+    private static bool Mentions(string haystack, string needle)
+    {
+        static string Flat(string s) => Regex.Replace(s, @"\s+", " ");
+        return Flat(haystack).Contains(Flat(needle), StringComparison.Ordinal);
+    }
+
+    private static readonly string[] Languages =
+        { "de", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN" };
+
+    /// <summary>Every key this release adds, in the two families it adds them for.</summary>
+    private static readonly string[] NewLocKeys =
+    {
+        "play_arcademy_title",
+        "play_arcademy_new",
+        "play_arcademy_blurb",
+        "play_arcademy_cta",
+        "play_arcademy_tooltip",
+        "arcademy_boot_error_body",
+        "arcademy_open_failed_body",
+        "arcademy_boot_failed_this_session",
+    };
+
+    // =====================================================================================
+    //  the door itself
+    // =====================================================================================
+
+    [Fact]
+    public void TheArcademyDoorIsOpen()
+    {
+        Assert.True(ConditioningControlPanel.Services.Arcademy.ArcademyHostService.DoorAvailable,
+            "the Arcademy door is shut - v6.8.5 is the release that opens it");
+    }
+
+    [Fact]
+    public void DoorAvailableStaysAFieldAndNeverBecomesAConst()
+    {
+        // A const would make the `if (!DoorAvailable && !devDoor)` refusal in Launch() compile-time
+        // unreachable (CS0162) and delete the only place the door can say no. Same law
+        // JustDropService.Withheld is written under.
+        var field = typeof(ConditioningControlPanel.Services.Arcademy.ArcademyHostService)
+            .GetField("DoorAvailable");
+        Assert.True(field != null, "DoorAvailable is gone");
+        Assert.False(field!.IsLiteral, "DoorAvailable became a const - the Launch() guard is now dead code");
+        Assert.True(field.IsInitOnly, "DoorAvailable should stay static readonly");
+    }
+
+    // =====================================================================================
+    //  the page log bridge (pure)
+    // =====================================================================================
+
+    [Theory]
+    [InlineData("error")]
+    [InlineData("ERROR")]
+    [InlineData(" Error ")]
+    public void PageErrorsStayLoud(string level)
+        => Assert.Equal(LogEventLevel.Error, ChaosWebViewHost.PageLogLevel(level));
+
+    [Theory]
+    [InlineData("warn")]
+    [InlineData("warning")]
+    [InlineData("WARNING")]
+    [InlineData(" Warn")]
+    public void PageWarningsStayWarnings(string level)
+        => Assert.Equal(LogEventLevel.Warning, ChaosWebViewHost.PageLogLevel(level));
+
+    [Theory]
+    [InlineData("info")]          // the arcademy bridge's own default
+    [InlineData("INFO")]
+    [InlineData("debug")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]            // a page that sends no level field at all
+    [InlineData("chatter")]
+    [InlineData("fatal")]         // nothing sends it; unknown reads as chatter, never as loud
+    public void EverythingElseDropsToDebug(string? level)
+        => Assert.Equal(LogEventLevel.Debug, ChaosWebViewHost.PageLogLevel(level));
+
+    [Fact]
+    public void TheLogBridgeActuallyRoutesThroughTheRouter()
+    {
+        // The router is only worth anything if the message handler calls it. Guards the case where
+        // someone "simplifies" the case back to a flat Information write.
+        var src = ReadSource("Chaos", "ChaosWebViewHost.cs");
+        Assert.True(Mentions(src, "App.Logger?.Write(PageLogLevel((string?)o[\"level\"])"),
+            "the {type:'log'} case no longer routes through PageLogLevel");
+        Assert.False(Mentions(src, "App.Logger?.Information(\"{Tag}[page]: {Msg}\""),
+            "the flat Information page log is back");
+    }
+
+    [Fact]
+    public void TheArcademyBridgeStillSendsALevelField()
+    {
+        // PageLogLevel reads o["level"]. If the page ever stops sending one the router still works
+        // (absent reads as Debug) but the page loses the ability to be loud, which is the half that
+        // matters for boot failures.
+        var bridge = File.ReadAllText(Path.Combine(AppDir(), "Resources", "web", "arcademy", "bridge.js"));
+        Assert.True(Mentions(bridge, "type: 'log', level:"),
+            "arcademy bridge.js no longer sends a level with its log frames");
+    }
+
+    // =====================================================================================
+    //  the dev door
+    // =====================================================================================
+
+    [Fact]
+    public void TheArcademyDevSwitchIsNotReachableFromAShippedBuild()
+    {
+        // init.devDoor is a dev PASS: the campus offers Begin on rooms the seed did not deal, and
+        // those classes are still graded and still pay real XP. `--arcademy` shipped it in Release.
+        var src = ReadSource("App.xaml.cs");
+        var i = src.IndexOf("e.Args.Contains(\"--arcademy\")", StringComparison.Ordinal);
+        Assert.True(i > 0, "the --arcademy switch is gone");
+        var block = src.Substring(i, Math.Min(1400, src.Length - i));
+
+        Assert.True(Mentions(block, "#if DEBUG"), "the --arcademy dev door is not compiled out of Release");
+        Assert.True(Mentions(block, "System.Diagnostics.Debugger.IsAttached"),
+            "the Release half of --arcademy does not require a debugger");
+
+        // ...and LaunchDev must not be callable from the guarded block's else branch.
+        var elseAt = block.IndexOf("#else", StringComparison.Ordinal);
+        var endAt = block.IndexOf("#endif", StringComparison.Ordinal);
+        Assert.True(elseAt > 0 && endAt > elseAt, "the --arcademy guard has no #else/#endif pair");
+        var releaseHalf = block.Substring(elseAt, endAt - elseAt);
+        var debuggerAt = releaseHalf.IndexOf("Debugger.IsAttached", StringComparison.Ordinal);
+        var launchDevAt = releaseHalf.IndexOf("LaunchDev", StringComparison.Ordinal);
+        Assert.True(launchDevAt > debuggerAt,
+            "the Release half calls LaunchDev before it checks for a debugger");
+    }
+
+    [Fact]
+    public void LaunchDevIsTheOnlyProducerOfDevDoor()
+    {
+        // If any other call site can pass devDoor:true, guarding App.xaml.cs guards nothing.
+        var svc = ReadSource("Services", "Arcademy", "ArcademyHostService.cs");
+        var producers = Regex.Matches(svc, @"devDoor:\s*true").Count;
+        Assert.True(producers == 1,
+            $"expected exactly one `devDoor: true` (LaunchDev), found {producers}");
+        Assert.True(Mentions(svc, "public static void LaunchDev() => Launch(devDoor: true);"),
+            "LaunchDev is no longer the single producer of the dev pass");
+    }
+
+    [Fact]
+    public void BuildInitStillEmitsNoDevAnnexField()
+    {
+        // shell.js reads `src.devAnnex === true` to peek the secret lab. The host must never
+        // project it, or the annex opens for every player on the day the door does.
+        var svc = ReadSource("Services", "Arcademy", "ArcademyHostService.cs");
+        Assert.False(svc.Contains("devAnnex", StringComparison.Ordinal),
+            "BuildInit now projects devAnnex - the annex peek would ship open");
+    }
+
+    // =====================================================================================
+    //  entitlement lapse, mod switch, awareness
+    // =====================================================================================
+
+    [Fact]
+    public void EntitlementLapseClosesALiveArcademy()
+    {
+        // The Arcademy is not a setting on a veiled tab, so the veil pass cannot cover it: a lapsed
+        // T2 keeps a live window with its own XP payouts. The rung closes the WINDOW instead.
+        var src = ReadSource("MainWindow", "MainWindow.Patreon.cs");
+        Assert.True(Mentions(src,
+            "if (App.Patreon?.HasLabAccess != true && Services.Arcademy.ArcademyHostService.IsActive)"),
+            "EnforceEntitlementLapse has no Arcademy rung");
+        Assert.True(Mentions(src, "Services.Arcademy.ArcademyHostService.CloseActive();"),
+            "the Arcademy rung does not close the window");
+
+        // HasLabAccess, not a tier comparison: the 14-day offline grace and the whitelist both live
+        // inside it, and a bare tier read would throw entitled subscribers out mid-class.
+        var patreon = ReadSource("Services", "Account", "PatreonService.cs");
+        Assert.True(Mentions(patreon, "public bool HasLabAccess"), "HasLabAccess is gone");
+    }
+
+    [Fact]
+    public void SwitchingModsClosesTheArcademyLikeItClosesDtrh()
+    {
+        // Both hosts snapshot the active mod at launch (virtual-host root + init payload), so a
+        // mid-session switch leaves the window wearing the old mod.
+        var src = ReadSource("Services", "ModService.cs");
+        Assert.True(Mentions(src,
+            "try { if (Arcademy.ArcademyHostService.IsActive) Arcademy.ArcademyHostService.CloseActive(); }"),
+            "ActivateMod still leaves a live Arcademy on the old mod's snapshot");
+        Assert.True(Mentions(src,
+            "try { if (Chaos.DtrhHostService.IsActive) Chaos.DtrhHostService.CloseActive(); }"),
+            "the DTRH close this one mirrors is gone");
+    }
+
+    [Fact]
+    public void AwarenessDoesNotTalkOverAClass()
+    {
+        var src = ReadSource("Services", "Awareness", "AwarenessProbes.cs");
+        Assert.True(Mentions(src,
+            "try { if (Services.Arcademy.ArcademyHostService.IsActive) return true; } catch { }"),
+            "IsBlockingSurfaceActive does not count a live Arcademy class");
+    }
+
+    [Fact]
+    public void ARepeatedBootFailureIsNotWalkedBackInto()
+    {
+        // BootFailedThisSession was set and never read. DTRH consumes its own the same way.
+        var src = ReadSource("MainWindow", "MainWindow.Lab.cs");
+        Assert.True(Mentions(src, "Services.Arcademy.ArcademyHostService.BootFailedThisSession"),
+            "BtnStartArcademy_Click still ignores BootFailedThisSession");
+        Assert.True(Mentions(src, "Loc.Get(\"arcademy_boot_failed_this_session\")"),
+            "the repeat-failure path does not tell the user anything");
+    }
+
+    // =====================================================================================
+    //  the Ctrl+K row (real, not source text)
+    // =====================================================================================
+
+    private static SettingsPaletteEntry ArcademyRow()
+    {
+        var row = SettingsPaletteIndex.All.FirstOrDefault(e => e.Id == "card.arcademy");
+        Assert.True(row != null, "the palette has no Arcademy row");
+        return row!;
+    }
+
+    [Fact]
+    public void ThePaletteHasAnArcademyRowThatLandsOnALiveTab()
+    {
+        var row = ArcademyRow();
+        Assert.Equal("play", row.TabKey);           // the wall the card lives on
+        Assert.Equal("play_arcademy_title", row.LabelKey);
+        Assert.Contains("BtnPlayArcademy", row.ElementNames);
+    }
+
+    [Fact]
+    public void TheArcademyRowIsGatedOnTheSameDoorTheCardIs()
+    {
+        var row = ArcademyRow();
+        Assert.True(row.IsAvailable != null,
+            "the Arcademy row has no availability predicate - Ctrl+K would leak a shut door");
+        Assert.Equal(
+            ConditioningControlPanel.Services.Arcademy.ArcademyHostService.DoorAvailable,
+            row.Available);
+
+        // And the predicate must read the service, not a copy of the answer.
+        var src = ReadSource("Services", "SettingsPaletteIndex.cs");
+        Assert.True(Mentions(src, "IsAvailable = () => Arcademy.ArcademyHostService.DoorAvailable"),
+            "the Arcademy row no longer reads ArcademyHostService.DoorAvailable");
+    }
+
+    [Theory]
+    [InlineData("arcademy")]
+    [InlineData("class")]
+    [InlineData("timetable")]
+    [InlineData("homeroom")]
+    public void SearchFindsTheArcademyWhileTheDoorIsOpen(string term)
+    {
+        Assert.True(SettingsPaletteIndex.Search(term).Any(e => e.Id == "card.arcademy"),
+            $"Ctrl+K search for \"{term}\" does not find the Arcademy");
+    }
+
+    [Fact]
+    public void TheArcademyRowStaysInTheRegistryEvenWhenSearchWouldHideIt()
+    {
+        // Same law the Just Drop row is written under: All is what the app CAN reach (parity tests
+        // read it), Search is what this account is allowed to see.
+        Assert.Contains(SettingsPaletteIndex.All, e => e.Id == "card.arcademy");
+    }
+
+    // =====================================================================================
+    //  localization
+    // =====================================================================================
+
+    [Fact]
+    public void ThePlayCardCarriesNoRawEnglish()
+    {
+        var xaml = ReadSource("Views", "Tabs", "PlayTabView.xaml");
+        var i = xaml.IndexOf("x:Name=\"SlotArcademy\"", StringComparison.Ordinal);
+        Assert.True(i > 0, "the Arcademy slot is gone from the Play wall");
+        var end = xaml.IndexOf("x:Name=\"SlotLoom\"", i, StringComparison.Ordinal);
+        Assert.True(end > i, "could not bound the Arcademy slot");
+        var card = xaml.Substring(i, end - i);
+
+        foreach (var key in new[] { "play_arcademy_title", "play_arcademy_new", "play_arcademy_blurb",
+                                    "play_arcademy_cta", "play_arcademy_tooltip" })
+            Assert.True(card.Contains("{loc:Str " + key + "}", StringComparison.Ordinal),
+                $"the Arcademy card does not use {key}");
+
+        foreach (var literal in new[] { "Text=\"The Arcademy\"", "Text=\"NEW\"", "Content=\"Attend\"" })
+            Assert.False(card.Contains(literal, StringComparison.Ordinal),
+                $"the Arcademy card still hardcodes {literal}");
+    }
+
+    [Fact]
+    public void TheFailureDialogsAreLocalizedToo()
+    {
+        var svc = ReadSource("Services", "Arcademy", "ArcademyHostService.cs");
+        Assert.True(Mentions(svc, "Loc.GetF(\"arcademy_boot_error_body\", ProductName, msg ?? string.Empty)"),
+            "the boot-error dialog is still raw English");
+
+        var lab = ReadSource("MainWindow", "MainWindow.Lab.cs");
+        Assert.True(Mentions(lab, "Loc.GetF(\"arcademy_open_failed_body\", ex.Message)"),
+            "the launch-failure dialog is still raw English");
+        Assert.False(lab.Contains("Couldn't open the Arcademy:", StringComparison.Ordinal),
+            "the old hardcoded launch-failure string is still there");
+    }
+
+    [Fact]
+    public void EveryLanguageFileCarriesTheNewKeysAndStillParsesStrictly()
+    {
+        foreach (var lang in Languages)
+        {
+            var path = Path.Combine(AppDir(), "Localization", "Languages", lang + ".json");
+            var text = File.ReadAllText(path);
+
+            // System.Text.Json, not Newtonsoft: the strict parse is the whole point (CLAUDE.md
+            // "Never put a literal line break inside a language-file string").
+            using var doc = JsonDocument.Parse(text);
+            var root = doc.RootElement;
+
+            foreach (var key in NewLocKeys)
+            {
+                Assert.True(root.TryGetProperty(key, out var v),
+                    $"{lang}.json is missing {key}");
+                var s = v.GetString() ?? string.Empty;
+                Assert.False(string.IsNullOrWhiteSpace(s), $"{lang}.json has an empty {key}");
+                Assert.False(s.Contains('—'), $"{lang}.json {key} contains an em-dash");
+            }
+
+            // "The Arcademy" is a proper noun and stays untranslated everywhere.
+            Assert.Equal("The Arcademy", root.GetProperty("play_arcademy_title").GetString());
+
+            // Only the two dialog bodies are allowed to carry a line break, and only an escaped one.
+            foreach (var key in NewLocKeys)
+            {
+                var s = root.GetProperty(key).GetString() ?? string.Empty;
+                var allowed = key is "arcademy_boot_error_body" or "arcademy_open_failed_body";
+                if (!allowed)
+                    Assert.False(s.Contains('\n') || s.Contains('\r'),
+                        $"{lang}.json {key} contains a line break");
+            }
+        }
+    }
+
+    [Fact]
+    public void TheDialogBodiesKeepTheirFormatPlaceholders()
+    {
+        // Loc.GetF is string.Format: a translation that drops {0} silently loses the exception text,
+        // and one that invents a brace throws FormatException inside a failure handler.
+        foreach (var lang in Languages)
+        {
+            var path = Path.Combine(AppDir(), "Localization", "Languages", lang + ".json");
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            var boot = doc.RootElement.GetProperty("arcademy_boot_error_body").GetString() ?? "";
+            var open = doc.RootElement.GetProperty("arcademy_open_failed_body").GetString() ?? "";
+
+            Assert.True(boot.Contains("{0}") && boot.Contains("{1}"),
+                $"{lang}.json arcademy_boot_error_body lost a placeholder");
+            Assert.True(open.Contains("{0}"), $"{lang}.json arcademy_open_failed_body lost {{0}}");
+            Assert.False(open.Contains("{1}"), $"{lang}.json arcademy_open_failed_body invented {{1}}");
+
+            foreach (var s in new[] { boot, open })
+                Assert.Equal(s.Count(c => c == '{'), s.Count(c => c == '}'));
+        }
+    }
+
+    // =====================================================================================
+    //  what ships in the box
+    // =====================================================================================
+
+    [Fact]
+    public void TheBrowserHarnessPagesAreExcludedFromTheBundle()
+    {
+        var csproj = ReadSource("ConditioningControlPanel.csproj");
+        foreach (var page in new[]
+                 {
+                     @"Resources\web\arcademy\annex\demo.html",
+                     @"Resources\web\arcademy\vn\demo.html",
+                     @"Resources\web\arcademy\emi\demo.html",
+                     @"Resources\web\arcademy\shell\recordsroom.demo.html",
+                 })
+        {
+            Assert.True(csproj.Contains(page, StringComparison.Ordinal),
+                $"{page} is not excluded from the Resources\\web content glob");
+            // ...and it must still exist on disk: excluded, not deleted.
+            Assert.True(File.Exists(Path.Combine(AppDir(), page)),
+                $"{page} was deleted rather than excluded");
+        }
+    }
+
+    [Fact]
+    public void NoShippedPageLinksAHarness()
+    {
+        // The exclusion is only safe while nothing in the page graph navigates to one.
+        var web = Path.Combine(AppDir(), "Resources", "web", "arcademy");
+        var offenders = new List<string>();
+        foreach (var f in Directory.EnumerateFiles(web, "*", SearchOption.AllDirectories))
+        {
+            var ext = Path.GetExtension(f).ToLowerInvariant();
+            if (ext is not (".js" or ".html" or ".json" or ".css")) continue;
+            if (Path.GetFileName(f).Contains("demo.html", StringComparison.OrdinalIgnoreCase)) continue;
+
+            foreach (var line in File.ReadLines(f))
+            {
+                if (!line.Contains("demo.html", StringComparison.OrdinalIgnoreCase)) continue;
+                // Prose in a comment is fine; a link or an import is not.
+                var t = line.TrimStart();
+                if (t.StartsWith("*") || t.StartsWith("//") || t.StartsWith("/*") || t.StartsWith("<!--")) continue;
+                offenders.Add(Path.GetRelativePath(web, f) + ": " + line.Trim());
+            }
+        }
+        Assert.True(offenders.Count == 0,
+            "a shipped arcademy page references a harness:\n" + string.Join("\n", offenders));
+    }
+
+    // =====================================================================================
+    //  art parity: a face and a crest ship together
+    // =====================================================================================
+
+    /// <summary>Reads the registry's own tables rather than restating them, so opening a semester
+    /// or retiring a class re-points this test automatically.</summary>
+    private static IReadOnlyList<string> OpenClassKeys()
+    {
+        var registry = File.ReadAllText(
+            Path.Combine(AppDir(), "Resources", "web", "arcademy", "games", "registry.js"));
+
+        var semBlock = Regex.Match(registry, @"GAME_SEMESTER\s*=\s*Object\.freeze\(\{(.*?)\}\)",
+            RegexOptions.Singleline);
+        Assert.True(semBlock.Success, "GAME_SEMESTER is gone from registry.js");
+        var semesters = Regex.Matches(semBlock.Groups[1].Value, @"(\w+)\s*:\s*(\d+)")
+            .ToDictionary(m => m.Groups[1].Value, m => int.Parse(m.Groups[2].Value));
+
+        var openBlock = Regex.Match(registry, @"OPEN_SEMESTERS\s*=\s*new Set\(\[([^\]]*)\]\)");
+        Assert.True(openBlock.Success, "OPEN_SEMESTERS is gone from registry.js");
+        var open = Regex.Matches(openBlock.Groups[1].Value, @"\d+")
+            .Select(m => int.Parse(m.Value)).ToHashSet();
+
+        var retiredBlock = Regex.Match(registry, @"RETIRED_GAMES\s*=\s*new Set\(\[([^\]]*)\]\)");
+        Assert.True(retiredBlock.Success, "RETIRED_GAMES is gone from registry.js");
+        var retired = Regex.Matches(retiredBlock.Groups[1].Value, @"'([^']+)'")
+            .Select(m => m.Groups[1].Value).ToHashSet();
+
+        var keys = semesters.Where(kv => open.Contains(kv.Value) && !retired.Contains(kv.Key))
+                            .Select(kv => kv.Key).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(keys.Count > 0, "no open classes - the registry parse went wrong");
+        return keys;
+    }
+
+    [Fact]
+    public void EveryOpenClassShipsBothAFaceAndACrest()
+    {
+        var art = Path.Combine(AppDir(), "Resources", "web", "arcademy", "art", "punchcard");
+        var gaps = new List<string>();
+        foreach (var key in OpenClassKeys())
+        {
+            if (!File.Exists(Path.Combine(art, $"face-{key}.png"))) gaps.Add($"{key}: no face");
+            if (!File.Exists(Path.Combine(art, $"crest-{key}.png"))) gaps.Add($"{key}: no crest");
+        }
+        Assert.True(gaps.Count == 0, "punch-card art gaps:\n" + string.Join("\n", gaps));
+    }
+
+    [Fact]
+    public void EveryOpenClassHasASlotRowInFacesJson()
+    {
+        var path = Path.Combine(AppDir(), "Resources", "web", "arcademy", "art", "punchcard", "faces.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var missing = OpenClassKeys().Where(k => !doc.RootElement.TryGetProperty(k, out _)).ToList();
+        Assert.True(missing.Count == 0,
+            "faces.json has no slot geometry for: " + string.Join(", ", missing));
+    }
+}


### PR DESCRIPTION
## What / why

`ArcademyHostService.DoorAvailable` flips to `true`: **the Arcademy opens for Tier 2 in v6.8.5 "First Bell"**. Semester I-III landed on main across ~171 commits and has been hidden since PR #241; this is the reveal.

The flip is one boolean. Everything else here is a gap the flip exposes - none of them fail a compile, none of them fail a play-test, which is why they now have standing tests.

| # | Gap | Fix |
|---|-----|-----|
| 1 | Door shut | `DoorAvailable = true` (still `static readonly`, never `const` - a const makes the `Launch()` refusal CS0162-unreachable). Stale "unreleased" log wording updated. |
| 2 | **`--arcademy` dev door shipped in Release** | It sets `init.devDoor`, which the campus reads as a dev pass: every room playable out of timetable, still graded, still paying real XP. Now `#if DEBUG`; in Release only honoured with `Debugger.IsAttached`, otherwise the switch opens the Arcademy through the ordinary front door. `LaunchDev()` kept, and verified to be the only producer of the pass. |
| 3 | Entitlement lapse never closed a class | `EnforceEntitlementLapse()` gains an Arcademy rung. The Arcademy is not a setting on a veiled tab, so the veil pass could not cover it - a lapsed T2 kept a live window with its own XP payouts. Reads `HasLabAccess` (tier / whitelist / 14-day offline grace, **semantics unchanged**) and calls `CloseActive()`, which asks the page to wind down so meta is flushed. Logged at Information. Does not touch `changed`: nothing was persisted. |
| 4 | Page log bridge shouted | See **Review round 2** below - the router now distinguishes an absent level from a declared one, and the quieting moves to the Arcademy page itself. |
| 5 | Play card was raw English | Title / NEW pill / blurb / Attend / tooltip -> `{loc:Str play_arcademy_*}`, plus both failure MessageBoxes (`ArcademyHostService.OnBootError`, `BtnStartArcademy_Click`). 8 keys x 9 language files. "The Arcademy" stays untranslated as a proper noun. |
| 6 | No Ctrl+K row | `card.arcademy` row on the Play wall (`TabKey = "play"`, highlights `BtnPlayArcademy`), `IsAvailable = () => ArcademyHostService.DoorAvailable` - the second predicate in the index, same law as the Just Drop row: in `All` so parity tests see it, hidden from Search while the door is shut. |
| 7 | Mod switch stranded a class | `ModService.ActivateMod` closes a live Arcademy exactly like it closes DTRH - both hosts snapshot the active mod (virtual-host root + init payload) at launch. |
| 8 | Awareness talked over classes | `AwarenessProbes.IsBlockingSurfaceActive()` now counts `ArcademyHostService.IsActive`. EMI is the voice in that window. |
| 9 | `BootFailedThisSession` set, never read | `BtnStartArcademy_Click` consumes it - see **Review round 2**: it warns and offers a retry rather than latching the door shut. |
| 10 | Harnesses shipped in the box | `annex/demo.html`, `vn/demo.html`, `emi/demo.html`, `shell/recordsroom.demo.html` out of the bundle. See **Review round 3** below - the `<Content>` Exclude alone was not the ship path. Excluded, **not deleted** - nothing in the page graph links them (only two prose comments name them). |

### Verified, no change needed
- **(11) Punch-card art parity:** all ten open classes (`daily_trigger, lost_and_found, deja_vu, impulse_control, sort, echo, instant_recall, anomaly, composure, the_deep_end`; `misdirection` is retired) ship **both** `face-*.png` and `crest-*.png` **and** a `faces.json` slot row. Zero gaps.
- **(12) `BuildInit()` emits no `devAnnex`** - `shell.js` reads it for the secret-lab peek, the host never projects it, so the annex stays shut for players. Now a test.

### Not done, by owner decision
No daily-free-day entry, no `ExclusiveFeature` / Vault shelf row (T2-discoverable only), no tease card, no achievements this release.

---

## Review round 2 (commit 2)

Two majors from the adversarial review, both cases where the code reads right and the behaviour is wrong.

### A. `PageLogLevel` was discarding, not demoting

The first pass routed everything that was not `error`/`warn` to Serilog **Debug**. `App.xaml.cs:1497` is the app's only logger configuration and it sets `MinimumLevel.Information()` unconditionally, in every build - no build-conditional floor, no level switch. So those messages were not quieter, they were **gone**, and the comment claiming a dev build's lower floor would pick them up was false.

Ten surfaces share `ChaosWebViewHost`. Six of their bridges send no `level` field at all (`dtrh/bridge.js`, `dtrh/m2test.js`, `tunnel/main.js` - including its only fatal report - `goon/bridge.js`, `intake/web-shim.js`, `player/player.js`), and `emergency-exit/shared/bridge.js` clamps its own to `info|warn`, so nine `log('info', ...)` calls on the panic/safety screen were in the blast radius too. On the release that opens the Arcademy, field triage of seven hosted surfaces would have lost its only devtools-less window.

**Fixed** by making the router distinguish an **absent** level from a **declared** one:

| level | Serilog |
|---|---|
| absent / blank | **Information** (the legacy contract the six levelless bridges rely on) |
| `info` / `information` | Information |
| `warn` / `warning` | Warning |
| `error` / `fatal` | Error |
| `debug`, `trace`, junk | Debug (dropped, on purpose) |

The noise cure moves to the page that has the noise, which is the one allowed web edit in the brief:
- `arcademy/boot.js` - `log(msg, level)` now defaults to `'debug'`. This is the single funnel every room reaches through `caps.log`/`say`, so it covers ~110 of the campus's 118 call sites at once.
- `arcademy/bridge.js` - `log()`'s one-argument form defaults to `'debug'` as well.
- `arcademy/annex/lab.js` - the seven genuine failure reports (save, sheet, quads, both mask paths, case photo, attendance) pass `'warn'`, so the reports worth reading stay in the log. `boot.js`'s `warn`/`error` paths were already loud and are untouched.

Net effect: **only the Arcademy goes quiet, and only where it says so.** Every other hosted surface logs exactly as it did before this PR.

### B. `BootFailedThisSession` barred the door for the rest of the session

The flag has no reset path anywhere in the codebase, and it is set not only by a page-reported `boot-error` but by the 45s no-progress `BootDeadline` - a transient environmental condition (cold WebView2 runtime start, machine under load, stalled GPU driver). The DTRH precedent behaves differently: there the flag **degrades** to the classic WPF game, so the user still gets a feature. Here there is nothing to degrade to, so one stall cost a paying T2 user the release's headline feature until they restarted the app - strictly worse than the pre-PR behaviour, where clicking Attend again would very likely have worked.

**Fixed** on both halves:
- `ArcademyHostService.OnPageReady` clears `BootFailedThisSession`, so it means "the last attempt failed", not "this session is over". Only a session where the campus has never once come up stays latched.
- `BtnStartArcademy_Click` asks instead of refusing: `MessageBoxButton.YesNo`, Yes calls `Launch()`, the choice is logged at Information. The nine `arcademy_boot_failed_this_session` strings become that question (escaped `\n`, no em-dashes, "The Arcademy" still a proper noun).

---

## Review round 3 (commit 3)

One major: **item 10 was not closed on the ship path.**

Round 1 added the four harness pages to the `<Content Include="Resources\web\**\*">` Exclude, which
does keep them out of `dotnet build` output. But `CopyContentAfterPublish` re-globs the whole web
tree independently, and its `WebFiles` Exclude only carried `$(ContentPackWebExcludeAbs)` (mp3 packs).
All four pages matched that second glob, `build-installer.bat` runs `dotnet publish -c Release`, and
`installer.iss` packs `{#PublishDir}\*` with `recursesubdirs` - so the shipped 6.8.5 installer would
still have carried every harness into `{app}\Resources\web\arcademy\` and into the WebView2 virtual
host. The target's own comment names this exact trap ("MUST mirror the `<Content>` items above, or
this target silently re-copies..."), and the first pass stepped in it.

**Fixed** by giving the harness list the same shape the content-pack excludes already have, so the
two Excludes cannot drift apart again:

- new `<ArcademyHarnessExclude>` (project-relative) and `<ArcademyHarnessExcludeAbs>`
  (`$(MSBuildProjectDirectory)\`-prefixed) beside `<ContentPackWebExclude*>`;
- `<Content>` Exclude now references `$(ArcademyHarnessExclude)`;
- `CopyContentAfterPublish`'s `WebFiles` Exclude now references `$(ArcademyHarnessExcludeAbs)`;
- the target's comment updated so it stops saying "the two content-pack excludes".

**Verified with a real publish**, not a re-read: `dotnet publish -c Debug -o <tmp>` then a recursive
find over the publish tree - **0** `*demo.html`, and `Resources/web/arcademy/index.html` plus the rest
of the campus still present. File counts: 338 in source, 333 published, i.e. exactly the 4 harnesses
and `arcademy/CLAUDE.md` dropped and nothing else.

## Files

`App.xaml.cs` · `Chaos/ChaosWebViewHost.cs` · `ConditioningControlPanel.csproj` · `MainWindow/MainWindow.Lab.cs` · `MainWindow/MainWindow.Patreon.cs` · `Services/Arcademy/ArcademyHostService.cs` · `Services/Awareness/AwarenessProbes.cs` · `Services/ModService.cs` · `Services/SettingsPaletteIndex.cs` · `Views/Tabs/PlayTabView.xaml` · `Localization/Languages/*.json` (9) · `Resources/web/arcademy/{boot.js, bridge.js, annex/lab.js}` · **new** `Tests/ConditioningControlPanel.Tests/ArcademyDoorOpenTests.cs`

## Tests

`dotnet build ConditioningControlPanel.sln -c Debug` -> **0 errors** (CA1416 / xUnit analyzer warnings only).

`dotnet test Tests/ConditioningControlPanel.Tests -c Debug` -> **4072 passed / 4072**, 0 failed.

`ArcademyDoorOpenTests` (~43 cases): the log-level theory now splits into *audible* (`null`, blank, `info`) versus *quiet* (declared `debug`, junk) with the reason in the failure message, plus `fatal` -> Error; tripwires for both page-side `'debug'` defaults and the annex's tagged failure sites; the Yes/No retry and the `OnPageReady` clear; the door is open and `DoorAvailable` is still a field; palette row shape, gate and search; loc keys present + strict `System.Text.Json` parse + no em-dashes + line breaks only in the three dialog bodies + `{0}`/`{1}` placeholder parity in all 9 files; art pairing read from `registry.js`'s own `GAME_SEMESTER` / `OPEN_SEMESTERS` / `RETIRED_GAMES` tables rather than restated; harness pages excluded but still on disk and unreferenced. Build + full suite re-run after the round 3 csproj change: **0 errors**, **4072 / 4072 passed**.

## Risk

- The three `Resources/web/arcademy` edits need mirroring to the web build at `app.cclabs.app/arcademy` on the next sync, or the hosted campus keeps the old (loud) defaults. Behaviourally harmless there - no Serilog on the other side - but the files will diverge.
- Anything reached only through a page's `log()` with no level argument inside the Arcademy is now Debug, i.e. absent from the log. That is the intent; if a specific campus report is wanted back, tag that call site `'warn'`, do not revert the default.
- **The Arcademy itself is English-only for now** - the keys here localize the CCP-side card and dialogs, but the web page's own lexicon is not translated.

## Refs

Arcademy go-live audit for v6.8.5 (memory `release-685-prep-0827`), entitlement lapse PR #267, Arcademy Semester I PR #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6xJB7QQLacJN9vN3gRAVe

