### PR TITLE
fix(video): per-surface multi-monitor playback - black/silent primary, dead sibling screens

### DIFF
--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -2799,11 +2799,31 @@ public class OverlayService : IDisposable
         // reconciler (and NotifyTopWindowClosed after each clip) buries the video behind the
         // spiral/pink filter; the video window is deliberately non-re-raising, so it never
         // recovers, and with autonomy chaining clips the next one shows "only by flashes" (#497).
+        //
+        // MULTI-MONITOR (#1016): "below the video" has to mean "below the video window on the SAME
+        // monitor". PrimaryVideoWindow is one window on one screen; ordering an overlay that lives on
+        // monitor 2 underneath monitor 1's video window leaves it ABOVE monitor 2's own video window
+        // (they are separate windows in one global z-order), which is the reported pink/spiral filter
+        // sitting on top of the second screen's clip. Collect every live video window with the monitor
+        // it covers and let each overlay pick its own anchor.
         IntPtr videoHwnd = IntPtr.Zero;
+        var videoAnchors = new List<(IntPtr Hwnd, IntPtr Monitor)>();
         try
         {
-            if (App.Video?.IsPlaying == true && App.Video.PrimaryVideoWindow is Window vw)
-                videoHwnd = new System.Windows.Interop.WindowInteropHelper(vw).Handle;
+            if (App.Video?.IsPlaying == true)
+            {
+                if (App.Video.PrimaryVideoWindow is Window vw)
+                    videoHwnd = new System.Windows.Interop.WindowInteropHelper(vw).Handle;
+
+                foreach (var vh in App.Video.GetVideoWindowHandles())
+                {
+                    // Handles are cached at window creation and cleared at teardown, so a dead one
+                    // here means a window went away mid-sweep. Ordering against a destroyed HWND makes
+                    // SetWindowPos fail outright, which would silently skip the pin for that overlay.
+                    if (vh == IntPtr.Zero || !IsWindow(vh)) continue;
+                    videoAnchors.Add((vh, MonitorFromWindow(vh, MONITOR_DEFAULTTONEAREST)));
+                }
+            }
         }
         catch { }
 
@@ -2818,7 +2838,7 @@ public class OverlayService : IDisposable
             {
                 var hwnd = new System.Windows.Interop.WindowInteropHelper(window).Handle;
                 if (hwnd == IntPtr.Zero) continue;
-                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref anyRecovered);
+                ReassertOne(hwnd, videoAnchors, videoHwnd, aboveVideo, force, ref anyRecovered);
             }
         }
 
@@ -2829,11 +2849,11 @@ public class OverlayService : IDisposable
         try
         {
             foreach (var hwnd in App.CornerGif?.GetOverlayHandles() ?? new List<IntPtr>())
-                ReassertOne(hwnd, videoHwnd, aboveVideo, force, ref anyRecovered);
+                ReassertOne(hwnd, videoAnchors, videoHwnd, aboveVideo, force, ref anyRecovered);
 
             var sessionCornerGif = SessionEngine.Active?.GetCornerGifHandle() ?? IntPtr.Zero;
             if (sessionCornerGif != IntPtr.Zero)
-                ReassertOne(sessionCornerGif, videoHwnd, aboveVideo, force, ref anyRecovered);
+                ReassertOne(sessionCornerGif, videoAnchors, videoHwnd, aboveVideo, force, ref anyRecovered);
         }
         catch (Exception ex)
         {
@@ -2850,7 +2870,7 @@ public class OverlayService : IDisposable
             if (App.Compositor is { } engine)
             {
                 foreach (var hostHwnd in engine.GetVisibleHostHandles())
-                    ReassertOne(hostHwnd, videoHwnd, aboveVideo, force, ref anyRecovered);
+                    ReassertOne(hostHwnd, videoAnchors, videoHwnd, aboveVideo, force, ref anyRecovered);
                 // The detached avatar tube parks itself directly BELOW the host covering its monitor
                 // so the pink tint stops flickering on and off the companion (#776). It does that on
                 // its OWN thread (AvatarOwnThread => cross-thread SetWindowPos is a deadlock source
@@ -2897,17 +2917,65 @@ public class OverlayService : IDisposable
         return ZOrderAction.None;
     }
 
-    private static void ReassertOne(IntPtr hwnd, IntPtr videoHwnd, bool aboveVideo, bool force, ref bool anyRecovered)
+    /// <summary>
+    /// Which video window a given topmost window must be pinned directly below, or
+    /// <see cref="IntPtr.Zero"/> for "there is nothing to sit under" (no video playing, or the window
+    /// being ordered IS a video window).
+    ///
+    /// Multi-monitor (#1016): a mandatory video is one fullscreen window PER SCREEN, all sharing one
+    /// global z-order. Anchoring every overlay to the primary window put overlays on the other screens
+    /// ABOVE the video windows there, which is the "pink filter / spiral covers the video on my second
+    /// monitor" report. So: prefer the video window on the same monitor as the target; fall back to
+    /// <paramref name="fallbackHwnd"/> (the primary) only when this monitor has no video window of its
+    /// own, where nothing overlaps and the choice is cosmetic.
+    ///
+    /// Pure and side-effect free so the set logic is unit-testable without any windows.
+    /// </summary>
+    internal static IntPtr ResolveVideoAnchor(
+        IReadOnlyList<(IntPtr Hwnd, IntPtr Monitor)> videoWindows,
+        IntPtr targetHwnd,
+        IntPtr targetMonitor,
+        IntPtr fallbackHwnd)
+    {
+        // Never anchor a window to itself: SetWindowPos(h, h, ...) is meaningless and would drop the
+        // window's pin entirely.
+        if (targetHwnd != IntPtr.Zero && targetHwnd == fallbackHwnd) return IntPtr.Zero;
+        if (videoWindows != null)
+        {
+            for (int i = 0; i < videoWindows.Count; i++)
+                if (videoWindows[i].Hwnd == targetHwnd) return IntPtr.Zero;
+        }
+
+        if (videoWindows == null || videoWindows.Count == 0) return fallbackHwnd;
+
+        if (targetMonitor != IntPtr.Zero)
+        {
+            for (int i = 0; i < videoWindows.Count; i++)
+                if (videoWindows[i].Monitor == targetMonitor) return videoWindows[i].Hwnd;
+        }
+        return fallbackHwnd;
+    }
+
+    private static void ReassertOne(IntPtr hwnd, IReadOnlyList<(IntPtr Hwnd, IntPtr Monitor)> videoAnchors,
+        IntPtr videoHwnd, bool aboveVideo, bool force, ref bool anyRecovered)
     {
         int exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
         bool needsPin = (exStyle & WS_EX_TOPMOST) == 0;
 
-        switch (ResolveZOrderAction(videoHwnd != IntPtr.Zero, hwnd == videoHwnd, aboveVideo, needsPin, force))
+        // Resolve THIS window's anchor: the video window covering the same monitor, if there is one.
+        IntPtr anchor = ResolveVideoAnchor(videoAnchors, hwnd,
+            hwnd != IntPtr.Zero ? MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) : IntPtr.Zero,
+            videoHwnd);
+        // ResolveVideoAnchor already returns Zero when the target is itself a video window, so the
+        // isVideoWindow arm below is only reached through the anchor being absent.
+        bool isVideoWindow = anchor == IntPtr.Zero && videoHwnd != IntPtr.Zero;
+
+        switch (ResolveZOrderAction(anchor != IntPtr.Zero, isVideoWindow, aboveVideo, needsPin, force))
         {
             case ZOrderAction.PinBelowVideo:
-                // Insert directly below the active video window: stays topmost (above the
-                // desktop and other apps) but under the video the user is meant to watch.
-                SetWindowPos(hwnd, videoHwnd, 0, 0, 0, 0,
+                // Insert directly below the video window on THIS window's monitor: stays topmost
+                // (above the desktop and other apps) but under the video the user is meant to watch.
+                SetWindowPos(hwnd, anchor, 0, 0, 0, 0,
                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
                 if (needsPin) anyRecovered = true;
                 break;
@@ -3122,6 +3190,14 @@ public class OverlayService : IDisposable
 
     [System.Runtime.InteropServices.DllImport("user32.dll")]
     private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool IsWindow(IntPtr hwnd);
+
+    private const uint MONITOR_DEFAULTTONEAREST = 2;
 
     [System.Runtime.InteropServices.DllImport("shcore.dll")]
     private static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -140,6 +140,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
         }
 
         private readonly List<BrowserVideoWindow> _windows = new();
+
+        // Mirrors dropped mid-session (DropSecondaryWindow). They are out of _windows so nothing
+        // broadcasts to them, but the host's strict Closing veto can CANCEL their Close(), which
+        // would otherwise strand a hidden window nobody owns. StopSession closes these too, by which
+        // point the veto is down.
+        private readonly List<BrowserVideoWindow> _dropped = new();
         private BrowserVideoWindow? _primary;
         private DispatcherTimer? _firstFrameWatch;
         private DateTime _firstFrameDeadlineUtc;
@@ -508,6 +514,18 @@ namespace ConditioningControlPanel.Services.Video.Browser
             var windows = _windows.ToArray();
             _windows.Clear();
             _primary = null;
+
+            // Mirrors dropped mid-clip: their Close() may have been vetoed by the host's strict
+            // Closing handler while the video was still playing. The veto is down by the time any
+            // teardown reaches here, so this is where they actually go.
+            var dropped = _dropped.ToArray();
+            _dropped.Clear();
+            foreach (var w in dropped)
+            {
+                try { w.Close(); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: dropped-mirror close failed: {E}", ex.Message); }
+            }
+
             foreach (var w in windows)
             {
                 try
@@ -697,8 +715,17 @@ namespace ConditioningControlPanel.Services.Video.Browser
             RaiseFailed("primary surface init failed: " + reason, blameFile: false);
         }
 
-        /// <summary>Unhook and close ONE mirror without touching the session. Shared by the two
-        /// secondary-only failure paths so they cannot drift apart.</summary>
+        /// <summary>Unhook and drop ONE mirror without touching the session. Shared by the two
+        /// secondary-only failure paths so they cannot drift apart.
+        ///
+        /// Hide() comes FIRST and is the load-bearing call. Every window the host builds carries the
+        /// strict Closing veto (VideoService.SetupStrictHandlers), which cancels Close() outright
+        /// while <c>_videoPlaying</c> is set - and it is already set by the time any surface can fail,
+        /// because PlayVideo sets it before the browser session starts. A vetoed Close would leave the
+        /// dead mirror on that monitor as an OPAQUE BLACK fullscreen window for the whole clip, with
+        /// every handler unhooked so nothing could act on it again: exactly the symptom this method
+        /// exists to remove. Hide() is not vetoable, so the screen is freed either way, and the real
+        /// Close lands here or at StopSession once the veto is down.</summary>
         private void DropSecondaryWindow(BrowserVideoWindow win, string why)
         {
             try
@@ -708,6 +735,9 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 win.Ready -= OnWindowReady;
                 win.InitFailed -= OnWindowInitFailed;
                 _windows.Remove(win);
+                if (!_dropped.Contains(win)) _dropped.Add(win);
+                try { win.Hide(); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: secondary hide after {Why} failed: {E}", why, ex.Message); }
                 win.Close();
             }
             catch (Exception ex) { App.Logger?.Debug("BrowserVideo: secondary close after {Why} failed: {E}", why, ex.Message); }

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -399,7 +399,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
             try
             {
                 _primary = CreateWindow(req, req.PrimaryScreen, primary: true, url);
-                if (_primary == null) return false;
+                if (_primary == null)
+                {
+                    App.Logger?.Warning("BrowserVideo: the audio-bearing window on {Screen} could not be created - handing the whole clip to LibVLC",
+                        req.PrimaryScreen.DeviceName);
+                    return false;
+                }
                 _windows.Add(_primary);
 
                 foreach (var scr in req.SecondaryScreens)
@@ -429,9 +434,11 @@ namespace ConditioningControlPanel.Services.Video.Browser
             try
             {
                 win = new BrowserVideoWindow(screen, primary);
+                win.SessionStartTick = Environment.TickCount64;
                 win.Message += OnWindowMessage;
                 win.ProcessFailed += OnWindowProcessFailed;
                 win.Ready += OnWindowReady;
+                win.InitFailed += OnWindowInitFailed;
 
                 // Queued until the page's ready handshake, so it is safe to post before the
                 // CoreWebView2 even exists.
@@ -462,6 +469,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "BrowserVideo: failed to create window on {Screen}", screen.DeviceName);
+                VideoSurfaceHealth.Report("browser", screen.DeviceName, primary, -1, "window creation threw: " + ex.Message);
                 try { win?.Close(); } catch { }
                 return null;
             }
@@ -507,6 +515,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     w.Message -= OnWindowMessage;
                     w.ProcessFailed -= OnWindowProcessFailed;
                     w.Ready -= OnWindowReady;
+                    w.InitFailed -= OnWindowInitFailed;
                     // Decoder hygiene: pause -> drop src -> load(). Queued messages are dropped with
                     // the window, so this is best-effort and the Close below is what really frees it.
                     if (w.IsReady) w.Post(new { type = "stop" });
@@ -570,13 +579,31 @@ namespace ConditioningControlPanel.Services.Video.Browser
                         return;
                 }
 
+                // Per-SURFACE bookkeeping, ahead of the primary-only gate below: every window posts its
+                // own `playing`, and until now only the primary's was looked at - so a mirror that
+                // silently never reached a frame left nothing in the trace at all. One line per surface
+                // is what tells "monitor 2 is black" apart from "the clip failed" in a bug report.
+                if (type == "playing" && !win.FirstFrameReported)
+                {
+                    win.FirstFrameReported = true;
+                    VideoSurfaceHealth.Report("browser", win.Screen.DeviceName, win.IsPrimary,
+                        Math.Max(0, Environment.TickCount64 - win.SessionStartTick), null);
+                }
+
                 // Only the audio-bearing window drives the session, exactly like the LibVLC primary
-                // player - a secondary's events would double every callback.
+                // player - a secondary's events would double every callback. A secondary's ERROR is
+                // still reported (Warning + a surface line): it is never allowed to end the run, but
+                // "swallowed entirely" is how a permanently black mirror stayed invisible to triage.
                 if (!win.IsPrimary)
                 {
                     if (type == "error")
-                        App.Logger?.Warning("BrowserVideo[secondary]: page error {Code} {Msg} (ignored - primary owns the session)",
-                            (int?)o["code"], (string?)o["message"]);
+                    {
+                        int scode = (int?)o["code"] ?? 0;
+                        var smsg = (string?)o["message"] ?? "";
+                        App.Logger?.Warning("BrowserVideo[secondary]: page error {Code} {Msg} on {Screen} - that mirror stays black, the primary keeps the session",
+                            scode, smsg, win.Screen.DeviceName);
+                        VideoSurfaceHealth.Report("browser", win.Screen.DeviceName, false, -1, $"page error {scode}: {smsg}");
+                    }
                     return;
                 }
 
@@ -644,6 +671,48 @@ namespace ConditioningControlPanel.Services.Video.Browser
             _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
         }
 
+        /// <summary>
+        /// A surface's WebView2 never came up (<see cref="BrowserVideoSurface.InitFailed"/>). Before
+        /// this handler existed the failure was a Warning and nothing else, which left an OPAQUE BLACK
+        /// fullscreen window on that monitor: on the PRIMARY - the only window carrying audio, and the
+        /// one <see cref="InitWindowsAsync"/> initialises first - that is exactly the reported "black
+        /// primary, no sound, secondaries fine", and the only thing that ever rescued it was the
+        /// <see cref="PreReadyTimeoutMs"/> budget expiring. Fail the session NOW instead so the host's
+        /// LibVLC fallback runs at once.
+        /// </summary>
+        private void OnWindowInitFailed(BrowserVideoWindow win, string reason)
+        {
+            VideoSurfaceHealth.Report("browser", win.Screen.DeviceName, win.IsPrimary, -1, "surface init failed: " + reason);
+            if (!win.IsPrimary)
+            {
+                App.Logger?.Warning("BrowserVideo[secondary]: surface init failed on {Screen} ({Reason}) - dropping that mirror, the primary keeps playing",
+                    win.Screen.DeviceName, reason);
+                DropSecondaryWindow(win, "init failed");
+                return;
+            }
+
+            App.Logger?.Warning("BrowserVideo: the PRIMARY surface never came up ({Reason}) - failing the session now instead of sitting black for the {Ms}ms first-frame budget",
+                reason, PreReadyTimeoutMs);
+            // Never blames the file: a WebView2 that would not start says nothing about the clip.
+            RaiseFailed("primary surface init failed: " + reason, blameFile: false);
+        }
+
+        /// <summary>Unhook and close ONE mirror without touching the session. Shared by the two
+        /// secondary-only failure paths so they cannot drift apart.</summary>
+        private void DropSecondaryWindow(BrowserVideoWindow win, string why)
+        {
+            try
+            {
+                win.Message -= OnWindowMessage;
+                win.ProcessFailed -= OnWindowProcessFailed;
+                win.Ready -= OnWindowReady;
+                win.InitFailed -= OnWindowInitFailed;
+                _windows.Remove(win);
+                win.Close();
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo: secondary close after {Why} failed: {E}", why, ex.Message); }
+        }
+
         private void OnWindowProcessFailed(BrowserVideoWindow win, CoreWebView2ProcessFailedKind kind)
         {
             // ONE dead browser process fires this on EVERY window sharing it, so a dual-monitor
@@ -652,15 +721,8 @@ namespace ConditioningControlPanel.Services.Video.Browser
             if (!win.IsPrimary)
             {
                 App.Logger?.Warning("BrowserVideo[secondary]: WebView2 process failed ({Kind}) - dropping that mirror, the primary keeps playing", kind);
-                try
-                {
-                    win.Message -= OnWindowMessage;
-                    win.ProcessFailed -= OnWindowProcessFailed;
-                    win.Ready -= OnWindowReady;
-                    _windows.Remove(win);
-                    win.Close();
-                }
-                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: secondary close after ProcessFailed failed: {E}", ex.Message); }
+                VideoSurfaceHealth.Report("browser", win.Screen.DeviceName, false, -1, "WebView2 process failed: " + kind);
+                DropSecondaryWindow(win, "ProcessFailed");
                 return;
             }
 
@@ -720,6 +782,9 @@ namespace ConditioningControlPanel.Services.Video.Browser
             if (_failedRaised) return;
             _failedRaised = true;
             StopFirstFrameWatch();
+            // The session-level verdict, said in the same per-surface shape as every other line so a
+            // report shows the primary's fate next to each mirror's.
+            VideoSurfaceHealth.Report("browser", _primary?.Screen.DeviceName, primary: true, firstFrameMs: -1, failureReason: reason);
             try { Failed?.Invoke(reason, blameFile); }
             catch (Exception ex) { App.Logger?.Warning("BrowserVideo: Failed handler threw: {E}", ex.Message); }
         }

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -51,6 +51,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// first-frame watchdog must not count that time, or a pause taken before the first frame
         /// would fake a decode failure and force a pointless LibVLC fallback.</summary>
         public Func<bool>? IsHostPaused { get; init; }
+
+        /// <summary>True while this clip is running under a STRICT lock (Lock Card / Lockdown /
+        /// Possession), where every screen is covered on purpose and Alt+F4 is refused. A dead mirror
+        /// is then left on screen as an opaque black window rather than hidden - see
+        /// <c>VideoSurfaceHealth.ShouldUncoverDeadSurface</c>. Absent = never strict.</summary>
+        public Func<bool>? IsHostStrict { get; init; }
     }
 
     /// <summary>
@@ -152,8 +158,17 @@ namespace ConditioningControlPanel.Services.Video.Browser
         // primary, which is exactly how a black mirror stayed invisible - see ArmFirstFrameWatch.
         private DispatcherTimer? _firstFrameWatch;
         private Func<bool>? _isHostPaused;
+        private Func<bool>? _isHostStrict;
         private bool _failedRaised;
         private int _sessionId;
+
+        /// <summary>A mirror was taken off screen mid-clip (dropped and hidden). The host keeps its own
+        /// window list and a cache of video-window HWNDs for z-order anchoring, and neither can learn
+        /// about the drop from <see cref="Windows"/> - the window is out of that list by then. Carries
+        /// the HWND because it is read BEFORE the Close(), after which it is gone. NOT raised for a
+        /// mirror that strict mode keeps on screen: that one is still a live fullscreen cover and must
+        /// stay in the host's bookkeeping.</summary>
+        public event Action<Window, IntPtr>? WindowDropped;
 
         private BrowserVideoEngine() { }
 
@@ -166,6 +181,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
 
         /// <summary>The windows of the live session, for the host to add to its own teardown list.</summary>
         public IReadOnlyList<Window> Windows => _windows;
+
+        /// <summary>Mirrors dropped mid-clip (<see cref="DropSecondaryWindow"/>), which are NOT in
+        /// <see cref="Windows"/> any more. The host has its own window list and its own cache of
+        /// video-window HWNDs, and both would otherwise keep a dropped mirror forever on the paths
+        /// that do not run CloseAll (the browser -> LibVLC handoff), so teardown reads this too.</summary>
+        public IReadOnlyList<Window> DroppedWindows => _dropped.ToArray();
 
         /// <summary>The audio-bearing window, or null when no session is live.</summary>
         public Window? PrimaryWindow => _primary;
@@ -401,6 +422,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
             var session = ++_sessionId;
             _failedRaised = false;
             _isHostPaused = req.IsHostPaused;
+            _isHostStrict = req.IsHostStrict;
 
             try
             {
@@ -441,8 +463,22 @@ namespace ConditioningControlPanel.Services.Video.Browser
             {
                 win = new BrowserVideoWindow(screen, primary);
                 win.SessionStartTick = Environment.TickCount64;
-                win.FirstFrameBudgetMs = PreReadyTimeoutMs;
-                win.FirstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(PreReadyTimeoutMs);
+                // Only the PRIMARY is armed here. InitWindowsAsync brings the windows up ONE AT A
+                // TIME, so arming a mirror now would charge it for the whole time it spends queued
+                // behind the primary's WebView2 - on a cold multi-screen start the last mirror could
+                // be past its deadline before its own init had even begun, and the sweep would then
+                // hide and close a perfectly healthy screen. Mirrors are armed when their init
+                // starts; until then they are UNARMED (DateTime.MaxValue) and cannot be judged.
+                //
+                // The primary keeps the session-start clock on purpose: it is initialised first so it
+                // never queues, and this is the only deadline that can still fire if the WebView2
+                // ENVIRONMENT task never completes - in that case the serial init loop never runs, so
+                // nothing else would ever end the session and hand the clip to LibVLC.
+                if (VideoSurfaceHealth.ArmsFrameDeadlineAtSessionStart(primary))
+                {
+                    win.FirstFrameBudgetMs = PreReadyTimeoutMs;
+                    win.FirstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(PreReadyTimeoutMs);
+                }
                 win.Message += OnWindowMessage;
                 win.ProcessFailed += OnWindowProcessFailed;
                 win.Ready += OnWindowReady;
@@ -497,6 +533,17 @@ namespace ConditioningControlPanel.Services.Video.Browser
             foreach (var w in _windows.ToArray())
             {
                 if (session != _sessionId) return;
+                // Arm a still-UNARMED window (every mirror) as its own init starts - never at session
+                // start, because this loop is serial and a window queued behind the primary has not
+                // begun coming up yet. A cold WebView2 can eat well over ten seconds by itself (see
+                // PreReadyTimeoutMs), which is exactly how a healthy third screen used to be
+                // condemned. The primary is already armed from session start and is NOT re-armed
+                // here: that clock is the backstop for a hung environment and must not slide.
+                if (w.FirstFrameDeadlineUtc == DateTime.MaxValue)
+                {
+                    w.FirstFrameBudgetMs = PreReadyTimeoutMs;
+                    w.FirstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(PreReadyTimeoutMs);
+                }
                 // EnsureCoreWebView2Async only works once the control is in the visual tree, which
                 // is why this runs after Show().
                 await w.InitAsync(env, mappings, StartUrl, GameHost).ConfigureAwait(true);
@@ -512,6 +559,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
             _sessionId++;   // invalidates every in-flight continuation and late page message
             StopFirstFrameWatch();
             _isHostPaused = null;
+            _isHostStrict = null;
 
             var windows = _windows.ToArray();
             _windows.Clear();
@@ -728,17 +776,24 @@ namespace ConditioningControlPanel.Services.Video.Browser
             RaiseFailed("primary surface init failed: " + reason, blameFile: false);
         }
 
-        /// <summary>Unhook and drop ONE mirror without touching the session. Shared by the two
+        /// <summary>Unhook and drop ONE mirror without touching the session. Shared by the three
         /// secondary-only failure paths so they cannot drift apart.
         ///
-        /// Hide() comes FIRST and is the load-bearing call. Every window the host builds carries the
-        /// strict Closing veto (VideoService.SetupStrictHandlers), which cancels Close() outright
-        /// while <c>_videoPlaying</c> is set - and it is already set by the time any surface can fail,
-        /// because PlayVideo sets it before the browser session starts. A vetoed Close would leave the
-        /// dead mirror on that monitor as an OPAQUE BLACK fullscreen window for the whole clip, with
-        /// every handler unhooked so nothing could act on it again: exactly the symptom this method
-        /// exists to remove. Hide() is not vetoable, so the screen is freed either way, and the real
-        /// Close lands here or at StopSession once the veto is down.</summary>
+        /// The window is always unhooked and taken out of <see cref="_windows"/>, so nothing
+        /// broadcasts to it and the sweep stops judging it. What happens to the SCREEN depends on the
+        /// lock (VideoSurfaceHealth.ShouldUncoverDeadSurface):
+        ///
+        ///   * NOT strict - Hide() then Close(). Hide() comes first and is the load-bearing call:
+        ///     every window the host builds carries the strict Closing veto
+        ///     (VideoService.SetupStrictHandlers), which cancels Close() while <c>_videoPlaying</c> is
+        ///     set - and it is already set by the time any surface can fail. A vetoed Close alone
+        ///     would leave the dead mirror on that monitor as an opaque black fullscreen window for
+        ///     the whole clip with every handler unhooked. Hide() is not vetoable, so the screen is
+        ///     freed either way, and the real Close lands here or at StopSession.
+        ///   * STRICT (Lock Card / Lockdown / Possession) - the window STAYS on screen, black. Every
+        ///     screen being covered is the point of that lock; hiding one would hand the user an
+        ///     interactive desktop mid-clip, which is a worse failure than a dead screen and is not
+        ///     something the released build ever did. StopSession closes it once the veto is down.</summary>
         private void DropSecondaryWindow(BrowserVideoWindow win, string why)
         {
             try
@@ -747,8 +802,30 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 win.ProcessFailed -= OnWindowProcessFailed;
                 win.Ready -= OnWindowReady;
                 win.InitFailed -= OnWindowInitFailed;
+                // Stops the sweep judging it again even if something re-adds it, and stops a late
+                // `playing` from this window double-reporting the surface.
+                win.FirstFrameReported = true;
                 _windows.Remove(win);
                 if (!_dropped.Contains(win)) _dropped.Add(win);
+
+                bool strict = false;
+                try { strict = _isHostStrict?.Invoke() == true; }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: strict probe threw: {E}", ex.Message); }
+
+                if (!VideoSurfaceHealth.ShouldUncoverDeadSurface(strict))
+                {
+                    App.Logger?.Warning("BrowserVideo[secondary]: {Screen} dropped after {Why}, but the clip is under a STRICT lock - the screen stays covered (black) instead of being uncovered mid-video",
+                        win.Screen.DeviceName, why);
+                    return;
+                }
+
+                // Read the HWND while the window still has one: the host prunes it from its z-order
+                // anchor cache, and after Close() there is nothing left to read.
+                IntPtr hwnd = IntPtr.Zero;
+                try { hwnd = new System.Windows.Interop.WindowInteropHelper(win).Handle; } catch { }
+                try { WindowDropped?.Invoke(win, hwnd); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: WindowDropped handler threw: {E}", ex.Message); }
+
                 try { win.Hide(); }
                 catch (Exception ex) { App.Logger?.Debug("BrowserVideo: secondary hide after {Why} failed: {E}", why, ex.Message); }
                 win.Close();
@@ -814,7 +891,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
                         foreach (var w in wins)
                         {
                             if (!w.FirstFrameReported)
-                                w.FirstFrameDeadlineUtc = w.FirstFrameDeadlineUtc.AddMilliseconds(WatchTickMs);
+                                w.FirstFrameDeadlineUtc = VideoSurfaceHealth.SlidePendingDeadline(w.FirstFrameDeadlineUtc, WatchTickMs);
                         }
                         return;
                     }
@@ -823,7 +900,11 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     bool anyPending = false;
                     foreach (var w in wins)
                     {
-                        switch (VideoSurfaceHealth.DecideBrowserFrameSweep(w.FirstFrameReported, now >= w.FirstFrameDeadlineUtc, w.IsPrimary))
+                        // An UNARMED deadline (this window's init has not started - the loop in
+                        // InitWindowsAsync is serial) reads as "not passed", so a queued window is
+                        // never condemned for the time it spent waiting its turn.
+                        switch (VideoSurfaceHealth.DecideBrowserFrameSweep(w.FirstFrameReported,
+                                    VideoSurfaceHealth.FrameDeadlinePassed(w.FirstFrameDeadlineUtc, now), w.IsPrimary))
                         {
                             case VideoSurfaceHealth.BrowserFrameSweepAction.Ignore:
                                 continue;

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -147,10 +147,11 @@ namespace ConditioningControlPanel.Services.Video.Browser
         // point the veto is down.
         private readonly List<BrowserVideoWindow> _dropped = new();
         private BrowserVideoWindow? _primary;
+        // ONE timer sweeps EVERY window; the deadline itself lives per window
+        // (BrowserVideoWindow.FirstFrameDeadlineUtc). A session-wide deadline could only judge the
+        // primary, which is exactly how a black mirror stayed invisible - see ArmFirstFrameWatch.
         private DispatcherTimer? _firstFrameWatch;
-        private DateTime _firstFrameDeadlineUtc;
         private Func<bool>? _isHostPaused;
-        private bool _playingSeen;
         private bool _failedRaised;
         private int _sessionId;
 
@@ -398,7 +399,6 @@ namespace ConditioningControlPanel.Services.Video.Browser
             StopSession();   // a previous session must never outlive its video
 
             var session = ++_sessionId;
-            _playingSeen = false;
             _failedRaised = false;
             _isHostPaused = req.IsHostPaused;
 
@@ -441,6 +441,8 @@ namespace ConditioningControlPanel.Services.Video.Browser
             {
                 win = new BrowserVideoWindow(screen, primary);
                 win.SessionStartTick = Environment.TickCount64;
+                win.FirstFrameBudgetMs = PreReadyTimeoutMs;
+                win.FirstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(PreReadyTimeoutMs);
                 win.Message += OnWindowMessage;
                 win.ProcessFailed += OnWindowProcessFailed;
                 win.Ready += OnWindowReady;
@@ -598,9 +600,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 }
 
                 // Per-SURFACE bookkeeping, ahead of the primary-only gate below: every window posts its
-                // own `playing`, and until now only the primary's was looked at - so a mirror that
-                // silently never reached a frame left nothing in the trace at all. One line per surface
-                // is what tells "monitor 2 is black" apart from "the clip failed" in a bug report.
+                // own `playing`, and until now only the primary's was looked at. This is the HEALTHY
+                // half of the per-surface diagnostics; the half that matters for a black mirror - the
+                // window that never posts `playing` at all - is ArmFirstFrameWatch's sweep, which
+                // reports and drops it on its own deadline. Together they guarantee one line per
+                // surface either way, which is what tells "monitor 2 is black" apart from "the clip
+                // failed" in a bug report.
                 if (type == "playing" && !win.FirstFrameReported)
                 {
                     win.FirstFrameReported = true;
@@ -636,8 +641,10 @@ namespace ConditioningControlPanel.Services.Video.Browser
                         break;
                     }
                     case "playing":
-                        _playingSeen = true;
-                        StopFirstFrameWatch();
+                        // Deliberately does NOT stop the sweep: the primary rendering says nothing
+                        // about the mirrors, and disarming here is how a black secondary used to go
+                        // unnoticed for the whole clip. The sweep stops itself once every window has
+                        // reported (or been dropped).
                         Playing?.Invoke();
                         break;
                     case "time":
@@ -680,13 +687,19 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>
         /// The page handshake landed, so the queued <c>load</c> only reaches the element NOW - which
         /// means everything before this point was environment start-up, not the clip failing to
-        /// decode. Restart the first-frame clock from here UNCONDITIONALLY (the pre-ready budget is
-        /// generous precisely so this always gets to run) and give the file its own full window.
+        /// decode. Restart THIS window's first-frame clock from here UNCONDITIONALLY (the pre-ready
+        /// budget is generous precisely so this always gets to run) and give the file its own full
+        /// window.
+        ///
+        /// Every screen gets this, not just the primary: a mirror's WebView2 comes up on its own
+        /// schedule, and the mirror that handshakes and THEN never decodes is exactly the surface the
+        /// sweep has to be able to time out (see ArmFirstFrameWatch).
         /// </summary>
         private void OnWindowReady(BrowserVideoWindow win)
         {
-            if (!win.IsPrimary || _playingSeen || _firstFrameWatch == null) return;
-            _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
+            if (win.FirstFrameReported || _firstFrameWatch == null) return;
+            win.FirstFrameBudgetMs = NoPlayingTimeoutMs;
+            win.FirstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
         }
 
         /// <summary>
@@ -766,33 +779,87 @@ namespace ConditioningControlPanel.Services.Video.Browser
 
         // ---- first-frame watchdog ----
 
+        /// <summary>
+        /// PER-SURFACE first-frame liveness for the browser engine. One timer, but the verdict is
+        /// taken per window against that window's own deadline.
+        ///
+        /// This used to watch the PRIMARY alone and disarm itself the instant the primary posted
+        /// <c>playing</c>. The browser engine is the DEFAULT for mp4/webm and it drives EVERY screen,
+        /// so that left the reported failure completely unguarded: a mirror whose WebView2 started,
+        /// completed the handshake and then never decoded a frame (GPU stall, a fetch the page
+        /// swallowed, a decode failure that never became an <c>error</c>) raised nothing, was dropped
+        /// by nothing, and sat as an opaque black fullscreen window for the whole clip - with no line
+        /// in video-diag.log to tell it apart from a window that was never created.
+        ///
+        /// Now: a mirror that misses its deadline is reported and dropped, the clip untouched; the
+        /// audio-bearing surface that misses its deadline still fails the session so the host replays
+        /// the clip through LibVLC. Verdict rule is pure - VideoSurfaceHealth.DecideBrowserFrameSweep.
+        /// </summary>
         private void ArmFirstFrameWatch()
         {
             StopFirstFrameWatch();
-            // Pre-ready budget: everything up to the page handshake is environment cost, not the
-            // clip's. OnWindowReady restarts the clock with the real (shorter) first-frame budget.
-            _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(PreReadyTimeoutMs);
             _firstFrameWatch = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(WatchTickMs) };
             _firstFrameWatch.Tick += (_, _) =>
             {
                 try
                 {
-                    if (_playingSeen || _windows.Count == 0) { StopFirstFrameWatch(); return; }
+                    var wins = _windows.ToArray();
+                    if (wins.Length == 0) { StopFirstFrameWatch(); return; }
+
                     // A grace pause holds playback on purpose, and the page suspends its own clock
-                    // for the same reason - slide the deadline instead of failing a healthy clip.
+                    // for the same reason - slide EVERY pending deadline instead of condemning
+                    // healthy surfaces for obeying the host.
                     if (_isHostPaused?.Invoke() == true)
                     {
-                        _firstFrameDeadlineUtc = _firstFrameDeadlineUtc.AddMilliseconds(WatchTickMs);
+                        foreach (var w in wins)
+                        {
+                            if (!w.FirstFrameReported)
+                                w.FirstFrameDeadlineUtc = w.FirstFrameDeadlineUtc.AddMilliseconds(WatchTickMs);
+                        }
                         return;
                     }
-                    if (DateTime.UtcNow < _firstFrameDeadlineUtc) return;
-                    StopFirstFrameWatch();
-                    // blameFile is ALWAYS false here. This timer cannot tell "undecodable clip" from
-                    // "the page never ran / the browser is still starting", and condemning a file to
-                    // LibVLC forever on that guess is the worse error. The page's OWN error 101 -
-                    // which is raised by a page that demonstrably loaded and then got no frame - is
-                    // the legitimate file-blame path (BlamesFile), and it still is.
-                    RaiseFailed("no playback before the first-frame deadline", blameFile: false);
+
+                    var now = DateTime.UtcNow;
+                    bool anyPending = false;
+                    foreach (var w in wins)
+                    {
+                        switch (VideoSurfaceHealth.DecideBrowserFrameSweep(w.FirstFrameReported, now >= w.FirstFrameDeadlineUtc, w.IsPrimary))
+                        {
+                            case VideoSurfaceHealth.BrowserFrameSweepAction.Ignore:
+                                continue;
+
+                            case VideoSurfaceHealth.BrowserFrameSweepAction.Wait:
+                                anyPending = true;
+                                continue;
+
+                            case VideoSurfaceHealth.BrowserFrameSweepAction.DropMirror:
+                                // Marked BEFORE the drop so a late `playing` from this window cannot
+                                // double-report it, and so a re-entrant tick cannot judge it twice.
+                                w.FirstFrameReported = true;
+                                App.Logger?.Warning("BrowserVideo[secondary]: no first frame within {Ms}ms on {Screen} - dropping that mirror, the primary keeps playing",
+                                    w.FirstFrameBudgetMs, w.Screen.DeviceName);
+                                VideoSurfaceHealth.Report("browser", w.Screen.DeviceName, false, -1,
+                                    "no first frame within " + w.FirstFrameBudgetMs + "ms");
+                                DropSecondaryWindow(w, "no first frame");
+                                continue;
+
+                            case VideoSurfaceHealth.BrowserFrameSweepAction.FailSession:
+                                w.FirstFrameReported = true;
+                                StopFirstFrameWatch();
+                                // blameFile is ALWAYS false here. This timer cannot tell "undecodable
+                                // clip" from "the page never ran / the browser is still starting", and
+                                // condemning a file to LibVLC forever on that guess is the worse
+                                // error. The page's OWN error 101 - raised by a page that demonstrably
+                                // loaded and then got no frame - is the legitimate file-blame path
+                                // (BlamesFile), and it still is.
+                                RaiseFailed("no playback before the first-frame deadline", blameFile: false);
+                                return;
+                        }
+                    }
+
+                    // Every surface has either presented a frame or been condemned - nothing left to
+                    // watch, and leaving the timer running would keep a dead session ticking.
+                    if (!anyPending) StopFirstFrameWatch();
                 }
                 catch (Exception ex) { App.Logger?.Debug("BrowserVideo: first-frame watch tick failed: {E}", ex.Message); }
             };

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
@@ -51,6 +51,17 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>Raised on the UI thread once the page posts <c>ready</c>.</summary>
         public event Action<BrowserVideoSurface>? Ready;
 
+        /// <summary>
+        /// The WebView2 for THIS surface could not be brought up: <c>EnsureCoreWebView2Async</c> threw,
+        /// or it completed and left the core null. Both used to be a Warning and nothing else - and
+        /// because the surface stays on screen as an OPAQUE BLACK window, that is precisely the
+        /// reported "the primary monitor is black with no sound while the other screens play fine"
+        /// (the engine inits the primary FIRST, so a swallowed failure there let every secondary go on
+        /// to play normally). The host now hears about it and can fall this surface back to LibVLC
+        /// instead of waiting out the whole pre-ready budget on a black screen.
+        /// </summary>
+        public event Action<BrowserVideoSurface, string>? InitFailed;
+
         public BrowserVideoSurface(string tag)
         {
             _tag = tag;
@@ -81,7 +92,11 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 await _web.EnsureCoreWebView2Async(env).ConfigureAwait(true);
                 if (_disposed || _web?.CoreWebView2 == null)
                 {
-                    if (!_disposed) App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 core null after Ensure", _tag);
+                    if (!_disposed)
+                    {
+                        App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 core null after Ensure", _tag);
+                        RaiseInitFailed("WebView2 core null after EnsureCoreWebView2Async");
+                    }
                     return;
                 }
 
@@ -119,7 +134,16 @@ namespace ConditioningControlPanel.Services.Video.Browser
             catch (Exception ex)
             {
                 App.Logger?.Warning("BrowserVideo[{Tag}]: InitAsync failed: {E}", _tag, ex.Message);
+                RaiseInitFailed(ex.Message);
             }
+        }
+
+        /// <summary>Tell the host this surface will never post <c>ready</c> or <c>playing</c>. Never
+        /// throws: a broken handler must not turn a recoverable surface failure into an unhandled one.</summary>
+        private void RaiseInitFailed(string reason)
+        {
+            try { InitFailed?.Invoke(this, reason); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: InitFailed handler threw: {E}", _tag, ex.Message); }
         }
 
         /// <summary>Give the page keyboard focus so its keydown handler (and therefore the

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
@@ -138,12 +138,38 @@ namespace ConditioningControlPanel.Services.Video.Browser
             }
         }
 
-        /// <summary>Tell the host this surface will never post <c>ready</c> or <c>playing</c>. Never
-        /// throws: a broken handler must not turn a recoverable surface failure into an unhandled one.</summary>
+        /// <summary>
+        /// Tell the host this surface will never post <c>ready</c> or <c>playing</c>. Never throws: a
+        /// broken handler must not turn a recoverable surface failure into an unhandled one.
+        ///
+        /// Posted to a LATER dispatcher turn, not raised inline, and that is not cosmetic. The engine's
+        /// WebView2 environment task is cached and warmed at startup, so <c>InitWindowsAsync</c>'s await
+        /// completes synchronously and <c>InitAsync</c> runs INSIDE
+        /// <c>BrowserVideoEngine.StartSession</c> - before the host has set <c>_browserActive</c>,
+        /// adopted the windows or recorded the primary. A synchronous raise from there reaches
+        /// <c>VideoService.OnBrowserFailed</c> while <c>_browserActive</c> is still false, where its
+        /// first line drops it on the floor: the black primary this event exists to end would survive
+        /// the very report meant to fix it, and any handler that DID run would be re-entering a host
+        /// mid-bookkeeping. One dispatcher hop puts the raise strictly after StartSession returns.
+        /// </summary>
         private void RaiseInitFailed(string reason)
         {
-            try { InitFailed?.Invoke(this, reason); }
-            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: InitFailed handler threw: {E}", _tag, ex.Message); }
+            var dispatcher = Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted)
+            {
+                App.Logger?.Debug("BrowserVideo[{Tag}]: InitFailed dropped - the dispatcher is shutting down", _tag);
+                return;
+            }
+            try
+            {
+                dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Normal, new Action(() =>
+                {
+                    if (_disposed) return;   // the session ended while the hop was in flight
+                    try { InitFailed?.Invoke(this, reason); }
+                    catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: InitFailed handler threw: {E}", _tag, ex.Message); }
+                }));
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: InitFailed dispatch failed: {E}", _tag, ex.Message); }
         }
 
         /// <summary>Give the page keyboard focus so its keydown handler (and therefore the

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
@@ -61,8 +61,20 @@ namespace ConditioningControlPanel.Services.Video.Browser
         public long SessionStartTick { get; set; } = Environment.TickCount64;
 
         /// <summary>One surface report per window per session (the page posts <c>playing</c> again
-        /// after a seek, and a mirror must not spam the log).</summary>
+        /// after a seek, and a mirror must not spam the log). Also the "stop watching me" flag for the
+        /// engine's first-frame sweep, which is why the sweep sets it when it condemns a window.</summary>
         public bool FirstFrameReported { get; set; }
+
+        /// <summary>When THIS window's first frame is overdue. Every screen carries its own deadline:
+        /// a session-wide one could only ever judge the primary, which is how a mirror that came up,
+        /// handshook and then never decoded stayed black and unlogged for a whole clip. Starts at the
+        /// generous pre-handshake budget and is restarted, shorter, when the page posts <c>ready</c>
+        /// (everything before that is WebView2 start-up cost, not the clip's).</summary>
+        public DateTime FirstFrameDeadlineUtc { get; set; } = DateTime.MaxValue;
+
+        /// <summary>The budget <see cref="FirstFrameDeadlineUtc"/> was last set from, in ms, so the
+        /// diagnostics line can say which window the surface actually missed.</summary>
+        public int FirstFrameBudgetMs { get; set; }
 
         public BrowserVideoWindow(Screen screen, bool primary)
         {

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
@@ -51,6 +51,19 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>Raised on the UI thread once the page posts <c>ready</c>.</summary>
         public event Action<BrowserVideoWindow>? Ready;
 
+        /// <summary>This surface's WebView2 never came up - see
+        /// <see cref="BrowserVideoSurface.InitFailed"/>. The window is still on screen and still
+        /// OPAQUE BLACK, so the engine must act on it rather than wait for a frame that cannot come.</summary>
+        public event Action<BrowserVideoWindow, string>? InitFailed;
+
+        /// <summary><see cref="Environment.TickCount64"/> when the session created this window. The
+        /// per-surface diagnostics line measures first-frame latency from here.</summary>
+        public long SessionStartTick { get; set; } = Environment.TickCount64;
+
+        /// <summary>One surface report per window per session (the page posts <c>playing</c> again
+        /// after a seek, and a mirror must not spam the log).</summary>
+        public bool FirstFrameReported { get; set; }
+
         public BrowserVideoWindow(Screen screen, bool primary)
         {
             _screen = screen;
@@ -83,6 +96,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
             _surface.Message += (_, o) => Message?.Invoke(this, o);
             _surface.ProcessFailed += (_, kind) => ProcessFailed?.Invoke(this, kind);
             _surface.Ready += _ => Ready?.Invoke(this);
+            _surface.InitFailed += (_, reason) => InitFailed?.Invoke(this, reason);
             Content = _surface;
 
             PinToScreen();

--- a/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
+++ b/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
@@ -400,6 +400,14 @@ namespace ConditioningControlPanel.Services
 
         private (Window Window, Image ImageControl) CreateFullscreenWindow(Screen screen, WriteableBitmap bitmap)
         {
+            // Screen.Bounds is PHYSICAL pixels; WPF Left/Top/Width/Height are DIPs. Assigning one to
+            // the other is only correct at 100% scaling - at 150% it produced a window 1.5x the screen
+            // (and on mixed-DPI rigs a part-width window on the secondary), which is the same class of
+            // bug ForceFullScreenBounds/PinToScreen already fix for the other video surfaces. The
+            // SourceInitialized SetWindowPos below is the real authority (Win32 works in pixels); this
+            // just stops the pre-HWND layout pass from flashing a wrong-sized black window first.
+            var dpiScale = BubbleCountWindow.GetDpiForScreen(screen);
+            if (dpiScale <= 0) dpiScale = 1.0;
             // Image control that displays this window's bitmap
             var image = new Image
             {
@@ -426,10 +434,10 @@ namespace ConditioningControlPanel.Services
                 ShowInTaskbar = false,
                 Background = Brushes.Black,
                 Content = grid,
-                Left = screen.Bounds.Left,
-                Top = screen.Bounds.Top,
-                Width = screen.Bounds.Width,
-                Height = screen.Bounds.Height
+                Left = screen.Bounds.Left / dpiScale,
+                Top = screen.Bounds.Top / dpiScale,
+                Width = screen.Bounds.Width / dpiScale,
+                Height = screen.Bounds.Height / dpiScale
             };
 
             // Handle keyboard input for escape to close

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -273,7 +273,13 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private void FallbackToLibVlc(string reason)
         {
-            if (_browserFallbackDone) return;
+            // The two branches below are the pure policy in VideoSurfaceHealth.DecideBrowserFailure;
+            // this call site is the ONLY one that acts on it for the primary surface. (Secondary
+            // failures never reach here at all - the engine drops the mirror and keeps the session,
+            // which is DecideBrowserFailure's DropSecondary arm.)
+            var action = VideoSurfaceHealth.DecideBrowserFailure(
+                isPrimarySurface: true, alreadyFellBack: _browserFallbackDone, playbackStartedFired: _browserStartedFired);
+            if (action == VideoSurfaceHealth.BrowserFailureAction.Ignore) return;
             _browserFallbackDone = true;
 
             var path = _browserPath;
@@ -286,7 +292,7 @@ namespace ConditioningControlPanel.Services
             // NEXT play of it routes to LibVLC anyway. Mirrors BubbleCountWindow's startedOnce
             // branch: end through the same funnel a natural end uses, so it is one VideoEnded and
             // EndCurrentVideo's normal attention pass/fail handling.
-            if (_browserStartedFired)
+            if (action == VideoSurfaceHealth.BrowserFailureAction.EndClip)
             {
                 App.Logger?.Warning("VideoService: browser playback failed MID-CLIP for {File} ({Reason}) - ending the video instead of replaying it",
                     Path.GetFileName(path ?? "(none)"), reason);

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -85,6 +85,7 @@ namespace ConditioningControlPanel.Services
                     engine.KeyPressed += OnBrowserKey;
                     engine.AttentionClicked += OnBrowserAttentionClicked;
                     engine.AttentionMoved += OnBrowserAttentionMoved;
+                    engine.WindowDropped += OnBrowserWindowDropped;
                 }
                 return engine;
             }
@@ -133,6 +134,11 @@ namespace ConditioningControlPanel.Services
                     // frozen machine, and attention targets are clicked over this surface.
                     HideCursor = false,
                     IsHostPaused = () => _gracePaused,
+                    // Lock Card / Lockdown / Possession: every screen is covered on purpose, so a
+                    // dead mirror is left black rather than uncovered mid-clip (the engine asks
+                    // VideoSurfaceHealth.ShouldUncoverDeadSurface with this). Read live, not
+                    // captured: the strict retry gap flips it while the session is up.
+                    IsHostStrict = () => IsStrictActive,
                     ConfigureBeforeShow = (win, _, _) =>
                     {
                         // Same strict contract as a LibVLC window: Closing veto + key swallowing.
@@ -235,6 +241,36 @@ namespace ConditioningControlPanel.Services
         // ===================== teardown =====================
 
         /// <summary>
+        /// A mirror was taken off screen mid-clip by the engine (init failure, ProcessFailed, or no
+        /// first frame within its own budget). The engine has already removed it from its own list, so
+        /// <see cref="StopBrowserSession"/>'s <c>engine.Windows</c> snapshot can no longer see it -
+        /// which is how a dropped window used to stay in <see cref="_windows"/> for the rest of the
+        /// run (keeping <see cref="HasOpenWindows"/> true, and getting PreventClickRaise'd on a
+        /// browser -> LibVLC handoff) and its HWND used to stay in the z-order anchor cache, which is
+        /// only cleared wholesale in CloseAll. A recycled HWND matching a live overlay window there
+        /// would flip that overlay from "below the video" to "topmost", i.e. the #497/#1016 symptom
+        /// this branch removes. Prune both at drop time so identity, not IsWindow(), keeps the anchor
+        /// list honest.
+        ///
+        /// Only fires for a mirror that actually LEFT the screen; one that strict mode keeps up as a
+        /// black cover is still a live fullscreen window and stays in the bookkeeping.
+        /// </summary>
+        private void OnBrowserWindowDropped(Window win, IntPtr hwnd)
+        {
+            try
+            {
+                _windows.Remove(win);
+                if (ReferenceEquals(_primaryVideoWindow, win)) _primaryVideoWindow = null;
+                if (hwnd != IntPtr.Zero)
+                {
+                    lock (_videoWindowHandlesLock) { _videoWindowHandles.Remove(hwnd); }
+                }
+                VideoDiag.Log("VIDEO", "browser mirror dropped from the host window list + z-order anchors");
+            }
+            catch (Exception ex) { App.Logger?.Debug("VideoService: OnBrowserWindowDropped failed - {Error}", ex.Message); }
+        }
+
+        /// <summary>
         /// Closes the browser surfaces and drops them from the shared window list. Called from
         /// CloseAll (the single teardown funnel for every path: natural end, panic, safety timeout,
         /// attention retry, session lock, suspend) and from the LibVLC fallback. Idempotent.
@@ -249,7 +285,23 @@ namespace ConditioningControlPanel.Services
             _browserPaused = false;
             _browserVideoAspect = 0;
 
-            var browserWindows = engine.Windows.ToList();
+            // DROPPED mirrors are deliberately included: they are out of engine.Windows already, so a
+            // snapshot of that alone left them in _windows and their HWNDs in the z-order anchor cache
+            // for the rest of the run - and the browser -> LibVLC handoff never runs CloseAll, which is
+            // the only place that clears the cache wholesale. Handles are read BEFORE StopSession
+            // closes the windows, because a closed window no longer has one.
+            var browserWindows = engine.Windows.Concat(engine.DroppedWindows).Distinct().ToList();
+            var browserHandles = new List<IntPtr>();
+            foreach (var w in browserWindows)
+            {
+                try
+                {
+                    var h = new System.Windows.Interop.WindowInteropHelper(w).Handle;
+                    if (h != IntPtr.Zero) browserHandles.Add(h);
+                }
+                catch { }
+            }
+
             try { engine.StopSession(); }
             catch (Exception ex) { App.Logger?.Debug("VideoService: browser StopSession failed - {Error}", ex.Message); }
 
@@ -257,6 +309,13 @@ namespace ConditioningControlPanel.Services
             {
                 _windows.Remove(w);
                 if (ReferenceEquals(_primaryVideoWindow, w)) _primaryVideoWindow = null;
+            }
+            if (browserHandles.Count > 0)
+            {
+                lock (_videoWindowHandlesLock)
+                {
+                    foreach (var h in browserHandles) _videoWindowHandles.Remove(h);
+                }
             }
         }
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -312,6 +312,15 @@ namespace ConditioningControlPanel.Services
         // instead of instantly returning false off the first init's completed TCS. Reads/writes are
         // under _libVLCLock or tolerate a stale snapshot (worst case: one early false).
         private static TaskCompletionSource<bool> _libVLCReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // ---- Deferred retire (see RetireSharedLibVLC + FlushDeferredRetire) ----
+        // A retire asked for by a FOREIGN owner (a leased bubble-count / mini-player / preview player
+        // whose Stop() wedged) while the mandatory video is still on screen. Parked here instead of
+        // executed, because retiring the shared instance mid-clip blacks out the OTHER monitors that
+        // are decoding on it. Flushed once the video is fully down.
+        private static LibVLC? _deferredRetireSuspect;
+        private static string _deferredRetireReason = "";
+        private static readonly object _deferredRetireLock = new();
         private readonly List<LibVLCSharp.Shared.MediaPlayer> _mediaPlayers = new();
         private readonly object _mediaPlayersLock = new();  // Thread-safe access to _mediaPlayers
 
@@ -320,9 +329,34 @@ namespace ConditioningControlPanel.Services
         // down in CloseAll — invalidates the frame buffer + unhooks the render tick, then frees the
         // native buffer after a delay so an in-flight LibVLC frame can't touch freed memory.
         private readonly List<BlurVmemSurface> _blurSurfaces = new();
+
+        /// <summary>
+        /// One monitor's blur surface plus the state its frame-liveness watchdog keeps. This used to
+        /// be a bare list of timers with no per-surface memory at all, which is why ONE stalled screen
+        /// ended the clip on EVERY screen (#533/#1015/#1035): there was nowhere to record "this one is
+        /// dead, the others are fine". See StartBlurFrameWatchdog.
+        /// </summary>
+        private sealed class BlurSurfaceWatch
+        {
+            public required BlurVmemSurface Surface { get; init; }
+            /// <summary>Human tag ("primary \\.\DISPLAY1") for the trace.</summary>
+            public required string Tag { get; init; }
+            /// <summary>Device name alone, for the per-surface diagnostics line.</summary>
+            public required string Monitor { get; init; }
+            /// <summary>The audio-bearing screen.</summary>
+            public required bool Primary { get; init; }
+            public System.Threading.Timer? Timer;
+            /// <summary>This surface has already had its one re-Play.</summary>
+            public volatile bool RetryUsed;
+            /// <summary>This surface produced no frame even after its retry.</summary>
+            public volatile bool Dead;
+            /// <summary>Its diagnostics line has been written (once per surface per clip).</summary>
+            public volatile bool Reported;
+        }
+
         // One frame-liveness watchdog per live blur surface (see StartBlurFrameWatchdog). Threadpool
         // timers, not DispatcherTimers, so they still fire while the UI thread is wedged.
-        private readonly List<System.Threading.Timer> _blurFrameWatchTimers = new();
+        private readonly List<BlurSurfaceWatch> _blurWatches = new();
         private readonly object _blurFrameWatchLock = new();
 
         // Primary-monitor refs for the Deeper enhancement engine. Set when the
@@ -373,6 +407,23 @@ namespace ConditioningControlPanel.Services
         /// Used to compute screen-space video rect for gaze-target rules.
         /// </summary>
         public Window? PrimaryVideoWindow => _primaryVideoWindow;
+
+        /// <summary>
+        /// HWNDs of EVERY live mandatory-video window, one per monitor, for BOTH engines (browser and
+        /// LibVLC both go through PreventClickRaise, which is where these are cached).
+        ///
+        /// <see cref="PrimaryVideoWindow"/> alone is not enough for z-order work on a multi-monitor
+        /// setup: an overlay sitting on monitor 2 was being ordered against the monitor 1 video window,
+        /// which is a different z-band, so the overlay landed on top of monitor 2's video (#1016, the
+        /// "pink filter over the video on my second screen" reports). Callers should pick the video
+        /// window on the SAME monitor as the window they are ordering.
+        ///
+        /// Safe from any thread; returns a snapshot, never the live list.
+        /// </summary>
+        public IReadOnlyList<IntPtr> GetVideoWindowHandles()
+        {
+            lock (_videoWindowHandlesLock) { return _videoWindowHandles.ToArray(); }
+        }
 
         /// <summary>
         /// Current primary-player playback time in milliseconds, or -1 if none.
@@ -816,7 +867,19 @@ namespace ConditioningControlPanel.Services
         /// the old instance after a vout retry already built the new one): pass the instance that
         /// misbehaved, and the retire is skipped if it is no longer the shared one.
         /// </summary>
-        private bool RetireSharedLibVLC(LibVLC? suspect, string reason)
+        /// <param name="fromCurrentPlayback">
+        /// True (default) when the caller IS the mandatory clip that is on screen right now - the vout
+        /// heal, the wedge ladder, its own teardown. False for a FOREIGN owner: a leased player
+        /// (bubble count, mini player, previews) whose Stop() wedged.
+        ///
+        /// That distinction is #1025/#1059's tail. A leased wedge used to retire the shared instance
+        /// while the mandatory video's per-monitor players were still decoding on it — which drops the
+        /// metadata cache, spends one of the four per-session retires, arms the 60s poison cooldown
+        /// (so bubble-pop audio stops for the rest of the session) and makes the next
+        /// EnsureLibVLCInitialized block the UI thread on the rebuild's _libVLCLock, mid-video. The
+        /// retire is not cancelled, only DEFERRED to teardown - see FlushDeferredRetire.
+        /// </param>
+        private bool RetireSharedLibVLC(LibVLC? suspect, string reason, bool fromCurrentPlayback = true)
         {
             // No suspect means the caller doesn't know which instance misbehaved (e.g. it captured
             // _libVLC after a retire already nulled it). Never condemn blind: on the vout-retry path
@@ -825,6 +888,21 @@ namespace ConditioningControlPanel.Services
             if (suspect == null)
             {
                 VideoDiag.Log("RETIRE", $"declined ({reason}) - no suspect instance supplied");
+                return false;
+            }
+
+            // Siblings on the other monitors are mid-clip on this very instance - hold the retire
+            // until the video is down rather than pulling the shared instance out from under them.
+            if (VideoSurfaceHealth.ShouldDeferRetire(fromCurrentPlayback, _videoPlaying || HasOpenWindows))
+            {
+                lock (_deferredRetireLock)
+                {
+                    _deferredRetireSuspect = suspect;
+                    _deferredRetireReason = reason;
+                }
+                App.Logger?.Warning("VideoService: retire DEFERRED ({Reason}) - a mandatory video is still decoding on this instance; it will be retired at teardown",
+                    reason);
+                VideoDiag.Log("RETIRE", $"deferred ({reason}) - sibling video window(s) are still playing on this instance");
                 return false;
             }
 
@@ -880,6 +958,38 @@ namespace ConditioningControlPanel.Services
                 VideoDiag.Log("RETIRE", $"background LibVLC rebuild end after {sw.ElapsedMilliseconds}ms");
             });
             return true;
+        }
+
+        /// <summary>
+        /// Execute a retire that <see cref="RetireSharedLibVLC"/> parked because a mandatory video was
+        /// still decoding on the suspect instance. Called from the teardown funnel (CloseAll's finally),
+        /// i.e. once no sibling can be hurt by it. Never throws.
+        ///
+        /// If the suspect is no longer the shared instance by now (something else retired it in the
+        /// meantime) the inner ReferenceEquals guard declines it, which is the correct outcome.
+        /// </summary>
+        private void FlushDeferredRetire()
+        {
+            LibVLC? suspect;
+            string reason;
+            lock (_deferredRetireLock)
+            {
+                suspect = _deferredRetireSuspect;
+                reason = _deferredRetireReason;
+                _deferredRetireSuspect = null;
+                _deferredRetireReason = "";
+            }
+            if (suspect == null) return;
+
+            try
+            {
+                VideoDiag.Log("RETIRE", $"flushing deferred retire at teardown ({reason})");
+                RetireSharedLibVLC(suspect, reason + " (deferred to teardown)");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("VideoService: FlushDeferredRetire failed: {E}", ex.Message);
+            }
         }
 
         #region Managed lease (shared LibVLC for consumers outside the mandatory-video pipeline)
@@ -987,7 +1097,11 @@ namespace ConditioningControlPanel.Services
                     if (stopTask != null && !stopTask.IsCompleted)
                     {
                         QuarantineNative(player, $"{ownerTag}: Stop() never completed");
-                        RetireSharedLibVLC(owner, $"a wedged {ownerTag} player was quarantined");
+                        // fromCurrentPlayback: false - this is a LEASED player (bubble count, mini
+                        // player, a preview), not the mandatory clip. If a mandatory video is on
+                        // screen right now its per-monitor players are decoding on this very
+                        // instance, so the retire is parked until teardown (#1025/#1059).
+                        RetireSharedLibVLC(owner, $"a wedged {ownerTag} player was quarantined", fromCurrentPlayback: false);
                         return;
                     }
 
@@ -2992,7 +3106,24 @@ namespace ConditioningControlPanel.Services
                 mediaPlayer.Vout += (s, e) => PushTrackAspect();
             }
             else
+            {
                 videoView!.MediaPlayer = mediaPlayer;
+                // Per-surface first-frame diagnostics for the classic VideoView path. The blur path
+                // gets its line from the frame watchdog; here the first Vout with an output attached
+                // is the equivalent "this monitor is actually showing something" signal. One line per
+                // surface per clip - the reporters upload video-diag.log and nothing in it used to say
+                // which monitor came up and how long it took.
+                long voutStartTick = Environment.TickCount64;
+                int voutReported = 0;
+                var voutMonitor = screen.DeviceName;
+                bool voutPrimary = withAudio;
+                mediaPlayer.Vout += (s, e) =>
+                {
+                    if (System.Threading.Interlocked.Exchange(ref voutReported, 1) != 0) return;
+                    VideoSurfaceHealth.Report("libvlc", voutMonitor, voutPrimary,
+                        Math.Max(0, Environment.TickCount64 - voutStartTick), null);
+                };
+            }
             VideoDiag.Log("VIDEO", $"win[{tag}]: surface attached +{winSw.ElapsedMilliseconds}ms");
 
             // Create media. A library/pack clip is a real file; a remote clip is an absolute
@@ -3096,7 +3227,7 @@ namespace ConditioningControlPanel.Services
             // a healthy secondary could not rescue a stalled primary (#767). The vout watchdog stays
             // primary-only — its heal retires and replays the whole video.
             if (useBlur)
-                StartBlurFrameWatchdog(blurSurface!, $"{tag} {screen.DeviceName}");
+                StartBlurFrameWatchdog(blurSurface!, $"{tag} {screen.DeviceName}", withAudio, screen.DeviceName);
             else if (withAudio)
                 StartVoutWatchdog(mediaPlayer, path, strict);
 
@@ -3270,12 +3401,21 @@ namespace ConditioningControlPanel.Services
             => postedGeneration == currentGeneration;
 
         /// <summary>
-        /// Liveness watchdog for the blurred-background (memory-render) path: if the surface has
-        /// produced no frame within the grace window, the decode never started — skip to the next
-        /// video rather than sit on a black screen. Cheaper counterpart to StartVoutWatchdog, which
-        /// targets the VideoView/DXVA white-screen the memory path can't hit.
+        /// PER-SURFACE liveness watchdog for the blurred-background (memory-render) path. Cheaper
+        /// counterpart to StartVoutWatchdog, which targets the VideoView/DXVA white-screen the memory
+        /// path can't hit.
+        ///
+        /// #533/#540/#1015/#1024/#1035/#1039 — this used to be a per-surface TIMER with a
+        /// whole-clip VERDICT: the first screen to miss its grace window called
+        /// <c>EndCurrentVideo(noFrameRendered: true)</c>, killing the video on every OTHER monitor
+        /// that was decoding perfectly ("black on one screen, and then it just skipped"). The ladder
+        /// is now per surface:
+        ///   1. no frame within the grace window ⇒ re-issue Play() on THIS monitor's player only,
+        ///      and give it one more full grace window;
+        ///   2. still nothing ⇒ this surface is dead. The clip ends ONLY when every surface is
+        ///      (VideoSurfaceHealth.ShouldAbortClip), otherwise the run continues on the live ones.
         /// </summary>
-        private void StartBlurFrameWatchdog(BlurVmemSurface surface, string surfaceTag)
+        private void StartBlurFrameWatchdog(BlurVmemSurface surface, string surfaceTag, bool primary, string monitor)
         {
             var gen = _teardownGeneration;
             // This used to be a DispatcherTimer, and its own comment admitted the flaw: the blurred
@@ -3284,57 +3424,130 @@ namespace ConditioningControlPanel.Services
             // threadpool timer like StartVoutWatchdog, so the verdict lands in the trace even during
             // a freeze; only the teardown it decides on is marshalled back to the dispatcher.
             VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog armed (threadpool timer, {VoutGraceMs}ms)");
-            System.Threading.Timer? self = null;
+            var watch = new BlurSurfaceWatch { Surface = surface, Tag = surfaceTag, Monitor = monitor, Primary = primary };
             var timer = new System.Threading.Timer(_ =>
             {
                 try
                 {
-                    if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration) return; // torn down / superseded
-                    // #735: a grace-paused vmem surface produces no new frames BY DESIGN. Judging it
-                    // here would skip to the next video the moment the user paused inside the grace
-                    // window. Re-arm for another full grace instead of standing down for good.
-                    if (_gracePaused)
+                    bool tornDown = !_videoPlaying || _isCleaningUp || gen != _teardownGeneration;
+                    switch (VideoSurfaceHealth.DecideFrameWatchdog(tornDown, _gracePaused, surface.HasRendered, watch.RetryUsed))
                     {
-                        VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog deferred - video is grace-paused");
-                        try { self?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
-                        return;
-                    }
-                    if (surface.HasRendered) { VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog: frames are arriving, all good"); return; }
-                    App.Logger?.Warning("VideoService: blurred-background video produced no frame within {Ms}ms on {Surface} — skipping to next",
-                        VoutGraceMs, surfaceTag);
-                    VideoDiag.Log("BLUR", $"[{surfaceTag}] NO FRAME within {VoutGraceMs}ms - black-screen state confirmed, skipping to next video");
+                        case VideoSurfaceHealth.FrameWatchdogAction.Ignore:
+                            if (!tornDown && surface.HasRendered && !watch.Reported)
+                            {
+                                watch.Reported = true;
+                                VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog: frames are arriving, all good");
+                                VideoSurfaceHealth.Report("libvlc", monitor, primary, surface.FirstFrameMs, null);
+                            }
+                            return;
 
-                    var dispatcher = Application.Current?.Dispatcher;
-                    if (dispatcher == null || dispatcher.HasShutdownStarted) return;
-                    dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration) return;
-                        // Nothing was ever on screen for this surface: the natural-end path must NOT
-                        // seed the watch position to the full clip length (#767).
-                        try { EndCurrentVideo(noFrameRendered: true); }
-                        catch (Exception ex) { App.Logger?.Debug("StartBlurFrameWatchdog OnEnded threw: {E}", ex.Message); }
-                    }));
+                        case VideoSurfaceHealth.FrameWatchdogAction.Defer:
+                            // #735: a grace-paused vmem surface produces no new frames BY DESIGN.
+                            // Judging it here would skip to the next video the moment the user paused
+                            // inside the grace window. Re-arm for another full grace instead.
+                            VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog deferred - video is grace-paused");
+                            try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
+                            return;
+
+                        case VideoSurfaceHealth.FrameWatchdogAction.Retry:
+                            watch.RetryUsed = true;
+                            App.Logger?.Warning("VideoService: blurred-background video produced no frame within {Ms}ms on {Surface} - retrying THAT surface only, the other screens keep playing",
+                                VoutGraceMs, surfaceTag);
+                            VideoDiag.Log("BLUR", $"[{surfaceTag}] NO FRAME within {VoutGraceMs}ms - per-surface retry, clip untouched");
+                            RetryBlurSurface(watch);
+                            try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
+                            return;
+
+                        case VideoSurfaceHealth.FrameWatchdogAction.GiveUp:
+                            watch.Dead = true;
+                            watch.Reported = true;
+                            int total, dead;
+                            lock (_blurFrameWatchLock)
+                            {
+                                total = _blurWatches.Count;
+                                dead = _blurWatches.Count(w => w.Dead);
+                            }
+                            VideoSurfaceHealth.Report("libvlc", monitor, primary, -1,
+                                $"no frame within {VoutGraceMs}ms, and none after one retry");
+                            if (!VideoSurfaceHealth.ShouldAbortClip(total, dead))
+                            {
+                                App.Logger?.Warning("VideoService: giving up on the blurred surface {Surface} ({Dead}/{Total} dead) - the clip keeps playing on the live screen(s)",
+                                    surfaceTag, dead, total);
+                                VideoDiag.Log("BLUR", $"[{surfaceTag}] surface DEAD ({dead}/{total}) - clip continues on the rest");
+                                return;
+                            }
+                            App.Logger?.Warning("VideoService: every blurred surface ({Total}) produced no frame - skipping to next",
+                                total);
+                            VideoDiag.Log("BLUR", $"[{surfaceTag}] LAST surface dead ({dead}/{total}) - black-screen state confirmed, skipping to next video");
+
+                            var dispatcher = Application.Current?.Dispatcher;
+                            if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                            dispatcher.BeginInvoke(new Action(() =>
+                            {
+                                if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration) return;
+                                // Nothing was ever on screen for this surface: the natural-end path must NOT
+                                // seed the watch position to the full clip length (#767).
+                                try { EndCurrentVideo(noFrameRendered: true); }
+                                catch (Exception ex) { App.Logger?.Debug("StartBlurFrameWatchdog OnEnded threw: {E}", ex.Message); }
+                            }));
+                            return;
+                    }
                 }
                 catch (Exception ex) { App.Logger?.Debug("StartBlurFrameWatchdog tick error: {E}", ex.Message); }
             }, null, VoutGraceMs, System.Threading.Timeout.Infinite);
-            self = timer;   // lets the grace-pause branch above re-arm this very timer
+            watch.Timer = timer;   // lets the defer/retry branches above re-arm this very timer
 
-            lock (_blurFrameWatchLock) { _blurFrameWatchTimers.Add(timer); }
+            lock (_blurFrameWatchLock) { _blurWatches.Add(watch); }
+        }
+
+        /// <summary>
+        /// One monitor's decoder gets a second chance, WITHOUT touching its siblings. Re-issuing
+        /// Play() only helps when the player has actually fallen out of playback (Error/Stopped/Ended);
+        /// a player still in Opening/Buffering is simply slow, and poking native state under it is the
+        /// exact class of move that wedges LibVLC — so that case just spends the extra grace window
+        /// the caller has already armed. Off the timer thread: a native call must never be able to
+        /// hold up the other surfaces' watchdogs.
+        /// </summary>
+        private void RetryBlurSurface(BlurSurfaceWatch watch)
+        {
+            var player = watch.Surface.Player;
+            if (player == null)
+            {
+                VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - no player attached to this surface");
+                return;
+            }
+            Task.Run(() =>
+            {
+                try
+                {
+                    var state = player.State;
+                    if (state is VLCState.Error or VLCState.Stopped or VLCState.Ended or VLCState.NothingSpecial)
+                    {
+                        player.Play();
+                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry: player was {state} - Play() re-issued on this surface only");
+                    }
+                    else
+                    {
+                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry: player is {state} (still coming up) - extending the grace window instead of poking native state");
+                    }
+                }
+                catch (Exception ex) { App.Logger?.Debug("VideoService: blur surface retry failed - {Error}", ex.Message); }
+            });
         }
 
         /// <summary>Disarm every blur frame watchdog armed for the current playback. Called from the
         /// CloseAll finally, next to StopVoutWatchdog.</summary>
         private void StopBlurFrameWatchdogs()
         {
-            List<System.Threading.Timer> timers;
+            List<BlurSurfaceWatch> watches;
             lock (_blurFrameWatchLock)
             {
-                timers = _blurFrameWatchTimers.ToList();
-                _blurFrameWatchTimers.Clear();
+                watches = _blurWatches.ToList();
+                _blurWatches.Clear();
             }
-            foreach (var t in timers)
+            foreach (var t in watches.Select(w => w.Timer).Where(t => t != null))
             {
-                try { t.Dispose(); } catch { }
+                try { t!.Dispose(); } catch { }
             }
         }
 
@@ -3441,6 +3654,13 @@ namespace ConditioningControlPanel.Services
 
             /// <summary>True once at least one frame has been blitted to the surface.</summary>
             public bool HasRendered => _hasRendered;
+
+            /// <summary>Milliseconds from this surface being built to its FIRST blitted frame, or -1
+            /// when no frame ever arrived. The per-surface diagnostics line reports it so a report can
+            /// show "monitor 1 took 4200ms, monitor 2 never came up" instead of one clip-wide verdict.</summary>
+            public long FirstFrameMs => _firstFrameMs;
+            private readonly long _createdTick = Environment.TickCount64;
+            private long _firstFrameMs = -1;
 
             /// <summary>Tagged BLUR trace line for this surface. Enqueue-only, safe from the UI
             /// thread and from LibVLC's native callback threads alike.</summary>
@@ -3919,7 +4139,10 @@ namespace ConditioningControlPanel.Services
                     if (blitMs >= 250)
                         Diag($"UI-thread frame blit took {blitMs}ms (WriteableBitmap.Lock contended with the render thread)");
                     if (!_hasRendered)
-                        Diag($"first frame blitted ({w}x{h})");
+                    {
+                        _firstFrameMs = Environment.TickCount64 - _createdTick;
+                        Diag($"first frame blitted ({w}x{h}) after {_firstFrameMs}ms");
+                    }
                     _hasRendered = true;
 
                     RefreshBackgroundSnapshot(staging, w, h);
@@ -6525,6 +6748,12 @@ namespace ConditioningControlPanel.Services
                 {
                     _isCleaningUp = false;
                 }
+
+                // A leased player's wedge may have asked to retire the shared instance WHILE this
+                // video's per-monitor players were still decoding on it; that retire was parked
+                // rather than executed (RetireSharedLibVLC / ShouldDeferRetire). The video is down
+                // now, so it is safe to carry out.
+                FlushDeferredRetire();
 
                 // Total UI-thread block for this teardown. Anything past ~1s here is the app being
                 // unresponsive to the user (and to the low-level keyboard hook) — #616-#623.

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -3409,11 +3409,21 @@ namespace ConditioningControlPanel.Services
         /// whole-clip VERDICT: the first screen to miss its grace window called
         /// <c>EndCurrentVideo(noFrameRendered: true)</c>, killing the video on every OTHER monitor
         /// that was decoding perfectly ("black on one screen, and then it just skipped"). The ladder
-        /// is now per surface:
-        ///   1. no frame within the grace window ⇒ re-issue Play() on THIS monitor's player only,
-        ///      and give it one more full grace window;
-        ///   2. still nothing ⇒ this surface is dead. The clip ends ONLY when every surface is
-        ///      (VideoSurfaceHealth.ShouldAbortClip), otherwise the run continues on the live ones.
+        /// is now per surface, and it is deliberately ASYMMETRIC:
+        ///
+        ///   * a MIRROR (secondary) that misses its grace window gets one re-Play() on its own player
+        ///     and one more full grace window; if it still shows nothing it is marked dead and the
+        ///     clip carries on wherever it IS rendering. That is the actual regression fix.
+        ///   * the AUDIO-BEARING surface gets NO retry rung and ends the clip the moment it misses,
+        ///     exactly as the released build does. It is the only player wired to EndReached /
+        ///     EncounteredError / LengthChanged, and the blurred path never arms StartVoutWatchdog, so
+        ///     if a live mirror were allowed to carry a dead primary the run's only remaining end
+        ///     condition would be the 10-minute fallback safety timer — the reported black-and-silent
+        ///     main screen would last minutes instead of 8s, un-closable in strict mode. On a
+        ///     single-monitor rig (the majority) the primary is the only surface, so this also keeps
+        ///     that path's timing exactly where it is today.
+        ///
+        /// See VideoSurfaceHealth.DecideFrameWatchdog / ShouldAbortClip for both rules in pure form.
         /// </summary>
         private void StartBlurFrameWatchdog(BlurVmemSurface surface, string surfaceTag, bool primary, string monitor)
         {
@@ -3430,7 +3440,9 @@ namespace ConditioningControlPanel.Services
                 try
                 {
                     bool tornDown = !_videoPlaying || _isCleaningUp || gen != _teardownGeneration;
-                    switch (VideoSurfaceHealth.DecideFrameWatchdog(tornDown, _gracePaused, surface.HasRendered, watch.RetryUsed))
+                    // retryAllowed: !primary — the audio-bearing surface is condemned on its first
+                    // missed window (see the ladder note above); only mirrors get a second chance.
+                    switch (VideoSurfaceHealth.DecideFrameWatchdog(tornDown, _gracePaused, surface.HasRendered, watch.RetryUsed, retryAllowed: !primary))
                     {
                         case VideoSurfaceHealth.FrameWatchdogAction.Ignore:
                             if (!tornDown && surface.HasRendered && !watch.Reported)
@@ -3454,7 +3466,7 @@ namespace ConditioningControlPanel.Services
                             App.Logger?.Warning("VideoService: blurred-background video produced no frame within {Ms}ms on {Surface} - retrying THAT surface only, the other screens keep playing",
                                 VoutGraceMs, surfaceTag);
                             VideoDiag.Log("BLUR", $"[{surfaceTag}] NO FRAME within {VoutGraceMs}ms - per-surface retry, clip untouched");
-                            RetryBlurSurface(watch);
+                            RetryBlurSurface(watch, gen);
                             try { watch.Timer?.Change(VoutGraceMs, System.Threading.Timeout.Infinite); } catch { }
                             return;
 
@@ -3462,23 +3474,44 @@ namespace ConditioningControlPanel.Services
                             watch.Dead = true;
                             watch.Reported = true;
                             int total, dead;
+                            bool primaryDead;
                             lock (_blurFrameWatchLock)
                             {
                                 total = _blurWatches.Count;
                                 dead = _blurWatches.Count(w => w.Dead);
+                                // `primary ||` guards the case of this watch not being in the list
+                                // yet: the verdict must never come out softer than "the surface I am
+                                // judging right this second is the audio-bearing one".
+                                primaryDead = primary || _blurWatches.Any(w => w.Primary && w.Dead);
                             }
                             VideoSurfaceHealth.Report("libvlc", monitor, primary, -1,
-                                $"no frame within {VoutGraceMs}ms, and none after one retry");
-                            if (!VideoSurfaceHealth.ShouldAbortClip(total, dead))
+                                primary
+                                    ? $"no frame within {VoutGraceMs}ms on the audio-bearing surface"
+                                    : $"no frame within {VoutGraceMs}ms, and none after one retry");
+                            if (!VideoSurfaceHealth.ShouldAbortClip(total, dead, primaryDead))
                             {
                                 App.Logger?.Warning("VideoService: giving up on the blurred surface {Surface} ({Dead}/{Total} dead) - the clip keeps playing on the live screen(s)",
                                     surfaceTag, dead, total);
                                 VideoDiag.Log("BLUR", $"[{surfaceTag}] surface DEAD ({dead}/{total}) - clip continues on the rest");
                                 return;
                             }
-                            App.Logger?.Warning("VideoService: every blurred surface ({Total}) produced no frame - skipping to next",
-                                total);
-                            VideoDiag.Log("BLUR", $"[{surfaceTag}] LAST surface dead ({dead}/{total}) - black-screen state confirmed, skipping to next video");
+                            if (primaryDead && dead < total)
+                            {
+                                // A live mirror cannot carry this clip: the audio is on the dead
+                                // surface and so are the ONLY EndReached/EncounteredError handlers.
+                                // Skipping now is what the released build does; letting the mirrors
+                                // run on would strand the user on a black, silent main screen until
+                                // the 10-minute fallback timer, unable to close it in strict mode.
+                                App.Logger?.Warning("VideoService: the audio-bearing blurred surface {Surface} produced no frame - skipping to next even though {Live} mirror screen(s) still render (black and silent is not a playable clip)",
+                                    surfaceTag, total - dead);
+                                VideoDiag.Log("BLUR", $"[{surfaceTag}] PRIMARY surface dead ({dead}/{total}) - no audio and no end events left on this clip, skipping to next video");
+                            }
+                            else
+                            {
+                                App.Logger?.Warning("VideoService: every blurred surface ({Total}) produced no frame - skipping to next",
+                                    total);
+                                VideoDiag.Log("BLUR", $"[{surfaceTag}] LAST surface dead ({dead}/{total}) - black-screen state confirmed, skipping to next video");
+                            }
 
                             var dispatcher = Application.Current?.Dispatcher;
                             if (dispatcher == null || dispatcher.HasShutdownStarted) return;
@@ -3501,25 +3534,51 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// One monitor's decoder gets a second chance, WITHOUT touching its siblings. Re-issuing
+        /// One MIRROR's decoder gets a second chance, WITHOUT touching its siblings (the audio-bearing
+        /// surface never reaches here — see the ladder note on StartBlurFrameWatchdog). Re-issuing
         /// Play() only helps when the player has actually fallen out of playback (Error/Stopped/Ended);
         /// a player still in Opening/Buffering is simply slow, and poking native state under it is the
         /// exact class of move that wedges LibVLC — so that case just spends the extra grace window
         /// the caller has already armed. Off the timer thread: a native call must never be able to
         /// hold up the other surfaces' watchdogs.
+        ///
+        /// <paramref name="gen"/> is the teardown generation the watchdog tick was judged against, and
+        /// it is re-checked INSIDE the task on purpose. The tick's own tornDown test runs before this
+        /// task is even queued, so without the re-check a CloseAll starting in that gap could let
+        /// Play() land on a player that is being stopped and disposed while its vmem frame buffer is
+        /// being freed — the native AV this file documents at ReleaseBufferAfter ("freeing the buffer
+        /// and nulling the plane pointer under a live decoder"), which no try/catch can catch.
         /// </summary>
-        private void RetryBlurSurface(BlurSurfaceWatch watch)
+        private void RetryBlurSurface(BlurSurfaceWatch watch, int gen)
         {
-            var player = watch.Surface.Player;
-            if (player == null)
-            {
-                VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - no player attached to this surface");
-                return;
-            }
             Task.Run(() =>
             {
                 try
                 {
+                    if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration)
+                    {
+                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry cancelled - teardown started between the watchdog tick and this callback");
+                        return;
+                    }
+
+                    // Read inside the guard, not captured on the timer thread, so the null check
+                    // and the native call below sit on the same side of the teardown re-check.
+                    var player = watch.Surface.Player;
+                    if (player == null)
+                    {
+                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - no player attached to this surface");
+                        return;
+                    }
+                    // CloseAll copies and CLEARS _mediaPlayers before it stops or disposes anything, so
+                    // "still in that list" is the tightest ownership proof available from off-thread.
+                    bool stillOurs;
+                    lock (_mediaPlayersLock) { stillOurs = _mediaPlayers.Contains(player); }
+                    if (!stillOurs)
+                    {
+                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - this surface's player is no longer owned by the current playback");
+                        return;
+                    }
+
                     var state = player.State;
                     if (state is VLCState.Error or VLCState.Stopped or VLCState.Ended or VLCState.NothingSpecial)
                     {

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -182,7 +182,10 @@ namespace ConditioningControlPanel.Services
         private double _creditedWatchSeconds;
 
         private bool _isRunning;
-        private bool _videoPlaying;
+        // volatile: written on the UI thread, and RetireSharedLibVLC now reads it from a threadpool
+        // thread to decide whether a FOREIGN wedge's retire must be parked. A stale read there parks a
+        // retire that nothing is left to flush.
+        private volatile bool _videoPlaying;
         // True only once a real player/window exists on screen. _videoPlaying goes true ~2.6s
         // EARLIER — at the top of PlayVideo, before the Discord/flash/duck prologue and the 1.3s
         // announce delay — so it cannot be used to answer "is playback actually live?". The wedge
@@ -318,8 +321,9 @@ namespace ConditioningControlPanel.Services
         // whose Stop() wedged) while the mandatory video is still on screen. Parked here instead of
         // executed, because retiring the shared instance mid-clip blacks out the OTHER monitors that
         // are decoding on it. Flushed once the video is fully down.
-        private static LibVLC? _deferredRetireSuspect;
-        private static string _deferredRetireReason = "";
+        // A LIST, not one slot: two foreign wedges in one clip are rare but a single slot silently
+        // overwrote the first suspect, dropping that retire entirely.
+        private static readonly List<(LibVLC Suspect, string Reason)> _deferredRetires = new();
         private static readonly object _deferredRetireLock = new();
         private readonly List<LibVLCSharp.Shared.MediaPlayer> _mediaPlayers = new();
         private readonly object _mediaPlayersLock = new();  // Thread-safe access to _mediaPlayers
@@ -345,13 +349,26 @@ namespace ConditioningControlPanel.Services
             public required string Monitor { get; init; }
             /// <summary>The audio-bearing screen.</summary>
             public required bool Primary { get; init; }
+            /// <summary>The fullscreen window this surface renders into. Needed because a surface that
+            /// gives up while the clip carries on elsewhere would otherwise leave an OPAQUE BLACK
+            /// topmost window parked over that monitor for the whole clip - the browser engine already
+            /// frees its dead mirrors' screens (DropSecondaryWindow), and the two engines must not
+            /// disagree about what a dead mirror looks like. Null only if the window could not be
+            /// captured.</summary>
+            public Window? Window { get; init; }
             public System.Threading.Timer? Timer;
             /// <summary>This surface has already had its one re-Play.</summary>
             public volatile bool RetryUsed;
             /// <summary>This surface produced no frame even after its retry.</summary>
             public volatile bool Dead;
-            /// <summary>Its diagnostics line has been written (once per surface per clip).</summary>
-            public volatile bool Reported;
+            /// <summary>Its diagnostics line has been written (once per surface per clip). 0/1 rather
+            /// than a bool: the healthy line is written from the UI thread's first frame blit and the
+            /// failure line from the watchdog's threadpool timer, so the claim has to be atomic.</summary>
+            public int ReportedFlag;
+            /// <summary>True once this surface's one diagnostics line exists.</summary>
+            public bool Reported => System.Threading.Volatile.Read(ref ReportedFlag) != 0;
+            /// <summary>Claim the right to write this surface's line. Only one caller ever wins.</summary>
+            public bool ClaimReport() => System.Threading.Interlocked.Exchange(ref ReportedFlag, 1) == 0;
         }
 
         // One frame-liveness watchdog per live blur surface (see StartBlurFrameWatchdog). Threadpool
@@ -893,16 +910,25 @@ namespace ConditioningControlPanel.Services
 
             // Siblings on the other monitors are mid-clip on this very instance - hold the retire
             // until the video is down rather than pulling the shared instance out from under them.
-            if (VideoSurfaceHealth.ShouldDeferRetire(fromCurrentPlayback, _videoPlaying || HasOpenWindows))
+            if (VideoSurfaceHealth.ShouldDeferRetire(fromCurrentPlayback, PlaybackLiveForRetire))
             {
                 lock (_deferredRetireLock)
                 {
-                    _deferredRetireSuspect = suspect;
-                    _deferredRetireReason = reason;
+                    _deferredRetires.Add((suspect, reason));
                 }
                 App.Logger?.Warning("VideoService: retire DEFERRED ({Reason}) - a mandatory video is still decoding on this instance; it will be retired at teardown",
                     reason);
                 VideoDiag.Log("RETIRE", $"deferred ({reason}) - sibling video window(s) are still playing on this instance");
+                // Park-then-recheck. This runs on a threadpool thread while the UI thread may be
+                // finishing the very teardown that flushes parked retires (CloseAll's finally), so a
+                // park landing just after that flush would sit here until the NEXT mandatory video's
+                // teardown - which may never come. Re-test now that it is parked: if playback is
+                // already down, carry it out ourselves.
+                if (!PlaybackLiveForRetire)
+                {
+                    VideoDiag.Log("RETIRE", "parked retire flushed inline - playback went down while it was being parked");
+                    FlushDeferredRetire();
+                }
                 return false;
             }
 
@@ -961,34 +987,55 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Execute a retire that <see cref="RetireSharedLibVLC"/> parked because a mandatory video was
-        /// still decoding on the suspect instance. Called from the teardown funnel (CloseAll's finally),
-        /// i.e. once no sibling can be hurt by it. Never throws.
+        /// Execute every retire that <see cref="RetireSharedLibVLC"/> parked because a mandatory video
+        /// was still decoding on the suspect instance. Two call sites, both meaning "no sibling can be
+        /// hurt by this any more": the teardown funnel (CloseAll's finally), and the park site itself
+        /// when its re-check finds playback already down (a park that lands just after the funnel's
+        /// flush would otherwise wait for a NEXT mandatory video that may never be scheduled).
+        /// Drains under the lock, so two concurrent flushes cannot retire the same suspect twice.
+        /// Never throws.
         ///
         /// If the suspect is no longer the shared instance by now (something else retired it in the
         /// meantime) the inner ReferenceEquals guard declines it, which is the correct outcome.
         /// </summary>
         private void FlushDeferredRetire()
         {
-            LibVLC? suspect;
-            string reason;
+            List<(LibVLC Suspect, string Reason)> parked;
             lock (_deferredRetireLock)
             {
-                suspect = _deferredRetireSuspect;
-                reason = _deferredRetireReason;
-                _deferredRetireSuspect = null;
-                _deferredRetireReason = "";
+                if (_deferredRetires.Count == 0) return;
+                parked = _deferredRetires.ToList();
+                _deferredRetires.Clear();
             }
-            if (suspect == null) return;
 
-            try
+            foreach (var (suspect, reason) in parked)
             {
-                VideoDiag.Log("RETIRE", $"flushing deferred retire at teardown ({reason})");
-                RetireSharedLibVLC(suspect, reason + " (deferred to teardown)");
+                if (suspect == null) continue;
+                try
+                {
+                    VideoDiag.Log("RETIRE", $"flushing deferred retire at teardown ({reason})");
+                    RetireSharedLibVLC(suspect, reason + " (deferred to teardown)");
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("VideoService: FlushDeferredRetire failed: {E}", ex.Message);
+                }
             }
-            catch (Exception ex)
+        }
+
+        /// <summary>
+        /// "Is a mandatory clip still live on the shared instance?", asked from a THREADPOOL thread by
+        /// the foreign-wedge retire path. <see cref="HasOpenWindows"/> is not usable there: it reads a
+        /// List&lt;Window&gt; the UI thread owns and mutates with no lock at all. The HWND cache is the
+        /// same population (both engines register through PreventClickRaise, CloseAll clears it) and it
+        /// is guarded, so it answers the same question without an unsynchronised cross-thread read.
+        /// </summary>
+        private bool PlaybackLiveForRetire
+        {
+            get
             {
-                App.Logger?.Debug("VideoService: FlushDeferredRetire failed: {E}", ex.Message);
+                if (_videoPlaying) return true;   // volatile
+                lock (_videoWindowHandlesLock) { return _videoWindowHandles.Count > 0; }
             }
         }
 
@@ -3227,7 +3274,7 @@ namespace ConditioningControlPanel.Services
             // a healthy secondary could not rescue a stalled primary (#767). The vout watchdog stays
             // primary-only — its heal retires and replays the whole video.
             if (useBlur)
-                StartBlurFrameWatchdog(blurSurface!, $"{tag} {screen.DeviceName}", withAudio, screen.DeviceName);
+                StartBlurFrameWatchdog(blurSurface!, $"{tag} {screen.DeviceName}", withAudio, screen.DeviceName, win);
             else if (withAudio)
                 StartVoutWatchdog(mediaPlayer, path, strict);
 
@@ -3430,7 +3477,7 @@ namespace ConditioningControlPanel.Services
         ///
         /// See VideoSurfaceHealth.DecideFrameWatchdog / ShouldAbortClip for both rules in pure form.
         /// </summary>
-        private void StartBlurFrameWatchdog(BlurVmemSurface surface, string surfaceTag, bool primary, string monitor)
+        private void StartBlurFrameWatchdog(BlurVmemSurface surface, string surfaceTag, bool primary, string monitor, Window? window)
         {
             var gen = _teardownGeneration;
             // This used to be a DispatcherTimer, and its own comment admitted the flaw: the blurred
@@ -3439,7 +3486,24 @@ namespace ConditioningControlPanel.Services
             // threadpool timer like StartVoutWatchdog, so the verdict lands in the trace even during
             // a freeze; only the teardown it decides on is marshalled back to the dispatcher.
             VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog armed (threadpool timer, {VoutGraceMs}ms)");
-            var watch = new BlurSurfaceWatch { Surface = surface, Tag = surfaceTag, Monitor = monitor, Primary = primary };
+            var watch = new BlurSurfaceWatch { Surface = surface, Tag = surfaceTag, Monitor = monitor, Primary = primary, Window = window };
+
+            // The headline diagnostic must not depend on the watchdog living long enough to tick. A
+            // short clip, an attention-check retry, a panic or any other teardown inside the 8s grace
+            // disposes this timer, and until now that meant a HEALTHY surface wrote no line at all -
+            // video-diag.log for those runs was exactly as uninformative as before. Report the moment
+            // the surface actually renders instead; the Ignore arm below is now only the fallback for
+            // a surface whose first frame predates this hookup.
+            surface.FirstFrameObserved = ms =>
+            {
+                try
+                {
+                    if (watch.ClaimReport())
+                        VideoSurfaceHealth.Report("libvlc", monitor, primary, ms, null);
+                }
+                catch (Exception ex) { App.Logger?.Debug("VideoService: first-frame surface report failed: {E}", ex.Message); }
+            };
+
             var timer = new System.Threading.Timer(_ =>
             {
                 try
@@ -3456,9 +3520,8 @@ namespace ConditioningControlPanel.Services
                                 retryAllowed: VideoSurfaceHealth.AllowsFrameRetry(primary, armed)))
                     {
                         case VideoSurfaceHealth.FrameWatchdogAction.Ignore:
-                            if (!tornDown && surface.HasRendered && !watch.Reported)
+                            if (!tornDown && surface.HasRendered && watch.ClaimReport())
                             {
-                                watch.Reported = true;
                                 VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog: frames are arriving, all good");
                                 VideoSurfaceHealth.Report("libvlc", monitor, primary, surface.FirstFrameMs, null);
                             }
@@ -3483,7 +3546,7 @@ namespace ConditioningControlPanel.Services
 
                         case VideoSurfaceHealth.FrameWatchdogAction.GiveUp:
                             watch.Dead = true;
-                            watch.Reported = true;
+                            watch.ClaimReport();   // the failure line below IS this surface's one line
                             int total, dead;
                             bool primaryDead;
                             lock (_blurFrameWatchLock)
@@ -3504,6 +3567,14 @@ namespace ConditioningControlPanel.Services
                                 App.Logger?.Warning("VideoService: giving up on the blurred surface {Surface} ({Dead}/{Total} dead) - the clip keeps playing on the live screen(s)",
                                     surfaceTag, dead, total);
                                 VideoDiag.Log("BLUR", $"[{surfaceTag}] surface DEAD ({dead}/{total}) - clip continues on the rest");
+                                // The clip carries on, so this screen's window is NOT about to be torn
+                                // down: without this it stays an opaque black fullscreen topmost window
+                                // over that monitor for the WHOLE clip (before this branch the abort
+                                // bounded it to ~8s). Same rule the browser engine's DropSecondaryWindow
+                                // uses, so both engines leave the same visible state - and the same
+                                // strict exception, because uncovering a screen mid-clip would hand a
+                                // Lock Card / Lockdown / Possession user their desktop back.
+                                ReleaseDeadBlurSurfaceScreen(watch, gen);
                                 return;
                             }
                             if (primaryDead && dead < total)
@@ -3559,7 +3630,9 @@ namespace ConditioningControlPanel.Services
         /// task is even queued, so without the re-check a CloseAll starting in that gap could let
         /// Play() land on a player that is being stopped and disposed while its vmem frame buffer is
         /// being freed — the native AV this file documents at ReleaseBufferAfter ("freeing the buffer
-        /// and nulling the plane pointer under a live decoder"), which no try/catch can catch.
+        /// and nulling the plane pointer under a live decoder"), which no try/catch can catch. The
+        /// re-check NARROWS that window; what CLOSES it is holding _mediaPlayersLock across the
+        /// ownership proof AND the native calls, so a CloseAll cannot clear-and-dispose between them.
         /// </summary>
         private void RetryBlurSurface(BlurSurfaceWatch watch, int gen)
         {
@@ -3581,29 +3654,118 @@ namespace ConditioningControlPanel.Services
                         VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - no player attached to this surface");
                         return;
                     }
-                    // CloseAll copies and CLEARS _mediaPlayers before it stops or disposes anything, so
-                    // "still in that list" is the tightest ownership proof available from off-thread.
-                    bool stillOurs;
-                    lock (_mediaPlayersLock) { stillOurs = _mediaPlayers.Contains(player); }
-                    if (!stillOurs)
-                    {
-                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - this surface's player is no longer owned by the current playback");
-                        return;
-                    }
 
-                    var state = player.State;
-                    if (state is VLCState.Error or VLCState.Stopped or VLCState.Ended or VLCState.NothingSpecial)
+                    // The ownership proof and the native calls are ONE critical section, not two.
+                    // CloseAll sets _isCleaningUp, then takes this same lock to copy-and-CLEAR
+                    // _mediaPlayers, and only then stops and disposes the players - so holding it
+                    // across State/Play() means a teardown can no longer start in the gap between
+                    // "this player is still ours" and the call itself. Whoever gets here first wins:
+                    // either the retry finishes its Play() while CloseAll waits out one native call,
+                    // or CloseAll gets in first and the checks below decline the retry. Anything
+                    // looser leaves Play() able to land on a player mid-dispose while its vmem frame
+                    // buffer is being freed, which is the uncatchable native AV this file documents
+                    // at ReleaseBufferAfter.
+                    lock (_mediaPlayersLock)
                     {
-                        player.Play();
-                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry: player was {state} - Play() re-issued on this surface only");
-                    }
-                    else
-                    {
-                        VideoDiag.Log("BLUR", $"[{watch.Tag}] retry: player is {state} (still coming up) - extending the grace window instead of poking native state");
+                        if (_isCleaningUp || gen != _teardownGeneration || !_videoPlaying)
+                        {
+                            VideoDiag.Log("BLUR", $"[{watch.Tag}] retry cancelled - teardown began before the retry could take the player lock");
+                            return;
+                        }
+                        // CloseAll copies and CLEARS _mediaPlayers before it stops or disposes anything,
+                        // so "still in that list" is the tightest ownership proof available off-thread.
+                        if (!_mediaPlayers.Contains(player))
+                        {
+                            VideoDiag.Log("BLUR", $"[{watch.Tag}] retry skipped - this surface's player is no longer owned by the current playback");
+                            return;
+                        }
+
+                        var state = player.State;
+                        if (state is VLCState.Error or VLCState.Stopped or VLCState.Ended or VLCState.NothingSpecial)
+                        {
+                            player.Play();
+                            VideoDiag.Log("BLUR", $"[{watch.Tag}] retry: player was {state} - Play() re-issued on this surface only");
+                        }
+                        else
+                        {
+                            VideoDiag.Log("BLUR", $"[{watch.Tag}] retry: player is {state} (still coming up) - extending the grace window instead of poking native state");
+                        }
                     }
                 }
                 catch (Exception ex) { App.Logger?.Debug("VideoService: blur surface retry failed - {Error}", ex.Message); }
             });
+        }
+
+        /// <summary>
+        /// A blurred surface gave up while the clip CARRIES ON elsewhere - free that monitor.
+        ///
+        /// The per-screen blur window is a fullscreen, Topmost, OPAQUE BLACK window (its Grid's
+        /// Background is Brushes.Black and the vmem composite that should cover it never rendered).
+        /// Before the per-surface ladder existed, a dead surface aborted the clip, so that black
+        /// rectangle was bounded to the ~8s grace window. Now the clip keeps playing, so leaving it up
+        /// would convert a short black flash into a dead black screen for the WHOLE clip - and under a
+        /// strict lock the Closing veto makes it un-closable as well. The browser engine already fixed
+        /// exactly this on its side (DropSecondaryWindow); this is the same treatment for the LibVLC
+        /// path so the two engines cannot disagree about what a dead mirror looks like.
+        ///
+        /// Hide(), never Close(): Hide is not vetoable, the window is still owned by the run and
+        /// CloseAll is still the only thing that tears it down, and the player is deliberately left
+        /// alone - a fresh Stop() from here is precisely the move that wedges LibVLC, and teardown's
+        /// existing wedge/quarantine machinery already knows how to handle this player.
+        ///
+        /// STRICT (Lock Card / Lockdown / Possession) is the one exception: every screen is covered on
+        /// purpose there, so the dead screen stays black rather than becoming an uncovered, fully
+        /// interactive desktop mid-video (VideoSurfaceHealth.ShouldUncoverDeadSurface).
+        /// </summary>
+        private void ReleaseDeadBlurSurfaceScreen(BlurSurfaceWatch watch, int gen)
+        {
+            var win = watch.Window;
+            if (win == null) return;
+
+            // Cheap early-out only. This runs on the watchdog's THREADPOOL thread and IsStrictActive
+            // reads _strictActive/_strictRetryPending, which are written on the UI thread without a
+            // barrier, so a stale read is possible in BOTH directions here. That is safe because it
+            // can only skip or schedule work: the binding decision is re-asked on the UI thread
+            // below, where those fields are authoritative, and nothing is uncovered before then.
+            if (!VideoSurfaceHealth.ShouldUncoverDeadSurface(IsStrictActive))
+            {
+                App.Logger?.Warning("VideoService: the dead blurred surface {Surface} stays on screen (black) - the clip is under a STRICT lock and every monitor must remain covered",
+                    watch.Tag);
+                VideoDiag.Log("BLUR", $"[{watch.Tag}] dead surface KEPT on screen - strict lock, the monitor stays covered");
+                return;
+            }
+
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+            dispatcher.BeginInvoke(new Action(() =>
+            {
+                try
+                {
+                    // Late callback: a teardown that started in the meantime owns these windows now.
+                    if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration) return;
+                    // THE binding strict check, on the thread that owns those flags: strict can be
+                    // entered or left between the verdict and here, and only this read is trustworthy.
+                    if (!VideoSurfaceHealth.ShouldUncoverDeadSurface(IsStrictActive)) return;
+                    if (!win.IsVisible) return;
+
+                    // Out of the z-order anchor set first: an overlay on this monitor must stop being
+                    // pinned below a window that is no longer covering anything (#1016's rule only
+                    // makes sense while the video window is actually on screen).
+                    try
+                    {
+                        var hwnd = new WindowInteropHelper(win).Handle;
+                        if (hwnd != IntPtr.Zero)
+                            lock (_videoWindowHandlesLock) { _videoWindowHandles.Remove(hwnd); }
+                    }
+                    catch { }
+
+                    win.Hide();
+                    App.Logger?.Warning("VideoService: the dead blurred surface {Surface} was hidden - that monitor is free instead of holding a black fullscreen window for the rest of the clip",
+                        watch.Tag);
+                    VideoDiag.Log("BLUR", $"[{watch.Tag}] dead surface HIDDEN - monitor released, clip continues on the live screen(s)");
+                }
+                catch (Exception ex) { App.Logger?.Debug("VideoService: releasing a dead blur surface's screen failed: {E}", ex.Message); }
+            }));
         }
 
         /// <summary>Disarm every blur frame watchdog armed for the current playback. Called from the
@@ -3732,6 +3894,14 @@ namespace ConditioningControlPanel.Services
             public long FirstFrameMs => _firstFrameMs;
             private readonly long _createdTick = Environment.TickCount64;
             private long _firstFrameMs = -1;
+
+            /// <summary>Raised (UI thread) with <see cref="FirstFrameMs"/> the instant this surface
+            /// blits its FIRST frame. The per-surface diagnostics line hangs off this rather than off
+            /// the frame watchdog's single tick: a clip that ends inside the grace window - a short
+            /// video, an attention-check retry, a panic - disposes that timer, and a healthy surface
+            /// then wrote no line at all, which is the state video-diag.log was in before this work.
+            /// Set once, by StartBlurFrameWatchdog, before any frame can arrive (same UI thread).</summary>
+            public Action<long>? FirstFrameObserved { get; set; }
 
             /// <summary>Tagged BLUR trace line for this surface. Enqueue-only, safe from the UI
             /// thread and from LibVLC's native callback threads alike.</summary>
@@ -4213,6 +4383,11 @@ namespace ConditioningControlPanel.Services
                     {
                         _firstFrameMs = Environment.TickCount64 - _createdTick;
                         Diag($"first frame blitted ({w}x{h}) after {_firstFrameMs}ms");
+                        // One Information line per surface, written the moment the surface proves it
+                        // is alive - not 8s later when the watchdog ticks, which a short clip or an
+                        // early teardown never reaches. Never allowed to break the blit.
+                        try { FirstFrameObserved?.Invoke(_firstFrameMs); }
+                        catch (Exception rex) { App.Logger?.Debug("BlurVmemSurface: first-frame report threw: {E}", rex.Message); }
                     }
                     _hasRendered = true;
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -3414,14 +3414,19 @@ namespace ConditioningControlPanel.Services
         ///   * a MIRROR (secondary) that misses its grace window gets one re-Play() on its own player
         ///     and one more full grace window; if it still shows nothing it is marked dead and the
         ///     clip carries on wherever it IS rendering. That is the actual regression fix.
-        ///   * the AUDIO-BEARING surface gets NO retry rung and ends the clip the moment it misses,
-        ///     exactly as the released build does. It is the only player wired to EndReached /
+        ///   * the AUDIO-BEARING surface gets that same single re-Play() — but only on a MULTI-surface
+        ///     rig. That arm IS the headline report: a primary that missed its window on a dual-monitor
+        ///     rig used to skip the clip on the spot with no recovery rung of any kind, which is the
+        ///     "primary black, secondaries fine, and then it just skipped" trace verbatim. It still
+        ///     ends the clip when the retry fails — it is the only player wired to EndReached /
         ///     EncounteredError / LengthChanged, and the blurred path never arms StartVoutWatchdog, so
-        ///     if a live mirror were allowed to carry a dead primary the run's only remaining end
-        ///     condition would be the 10-minute fallback safety timer — the reported black-and-silent
-        ///     main screen would last minutes instead of 8s, un-closable in strict mode. On a
-        ///     single-monitor rig (the majority) the primary is the only surface, so this also keeps
-        ///     that path's timing exactly where it is today.
+        ///     a clip carried by mirrors alone would have no end condition short of the 10-minute
+        ///     fallback safety timer (black and silent for minutes, un-closable in strict mode). The
+        ///     retry only moves that skip from ~8s to ~16s, and buys back the runs where the decoder
+        ///     was merely slow to come up while three screens spun up at once.
+        ///   * on a SINGLE-surface rig (the majority) the primary is the only surface and gets NO retry
+        ///     rung at all, so that path skips at exactly the ~8s the released build does. The rung is
+        ///     decided by the RIG, not by the role: a lone primary has no siblings to be starved by.
         ///
         /// See VideoSurfaceHealth.DecideFrameWatchdog / ShouldAbortClip for both rules in pure form.
         /// </summary>
@@ -3440,9 +3445,15 @@ namespace ConditioningControlPanel.Services
                 try
                 {
                     bool tornDown = !_videoPlaying || _isCleaningUp || gen != _teardownGeneration;
-                    // retryAllowed: !primary — the audio-bearing surface is condemned on its first
-                    // missed window (see the ladder note above); only mirrors get a second chance.
-                    switch (VideoSurfaceHealth.DecideFrameWatchdog(tornDown, _gracePaused, surface.HasRendered, watch.RetryUsed, retryAllowed: !primary))
+                    // How many surfaces this clip armed. The retry rung is decided by the RIG, not by
+                    // the role (see the ladder note above): a mirror always gets its second chance, and
+                    // so does the audio-bearing surface as soon as it has siblings. A lone primary —
+                    // the single-monitor majority — gets none, which keeps that path's ~8s skip exactly
+                    // where the released build has it.
+                    int armed;
+                    lock (_blurFrameWatchLock) { armed = _blurWatches.Count; }
+                    switch (VideoSurfaceHealth.DecideFrameWatchdog(tornDown, _gracePaused, surface.HasRendered, watch.RetryUsed,
+                                retryAllowed: VideoSurfaceHealth.AllowsFrameRetry(primary, armed)))
                     {
                         case VideoSurfaceHealth.FrameWatchdogAction.Ignore:
                             if (!tornDown && surface.HasRendered && !watch.Reported)
@@ -3485,9 +3496,9 @@ namespace ConditioningControlPanel.Services
                                 primaryDead = primary || _blurWatches.Any(w => w.Primary && w.Dead);
                             }
                             VideoSurfaceHealth.Report("libvlc", monitor, primary, -1,
-                                primary
-                                    ? $"no frame within {VoutGraceMs}ms on the audio-bearing surface"
-                                    : $"no frame within {VoutGraceMs}ms, and none after one retry");
+                                watch.RetryUsed
+                                    ? $"no frame within {VoutGraceMs}ms, and none after one retry"
+                                    : $"no frame within {VoutGraceMs}ms, no retry rung on a single-surface rig");
                             if (!VideoSurfaceHealth.ShouldAbortClip(total, dead, primaryDead))
                             {
                                 App.Logger?.Warning("VideoService: giving up on the blurred surface {Surface} ({Dead}/{Total} dead) - the clip keeps playing on the live screen(s)",
@@ -3534,8 +3545,9 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// One MIRROR's decoder gets a second chance, WITHOUT touching its siblings (the audio-bearing
-        /// surface never reaches here — see the ladder note on StartBlurFrameWatchdog). Re-issuing
+        /// ONE surface's decoder gets a second chance, WITHOUT touching its siblings — any mirror, and
+        /// the audio-bearing surface too once the rig has more than one surface (on a lone primary
+        /// nothing reaches here; see the ladder note on StartBlurFrameWatchdog). Re-issuing
         /// Play() only helps when the player has actually fallen out of playback (Error/Stopped/Ended);
         /// a player still in Opening/Buffering is simply slow, and poking native state under it is the
         /// exact class of move that wedges LibVLC — so that case just spends the extra grace window

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -34,8 +34,8 @@ namespace ConditioningControlPanel.Services
             /// <summary>First strike: give THIS surface another go before condemning anything.</summary>
             Retry,
             /// <summary>Last strike: this surface is dead. The caller then asks
-            /// <see cref="ShouldAbortClip"/> whether the clip can go on without it. The audio-bearing
-            /// surface reaches this on its FIRST missed window - see the retryAllowed parameter.</summary>
+            /// <see cref="ShouldAbortClip"/> whether the clip can go on without it. A surface with no
+            /// retry rung reaches this on its FIRST missed window - see the retryAllowed parameter.</summary>
             GiveUp,
         }
 
@@ -60,13 +60,21 @@ namespace ConditioningControlPanel.Services
         /// then does "no frame" become a strike.
         /// </summary>
         /// <param name="retryAllowed">
-        /// Whether this surface gets a SECOND grace window before it is condemned. False for the
-        /// audio-bearing surface, deliberately: a dead primary ends the clip either way (see
-        /// <see cref="ShouldAbortClip"/>), so granting it a retry would only double the time the user
-        /// spends staring at a black, silent main screen - 16s where the released build takes 8s, and
-        /// on the single-monitor majority rig the primary is the ONLY surface, so the retry rung would
-        /// be pure added latency there. Mirrors do get the retry: the clip keeps playing while they
-        /// take it, so it costs the user nothing.
+        /// Whether this surface gets a SECOND grace window before it is condemned. The caller decides
+        /// this from the RIG, not from the role:
+        ///
+        ///   * a MIRROR always gets it - the clip keeps playing while it takes its retry, so a second
+        ///     window costs the user nothing;
+        ///   * the AUDIO-BEARING surface gets it too as soon as MORE THAN ONE surface is armed. That
+        ///     arm is the headline multi-monitor report (#533 #1015 #1024 #1035 #1039): a primary that
+        ///     missed its window on a dual-monitor rig used to skip the clip outright with no recovery
+        ///     rung of any kind, so one re-Play() is the only thing standing between "the decoder
+        ///     hiccuped while three screens spun up" and "the video was skipped". A dead primary still
+        ///     ends the clip (see <see cref="ShouldAbortClip"/>) - it just ends it one grace window
+        ///     later, after the retry demonstrably failed;
+        ///   * it is withheld on a SINGLE-surface rig, which is the majority. There the primary is the
+        ///     only surface, nothing else can be spinning up alongside it, and the retry would be pure
+        ///     added latency - 16s of black where the released build takes 8s.
         /// </param>
         internal static FrameWatchdogAction DecideFrameWatchdog(bool tornDown, bool gracePaused, bool hasRendered, bool retryUsed, bool retryAllowed)
         {
@@ -75,6 +83,20 @@ namespace ConditioningControlPanel.Services
             if (hasRendered) return FrameWatchdogAction.Ignore;
             return (retryUsed || !retryAllowed) ? FrameWatchdogAction.GiveUp : FrameWatchdogAction.Retry;
         }
+
+        /// <summary>
+        /// Whether this surface may spend a retry rung, decided by the RIG rather than by the role -
+        /// the <c>retryAllowed</c> argument of <see cref="DecideFrameWatchdog"/> in one line.
+        ///
+        /// A mirror always may: the clip keeps playing while it retries, so a second grace window
+        /// costs the user nothing. The audio-bearing surface may too, as soon as it has siblings -
+        /// that is the multi-monitor headline report, where a primary that missed its window used to
+        /// skip the clip on the spot with no recovery rung at all. A LONE primary may not: it is the
+        /// only surface on the rig, a dead primary ends the clip either way, and the rung would be
+        /// nothing but 8 extra seconds of black for the single-monitor majority.
+        /// </summary>
+        internal static bool AllowsFrameRetry(bool primarySurface, int armedSurfaces)
+            => !primarySurface || armedSurfaces > 1;
 
         /// <summary>
         /// Whether a dead surface should take the whole clip with it. This is the #1015/#1035 fix in
@@ -104,6 +126,43 @@ namespace ConditioningControlPanel.Services
             if (!isPrimarySurface) return BrowserFailureAction.DropSecondary;
             if (alreadyFellBack) return BrowserFailureAction.Ignore;
             return playbackStartedFired ? BrowserFailureAction.EndClip : BrowserFailureAction.FallbackWholeClip;
+        }
+
+        /// <summary>What one tick of the browser engine's per-surface first-frame sweep should do
+        /// with ONE window.</summary>
+        internal enum BrowserFrameSweepAction
+        {
+            /// <summary>This surface already presented a frame - there is nothing left to watch.</summary>
+            Ignore,
+            /// <summary>Its own deadline has not passed yet.</summary>
+            Wait,
+            /// <summary>The audio-bearing surface never rendered: fail the session so the host's
+            /// LibVLC fallback replays the clip.</summary>
+            FailSession,
+            /// <summary>A mirror never rendered: report it and drop THAT window. The clip is
+            /// untouched and keeps playing wherever it is rendering.</summary>
+            DropMirror,
+        }
+
+        /// <summary>
+        /// One window's verdict in the browser engine's first-frame sweep. The browser engine is the
+        /// DEFAULT for mp4/webm and it drives EVERY screen, so this is the multi-monitor liveness net
+        /// for most rigs, not a corner case.
+        ///
+        /// Before this rule existed the engine watched the PRIMARY alone, and it stopped watching the
+        /// instant the primary posted `playing` - so a mirror whose WebView2 came up, completed the
+        /// handshake and then never decoded a frame (a GPU stall, a swallowed fetch, a decode failure
+        /// the page never turned into an `error`) was never noticed, never dropped and never even
+        /// logged. It stayed an opaque black fullscreen window for the whole clip, and video-diag.log
+        /// carried no line at all for that monitor - indistinguishable, in a bug report, from a window
+        /// that was never created or a truncated log. Every screen now carries its own deadline and
+        /// gets its own verdict.
+        /// </summary>
+        internal static BrowserFrameSweepAction DecideBrowserFrameSweep(bool firstFrameSeen, bool deadlinePassed, bool isPrimarySurface)
+        {
+            if (firstFrameSeen) return BrowserFrameSweepAction.Ignore;
+            if (!deadlinePassed) return BrowserFrameSweepAction.Wait;
+            return isPrimarySurface ? BrowserFrameSweepAction.FailSession : BrowserFrameSweepAction.DropMirror;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -17,8 +17,10 @@ namespace ConditioningControlPanel.Services
     ///   * one dead LibVLC memory-render surface aborted the clip on ALL screens, even when N-1
     ///     surfaces were decoding happily.
     ///
-    /// The rules below are what replaced that: per-surface verdicts, with the clip only ending when
-    /// every surface is dead.
+    /// The rules below are what replaced that: per-surface verdicts. A dead MIRROR no longer touches
+    /// the clip - it ends only when every surface is dead, or when the audio-bearing one is (a black
+    /// and silent primary is not a playable clip, and it is the only surface wired to the end/error
+    /// events that could otherwise stop the run).
     /// </summary>
     internal static class VideoSurfaceHealth
     {
@@ -31,8 +33,9 @@ namespace ConditioningControlPanel.Services
             Defer,
             /// <summary>First strike: give THIS surface another go before condemning anything.</summary>
             Retry,
-            /// <summary>Second strike: this surface is dead. The caller then asks
-            /// <see cref="ShouldAbortClip"/> whether any sibling is still alive.</summary>
+            /// <summary>Last strike: this surface is dead. The caller then asks
+            /// <see cref="ShouldAbortClip"/> whether the clip can go on without it. The audio-bearing
+            /// surface reaches this on its FIRST missed window - see the retryAllowed parameter.</summary>
             GiveUp,
         }
 
@@ -56,12 +59,21 @@ namespace ConditioningControlPanel.Services
         /// the liveness verdict (#735 - a paused vmem surface produces no frames BY DESIGN), and only
         /// then does "no frame" become a strike.
         /// </summary>
-        internal static FrameWatchdogAction DecideFrameWatchdog(bool tornDown, bool gracePaused, bool hasRendered, bool retryUsed)
+        /// <param name="retryAllowed">
+        /// Whether this surface gets a SECOND grace window before it is condemned. False for the
+        /// audio-bearing surface, deliberately: a dead primary ends the clip either way (see
+        /// <see cref="ShouldAbortClip"/>), so granting it a retry would only double the time the user
+        /// spends staring at a black, silent main screen - 16s where the released build takes 8s, and
+        /// on the single-monitor majority rig the primary is the ONLY surface, so the retry rung would
+        /// be pure added latency there. Mirrors do get the retry: the clip keeps playing while they
+        /// take it, so it costs the user nothing.
+        /// </param>
+        internal static FrameWatchdogAction DecideFrameWatchdog(bool tornDown, bool gracePaused, bool hasRendered, bool retryUsed, bool retryAllowed)
         {
             if (tornDown) return FrameWatchdogAction.Ignore;
             if (gracePaused) return FrameWatchdogAction.Defer;
             if (hasRendered) return FrameWatchdogAction.Ignore;
-            return retryUsed ? FrameWatchdogAction.GiveUp : FrameWatchdogAction.Retry;
+            return (retryUsed || !retryAllowed) ? FrameWatchdogAction.GiveUp : FrameWatchdogAction.Retry;
         }
 
         /// <summary>
@@ -69,9 +81,18 @@ namespace ConditioningControlPanel.Services
         /// one line: it used to be "any dead surface ends the clip", which is how a stalled decoder on
         /// monitor 2 blacked out a video that monitor 1 was playing perfectly.
         /// <paramref name="deadSurfaces"/> INCLUDES the surface that just gave up.
+        ///
+        /// <paramref name="primarySurfaceDead"/> is not a nicety, it is the whole safety net. Only the
+        /// AUDIO-BEARING surface is wired to EndReached / EncounteredError / LengthChanged, and the
+        /// blurred path (the default) never arms the vout watchdog either - so a primary that decoded
+        /// nothing raises NOTHING. If a live mirror were allowed to carry that clip, the only remaining
+        /// backstop would be the 10-minute fallback safety timer, i.e. the reported "primary black and
+        /// silent" would last minutes instead of the 8 seconds the released build takes. A dead primary
+        /// therefore always ends the clip; a dead MIRROR only does when every surface is gone, which is
+        /// the actual #1015/#1035 win.
         /// </summary>
-        internal static bool ShouldAbortClip(int totalSurfaces, int deadSurfaces)
-            => totalSurfaces > 0 && deadSurfaces >= totalSurfaces;
+        internal static bool ShouldAbortClip(int totalSurfaces, int deadSurfaces, bool primarySurfaceDead)
+            => primarySurfaceDead || (totalSurfaces > 0 && deadSurfaces >= totalSurfaces);
 
         /// <summary>
         /// Policy for a browser-engine surface failure. A secondary is a mirror and is never allowed
@@ -87,11 +108,18 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Whether a retire request that did NOT come from the currently playing clip must wait.
-        /// A leased player (bubble count, mini player, previews) whose Stop() wedged used to retire
-        /// the shared LibVLC instance immediately - the same instance the mandatory video's per-monitor
-        /// players were mid-decode on. That spends one of the four per-session retires, arms the 60s
-        /// poison cooldown and drops the metadata cache while the user is still watching, which is the
-        /// "and then there was no bubble-pop sound for the rest of the session" tail on these reports.
+        /// A leased player (bubble count, mini player, previews) whose Stop() wedged used to retire the
+        /// shared LibVLC instance immediately - the same instance the mandatory video's per-monitor
+        /// players were mid-decode on. That drops the metadata cache under a live clip and makes the
+        /// next EnsureLibVLCInitialized block the UI thread on the rebuild's lock, mid-video. Parking
+        /// it until teardown keeps a foreign wedge from reaching under the screens that are playing.
+        ///
+        /// SCOPE, stated precisely so nobody reads more into it: this does NOT suppress the 60s native
+        /// poison cooldown (QuarantineNative arms that before any retire decision is reached), it does
+        /// not save a retire from the per-session budget (the parked retire still runs at teardown),
+        /// and it does not touch the two retire sites inside the mandatory pipeline's own CloseAll,
+        /// which are that clip's self-heal and must stay immediate. The "no bubble-pop audio for the
+        /// rest of the session" tail on these reports is separate, still-open work.
         /// </summary>
         internal static bool ShouldDeferRetire(bool fromCurrentPlayback, bool playbackLive)
             => !fromCurrentPlayback && playbackLive;

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -166,6 +166,58 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Whether a browser surface's first-frame deadline has actually expired.
+        ///
+        /// <see cref="DateTime.MaxValue"/> means UNARMED, and that is load-bearing rather than a
+        /// convenience sentinel: the engine initialises its windows STRICTLY SERIALLY
+        /// (BrowserVideoEngine.InitWindowsAsync), so on a cold start a mirror's WebView2 has not begun
+        /// coming up at all while the primary's is still building. Arming every window's budget at
+        /// SESSION start therefore made the trailing mirrors burn their whole pre-ready budget while
+        /// QUEUED, and on a 2-4 monitor rig with a slow disk a window could reach its deadline before
+        /// its own init even started - condemning and closing a perfectly healthy secondary. A mirror
+        /// is now armed when ITS init starts; until then it is unarmed and can never be judged. (The
+        /// primary still arms at session start - see <see cref="ArmsFrameDeadlineAtSessionStart"/>.)
+        /// </summary>
+        internal static bool FrameDeadlinePassed(DateTime deadlineUtc, DateTime nowUtc)
+            => deadlineUtc != DateTime.MaxValue && nowUtc >= deadlineUtc;
+
+        /// <summary>
+        /// Which surfaces get their first-frame budget armed at SESSION start rather than when their
+        /// own init begins. Only the audio-bearing one, and it is a safety net rather than a nicety:
+        /// the primary is initialised FIRST, so it never queues behind anybody, and its session-start
+        /// deadline is the ONLY thing that ends a session whose WebView2 environment task never
+        /// completes at all - the serial init loop cannot arm anything in that case because it never
+        /// runs. Every MIRROR is armed when its own init starts instead, so the time it spent queued
+        /// behind the primary can never condemn it.
+        /// </summary>
+        internal static bool ArmsFrameDeadlineAtSessionStart(bool isPrimarySurface) => isPrimarySurface;
+
+        /// <summary>
+        /// Push a pending first-frame deadline out by one watch tick (the grace-pause slide). An
+        /// UNARMED deadline stays unarmed: sliding <see cref="DateTime.MaxValue"/> would throw
+        /// ArgumentOutOfRangeException and abandon the rest of that tick's sweep.
+        /// </summary>
+        internal static DateTime SlidePendingDeadline(DateTime deadlineUtc, int tickMs)
+            => deadlineUtc == DateTime.MaxValue ? deadlineUtc : deadlineUtc.AddMilliseconds(tickMs);
+
+        /// <summary>
+        /// Whether a dead surface's screen may be UNCOVERED (its window hidden), or has to stay covered
+        /// by that opaque black window for the rest of the clip.
+        ///
+        /// A mandatory video under a STRICT lock (Lock Card / Lockdown / Possession) covers every
+        /// screen and refuses Alt+F4 on purpose - that IS the commitment device. Freeing a dead
+        /// mirror's monitor there would hand the user a fully interactive desktop mid-clip, so under
+        /// strict a stalled mirror stays black: a dead screen is a far better outcome than an escape
+        /// hatch, and it is what the released build already did (a vetoed Close left the window up).
+        /// Outside strict mode nothing is being committed to, and parking a dead fullscreen topmost
+        /// window over someone's second monitor for the whole clip is pure harm - so it goes.
+        ///
+        /// Both engines ask this, so the WebView2 path and the LibVLC blur path leave the same visible
+        /// state for the same failure instead of disagreeing about it.
+        /// </summary>
+        internal static bool ShouldUncoverDeadSurface(bool hostStrict) => !hostStrict;
+
+        /// <summary>
         /// Whether a retire request that did NOT come from the currently playing clip must wait.
         /// A leased player (bubble count, mini player, previews) whose Stop() wedged used to retire the
         /// shared LibVLC instance immediately - the same instance the mandatory video's per-monitor

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Text;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// The multi-monitor half of the mandatory-video pipeline, extracted as pure decisions so it can
+    /// be unit-tested without a second monitor.
+    ///
+    /// Background (#533 #540 #542 #559 #592 #617 #918 #1015 #1016 #1024 #1025 #1035 #1039 #1059):
+    /// every one of those reports is the same shape - "the video is black on ONE monitor and fine on
+    /// the others, and there is no sound". The pipeline runs one surface per screen, and it used to
+    /// treat the whole clip as a single pass/fail:
+    ///
+    ///   * a browser surface whose WebView2 never came up raised nothing at all, so the audio-bearing
+    ///     PRIMARY could sit black for the full pre-ready budget while every secondary played;
+    ///   * one dead LibVLC memory-render surface aborted the clip on ALL screens, even when N-1
+    ///     surfaces were decoding happily.
+    ///
+    /// The rules below are what replaced that: per-surface verdicts, with the clip only ending when
+    /// every surface is dead.
+    /// </summary>
+    internal static class VideoSurfaceHealth
+    {
+        /// <summary>What one tick of a per-surface frame-liveness watchdog should do.</summary>
+        internal enum FrameWatchdogAction
+        {
+            /// <summary>Nothing to do: the surface rendered, or the clip is already torn down.</summary>
+            Ignore,
+            /// <summary>Playback is deliberately held (grace pause) - slide the deadline, judge nothing.</summary>
+            Defer,
+            /// <summary>First strike: give THIS surface another go before condemning anything.</summary>
+            Retry,
+            /// <summary>Second strike: this surface is dead. The caller then asks
+            /// <see cref="ShouldAbortClip"/> whether any sibling is still alive.</summary>
+            GiveUp,
+        }
+
+        /// <summary>What the host should do when the browser engine reports a failed surface.</summary>
+        internal enum BrowserFailureAction
+        {
+            /// <summary>Already handled - one fallback per session reaches the host.</summary>
+            Ignore,
+            /// <summary>A mirror died. Log it, drop it, and let the audio-bearing primary keep playing.</summary>
+            DropSecondary,
+            /// <summary>The primary died BEFORE the first frame: replay the whole clip through LibVLC.</summary>
+            FallbackWholeClip,
+            /// <summary>The primary died AFTER playback started: end the run through the normal funnel
+            /// rather than making the user rewatch the clip from zero.</summary>
+            EndClip,
+        }
+
+        /// <summary>
+        /// One tick of a surface's frame-liveness watchdog. Ordering is load-bearing: teardown beats
+        /// everything (a late timer must never act on a video that already ended), a grace pause beats
+        /// the liveness verdict (#735 - a paused vmem surface produces no frames BY DESIGN), and only
+        /// then does "no frame" become a strike.
+        /// </summary>
+        internal static FrameWatchdogAction DecideFrameWatchdog(bool tornDown, bool gracePaused, bool hasRendered, bool retryUsed)
+        {
+            if (tornDown) return FrameWatchdogAction.Ignore;
+            if (gracePaused) return FrameWatchdogAction.Defer;
+            if (hasRendered) return FrameWatchdogAction.Ignore;
+            return retryUsed ? FrameWatchdogAction.GiveUp : FrameWatchdogAction.Retry;
+        }
+
+        /// <summary>
+        /// Whether a dead surface should take the whole clip with it. This is the #1015/#1035 fix in
+        /// one line: it used to be "any dead surface ends the clip", which is how a stalled decoder on
+        /// monitor 2 blacked out a video that monitor 1 was playing perfectly.
+        /// <paramref name="deadSurfaces"/> INCLUDES the surface that just gave up.
+        /// </summary>
+        internal static bool ShouldAbortClip(int totalSurfaces, int deadSurfaces)
+            => totalSurfaces > 0 && deadSurfaces >= totalSurfaces;
+
+        /// <summary>
+        /// Policy for a browser-engine surface failure. A secondary is a mirror and is never allowed
+        /// to end the run; the primary carries the audio and the session, so its pre-first-frame
+        /// failure replays through LibVLC and its mid-clip failure ends the run.
+        /// </summary>
+        internal static BrowserFailureAction DecideBrowserFailure(bool isPrimarySurface, bool alreadyFellBack, bool playbackStartedFired)
+        {
+            if (!isPrimarySurface) return BrowserFailureAction.DropSecondary;
+            if (alreadyFellBack) return BrowserFailureAction.Ignore;
+            return playbackStartedFired ? BrowserFailureAction.EndClip : BrowserFailureAction.FallbackWholeClip;
+        }
+
+        /// <summary>
+        /// Whether a retire request that did NOT come from the currently playing clip must wait.
+        /// A leased player (bubble count, mini player, previews) whose Stop() wedged used to retire
+        /// the shared LibVLC instance immediately - the same instance the mandatory video's per-monitor
+        /// players were mid-decode on. That spends one of the four per-session retires, arms the 60s
+        /// poison cooldown and drops the metadata cache while the user is still watching, which is the
+        /// "and then there was no bubble-pop sound for the rest of the session" tail on these reports.
+        /// </summary>
+        internal static bool ShouldDeferRetire(bool fromCurrentPlayback, bool playbackLive)
+            => !fromCurrentPlayback && playbackLive;
+
+        /// <summary>
+        /// The one-line-per-surface diagnostic the bug reports need. Reporters upload video-diag.log,
+        /// and until now nothing in it said WHICH engine a given monitor ended up on or how long its
+        /// first frame took - so "black on the primary, fine on the others" could not be told apart
+        /// from "the whole clip failed". Pure so the exact shape is locked by a test.
+        /// </summary>
+        /// <param name="firstFrameMs">Milliseconds from surface creation to the first presented frame,
+        /// or a negative value when no frame was ever seen.</param>
+        /// <param name="failureReason">Why this surface fell back / died, or null when it is healthy.</param>
+        internal static string FormatSurfaceLine(string? engine, string? monitor, bool primary, long firstFrameMs, string? failureReason)
+        {
+            var sb = new StringBuilder();
+            sb.Append("engine=").Append(string.IsNullOrWhiteSpace(engine) ? "?" : engine);
+            sb.Append(" monitor=").Append(string.IsNullOrWhiteSpace(monitor) ? "?" : monitor);
+            sb.Append(" role=").Append(primary ? "primary" : "secondary");
+            sb.Append(" firstFrame=").Append(firstFrameMs < 0 ? "none" : firstFrameMs.ToString(System.Globalization.CultureInfo.InvariantCulture) + "ms");
+            if (!string.IsNullOrWhiteSpace(failureReason))
+                sb.Append(" reason=").Append(failureReason!.Replace('\r', ' ').Replace('\n', ' '));
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Emit one <see cref="FormatSurfaceLine"/> to BOTH sinks: Serilog (Information, so it lands in
+        /// the log the support flow collects) and the video trace (which is the file reporters attach).
+        /// Never throws - a diagnostic must not be able to break playback.
+        /// </summary>
+        internal static void Report(string engine, string? monitor, bool primary, long firstFrameMs, string? failureReason)
+        {
+            try
+            {
+                var line = FormatSurfaceLine(engine, monitor, primary, firstFrameMs, failureReason);
+                App.Logger?.Information("VideoSurface: {Surface}", line);
+                VideoDiag.Log("SURFACE", line);
+            }
+            catch (Exception ex)
+            {
+                try { App.Logger?.Debug("VideoSurfaceHealth.Report failed: {E}", ex.Message); } catch { }
+            }
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
@@ -20,9 +20,9 @@ public class MultiMonitorVideoSurfaceTests
     public void FrameWatchdog_SurfaceThatRendered_IsLeftAlone()
     {
         Assert.Equal(FrameWatchdogAction.Ignore,
-            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: true, retryUsed: false));
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: true, retryUsed: false, retryAllowed: true));
         Assert.Equal(FrameWatchdogAction.Ignore,
-            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: true, retryUsed: true));
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: true, retryUsed: true, retryAllowed: false));
     }
 
     [Fact]
@@ -30,9 +30,9 @@ public class MultiMonitorVideoSurfaceTests
     {
         // A late timer tick must never act on a clip that already ended - not even to retry.
         Assert.Equal(FrameWatchdogAction.Ignore,
-            DecideFrameWatchdog(tornDown: true, gracePaused: false, hasRendered: false, retryUsed: true));
+            DecideFrameWatchdog(tornDown: true, gracePaused: false, hasRendered: false, retryUsed: true, retryAllowed: true));
         Assert.Equal(FrameWatchdogAction.Ignore,
-            DecideFrameWatchdog(tornDown: true, gracePaused: true, hasRendered: false, retryUsed: false));
+            DecideFrameWatchdog(tornDown: true, gracePaused: true, hasRendered: false, retryUsed: false, retryAllowed: false));
     }
 
     [Fact]
@@ -40,38 +40,71 @@ public class MultiMonitorVideoSurfaceTests
     {
         // #735: a deliberately paused vmem surface produces no frames BY DESIGN.
         Assert.Equal(FrameWatchdogAction.Defer,
-            DecideFrameWatchdog(tornDown: false, gracePaused: true, hasRendered: false, retryUsed: false));
+            DecideFrameWatchdog(tornDown: false, gracePaused: true, hasRendered: false, retryUsed: false, retryAllowed: true));
         Assert.Equal(FrameWatchdogAction.Defer,
-            DecideFrameWatchdog(tornDown: false, gracePaused: true, hasRendered: false, retryUsed: true));
+            DecideFrameWatchdog(tornDown: false, gracePaused: true, hasRendered: false, retryUsed: true, retryAllowed: false));
     }
 
     [Fact]
-    public void FrameWatchdog_FirstStrikeRetries_SecondStrikeGivesUp()
+    public void FrameWatchdog_AMirrorGetsOneRetry_ThenGivesUp()
     {
         Assert.Equal(FrameWatchdogAction.Retry,
-            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false));
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: true));
         Assert.Equal(FrameWatchdogAction.GiveUp,
-            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: true));
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: true, retryAllowed: true));
+    }
+
+    [Fact]
+    public void FrameWatchdog_TheAudioBearingSurfaceGetsNoRetryRung()
+    {
+        // The primary ends the clip either way, so a retry rung there would only double the time the
+        // user stares at a black, silent main screen (16s vs the released build's 8s) - and on the
+        // single-monitor majority rig the primary is the ONLY surface, so it would be pure latency
+        // for everyone with one screen.
+        Assert.Equal(FrameWatchdogAction.GiveUp,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: false));
     }
 
     // ---- liveness aggregation (deliverable 2) ----
 
     [Fact]
-    public void OneDeadSurfaceOfTwo_DoesNotAbortTheClip()
+    public void OneDeadMIRROR_DoesNotAbortTheClip()
     {
         // THE regression this whole branch exists for: the old code ended the clip on every screen
-        // the moment one surface missed its frame budget.
-        Assert.False(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 1));
-        Assert.False(ShouldAbortClip(totalSurfaces: 3, deadSurfaces: 2));
+        // the moment one surface missed its frame budget. A dead mirror is now survivable...
+        Assert.False(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 1, primarySurfaceDead: false));
+        Assert.False(ShouldAbortClip(totalSurfaces: 3, deadSurfaces: 2, primarySurfaceDead: false));
+    }
+
+    [Fact]
+    public void ADeadPRIMARY_AbortsTheClip_EvenWhileMirrorsStillRender()
+    {
+        // ...but a dead AUDIO-BEARING surface is not. It is the only player wired to EndReached /
+        // EncounteredError / LengthChanged, and the blurred path arms no vout watchdog, so a clip
+        // carried by mirrors alone would have no end condition short of the 10-minute fallback
+        // timer: black and silent on the main screen for minutes, un-closable in strict mode. That
+        // is the headline report (#533 #1015 #1024 #1035 #1039), so it must skip immediately.
+        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 1, primarySurfaceDead: true));
+        Assert.True(ShouldAbortClip(totalSurfaces: 4, deadSurfaces: 1, primarySurfaceDead: true));
     }
 
     [Fact]
     public void EverySurfaceDead_AbortsTheClip()
     {
-        Assert.True(ShouldAbortClip(totalSurfaces: 1, deadSurfaces: 1));
-        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 2));
+        Assert.True(ShouldAbortClip(totalSurfaces: 1, deadSurfaces: 1, primarySurfaceDead: true));
+        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 2, primarySurfaceDead: false));
         // Defensive: a double-report must not read as "still alive".
-        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 3));
+        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 3, primarySurfaceDead: false));
+    }
+
+    [Fact]
+    public void SingleMonitorRig_BehavesExactlyLikeTheReleasedBuild()
+    {
+        // One screen means one surface and it IS the primary: first missed window -> GiveUp (no
+        // retry rung) -> abort. Same ~8s skip the released build does, no added latency.
+        Assert.Equal(FrameWatchdogAction.GiveUp,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: false));
+        Assert.True(ShouldAbortClip(totalSurfaces: 1, deadSurfaces: 1, primarySurfaceDead: true));
     }
 
     [Fact]
@@ -79,8 +112,8 @@ public class MultiMonitorVideoSurfaceTests
     {
         // Nothing was ever built, so there is nothing for this watchdog to end; the pre-roll
         // watchdogs own that case.
-        Assert.False(ShouldAbortClip(totalSurfaces: 0, deadSurfaces: 0));
-        Assert.False(ShouldAbortClip(totalSurfaces: 0, deadSurfaces: 5));
+        Assert.False(ShouldAbortClip(totalSurfaces: 0, deadSurfaces: 0, primarySurfaceDead: false));
+        Assert.False(ShouldAbortClip(totalSurfaces: 0, deadSurfaces: 5, primarySurfaceDead: false));
     }
 
     // ---- browser failure policy (deliverable 1) ----
@@ -137,8 +170,10 @@ public class MultiMonitorVideoSurfaceTests
     [Fact]
     public void TheClipsOwnWedge_IsNeverDeferred()
     {
-        // The vout heal and the wedge ladder ARE the current playback; deferring them would disarm
-        // the self-heal entirely.
+        // The vout heal, the wedge ladder and CloseAll's own quarantine ARE the current playback;
+        // deferring them would disarm the self-heal entirely. Those are also the retire sites the
+        // bug traces actually show, so this rule deliberately does NOT cover them - the deferral is
+        // only about a FOREIGN lease reaching under a live clip.
         Assert.False(ShouldDeferRetire(fromCurrentPlayback: true, playbackLive: true));
         Assert.False(ShouldDeferRetire(fromCurrentPlayback: true, playbackLive: false));
     }

--- a/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
@@ -55,14 +55,67 @@ public class MultiMonitorVideoSurfaceTests
     }
 
     [Fact]
-    public void FrameWatchdog_TheAudioBearingSurfaceGetsNoRetryRung()
+    public void FrameWatchdog_ASurfaceWithNoRetryRung_IsCondemnedOnItsFirstMissedWindow()
     {
-        // The primary ends the clip either way, so a retry rung there would only double the time the
-        // user stares at a black, silent main screen (16s vs the released build's 8s) - and on the
-        // single-monitor majority rig the primary is the ONLY surface, so it would be pure latency
-        // for everyone with one screen.
         Assert.Equal(FrameWatchdogAction.GiveUp,
             DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: false));
+    }
+
+    [Fact]
+    public void FrameWatchdog_AMultiMonitorPrimary_GetsTheSameOneRetry()
+    {
+        // The exact hole round 2 caught: the audio-bearing surface used to be condemned on its FIRST
+        // missed window on EVERY rig, so a dual-monitor user whose primary stalled got the released
+        // build's behaviour verbatim (skip, no re-Play, no recovery rung of any kind) - i.e. the
+        // headline trace "blurred-background video produced no frame within 8000ms on primary
+        // \\.\DISPLAY1 - skipping to next" was unchanged by the whole branch.
+        Assert.Equal(FrameWatchdogAction.Retry,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: true));
+        Assert.Equal(FrameWatchdogAction.GiveUp,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: true, retryAllowed: true));
+    }
+
+    // ---- who is allowed a retry rung: the RIG decides, not the role ----
+
+    [Fact]
+    public void RetryRung_AMirrorAlwaysGetsOne()
+    {
+        // The clip keeps playing while a mirror retries, so the second window costs the user nothing.
+        Assert.True(AllowsFrameRetry(primarySurface: false, armedSurfaces: 1));
+        Assert.True(AllowsFrameRetry(primarySurface: false, armedSurfaces: 2));
+        Assert.True(AllowsFrameRetry(primarySurface: false, armedSurfaces: 4));
+    }
+
+    [Fact]
+    public void RetryRung_APrimaryWithSiblingsGetsOne()
+    {
+        // Multi-monitor: one re-Play() is the only thing between "the decoder hiccuped while three
+        // screens spun up at once" and "the video was skipped".
+        Assert.True(AllowsFrameRetry(primarySurface: true, armedSurfaces: 2));
+        Assert.True(AllowsFrameRetry(primarySurface: true, armedSurfaces: 3));
+    }
+
+    [Fact]
+    public void RetryRung_ALonePrimaryGetsNone()
+    {
+        // The single-monitor majority: nothing else is competing for the decoder, the clip ends
+        // either way, and the rung would be 8 extra seconds of black screen for everyone.
+        Assert.False(AllowsFrameRetry(primarySurface: true, armedSurfaces: 1));
+        // Defensive: a watch judged before it was registered must not read softer than "lone".
+        Assert.False(AllowsFrameRetry(primarySurface: true, armedSurfaces: 0));
+    }
+
+    [Fact]
+    public void DualMonitorPrimary_StillEndsTheClip_JustOneGraceWindowLater()
+    {
+        // Round 1's blocker holds: a dead primary must end the clip. The retry rung only moves that
+        // from ~8s to ~16s, and only on a rig where something else could have starved it.
+        bool allowed = AllowsFrameRetry(primarySurface: true, armedSurfaces: 2);
+        Assert.Equal(FrameWatchdogAction.Retry,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: allowed));
+        Assert.Equal(FrameWatchdogAction.GiveUp,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: true, retryAllowed: allowed));
+        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 1, primarySurfaceDead: true));
     }
 
     // ---- liveness aggregation (deliverable 2) ----
@@ -100,10 +153,13 @@ public class MultiMonitorVideoSurfaceTests
     [Fact]
     public void SingleMonitorRig_BehavesExactlyLikeTheReleasedBuild()
     {
-        // One screen means one surface and it IS the primary: first missed window -> GiveUp (no
-        // retry rung) -> abort. Same ~8s skip the released build does, no added latency.
+        // One screen means one surface and it IS the primary: no retry rung, first missed window ->
+        // GiveUp -> abort. Same ~8s skip the released build does, no added latency. Driven through
+        // AllowsFrameRetry so the rig rule and the ladder cannot drift apart.
+        bool allowed = AllowsFrameRetry(primarySurface: true, armedSurfaces: 1);
+        Assert.False(allowed);
         Assert.Equal(FrameWatchdogAction.GiveUp,
-            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: false));
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: allowed));
         Assert.True(ShouldAbortClip(totalSurfaces: 1, deadSurfaces: 1, primarySurfaceDead: true));
     }
 
@@ -149,6 +205,60 @@ public class MultiMonitorVideoSurfaceTests
             DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: true, playbackStartedFired: false));
         Assert.Equal(BrowserFailureAction.Ignore,
             DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: true, playbackStartedFired: true));
+    }
+
+    // ---- browser per-surface first-frame sweep (deliverables 2 + 6, DEFAULT engine) ----
+    //
+    // BrowserVideoEngineEnabled defaults true and the browser engine drives EVERY screen, so for most
+    // users an mp4 mandatory video is a WebView2 session on all monitors. The engine used to watch the
+    // PRIMARY only, and to disarm the moment the primary posted `playing` - so a mirror that came up,
+    // handshook and then never decoded was never noticed, never dropped and never logged.
+
+    [Fact]
+    public void BrowserSweep_ASurfaceThatRendered_IsLeftAlone()
+    {
+        Assert.Equal(BrowserFrameSweepAction.Ignore,
+            DecideBrowserFrameSweep(firstFrameSeen: true, deadlinePassed: true, isPrimarySurface: true));
+        Assert.Equal(BrowserFrameSweepAction.Ignore,
+            DecideBrowserFrameSweep(firstFrameSeen: true, deadlinePassed: true, isPrimarySurface: false));
+    }
+
+    [Fact]
+    public void BrowserSweep_BeforeItsOwnDeadline_ASurfaceIsJustWaiting()
+    {
+        // Each window carries its own deadline (pre-handshake budget, restarted shorter at `ready`),
+        // so a slow mirror is never judged on the primary's clock.
+        Assert.Equal(BrowserFrameSweepAction.Wait,
+            DecideBrowserFrameSweep(firstFrameSeen: false, deadlinePassed: false, isPrimarySurface: false));
+        Assert.Equal(BrowserFrameSweepAction.Wait,
+            DecideBrowserFrameSweep(firstFrameSeen: false, deadlinePassed: false, isPrimarySurface: true));
+    }
+
+    [Fact]
+    public void BrowserSweep_ABlackMirrorIsReportedAndDropped_NotLeftOnScreen()
+    {
+        // "Monitor 2 is permanently black": an opaque fullscreen window with a page that never
+        // decoded. It gets its own surface line and then goes away; the clip is untouched.
+        Assert.Equal(BrowserFrameSweepAction.DropMirror,
+            DecideBrowserFrameSweep(firstFrameSeen: false, deadlinePassed: true, isPrimarySurface: false));
+    }
+
+    [Fact]
+    public void BrowserSweep_ABlackPrimaryFailsTheSession_SoLibVlcCanReplayTheClip()
+    {
+        Assert.Equal(BrowserFrameSweepAction.FailSession,
+            DecideBrowserFrameSweep(firstFrameSeen: false, deadlinePassed: true, isPrimarySurface: true));
+    }
+
+    [Fact]
+    public void BrowserSweep_AHealthyPrimaryDoesNotExcuseABlackMirror()
+    {
+        // The regression in one pair of asserts: the primary reporting `playing` used to disarm the
+        // whole watch, which is precisely why the mirror below was never judged.
+        Assert.Equal(BrowserFrameSweepAction.Ignore,
+            DecideBrowserFrameSweep(firstFrameSeen: true, deadlinePassed: true, isPrimarySurface: true));
+        Assert.Equal(BrowserFrameSweepAction.DropMirror,
+            DecideBrowserFrameSweep(firstFrameSeen: false, deadlinePassed: true, isPrimarySurface: false));
     }
 
     // ---- retire deferral (deliverable 4) ----

--- a/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
@@ -394,4 +394,89 @@ public class MultiMonitorVideoSurfaceTests
         Assert.Equal(Video1, OverlayService.ResolveVideoAnchor(
             TwoScreenVideo(), targetHwnd: Overlay2, targetMonitor: IntPtr.Zero, fallbackHwnd: Video1));
     }
+
+    // ---- browser first-frame deadline arming (round 4 blocker) ----
+
+    [Fact]
+    public void AMirrorWhoseInitHasNotStartedIsNeverCondemned()
+    {
+        // BrowserVideoEngine.InitWindowsAsync brings the WebView2 windows up STRICTLY SERIALLY. A
+        // mirror sitting in that queue has not been asked to render anything yet, so no amount of
+        // wall clock may condemn it. DateTime.MaxValue is the "unarmed" state.
+        Assert.False(FrameDeadlinePassed(DateTime.MaxValue, new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Utc)));
+        Assert.False(FrameDeadlinePassed(DateTime.MaxValue, DateTime.MaxValue));
+    }
+
+    [Fact]
+    public void AQueuedMirrorSurvivesTheSweepNoMatterHowLongThePrimaryTakes()
+    {
+        // The regression this pins: a 4-monitor rig on a cold disk used to reach the 20s pre-ready
+        // budget on mirror 4 while mirror 4's WebView2 had not started, and the sweep closed a
+        // perfectly healthy window. Unarmed must resolve to Wait, never DropMirror.
+        var anHourLater = new DateTime(2026, 8, 27, 13, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(BrowserFrameSweepAction.Wait, DecideBrowserFrameSweep(
+            firstFrameSeen: false,
+            deadlinePassed: FrameDeadlinePassed(DateTime.MaxValue, anHourLater),
+            isPrimarySurface: false));
+    }
+
+    [Fact]
+    public void AnArmedSurfacePastItsBudgetIsCondemned()
+    {
+        var now = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Utc);
+        Assert.True(FrameDeadlinePassed(now.AddSeconds(-1), now));
+        Assert.True(FrameDeadlinePassed(now, now)); // the deadline itself counts as passed
+    }
+
+    [Fact]
+    public void AnArmedSurfaceInsideItsBudgetIsLeftAlone()
+    {
+        var now = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Utc);
+        Assert.False(FrameDeadlinePassed(now.AddSeconds(1), now));
+    }
+
+    [Fact]
+    public void OnlyThePrimaryArmsItsFrameClockAtSessionStart()
+    {
+        // The primary is initialised first so it never queues, and its session-start clock is the
+        // only deadline left that can still fire if the shared WebView2 environment task hangs
+        // forever - without it a hung environment would sit black until the 10 minute safety timer.
+        Assert.True(ArmsFrameDeadlineAtSessionStart(isPrimarySurface: true));
+        Assert.False(ArmsFrameDeadlineAtSessionStart(isPrimarySurface: false));
+    }
+
+    [Fact]
+    public void AGracePauseSlidesAnArmedDeadlineByOneTick()
+    {
+        var deadline = new DateTime(2026, 8, 27, 12, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(deadline.AddMilliseconds(500), SlidePendingDeadline(deadline, 500));
+    }
+
+    [Fact]
+    public void AGracePauseLeavesAQueuedMirrorUnarmed()
+    {
+        // Sliding MaxValue would overflow; it must stay the unarmed sentinel instead, so a session
+        // paused while the mirrors are still queuing does not silently arm them.
+        Assert.Equal(DateTime.MaxValue, SlidePendingDeadline(DateTime.MaxValue, 500));
+    }
+
+    // ---- uncovering a dead surface (round 4 strict-mode guard) ----
+
+    [Fact]
+    public void ADeadMirrorUnderAStrictLockStaysCovered()
+    {
+        // Lock Card / Lockdown / Possession are commitment devices: the user asked to be unable to
+        // look away. Hiding a dead mirror would hand back a monitor mid-clip, so it stays on screen
+        // as an opaque black cover instead. Close() is vetoed by the strict Closing handler, but
+        // Hide() is not, so this rule is the only thing standing between a wedge and an escape hatch.
+        Assert.False(ShouldUncoverDeadSurface(hostStrict: true));
+    }
+
+    [Fact]
+    public void ADeadMirrorOutsideStrictIsUncovered()
+    {
+        // No commitment in play: leaving a black rectangle over a second screen for the rest of the
+        // clip is just broken, so the window goes away and that monitor comes back.
+        Assert.True(ShouldUncoverDeadSurface(hostStrict: false));
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using static ConditioningControlPanel.Services.VideoSurfaceHealth;
+using OverlayService = ConditioningControlPanel.Services.OverlayService;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The #1 open bug: mandatory video on a multi-monitor rig plays on the secondary screens while the
+/// primary sits black and silent (#533 #540 #542 #559 #592 #617 #918 #1015 #1016 #1024 #1025 #1035
+/// #1039 #1059, 6.3.2 through 6.8.4). Every rule the fix rests on is pure and lives here; the
+/// windowing itself needs a real second monitor and is listed as a play-test.
+/// </summary>
+public class MultiMonitorVideoSurfaceTests
+{
+    // ---- per-surface frame watchdog (deliverable 2) ----
+
+    [Fact]
+    public void FrameWatchdog_SurfaceThatRendered_IsLeftAlone()
+    {
+        Assert.Equal(FrameWatchdogAction.Ignore,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: true, retryUsed: false));
+        Assert.Equal(FrameWatchdogAction.Ignore,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: true, retryUsed: true));
+    }
+
+    [Fact]
+    public void FrameWatchdog_TeardownBeatsEverything()
+    {
+        // A late timer tick must never act on a clip that already ended - not even to retry.
+        Assert.Equal(FrameWatchdogAction.Ignore,
+            DecideFrameWatchdog(tornDown: true, gracePaused: false, hasRendered: false, retryUsed: true));
+        Assert.Equal(FrameWatchdogAction.Ignore,
+            DecideFrameWatchdog(tornDown: true, gracePaused: true, hasRendered: false, retryUsed: false));
+    }
+
+    [Fact]
+    public void FrameWatchdog_GracePauseDefers_ItDoesNotCondemn()
+    {
+        // #735: a deliberately paused vmem surface produces no frames BY DESIGN.
+        Assert.Equal(FrameWatchdogAction.Defer,
+            DecideFrameWatchdog(tornDown: false, gracePaused: true, hasRendered: false, retryUsed: false));
+        Assert.Equal(FrameWatchdogAction.Defer,
+            DecideFrameWatchdog(tornDown: false, gracePaused: true, hasRendered: false, retryUsed: true));
+    }
+
+    [Fact]
+    public void FrameWatchdog_FirstStrikeRetries_SecondStrikeGivesUp()
+    {
+        Assert.Equal(FrameWatchdogAction.Retry,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false));
+        Assert.Equal(FrameWatchdogAction.GiveUp,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: true));
+    }
+
+    // ---- liveness aggregation (deliverable 2) ----
+
+    [Fact]
+    public void OneDeadSurfaceOfTwo_DoesNotAbortTheClip()
+    {
+        // THE regression this whole branch exists for: the old code ended the clip on every screen
+        // the moment one surface missed its frame budget.
+        Assert.False(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 1));
+        Assert.False(ShouldAbortClip(totalSurfaces: 3, deadSurfaces: 2));
+    }
+
+    [Fact]
+    public void EverySurfaceDead_AbortsTheClip()
+    {
+        Assert.True(ShouldAbortClip(totalSurfaces: 1, deadSurfaces: 1));
+        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 2));
+        // Defensive: a double-report must not read as "still alive".
+        Assert.True(ShouldAbortClip(totalSurfaces: 2, deadSurfaces: 3));
+    }
+
+    [Fact]
+    public void NoSurfacesAtAll_IsNotAnAbort()
+    {
+        // Nothing was ever built, so there is nothing for this watchdog to end; the pre-roll
+        // watchdogs own that case.
+        Assert.False(ShouldAbortClip(totalSurfaces: 0, deadSurfaces: 0));
+        Assert.False(ShouldAbortClip(totalSurfaces: 0, deadSurfaces: 5));
+    }
+
+    // ---- browser failure policy (deliverable 1) ----
+
+    [Fact]
+    public void SecondaryBrowserFailure_NeverEndsTheRun()
+    {
+        Assert.Equal(BrowserFailureAction.DropSecondary,
+            DecideBrowserFailure(isPrimarySurface: false, alreadyFellBack: false, playbackStartedFired: false));
+        Assert.Equal(BrowserFailureAction.DropSecondary,
+            DecideBrowserFailure(isPrimarySurface: false, alreadyFellBack: true, playbackStartedFired: true));
+    }
+
+    [Fact]
+    public void PrimaryFailsBeforeFirstFrame_FallsTheClipBackToLibVlc()
+    {
+        Assert.Equal(BrowserFailureAction.FallbackWholeClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: false));
+    }
+
+    [Fact]
+    public void PrimaryFailsMidClip_EndsTheRunInsteadOfReplayingIt()
+    {
+        // The user has already watched most of it; a fallback here would restart from zero.
+        Assert.Equal(BrowserFailureAction.EndClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: true));
+    }
+
+    [Fact]
+    public void FallbackHappensAtMostOnce()
+    {
+        Assert.Equal(BrowserFailureAction.Ignore,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: true, playbackStartedFired: false));
+        Assert.Equal(BrowserFailureAction.Ignore,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: true, playbackStartedFired: true));
+    }
+
+    // ---- retire deferral (deliverable 4) ----
+
+    [Fact]
+    public void ForeignWedgeDuringPlayback_DefersTheRetire()
+    {
+        // A bubble-count / mini-player lease wedging must not pull the shared LibVLC instance out
+        // from under the per-monitor players that are decoding the video on screen right now.
+        Assert.True(ShouldDeferRetire(fromCurrentPlayback: false, playbackLive: true));
+    }
+
+    [Fact]
+    public void RetireRunsImmediately_WhenNothingIsPlaying()
+    {
+        Assert.False(ShouldDeferRetire(fromCurrentPlayback: false, playbackLive: false));
+    }
+
+    [Fact]
+    public void TheClipsOwnWedge_IsNeverDeferred()
+    {
+        // The vout heal and the wedge ladder ARE the current playback; deferring them would disarm
+        // the self-heal entirely.
+        Assert.False(ShouldDeferRetire(fromCurrentPlayback: true, playbackLive: true));
+        Assert.False(ShouldDeferRetire(fromCurrentPlayback: true, playbackLive: false));
+    }
+
+    // ---- the diagnostics line reporters upload (video-diag.log) ----
+
+    [Fact]
+    public void SurfaceLine_CarriesEngineMonitorRoleAndLatency()
+    {
+        Assert.Equal(
+            @"engine=browser monitor=\\.\DISPLAY1 role=primary firstFrame=412ms",
+            FormatSurfaceLine("browser", @"\\.\DISPLAY1", primary: true, firstFrameMs: 412, failureReason: null));
+    }
+
+    [Fact]
+    public void SurfaceLine_NoFrameReadsAsNoneAndCarriesTheReason()
+    {
+        Assert.Equal(
+            @"engine=libvlc monitor=\\.\DISPLAY2 role=secondary firstFrame=none reason=no frame within 8000ms",
+            FormatSurfaceLine("libvlc", @"\\.\DISPLAY2", primary: false, firstFrameMs: -1,
+                failureReason: "no frame within 8000ms"));
+    }
+
+    [Fact]
+    public void SurfaceLine_StaysOnOneLine_EvenWithAMultiLineExceptionMessage()
+    {
+        var line = FormatSurfaceLine("browser", "MON", primary: true, firstFrameMs: -1,
+            failureReason: "InitAsync failed:\r\nWebView2 runtime missing");
+        Assert.DoesNotContain("\n", line);
+        Assert.DoesNotContain("\r", line);
+        Assert.Contains("reason=InitAsync failed:  WebView2 runtime missing", line);
+    }
+
+    [Fact]
+    public void SurfaceLine_MissingFieldsDegradeInsteadOfThrowing()
+    {
+        Assert.Equal("engine=? monitor=? role=secondary firstFrame=none",
+            FormatSurfaceLine(null, "   ", primary: false, firstFrameMs: -1, failureReason: null));
+    }
+
+    // ---- multi-monitor z-order anchor (deliverable 3, #1016) ----
+
+    private static readonly IntPtr Mon1 = new IntPtr(0x1001);
+    private static readonly IntPtr Mon2 = new IntPtr(0x1002);
+    private static readonly IntPtr Video1 = new IntPtr(0xA001);
+    private static readonly IntPtr Video2 = new IntPtr(0xA002);
+    private static readonly IntPtr Overlay2 = new IntPtr(0xB002);
+
+    private static List<(IntPtr Hwnd, IntPtr Monitor)> TwoScreenVideo() =>
+        new() { (Video1, Mon1), (Video2, Mon2) };
+
+    [Fact]
+    public void OverlayOnSecondMonitor_AnchorsToThatMonitorsVideoWindow()
+    {
+        // #1016 itself: anchoring to the primary left the overlay ABOVE monitor 2's video window,
+        // which is the "pink filter covers the video on my second screen" report.
+        Assert.Equal(Video2, OverlayService.ResolveVideoAnchor(
+            TwoScreenVideo(), targetHwnd: Overlay2, targetMonitor: Mon2, fallbackHwnd: Video1));
+    }
+
+    [Fact]
+    public void OverlayOnPrimaryMonitor_StillAnchorsToThePrimaryVideoWindow()
+    {
+        Assert.Equal(Video1, OverlayService.ResolveVideoAnchor(
+            TwoScreenVideo(), targetHwnd: new IntPtr(0xB001), targetMonitor: Mon1, fallbackHwnd: Video1));
+    }
+
+    [Fact]
+    public void OverlayOnAMonitorWithNoVideoWindow_FallsBackToThePrimary()
+    {
+        // Nothing overlaps there, so the choice is cosmetic - but it must be a real window, not zero.
+        Assert.Equal(Video1, OverlayService.ResolveVideoAnchor(
+            TwoScreenVideo(), targetHwnd: new IntPtr(0xB003), targetMonitor: new IntPtr(0x1003),
+            fallbackHwnd: Video1));
+    }
+
+    [Fact]
+    public void NoVideoPlaying_YieldsNoAnchor()
+    {
+        Assert.Equal(IntPtr.Zero, OverlayService.ResolveVideoAnchor(
+            new List<(IntPtr, IntPtr)>(), targetHwnd: Overlay2, targetMonitor: Mon2,
+            fallbackHwnd: IntPtr.Zero));
+    }
+
+    [Fact]
+    public void AVideoWindowIsNeverAnchoredToAnotherVideoWindow()
+    {
+        // Ordering a video window below its sibling would bury one of the screens outright.
+        Assert.Equal(IntPtr.Zero, OverlayService.ResolveVideoAnchor(
+            TwoScreenVideo(), targetHwnd: Video2, targetMonitor: Mon2, fallbackHwnd: Video1));
+        Assert.Equal(IntPtr.Zero, OverlayService.ResolveVideoAnchor(
+            TwoScreenVideo(), targetHwnd: Video1, targetMonitor: Mon1, fallbackHwnd: Video1));
+    }
+
+    [Fact]
+    public void AWindowIsNeverAnchoredToItself()
+    {
+        // SetWindowPos(h, h, ...) would drop the pin entirely.
+        Assert.Equal(IntPtr.Zero, OverlayService.ResolveVideoAnchor(
+            new List<(IntPtr, IntPtr)>(), targetHwnd: Video1, targetMonitor: Mon1, fallbackHwnd: Video1));
+    }
+
+    [Fact]
+    public void UnknownMonitorHandle_FallsBackRatherThanReturningZero()
+    {
+        // MonitorFromWindow can hand back NULL during a display-topology change; the sweep must
+        // still pin the overlay below the video instead of skipping the #497 rule.
+        Assert.Equal(Video1, OverlayService.ResolveVideoAnchor(
+            TwoScreenVideo(), targetHwnd: Overlay2, targetMonitor: IntPtr.Zero, fallbackHwnd: Video1));
+    }
+}


### PR DESCRIPTION
## What / why

The #1 open bug: on a multi-monitor rig the mandatory video plays on the secondary screens
while the **primary sits black and silent**, and sometimes bubble-pop audio never comes back
for the rest of the session. 14 issues, at least 5 distinct reporters, 6.3.2 through 6.8.4,
still reproducing 2026-08-26.

The pipeline builds one surface per screen but judged them as one clip. Five seams, fixed in
the brief's priority order:

**1. The browser primary could go black silently.** `BrowserVideoSurface.InitAsync` swallowed
both of its failure modes (an `EnsureCoreWebView2Async` throw, and a core left null after it)
as a Warning and nothing else. The surface stays on screen as an **opaque black** window, and
`InitWindowsAsync` initialises the PRIMARY first, so a swallowed failure there let every
secondary go on to play normally - the reported symptom verbatim. The only thing that ever
rescued it was the 20s pre-ready budget expiring.
It now raises `InitFailed`. The engine fails the session immediately for the primary (which
reaches the existing `Failed` -> `OnBrowserFailed` -> `FallbackToLibVlc` path) and drops just
that mirror for a secondary. Every browser failure site now routes through `RaiseFailed`.

**2. One dead surface aborted the whole clip.** `StartBlurFrameWatchdog` armed a timer per
surface but each one called `EndCurrentVideo(noFrameRendered: true)` on its own, so the first
screen to miss its 8s frame budget killed the video on every other monitor that was decoding
perfectly. The ladder is now per surface and deliberately **asymmetric**:

- a **mirror** that misses its grace window gets one re-`Play()` on its own player and one more
  full grace window; still nothing and it is marked dead, while the clip carries on wherever it
  is still rendering. That is the actual regression fix.
- the **audio-bearing** surface gets that same single re-`Play()` **once the rig has more than
  one surface**. That arm is the headline trace itself
  (`blurred-background video produced no frame within 8000ms on primary \\.\DISPLAY1 - skipping
  to next`): a dual-monitor primary that stalled used to skip the clip on the spot with no
  recovery rung of any kind. It still **ends the clip** when the retry fails - it is the only
  player wired to `EndReached` / `EncounteredError` / `LengthChanged`, and the blurred path never
  arms `StartVoutWatchdog`, so a clip carried by mirrors alone would have no end condition short
  of the 10-minute fallback timer (black and silent for minutes, un-closable in strict mode).
  The rung only moves that skip from ~8s to ~16s on a multi-screen rig.
- on a **single-monitor** rig the primary is the only surface and gets **no rung at all**, so the
  majority path keeps the released build's ~8s timing with zero added latency. The rung is
  decided by the **rig** (`AllowsFrameRetry(primary, armedSurfaces)`), not by the role.

The retry only re-`Play()`s from `Error`/`Stopped`/`Ended`/`NothingSpecial`. Poking native
state under a player that is merely slow (`Opening`/`Buffering`) is the exact move that wedges
LibVLC, so that case just spends the extra grace window. It is also re-guarded against teardown
inside its own `Task.Run` (see "Round 2" below).

**3. Z-order anchored to one screen.** `ReassertZOrder` resolved `videoHwnd` from
`PrimaryVideoWindow` alone. All video windows share one global z-order, so pinning an overlay
that lives on monitor 2 below monitor 1's video window leaves it **above** monitor 2's own
video window - the "pink filter / spiral over the video on my second screen" report (#1016).
`VideoService.GetVideoWindowHandles()` exposes the handles already collected for BOTH engines
by `PreventClickRaise`, and each window now resolves its own anchor by monitor
(`OverlayService.ResolveVideoAnchor`). The existing `ResolveZOrderAction` and its tests are
untouched.

**4. A foreign wedge retired the instance siblings were decoding on.** A leased player (bubble
count, mini player, previews) whose `Stop()` wedged called `RetireSharedLibVLC` immediately,
while the mandatory video's per-monitor players were still live on that same instance. That
drops the metadata cache under a live clip and makes the next `EnsureLibVLCInitialized` block
the UI thread on the rebuild's lock, mid-video. `RetireSharedLibVLC` now takes
`fromCurrentPlayback` and **defers** a foreign retire to teardown (`FlushDeferredRetire`, called
from `CloseAll`'s finally). It is never cancelled, only parked.

Scope of that, stated exactly (the first round of this PR overclaimed it): **a stuck side player
can no longer reset the shared video engine while a video is still playing on it.** It does NOT
suppress the 60s native poison cooldown - `QuarantineNative` arms that before any retire
decision is reached - it does not save a retire from the per-session budget (the parked retire
still runs at teardown), and it does not touch the two retire sites inside the mandatory
pipeline's own `CloseAll`, which are that clip's self-heal and must stay immediate. The "no
bubble-pop audio for the rest of the session" tail is therefore **still open**; see NOT done.

**5. DPI.** `DualMonitorVideoService.CreateFullscreenWindow` assigned `Screen.Bounds`
(physical px) straight to WPF `Left/Top/Width/Height` (DIPs), so at 150% the pre-HWND layout
pass sized the window 1.5x the screen. The `SourceInitialized` `SetWindowPos` was already
correct and remains the authority.

**Diagnostics.** One Information line per surface, to Serilog *and* `video-diag.log` (the file
reporters attach): `engine=browser monitor=\\.\DISPLAY1 role=primary firstFrame=412ms`, with a
`reason=` field on failure. Nothing in that log used to say which engine a monitor ended up on
or whether it ever produced a frame, so "monitor 2 is black" and "the clip failed" looked
identical in triage. Secondary page errors now name their screen instead of logging
"(ignored)".

## Round 2 - adversarial review fixes

An adversarial verifier rejected the first push. Everything below is in this branch now:

1. **(blocker) A dead audio-bearing surface no longer ended the clip.** With blurred background
   on (the default) every screen gets a frame watchdog, and the first cut asked only
   `ShouldAbortClip(total, dead)`, so a dead primary next to a live secondary logged "clip
   continues on the rest" and returned - with `EndReached`/`EncounteredError` wired only on the
   primary and no vout watchdog on the blur path, nothing was left to end the run but the
   600s fallback timer. `ShouldAbortClip` now takes `primarySurfaceDead` and the watchdog
   computes it from `_blurWatches`. The mis-locked test is rewritten
   (`OneDeadMIRROR_DoesNotAbortTheClip`) and
   `ADeadPRIMARY_AbortsTheClip_EvenWhileMirrorsStillRender` was added.
2. **(major) The retry rung was pure latency on the single-monitor path.** `RetryBlurSurface`
   can only act from `Error`/`Stopped`/`Ended`/`NothingSpecial`, which is not the stall shape
   the reports describe, so a one-screen user got ~16s of black instead of ~8s for nothing. The
   rung became conditional (`DecideFrameWatchdog(..., retryAllowed)`), which restores the
   released build's timing for single-monitor rigs. **Round 3 narrowed this further:** it was
   suppressed for the primary on *every* rig, which took the recovery rung away from the exact
   failure the 14 issues quote. It is now suppressed only where the rationale actually holds -
   a rig with one surface. See Round 3 item 2.
3. **(major) `RetryBlurSurface` could touch native state under teardown.** The tick's `tornDown`
   guard was evaluated before the `Task.Run` was queued. The task body now re-checks
   `_videoPlaying` / `_isCleaningUp` / the captured `_teardownGeneration`, re-reads
   `watch.Surface.Player`, and confirms the player is still in `_mediaPlayers` (which `CloseAll`
   clears before it stops or disposes anything) before calling `State`/`Play()`.
4. **(major) `DropSecondaryWindow`'s `Close()` was vetoed.** Every browser window carries the
   strict `Closing` veto and `_videoPlaying` is already true when a surface fails, so "drop that
   mirror" left an opaque black window on the monitor with all handlers unhooked. It now
   `Hide()`s first (not vetoable) and keeps the window in a `_dropped` list that `StopSession`
   closes once the veto is down, so nothing is stranded either on screen or in memory.
   **Round 4 narrowed this:** "not vetoable" also meant it uncovered a monitor mid-clip under a
   strict lock, which is a weakening of a commitment device. The hide now happens only when the
   clip is NOT strict. See Round 4 item 2.
5. **(major) `InitFailed` could fire synchronously inside `StartSession`.** The WebView2
   environment task is cached and warmed at startup, so `InitWindowsAsync` runs inline and a
   `RaiseInitFailed` from there reached `OnBrowserFailed` while `_browserActive` was still
   false - where its first line dropped it, leaving exactly the black primary the event exists
   to end (and any handler that did run would re-enter a host mid-bookkeeping).
   `RaiseInitFailed` now posts through `Dispatcher.BeginInvoke`.
6. **(major) The deliverable-4 claim was too broad.** The PR body, the patch note and the XML
   docs on `RetireSharedLibVLC` / `ShouldDeferRetire` all said the deferral fixed the
   "no bubble-pop audio afterwards" tail. It does not: the poison cooldown is armed by
   `QuarantineNative` before the deferral decision, and the parked retire still spends its
   budget at teardown. All four places now say exactly what the code does, and the retire-budget
   / poison work moved to the follow-up list.

## Round 3 - second adversarial review

A second verifier rejected the previous push with four majors. All four are fixed here.

1. **(major) The DEFAULT engine had no per-surface liveness and emitted no line for a black
   mirror.** `BrowserVideoEngineEnabled` defaults **true** and `StartBrowserVideoPlayback` hands
   the primary **and every secondary** to WebView2, so for most users an mp4/webm mandatory video
   is a browser session on *all* screens - deliverables 2 and 6 were being met only on the LibVLC
   blur path, which those users never reach. In the browser engine the only net was
   `_firstFrameWatch`: primary-only (`OnWindowReady` returned for secondaries) and self-cancelling
   the moment the primary posted `playing`. A secondary whose WebView2 initialised fine and then
   never decoded (GPU stall, a swallowed fetch, a decode failure that never became a page `error`)
   was never noticed, never dropped and **never logged** - `VideoSurfaceHealth.Report` for a
   browser surface only fired *on* `playing`, so `video-diag.log` showed nothing at all for that
   monitor, indistinguishable from a window that was never created.
   The watchdog is now a **per-surface sweep**: every `BrowserVideoWindow` carries its own
   `FirstFrameDeadlineUtc` (generous pre-handshake budget, restarted shorter at that window's own
   `ready`), the timer sweeps all of them each tick, and a grace pause slides every pending
   deadline. A mirror past its deadline gets its `VideoSurface: ... reason=no first frame within
   <n>ms` line and is dropped via the existing hide-then-close path; the primary past its deadline
   still fails the session so the LibVLC fallback replays the clip. The primary's `playing` no
   longer disarms the other screens' watchdog, and the sweep stops itself once every window has
   reported or been condemned. Verdict rule is pure: `DecideBrowserFrameSweep`, 5 new tests.
2. **(major) The headline failure's own code path was unchanged from the released build.**
   `DecideFrameWatchdog` was called with `retryAllowed: !primary`, so the audio-bearing surface
   returned `GiveUp` on its **first** missed window and `ShouldAbortClip` aborted - i.e. for a
   dual-monitor user whose primary stalled, this branch's user-visible behaviour was identical to
   6.8.4 (diagnostics aside). The rationale for removing the rung (single-monitor latency) only
   ever required suppressing it when the primary is the **only** surface. The watchdog now
   captures the armed surface count under `_blurFrameWatchLock` and asks
   `VideoSurfaceHealth.AllowsFrameRetry(primary, armed)`: a lone primary keeps today's exact ~8s
   skip, a multi-monitor primary gets one `RetryBlurSurface()` re-`Play()` and one more grace
   window before `ShouldAbortClip` ends the clip. Round 1's blocker still holds - a dead primary
   always ends the clip, it just ends it one grace window later. 5 new tests pin both arms.
3. **(major) A comment asserted the opposite of what the code did.** The note above the
   `playing` surface report claimed per-surface diagnostics were covered; they were covered only
   for surfaces that *did* render. It now says which half it is and points at the sweep that owns
   the other half.
4. **(major) The dual-monitor checklist could not reach the code it was verifying.** Items 2-4
   described blur-watchdog trace lines that are unreachable on a default install, because
   `BrowserVideoGate.ShouldUseBrowser` sends any `.mp4`/`.webm` without an explicit
   `AudioOutputDeviceId` to WebView2. Those items now state the precondition explicitly and the
   list carries separate items for the same two stalls **with** the browser engine on.

## Round 4 - final adversarial review

A third verifier rejected the previous push with one blocker, two majors and six minors. Every
one was reproduced on the branch and fixed at the root; none were refuted.

1. **(blocker) A queued mirror was condemned for the time it spent waiting its turn.**
   Round 3's per-surface sweep armed every window's 20s pre-ready budget in `CreateWindow`, i.e.
   at **session** start, but `InitWindowsAsync` brings the windows up **strictly serially**
   (`foreach (var w in _windows) await w.InitAsync(...)`). A mirror cannot post `ready` before its
   own `InitAsync` begins, so it burned its whole budget queued behind the primary - and the same
   file's own note on `PreReadyTimeoutMs` says a cold WebView2 "can eat well over ten seconds on a
   slow disk" for **one** window. On a 2-4 screen cold start the trailing mirrors could pass their
   deadline before init even started, and the sweep would hide and close perfectly healthy
   screens. `origin/main` never watched secondaries at all, so this was a regression introduced by
   this branch, on the default engine, on exactly the slow multi-monitor machines the 14 reports
   come from.
   `FirstFrameDeadlineUtc` now starts at `DateTime.MaxValue` = **UNARMED**, and
   `VideoSurfaceHealth.FrameDeadlinePassed` reads unarmed as "not passed", so a window whose init
   has not started can never be condemned. Mirrors arm at the top of their own iteration of the
   init loop. The **primary** deliberately keeps its session-start clock
   (`ArmsFrameDeadlineAtSessionStart`): it is initialised first so it never queues, and it is the
   only deadline that can still fire if the shared WebView2 **environment** task hangs forever -
   in that case the serial loop never runs at all, and without it a hung environment would sit
   black until the 600s fallback timer instead of handing the clip to LibVLC. 4 new tests, one of
   which pins the sweep verdict itself (`Wait`, never `DropMirror`) for an unarmed window.

2. **(major) A dead browser mirror uncovered a monitor under a strict lock.** Round 2 item 4
   added `Hide()` before `Close()` precisely *because* `Hide()` is not vetoable by the strict
   `Closing` handler. That is right outside strict mode and wrong inside it: under a Lock Card /
   Lockdown / Possession video the whole point is that every screen is covered and Alt+F4 is
   refused, and on `origin/main` a vetoed `Close()` left the mirror as an opaque black cover. The
   branch turned that into a **fully interactive desktop** on that monitor for the rest of the
   clip - and Round 3's `DropMirror` arm made it reachable from a merely slow mirror, not just a
   WebView2 crash. A commitment device must not be weakened by a failure path.
   `BrowserVideoRequest` now carries `IsHostStrict` (wired to `VideoService.IsStrictActive`, read
   live, next to the existing `IsHostPaused`). `DropSecondaryWindow` still unhooks the window,
   removes it from the sweep and sets `FirstFrameReported`, but when strict is active the window
   **stays on screen, black**; `StopSession` closes it once the veto is down. The rule is pure:
   `VideoSurfaceHealth.ShouldUncoverDeadSurface`.

3. **(major) A dead LibVLC mirror left an opaque black window for the whole clip.** The
   per-screen blur window is a fullscreen Topmost window whose Grid background is
   `Brushes.Black`, covered only by a vmem composite that - for a dead surface - never rendered.
   Before this branch a dead surface aborted the clip, so that black rectangle was bounded to the
   ~8s grace window. Round 1 removed the abort (correctly) but never freed the screen, converting
   a short black flash into a **dead black screen for the entire clip** on the very issues being
   closed (#1015 #1035, "one monitor is black"). The browser engine had already fixed exactly
   this on its own side, so the two engines disagreed about what a dead mirror looks like.
   `BlurSurfaceWatch` now carries its `Window`, and the "clip continues on the rest" arm calls
   `ReleaseDeadBlurSurfaceScreen`, which marshals to the dispatcher and `Hide()`s that screen's
   window - subject to the **same** `ShouldUncoverDeadSurface` guard as the browser path, so both
   engines now leave the same visible state and both honour strict. `Hide()`, never `Close()`:
   the window is still owned by the run and `CloseAll` is still the only thing that tears it down,
   and the player is deliberately left alone because a fresh `Stop()` from there is the exact move
   that wedges LibVLC.

4. **(minor) Dropped browser mirrors leaked out of the host's bookkeeping.**
   `DropSecondaryWindow` moves the window out of the engine's `_windows`, so
   `StopBrowserSession`'s `engine.Windows` snapshot could no longer see it: the dropped mirror
   stayed in `VideoService._windows` for the rest of the run (keeping `HasOpenWindows` true and
   getting `PreventClickRaise`'d on a browser to LibVLC handoff) and its HWND stayed in the
   z-order anchor cache, which is only cleared wholesale in `CloseAll` - a path the handoff never
   runs. `IsWindow()` contains the damage today, but Windows recycles HWND values within a
   process, and a recycled handle matching a live overlay window would flip that overlay from
   "below the video" to topmost, i.e. the #497/#1016 symptom this PR exists to remove.
   The engine now raises `WindowDropped(window, hwnd)` (HWND read before the `Close`, and **not**
   raised for a mirror strict mode keeps on screen, which is still a live cover), the host prunes
   both its window list and the anchor cache at drop time, and `StopBrowserSession` reads
   `engine.Windows.Concat(engine.DroppedWindows)` and prunes their handles too. Identity, not
   `IsWindow`, now keeps the anchor list honest.

5. **(minor) `RetryBlurSurface`'s ownership proof and its native calls were two critical
   sections.** It proved `_mediaPlayers.Contains(player)` under `_mediaPlayersLock` and then
   called `State`/`Play()` outside it, from a threadpool task. `CloseAll` copies-and-clears
   `_mediaPlayers` under that same lock and only then stops and disposes, so a teardown starting
   in the gap let a native call land on a player mid-dispose while its vmem frame buffer was being
   freed - the uncatchable native AV this file documents at `ReleaseBufferAfter`. The proof, the
   `State` read and the `Play()` are now one region, with the teardown re-checks inside it.
   Whoever gets the lock first wins: either the retry finishes while `CloseAll` waits out a single
   native call, or `CloseAll` gets in first and the retry declines.

6. **(minor) A parked retire could be lost for the rest of the session.**
   `FlushDeferredRetire` had exactly one call site (`CloseAll`'s finally), so a foreign wedge that
   parked a retire just after that flush sat parked until the **next** mandatory video's teardown,
   which may never come. The defer test also read `_videoPlaying` (a plain bool) and
   `HasOpenWindows` (`List<Window>.Count`, UI-thread-owned, unlocked) from a threadpool thread,
   and a single suspect slot silently overwrote a second parked retire.
   `_videoPlaying` is now `volatile`; liveness is asked through `PlaybackLiveForRetire`, which
   uses the lock-guarded HWND cache instead of an unsynchronised `List<Window>` read; the park
   site re-tests and flushes inline when playback is already down; and the parked suspects are a
   list, drained under the lock so two concurrent flushes cannot double-retire.

7. **(minor) A healthy LibVLC surface wrote no diagnostics line unless the 8s watchdog ticked.**
   The headline "one Information line per surface" hung off the watchdog's single tick, so any
   clip that ended inside the grace window - a short video, an attention-check retry, a panic -
   disposed the timer and logged **nothing**, leaving `video-diag.log` exactly as uninformative as
   before for those runs. `BlurVmemSurface` now raises `FirstFrameObserved` from the first blit
   (where the latency is already computed) and the line is written there; the watchdog's `Ignore`
   arm is the fallback. The claim is atomic (`Interlocked.Exchange` on `BlurSurfaceWatch`) because
   the healthy line comes from the UI thread and the failure line from a threadpool timer.

**Behaviour deltas a reviewer should weigh.** Under a strict lock a dead mirror now stays on
screen as a black cover on **both** engines. That restores `origin/main`'s visible behaviour and
is the deliberate choice: a commitment device must not hand a monitor back mid-clip. Outside
strict, a dead mirror's screen is freed on both engines. Single-monitor rigs on default settings
are untouched by all seven fixes: the primary keeps its session-start clock and its exact ~8s
no-retry timing, and a lone dead surface still aborts the clip rather than reaching either
screen-release path.

## Files

- `Services/Video/VideoSurfaceHealth.cs` **(new)** - every pure decision: `DecideFrameWatchdog`
  (with `retryAllowed`), `AllowsFrameRetry` (the rig rule), `ShouldAbortClip` (with
  `primarySurfaceDead`), `DecideBrowserFailure`, `DecideBrowserFrameSweep` (the browser engine's
  per-surface first-frame verdict), `FrameDeadlinePassed` + `ArmsFrameDeadlineAtSessionStart` +
  `SlidePendingDeadline` (the browser deadline-arming rules), `ShouldUncoverDeadSurface` (whether a
  dead mirror's screen may be freed - the strict guard both engines share), `ShouldDeferRetire`,
  `FormatSurfaceLine`, `Report`
- `Services/Video/VideoService.cs` - per-surface blur watchdog ladder + teardown-safe
  `RetryBlurSurface` (ownership proof and native calls in one `_mediaPlayersLock` region),
  `BlurSurfaceWatch` (now carries its `Window` and an interlocked report claim),
  `ReleaseDeadBlurSurfaceScreen`, deferred retire as a list + `FlushDeferredRetire` +
  `PlaybackLiveForRetire`, volatile `_videoPlaying`, `GetVideoWindowHandles`,
  `BlurVmemSurface.FirstFrameMs` + `FirstFrameObserved`, first-`Vout` surface line for the
  VideoView path
- `Services/Video/Browser/BrowserVideoSurface.cs` - `InitFailed` event, raised off the
  synchronous init path
- `Services/Video/Browser/BrowserVideoWindow.cs` - forwards `InitFailed`, `SessionStartTick`,
  per-window `FirstFrameDeadlineUtc` / `FirstFrameBudgetMs`
- `Services/Video/Browser/BrowserVideoEngine.cs` - `OnWindowInitFailed`, `DropSecondaryWindow`
  (hide-then-close outside strict, stay-black under it, + `_dropped`), `WindowDropped` event and
  `DroppedWindows`, `BrowserVideoRequest.IsHostStrict`, per-surface reporting, and
  `ArmFirstFrameWatch` rewritten as a per-surface sweep with per-window deadline arming (the
  session-wide `_firstFrameDeadlineUtc` / `_playingSeen` pair is gone)
- `Services/Video/VideoService.Browser.cs` - `FallbackToLibVlc` runs the pure policy;
  `IsHostStrict` wiring, `OnBrowserWindowDropped`, and `StopBrowserSession` pruning dropped
  mirrors from `_windows` and their HWNDs from the z-order anchor cache
- `Services/Notifications/OverlayService.cs` - `ResolveVideoAnchor`, per-monitor anchors in
  `ReassertZOrder`/`ReassertOne`, `MonitorFromWindow`/`IsWindow` P/Invokes
- `Services/Video/DualMonitorVideoService.cs` - DIP conversion
- `Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs` **(new)** - 47 tests

No localization changes: every new string is a log line, none are user-visible.

## Tests

- `dotnet build ConditioningControlPanel.sln -c Debug` - **0 errors**
- `dotnet test Tests/ConditioningControlPanel.Tests -c Debug` - **4070 / 4070 pass**, 0 failed
- 47 tests covering the browser fallback policy, the browser engine's per-surface first-frame
  sweep and its deadline-arming rules (an unarmed window is never condemned; only the primary
  arms at session start; a grace pause leaves an unarmed window unarmed), the frame-watchdog
  ladder and the rig rule that decides its retry rung (both arms), primary-aware liveness
  aggregation, whether a dead mirror's screen may be freed (strict keeps it covered), the
  retire-deferral rule and its stated limits, the z-order anchor set, and the exact diagnostics
  line

## NOT done / needs a human

**No two-screen verification happened here.** This machine cannot play a real multi-monitor
mandatory video, so every windowing, decoder and z-order effect below is reasoned from the code
and the reports, not observed. A dual-monitor run must check:

**Which engine you are testing matters.** `BrowserVideoEngineEnabled` defaults **on**, and
`BrowserVideoGate.ShouldUseBrowser` sends any `.mp4`/`.webm` with no explicit
`AudioOutputDeviceId` to WebView2 - primary *and* secondaries. The LibVLC blurred path (items
2-4) is only reached with **Settings > System > browser video engine OFF**, or with a clip whose
extension the gate never takes (e.g. `.wmv`), or with an explicit audio output device selected.
Items 11-12 cover the same two stalls on the default engine.

1. A blurred-background mandatory video on 2+ screens: **all** screens show frames, the primary
   has audio. `video-diag.log` should now carry one `VideoSurface: engine=... monitor=...` line
   per screen with a plausible `firstFrame=` value - on the default install those lines read
   `engine=browser`, one per monitor.
2. **(browser engine OFF, or a `.wmv`)** Force a SECONDARY screen to stall (or unplug/replug a
   secondary mid-clip): that screen alone goes black, the others keep playing to the end, and the
   trace shows `surface DEAD (1/2) - clip continues on the rest`.
3. **(browser engine OFF, or a `.wmv`)** Force the PRIMARY to stall on a 2-screen rig: it must get
   ONE re-`Play()` (`retry: player was ... - Play() re-issued on this surface only`) and then, if
   still nothing, skip at ~16s with `PRIMARY surface dead (1/2) ... skipping to next video` - NOT
   keep running on the mirror, and NOT skip at 8s without trying.
4. **(browser engine OFF, or a `.wmv`)** Single-monitor no-frame case: a broken clip must still be
   skipped after ~8s with `reason=... no retry rung on a single-surface rig`, i.e. unchanged from
   the released build. This is the timing regression guard for the majority rig.
5. Pink filter / spiral / Brain Drain / corner GIFs while a video plays on 2 screens: each
   overlay sits **under** the video on its own monitor (#1016), and the video is not buried
   (#497 must not regress).
6. A Deeper enhancement band over a 2-screen video still renders **above** the video.
7. Start bubble count (or a mini player) during a mandatory video, then end it, on a machine
   where the wedge reproduces: the video must not go black on any screen, and the trace should
   read `retire DEFERRED` then `flushing deferred retire at teardown`.
8. Mixed-DPI pair (100% + 150%): `DualMonitorVideoService` windows cover each screen exactly.
9. WebView2 forced to fail on the primary (rename the runtime, or kill the browser process
   during init): the clip must fall back to LibVLC promptly instead of sitting black for 20s.
10. WebView2 forced to fail on a SECONDARY only, with **no** strict lock (no Lock Card, no
    Lockdown, no Possession): that monitor must go clear (window hidden), the primary keeps
    playing, and nothing is left on screen after the clip ends.
11. **(browser engine ON - the default)** A SECONDARY that comes up and then never decodes (throttle
    that GPU, or block the video file for that window): within ~10s of that window's `ready` it must
    log `BrowserVideo[secondary]: no first frame within ...` plus a
    `VideoSurface: engine=browser monitor=... role=secondary firstFrame=none reason=no first frame
    within ...` line, the window must disappear from that monitor (**outside strict mode** - see
    item 13), and the clip must keep playing on the primary to its natural end. This is the item
    that was untestable before Round 3.
12. **(browser engine ON - the default)** The PRIMARY never decodes while a secondary plays fine:
    the session must fail and replay through LibVLC (`FallbackToLibVlc`), and the trace must still
    carry a per-surface line for the healthy mirror. Confirm the fallback happens **once**.

13. **The strict-lock counterpart of items 10-11 (new in Round 4, both engines).** Repeat the
    same forced secondary failure while the clip is under a Lock Card / Lockdown / Possession
    lock. That monitor must stay **covered and black** for the rest of the clip - the desktop must
    never become visible or clickable on it - and the black window must disappear when the clip
    ends. The trace should read `... but the clip is under a STRICT lock - the screen stays
    covered` (browser) or `dead surface KEPT on screen - strict lock` (LibVLC blur path).
14. **The LibVLC counterpart of item 10 (new in Round 4).** With **browser engine OFF** (or a
    `.wmv`), force a SECONDARY blur surface to stall with no strict lock: after the ~16s ladder
    that monitor must be **released** (the black fullscreen window disappears, the desktop is
    usable) while the clip plays on to its natural end elsewhere, trace `dead surface HIDDEN -
    monitor released`. Before Round 4 that screen stayed black for the whole clip.
15. **Cold 3-4 monitor start (the Round 4 blocker, browser engine ON).** On a slow disk with a
    cold WebView2 cache, start a mandatory video on 3+ screens. **Every** screen must come up and
    play; no `BrowserVideo[secondary]: no first frame within ...` line may appear for a window
    that simply took a long time to initialise. Check the per-surface `firstFrame=` values: large
    values on the trailing mirrors are expected and must not be treated as failures.

Also not done:

- **The "no bubble-pop audio afterwards" tail.** Neither the 60s native poison cooldown
  (`RecordNativePoisoning`, armed from `QuarantineNative`) nor the 4-retire-per-session budget
  is changed by this PR. Making a merely-suspected wedge stop spending both is the follow-up.
- Per-surface engine mixing. When the browser PRIMARY fails, the whole clip replays through
  LibVLC (the engine has no per-window engine switch). Deliverable 1 asked to "fall back THAT
  surface"; for a secondary the mirror is **reported and dropped** rather than rebuilt on LibVLC.
  That is the cheapest correct behaviour and it is now genuinely per-surface for liveness and for
  diagnostics, but a dead mirror still ends up as one fewer screen rather than a LibVLC mirror.
- A browser mirror that decodes for a while and *then* freezes mid-clip is still only visible
  through the page's own stall report, which is primary-scoped. The per-surface sweep covers the
  **first frame** only. Extending it to a mid-clip per-surface stall needs a `time` heartbeat per
  window and is not a v6.8.5-sized change.
- Isolating per-monitor players onto separate `LibVLC` instances (deliverable 4's stronger
  form). This PR takes the stated minimum - never retire while siblings are mid-playback -
  because a per-monitor instance changes the lifetime model for the whole wedge/quarantine
  machinery and is not a v6.8.5-sized change.
- `_deferredRetires` is static, matching the other shared-LibVLC statics; a second
  `VideoService` instance would share it. There is only ever one (`App.Video`).
- A browser mirror that strict mode keeps on screen is a **black** screen for the rest of the
  clip. That is deliberate (see Round 4 item 2) and matches the released build, but it means a
  strict-locked user on a rig where a mirror dies loses that screen's picture with no in-clip
  recovery. Rebuilding a dead mirror on the other engine mid-clip is the per-surface engine
  mixing listed above, and is not a v6.8.5-sized change.

Refs: #533 #540 #542 #559 #592 #617 #918 #1015 #1016 #1024 #1025 #1035 #1039 #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6xJB7QQLacJN9vN3gRAVe

