### PR TITLE
fix(gaze): debug cursor + calibration accuracy test paint on the wrong monitor

### DIFF
--- a/ConditioningControlPanel/Services/Tracking/GazeDebugCursorService.cs
+++ b/ConditioningControlPanel/Services/Tracking/GazeDebugCursorService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -463,14 +463,20 @@ public class GazeDebugCursorService : IDisposable
     /// folded in before painting. <see cref="Fyp.FypHostService"/> does the same conversion on
     /// the same event; this is that math, ending in the WPF units Window.Left/Top speak.
     ///
-    /// Painting <c>_pos - _overlay.Left</c> raw (the pre-2026-08-27 code) is invisibly correct
-    /// on a single primary monitor at (0,0) @100% — origin 0, scale 1 — and wrong on every
-    /// other layout. A monitor placed above or left of the primary makes VirtualScreenTop/Left
-    /// negative, which painted the dot a whole monitor low: the "gaze dot pinned to the bottom
-    /// of the screen" reports (tier-2, 2026-08-27). The calibration Accuracy test renders
-    /// through this same service (WebcamCalibrationWindow BubbleTestCursorKey /
-    /// "calibration-verify"), so the bad mapping also made calibration itself look broken for
-    /// multi-monitor users — the dot they were judging was not where the tracker said to look.
+    /// Painting <c>_pos - _overlay.Left</c> raw (the pre-2026-08-27 code) is correct whenever
+    /// calibration ran on the PRIMARY monitor at the overlay's scale, and only then. The
+    /// primary's origin is always (0,0) on the virtual desktop, so at scale 1 the two
+    /// expressions are identical at any monitor layout — which is why this survived. It breaks
+    /// when <see cref="MonitorBoundsRecord.X"/>/<c>Y</c> are non-zero, i.e. calibration
+    /// ran on a non-primary monitor (they are written from that screen's Bounds in
+    /// WebcamCalibrationWindow) — the dot then lands a whole monitor offset away, usually on the
+    /// primary instead of the screen being looked at — or when the calibrated monitor's DpiScale
+    /// differs from the overlay's, which multiplies positions by the wrong factor.
+    ///
+    /// The calibration Accuracy test renders through this same service (WebcamCalibrationWindow
+    /// BubbleTestCursorKey / "calibration-verify"), so this was never only a debug dot: a user
+    /// who calibrated on their second monitor was judging — and re-running — calibration against
+    /// a dot drawn somewhere the tracker never claimed (tier-2 reports, 2026-08-27).
     /// </summary>
     /// <returns>false when the overlay is gone, in which case nothing should be drawn.</returns>
     private bool TryOverlayLocal(out float lx, out float ly)

--- a/ConditioningControlPanel/Services/Tracking/GazeDebugCursorService.cs
+++ b/ConditioningControlPanel/Services/Tracking/GazeDebugCursorService.cs
@@ -328,10 +328,8 @@ public class GazeDebugCursorService : IDisposable
             }
 
             // Feed the trail from the latest cursor position (overlay-local).
-            if (_hasPos && !_faceLost)
+            if (_hasPos && !_faceLost && TryOverlayLocal(out float lx, out float ly))
             {
-                float lx = (float)(_pos.X - _overlay.Left);
-                float ly = (float)(_pos.Y - _overlay.Top);
                 bool add = _trail.Count == 0;
                 if (!add)
                 {
@@ -435,8 +433,7 @@ public class GazeDebugCursorService : IDisposable
         // white rim so it stays readable over busy/light content (the rim
         // is normal alpha blending, not additive — additive vanishes on
         // white backgrounds).
-        float cx = (float)(_pos.X - _overlay.Left);
-        float cy = (float)(_pos.Y - _overlay.Top);
+        if (!TryOverlayLocal(out float cx, out float cy)) { canvas.Restore(); return; }
         var sprite = DotSprite();
         var bodyCF = _locked ? _lockedCF : _idleCF;
         if (sprite != null)
@@ -458,6 +455,47 @@ public class GazeDebugCursorService : IDisposable
         _spritePaint.Color = new SKColor(255, 255, 255, alpha);
         var dest = new SKRect(cx - radius, cy - radius, cx + radius, cy + radius);
         canvas.DrawImage(img, dest, _spritePaint);
+    }
+
+    /// <summary>
+    /// Gaze events arrive in DIPs local to the monitor calibration ran on, but this overlay
+    /// spans the whole virtual desktop — so the calibrated monitor's origin and DPI have to be
+    /// folded in before painting. <see cref="Fyp.FypHostService"/> does the same conversion on
+    /// the same event; this is that math, ending in the WPF units Window.Left/Top speak.
+    ///
+    /// Painting <c>_pos - _overlay.Left</c> raw (the pre-2026-08-27 code) is invisibly correct
+    /// on a single primary monitor at (0,0) @100% — origin 0, scale 1 — and wrong on every
+    /// other layout. A monitor placed above or left of the primary makes VirtualScreenTop/Left
+    /// negative, which painted the dot a whole monitor low: the "gaze dot pinned to the bottom
+    /// of the screen" reports (tier-2, 2026-08-27). The calibration Accuracy test renders
+    /// through this same service (WebcamCalibrationWindow BubbleTestCursorKey /
+    /// "calibration-verify"), so the bad mapping also made calibration itself look broken for
+    /// multi-monitor users — the dot they were judging was not where the tracker said to look.
+    /// </summary>
+    /// <returns>false when the overlay is gone, in which case nothing should be drawn.</returns>
+    private bool TryOverlayLocal(out float lx, out float ly)
+    {
+        lx = 0f;
+        ly = 0f;
+        if (_overlay == null) return false;
+
+        var bounds = App.Webcam?.Calibration?.MonitorBounds;
+        // A pre-hotfix save carries no DeviceName: the monitor is unknown, so fall back to
+        // "primary, at the origin" rather than trusting a stale X/Y. Same rule as FypHostService.
+        bool known = bounds?.DeviceName != null;
+        double scale = bounds is { DpiScale: > 0.25 and < 8.0 } ? bounds.DpiScale : 1.0;
+        double originX = known ? bounds!.X : 0;
+        double originY = known ? bounds!.Y : 0;
+
+        // monitor-local DIPs -> physical desktop px -> WPF units.
+        double physX = _pos.X * scale + originX;
+        double physY = _pos.Y * scale + originY;
+        double sx = _dpiX > 0 ? _dpiX : 1.0;
+        double sy = _dpiY > 0 ? _dpiY : 1.0;
+
+        lx = (float)(physX / sx - _overlay.Left);
+        ly = (float)(physY / sy - _overlay.Top);
+        return true;
     }
 
     private void CacheDpi()


### PR DESCRIPTION
## What

`GazeDebugCursorService` painted the dot at `_pos - _overlay.Left`, but `_pos` arrives in **DIPs local to the monitor calibration ran on**, while `_overlay` spans the whole virtual desktop. The calibrated monitor's origin and DPI scale were never applied.

New `TryOverlayLocal()` does the conversion, mirroring `FypHostService.cs:1315-1320`, which already handles the same event correctly:

```
monitor-local DIPs  ->  * DpiScale + MonitorBounds.X/Y  ->  physical desktop px
                    ->  / overlay DPI - overlay.Left/Top  ->  WPF window-local
```

Both paint sites (trail and cursor) route through it.

## When it bites

`MonitorBounds.X/Y` are written from `calScreen.Bounds.X/Y` (`WebcamCalibrationWindow.xaml.cs:660-668`), i.e. the physical origin of whichever screen the calibration window was on:

- **calibrated on a non-primary monitor** -> origin is non-zero -> the dot is painted a whole monitor offset away, typically on the primary rather than the screen being looked at
- **calibrated monitor scaled differently from the overlay** -> positions come out multiplied by the wrong factor, error growing with distance from the origin

Calibrate on the primary at 100% and the old and new expressions are identical - the primary's origin is always (0,0) - which is why this survived. Correcting my own earlier triage note: this does **not** explain a dot pinned low on a single-monitor or primary-calibrated setup.

## Why it is not just a debug dot

The calibration **Accuracy test** renders through this same service (`WebcamCalibrationWindow.xaml.cs:1533` `BubbleTestCursorKey`, `:771` `"calibration-verify"`). A user who calibrated on their second monitor was judging - and re-running - calibration against a dot drawn somewhere the tracker never claimed.

## Compatibility

A pre-hotfix save has no `DeviceName`; the monitor is unknown, so we fall back to "primary, at the origin" instead of trusting a stale `X/Y`. Same rule `FypHostService` uses.

## Testing

`dotnet build` clean: 0 errors, 342 warnings (baseline), none referencing the changed file. Diff is 1 file, +43/-5. Not yet play-tested on a multi-monitor rig - that is the ask on this PR.

## Not in this PR

`GazeFocusService.SetCursorLock:400-414` passes absolute window centres to `SetGazeAttractor`, which documents monitor-local. Separate bug, still open.

Reported in tier-2 by Yiin and beebee (both multi-monitor), 2026-08-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGbd9Znp92UefzLGiXEcch