### PR TITLE
fix(sort): vet every Scrolller url before the deal (no more striped placeholder cards)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1729,6 +1729,26 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     right. `prefer:'loop'|'still'` is a SWAP, not a skip - the wanted kind is pulled forward
     into the cursor's slot and the row it displaced keeps its place, so a preference can never
     starve a kind out of the pass.
+124. **A SORT DEALS ONLY OFF VETTED URLS, AND THE VET IS THE ONE DETACHED `<video>` IN THE
+    SCHOOL.** Scrolller's index serves posts whose CDN file is GONE (0827 probe: 7/30 r/aww
+    loops and 8/30 stills answered 404), the host validates format and never liveness, and a
+    dealt dead row is the striped card back the owner was "sick of". `provider/vet.js` probes
+    every remote row between the claim and the deal (`pool.vet(rows, {enough, maxMs})`): a
+    detached `Image` for a still/gif, a `preload=metadata` `<video>` for a clip - the media
+    CDN sends NO CORS headers, so an element is the only status a page can read; `fetch()`
+    sees an opaque reply and learns nothing. A dead verdict is a PERMANENT blacklist strike
+    (`markBrokenUrl(url, true)` - the 45s TTL is for guesses, a 404 is proof); `unsure`
+    (timeout, ABORTED/DECODE codes) is never a conviction and never counts as alive. The door
+    (`games/sort/index.js` VET_GATE) opens on ENOUGH alive rows per tag, or every row judged,
+    or MAX_MS, and a tag short of `DECK.PER_SOURCE_MIN` alive rows asks the host for more
+    first (`pool.refill(tag)`, TAGGED.REFILL_MAX rounds, a fresh MAX_ASKS each). Trap 36 still
+    holds: the vet runs ONLY while the door is up (nothing minted), holds at most VIDEO_LANES
+    (= DECODER_CEILING) probes, tears each src down on its verdict, and `open()` aborts every
+    video probe the instant the gate opens - a class never shares a decoder with the vet. Do
+    NOT "optimise" the vet into the warm rail's no-cors fetch (no verdict) or into the class
+    (a demuxer the ceiling cannot see). The desktop host now serves SORT the card rendition
+    (`Entry.SmallUrl`, clip <= 640 / still <= 1280, the web port's caps) instead of the 1920px
+    feed one; the page never reads `smallUrl` - the host substitutes.
 54. **THE NEW MEDIA FRAMES ARE ADDITIVE OR THEY ARE A REGRESSION IN NINE OTHER CLASSES.**
     `assets-request` WITHOUT `subs` must stay byte-for-byte the ask it always was (the host's
     app-wide pull), and `local-sample-request` is a SEPARATE type answered by the SAME `assets`

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
@@ -205,6 +205,15 @@ export function wrapQuickPool(claimPool) {
     isBroken(url) {
       try { return !!(p && typeof p.isBroken === 'function' && p.isBroken(url)); } catch (e) { return false; }
     },
+    /* THE VET SEAM (0827) rides through too. A quick pool is the host's own
+     * disk, which the vet answers "alive" for without a probe - so the door's
+     * gate over a quick sort opens on the next tick, exactly as it did. */
+    vet(rows, opts) {
+      try { if (p && typeof p.vet === 'function') return p.vet(rows, opts); } catch (e) { /* fall through */ }
+      return Promise.resolve(null);
+    },
+    /** A quick pool has no tag to top up - the ordinary claim keeps itself fed. */
+    refill() { return Promise.resolve(0); },
     dealt() {
       const rows = [];
       for (const tg of DECK.TAGS) for (const url of seen[tg]) rows.push({ url, tag: tg, src: 'local' });

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -218,6 +218,28 @@ const DECODER_CEILING = 2;
  *  supply figure - six rows in front of a cursor is six rows whether the deck
  *  is 60 long or 120. Stays 6. */
 const PREWARM = 6;
+/**
+ * THE VET GATE (owner 2026-08-27: "pre-fetch the images and only start the
+ * game when we got enough"). Scrolller's index serves posts whose CDN file is
+ * gone (a live probe found a quarter of r/aww's rows answering 404), the host
+ * validates format and never liveness, and the class dealt them - a card
+ * whose face errors is the striped back the owner was sick of. So the door
+ * now PROBES every remote row the claim brought in (provider/vet.js: a
+ * detached Image for a still/gif, a metadata-only <video> for a clip - the
+ * media CDN sends no CORS headers, so an element is the only status a page
+ * can read) and deals only once ENOUGH alive rows stand per tag, or every
+ * row has a verdict, or MAX_MS has passed. A dead verdict is a PERMANENT
+ * blacklist strike, so buildDeck (pool.next skips the blacklist) never deals
+ * it and substituteFor never picks it. A tag left with fewer than
+ * DECK.PER_SOURCE_MIN alive rows asks the host for more (pool.refill) and
+ * vets those too, REFILL_ROUNDS at most. Rows still unjudged when the gate
+ * opens keep the ordinary road: faceDied -> blacklist -> substitute.
+ */
+const VET_GATE = Object.freeze({
+  ENOUGH: 24,             // alive rows per tag that open the gate early
+  MAX_MS: 20000,          // the ceiling a slow CDN may hold the door for
+  REFILL_ROUNDS: 2,       // top-up asks when a tag is short (= TAGGED.REFILL_MAX)
+});
 /* (The game-local WARM_AHEAD/WARM_INFLIGHT byte rail moved INTO the provider
  * as the manifest warmer, 0825: buildDeck knows the whole ordered deck before
  * the first card shows, so warmDeck() below hands it to pool.warmManifest()
@@ -644,10 +666,97 @@ export default {
            Each press is a generation; an older claim or ghost that lands late
            is disposed, never dealt. */
         let playGen = 0;
+        let pendingVet = null;
+        const cancelVet = () => {
+          try { if (pendingVet && typeof pendingVet.cancel === 'function') pendingVet.cancel(); }
+          catch (e) { /* noop */ }
+          pendingVet = null;
+        };
         const disposePending = () => {
+          cancelVet();
           try { if (pending && pending.pool && typeof pending.pool.dispose === 'function') pending.pool.dispose(); }
           catch (e) { /* noop */ }
           pending = { pool: null, quick: false, hot: false, thin: false, sources: null };
+        };
+        /**
+         * THE VET, between the claim and the deal (VET_GATE above). Never
+         * rejects and never holds a stale generation: `live()` is asked after
+         * every await and a press that lost its turn just stops. A pool
+         * without the seam (a quick sort, an old double) passes straight through.
+         */
+        const busy = (key, detail) => {
+          try { if (door && typeof door.setBusy === 'function') door.setBusy(true, key, detail); }
+          catch (e) { /* noop */ }
+        };
+        const vetPending = (live) => {
+          const pool = pending.pool;
+          if (pending.quick || !pool || typeof pool.vet !== 'function' || typeof pool.dealt !== 'function') {
+            return Promise.resolve();
+          }
+          const alive = { target: 0, noise: 0 };
+          const vetted = new Set();
+          let base = { ok: 0, total: 0 };
+          const startedAt = now();
+          /* ONE ceiling for the whole gate, however many rounds it takes */
+          const msLeft = () => Math.max(1000, VET_GATE.MAX_MS - (now() - startedAt));
+          const unvetted = () => {
+            try { return (pool.dealt() || []).filter((r) => r && r.url && !vetted.has(r.url)); }
+            catch (e) { return []; }
+          };
+          const okOf = (st, tg) => (st && st.byTag && st.byTag[tg] ? (st.byTag[tg].ok | 0) : 0);
+          const enough = (st) => ['target', 'noise'].every((tg) => alive[tg] + okOf(st, tg) >= VET_GATE.ENOUGH);
+          const run = (rows) => {
+            busy('sort_vetting', base.ok + '/' + (base.total + rows.length));
+            let pr = null;
+            try {
+              pr = pool.vet(rows, {
+                maxMs: msLeft(),
+                enough,
+                onProgress: (st) => { if (live()) busy('sort_vetting', (base.ok + st.ok) + '/' + (base.total + st.total)); },
+              });
+            } catch (e) { pr = null; }
+            if (!pr || typeof pr.then !== 'function') return Promise.resolve(null);
+            pendingVet = pr;
+            return pr;
+          };
+          const round = (n, rows) => {
+            if (!live() || !rows.length) return Promise.resolve();
+            for (const r of rows) if (r && r.url) vetted.add(r.url);
+            return run(rows).then((st) => {
+              pendingVet = null;
+              if (!live()) return undefined;
+              if (st) {
+                for (const tg of ['target', 'noise']) alive[tg] += okOf(st, tg);
+                base = { ok: base.ok + (st.ok | 0), total: base.total + (st.total | 0) };
+              }
+              const short = ['target', 'noise'].filter((tg) => alive[tg] < DECK.PER_SOURCE_MIN);
+              if (n >= VET_GATE.REFILL_ROUNDS) return undefined;
+              if (!short.length || typeof pool.refill !== 'function') {
+                /* THE LATE ROWS. The pool keeps absorbing the host's background
+                   batches while the vet runs, and a row that landed after the
+                   round began would reach the deal unjudged - the one hole the
+                   gate must not leave. Sweep them (same rounds bound, same
+                   ceiling); a pool that stood still ends here. */
+                const late = unvetted();
+                return late.length ? round(n + 1, late) : undefined;
+              }
+              busy('sort_vet_more');
+              return Promise.all(short.map((tg) => {
+                try { return Promise.resolve(pool.refill(tg)).catch(() => 0); } catch (e) { return Promise.resolve(0); }
+              })).then((got) => {
+                if (!live()) return undefined;
+                const added = got.reduce((a, b) => a + (Number(b) || 0), 0);
+                say('vet: ' + short.join(' and ') + ' short (' + alive.target + '/' + alive.noise + ' alive), refill +' + added);
+                if (!added) return undefined;
+                return round(n + 1, unvetted());
+              });
+            });
+          };
+          let rows = [];
+          try { rows = pool.dealt() || []; } catch (e) { rows = []; }
+          return round(0, rows)
+            .then(() => { if (live()) say('vet: alive target ' + alive.target + ' / noise ' + alive.noise); })
+            .catch((e) => { say('vet threw: ' + ((e && e.message) || e)); });
         };
         const onPlay = (blob, resolved) => {
           if (settled) return;
@@ -678,6 +787,11 @@ export default {
               thin: false,
               sources: res.sources || [],
             };
+            /* THE VET GATE sits between the claim and everything below it:
+               the thin strip, the ghost round and the deal all wait on it. */
+            const live = () => !settled && gen === playGen;
+            vetPending(live).then(() => {
+            if (!live()) return;
             try { if (door && typeof door.setBusy === 'function') door.setBusy(false, ''); }
             catch (e) { /* noop */ }
             /* THIN is only knowable now: the door raises its strip (non-blocking,
@@ -705,6 +819,7 @@ export default {
             } catch (e) { say('ghost round threw: ' + ((e && e.message) || e)); go(); }
             /* a door whose ghost never resolves may not hold the class hostage */
             timers.after(12000, go);
+            });
           }, (e) => {
             if (settled || gen !== playGen) return;
             say('the deal failed: ' + ((e && e.message) || e));

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup-lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup-lex.js
@@ -30,6 +30,8 @@ export const SETUP_LEX = Object.freeze({
   sort_next: 'Next',
   sort_play: 'Deal me in',
   sort_dealing: 'Dealing your deck',
+  sort_vetting: 'Checking your cards',
+  sort_vet_more: 'Fetching more cards',
   sort_vs: 'vs',
 
   /* ---- first night hand holding (hidden by Skip class tutorials) --------- */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
@@ -1145,9 +1145,15 @@ export function createSetupDoor(o) {
 
   /* ----------------------------------------------------------- the handle -- */
 
-  function setBusy(onFlag, msgKey) {
+  /**
+   * setBusy(on, msgKey[, detail]). `detail` (0827) is the vet's live count
+   * ("14/48") - a number, never a sentence, so the lexicon stays the only
+   * source of words: the row is `t(msgKey)` and the detail rides after it.
+   */
+  function setBusy(onFlag, msgKey, detail) {
     if (destroyed) return;
     busyKey = onFlag ? String(msgKey || 'sort_dealing') : '';
+    const line = () => t(busyKey) + (detail == null || detail === '' ? '' : ' ' + String(detail));
     if (!onFlag) {
       if (busyEl && busyEl.parentNode) busyEl.parentNode.removeChild(busyEl);
       busyEl = null;
@@ -1157,11 +1163,11 @@ export function createSetupDoor(o) {
       busyEl = el('div', 'g-sort-busy');
       attr(busyEl, 'role', 'status');
       busyEl.appendChild(el('i', 'g-sort-spin'));
-      busyEl._sdText = el('span', 'g-sort-busy-t', t(busyKey));
+      busyEl._sdText = el('span', 'g-sort-busy-t', line());
       busyEl.appendChild(busyEl._sdText);
       root.appendChild(busyEl);
     } else {
-      busyEl._sdText.textContent = t(busyKey);
+      busyEl._sdText.textContent = line();
     }
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -74,6 +74,7 @@
 import { buildLocalPools, isLocalUrl, formatOk, kindOf, wantRemote } from './inventory.js';
 import { createRemoteChannel } from './remote.js';
 import { createTaggedPool, TAGGED } from './tagged.js';
+import { createVetter } from './vet.js';
 
 /** Bundled placeholder tiles (geometric mono-pink, no text). The floor. */
 export const PLACEHOLDER_FILES = Object.freeze([
@@ -181,10 +182,17 @@ export const MANIFEST_AHEAD_PLAY = 10;
 const BROKEN_URL_CAP = 400;
 const BROKEN_TTL_MS = 45000;      // one strike heals after this; two never do
 const brokenUrls = new Map();     // url -> { at, strikes }
-export function markBrokenUrl(url) {
+export function markBrokenUrl(url, permanent) {
   const s = String(url || '');
   if (!s) return false;
   const prior = brokenUrls.get(s);
+  if (permanent) {
+    /* PROOF, not a guess (the vet's 404): two strikes at once, so the TTL
+     * never forgives it - a dead CDN file does not come back in 45 seconds */
+    brokenUrls.delete(s);
+    brokenUrls.set(s, { at: Date.now(), strikes: 2 });
+    return !prior;
+  }
   if (prior) {
     /* a repeat offender: bump the strike and re-stamp. delete + set keeps the
      * Map's insertion order meaning "least recently struck evicts first". */
@@ -614,10 +622,10 @@ export function createAssets(options = {}) {
   }
   /** The instance's blacklist verb: the module Set, plus this instance's
    *  waiters answered "no" so a gate consulting ready() moves on at once. */
-  function markBroken(url) {
+  function markBroken(url, permanent) {
     const s = String(url || '');
     if (!s) return;
-    markBrokenUrl(s);
+    markBrokenUrl(s, !!permanent);
     flushReady(s, false);
   }
 
@@ -829,12 +837,17 @@ export function createAssets(options = {}) {
 
   /** The media seam every pool shape exposes (claim() below, claimTagged's
    *  wrapper, and deck-side adapters forward these five verbs verbatim). */
+  /* THE VET (0827, see ./vet.js): liveness proof for a list of rows before a
+   * game deals off them. Its dead verdicts land in the blacklist above as
+   * PERMANENT strikes, so a tagged serve / a substitute pick skips them. */
+  const vetter = createVetter({ markBroken, isBroken: isBrokenUrl, isLocal: isLocalUrl, log });
   const mediaSeam = {
     warmManifest: (entries, opts) => { void opts; return warmManifest(entries); },
     warmCursor: (i) => warmCursor(i),
     ready: (url, opts) => readyFor(url, opts),
-    markBroken: (url) => markBroken(url),
+    markBroken: (url, permanent) => markBroken(url, permanent),
     isBroken: (url) => isBrokenUrl(url),
+    vet: (rows, opts) => (disposed ? Promise.resolve(null) : vetter.vet(rows, opts)),
   };
 
   /* ==========================================================================
@@ -1374,12 +1387,14 @@ export function createAssets(options = {}) {
        *   warmCursor(i)                  the game's play position in it
        *   ready(url, {timeoutMs})       -> Promise<boolean> (see readyFor)
        *   markBroken(url) / isBroken(url) the shared url blacklist
+       *   vet(rows, opts)               -> Promise<stats> (see ./vet.js)
        */
       warmManifest: mediaSeam.warmManifest,
       warmCursor: mediaSeam.warmCursor,
       ready: mediaSeam.ready,
       markBroken: mediaSeam.markBroken,
       isBroken: mediaSeam.isBroken,
+      vet: mediaSeam.vet,
       /** How many candidates the pool can actually serve right now. */
       stats() {
         return {
@@ -1449,6 +1464,7 @@ export function createAssets(options = {}) {
         pool.ready = mediaSeam.ready;
         pool.markBroken = mediaSeam.markBroken;
         pool.isBroken = mediaSeam.isBroken;
+        pool.vet = mediaSeam.vet;
       }
       return pool;
     });

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
@@ -22,6 +22,7 @@
  *   pool.next('target', { prefer:'loop' })  -> row | null
  *   pool.counts() / pool.thin(tag) / pool.empty(tag) / pool.prewarm(n)
  *   pool.spare(tag) / pool.dealt() / pool.dispose()
+ *   pool.refill(tag) -> Promise<added>   (the vet's top-up, see below)
  *
  * FIVE LAWS
  *  1. THE TAG IS THE TRUTH. A row keeps the tag of the SOURCE that served it
@@ -57,6 +58,8 @@ export const TAGGED = Object.freeze({
   BATCH_MAX: 24,          // the host's own per-reply cap
   PREWARM_CAP: 12,        // per tag, per prewarm() call (see provider PREWARM_MAX)
   TAG_CAP: 120,           // a page never hoards media (REMOTE_CAP's law, per tag)
+  REFILL_MAX: 2,          // refill(tag) rounds a pool grants, each a fresh MAX_ASKS
+  REFILL_MS: 6000,        // a refill that hears nothing by then answers 0
 });
 
 /** The two tags every caller may read unconditionally, even with no sources. */
@@ -140,6 +143,7 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
       served: 0,
       cycle: 0,                 // 0 = the first pass; 1+ = a seeded re-serve
       asks: 0,
+      refills: 0,               // refill() rounds spent (each widens the ask budget)
       inFlight: 0,
       thin: false,              // frozen at resolve (law 4)
       /* Each tag owns its own mulberry32 stream, so adding a tag never shifts
@@ -166,6 +170,8 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
     timers.clear();
   }
 
+  const isDead = (url) => { try { return typeof broken === 'function' && !!broken(url); } catch (e) { return false; } };
+
   /* ---------------------- the ask ---------------------------------------- */
   /** How many distinct rows a tag is still worth asking for.
    *
@@ -182,11 +188,21 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
     return Math.max(perSourceMin, Math.min(TAGGED.TAG_CAP, share || perSourceMin * 2, rows * 80));
   }
 
+  /** The ask budget, widened by every refill() round the vet spent. */
+  function askCap(tag) { return TAGGED.MAX_ASKS * (1 + (tag.refills | 0)); }
+  /** Rows the blacklist has NOT convicted - the only rows worth counting when
+   *  deciding whether to keep asking (a pile of 40 dead urls is an empty pile). */
+  function liveRows(tag) {
+    let n = 0;
+    for (const r of tag.rows) if (!isDead(r.url)) n += 1;
+    return n;
+  }
+
   function ask(src, kind, attempt) {
     if (disposed) return;
     const tag = tags[src.tag];
     if (!tag) return;
-    if (tag.asks >= TAGGED.MAX_ASKS) return;
+    if (tag.asks >= askCap(tag)) return;
     if (src.kind === 'remote' && !remoteAllowed) return;
     const count = Math.max(4, Math.min(TAGGED.BATCH_MAX, Math.ceil(want[kind] / Math.max(1, sources.length)) || 8));
     const payload = { count, kind, tag: src.tag };
@@ -209,7 +225,7 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
         /* THE HOST CONTRACT IS "ASK AGAIN AFTER EVERY REPLY" - a cold buffer
          * answers empty and streams the real batch later, so one ask per source
          * would deal a class off nothing. Bounded by the tag's ask budget. */
-        if (tag.rows.length < targetFor(tag) && tag.asks < TAGGED.MAX_ASKS) {
+        if (liveRows(tag) < targetFor(tag) && tag.asks < askCap(tag)) {
           later(() => ask(src, kind, attempt + 1), TAGGED.RETRY_MS * Math.max(1, attempt));
         }
         settleCheck();
@@ -268,7 +284,7 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
   function budgetSpent() {
     const used = tagNames.filter((n) => sources.some((x) => x.tag === n));
     if (!used.length) return true;
-    return used.every((n) => tags[n].asks >= TAGGED.MAX_ASKS && tags[n].inFlight === 0);
+    return used.every((n) => tags[n].asks >= askCap(tags[n]) && tags[n].inFlight === 0);
   }
 
   function settleCheck() {
@@ -292,8 +308,6 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
     tag.order = shuffled(tag.rows, tag.rng);
     tag.cursor = 0;
   }
-
-  const isDead = (url) => { try { return typeof broken === 'function' && !!broken(url); } catch (e) { return false; } };
 
   function nextRow(tagName, opts) {
     const tag = tags[tagName];
@@ -383,6 +397,45 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
       return x ? x.rows.slice() : [];
     },
 
+    /**
+     * THE TOP-UP (0827, the vet's road back to the host). When the vet has
+     * convicted enough of a tag's rows that fewer than perSourceMin are alive,
+     * the door asks for MORE before it deals: one fresh MAX_ASKS budget for
+     * every source of the tag, the same ask() chain the claim ran (so RANDOM
+     * sort on the host's side hands back posts it has not served yet), and a
+     * promise that answers with how many distinct rows landed - on the first
+     * batch that grows the tag (plus a short settle so a second reply in the
+     * same breath is counted too), or 0 at REFILL_MS. Bounded by REFILL_MAX
+     * rounds per tag for the life of the pool. `thin` stays frozen (law 4).
+     */
+    refill(tagName) {
+      const tag = tags[String(tagName || '')];
+      if (!tag || disposed || !resolved) return Promise.resolve(0);
+      if (tag.refills >= TAGGED.REFILL_MAX) return Promise.resolve(0);
+      const srcs = sources.filter((x) => x.tag === tag.name && (x.kind === 'local' || remoteAllowed));
+      if (!srcs.length) return Promise.resolve(0);
+      tag.refills += 1;
+      const before = tag.rows.length;
+      for (const src of srcs) {
+        if (want.loop || (!want.loop && !want.still)) ask(src, 'loop', 1);
+        if (want.still) ask(src, 'still', 1);
+      }
+      if (!tag.inFlight) return Promise.resolve(0);          // nothing could be asked
+      say('refill ' + tag.name + ' (round ' + tag.refills + ')');
+      return new Promise((res) => {
+        let done = false;
+        let off = () => {};
+        const fin = () => {
+          if (done) return;
+          done = true;
+          try { off(); } catch { /* noop */ }
+          res(Math.max(0, tag.rows.length - before));
+        };
+        off = pool.onUpdate(() => { if (tag.rows.length > before) later(fin, 400); });
+        later(fin, TAGGED.REFILL_MS);
+      });
+    },
+
     /** Every DISTINCT row, for the retake cache (a superset of {url,tag,src}). */
     dealt() {
       const out = [];
@@ -406,7 +459,7 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
         sources: sources.map((x) => ({ tag: x.tag, kind: x.kind, label: sourceLabel(x) })),
         tags: tagNames.map((n) => ({
           tag: n, distinct: tags[n].rows.length, served: tags[n].served,
-          cycle: tags[n].cycle, asks: tags[n].asks, thin: tags[n].thin,
+          cycle: tags[n].cycle, asks: tags[n].asks, refills: tags[n].refills, thin: tags[n].thin,
         })),
       };
     },

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/vet.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/vet.js
@@ -1,0 +1,341 @@
+/**
+ * provider/vet.js - THE VET (0827). Proof that a url is ALIVE, before a deck
+ * is dealt off it.
+ *
+ * WHY THIS EXISTS. Scrolller's index keeps serving posts whose CDN file is
+ * gone: a live probe (2026-08-27) found 7 of 30 r/aww loops and 8 of 30 stills
+ * answering 404, and every one of them reached the page as a perfectly
+ * well-formed row - the host validates FORMAT, never liveness, and the page
+ * trusts the row. The card was dealt, its face fired `error`, and the player
+ * sat on the striped back. The blacklist + substitute layer (index.js
+ * markBrokenUrl / sort's substituteFor) only ever learned a url was dead AFTER
+ * it had been shown, and BROKEN_TTL_MS forgave the first strike 45s later, so
+ * the same dead card came back next pass. The owner's word: "pre-fetch the
+ * images and only start the game when we got enough".
+ *
+ * WHAT IT DOES. vet(rows) probes every remote url ONCE per page and answers
+ * with a verdict per url:
+ *   - a STILL / GIF rides a detached `new Image()`: `load` with pixels is
+ *     alive (and the bytes + decode now sit in the browser's image cache, so
+ *     the vet doubles as the warm), `error` is DEAD. The media CDN sends no
+ *     CORS headers, so this - not fetch() - is the only status a page can read.
+ *   - a VIDEO rides a detached `<video preload="metadata" muted>`:
+ *     `loadedmetadata` is alive, `error` with MEDIA_ERR_NETWORK (2) or
+ *     MEDIA_ERR_SRC_NOT_SUPPORTED (4) is dead (a 404 lands as 4), any other
+ *     code is UNSURE. This is the ONE sanctioned detached <video> in the
+ *     school (trap 36 forbids them because a demuxer no ceiling counts is a
+ *     third decoder off screen): it runs ONLY while the door is up - nothing
+ *     is minted yet - it holds at most VIDEO_LANES (= DECODER_CEILING) at a
+ *     time, its src is torn down the instant a verdict lands, and settle()
+ *     ABORTS every video probe still in flight the moment the gate opens, so
+ *     the class never shares a decoder with the vet.
+ *   - a probe that answers nothing inside PROBE_MS is UNSURE: a slow CDN is
+ *     not a 404, and the ordinary face-error road (faceDied) is still there
+ *     for it. Unsure is never a conviction and never counts as alive.
+ *   - a LOCAL / same-origin / data: / blob: url is alive by definition (the
+ *     host serving the player's own disk) and is never probed.
+ *
+ * A DEAD verdict is PROOF, so it goes to the blacklist as a PERMANENT strike
+ * (markBroken(url, true)) - the 45s TTL is for guesses, and a 404 is not one.
+ *
+ * THE GATE. vet() resolves when EVERY row has a verdict, or when `enough(stats)`
+ * says the caller can deal (SORT: N alive per tag), or at `maxMs` - whichever
+ * lands first. The IMAGE probes still queued keep running in the background
+ * after an early resolve (they cost no decoder, and every verdict they land
+ * feeds the same blacklist the deal reads); the video probes do not (above).
+ * Never rejects: a vet that could throw would be a class that could not start.
+ *
+ * INERT where it cannot see: a node harness (no `document`, no `Image`) gets
+ * every url back as alive at once - the suites see no new asynchrony.
+ */
+
+export const VET = Object.freeze({
+  IMAGE_LANES: 4,       // detached <img> probes in flight (a cache warm each)
+  VIDEO_LANES: 2,       // detached <video> probes in flight = DECODER_CEILING
+  PROBE_MS: 8000,       // a probe with no answer by then is UNSURE, not dead
+  MAX_MS: 20000,        // the gate's hard ceiling, whatever is still pending
+});
+
+const VIDEO_URL_RE = /\.(mp4|webm|m4v|mov)(\?|#|$)/i;
+
+/** One verdict per url per PAGE: 'ok' | 'dead' | 'unsure'. A second press of
+ *  PLAY, a retake, another class - none of them re-probe a url this page has
+ *  already judged (an unsure one IS re-probed: it was a timeout, not a verdict). */
+const verdicts = new Map();
+
+/**
+ * @param {Object} o
+ * @param {Function} o.markBroken (url, permanent) -> the provider's blacklist verb
+ * @param {Function} o.isBroken   (url) -> boolean
+ * @param {Function} o.isLocal    (url) -> boolean (inventory.js isLocalUrl)
+ * @param {Function} [o.log]
+ */
+export function createVetter(o = {}) {
+  const say = typeof o.log === 'function' ? o.log : () => {};
+  const markBroken = typeof o.markBroken === 'function' ? o.markBroken : () => {};
+  const isBroken = typeof o.isBroken === 'function' ? o.isBroken : () => false;
+  const isLocal = typeof o.isLocal === 'function' ? o.isLocal : () => false;
+
+  const canProbe = (() => {
+    try {
+      return typeof document !== 'undefined' && typeof document.createElement === 'function'
+        && typeof Image === 'function';
+    } catch (e) { return false; }
+  })();
+
+  /** Alive without asking: the host's own disk, our origin, inline data. */
+  function instant(url) {
+    const s = String(url || '');
+    if (!s) return false;
+    try { if (isLocal(s)) return true; } catch (e) { /* fall through */ }
+    if (!/^https?:\/\//i.test(s)) return true;
+    try {
+      if (typeof location !== 'undefined' && location.origin && new URL(s).origin === location.origin) return true;
+    } catch (e) { /* an unparsable url is not instant */ }
+    return false;
+  }
+
+  function isVideo(row) {
+    if (row && typeof row.mime === 'string' && /^video\//i.test(row.mime)) return true;
+    return VIDEO_URL_RE.test(String((row && row.url) || ''));
+  }
+
+  /* ---------------------------------------------------------- one probe -- */
+  /** @returns {{ promise: Promise<string>, abort: Function }} */
+  function probeImage(url) {
+    let img = null;
+    let timer = 0;
+    let settled = false;
+    let resolveFn = null;
+    const promise = new Promise((res) => { resolveFn = res; });
+    const finish = (v) => {
+      if (settled) return;
+      settled = true;
+      try { clearTimeout(timer); } catch (e) { /* noop */ }
+      try { if (img) { img.onload = null; img.onerror = null; } } catch (e) { /* noop */ }
+      resolveFn(v);
+    };
+    try {
+      img = new Image();
+      img.decoding = 'async';
+      try { img.fetchPriority = 'low'; } catch (e) { /* older engines */ }
+      img.onload = () => finish(Number(img.naturalWidth) > 0 ? 'ok' : 'dead');
+      img.onerror = () => finish('dead');
+      timer = setTimeout(() => {
+        /* a hung request is let go of, not condemned */
+        try { img.src = ''; } catch (e) { /* noop */ }
+        finish('unsure');
+      }, VET.PROBE_MS);
+      img.src = url;
+      /* an engine that already had it answers synchronously */
+      if (img.complete && Number(img.naturalWidth) > 0) finish('ok');
+    } catch (e) { finish('unsure'); }
+    return { promise, abort: () => { try { if (img) img.src = ''; } catch (e) { /* noop */ } finish('unsure'); } };
+  }
+
+  function probeVideo(url) {
+    let v = null;
+    let timer = 0;
+    let settled = false;
+    let resolveFn = null;
+    const promise = new Promise((res) => { resolveFn = res; });
+    const teardown = () => {
+      if (!v) return;
+      try { v._aeDying = true; } catch (e) { /* noop */ }
+      try { if (v.pause) v.pause(); } catch (e) { /* noop */ }
+      try { v.removeAttribute('src'); if (v.load) v.load(); } catch (e) { /* noop */ }
+      v = null;
+    };
+    const finish = (verdict) => {
+      if (settled) return;
+      settled = true;
+      try { clearTimeout(timer); } catch (e) { /* noop */ }
+      teardown();
+      resolveFn(verdict);
+    };
+    try {
+      v = document.createElement('video');
+      if (!v || typeof v.addEventListener !== 'function') { finish('unsure'); return { promise, abort: () => finish('unsure') }; }
+      v.muted = true; v.playsInline = true; v.autoplay = false;
+      try {
+        v.setAttribute('muted', ''); v.setAttribute('playsinline', '');
+        v.setAttribute('preload', 'metadata'); v.setAttribute('disablepictureinpicture', '');
+      } catch (e) { /* noop */ }
+      try { v.disableRemotePlayback = true; } catch (e) { /* not everywhere */ }
+      v.addEventListener('loadedmetadata', () => finish('ok'), { once: true });
+      v.addEventListener('error', () => {
+        const code = v && v.error && v.error.code;
+        finish(code === 2 || code === 4 ? 'dead' : 'unsure');
+      }, { once: true });
+      timer = setTimeout(() => finish('unsure'), VET.PROBE_MS);
+      v.src = url;
+      try { if (typeof v.load === 'function') v.load(); } catch (e) { /* noop */ }
+    } catch (e) { finish('unsure'); }
+    return { promise, abort: () => finish('unsure') };
+  }
+
+  /* ---------------------------------------------------------- the vet ---- */
+  /**
+   * vet(rows, opts) -> Promise<stats> (+ .cancel()).
+   *   rows        [{url, tag?, mime?, kind?}] (or bare url strings)
+   *   opts.enough (stats) -> boolean, asked after every verdict; true opens the gate
+   *   opts.onProgress (stats)
+   *   opts.maxMs  the gate's ceiling (VET.MAX_MS)
+   * stats: { total, done, ok, dead, unsure, byTag: {tag: {ok, dead, unsure, total}},
+   *          complete, elapsed, urls: {ok: [], dead: [], unsure: []} }
+   */
+  function vet(rows, opts) {
+    const o = opts || {};
+    const enough = typeof o.enough === 'function' ? o.enough : null;
+    const onProgress = typeof o.onProgress === 'function' ? o.onProgress : null;
+    const maxMs = o.maxMs == null ? VET.MAX_MS : Math.max(0, Number(o.maxMs) || 0);
+    const startedAt = Date.now();
+
+    /* distinct urls, first row's tag/mime wins */
+    const jobs = [];
+    const seen = new Set();
+    for (const r of (Array.isArray(rows) ? rows : [])) {
+      const url = typeof r === 'string' ? r : (r && r.url);
+      if (!url || typeof url !== 'string' || seen.has(url)) continue;
+      seen.add(url);
+      const row = typeof r === 'string' ? { url } : r;
+      jobs.push({ url, tag: String(row.tag || ''), video: isVideo(row), verdict: '' });
+    }
+
+    const stats = {
+      total: jobs.length, done: 0, ok: 0, dead: 0, unsure: 0,
+      byTag: Object.create(null), complete: jobs.length === 0, elapsed: 0,
+      urls: { ok: [], dead: [], unsure: [] },
+    };
+    const tagBox = (tag) => {
+      const k = tag || '';
+      if (!stats.byTag[k]) stats.byTag[k] = { ok: 0, dead: 0, unsure: 0, total: 0 };
+      return stats.byTag[k];
+    };
+    for (const j of jobs) tagBox(j.tag).total += 1;
+
+    let opened = false;          // the gate has resolved (early or complete)
+    let cancelled = false;
+    let resolveFn = null;
+    const promise = new Promise((res) => { resolveFn = res; });
+    let gateTimer = 0;
+    const inflight = new Set();  // {job, abort}
+    const queue = [];
+    let imgFlight = 0;
+    let vidFlight = 0;
+
+    function record(job, verdict) {
+      if (job.verdict) return;
+      job.verdict = verdict;
+      stats.done += 1;
+      stats[verdict] += 1;
+      tagBox(job.tag)[verdict] += 1;
+      stats.urls[verdict].push(job.url);
+      if (verdict !== 'unsure') verdicts.set(job.url, verdict);
+      if (verdict === 'dead') { try { markBroken(job.url, true); } catch (e) { /* noop */ } }
+      stats.elapsed = Date.now() - startedAt;
+      stats.complete = stats.done >= stats.total;
+    }
+
+    function open(reason) {
+      if (opened) return;
+      opened = true;
+      try { clearTimeout(gateTimer); } catch (e) { /* noop */ }
+      stats.elapsed = Date.now() - startedAt;
+      /* the class is about to mint: no vet may hold a decoder past this line.
+       * Queued videos are let go of unjudged (unsure), in-flight ones aborted. */
+      for (let i = queue.length - 1; i >= 0; i--) {
+        if (queue[i].video) { record(queue[i], 'unsure'); queue.splice(i, 1); }
+      }
+      for (const f of [...inflight]) if (f.job.video) { try { f.abort(); } catch (e) { /* noop */ } }
+      say('vet ' + reason + ': ' + stats.ok + ' ok / ' + stats.dead + ' dead / ' + stats.unsure
+        + ' unsure of ' + stats.total + ' in ' + stats.elapsed + 'ms'
+        + (stats.complete ? '' : ' (' + (stats.total - stats.done) + ' still probing)'));
+      resolveFn(stats);
+    }
+
+    function progress() {
+      if (onProgress) { try { onProgress(stats); } catch (e) { /* a bad listener never stops the vet */ } }
+      if (opened) return;
+      if (stats.complete) { open('complete'); return; }
+      /* asked after EVERY verdict, never throttled: the last verdict before a
+       * hung tail is the one that opens the gate, and a skipped check there
+       * would park the door on the ceiling */
+      if (enough) {
+        let yes = false;
+        try { yes = !!enough(stats); } catch (e) { yes = false; }
+        if (yes) open('enough');
+      }
+    }
+
+    function pump() {
+      if (cancelled) return;
+      let moved = false;
+      for (let i = 0; i < queue.length;) {
+        const job = queue[i];
+        if (job.video) {
+          if (opened || vidFlight >= VET.VIDEO_LANES) { i += 1; continue; }
+          vidFlight += 1;
+        } else {
+          if (imgFlight >= VET.IMAGE_LANES) { i += 1; continue; }
+          imgFlight += 1;
+        }
+        queue.splice(i, 1);
+        moved = true;
+        const probe = job.video ? probeVideo(job.url) : probeImage(job.url);
+        const flight = { job, abort: probe.abort };
+        inflight.add(flight);
+        probe.promise.then((verdict) => {
+          inflight.delete(flight);
+          if (job.video) vidFlight = Math.max(0, vidFlight - 1); else imgFlight = Math.max(0, imgFlight - 1);
+          record(job, verdict || 'unsure');
+          progress();
+          pump();
+        });
+      }
+      if (!moved && !inflight.size && queue.length && !stats.complete) {
+        /* only videos queued and the gate is open: nothing will ever run them */
+        for (const job of queue.splice(0, queue.length)) record(job, 'unsure');
+        progress();
+      }
+    }
+
+    /* the instant answers first, then the probes */
+    for (const job of jobs) {
+      if (instant(job.url)) { record(job, 'ok'); continue; }
+      let dead = false;
+      try { dead = !!isBroken(job.url); } catch (e) { dead = false; }
+      if (dead) { record(job, 'dead'); continue; }
+      const known = verdicts.get(job.url);
+      if (known === 'ok' || known === 'dead') { record(job, known); continue; }
+      if (!canProbe) { record(job, 'ok'); continue; }        // inert: a harness sees no network
+      queue.push(job);
+    }
+    if (maxMs > 0 && !stats.complete) gateTimer = setTimeout(() => open('ceiling'), maxMs);
+    /* progress() first: a vet with nothing to probe resolves on this tick */
+    Promise.resolve().then(() => { if (!cancelled) { progress(); pump(); } });
+
+    promise.cancel = () => {
+      if (cancelled) return;
+      cancelled = true;
+      for (let i = queue.length - 1; i >= 0; i--) { record(queue[i], 'unsure'); }
+      queue.length = 0;
+      for (const f of [...inflight]) { try { f.abort(); } catch (e) { /* noop */ } }
+      open('cancelled');
+    };
+    return promise;
+  }
+
+  return {
+    vet,
+    /** What this page already knows about a url: 'ok' | 'dead' | '' */
+    verdict(url) { return verdicts.get(String(url || '')) || ''; },
+    diagnostics() {
+      let ok = 0, dead = 0;
+      for (const v of verdicts.values()) { if (v === 'ok') ok += 1; else if (v === 'dead') dead += 1; }
+      return { ok, dead, canProbe };
+    },
+  };
+}
+
+export default createVetter;

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -2565,6 +2565,8 @@ internal static class ArcademyHostService
         ["sort_target_head"] = "What do you want?",
         ["sort_target_hint"] = "These go RIGHT. Pick one or more.",
         ["sort_thin"] = "Thin pile: expect repeats.",
+        ["sort_vet_more"] = "Fetching more cards",
+        ["sort_vetting"] = "Checking your cards",
         ["sort_thin_add"] = "Add another pick",
         ["sort_ticket_chain"] = "Longest chain",
         ["sort_ticket_passed"] = "Passed",
@@ -4098,7 +4100,11 @@ internal static class ArcademyHostService
                     App.Logger?.Debug("ArcademyHost: rejected remote entry {Id}: {Reason}", e.Id, reason);
                     continue;
                 }
-                fresh.Add(new AssetUrl(e.Url, kind, MimeFor(e.Url, kind)));
+                // A card is not a feed tile: the page paints it at a few hundred px, so the
+                // smaller rendition (ScrolllerSource.SmallUrl, <= 640 clip / <= 1280 still,
+                // the web port's numbers) loads in a fraction of the time the 1920px one did.
+                var url = e.SmallUrl ?? e.Url;
+                fresh.Add(new AssetUrl(url, kind, MimeFor(url, kind)));
                 if (fresh.Count >= RemoteBatchCap) break;
             }
 
@@ -4357,7 +4363,10 @@ internal static class ArcademyHostService
                 var folder = (e.Folder ?? "").Trim();
                 var bare = folder.StartsWith("r/", StringComparison.OrdinalIgnoreCase) ? folder[2..] : folder;
                 if (bare.Length == 0 || !allowed.Contains(bare)) continue;
-                fresh.Add(new AssetUrl(e.Url, kind, MimeFor(e.Url, kind), tag, "r/" + bare));
+                // The card rendition, not the feed one (see ServeRemoteBatch): SORT's ring is
+                // 0.75-2.4s and a 1920px 15MB mp4 was the striped back the owner kept seeing.
+                var url = e.SmallUrl ?? e.Url;
+                fresh.Add(new AssetUrl(url, kind, MimeFor(url, kind), tag, "r/" + bare));
                 if (fresh.Count >= RemoteBatchCap) break;
             }
 

--- a/ConditioningControlPanel/Services/Fyp/FypAssetManifest.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypAssetManifest.cs
@@ -45,6 +45,12 @@ internal static class FypAssetManifest
         /// files and for entries that are already stills.</summary>
         [Newtonsoft.Json.JsonProperty("posterUrl", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? PosterUrl { get; init; }
+        /// <summary>A SMALLER rendition of the same media (clip &lt;= 640px, still &lt;= 1280px),
+        /// for consumers that paint at card size rather than feed size - the Arcademy's SORT
+        /// deals off it. Null when the post has no smaller rendition (the main url is it) and
+        /// for library files. Remote only; the page never reads it (the host substitutes).</summary>
+        [Newtonsoft.Json.JsonProperty("smallUrl", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? SmallUrl { get; init; }
     }
 
     /// <summary>Build the asset list for the current EffectiveAssetsPath. Never throws.</summary>

--- a/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
@@ -49,6 +49,8 @@ internal sealed class ScrolllerSource : IFeedSource
     private const int PageLimit = 30;
     private const int MaxSourceWidth = 1920;          // don't stream 4K into a feed tile
     private const int MaxPosterWidth = 960;           // a poster is a placeholder, not the media
+    private const int MaxSmallClipWidth = 640;        // Entry.SmallUrl: a card-sized clip (the web port's cap)
+    private const int MaxSmallStillWidth = 1280;      // Entry.SmallUrl: a card-sized still (idem)
     private static readonly TimeSpan MinRequestGap = TimeSpan.FromSeconds(1.1);
 
     // Field subset of the reference SubredditQuery — GraphQL lets us ask for less.
@@ -244,10 +246,21 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
         var title = ((string?)item["title"] ?? "").Trim();
         if (title.Length > 90) title = title[..87] + "...";
 
+        var bestUrl = (string?)best["url"] ?? "";
+        // The card-sized sibling: same shape, same accept filter, a lower width cap. Only
+        // stamped when it is a DIFFERENT file - a post whose best rendition already fits
+        // the cap has no smaller one to offer.
+        var small = stills
+            ? PickSource(sources, RemoteMediaFormats.IsRemoteImage, MaxSmallStillWidth)
+            : PickSource(sources, RemoteMediaFormats.IsRemoteVideo, MaxSmallClipWidth);
+        var smallUrl = (string?)small?["url"];
+        if (string.IsNullOrEmpty(smallUrl) || string.Equals(smallUrl, bestUrl, StringComparison.Ordinal)) smallUrl = null;
+
         var entry = new FypAssetManifest.Entry
         {
             Id = $"scrolller/{sub}/{postId}",
-            Url = (string?)best["url"] ?? "",
+            Url = bestUrl,
+            SmallUrl = smallUrl,
             // scrolller "GIFs" arrive as silent webm/mp4, so the only two shapes an entry
             // can take are a clip and a static still.
             Type = stills ? RemoteMediaFormats.TypeImage : RemoteMediaFormats.TypeVideo,


### PR DESCRIPTION
## What
SORT (room 201) dealt cards whose Scrolller CDN file is gone, so the face errored and the player sat on the striped back. This adds **the VET**: every remote url the claim brought in is probed *before* the deal, dead ones are permanently blacklisted, a short tag asks the host for more, and the door only opens once enough alive cards stand per pile (`Checking your cards 14/48` on the busy overlay).

## Why it happened
- Live probe 2026-08-27: r/aww 7/30 loops + 8/30 stills = 404 at the CDN while the index still lists them. Host `RemoteMediaFormats.Validate` is format-only; the page trusted the row.
- The existing blacklist/substitute layer only reacted *after* a face errored, and `BROKEN_TTL_MS` forgave the first strike after 45s - the same dead card came back next pass.
- Desktop served the **1920px** feed rendition (8-17MB mp4) into a 0.75-2.4s ring; web already used 640px.

## Changes
- `provider/vet.js` (new) - Image / `preload=metadata` `<video>` probes (the media CDN sends no CORS headers, so `fetch` can't read a status). `VIDEO_LANES` = `DECODER_CEILING`, probes torn down on verdict, `open()` aborts video probes when the gate opens (trap 36 kept; **trap 124** documents the exception).
- `provider/index.js` - `markBrokenUrl(url, permanent)`; `vet` on the media seam for both pool shapes.
- `provider/tagged.js` - `pool.refill(tag)` (2 rounds, fresh `MAX_ASKS` each); ask loop counts live rows.
- `games/sort/index.js` - `VET_GATE` {ENOUGH 24/tag, MAX_MS 20s, REFILL_ROUNDS 2} between `claimPool` and the thin/ghost/deal; late-arriving rows get a final sweep; one shared ceiling.
- `games/sort/setup.js` - `setBusy(on, key, detail)`; lexicon `sort_vetting`, `sort_vet_more` (+ `NeutralLexicon` mirror).
- Desktop: `Entry.SmallUrl` (clip <= 640 / still <= 1280) from `ScrolllerSource.MapItem`; `ArcademyHostService` serves `SmallUrl ?? Url` on both arcademy remote paths. FYP untouched.

## Verification
- Scratch sort suite: same failure set as baseline (25 stale deck-size/budget expectations, pre-existing), **+13** new gate assertions green; new `test-vet.mjs` 6/6 (verdicts, permanent strike, early gate + video abort, ceiling, cancel).
- `dotnet build` succeeded.
- **Not play-tested** in the app / on web - owner play-test requested.

## After merge
- Dispatch cclabs-web `sync-arcademy.yml` (page JS is vendored; the cron is best-effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdnjK4ZQZ8QqE4VHex3Hv8
