### PR TITLE
release(6.8.5): Arcademy go-live pass - card blurb four classes, comment fix, + fold-ins

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -4626,7 +4626,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "NEU",
-  "play_arcademy_blurb": "drei Kurse pro Tag. kleine, einfache Spiele, die alles andere auf deinem Bildschirm schwer macht. erscheine, lass dich benoten, halte die Serie.",
+  "play_arcademy_blurb": "vier Kurse pro Tag. kleine, einfache Spiele, die alles andere auf deinem Bildschirm schwer macht. erscheine, lass dich benoten, halte die Serie.",
   "play_arcademy_cta": "Teilnehmen",
   "play_arcademy_tooltip": "der Stundenplan von heute wartet.",
   "arcademy_boot_error_body": "{0} konnte auf diesem Rechner nicht gestartet werden.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -5176,7 +5176,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "NEW",
-  "play_arcademy_blurb": "three classes a day. simple little games made hard by everything else on your screen. show up, get graded, keep the streak.",
+  "play_arcademy_blurb": "four classes a day. simple little games made hard by everything else on your screen. show up, get graded, keep the streak.",
   "play_arcademy_cta": "Attend",
   "play_arcademy_tooltip": "today's timetable is waiting.",
   "arcademy_boot_error_body": "{0} could not start on this machine.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -4617,7 +4617,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "NUEVO",
-  "play_arcademy_blurb": "tres clases al día. juegos sencillos que todo lo demás en tu pantalla vuelve difíciles. preséntate, deja que te califiquen, mantén la racha.",
+  "play_arcademy_blurb": "cuatro clases al día. juegos sencillos que todo lo demás en tu pantalla vuelve difíciles. preséntate, deja que te califiquen, mantén la racha.",
   "play_arcademy_cta": "Asistir",
   "play_arcademy_tooltip": "el horario de hoy te espera.",
   "arcademy_boot_error_body": "{0} no pudo iniciarse en este equipo.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -4626,7 +4626,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "NOUVEAU",
-  "play_arcademy_blurb": "trois cours par jour. de petits jeux simples que tout le reste de ton écran rend difficiles. présente-toi, fais-toi noter, garde la série.",
+  "play_arcademy_blurb": "quatre cours par jour. de petits jeux simples que tout le reste de ton écran rend difficiles. présente-toi, fais-toi noter, garde la série.",
   "play_arcademy_cta": "Assister",
   "play_arcademy_tooltip": "l'emploi du temps du jour t'attend.",
   "arcademy_boot_error_body": "{0} n'a pas pu démarrer sur cette machine.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -4617,7 +4617,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "新着",
-  "play_arcademy_blurb": "一日に三つの授業。単純な小さいゲームを、画面の上のほかのすべてが難しくします。出席して、採点されて、連続記録を守りましょう。",
+  "play_arcademy_blurb": "一日に四つの授業。単純な小さいゲームを、画面の上のほかのすべてが難しくします。出席して、採点されて、連続記録を守りましょう。",
   "play_arcademy_cta": "出席する",
   "play_arcademy_tooltip": "今日の時間割が待っています。",
   "arcademy_boot_error_body": "{0} はこのパソコンで起動できませんでした。\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -4624,7 +4624,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "신규",
-  "play_arcademy_blurb": "하루에 세 과목. 화면 위의 다른 모든 것이 단순한 게임을 어렵게 만듭니다. 출석하고, 성적을 받고, 연속 기록을 지키세요.",
+  "play_arcademy_blurb": "하루에 네 과목. 화면 위의 다른 모든 것이 단순한 게임을 어렵게 만듭니다. 출석하고, 성적을 받고, 연속 기록을 지키세요.",
   "play_arcademy_cta": "출석하기",
   "play_arcademy_tooltip": "오늘의 시간표가 기다리고 있습니다.",
   "arcademy_boot_error_body": "{0}을(를) 이 컴퓨터에서 시작할 수 없습니다.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -4625,7 +4625,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "NOVO",
-  "play_arcademy_blurb": "três aulas por dia. joguinhos simples que tudo o mais na sua tela deixa difícil. apareça, seja avaliada, mantenha a sequência.",
+  "play_arcademy_blurb": "quatro aulas por dia. joguinhos simples que tudo o mais na sua tela deixa difícil. apareça, seja avaliada, mantenha a sequência.",
   "play_arcademy_cta": "Comparecer",
   "play_arcademy_tooltip": "o horário de hoje está esperando.",
   "arcademy_boot_error_body": "{0} não conseguiu iniciar nesta máquina.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -4624,7 +4624,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "НОВОЕ",
-  "play_arcademy_blurb": "три занятия в день. простые маленькие игры, которые всё остальное на экране делает сложными. приходи, получай оценку, держи серию.",
+  "play_arcademy_blurb": "четыре занятия в день. простые маленькие игры, которые всё остальное на экране делает сложными. приходи, получай оценку, держи серию.",
   "play_arcademy_cta": "Прийти",
   "play_arcademy_tooltip": "сегодняшнее расписание ждёт.",
   "arcademy_boot_error_body": "Не удалось запустить {0} на этом компьютере.\n\n{1}",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -5084,7 +5084,7 @@
   "_comment_arcademy_door": "The Arcademy (Play wall card, Ctrl+K row, failure dialogs)",
   "play_arcademy_title": "The Arcademy",
   "play_arcademy_new": "新",
-  "play_arcademy_blurb": "每天三节课。简单的小游戏，被屏幕上的其他一切变得不简单。来上课，接受评分，保持连续出勤。",
+  "play_arcademy_blurb": "每天四节课。简单的小游戏，被屏幕上的其他一切变得不简单。来上课，接受评分，保持连续出勤。",
   "play_arcademy_cta": "上课",
   "play_arcademy_tooltip": "今天的课表已经排好了。",
   "arcademy_boot_error_body": "{0} 无法在这台电脑上启动。\n\n{1}",

--- a/ConditioningControlPanel/MainWindow/MainWindow.PlayTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.PlayTab.cs
@@ -103,10 +103,14 @@ namespace ConditioningControlPanel
                 SetLockband(tab.PlayLockArcademy,
                     TierGate.RequiresLab(Services.Arcademy.ArcademyHostService.ProductName));
 
-                // --- The Arcademy: present or absent, never locked ---------------------------
-                // Same posture as Just Drop below, for the same reason: Semester 1 is merged but
-                // unannounced, and a lockband would advertise a feature nobody can buy yet.
-                // Flipping ArcademyHostService.DoorAvailable is the whole reveal.
+                // --- The Arcademy: present, and locked when the account is not T2 ------------
+                // NOT the Just Drop posture below any more. Until v6.8.5 the door was shut and a
+                // lockband would have advertised a feature nobody could buy, so the card was
+                // hidden outright; the door is open now, so the card is PRESENT on every account
+                // and the band above is what tells a free one why Attend refuses. The hide is
+                // still what closing the door again would do - flipping
+                // ArcademyHostService.DoorAvailable back to false is a one-line retreat, and the
+                // band stays computed above so it is already right when it reopens.
                 if (tab.SlotArcademy != null)
                     tab.SlotArcademy.Visibility = Services.Arcademy.ArcademyHostService.DoorAvailable
                         ? Visibility.Visible

--- a/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
@@ -94,9 +94,9 @@ namespace ConditioningControlPanel.Services.Quiz
             try
             {
                 // The intake's vo/sfx/music (plus the dtrh bubble sfx it borrows) ship as the lazy
-                // audio-web pack. Fire-and-forget: no-op once installed, on a full install, or offline.
-                try { _ = App.ReleaseContent?.RequestPackAsync(ReleaseContentService.PackAudioWeb); }
-                catch (Exception ex) { App.Logger?.Debug("IntakeHost: audio-web request failed: {E}", ex.Message); }
+                // audio-web pack. Kicked here and still never awaited (see RequestAudioPack), but
+                // the OUTCOME is observed now - dropping it on the floor is bug #1032.
+                RequestAudioPack();
 
                 _exiting = false;
                 _resultReceived = false;
@@ -176,6 +176,65 @@ namespace ConditioningControlPanel.Services.Quiz
                 }
             }
             catch (Exception ex) { App.Logger?.Debug("IntakeHostService.CloseActive: {E}", ex.Message); DisposeAll(); }
+        }
+
+        /// <summary>
+        /// Kick the lazy <c>audio-web</c> pack every recorded clip in the intake lives in (vo, sfx,
+        /// music, plus the dtrh bubble sfx the page borrows) and OBSERVE the result.
+        ///
+        /// Deliberately still not awaited by <see cref="Launch"/>: a first-run download must never
+        /// hold the window back, and the page degrades on its own - core/audioSrc.js retries the
+        /// other virtual host once per file and render/audio.js falls back to its synth voices for
+        /// anything that never decodes. What was missing (bug #1032, "no sound in Graded Intake")
+        /// was the DIAGNOSIS: the task was discarded, so a pack that never arrived - offline mode,
+        /// a dead manifest, a failed download - was indistinguishable from a working one. The run
+        /// just came up quiet and the log said nothing at all.
+        ///
+        /// A failure with the pack already on disk is NOT silence: the installed clips are still
+        /// there and only an update was missed, so that case stays at Information.
+        /// </summary>
+        private static void RequestAudioPack()
+        {
+            try
+            {
+                var svc = App.ReleaseContent;
+                if (svc == null) return;
+
+                var task = svc.RequestPackAsync(ReleaseContentService.PackAudioWeb);
+                // The overwhelmingly common path (already installed, or a full install) completes
+                // synchronously with true - stay quiet rather than log a line on every launch.
+                if (task.IsCompleted && !task.IsFaulted && !task.IsCanceled && task.Result) return;
+
+                _ = task.ContinueWith(t =>
+                {
+                    try
+                    {
+                        if (!t.IsFaulted && !t.IsCanceled && t.Result)
+                        {
+                            App.Logger?.Information("IntakeHost: audio-web pack ready");
+                            return;
+                        }
+
+                        var reason = t.IsFaulted ? (t.Exception?.GetBaseException().Message ?? "faulted")
+                            : t.IsCanceled ? "cancelled"
+                            : App.Settings?.Current?.OfflineMode == true ? "offline mode is on"
+                            : "download or manifest fetch failed (see the ReleaseContentService lines above)";
+
+                        if (svc.IsInstalled(ReleaseContentService.PackAudioWeb))
+                        {
+                            App.Logger?.Information(
+                                "IntakeHost: audio-web refresh failed ({Reason}) - the installed clips still play", reason);
+                            return;
+                        }
+
+                        App.Logger?.Warning(
+                            "IntakeHost: audio-web pack unavailable ({Reason}) - this run has no recorded VO or music and "
+                            + "falls back to the in-page synth sfx", reason);
+                    }
+                    catch { /* diagnosis must never take the app down */ }
+                }, TaskScheduler.Default);
+            }
+            catch (Exception ex) { App.Logger?.Debug("IntakeHost: audio-web request failed: {E}", ex.Message); }
         }
 
         // ============================ ducking the control panel ============================


### PR DESCRIPTION
Second ready pass for v6.8.5 "First Bell".

- Play card blurb said "three classes a day"; the timetable has dealt four since 08-23 (`ArcademyMetaStore.cs:62`). Fixed in all 9 language files (1 line each, strict-parse clean).
- `MainWindow.PlayTab.cs` header comment described the pre-lockband posture; rewritten to match the shipped `SetLockband` behaviour.
- Go-live audit: `DoorAvailable=true`, T2 stamp (`fx:TierBadge Tier="2"`), dev door `#if DEBUG`, lapse rung, say() log router, Ctrl+K row, mod-switch close, demo.html csproj exclusion all verified on main. No code change needed.
- Follow-up commits on this branch: #1032 Graded Intake no-sound fold-in.

Release build 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6xJB7QQLacJN9vN3gRAVe