### PR TITLE
fix(arcademy): pre-gesture holds are parked, not dropped (web campus had no soundtrack)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2961,6 +2961,22 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     anywhere. `econtests/test-seam.mjs` reads both sides at once and fails on a
     drift; run it whenever a key moves.
 
+125. **A HOLD FIRED BEFORE THE FIRST TOUCH IS PARKED, NOT DROPPED - AND ON THE WEB THE
+    CAMPUS IS BUILT UNDER THE SPLASH** (soundtrack, 2026-08-27). `audio.js` drops every cue
+    that arrives before its context exists (`ensureContext()` is null until the first
+    pointerdown/keydown; the desktop host promises `autoplayOk` so it never sees this). On a
+    browser host the shell builds the campus ~400ms after init, a whole knock BEFORE the
+    first pointer, so `ost.enter('campus')` and `campus_idle` both fired into no context and
+    were dropped - and a hold has no re-fire, so the web campus was silent until the next
+    screen. Reproduced headless (Edge, vendored tree served locally): `ost: ost_campus in`
+    logged at 430ms, `[audio] context up` at the first click, no element ever made.
+    `audio.js` now keeps a pre-gesture `hold` by slot (`pendingHolds`) and replays it from
+    `onGesture` once `ac` exists; `stop` on the slot and `stop_clips` forget it. A one-shot
+    fired early is still spent (trap 70). `ost.js` law 6 (never under lite) went with it:
+    a track streams from an element, nothing is decoded, and the desktop rung is AUTOMATIC
+    (eight flash windows = Balanced), so the gate made the music vanish whenever the app
+    was busy, with nothing in the log. `createOst({ lite })` is accepted and ignored.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -590,7 +590,7 @@ export function createAudio({ init, bridge, log, autoplayOk, brassBell } = {}) {
    *  names are ready to do so - between them they say whether the latency fix is
    *  actually running in this host or whether everything fell to a recipe. */
   const stats = {
-    handled: 0, played: 0, dropped: 0, ducks: 0, clips: 0, samples: 0,
+    handled: 0, played: 0, dropped: 0, ducks: 0, clips: 0, samples: 0, deferred: 0,
     buffered: 0, decoded: 0, last: null,
   };
   /** Names that fell through to `blip`, logged once each (trap 115). */
@@ -789,6 +789,17 @@ export function createAudio({ init, bridge, log, autoplayOk, brassBell } = {}) {
   /* ---- CLIPS: a url played through a bus ------------------------------- */
   /** key -> {el, gain, node, timer} . One live clip per slot, cut on re-fire. */
   const clips = new Map();
+  /** HOLDS ASKED FOR BEFORE THE FIRST TOUCH (2026-08-27). On a browser host the
+   *  shell builds the campus UNDER the splash, ~400ms after init and a full
+   *  knock before the first pointer, so the campus theme and the campus room
+   *  tone both arrived at a mixer with no context and were dropped - and a
+   *  hold has no re-fire, so the web campus was silent until the next screen.
+   *  A one-shot fired early is rightly spent (trap 70: late is worse than
+   *  missed); a HOLD is not a beat, it is a state the room is in, so it is
+   *  kept by slot and started by onGesture the moment the context exists.
+   *  `stop` on the slot (and `stop_clips`) forgets it, the same way they would
+   *  have stopped it. The desktop host promises autoplay and never lands here. */
+  const pendingHolds = new Map();
 
   function killClip(rec, fadeMs) {
     if (!rec) return;
@@ -1129,11 +1140,12 @@ export function createAudio({ init, bridge, log, autoplayOk, brassBell } = {}) {
     // The one CONTROL message on the sfx bus: the shell sends it when a class is
     // torn down so a trigger clip (<=1.2s) never leaks into the lobby. No audio
     // handle crosses into shell.js for this; the bus was already the seam.
-    if (d.name === 'stop_clips') { stopAllClips(); settle('dropped'); return; }
+    if (d.name === 'stop_clips') { pendingHolds.clear(); stopAllClips(); settle('dropped'); return; }
     // The second control message (HOLD): leave a room. Honoured before the mute
     // check so a bed started before the mute echo can still be let go of.
     if (d.stop === true) {
       const k = String(d.key == null ? (d.name || '') : d.key);
+      pendingHolds.delete(k);
       const held = clips.get(k);
       if (held) { clips.delete(k); killClip(held, CLIP_FADE_MS); }
       settle('stopped');
@@ -1152,7 +1164,16 @@ export function createAudio({ init, bridge, log, autoplayOk, brassBell } = {}) {
       url: d.url || null,
     };
     if (mute || master <= 0) { stats.dropped += 1; settle('dropped'); return; }
-    if (!ensureContext()) { stats.dropped += 1; settle('dropped'); return; }
+    if (!ensureContext()) {
+      if (d.hold === true && !gestured) {
+        // Kept, not dropped (pendingHolds above). The caller's onEnded is NOT
+        // answered here: the replay wraps it again and answers it for real.
+        pendingHolds.set(String(d.key == null ? (d.name || '') : d.key), d);
+        stats.deferred += 1;
+        return;
+      }
+      stats.dropped += 1; settle('dropped'); return;
+    }
     const bus = BUSES.indexOf(d.bus) >= 0 ? d.bus : 'fx';
     // PERCEPTUAL CURVE (2026-08-24): engine levels are fractions of fractions - a 0.25
     // cue under the bus and master gains landed near -29 dB and the whole campus read
@@ -1281,6 +1302,14 @@ export function createAudio({ init, bridge, log, autoplayOk, brassBell } = {}) {
     gestured = true;
     if (first || !ac) ensureContext();
     if (ac && ac.state === 'suspended' && typeof ac.resume === 'function') { try { ac.resume(); } catch { /* ignore */ } }
+    // The rooms that were entered before the first touch start now, in the
+    // order they were asked for. Cleared BEFORE replaying so a hold that
+    // somehow lands back here cannot loop.
+    if (ac && pendingHolds.size) {
+      const late = Array.from(pendingHolds.values());
+      pendingHolds.clear();
+      for (const d of late) { try { onSfx({ detail: d }); } catch { /* one bad hold must not eat the rest */ } }
+    }
   }
 
   if (doc && doc.addEventListener) {

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/ost.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/ost.js
@@ -39,9 +39,18 @@
  *     that lands on the same track (the booth window into the counter, both on
  *     ost_prizes) keeps the tune running instead of restarting it from the top.
  *     A leave() nobody follows up still stops the track, one tick later.
- *  6. NEVER UNDER LITE. The lite rung is a performance cap and a 140s mp3
- *     decoding on a phone is exactly what it exists to refuse. Read at call
- *     time, like the PA.
+ *  6. LITE DOES NOT SILENCE THE SCHOOL (was: never under lite, 2026-08-27).
+ *     A track is NEVER_BUFFERED in audio.js - an element streams it, nothing
+ *     is decoded into memory - so the performance rung has no cost to refuse
+ *     here. And the desktop's rung is AUTOMATIC (PerformanceProfile: eight
+ *     flash windows on screen is "Balanced"), so gating on it made the music
+ *     vanish whenever the rest of the app was busy, with nothing in the log.
+ *     The `lite` option is still accepted and ignored, so no caller breaks.
+ *  7. A HOLD ASKED FOR BEFORE THE FIRST TOUCH IS KEPT. On a browser host the
+ *     campus is built under the splash, before the knock, and audio.js used to
+ *     drop that cue (no context yet) - the web campus was silent until the
+ *     next screen. audio.js now parks a pre-gesture hold by slot and starts
+ *     it from the first pointer/key (pendingHolds); this module needs no retry.
  *
  * ---------------------------------------------------------------------------
  * THE PUBLIC SURFACE
@@ -50,7 +59,7 @@
  *     sfx   (name, level, extra)  optional cue helper; omitted, the module
  *                                 dispatches the `arcademy-sfx` event itself.
  *     log   (msg)=>void           the shell's `say`.
- *     lite  bool | ()=>bool       the performance cap, read at call time.
+ *     lite  bool | ()=>bool       accepted, ignored (law 6).
  *
  *   ost.enter(place)   start the track for a place ('campus', 'records', or a
  *                      class gameKey). Unknown place = leave().
@@ -125,12 +134,6 @@ function dispatchCue(name, level, extra) {
   } catch (e) { /* a cue must never be the thing that throws */ }
 }
 
-/** A cap that may be a value or a getter. Read it EVERY time; never cache. */
-function readFlag(v) {
-  if (typeof v === 'function') { try { return !!v(); } catch (e) { return false; } }
-  return !!v;
-}
-
 export function createOst(opts) {
   const o = opts || {};
   const say = (typeof o.log === 'function') ? o.log : () => {};
@@ -168,7 +171,6 @@ export function createOst(opts) {
   function enter(place) {
     const row = trackFor(place);
     if (!row) { leave(); return; }
-    if (readFlag(o.lite)) { leave(); return; }             // law 6
     if (held === row.name) { cancelPending(); return; }     // law 5
     /* The slot is keyed, so a new hold on `OST_KEY` REPLACES the old one in the
      * mixer - but the old element would be dropped without its fade. Stop

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -2779,7 +2779,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   } catch (e) { say('pa unavailable (' + ((e && e.message) || e) + ')'); pa = null; }
 
   try {
-    ost = createOst({ log: say, lite: () => !!src.performanceMode });
+    ost = createOst({ log: say });
   } catch (e) { say('ost unavailable (' + ((e && e.message) || e) + ')'); ost = null; }
 
   /* ---------------------------- THE EXTRA CREDIT LEVER -------------------


### PR DESCRIPTION
## What
The Arcademy soundtrack was inaudible on the web: the shell builds the campus **under the splash**, before the knock tap, so `ost.enter('campus')` (and the `campus_idle` room tone) hit `audio.js` with no AudioContext and were dropped. A hold has no re-fire, so the campus stayed silent until the next screen. Desktop promises `autoplayOk`, so it never showed there.

## Fix
- `shell/audio.js`: a `hold` that arrives before the first gesture is parked by slot (`pendingHolds`) and replayed from `onGesture` once the context is up. `stop` on the slot and `stop_clips` forget it. One-shots fired early are still spent (trap 70). New `stats.deferred`.
- `shell/ost.js`: law 6 (never under lite) removed. A track streams from an element (NEVER_BUFFERED), nothing is decoded, and the desktop rung is automatic (8 flash windows = Balanced) so the gate silently killed the music whenever the app was busy. `lite` is accepted and ignored.
- `shell/shell.js`: no longer passes `lite` to `createOst`.
- `arcademy/CLAUDE.md`: trap 125.

## Verified
Headless Edge against the vendored tree served locally (prod is behind the login wall):
- before: `ost: ost_campus in (campus)` at 430ms, `[audio] context up` at the first click, no element ever created
- after: `ost_campus.mp3` playing and looping after the first tap; a hold stopped before the gesture never sounds; keyed swap `ost -> ost_daily_trigger` works

Web parity: dispatch `sync-arcademy.yml` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jo6kG6ia6cX1KW3JWAYS1q