### PR TITLE
fix(sort): the vet judges the clips, the poster stands in, an empty pile is re-asked

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
@@ -167,6 +167,7 @@ export function wrapQuickPool(claimPool) {
         remote: !!row.remote,
         kind,
         mime: '',
+        poster: (row && typeof row.poster === 'string') ? row.poster : '',
         tag: tg,
         src: row.remote ? 'remote' : 'local',
       };
@@ -236,6 +237,9 @@ function cardFrom(row, i, quick) {
     mime: String(row.mime || ''),
     tag,
     src: String(row.src || ''),
+    /** The clip's own still, when the host sent one (a remote loop): the face
+     *  while the clip buffers, the face over the decoder ceiling. */
+    poster: String(row.poster || ''),
     remote: !!row.remote,
     /** A url this deck has already dealt. Repeats are fine in a sort - and a
      *  deck that knows about them hands LOT D's SEEN card for free. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -239,7 +239,12 @@ const VET_GATE = Object.freeze({
   ENOUGH: 24,             // alive rows per tag that open the gate early
   MAX_MS: 20000,          // the ceiling a slow CDN may hold the door for
   REFILL_ROUNDS: 2,       // top-up asks when a tag is short (= TAGGED.REFILL_MAX)
+  CLIP_HOLD_MS: 10000,    // how long ENOUGH stills wait for the clips to be judged
 });
+/** An EMPTY tagged claim is asked again before the door gives up on it (see
+ *  claimPool): CLAIM_TRIES claims, CLAIM_RETRY_MS apart, then the QUICK SORT floor. */
+const CLAIM_TRIES = 3;
+const CLAIM_RETRY_MS = 4000;
 /* (The game-local WARM_AHEAD/WARM_INFLIGHT byte rail moved INTO the provider
  * as the manifest warmer, 0825: buildDeck knows the whole ordered deck before
  * the first card shows, so warmDeck() below hands it to pool.warmManifest()
@@ -610,23 +615,36 @@ export default {
       };
     }
     /** The tagged claim, with the QUICK SORT floor under it. Never throws. */
-    async function claimPool(resolved) {
+    async function claimPool(resolved, wait) {
       const wantQuick = !!(resolved && resolved.quick);
       const tagged = ctx.assets && typeof ctx.assets.claimTagged === 'function';
       if (!wantQuick && tagged && resolved && resolved.sources && resolved.sources.length) {
-        try {
-          const pool = await ctx.assets.claimTagged(claimOpts(resolved));
-          if (pool && typeof pool.next === 'function') {
-            try { if (typeof pool.prewarm === 'function') pool.prewarm(PREWARM); } catch (e) { /* noop */ }
-            const dead = ['target', 'noise'].filter((tg) => {
-              try { return typeof pool.empty === 'function' ? pool.empty(tg) : false; }
-              catch (e) { return false; }
-            });
-            if (!dead.length) return { pool, quick: false };
-            say('claimTagged answered with an EMPTY ' + dead.join(' and ') + ' pile - falling back to QUICK SORT');
-            try { if (typeof pool.dispose === 'function') pool.dispose(); } catch (e) { /* noop */ }
+        /* AN EMPTY PILE IS ASKED AGAIN BEFORE IT IS GIVEN UP ON (0827). The desktop
+         * host answers a cold or rate-limited pile with empty replies, and one such
+         * moment used to turn the player's own sort into a QUICK SORT - a different
+         * game - without a word. CLAIM_TRIES claims, `wait(attempt)` apart (the door
+         * says "Fetching more cards" meanwhile), then the floor. */
+        const tries = typeof wait === 'function' ? CLAIM_TRIES : 1;
+        for (let attempt = 0; attempt < tries; attempt++) {
+          if (attempt) {
+            try { await wait(attempt); } catch (e) { break; }
           }
-        } catch (e) { say('claimTagged failed (' + ((e && e.message) || e) + ') - QUICK SORT'); }
+          const last = attempt + 1 >= tries;
+          try {
+            const pool = await ctx.assets.claimTagged(claimOpts(resolved));
+            if (pool && typeof pool.next === 'function') {
+              try { if (typeof pool.prewarm === 'function') pool.prewarm(PREWARM); } catch (e) { /* noop */ }
+              const dead = ['target', 'noise'].filter((tg) => {
+                try { return typeof pool.empty === 'function' ? pool.empty(tg) : false; }
+                catch (e) { return false; }
+              });
+              if (!dead.length) return { pool, quick: false };
+              say('claimTagged answered with an EMPTY ' + dead.join(' and ') + ' pile'
+                + (last ? ' - falling back to QUICK SORT' : ' - asking again'));
+              try { if (typeof pool.dispose === 'function') pool.dispose(); } catch (e) { /* noop */ }
+            }
+          } catch (e) { say('claimTagged failed (' + ((e && e.message) || e) + ')' + (last ? ' - QUICK SORT' : ' - asking again')); }
+        }
       }
       /* QUICK SORT: the ordinary claim, wrapped so the deck speaks one API. */
       try {
@@ -704,7 +722,17 @@ export default {
             catch (e) { return []; }
           };
           const okOf = (st, tg) => (st && st.byTag && st.byTag[tg] ? (st.byTag[tg].ok | 0) : 0);
-          const enough = (st) => ['target', 'noise'].every((tg) => alive[tg] + okOf(st, tg) >= VET_GATE.ENOUGH);
+          /* ENOUGH alive per tag, AND THE CLIPS JUDGED - or CLIP_HOLD_MS spent on
+           * them (owner 0827: "even now we got some placeholders" after the check
+           * said done - the gate opened on the stills alone while the video lanes
+           * had barely started, and every dead loop walked into the deck
+           * unjudged). A phone's two lanes cannot judge a hundred clips, so the
+           * hold is bounded and the deal takes it from there: a judged-alive row
+           * deals first (tagged.js nextRow) and an unjudged clip wears its poster
+           * while it buffers (mintFace). The ceiling still bounds the whole gate. */
+          const clipsPending = (st) => !!(st && st.pending && (st.pending.video | 0) > 0);
+          const enough = (st) => ['target', 'noise'].every((tg) => alive[tg] + okOf(st, tg) >= VET_GATE.ENOUGH)
+            && (!clipsPending(st) || (now() - startedAt) >= VET_GATE.CLIP_HOLD_MS);
           const run = (rows) => {
             busy('sort_vetting', base.ok + '/' + (base.total + rows.length));
             let pr = null;
@@ -774,7 +802,14 @@ export default {
           }
           try { if (door && typeof door.setBusy === 'function') door.setBusy(true, 'sort_dealing'); }
           catch (e) { /* noop */ }
-          claimPool(res).then((got) => {
+          claimPool(res, (attempt) => new Promise((resolve) => {
+            /* the door says why the deal waits, then a breath before the re-ask;
+               a press that lost its turn is caught by the stale check below */
+            try { if (door && typeof door.setBusy === 'function') door.setBusy(true, 'sort_vet_more'); }
+            catch (e) { /* noop */ }
+            say('claim: empty pile, re-asking (' + attempt + '/' + (CLAIM_TRIES - 1) + ')');
+            timers.after(CLAIM_RETRY_MS, resolve);
+          })).then((got) => {
             if (settled || gen !== playGen) {
               try { if (got && got.pool && typeof got.pool.dispose === 'function') got.pool.dispose(); }
               catch (e) { /* noop */ }
@@ -1122,7 +1157,7 @@ export default {
      *  the drawn back stands, which is the fair round it always was. */
     function displaySrcOf(card) {
       if (!card || !card.url) return null;
-      if (!poolIsBroken(card.url)) return { url: card.url, mime: card.mime || '' };
+      if (!poolIsBroken(card.url)) return { url: card.url, mime: card.mime || '', poster: card.poster || '' };
       const sub = substituteFor(card);
       return sub || null;
     }
@@ -1200,6 +1235,49 @@ export default {
       }
     }
 
+    /** The post's own still for a clip, when the row carries one and it is not condemned. */
+    function posterOf(src) {
+      const p = src && typeof src.poster === 'string' ? src.poster : '';
+      if (!p || p === src.url) return '';
+      return poolIsBroken(p) ? '' : p;
+    }
+    /**
+     * OVER THE DECODER CEILING THE POSTER IS THE FACE (0827). An <img> of the
+     * clip's own still: it holds no decoder slot, and it is flagged so reseat()
+     * upgrades it to the real <video> the moment a slot frees. A dead poster
+     * convicts the POSTER url only (faceDied reads _aeUrl) - the clip is not on
+     * trial here. A row with no poster keeps the old answer: the back.
+     */
+    function mintPosterFace(src) {
+      const poster = posterOf(src);
+      if (!poster) return null;
+      const img = el('img', 'g-sort-face g-sort-face-poster');
+      if (!img) return null;
+      img.alt = '';
+      try { img.setAttribute('draggable', 'false'); img.setAttribute('decoding', 'async'); }
+      catch (e) { /* DOM double */ }
+      try { img._aeUrl = poster; img._aePosterOnly = true; } catch (e) { /* noop */ }
+      if (typeof img.addEventListener === 'function') {
+        img.addEventListener('error', () => faceDied(img));
+      }
+      img.src = poster;
+      return img;
+    }
+    /** A top clip whose play() was refused (iOS Low Power Mode, an autoplay
+     *  policy) plays on the player's next gesture - a swipe or a key IS one.
+     *  Until then the poster holds the face, never the back. */
+    function retryBlockedPlay() {
+      if (!S || destroyed) return;
+      const top = S.live[0];
+      const v = top && top.video ? top.face : null;
+      if (!v || !v._aePlayBlocked || typeof v.play !== 'function') return;
+      try {
+        v._aePlayBlocked = false;
+        const p = v.play();
+        if (p && p.catch) p.catch(() => { try { v._aePlayBlocked = true; } catch (e) { /* noop */ } });
+      } catch (e) { /* noop */ }
+    }
+
     function mintFace(card, depth) {
       if (!card || !card.url) return null;
       if (depth > 1) return null;                       // the third card is a back
@@ -1236,16 +1314,25 @@ export default {
         } catch (e) { /* DOM double */ }
         try { v.disableRemotePlayback = true; } catch (e) { /* not everywhere */ }
         try { v._aeUrl = src.url; } catch (e) { /* noop */ }
+        /* THE POSTER STANDS IN while the clip buffers (0827): the striped back
+         * never shows through a <video> that has one - a slow link, a phone
+         * holding preload to metadata, Low Power Mode refusing autoplay all
+         * paint the post's own still instead. */
+        const poster = posterOf(src);
+        if (poster) { try { v.setAttribute('poster', poster); } catch (e) { /* noop */ } }
         if (typeof v.addEventListener === 'function') {
           v.addEventListener('error', () => faceDied(v));
         }
         v.src = src.url;
         if (isTop && typeof v.play === 'function') {
-          try { const p = v.play(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* autoplay policy */ }
+          try {
+            const p = v.play();
+            if (p && p.catch) p.catch(() => { try { v._aePlayBlocked = true; } catch (e2) { /* noop */ } });
+          } catch (e) { /* autoplay policy */ }
         }
         return v;
       }
-      if (wantVideo) return null;                       // budget spent: the back stands
+      if (wantVideo) return mintPosterFace(src);        // budget spent: the poster stands, or the back
       /* owner 2026-08-24 (blank-card fix): a video url NEVER goes into an <img>.
        * The old dud face downloaded the whole mp4, painted nothing, and - being
        * a face - blocked reseat()'s grow branch, so every promoted video card
@@ -1375,9 +1462,17 @@ export default {
         setVar(live.node, '--sort-scale', String(scaleForDepth(i)));
         /* THE SECOND CARD GROWS A FACE when it becomes the top one; a card that
          * was minted at depth 2 never had one. */
-        if (i <= 1 && !live.face) {
+        /* ...or it STOOD IN AS A POSTER over the ceiling and a slot has freed since */
+        const posterOnly = !!(live.face && live.face._aePosterOnly);
+        if (i <= 1 && (!live.face || (posterOnly && videoCount < DECODER_CEILING))) {
+          /* the poster is torn out only once the clip was actually minted: a
+           * mint that answers with nothing (or another poster) keeps the still */
           const face = mintFace(live.card, i);
-          if (face) {
+          const upgrade = !!(face && face.tagName === 'VIDEO');
+          if (posterOnly && !upgrade) {
+            if (face) { try { face.remove(); } catch (e) { /* noop */ } }
+          } else if (face) {
+            if (posterOnly) killFace(live);
             live.face = face;
             live.video = face.tagName === 'VIDEO';
             /* a fresh face is a fresh slot claim: the free that matters is the
@@ -1402,7 +1497,10 @@ export default {
             const v = live.face;
             if (v.paused !== false) {
               v.autoplay = true;
-              if (typeof v.play === 'function') { const p = v.play(); if (p && p.catch) p.catch(() => {}); }
+              if (typeof v.play === 'function') {
+                const p = v.play();
+                if (p && p.catch) p.catch(() => { try { v._aePlayBlocked = true; } catch (e2) { /* noop */ } });
+              }
             }
           } catch (e) { /* autoplay policy */ }
         }
@@ -2061,6 +2159,7 @@ export default {
         widthOf: () => cardWidth(),
         viewportOf: () => stageBox().w,
         onGrab: () => {
+          retryBlockedPlay();
           if (!S || !S.armed) return;
           const top = S.live[0];
           if (top) addCls(top.node, 'is-held');
@@ -2125,6 +2224,14 @@ export default {
       const meta = metaOf();
       if (retake && cacheUsable(meta.deck, S.day, seed)) {
         const built = deckFromRows(meta.deck.rows, !!meta.deck.quick);
+        /* the cache keeps no poster (its blob is capped): a loop the live pool
+         * absorbed again this claim gets the pool's (0827) */
+        if (S.pool && typeof S.pool.posterOf === 'function') {
+          for (const c of built.cards) {
+            if (c.poster || c.kind !== 'loop') continue;
+            try { c.poster = S.pool.posterOf(c.url) || ''; } catch (e) { /* noop */ }
+          }
+        }
         S.cards = built.cards;
         S.deckRows = built.cards.slice();     // same rows, same order, same substitutes
         warmDeck();
@@ -2239,8 +2346,8 @@ export default {
       const offs = [];
       try {
         if (ctx.keys && typeof ctx.keys.on === 'function') {
-          offs.push(ctx.keys.on('left', () => { if (S && S.swipe) S.swipe.key('left'); }));
-          offs.push(ctx.keys.on('right', () => { if (S && S.swipe) S.swipe.key('right'); }));
+          offs.push(ctx.keys.on('left', () => { retryBlockedPlay(); if (S && S.swipe) S.swipe.key('left'); }));
+          offs.push(ctx.keys.on('right', () => { retryBlockedPlay(); if (S && S.swipe) S.swipe.key('right'); }));
         }
       } catch (e) { say('keybind wiring failed: ' + ((e && e.message) || e)); }
       unbindKeys = () => { for (const off of offs) { try { off(); } catch (e) { /* noop */ } } };

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -1448,6 +1448,9 @@ export function createAssets(options = {}) {
       /* the shared url blacklist: a tagged serve skips a dead row and the
        * seeded re-serve is its substitute source (see tagged.js nextRow) */
       broken: isBrokenUrl,
+      /* the vet's verdicts (./vet.js): a tagged serve deals a row PROVED alive
+       * ahead of one it never reached (tagged.js nextRow, 0827) */
+      verdict: (u) => vetter.verdict(u),
       /* The remote gate is the app's, not the door's: with remote media off (or
        * OfflineMode on) a remote source row simply never asks, the tag lands
        * empty, and the door refuses to start on pool.empty(). A LOCAL row is

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/tagged.js
@@ -116,7 +116,7 @@ export function normalizeSources(list) {
  *                               blacklist; a dead row is skipped at serve time
  * @returns {Promise<Object>} the pool (resolves per law 3, never rejects)
  */
-export function createTaggedPool({ spec, channel, platform, prewarm, log, remoteAllowed, broken } = {}) {
+export function createTaggedPool({ spec, channel, platform, prewarm, log, remoteAllowed, broken, verdict } = {}) {
   const s = spec || {};
   const say = typeof log === 'function' ? log : () => {};
   const sources = normalizeSources(s.sources);
@@ -171,6 +171,8 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
   }
 
   const isDead = (url) => { try { return typeof broken === 'function' && !!broken(url); } catch (e) { return false; } };
+  /** The vet's word (provider/vet.js verdict()): 'ok' is a row PROVED alive this page. */
+  const isOk = (url) => { try { return typeof verdict === 'function' && verdict(url) === 'ok'; } catch (e) { return false; } };
 
   /* ---------------------- the ask ---------------------------------------- */
   /** How many distinct rows a tag is still worth asking for.
@@ -253,6 +255,9 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
         remote: !isLocalUrl(url),
         kind: rowKind(e),
         mime: String((e && e.mime) || ''),
+        /* THE CLIP'S OWN STILL (0827): the host sends a remote loop's poster so a
+         * card can paint it while the clip buffers, or over the decoder ceiling. */
+        poster: (e && typeof e.poster === 'string' && e.poster && !isLocalUrl(url)) ? e.poster : '',
         tag: rowTag,
         src: (e && typeof e.src === 'string' && e.src) ? e.src : sourceLabel(src),
       });
@@ -326,17 +331,27 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
     for (let attempt = 0; attempt <= cap; attempt++) {
       if (tag.cursor >= tag.order.length) reserve(tag);
       if (!tag.order.length) return null;
-      if (prefer && attempt === 0) {
-        /* PREFERENCE IS A SWAP, NOT A SKIP: the wanted kind is pulled forward
+      if (attempt === 0) {
+        /* PREFERENCE IS A SWAP, NOT A SKIP: the wanted row is pulled forward
          * into the cursor's slot and the row it displaced keeps its place in
-         * the pass, so a preference can never starve a kind out of the deck. */
+         * the pass, so a preference can never starve a kind out of the deck.
+         * Two preferences, in order: A JUDGED-ALIVE ROW FIRST (0827 - the
+         * vet's 'ok'; a row the vet never reached is dealt only once the
+         * judged ones left in this pass are spent, a dead one never), then
+         * the wanted kind. With no verdicts in hand this is the old kind-only
+         * swap, and with a clean blacklist and no vet the sequence is the one
+         * this pool always served. */
+        let best = -1;
+        let bestScore = 9;
         for (let i = tag.cursor; i < tag.order.length; i++) {
-          if (tag.order[i].kind === prefer) {
-            if (i !== tag.cursor) {
-              const t = tag.order[i]; tag.order[i] = tag.order[tag.cursor]; tag.order[tag.cursor] = t;
-            }
-            break;
-          }
+          const r = tag.order[i];
+          if (!r || isDead(r.url)) continue;
+          const score = (isOk(r.url) ? 0 : 2) + ((prefer && r.kind !== prefer) ? 1 : 0);
+          if (score < bestScore) { best = i; bestScore = score; }
+          if (score === 0) break;
+        }
+        if (best > tag.cursor) {
+          const t = tag.order[best]; tag.order[best] = tag.order[tag.cursor]; tag.order[tag.cursor] = t;
         }
       }
       const cand = tag.order[tag.cursor];
@@ -354,6 +369,17 @@ export function createTaggedPool({ spec, channel, platform, prewarm, log, remote
   const pool = {
     /** row | null - null ONLY when this tag has zero rows (law 2). */
     next(tag, opts) { return disposed ? null : nextRow(String(tag || ''), opts); },
+    /** The poster this pool holds for a url ('' when none): a retake re-deals
+     *  a cached row list that carries no poster (deck.js rowsFromCards keeps
+     *  the meta blob small), and asks the live pool for it instead. */
+    posterOf(url) {
+      const u = String(url || '');
+      if (!u) return '';
+      for (const n of tagNames) {
+        for (const r of tags[n].rows) if (r.url === u) return r.poster || '';
+      }
+      return '';
+    },
 
     counts() {
       const out = Object.create(null);

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/vet.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/vet.js
@@ -51,12 +51,25 @@
 
 export const VET = Object.freeze({
   IMAGE_LANES: 4,       // detached <img> probes in flight (a cache warm each)
-  VIDEO_LANES: 2,       // detached <video> probes in flight = DECODER_CEILING
+  VIDEO_LANES: 4,       // detached <video> probes in flight AT THE DOOR (see videoLanes)
+  VIDEO_LANES_IOS: 2,   // a phone's WebKit: the class's own DECODER_CEILING, no more
   PROBE_MS: 8000,       // a probe with no answer by then is UNSURE, not dead
   MAX_MS: 20000,        // the gate's hard ceiling, whatever is still pending
 });
 
 const VIDEO_URL_RE = /\.(mp4|webm|m4v|mov)(\?|#|$)/i;
+
+/** Metadata probes in flight. The vet only ever runs AT THE DOOR - open() aborts
+ *  every video lane before the class mints its first face - so on a desktop it
+ *  may hold more demuxers than the class's ceiling; a phone keeps its number
+ *  (0827: two lanes judged a handful of clips before the stills opened the
+ *  gate, and every dead loop walked into the deck unjudged). */
+function videoLanes() {
+  try {
+    if (typeof navigator !== 'undefined' && /iP(hone|ad|od)/.test(String(navigator.userAgent || ''))) return VET.VIDEO_LANES_IOS;
+  } catch (e) { /* noop */ }
+  return VET.VIDEO_LANES;
+}
 
 /** One verdict per url per PAGE: 'ok' | 'dead' | 'unsure'. A second press of
  *  PLAY, a retake, another class - none of them re-probe a url this page has
@@ -206,6 +219,9 @@ export function createVetter(o = {}) {
       total: jobs.length, done: 0, ok: 0, dead: 0, unsure: 0,
       byTag: Object.create(null), complete: jobs.length === 0, elapsed: 0,
       urls: { ok: [], dead: [], unsure: [] },
+      /* rows still queued or in flight, by lane - a gate rule can refuse to
+       * open while a clip is unjudged (games/sort VET_GATE, 0827) */
+      pending: { video: 0, image: 0 },
     };
     const tagBox = (tag) => {
       const k = tag || '';
@@ -254,7 +270,16 @@ export function createVetter(o = {}) {
       resolveFn(stats);
     }
 
+    function refreshPending() {
+      let v = 0, im = 0;
+      for (const j of queue) { if (j.video) v += 1; else im += 1; }
+      for (const f of inflight) { if (f.job.video) v += 1; else im += 1; }
+      stats.pending.video = v;
+      stats.pending.image = im;
+    }
+
     function progress() {
+      refreshPending();
       if (onProgress) { try { onProgress(stats); } catch (e) { /* a bad listener never stops the vet */ } }
       if (opened) return;
       if (stats.complete) { open('complete'); return; }
@@ -274,7 +299,7 @@ export function createVetter(o = {}) {
       for (let i = 0; i < queue.length;) {
         const job = queue[i];
         if (job.video) {
-          if (opened || vidFlight >= VET.VIDEO_LANES) { i += 1; continue; }
+          if (opened || vidFlight >= videoLanes()) { i += 1; continue; }
           vidFlight += 1;
         } else {
           if (imgFlight >= VET.IMAGE_LANES) { i += 1; continue; }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -4015,7 +4015,13 @@ internal static class ArcademyHostService
     /// <summary>One servable row. <c>Tag</c> and <c>Src</c> are null on the app-wide path (the
     /// reply there is byte-for-byte what it always was) and set on the tagged path, where the tag
     /// IS the answer key the class grades on.</summary>
-    private sealed record AssetUrl(string Url, string Kind, string Mime, string? Tag = null, string? Src = null);
+    private sealed record AssetUrl(string Url, string Kind, string Mime, string? Tag = null, string? Src = null, string? Poster = null);
+
+    /// <summary>A remote loop's own still (<see cref="FypAssetManifest.Entry.PosterUrl"/>): the
+    /// page paints it while the clip buffers and over its decoder ceiling, instead of the striped
+    /// back the owner kept seeing (0827). Stills and library files carry none.</summary>
+    private static string? PosterFor(Fyp.FypAssetManifest.Entry e, string kind)
+        => kind == "loop" && !string.IsNullOrEmpty(e.PosterUrl) ? e.PosterUrl : null;
 
     private static void OnAssetsRequest(JObject o)
     {
@@ -4051,7 +4057,7 @@ internal static class ArcademyHostService
         {
             type = "assets",
             reqId,
-            urls = served.Select(u => new { url = u.Url, kind = u.Kind, mime = u.Mime }).ToArray(),
+            urls = served.Select(u => new { url = u.Url, kind = u.Kind, mime = u.Mime, poster = u.Poster }).ToArray(),
             done = satisfied,
         });
         if (!satisfied) ServeRemoteBatch(reqId, kind, count - served.Count);
@@ -4115,7 +4121,7 @@ internal static class ArcademyHostService
                 // smaller rendition (ScrolllerSource.SmallUrl, <= 640 clip / <= 1280 still,
                 // the web port's numbers) loads in a fraction of the time the 1920px one did.
                 var url = e.SmallUrl ?? e.Url;
-                fresh.Add(new AssetUrl(url, kind, MimeFor(url, kind)));
+                fresh.Add(new AssetUrl(url, kind, MimeFor(url, kind), Poster: PosterFor(e, kind)));
                 if (fresh.Count >= RemoteBatchCap) break;
             }
 
@@ -4136,7 +4142,7 @@ internal static class ArcademyHostService
                 {
                     type = "assets",
                     reqId,
-                    urls = send.Select(u => new { url = u.Url, kind = u.Kind, mime = u.Mime }).ToArray(),
+                    urls = send.Select(u => new { url = u.Url, kind = u.Kind, mime = u.Mime, poster = u.Poster }).ToArray(),
                     // Done either way: an empty pool must end the exchange, not restart it.
                     done = true,
                     error,
@@ -4195,6 +4201,31 @@ internal static class ArcademyHostService
     /// <see cref="_remoteFetchInFlight"/> latch the app-wide path uses: target and noise are two
     /// different asks, and one must not end the other's exchange with an empty reply.</summary>
     private static readonly HashSet<string> TaggedFetchesInFlight = new(StringComparer.Ordinal);
+
+    /// <summary>Asks that arrived while <see cref="TaggedFetchesInFlight"/> held their pile's key.
+    /// They used to be answered EMPTY on the spot - and the page, which asks again after every
+    /// reply, burned its whole ask budget on empties in under four seconds and fell back to a
+    /// QUICK SORT (a different game) while the fetch was still on its way (0827, a Retake). Now
+    /// they queue behind that fetch and are served off its buffer the moment it lands. Guarded
+    /// by <see cref="TaggedFetchesInFlight"/>'s lock; a waiter from a closed Arcademy (epoch
+    /// moved on) is dropped, never posted.</summary>
+    private static readonly Dictionary<string, List<(string ReqId, string Tag, int Want, int Epoch)>> TaggedWaiters
+        = new(StringComparer.Ordinal);
+
+    private static void DrainTaggedWaiters(string key)
+    {
+        List<(string ReqId, string Tag, int Want, int Epoch)>? list;
+        lock (TaggedFetchesInFlight)
+        {
+            if (!TaggedWaiters.Remove(key, out list) || list == null) return;
+        }
+        int epoch = Volatile.Read(ref _generation);
+        foreach (var w in list)
+        {
+            if (w.Epoch != epoch) continue;
+            try { PostTaggedAssets(w.ReqId, w.Tag, TakeBuffered(key, w.Want), true); } catch { }
+        }
+    }
 
     private static bool _taggedSubsEmptyLogged;
 
@@ -4323,6 +4354,7 @@ internal static class ArcademyHostService
                 mime = u.Mime,
                 tag = u.Tag ?? tag,
                 src = u.Src ?? "",
+                poster = u.Poster,
             }).ToArray(),
             done,
         });
@@ -4340,9 +4372,11 @@ internal static class ArcademyHostService
         {
             if (!TaggedFetchesInFlight.Add(key))
             {
-                // End THIS exchange rather than leaving the page's latch open; the pool it wanted
-                // is one ask away (the page asks again after every reply).
-                PostTaggedAssets(reqId, tag, Array.Empty<AssetUrl>(), true);
+                // The fetch this ask wants is already on its way: queue behind it and let the
+                // landing serve it (see TaggedWaiters) - an empty reply here was the Retake's
+                // road to a QUICK SORT.
+                if (!TaggedWaiters.TryGetValue(key, out var waiters)) TaggedWaiters[key] = waiters = new();
+                waiters.Add((reqId, tag, want, epoch));
                 return;
             }
         }
@@ -4352,6 +4386,7 @@ internal static class ArcademyHostService
             if (allowed.Count == 0)
             {
                 PostTaggedAssets(reqId, tag, Array.Empty<AssetUrl>(), true);
+                DrainTaggedWaiters(key);
                 return;
             }
 
@@ -4377,7 +4412,7 @@ internal static class ArcademyHostService
                 // The card rendition, not the feed one (see ServeRemoteBatch): SORT's ring is
                 // 0.75-2.4s and a 1920px 15MB mp4 was the striped back the owner kept seeing.
                 var url = e.SmallUrl ?? e.Url;
-                fresh.Add(new AssetUrl(url, kind, MimeFor(url, kind), tag, "r/" + bare));
+                fresh.Add(new AssetUrl(url, kind, MimeFor(url, kind), tag, "r/" + bare, PosterFor(e, kind)));
                 if (fresh.Count >= RemoteBatchCap) break;
             }
 
@@ -4396,6 +4431,7 @@ internal static class ArcademyHostService
                 }
                 if (error != null) App.Logger?.Debug("ArcademyHost: tagged batch '{Tag}' error {E}", tag, error);
                 PostTaggedAssets(reqId, tag, send, true);
+                DrainTaggedWaiters(key);
             });
         }
         catch (Exception ex)
@@ -4405,6 +4441,7 @@ internal static class ArcademyHostService
             {
                 try { PostTaggedAssets(reqId, tag, Array.Empty<AssetUrl>(), true); } catch { }
             }
+            DrainTaggedWaiters(key);
         }
         finally { lock (TaggedFetchesInFlight) TaggedFetchesInFlight.Remove(key); }
     }


### PR DESCRIPTION
Follow-up to #354. Owner: "even now we got some placeholders" after the check said done.

Desktop could not reproduce a persistent bare back (3 CDP-driven retakes, incl. 3 and 4 Mbps throttles), so the report is most likely from the phone. Three leaks stood regardless of platform, all closed here:

1. **The gate opened on stills alone.** ENOUGH counted alive rows while the 2 video lanes had judged almost nothing, and open() dropped the queued clips unjudged. Now 4 door lanes on desktop (2 on iOS), `stats.pending` per lane, and the gate waits for the clips up to CLIP_HOLD_MS 10s inside the same 20s ceiling. `nextRow` deals a judged-alive row first (a swap; identical sequence when there are no verdicts).
2. **Over the decoder ceiling / buffering / autoplay refused = striped back.** The host sends a remote loop's PosterUrl; the card paints it as the `<video>` poster, or as an `<img>` over the ceiling (upgraded to the clip when a slot frees); a refused play() retries on the next swipe or key.
3. **Desktop Retake became a QUICK SORT.** A second ask on an in-flight tagged key was answered EMPTY and the page burned its ask budget. The host now queues the ask (`TaggedWaiters`) and serves it when the fetch lands; the page re-asks an empty pile 3 times before the floor.

Web side: CodeBambi/cclabs-web PR adds the poster to the shim's loop rows (same row shape). Sync arcademy after merge.

Tests: scratchpad suite unchanged baseline (same stale deck-size failures), class suite +10 assertions for the re-ask, new vet pending + tagged ok-first unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdnjK4ZQZ8QqE4VHex3Hv8