### PR TITLE
rel(6.8.5): cut-day fold-ins - bell chip UTC, Bugle panel, DTRH shake, Quick Recal hint, intake determinism

### DIFF
--- a/ConditioningControlPanel/CLAUDE.md
+++ b/ConditioningControlPanel/CLAUDE.md
@@ -20,7 +20,7 @@ dotnet run
 | `Services/Update/UpdateService.cs:~29` | `CurrentPatchNotes` |
 | `../installer.iss:16` | `MyAppVersion` |
 | `../build-installer.bat:10` | `VERSION` |
-| `MainWindow/MainWindow.xaml:~569` | `BtnUpdateAvailable` Content + ToolTip loc keys |
+| `MainWindow/MainWindow.xaml:~1985` | `BtnUpdateAvailable` Content + ToolTip loc keys |
 | `Localization/Languages/*.json` (9 files) | `btn_vX_Y_Z_is_out` + `tooltip_vX_Y_Z_*` keys |
 
 Use `/release X.Y.Z "Subtitle"` to automate this. Also write `../notes-vX.Y.Z.txt` (plain-text notes for the GitHub release; no em-dashes). After signing: push main, tag `vX.Y.Z`, create the GitHub release (mark Latest), POST server marquee + update-banner (`x-admin-token`), update download links + version badge in `C:\Projects\cclabs-site` (index.html + guide-getting-started.html, then commit+push and `vercel deploy --prod`), announce on Discord. The language files are strict-JSON clean as of 2026-07-29 - see **Localization** under Known Issues before editing them.

--- a/ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs
@@ -417,6 +417,40 @@ namespace ConditioningControlPanel
 
             SyncBlinkRecalToggles(s.BlinkRecalibrateShortcutEnabled);
             UpdatePanicKeyButton();
+
+            RefreshQuickRecalHotkeyHint();
+        }
+
+        /// <summary>Base ToolTip text authored on BtnWebcamDebugQuickRecal in
+        /// DevicesSettingsSection.xaml, captured once so repeated refreshes append the hotkey
+        /// line to the original copy instead of to their own previous output.</summary>
+        private string? _quickRecalTooltipBase;
+
+        /// <summary>
+        /// Teaches the global Quick Recal chord on the webcam bar in Settings → Devices — the
+        /// gaze section people already visit when the cursor starts drifting. It rides the
+        /// existing Quick Recal button's ToolTip so the chord sits on the very control it
+        /// replaces, and it names the camera start/stop shortcut in the same breath so the two
+        /// webcam hotkeys can't be mistaken for each other.
+        /// </summary>
+        private void RefreshQuickRecalHotkeyHint()
+        {
+            try
+            {
+                var btn = AppSettingsTab?.BtnWebcamDebugQuickRecal;
+                if (btn == null) return;
+
+                _quickRecalTooltipBase ??= btn.ToolTip as string ?? "";
+
+                var hint = QuickRecalHotkeyHint();
+                btn.ToolTip = string.IsNullOrEmpty(_quickRecalTooltipBase)
+                    ? hint
+                    : _quickRecalTooltipBase + "\n\n" + hint;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("RefreshQuickRecalHotkeyHint failed: {Error}", ex.Message);
+            }
         }
 
         private void WebcamActivePill_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -448,6 +448,7 @@ export const DEFAULT_LEXICON = Object.freeze({
   bugle_prev: 'Previous page',
   bugle_next: 'Next page',
   bugle_comics: 'Comics',
+  bugle_comics_held: 'Picture held at the printer. Described below.',
   bugle_empty: 'Nothing set for this page.',
   bugle_prop_label: 'The paper',
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
@@ -332,8 +332,8 @@
   animation: emi-toy-bob 3.4s ease-in-out infinite;
 }
 /* Trap 27 again: `[hidden]` is a user-agent rule and the block above is not,
-   so the prop hides itself rather than leaning on styles.css's reset - EMI
-   also ships standalone (demo.html) and a skin must hide its own node. */
+ * so the prop hides itself rather than leaning on styles.css's reset - EMI
+ * also ships standalone (demo.html) and a skin must hide its own node. */
 .arc-emi .emi .emi-toy[hidden] { display: none !important; }
 
 @keyframes emi-toy-bob {

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/bugle.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/bugle.css
@@ -392,3 +392,9 @@ html.arc-reduced .arc-bugleprop-new { transition:none; }
 }
 /* THE SINGLE PANEL: the season's comics form - one wide frame, caption below. */
 .arc-bugle-panel.is-wide { flex: 1 1 100%; min-height: 96px; }
+.arc-bugle-panelheld {
+  position:absolute; inset:0; display:flex; align-items:center; justify-content:center;
+  padding:8px 14px; text-align:center;
+  font-size:10px; letter-spacing:.12em; text-transform:uppercase;
+  color:color-mix(in srgb, var(--news-ink), transparent 45%);
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/bugle.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/bugle.js
@@ -576,6 +576,10 @@ export function openBugle(issueId, opts) {
       for (let i = 0; i < frames; i += 1) {
         const panel = el('div', 'arc-bugle-panel' + (single ? ' is-wide' : ''));
         if (!single) panel.appendChild(el('span', 'arc-bugle-panelnum', String(i + 1)));
+        /* The single panel is empty on purpose; without a printed reason a
+         * reader takes it for a picture that failed to load (T2, 08-27). */
+        if (single) panel.appendChild(el('span', 'arc-bugle-panelheld',
+          t('bugle_comics_held', 'Picture held at the printer. Described below.')));
         strip.appendChild(panel);
       }
       box.appendChild(strip);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -484,8 +484,11 @@ export function campusState({ classes, records, suspended, endless, devPass, unl
 /** Seconds until the next local midnight - the next bell. Pure. */
 export function bellSecondsLeft(now) {
   const d = now instanceof Date ? now : new Date();
-  const next = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1, 0, 0, 0, 0);
-  return Math.max(0, Math.round((next.getTime() - d.getTime()) / 1000));
+  /* UTC midnight, NOT local: the timetable day key (`core/timetable.js fmtDay`)
+   * and the Daily Trigger seed are UTC days. Counting to local midnight let a
+   * 23:00 US session and the next morning land on ONE arcademy day. */
+  const next = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1, 0, 0, 0, 0);
+  return Math.max(0, Math.round((next - d.getTime()) / 1000));
 }
 
 /** 'HH:MM:SS' for the bell chip. Pure. */

--- a/ConditioningControlPanel/Resources/web/dtrh/game/chaosRun.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/chaosRun.js
@@ -51,6 +51,7 @@ import { getVoice, setVoiceDefault, onVoice, getLevel } from '../engine/audioLev
 import { createChaosField } from './chaosField.js';
 import { createFieldFx } from './fieldFx.js';
 import { createPayloadFx } from './payloadFx.js';
+import { createScreenShake } from './screenShake.js';
 import { createChaosHud } from './chaosHud.js';
 import { createOverlays } from './overlays.js';
 import { createWarren } from './warren.js';
@@ -102,7 +103,7 @@ const PLAIN_BUBBLE_CHANCE = 0.30;   // share of ordinary spawns that are plain, 
 const PLAIN_BUBBLE_CHANCE_EARLY = 0.80; // at the top of the run: mostly plain bubbles, effects rare - ramps down to PLAIN_BUBBLE_CHANCE as intensity peaks
 const MATERIAL_DROP_CAP = 8;        // crafting: max material drops per run (tube + pop combined)
 const MATERIAL_POP_CHANCE = 0.008;  // crafting: chance a popped treat sheds a raw ingredient
-const VIDEO_HEAVY_SEC = 17;         // the stuck POV video holds 15s (payloadFx VIDEO_HOLD_SEC) + slack
+const VIDEO_HEAVY_SLACK_SEC = 2;    // the stuck POV video holds S.spotSeconds (payloadFx videoHoldSec) + this slack
 const CASCADE_BASE_SEC = 6;         // GifCascadePayload.DURATION_SEC (+5 ride-out)
 const RANK = { Curious: 0, Tempted: 1, Slipping: 2, Entranced: 3, Devoted: 4, Claimed: 5 };
 
@@ -156,6 +157,10 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
       sparkGainMult: rc.sparkGainMult ?? 1.0,
       spawnRateMult: clamp(rc.spawnRateMult ?? 1.0, 0.1, 10.0),
       colorFlashes: rc.colorFlashes !== false,
+      // The screen-shake dials (ChaosRunConfig.ScreenShakeEnabled/.ShakeIntensity).
+      // Off stands the jolt fully down; the intensity is the user's 0..1 amplitude.
+      screenShake: rc.screenShake !== false,
+      shakeIntensity: clamp(rc.shakeIntensity ?? 0.8, 0, 1),
       boonDraftEnabled: rc.boonDraftEnabled !== false,
       allowCurses: rc.allowCurses !== false,
       dartersEnabled: rc.dartersEnabled !== false,
@@ -192,6 +197,9 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
     discovered.clear();
     (rc.discoveredCodexIds || []).forEach((id) => discovered.add(id));
     rippleCastCount = 0;
+    // the dials can change between descents (the Warren's options console)
+    shakeFx?.setEnabled(cfg.screenShake);
+    shakeFx?.setIntensity(cfg.shakeIntensity);
     bridge.log(`runcfg: diff=${cfg.difficulty} scripted=${cfg.scriptedFirstRun} runs=${cfg.runsCompleted}`
       + ` variants=${JSON.stringify(cfg.enabledVariants)} draft=${cfg.boonDraftEnabled} sin=${cfg.sinChance}`);
     // Seen-once flags: a local mutable mirror of chaos_meta (persisted one-way
@@ -207,6 +215,7 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
 
   let ctx = null;      // { nav, fx, director, hud, canvas } from scene.start
   let field = null, ffx = null, hudUi = null, overlays = null, payloadFx = null;
+  let shakeFx = null;  // the run-config screenShake consumer (game/screenShake.js), built in attach
   let bMech = null;    // the biome mechanic controller (game/biomeMech.js), built in attach
   let warren = null, lessons = null, happy = null, vn = null, lessonCardUi = null, hubGuide = null;
   let chesh = null, guide = null;   // the Cheshire VN engine + tutorial director (null when CHESHIRE_DISABLED)
@@ -572,9 +581,11 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
         return;
       }
       heavyUntil = performance.now() + (kind === 'video'
-        ? VIDEO_HEAVY_SEC * 1000
+        ? ((payloadFx?.videoHoldSec() ?? 15) + VIDEO_HEAVY_SLACK_SEC) * 1000
         : (CASCADE_BASE_SEC * durationMult + 5) * 1000);
       sfx(kind === 'video' ? 'trigger' : 'fx_rain_start', 0.45);
+      // the heavies land like a hit: the tube rocks under the detonation
+      shakeFx?.shake(kind === 'video' ? 1.0 : 0.7, 380);
     }
     if (isDetonation && spec.variantId === 'braindrain') sfx('fx_drain', 0.45);
     // Hard cutover (2026-07): every effect renders IN-WORLD (payloadFx) instead
@@ -1328,6 +1339,7 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
     if (ctx.spawner) ctx.spawner.setPickupTimeScale(0);
     ctx.director.setTimeFactor(0.06);   // P1: visible time dilation - the tunnel all but stops
     sfx('freeze_catch', 0.55);
+    shakeFx?.shake(0.6, 280);   // the world slamming to a stop
     hudUi.announce('❄ FREEZE', 'freeze', 1800, { artKey: 'freeze' });
     pulse('150,210,255', 0.30);
     // The world stops with the field: ask the host to pause any native voiceline +
@@ -2683,6 +2695,7 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
         if (hit) {
           ctx.fx.strikeNow();
           sfx('estim_zap', 0.35);
+          shakeFx?.shake(0.35, 160);   // the bolt's kick (small - these repeat all storm long)
           if (hit.kind === 'life') hudUi.toast('⚡ static bit a fuse — it burns faster now');
         }
       }
@@ -3888,6 +3901,7 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
     // A mandatory-video card is an in-world DOM node (payloadFx front layer); the
     // field teardown doesn't touch it, so stop it here or it overlays the recap + hub.
     try { payloadFx?.cancelHeavy(); } catch (e) { /* ignore */ }
+    shakeFx?.stop();   // no jolt rides the surfacing into the recap
     // A run ending WHILE an in-tube boon draft is open would leave its card row in
     // the shared scene (junctions are torn down by setRunActive(false), but boonPick
     // is not) - force it closed so no phantom draft rides the idle crawl into the
@@ -4026,6 +4040,10 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
       preloadRecipeArt();   // warm the ingredient photos so a deep-run recipe plaster draws them, not glyphs
       ffx = createFieldFx(ctx.hud);
       payloadFx = createPayloadFx({ hud: ctx.hud, fx: ctx.fx, media: ctx.media, flashBurst: ctx.flashBurst });
+      // The screen-shake consumer rocks the 3D canvas only (never the hud - see
+      // screenShake.js). Seeded from the live cfg when a run-config already landed.
+      shakeFx = createScreenShake({ el: ctx.canvas });
+      if (cfg) { shakeFx.setEnabled(cfg.screenShake); shakeFx.setIntensity(cfg.shakeIntensity); }
       try { window.__sfPayloadFx = payloadFx; } catch { /* diagnostics seam (m2test) */ }
       try { window.__sfFireJunction = () => fireJunction(); } catch { /* diagnostics seam: force a branch fork */ }
       try {
@@ -4479,11 +4497,12 @@ export function createChaosGame({ bridge, hostState, runSetup, requestExit, modI
       field?.dispose();
       ffx?.dispose();
       payloadFx?.dispose();
+      shakeFx?.dispose();   // drops any jolt in flight and clears the canvas transform
       vn?.dispose();   // closes the VN AudioContext + removes its overlay/listeners (else it leaks per attach and hits Chromium's context ceiling)
       try { if (window.__sfPayloadFx === payloadFx) delete window.__sfPayloadFx; } catch { /* seam cleanup */ }
       try { delete window.__sfFireJunction; } catch { /* seam cleanup */ }
       try { delete window.__sfRegion; } catch { /* seam cleanup */ }
-      field = null; hudUi = null; overlays = null; ffx = null; payloadFx = null;
+      field = null; hudUi = null; overlays = null; ffx = null; payloadFx = null; shakeFx = null;
       warren = null; lessons = null; happy = null; vn = null;
     },
   };

--- a/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
@@ -270,10 +270,15 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
   // The in-world port of the mandatory video: the tape RUSHES UP AT THE POV and
   // STICKS there - dead center, way closer than the tube's seated clips - caged
   // in a red, electric, vibrating frame (styles.css .sf-pfx-vidframe). It cannot
-  // be clicked away: it holds the full VIDEO_HOLD_SEC and only lets go early
-  // when the fall reaches a room (the junction/draft antechamber calls
-  // cancelHeavy). Only one at a time; the game keeps running underneath.
-  const VIDEO_HOLD_SEC = 15;
+  // be clicked away: it holds for the player's 'video spotlight time' and only
+  // lets go early when the fall reaches a room (the junction/draft antechamber
+  // calls cancelHeavy). Only one at a time; the game keeps running underneath.
+  //
+  // The hold is the LIVE S.spotSeconds dial (10-30s - the same knob the tube's
+  // proximity spotlight reads in engine/spawner.js), clamped to its slider range;
+  // VIDEO_HOLD_FALLBACK_SEC is only reached if the setting goes missing.
+  const VIDEO_HOLD_FALLBACK_SEC = 15;
+  const videoHoldSec = () => clamp(S.spotSeconds || VIDEO_HOLD_FALLBACK_SEC, 10, 30);
   async function videoCard() {
     if (disposed || videoCardEl) return;   // one card at a time
     if (!media) return;
@@ -323,11 +328,12 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
     };
     // rush at the face on the next frame, stick, then recede
     requestAnimationFrame(() => { if (!disposed) card.classList.add('in'); });
-    const life = setTimeout(remove, VIDEO_HOLD_SEC * 1000);
+    const holdMs = videoHoldSec() * 1000;   // read once so both timers agree
+    const life = setTimeout(remove, holdMs);
     const handle = { cancel: () => { clearTimeout(life); remove(); } };
     videoCardCancel = handle.cancel;
     loops.add(handle);
-    setTimeout(() => loops.delete(handle), VIDEO_HOLD_SEC * 1000 + 900);
+    setTimeout(() => loops.delete(handle), holdMs + 900);
   }
 
   /** Room arrival cuts the heavies short: the stuck video card recedes and any
@@ -416,5 +422,7 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
     front.remove();
   }
 
-  return { applyPayload, cancelHeavy, showPinnedSpiral, refreshPinnedSpiral, hidePinnedSpiral, dispose };
+  // videoHoldSec is public so the run brain's heavy-busy window tracks the same
+  // live 'video spotlight time' dial the card holds for (chaosRun VIDEO_HEAVY_SLACK_SEC).
+  return { applyPayload, cancelHeavy, videoHoldSec, showPinnedSpiral, refreshPinnedSpiral, hidePinnedSpiral, dispose };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/game/screenShake.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/screenShake.js
@@ -1,0 +1,92 @@
+/* ============================================================================
+ * screenShake.js - the run-config `screenShake` / `shakeIntensity` dials, rendered.
+ *
+ * The host has always sent both knobs down with run-config (the WPF game feeds
+ * them to App.ScreenShake); the page had no consumer, so the setting was a dead
+ * wire in DtRH. This is that consumer: a translate-only jolt on the 3D canvas.
+ *
+ * WHY THE CANVAS, NOT THE HUD: the tube is the world, and #sf-hud carries the
+ * score/dock chrome AND every DOM overlay (bubble field, payloadFx). Shaking the
+ * hud would jitter unreadable text and double-shake anything already animating.
+ * The canvas is a single fixed, GPU-composited element that nothing else
+ * transforms, so the world can rock while the readouts hold still.
+ *
+ * Modest by design: amplitude tops out at MAX_PX * shakeIntensity and decays to
+ * nothing inside MAX_MS. Overlapping triggers EXTEND the window and take the
+ * louder amplitude - they never stack into a seizure. Hard off when the user's
+ * dial is off or the OS asks for reduced motion.
+ * ==========================================================================*/
+
+const MAX_PX = 8;     // peak offset at amount 1.0 x intensity 1.0
+const MAX_MS = 400;   // longest a single jolt may ring for
+
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+export function createScreenShake({ el } = {}) {
+  const reduced = !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  let enabled = true;
+  let intensity = 0.8;   // matches ChaosRunConfig.ShakeIntensity's default
+  let peak = 0;          // current amplitude in px
+  let spanMs = MAX_MS;   // the window the decay is measured against
+  let endAt = 0;
+  let raf = 0;
+  let disposed = false;
+
+  const live = () => !disposed && !!el && enabled && !reduced;
+
+  function rest() {
+    if (raf) { cancelAnimationFrame(raf); raf = 0; }
+    peak = 0; endAt = 0;
+    if (el) el.style.transform = '';
+  }
+
+  function step() {
+    raf = 0;
+    if (disposed || !el) return;
+    const left = endAt - performance.now();
+    if (left <= 0 || peak <= 0) { rest(); return; }
+    const decay = clamp(left / spanMs, 0, 1);
+    const a = peak * decay * decay;   // quadratic ring-down: hits hard, settles fast
+    const x = (Math.random() * 2 - 1) * a;
+    const y = (Math.random() * 2 - 1) * a;
+    el.style.transform = `translate3d(${x.toFixed(2)}px, ${y.toFixed(2)}px, 0)`;
+    raf = requestAnimationFrame(step);
+  }
+
+  return {
+    /** Jolt the world. amount 0..1 = how heavy the moment was; ms is clamped to MAX_MS. */
+    shake(amount = 1, ms = 260) {
+      if (!live()) return;
+      const a = clamp(amount, 0, 1) * clamp(intensity, 0, 1) * MAX_PX;
+      if (a < 0.1) return;
+      const now = performance.now();
+      const dur = clamp(ms, 60, MAX_MS);
+      // extend-not-stack: keep whichever amplitude is louder RIGHT NOW and push
+      // the deadline out, so a burst of triggers reads as one longer rumble.
+      const left = Math.max(0, endAt - now);
+      const decay = spanMs > 0 ? clamp(left / spanMs, 0, 1) : 0;
+      peak = Math.max(a, peak * decay);
+      endAt = Math.max(endAt, now + dur);
+      spanMs = Math.max(dur, endAt - now);
+      if (!raf) raf = requestAnimationFrame(step);
+    },
+    /** The user's `screenShake` dial (run-config). Off stands the effect fully down. */
+    setEnabled(on) {
+      enabled = !!on;
+      if (!enabled) rest();
+    },
+    /** The user's `shakeIntensity` dial, 0..1 (0 = silent, same as off). */
+    setIntensity(v) {
+      intensity = clamp(Number.isFinite(v) ? v : 0.8, 0, 1);
+    },
+    /** Drop any jolt in flight (run end / teardown) - the canvas returns to centre. */
+    stop: rest,
+    dispose() {
+      rest();
+      disposed = true;
+      el = null;
+    },
+  };
+}
+
+export default createScreenShake;

--- a/ConditioningControlPanel/Resources/web/intake/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/intake/CLAUDE.md
@@ -405,13 +405,16 @@ only, and breath tags cost 1–2 s each.
    window-mode key.
 9. **`is-correct` / `is-answer` must never gain visual styling** — they are DOM hooks. The pink-means-correct
    colour tell was the single biggest early play-test complaint.
-10. **Reward determinism has one hole**: `pickKind` uses `Math.random()` while the rest of `reward.js` runs
-    on the seeded `hash01` stream.
+10. **Reward determinism is whole**: `pickKind`'s gifburst/gifrain rolls now ride the same seeded
+    `hash01` stream as VariableRatio (own tag namespace + a per-`planFor` counter), so a fixed
+    `config.seed` replays an identical kind sequence. It used to call `Math.random()`.
 11. **Duplicated by design, no shared module**: `backdropRef` (beats + effects, ref-counted via
     `body.dataset.ixBackdrop`), `freshSpiralParams` + `window.__ixSpiralSig`, and the three CustomEvent name
     literals (`intake-sfx`, `intake-garnish`, `intake-log`). Effects and steering hold **no** audio handle —
     that is why the seams exist.
-12. **`'gifburst'` / `'gifrain'` are string literals**, not `RewardKind` members — a known contract gap.
+12. **`'gifburst'` / `'gifrain'` are `RewardKind.GifBurst` / `RewardKind.GifRain`** (contract gap closed).
+    The wire strings live in `core/contracts.js` only; `effects.js` re-exports `GIFBURST_KIND` /
+    `GIFRAIN_KIND` as aliases of the enum so older test references still resolve.
 13. **`quiz-result` is one-way.** The page mirrors C#'s session-naming rule to guess a name
     (`derived:true`), then the later `session-drafted` reply overwrites it. The certificate's exit is held
     shut until that reply lands (or 12 s), because clicking early tore the window down mid-draft and the

--- a/ConditioningControlPanel/Resources/web/intake/core/contracts.js
+++ b/ConditioningControlPanel/Resources/web/intake/core/contracts.js
@@ -382,12 +382,14 @@ export const RewardMode = Object.freeze({
 });
 
 export const RewardKind = Object.freeze({
-  Chime:   'chime',
-  Flash:   'flash',
-  Bubble:  'bubble',
-  Praise:  'praise',   // voiced/subtitled affirmation
-  Drop:    'drop',     // gif burst / subliminal drop
-  None:    'none',
+  Chime:    'chime',
+  Flash:    'flash',
+  Bubble:   'bubble',
+  Praise:   'praise',   // voiced/subtitled affirmation
+  Drop:     'drop',     // gif burst / subliminal drop
+  GifBurst: 'gifburst', // in-browser CCP-flash reward (render/effects.js showGifBurst)
+  GifRain:  'gifrain',  // the burst's rare sibling: the DTRH gif-cascade port
+  None:     'none',
 });
 
 /**

--- a/ConditioningControlPanel/Resources/web/intake/core/reward.js
+++ b/ConditioningControlPanel/Resources/web/intake/core/reward.js
@@ -30,7 +30,9 @@
  * (or config.rewardSeed) for reproducible fires (tests/harness). With no seed a
  * per-instance random seed is chosen so production runs differ. hash01 (from
  * contracts.js) drives the stream, so a fixed seed yields an identical fire
- * sequence for a fixed sequence of VariableRatio resolves.
+ * sequence for a fixed sequence of VariableRatio resolves. The gifburst/gifrain
+ * KIND rolls ride the same stream under their own tag, so planFor is seeded too
+ * (it used to call Math.random(), the one determinism hole in this file).
  * ==========================================================================*/
 
 import {
@@ -70,12 +72,10 @@ const STREAK_STEP = 0.03;        // intensity multiplier step per streak beat
 /* GifBurst: an in-browser CCP-flash reward (owner-directed). It joins the kind
  * roll in pickKind at GIFBURST_CHANCE — a weight comparable to how often the
  * heavy Flash / gif-Drop payloads land (Flash is the deep-beat default, Drop the
- * hottest; ~18% keeps GifBurst a frequent-but-not-dominant reward). The kind
- * string mirrors a recommended contracts.js `RewardKind.GifBurst: 'gifburst'`
- * (see FINAL REPORT contract-gap note); until that enum lands the literal is
- * duplicated here + in effects.js (same pattern as the GARNISH_CUE_EVENT
- * literal). effects.js renders it; audio/stats ignore an unknown kind. */
-const GIFBURST_KIND = 'gifburst';
+ * hottest; ~18% keeps GifBurst a frequent-but-not-dominant reward). The kind is
+ * `RewardKind.GifBurst` ('gifburst') — the contract gap is closed, so the wire
+ * string lives in contracts.js and nowhere else. effects.js renders it;
+ * audio/stats ignore an unknown kind. */
 const GIFBURST_CHANCE = 0.18;
 
 /* GifRain: the burst's RARE sibling — a ~6s downpour of falling gifs (the DTRH
@@ -84,7 +84,6 @@ const GIFBURST_CHANCE = 0.18;
  * that survive the burst roll (~4% overall) a player meets it a couple of times
  * in a long descent and it stays a prize instead of becoming wallpaper. Rolled
  * AFTER the burst so the burst's existing 18% tuning is untouched. */
-const GIFRAIN_KIND = 'gifrain';
 const GIFRAIN_CHANCE = 0.05;
 
 function baseChanceFor(mode, band, depth) {
@@ -129,16 +128,20 @@ function rewardIntensity01(depth) {
  * bubble (the centerpiece: the effect bubble IS the reward). Hotter prompts pay
  * in the heavier payloads (drop/praise); deeper beats favour flash; the honest
  * warm-up favours a gentle chime.
+ *
+ * `roll(tag)` is the caller's SEEDED stream (createReward.kindRoll) — the burst /
+ * rain rolls stay on the same hash01 stream as VariableRatio so a fixed seed
+ * replays an identical kind sequence (this used to be Math.random()).
  * -------------------------------------------------------------------------- */
-function pickKind(band, depth, prompt) {
+function pickKind(band, depth, prompt, roll) {
   if (band === Band.Recovery) return RewardKind.None;
   const hints = (prompt && Array.isArray(prompt.mechanicHints)) ? prompt.mechanicHints : [];
   const heat = (prompt && typeof prompt.heat === 'number') ? prompt.heat : 0;
   if (hints.includes(Mechanic.BubblePop)) return RewardKind.Bubble;
   // GifBurst joins the roll as a random in-browser flash reward (BubblePop still
   // wins — its bubble IS the reward). Opacity ramps by band inside effects.js.
-  if (Math.random() < GIFBURST_CHANCE) return GIFBURST_KIND;
-  if (Math.random() < GIFRAIN_CHANCE) return GIFRAIN_KIND;
+  if (roll('burst') < GIFBURST_CHANCE) return RewardKind.GifBurst;
+  if (roll('rain') < GIFRAIN_CHANCE) return RewardKind.GifRain;
   if (heat >= 4) return RewardKind.Drop;    // hottest -> gif burst / subliminal drop
   if (heat >= 3) return RewardKind.Praise;  // voiced/subtitled affirmation
   if (depth >= 0.6) return RewardKind.Flash;
@@ -180,6 +183,13 @@ export function createReward({ config } = {}) {
   let runPeak  = 0;   // best single scoreDelta seen (proxy for per-beat max)
   let runBeats = 0;   // number of scored beats
   let vrCount  = 0;   // VariableRatio resolves so far (drives the seeded stream)
+  let kindCount = 0;  // planFor calls so far (drives the seeded KIND stream)
+
+  /** The seeded roll pickKind uses (its own tag namespace, so adding a kind roll
+   *  never shifts the VariableRatio fire sequence for a given seed). */
+  function kindRoll(tag) {
+    return hash01(seed + '|kind-' + tag + '|' + kindCount);
+  }
 
   /** Running 0..1 fraction of best-achievable score (ScaleWithScore magnitude). */
   function runningScoreRate() {
@@ -201,8 +211,9 @@ export function createReward({ config } = {}) {
       mode,
       baseChance: baseChanceFor(mode, band, d),
       baseIntensity: isRecovery ? 0 : rewardIntensity01(d),
-      kind: pickKind(band, d, prompt),
+      kind: pickKind(band, d, prompt, kindRoll),
     };
+    kindCount += 1;                    // advance the seeded kind stream one beat
     plan._heat = promptHeat01(prompt); // additive, ignored by non-reward consumers
     return plan;
   }

--- a/ConditioningControlPanel/Resources/web/intake/render/effects.js
+++ b/ConditioningControlPanel/Resources/web/intake/render/effects.js
@@ -184,18 +184,16 @@ export function gifBurstSpec(intensity) {
 }
 
 /* ----------------------------------------------------------------------------
- * GIFBURST — in-browser CCP-flash REWARD (owner-directed). The kind string
- * mirrors a recommended contracts.js `RewardKind.GifBurst: 'gifburst'` (see the
- * FINAL REPORT contract-gap note); until that enum lands the literal is
- * duplicated here + in reward.js (same pattern as GARNISH_CUE_EVENT). Exported
- * so reward-roll / opacity tests can reference the shipped values.
+ * GIFBURST — in-browser CCP-flash REWARD (owner-directed). The kind is now a
+ * first-class `RewardKind.GifBurst` ('gifburst') in contracts.js — the literal
+ * lives there and nowhere else. Re-exported under the old name so reward-roll /
+ * opacity tests can still reference the shipped value.
  * -------------------------------------------------------------------------- */
-export const GIFBURST_KIND = 'gifburst';
+export const GIFBURST_KIND = RewardKind.GifBurst;
 
-/** GIF RAIN — the burst's rarer sibling (the DTRH gif-cascade port). Same
- *  contract-gap story as GIFBURST_KIND above: the literal is duplicated in
- *  core/reward.js, which is where the roll that fires it lives. */
-export const GIFRAIN_KIND = 'gifrain';
+/** GIF RAIN — the burst's rarer sibling (the DTRH gif-cascade port), likewise
+ *  `RewardKind.GifRain` ('gifrain'). core/reward.js owns the roll that fires it. */
+export const GIFRAIN_KIND = RewardKind.GifRain;
 
 /** Run-progress -> GifBurst opacity, HARDCODED per owner (no settings). The
  *  owner's ladder is BY BAND (Calibration .15 / Establishing .30 / Deepening

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -2764,6 +2764,7 @@ internal static class ArcademyHostService
         ["bugle_prev"] = "Previous page",
         ["bugle_next"] = "Next page",
         ["bugle_comics"] = "Comics",
+        ["bugle_comics_held"] = "Picture held at the printer. Described below.",
         ["bugle_empty"] = "Nothing set for this page.",
         ["bugle_prop_label"] = "The paper",
         // ---- wet ink (THE SEEP, tell 09) -----------------------------------------------

--- a/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
@@ -1049,6 +1049,7 @@ internal static class DtrhHostService
                 spawnRateMult = cfg.SpawnRateMult,
                 colorFlashes = cfg.ColorFlashesEnabled,
                 screenShake = cfg.ScreenShakeEnabled,
+                shakeIntensity = cfg.ShakeIntensity,   // 0..1 amplitude for the page's shake (game/screenShake.js)
 
                 // ---- M4: run-shape knobs ----
                 boonDraftEnabled = cfg.BoonDraftEnabled,

--- a/ConditioningControlPanel/Services/Webcam/WebcamCalibrationData.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamCalibrationData.cs
@@ -17,7 +17,26 @@ namespace ConditioningControlPanel.Services
     {
         public const string FileName = "webcam-calibration.json";
 
-        /// <summary>"TwoPoint" (gaze-side only), "FivePoint" (legacy), "NinePoint" (3×3), "SixteenPoint" (4×4), or "TwentyFivePoint" (current, 5×5 with margin=40). The 5×5 grid puts dots at every edge midpoint and shrinks the corner-to-bezel extrapolation from ~90 DIPs to ~40 DIPs — directly addresses the top/bottom undershoot that 4×4 had to extrapolate. Earlier 5×5 attempts had jumpy cursor + drift, but those traced to issues in the regression / outlier rejection / head-pose comp / edge-pull, all since fixed.</summary>
+        /// <summary>
+        /// "TwoPoint" (gaze-side only), "FivePoint" (legacy), "NinePoint" (3×3),
+        /// or "SixteenPoint" (4×4) — <b>SixteenPoint is what the calibration
+        /// window actually writes today</b> (WebcamCalibrationWindow GridSize = 4).
+        /// <para>
+        /// CORRECTED 2026-08-27: this summary previously claimed "TwentyFivePoint
+        /// (current, 5×5)" and that the 5×5 grid "directly addresses the top/bottom
+        /// undershoot". No 5×5 mode is written by any current code path, and the
+        /// top/bottom undershoot was NOT solved — it was simply never measured,
+        /// because the bubble accuracy test only sampled the middle band
+        /// (h × {0.30, 0.72}) and never probed the top or bottom 25% of the
+        /// screen. That blind spot was fixed in the accuracy test itself (four
+        /// distinct y-levels at 0.15 / 0.38 / 0.62 / 0.85), not by a grid change.
+        /// Vertical error remains structurally ~1.5-2× horizontal: vertical
+        /// eyeball rotation for a full-screen sweep is roughly half the
+        /// horizontal, so the iris translates half as far per screen unit, and
+        /// the eyelid occludes the iris exactly where it matters. Do not read
+        /// this field as evidence that vertical is solved.
+        /// </para>
+        /// </summary>
         [JsonProperty] public string Mode { get; set; } = "";
 
         [JsonProperty] public DateTime Timestamp { get; set; }
@@ -33,7 +52,7 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Legacy. Iris vector at the top edge of the calibration grid, written
         /// by older builds that ran an iris-extreme edge-pull heuristic at
-        /// runtime. The edge-pull was retired once the 5×5 grid + Cerrolaza
+        /// runtime. The edge-pull was retired once the calibration grid + Cerrolaza
         /// polynomial reached the screen edges on its own; new calibrations
         /// don't populate this. Kept here so saves from older builds still
         /// deserialize.
@@ -60,15 +79,25 @@ namespace ConditioningControlPanel.Services
         [JsonProperty] public PolynomialFitData? Polynomial { get; set; }
 
         /// <summary>
-        /// Calibration-time average head pose ("looking forward" reference).
-        /// Paired with <see cref="HeadPoseComp"/> to correct the iris vector
-        /// when the live head pose leaves this baseline. History: an earlier
-        /// comp pipeline fit its coefficients from the NATURAL head variance
-        /// during dot sampling — users hold still, so the fit was noise and
-        /// got retired. It's now back with a well-conditioned source: a
-        /// guided head-motion step (eyes on a center dot, deliberate nod +
-        /// turn) — see WebcamCalibrationWindow.RunHeadMotionPhaseAsync. Null
-        /// when the guided fit was skipped or failed.
+        /// DEAD FIELD. Deserialized for back-compat with old saves; never
+        /// populated by current code and never read at runtime.
+        /// <para>
+        /// CORRECTED 2026-08-27: this summary previously described a "guided
+        /// head-motion step … see WebcamCalibrationWindow.RunHeadMotionPhaseAsync".
+        /// <b>That method no longer exists.</b> Head-pose compensation has now
+        /// been built and retired TWICE — first fit from natural head variance
+        /// during dot sampling (users hold still, so the fit was noise), then
+        /// again from a guided nod+turn phase (retired 2026-07-02). See the
+        /// tombstone in WebcamTrackingService near the head-pose block.
+        /// </para><para>
+        /// Do not resurrect this. Multiplying head pose into the projection is
+        /// a twice-failed design. Head pose IS used productively — but only as
+        /// a TRIGGER, never as a correction term: GazeDriftCorrectionService
+        /// watches LastYaw/LastPitch and, when it detects a settled reposition,
+        /// temporarily raises the residual-folding gain so the existing proven
+        /// drift machinery re-converges in seconds instead of minutes. That
+        /// baseline is held in memory only, deliberately not persisted here.
+        /// </para>
         /// </summary>
         [JsonProperty] public CalibrationHeadPose? BaselineHeadPose { get; set; }
 
@@ -83,7 +112,7 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Translational nudge in screen DIPs, applied after the polynomial
         /// projection. Set by the Quick Recal flow when the user wants to
-        /// correct overall drift without redoing the full 25-point calibration.
+        /// correct overall drift without redoing the full 16-point calibration.
         /// Null on calibrations from older app versions or when the user has
         /// never run quick-recal — projection path skips the nudge.
         /// </summary>

--- a/ConditioningControlPanel/Windows/WebcamCalibrationWindow.xaml
+++ b/ConditioningControlPanel/Windows/WebcamCalibrationWindow.xaml
@@ -180,12 +180,30 @@
         <!-- Bubble accuracy test: optional post-calibration minigame launched
              from the verify panel. One bubble at a time; the user pops it by
              holding their gaze cursor on it (~0.7s dwell). Residuals feed a
-             drift fine-tune — see RunBubbleTestAsync. -->
+             drift fine-tune — see RunBubbleTestAsync.
+
+             The bubble and its ring are deliberately TALLER THAN WIDE. CHI
+             2025 gaze-target guidance says the target's shape should absorb
+             the axis carrying more error, and vertical gaze error runs
+             1.5-2x horizontal (half the eyeball rotation per screen unit,
+             plus eyelid occlusion of the iris top/bottom). Sizes are
+             ~3 degrees wide by ~4 tall: at 60cm on a 27" 1440p panel 1
+             degree is ~45 px, so 3 x 45 = 135 -> 136 wide and 4 x 45 = 180
+             tall. Rings sit 48 DIPs outside on each axis. UpdateRing() uses
+             a Ramanujan perimeter so the dwell arc stays correct on an
+             ellipse. -->
         <Grid x:Name="BubbleTestPanel" Visibility="Collapsed">
             <Canvas x:Name="BubbleTestCanvas">
-                <Ellipse x:Name="TestBubbleRingBg" Width="176" Height="176"
+                <Ellipse x:Name="TestBubbleRingBg" Width="184" Height="228"
                          Stroke="#33FFFFFF" StrokeThickness="4" Visibility="Collapsed"/>
-                <Ellipse x:Name="TestBubbleRingFg" Width="176" Height="176"
+                <!-- Width/Height are deliberately SWAPPED relative to TestBubbleRingBg.
+                     The RotateTransform below (-90, to start the dash at 12 o'clock) also
+                     rotates the ellipse's own axes, so an ellipse authored 228x184 RENDERS
+                     as 184x228 and matches the upright background ring. Authoring it
+                     184x228 like the bg makes the pink arc render as a WIDE oval crossing
+                     the grey tall oval at four points. Ramanujan's perimeter is symmetric
+                     in a/b, so UpdateRing is unaffected by the swap. -->
+                <Ellipse x:Name="TestBubbleRingFg" Width="228" Height="184"
                          Stroke="#FFFF69B4" StrokeThickness="5"
                          StrokeDashArray="0 10000" StrokeDashCap="Round"
                          RenderTransformOrigin="0.5,0.5" Visibility="Collapsed">
@@ -193,7 +211,7 @@
                         <RotateTransform Angle="-90"/>
                     </Ellipse.RenderTransform>
                 </Ellipse>
-                <Ellipse x:Name="TestBubble" Width="128" Height="128"
+                <Ellipse x:Name="TestBubble" Width="136" Height="180"
                          RenderTransformOrigin="0.5,0.5" Visibility="Collapsed">
                     <Ellipse.RenderTransform>
                         <ScaleTransform x:Name="TestBubbleScale" ScaleX="1" ScaleY="1"/>

--- a/ConditioningControlPanel/Windows/WebcamQuickRecalWindow.xaml
+++ b/ConditioningControlPanel/Windows/WebcamQuickRecalWindow.xaml
@@ -36,6 +36,12 @@
                        Foreground="#FFB6E1" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Center"/>
             <TextBlock Text="ESC to cancel."
                        Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,4,0,0" HorizontalAlignment="Center"/>
+            <!-- Teaches the global chord at the one moment it is guaranteed to be relevant:
+                 the user has just dug this window out of a setup card. Text is set in the
+                 constructor (it quotes the user's own, rebindable, camera chord). -->
+            <TextBlock x:Name="TxtHotkeyHint" Text=""
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,10,0,0"
+                       MaxWidth="620" TextWrapping="Wrap" TextAlignment="Center" HorizontalAlignment="Center"/>
         </StackPanel>
 
         <Border x:Name="ErrorPanel" Visibility="Collapsed"

--- a/ConditioningControlPanel/Windows/WebcamQuickRecalWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/WebcamQuickRecalWindow.xaml.cs
@@ -34,6 +34,14 @@ namespace ConditioningControlPanel
         public WebcamQuickRecalWindow()
         {
             InitializeComponent();
+
+            // Discoverability: this window is the one place every user of Quick Recal
+            // provably reaches, so it is where the global chord gets taught. Built here
+            // rather than in XAML because the line quotes the user's own (rebindable)
+            // camera shortcut alongside it — the two webcam hotkeys must never read as
+            // interchangeable.
+            try { TxtHotkeyHint.Text = MainWindow.QuickRecalHotkeyHint(); }
+            catch (Exception ex) { App.Logger?.Debug("Quick recal hotkey hint unavailable: {Error}", ex.Message); }
         }
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Cut-day fold-ins for v6.8.5 "First Bell", all ported from the primary checkout or found by the 08-28 recon. No version bump here (that is the /release step).

- **Arcademy bell chip counts to UTC midnight** (`shell/campus.js bellSecondsLeft`). The timetable day key and Daily Trigger seed are UTC (`core/timetable.js fmtDay`), the chip counted to LOCAL midnight, so a 23:00 US session and the next morning landed on one school day (T2 report, Wobberjockey). Web mirror follows via the sync Action.
- **Bugle comic panel prints "Picture held at the printer. Described below."** inside the deliberately empty frame; a tester read the blank as a broken image. New lexicon key `bugle_comics_held` in lexicon.js + the C# mirror.
- **DTRH screen shake** finally has a consumer (`game/screenShake.js`, wired from chaosRun/payloadFx). Translate-only jolt on the tube canvas, never stacks, off on reduced motion.
- **Quick Recal chord taught** on the Settings > Devices Quick Recal button tooltip; taller Accuracy bubble; `WebcamCalibrationData` docs corrected.
- **Intake reward determinism**: kind rolls ride the seeded stream (`planFor` used `Math.random`); `RewardKind.GifBurst` first-class in contracts.js. Needs a manual `sync-intake.mjs` run in cclabs-web after merge.
- CLAUDE.md version table line (`BtnUpdateAvailable` at ~1985).

Debug build 0 errors. JS `node --check` clean on every touched file; `bellSecondsLeft` verified 05:00Z -> 68400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpGh5B86bg4UWAXCzuet2t
