### PR TITLE
fix(hotkeys): Quick Recal clash guard checks every hook binding (PanicKey + PauseKey) as a set

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -893,6 +893,9 @@ namespace ConditioningControlPanel
                     App.Settings?.Save();
                     App.Logger?.Information("Pause key changed to: {Key}",
                         string.IsNullOrEmpty(App.Settings.Current.PauseKey) ? "(unbound)" : App.Settings.Current.PauseKey);
+                    // The pause key rides the same modifier-blind hook as panic, so it is in the
+                    // Quick Recal clash set too: re-evaluate the chord exactly as the panic rebind does.
+                    ApplyGlobalQuickRecalHotkey();
                 });
                 return;
             }
@@ -1196,7 +1199,7 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// Arms (or, when the setting is off or the panic key would clash, disarms) the
+        /// Arms (or, when the setting is off or a global-hook binding would clash, disarms) the
         /// system-wide Quick Recal hotkey. Failure is never fatal: any refusal leaves the three
         /// in-app entry points working and only costs a Warning line naming the reason.
         /// </summary>
@@ -1213,28 +1216,31 @@ namespace ConditioningControlPanel
                     return;
                 }
 
-                // Case (b) from the trap note, checked BEFORE we register. The panic key rides the
-                // WH_KEYBOARD_LL hook (GlobalKeyboardHook), which compares the bare key and ignores
-                // modifiers — and it does NOT consume the keystroke: HookCallback only returns
-                // handled inside the SuppressSystemKeys lockdown branch, so the panic path invokes
-                // KeyPressed and still falls through to CallNextHookEx. RegisterHotKey therefore
-                // fires too. With a panic key of "G" the chord would run Quick Recal AND tear the
-                // whole session down. That is destructive, not merely noisy, so refuse the binding
-                // rather than arm it with a warning. Quick Recal stays reachable from its three
-                // buttons. Fix the class here, on the binding side: the hook's event is
-                // Action<Key> and carries no modifier state, and making panic modifier-aware would
-                // be wrong anyway — someone reaching for panic with a stray Ctrl held must get panic.
+                // Case (b) from the trap note, checked BEFORE we register. The panic key AND the
+                // optional pause key ride the WH_KEYBOARD_LL hook (GlobalKeyboardHook), which
+                // compares the bare key and ignores modifiers — and it does NOT consume the
+                // keystroke: HookCallback only returns handled inside the SuppressSystemKeys
+                // lockdown branch, so the hook path invokes KeyPressed and still falls through to
+                // CallNextHookEx. RegisterHotKey therefore fires too. With a panic key of "G" the
+                // chord would run Quick Recal AND tear the whole session down. That is destructive,
+                // not merely noisy, so refuse the binding rather than arm it with a warning. Quick
+                // Recal stays reachable from its three buttons. Fix the class here, on the binding
+                // side: the hook's event is Action<Key> and carries no modifier state, and making
+                // the hook modifier-aware would be wrong anyway — someone reaching for panic with a
+                // stray Ctrl held must get panic. PanicPolicy.HookBoundBaseKeys is the one list of
+                // what is on that hook, so a future binding joins this guard by joining that set.
                 var s = App.Settings?.Current;
-                if (s?.PanicKeyEnabled == true &&
-                    string.Equals(s.PanicKey, QuickRecalHotkeyKey.ToString(), StringComparison.OrdinalIgnoreCase))
+                if (Services.Safety.PanicPolicy.FindHookClash(
+                        QuickRecalHotkeyKey.ToString(), Services.Safety.PanicPolicy.HookBoundBaseKeys(s)) is { } clash)
                 {
                     Services.GlobalHotkeyService.Unregister(Services.GlobalHotkeyService.QuickRecalHotkeyId);
                     App.Logger?.Warning(
-                        "Quick Recal hotkey {Chord} NOT armed: it shares its base key with the panic key ({PanicKey}), and the " +
-                        "panic hook ignores modifiers without consuming the press — arming it would trip panic and tear down the " +
-                        "session on every Quick Recal. Rebind the panic key to free {Key}. The Quick Recal buttons in " +
-                        "Settings → Devices, the Blink Trainer setup card and the Deeper setup card are unaffected.",
-                        chord, s.PanicKey, QuickRecalHotkeyKey);
+                        "Quick Recal hotkey {Chord} NOT armed: it shares its base key with the {Binding} binding ({BoundKey}), and the " +
+                        "global keyboard hook ignores modifiers without consuming the press — arming it would fire that binding " +
+                        "on every Quick Recal (panic tears the session down; pause parks the video). Rebind it to free {Key}. " +
+                        "The Quick Recal buttons in Settings → Devices, the Blink Trainer setup card and the Deeper setup card " +
+                        "are unaffected.",
+                        chord, clash.Name, clash.Key, QuickRecalHotkeyKey);
                     return;
                 }
 
@@ -1308,20 +1314,21 @@ namespace ConditioningControlPanel
                     return;
                 }
 
-                // Re-check the panic clash HERE and not only at registration. PanicKeyEnabled is
+                // Re-check the hook clash HERE and not only at registration. PanicKeyEnabled is
                 // written by LockdownService (:148/:189), RemoteControlService and preset loads —
                 // any of which can turn a chord that was safe to arm at Loaded into a live clash
-                // without passing through ApplyGlobalQuickRecalHotkey. We cannot stop panic from
-                // firing (it rides its own hook), but we can refuse to stack a calibration window
-                // on top of the teardown, which is the genuinely bad outcome.
+                // without passing through ApplyGlobalQuickRecalHotkey. Same set as the arm-time
+                // check (panic key + pause key). We cannot stop the hook binding from firing (it
+                // rides its own hook), but we can refuse to stack a calibration window on top of
+                // the teardown, which is the genuinely bad outcome.
                 var cfg = App.Settings?.Current;
-                if (cfg?.PanicKeyEnabled == true &&
-                    string.Equals(cfg.PanicKey, QuickRecalHotkeyKey.ToString(), StringComparison.OrdinalIgnoreCase))
+                if (Services.Safety.PanicPolicy.FindHookClash(
+                        QuickRecalHotkeyKey.ToString(), Services.Safety.PanicPolicy.HookBoundBaseKeys(cfg)) is { } live)
                 {
                     App.Logger?.Warning(
-                        "Quick Recal hotkey {Chord} suppressed at invocation: the panic key is now bound to {PanicKey}, so this " +
-                        "press is already tripping panic. Not opening Quick Recal on top of it.",
-                        QuickRecalHotkeyChord, cfg.PanicKey);
+                        "Quick Recal hotkey {Chord} suppressed at invocation: {Binding} is now bound to {BoundKey}, so this " +
+                        "press is already firing it on the global hook. Not opening Quick Recal on top of it.",
+                        QuickRecalHotkeyChord, live.Name, live.Key);
                     Services.GlobalHotkeyService.Unregister(Services.GlobalHotkeyService.QuickRecalHotkeyId);
                     return;
                 }

--- a/ConditioningControlPanel/Services/Safety/PanicPolicy.cs
+++ b/ConditioningControlPanel/Services/Safety/PanicPolicy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Services.Safety
@@ -144,6 +145,58 @@ namespace ConditioningControlPanel.Services.Safety
             if (!panicKeyEnabled) return false;
             if (string.IsNullOrWhiteSpace(panicKey) || string.IsNullOrWhiteSpace(pauseKey)) return false;
             return string.Equals(panicKey.Trim(), pauseKey.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>One bare-key binding that rides the modifier-blind global keyboard hook.
+        /// <see cref="Name"/> is the owning setting (<c>PanicKey</c> / <c>PauseKey</c>), for logs.</summary>
+        internal readonly record struct HookBinding(string Name, string Key);
+
+        /// <summary>
+        /// The SET of bare keys currently bound on the WH_KEYBOARD_LL hook (GlobalKeyboardHook),
+        /// each with the setting that owns it. Every binding on that hook is compared MODIFIER-BLIND
+        /// and does not consume the keystroke, so a Win32 RegisterHotKey chord whose base key is in
+        /// this set fires BOTH handlers at once: Ctrl+Alt+G with panic on G runs Quick Recal and
+        /// tears the session down. The Quick Recal hotkey asks this set before it arms and again
+        /// when it fires, instead of checking the panic key alone, so the optional pause key (and
+        /// any binding added to the hook later) is covered by the same guard.
+        ///
+        /// <para>Membership: <c>PanicKey</c> while <c>PanicKeyEnabled</c>; <c>PauseKey</c> whenever
+        /// it is non-blank (it has no enable flag of its own - see <see cref="IsPauseKeyPress"/>).
+        /// The pause key is counted even while the panic key shadows it and even if the hook
+        /// happens not to be installed right now: hook state flips at runtime (lockdown, remote
+        /// control, preset loads), and the only cost of a false positive is the global chord.
+        /// Panic is listed first so a key bound to both is reported as the panic clash.</para>
+        /// </summary>
+        internal static IReadOnlyList<HookBinding> HookBoundBaseKeys(bool panicKeyEnabled, string? panicKey, string? pauseKey)
+        {
+            var bound = new List<HookBinding>(2);
+            if (panicKeyEnabled && !string.IsNullOrWhiteSpace(panicKey))
+                bound.Add(new HookBinding(nameof(AppSettings.PanicKey), panicKey.Trim()));
+            if (!string.IsNullOrWhiteSpace(pauseKey))
+                bound.Add(new HookBinding(nameof(AppSettings.PauseKey), pauseKey.Trim()));
+            return bound;
+        }
+
+        /// <summary>Settings-shaped overload for the MainWindow call sites. Missing settings bind nothing.</summary>
+        internal static IReadOnlyList<HookBinding> HookBoundBaseKeys(AppSettings? settings)
+            => settings == null
+                ? Array.Empty<HookBinding>()
+                : HookBoundBaseKeys(settings.PanicKeyEnabled, settings.PanicKey, settings.PauseKey);
+
+        /// <summary>
+        /// The hook binding whose bare key equals <paramref name="baseKey"/> (case- and
+        /// whitespace-insensitive, like every other key compare in here), or null when the chord's
+        /// base key is free. A blank base key never clashes.
+        /// </summary>
+        internal static HookBinding? FindHookClash(string? baseKey, IReadOnlyList<HookBinding> bound)
+        {
+            if (string.IsNullOrWhiteSpace(baseKey)) return null;
+            var wanted = baseKey.Trim();
+            foreach (var b in bound)
+            {
+                if (string.Equals(b.Key, wanted, StringComparison.OrdinalIgnoreCase)) return b;
+            }
+            return null;
         }
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/PanicPolicyTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PanicPolicyTests.cs
@@ -318,6 +318,84 @@ public class PanicPolicyTests
     public void UnboundPauseKey_IsNotShadowed()
         => Assert.False(PauseKeyIsShadowedByPanicKey("F9", panicKeyEnabled: true, pauseKey: ""));
 
+    // ---- 5b. the global-hook clash set (Quick Recal Ctrl+Alt+G vs every modifier-blind binding) ----
+    //
+    // The panic key and the pause key both ride the modifier-blind WH_KEYBOARD_LL hook, which does
+    // not consume the press, so a RegisterHotKey chord whose base key is bound there fires both.
+    // The Quick Recal guard used to ask "is the panic key G"; it now asks the SET, so the pause key
+    // (and anything bound to the hook later) is refused the same way.
+
+    private const string QuickRecalBaseKey = "G";
+
+    [Fact]
+    public void FreshInstall_BindsOnlyThePanicKey_AndDoesNotClashWithQuickRecal()
+    {
+        var bound = HookBoundBaseKeys(new AppSettings());
+        Assert.Single(bound);
+        Assert.Equal(new HookBinding("PanicKey", "Escape"), bound[0]);
+        Assert.Null(FindHookClash(QuickRecalBaseKey, bound));
+    }
+
+    [Fact]
+    public void PanicKeyOnG_ClashesAsPanicKey()
+    {
+        var hit = FindHookClash(QuickRecalBaseKey, HookBoundBaseKeys(panicKeyEnabled: true, panicKey: "G", pauseKey: ""));
+        Assert.Equal(new HookBinding("PanicKey", "G"), hit);
+    }
+
+    [Fact]
+    public void PauseKeyOnG_ClashesAsPauseKey_EvenWithPanicElsewhere()
+    {
+        var hit = FindHookClash(QuickRecalBaseKey, HookBoundBaseKeys(panicKeyEnabled: true, panicKey: "Escape", pauseKey: "G"));
+        Assert.Equal(new HookBinding("PauseKey", "G"), hit);
+    }
+
+    [Fact]
+    public void PauseKeyOnG_ClashesEvenWhenPanicIsDisabled()
+    {
+        // The pause key has no enable flag: non-blank means bound.
+        var hit = FindHookClash(QuickRecalBaseKey, HookBoundBaseKeys(panicKeyEnabled: false, panicKey: "G", pauseKey: "g"));
+        Assert.Equal(new HookBinding("PauseKey", "g"), hit);
+    }
+
+    [Fact]
+    public void DisabledPanicKeyOnG_WithNoPauseKey_IsFree()
+        => Assert.Null(FindHookClash(QuickRecalBaseKey, HookBoundBaseKeys(panicKeyEnabled: false, panicKey: "G", pauseKey: "")));
+
+    [Fact]
+    public void BothBoundToG_ReportsThePanicKey()
+    {
+        var hit = FindHookClash(QuickRecalBaseKey, HookBoundBaseKeys(panicKeyEnabled: true, panicKey: "G", pauseKey: "G"));
+        Assert.Equal("PanicKey", hit?.Name);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankPauseKey_IsNotInTheSet(string? pauseKey)
+        => Assert.Single(HookBoundBaseKeys(panicKeyEnabled: true, panicKey: "Escape", pauseKey: pauseKey));
+
+    [Fact]
+    public void ClashCompare_IgnoresCaseAndStrayWhitespace()
+    {
+        var bound = HookBoundBaseKeys(panicKeyEnabled: true, panicKey: " g ", pauseKey: null);
+        Assert.NotNull(FindHookClash("G", bound));
+        Assert.NotNull(FindHookClash(" G ", bound));
+        Assert.Null(FindHookClash("H", bound));
+    }
+
+    [Fact]
+    public void MissingSettings_BindNothing()
+    {
+        Assert.Empty(HookBoundBaseKeys((AppSettings?)null));
+        Assert.Null(FindHookClash(QuickRecalBaseKey, HookBoundBaseKeys((AppSettings?)null)));
+    }
+
+    [Fact]
+    public void BlankBaseKey_NeverClashes()
+        => Assert.Null(FindHookClash("", HookBoundBaseKeys(panicKeyEnabled: true, panicKey: "G", pauseKey: "G")));
+
     // ---- 6. the stop-everything surface list ----
     //
     // PanicStopEverySurface is UI-thread WPF code, so it cannot be exercised from a unit test; what


### PR DESCRIPTION
## Summary

The Ctrl+Alt+G Quick Recal global hotkey (Win32 `RegisterHotKey`, id 0xB1B3) double-fires with any binding on the modifier-blind `WH_KEYBOARD_LL` hook whose bare key is `G`, because the hook does not consume the keystroke. The existing guard only checked `PanicKey`; the new optional `PauseKey` (v6.8.5) rides the same hook and was not covered.

This generalises the guard from "equals PanicKey" to "equals any hook binding" as a set:

- **`PanicPolicy.HookBoundBaseKeys()`** (new, pure): the one list of what is bound on the hook, each entry carrying the owning setting name. Membership: `PanicKey` while `PanicKeyEnabled`; `PauseKey` whenever non-blank (it has no enable flag of its own, see `IsPauseKeyPress`). Panic is listed first so a key bound to both is reported as the panic clash. An `AppSettings?` overload serves the MainWindow call sites.
- **`PanicPolicy.FindHookClash()`** (new): returns the clashing binding (name + key) or null; case/whitespace-insensitive like every other key compare in `PanicPolicy`.
- **`ApplyGlobalQuickRecalHotkey`** pre-register check and **`OpenQuickRecalFromHotkey`** invocation re-check both use the set. Chord still logged at Information; refusal still logged as Warning, now naming which binding (`PanicKey` / `PauseKey`) clashed and on which key.
- **PauseKey capture site** (`MainWindow.xaml.cs`, hook handler) now calls `ApplyGlobalQuickRecalHotkey()` after the rebind, mirroring what the PanicKey capture already did.
- Panic itself stays modifier-blind; nothing in the hook path changed.

## Tests

12 new pure tests in `PanicPolicyTests` (section 5b): fresh install binds only Escape and does not clash; panic on G clashes as PanicKey; pause on G clashes as PauseKey with panic elsewhere AND with panic disabled; disabled panic on G with no pause key is free; both on G reports PanicKey; blank pause key is not in the set; case/whitespace tolerance; null settings bind nothing; blank base key never clashes.

- `dotnet build -c Debug`: 0 errors
- `dotnet test --filter PanicPolicyTests`: 89/89 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpGh5B86bg4UWAXCzuet2t
