### PR TITLE
feat(intake): host Vosk speech bridge for say-it items (T2 Ashley), typed fallback on error

### DIFF
--- a/ConditioningControlPanel/Resources/web/intake/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/intake/CLAUDE.md
@@ -250,11 +250,26 @@ with DTRH, Loom and the Bureau — edits there hit four features).
 - **BootConfig** (`OnPageReady`): `niche` (mod-derived: Dronification→drone, SissyHypno→sissy,
   Locked→circe, else bambi; `SafeNiche` silently falls back to bambi if the bank is missing), `caps`
   (all 1.0 today), `endless:false`, `steerValve:1.0`, `priorRun:null` (the page's stats own continuity),
-  `micEnabled` (= `MicConsentGiven`), `media` (10 sampled gifs/images as `ccp.assets` URLs + a mod-aware
+  `micEnabled` (= `MicConsentGiven`), `speech` (`{bridge:true, available, reason}` — the say-it
+  speech bridge's feature-detect, see below), `media` (10 sampled gifs/images as `ccp.assets` URLs + a mod-aware
   `bubbleSprite` **data URI**), `subjectId` (4 digits persisted at `%APPDATA%/…/intake_subject.txt` —
   deliberately not a setting), `subliminals` (≤400 enabled phrases, whisper clips inlined as data URIs
   because the audio dirs are outside both vhosts; **gated on `SubAudioEnabled`**; 512 KB/clip, 6 MB total),
   and `ai {serverBase, authToken}` where the token is the **Patreon** bearer.
+- **Speech bridge** (`IntakeHostService.Speech.cs`, since v6.8.5): the Mantra ("say it") beat used to ask the
+  browser for `window.SpeechRecognition`, which errors inside WebView2 (`network` / `not-allowed` — no cloud
+  recognizer), so desktop players could never advance it by voice (T2 Ashley, 2026-08-28). The host now lends
+  the app's **offline Vosk** engine (`SpeechService`, the same engine + `SpeechMatchThreshold` + loudness gate
+  spoken mantras use): page `speech-start {id, phrase}` / `speech-stop {id}` → host `speech-event {id, kind,
+  transcript?, matched?, score?, loudEnough?, reason?}` with kinds `listening · partial · final · silence · idle ·
+  unavailable · stopped`. The page (`web-shim.hostSpeech` → `beats.js renderHostEar`) feature-detects
+  `init.config.speech.bridge === true` **first** and keeps its browser path otherwise (website / RN host), and
+  auto-opens the mic when the card mounts. Reasons for `unavailable` are wire strings in `IntakeSpeechPolicy.cs`
+  (`consent · no-mic · no-model · model-failed · busy · error`) and each maps to a note in beats.js. **The bridge
+  never evicts another mic owner** (wake word, push-to-talk, lock card, spoken mantra) — it reports `busy` and
+  the page drops to typed input. Either ear drops to typed input on any hard error; the host goes `idle` after
+  3 silent windows or 6 misses and a tap restarts it. `DisposeAll` closes the session. Pinned by
+  `Tests/.../IntakeSpeechBridgeTests.cs`.
 - **Watchdogs**: 5 s heartbeat timer, >20 s silence or `ProcessFailed` → `Recover()` — dispose + relaunch
   **once** per app session, always windowed.
 - **Run end** (`OnQuizResult`): XP `25 + 50×peakDepth + 5×min(mantras,5)`, hard-capped at 100 →
@@ -420,6 +435,10 @@ only, and breath tags cost 1–2 s each.
     `bin\Debug\net8.0-windows10.0.19041.0\win-x64\Resources\web\intake\` and a fresh run picks them up with
     no rebuild and no app restart. An incremental build does **not** reliably refresh web assets.
 15. **One build at a time** if two sessions share the checkout — a torn build reads exactly like a crash bug.
+16. **`window.SpeechRecognition` does not work inside WebView2.** It exists, `start()` succeeds, then `onerror`
+    fires `network` (or `not-allowed`). Never route a desktop feature through it — use the host speech bridge
+    (§6). The browser ear stays only for the website, and now drops to typed input on any hard error instead of
+    printing "didn't catch that" forever.
 
 ---
 

--- a/ConditioningControlPanel/Resources/web/intake/boot.js
+++ b/ConditioningControlPanel/Resources/web/intake/boot.js
@@ -233,7 +233,9 @@ shim.onBoot(async (config) => {
     const beats = createBeats
       // micEnabled: the host's MicConsentGiven. Absent (standalone/harness) => true,
       // where the browser's own permission prompt is the gate and no WPF setting exists.
-      ? tryMake('beats', () => createBeats({ root: dom.stage, effects, audio, steering, reward, caps: config.caps, background, theme, media: config.media || null, niche: config.niche, micEnabled: config.micEnabled !== false }), stubBeats)
+      // speech: the host's offline recognizer, when it lent us one (web-shim hostSpeech;
+      // bridge=false on the website / RN host, where beats.js keeps its browser path).
+      ? tryMake('beats', () => createBeats({ root: dom.stage, effects, audio, steering, reward, caps: config.caps, background, theme, media: config.media || null, niche: config.niche, micEnabled: config.micEnabled !== false, speech: shim.hostSpeech }), stubBeats)
       : stubBeats();
 
     // --- fiction identity + feed-forward ----------------------------------

--- a/ConditioningControlPanel/Resources/web/intake/render/beats.js
+++ b/ConditioningControlPanel/Resources/web/intake/render/beats.js
@@ -1,7 +1,7 @@
 /* ============================================================================
  * render/beats.js — RESPONSE MECHANICS for "Graded Intake"  (Agent C)
  *
- * createBeats({ root, effects, audio, steering, reward, caps, background, theme, media })
+ * createBeats({ root, effects, audio, steering, reward, caps, background, theme, media, niche, micEnabled, speech })
  *   -> { render(beat) }
  *   render(beat: BeatSpec) -> Promise<AnswerEvent>
  *
@@ -14,7 +14,9 @@
  *   own slow drift shortly after landing and commits by drifting fully
  *   offscreen
  *   after the answer window; climax pop-storm decoys; pop = reward chain of
- *   mini bubbles), Mantra (Web Speech -> type-it degrade), CheckIn
+ *   mini bubbles), Mantra (host's offline Vosk over the speech bridge when the
+ *   desktop lends it -> Web Speech -> type-it degrade; any hard error goes
+ *   straight to type-it), CheckIn
  *   (slider), Mono (single agree), Funnel (wrong -> respawns correct),
  *   Destruct (correct shatters but STILL registers), Interlude (non-question
  *   pacing valley: 'watch' spiral stare / 'breathe' cycle, auto-commits).
@@ -679,7 +681,7 @@ function fadeLayerOutRemove(node, outMs, removeMs) {
 /* ----------------------------------------------------------------------------
  * FACTORY
  * -------------------------------------------------------------------------- */
-export function createBeats({ root, effects, audio, steering, reward, caps, background, theme, media, niche, micEnabled } = {}) {
+export function createBeats({ root, effects, audio, steering, reward, caps, background, theme, media, niche, micEnabled, speech } = {}) {
   const stage = root;
   caps = caps || {};
   // Kick the guarded, one-time captcha-layer import (Verify* mechanics). Safe to
@@ -688,6 +690,11 @@ export function createBeats({ root, effects, audio, steering, reward, caps, back
   // Host's MicConsentGiven. Undefined (standalone/harness) => allowed, since there
   // the browser's permission prompt is the only gate that exists.
   const micAllowed = micEnabled !== false;
+  // The host's offline recognizer (web-shim hostSpeech), FEATURE-DETECTED: only the
+  // desktop host sets bridge=true. Everywhere else (website, harness, RN) this is
+  // null and the say-it beat keeps its browser SpeechRecognition path.
+  const speechBridge = (speech && typeof speech === 'object' && speech.bridge === true
+                        && typeof speech.start === 'function') ? speech : null;
 
   // NEW RUN: re-arm the once-per-run "are you sure?" jumpscare latch.
   _ixEventFired = false;
@@ -3661,7 +3668,17 @@ export function createBeats({ root, effects, audio, steering, reward, caps, back
         cleanups.push(() => clearTimeout(t));
       }
 
-      // Mantra — say-it via Web Speech; degrades to type-it. Commits the string.
+      // Mantra — say it. Two ears, one contract; commits the string.
+      //   HOST BRIDGE (desktop WebView2, feature-detected FIRST): the app lends its
+      //     OFFLINE Vosk recognizer over web-shim's hostSpeech (speech-start /
+      //     speech-event) — the same engine + leniency spoken mantras and She's
+      //     Listening use. The mic opens the moment the card mounts, the way those
+      //     do; the button is a live indicator and a re-tap after the host goes idle.
+      //   BROWSER (website, harness): window.SpeechRecognition, tap & say it. Inside
+      //     WebView2 this API errors ('network' / 'not-allowed' — no cloud recognizer),
+      //     which is why the bridge exists.
+      // EITHER EAR: any hard error drops the item to typed input AT ONCE. It must
+      // never loop "didn't catch that" with no way forward (T2 Ashley, 2026-08-28).
       function renderMantra() {
         const phrase = prompt.answer != null ? String(prompt.answer) : (prompt.text || '');
         const say = el('div', 'ib-mantra-say', '“' + phrase + '”');
@@ -3690,7 +3707,7 @@ export function createBeats({ root, effects, audio, steering, reward, caps, back
           if (target) { target.classList.remove('ib-shake'); void target.offsetWidth; target.classList.add('ib-shake'); }
         };
 
-        // --- type-it degrade path ---
+        // --- type-it path (the degrade target of BOTH ears) ---
         const buildTypeIt = (note) => {
           if (note) status.textContent = note;
           const row = el('div', 'ib-mantra-type');
@@ -3706,77 +3723,213 @@ export function createBeats({ root, effects, audio, steering, reward, caps, back
           setTimeout(() => { try { inp.focus(); } catch (_e) {} }, 40);
         };
 
-        // --- lazily probe Web Speech ONLY here (never at import) ---
-        let SR = null;
-        try { SR = (typeof window !== 'undefined') && (window.SpeechRecognition || window.webkitSpeechRecognition); } catch (_e) { SR = null; }
-
-        if (!SR) { buildTypeIt(''); card.appendChild(skip); installSteering([]); return; }
-
-        let rec = null;
-        try {
-          rec = new SR();
-          rec.lang = 'en-US';
-          rec.interimResults = false;
-          rec.maxAlternatives = 3;
-        } catch (_e) { buildTypeIt('type it'); card.appendChild(skip); installSteering([]); return; }
-
-        const mic = mkBtn('🎙 tap & say it', null, 'ib-opt ib-mic');
-        card.appendChild(mic);
-        // PILL RULE: mic off in the app => the affordance is shown DISABLED, not
-        // hidden and not live. Hiding it would silently remove a feature the user
-        // owns; leaving it live would offer a button that can only fail. Greyed
-        // says "this exists, turn the mic on" — and type-it is still right there.
-        if (!micAllowed) {
-          mic.disabled = true;
-          mic.classList.add('is-off');
-          mic.textContent = '🎙 mic is off';
-          mic.title = 'Microphone is disabled in settings.';
-          mic.setAttribute('aria-disabled', 'true');
-        }
+        // Shared degrade: show the typed input ONCE. keepMic=true leaves a working ear
+        // live beside it (after repeated misses); false closes the ear and removes its
+        // button (hard error / user chose to type). The skip stays under everything.
         let typeOffered = false;
-        const offerType = mkBtn('type instead', () => {
-          if (typeOffered) return; typeOffered = true;
-          mic.remove(); offerType.remove();
-          buildTypeIt('');
-        }, 'ib-alt');
-        card.appendChild(offerType);
-
-        rec.onresult = (e) => {
-          let best = '';
-          let ok = false;
-          try {
-            for (let i = 0; i < e.results.length; i++) {
-              for (let j = 0; j < e.results[i].length; j++) {
-                const tr = e.results[i][j].transcript;
-                if (!best) best = tr;
-                if (matchMantra(tr, phrase)) { ok = true; best = tr; break; }
-              }
-              if (ok) break;
-            }
-          } catch (_e) {}
-          if (ok || !phrase) commitSaid(best);
-          else reject(mic, 'almost — say it again');
-        };
-        rec.onerror = (ev) => {
-          mic.classList.remove('is-live');
-          const err = ev && ev.error;
-          if (err === 'not-allowed' || err === 'service-not-allowed') {
-            if (!typeOffered) { typeOffered = true; mic.remove(); offerType.remove(); buildTypeIt('mic unavailable — type it'); }
-          } else {
-            status.textContent = 'didn’t catch that';
+        let micEl = null, offerTypeEl = null;
+        let stopEars = () => {};   // set by whichever ear is live; closes the mic
+        const dropToTyped = (note, keepMic) => {
+          if (committed) return;
+          if (typeOffered) { if (note) status.textContent = note; return; }
+          typeOffered = true;
+          if (!keepMic) {
+            try { stopEars(); } catch (_e) {}
+            if (micEl) { try { micEl.remove(); } catch (_e) {} micEl = null; }
           }
+          if (offerTypeEl) { try { offerTypeEl.remove(); } catch (_e) {} offerTypeEl = null; }
+          buildTypeIt(note);
+          card.appendChild(skip);   // appendChild MOVES it back under the new row
         };
-        rec.onend = () => { mic.classList.remove('is-live'); };
-        mic.addEventListener('click', () => {
-          if (committed || !micAllowed) return;   // disabled is belt; this is braces
-          try { rec.start(); mic.classList.add('is-live'); status.textContent = 'listening…'; }
-          catch (_e) { /* start() throws if already running; ignore */ }
-        });
-        cleanups.push(() => {
-          try { if (rec) { rec.onresult = rec.onerror = rec.onend = null; if (rec.abort) rec.abort(); } } catch (_e) {}
-        });
-        card.appendChild(skip);
-        installSteering([]);
+
+        if (speechBridge) { renderHostEar(); return; }
+        renderBrowserEar();
+
+        // =================== HOST EAR (desktop: offline Vosk) ===================
+        function renderHostEar() {
+          const mic = mkBtn('🎙 listening…', null, 'ib-opt ib-mic');
+          micEl = mic;
+          card.appendChild(mic);
+          const offerType = mkBtn('type instead', () => dropToTyped('', false), 'ib-alt');
+          offerTypeEl = offerType;
+          card.appendChild(offerType);
+          card.appendChild(skip);
+          installSteering([]);
+
+          // PILL RULE: mic off in the app => the affordance is shown DISABLED, not
+          // hidden and not live (see the browser ear). Nothing to start.
+          if (!micAllowed) {
+            mic.disabled = true;
+            mic.classList.add('is-off');
+            mic.textContent = '🎙 mic is off';
+            mic.title = 'Microphone is disabled in settings.';
+            mic.setAttribute('aria-disabled', 'true');
+            return;
+          }
+
+          // What to print when the host says it cannot open the mic. Keys are the
+          // host's wire reasons (IntakeSpeechPolicy.cs); unknown => the generic line.
+          const REASON_NOTE = {
+            'consent':      'mic is off — type it',
+            'no-mic':       'no microphone — type it',
+            'no-model':     'speech model not installed — type it',
+            'model-failed': 'speech model failed to load — type it',
+            'busy':         'mic is busy elsewhere — type it',
+            'error':        'mic unavailable — type it',
+          };
+
+          let sid = 0;         // the host session id events must carry; 0 = none open
+          let misses = 0;
+          const setLive = (on) => {
+            mic.classList.toggle('is-live', !!on);
+            mic.textContent = on ? '🎙 listening…' : '🎙 tap & say it';
+          };
+          const onEvent = (m) => {
+            if (committed || !m || m.id !== sid) return;   // stale session: not ours
+            switch (m.kind) {
+              case 'listening':
+                setLive(true); status.textContent = 'listening…';
+                break;
+              case 'partial':
+                if (m.transcript) status.textContent = '…' + String(m.transcript);
+                break;
+              case 'final': {
+                const heard = String(m.transcript || '');
+                // The host's verdict carries the mantra threshold AND the loudness gate.
+                // The page's own tolerance is a second ear on the transcript — but never
+                // past that gate: a whisper the host judged too quiet stays a miss.
+                const ok = m.matched === true
+                        || (m.loudEnough !== false && !!phrase && matchMantra(heard, phrase));
+                if (ok || !phrase) { sid = 0; setLive(false); commitSaid(heard || phrase); return; }
+                misses++;
+                reject(mic, m.loudEnough === false ? 'louder — say it again' : 'almost — say it again');
+                // Three misses: keep listening, but put the keyboard right there too.
+                if (misses >= 3) dropToTyped('or just type it', true);
+                break;
+              }
+              case 'silence':
+                status.textContent = 'didn’t catch that — say it out loud';
+                break;
+              case 'idle':       // host stopped re-opening the mic; a tap starts it again
+                sid = 0; setLive(false); status.textContent = 'tap to listen again';
+                break;
+              case 'unavailable':
+                sid = 0; setLive(false);
+                dropToTyped(REASON_NOTE[m.reason] || REASON_NOTE.error, false);
+                break;
+              case 'stopped':
+                sid = 0; setLive(false);
+                break;
+            }
+          };
+          const unsub = speechBridge.listen(onEvent);
+          const stop = () => { const id = sid; sid = 0; if (id) { try { speechBridge.stop(id); } catch (_e) {} } };
+          stopEars = stop;
+          const start = () => {
+            if (committed || sid) return;
+            let id = 0;
+            try { id = speechBridge.start(phrase); } catch (_e) { id = 0; }
+            if (!id) { dropToTyped(REASON_NOTE.error, false); return; }
+            sid = id;
+            setLive(true); status.textContent = 'listening…';
+          };
+          mic.addEventListener('click', start);
+          cleanups.push(() => {
+            try { unsub(); } catch (_e) {}
+            try { stop(); } catch (_e) {}
+          });
+          // Auto-open, the way spoken mantras and the voice lock card do.
+          start();
+        }
+
+        // =================== BROWSER EAR (website / harness) ===================
+        function renderBrowserEar() {
+          // --- lazily probe Web Speech ONLY here (never at import) ---
+          let SR = null;
+          try { SR = (typeof window !== 'undefined') && (window.SpeechRecognition || window.webkitSpeechRecognition); } catch (_e) { SR = null; }
+
+          if (!SR) { buildTypeIt(''); card.appendChild(skip); installSteering([]); return; }
+
+          let rec = null;
+          try {
+            rec = new SR();
+            rec.lang = 'en-US';
+            rec.interimResults = false;
+            rec.maxAlternatives = 3;
+          } catch (_e) { buildTypeIt('type it'); card.appendChild(skip); installSteering([]); return; }
+
+          const mic = mkBtn('🎙 tap & say it', null, 'ib-opt ib-mic');
+          micEl = mic;
+          card.appendChild(mic);
+          // PILL RULE: mic off in the app => the affordance is shown DISABLED, not
+          // hidden and not live. Hiding it would silently remove a feature the user
+          // owns; leaving it live would offer a button that can only fail. Greyed
+          // says "this exists, turn the mic on" — and type-it is still right there.
+          if (!micAllowed) {
+            mic.disabled = true;
+            mic.classList.add('is-off');
+            mic.textContent = '🎙 mic is off';
+            mic.title = 'Microphone is disabled in settings.';
+            mic.setAttribute('aria-disabled', 'true');
+          }
+          const offerType = mkBtn('type instead', () => dropToTyped('', false), 'ib-alt');
+          offerTypeEl = offerType;
+          card.appendChild(offerType);
+
+          let misses = 0, softErrors = 0;
+          rec.onresult = (e) => {
+            let best = '';
+            let ok = false;
+            try {
+              for (let i = 0; i < e.results.length; i++) {
+                for (let j = 0; j < e.results[i].length; j++) {
+                  const tr = e.results[i][j].transcript;
+                  if (!best) best = tr;
+                  if (matchMantra(tr, phrase)) { ok = true; best = tr; break; }
+                }
+                if (ok) break;
+              }
+            } catch (_e) {}
+            if (ok || !phrase) { commitSaid(best); return; }
+            misses++;
+            reject(mic, 'almost — say it again');
+            if (misses >= 3) dropToTyped('or just type it', true);
+          };
+          rec.onerror = (ev) => {
+            mic.classList.remove('is-live');
+            const err = (ev && ev.error) || 'error';
+            // 'no-speech' (nothing said) and 'aborted' (we cancelled) are not failures
+            // of the ear — but even those must not loop forever.
+            if (err === 'no-speech' || err === 'aborted') {
+              softErrors++;
+              if (softErrors >= 3) { dropToTyped('didn’t catch that — type it', false); return; }
+              status.textContent = 'didn’t catch that — tap & try again';
+              return;
+            }
+            // network / not-allowed / service-not-allowed / audio-capture / anything
+            // else: this ear cannot work here. Typed input, now.
+            dropToTyped(
+              (err === 'not-allowed' || err === 'service-not-allowed') ? 'mic unavailable — type it'
+                                                                       : 'speech isn’t working here — type it',
+              false);
+          };
+          rec.onend = () => { mic.classList.remove('is-live'); };
+          mic.addEventListener('click', () => {
+            if (committed || !micAllowed) return;   // disabled is belt; this is braces
+            try { rec.start(); mic.classList.add('is-live'); status.textContent = 'listening…'; }
+            catch (e) {
+              // start() throws InvalidStateError when already running (ignore); anything
+              // else means the recognizer is dead — go typed.
+              if (!(e && e.name === 'InvalidStateError')) dropToTyped('speech isn’t working here — type it', false);
+            }
+          });
+          stopEars = () => { try { if (rec && rec.abort) rec.abort(); } catch (_e) {} };
+          cleanups.push(() => {
+            try { if (rec) { rec.onresult = rec.onerror = rec.onend = null; if (rec.abort) rec.abort(); } } catch (_e) {}
+          });
+          card.appendChild(skip);
+          installSteering([]);
+        }
       }
     });
   }

--- a/ConditioningControlPanel/Resources/web/intake/web-shim.js
+++ b/ConditioningControlPanel/Resources/web/intake/web-shim.js
@@ -15,7 +15,9 @@
  *
  * Protocol (host <-> page), v1 (see contracts.PROTOCOL):
  *   Host -> Page:  init {config, ai} · manifest · payload-state · meta · ping
+ *                  speech-event {id, kind, ...}          (SPEECH BRIDGE, additive)
  *   Page -> Host:  ready · log · boot-error · heartbeat/pong · quiz-result · exit
+ *                  speech-start {id, phrase} · speech-stop {id}
  * ==========================================================================*/
 
 import { PROTOCOL, defaultBootConfig, DEFAULT_CAPS, NICHES, Niche } from './core/contracts.js';
@@ -123,6 +125,11 @@ function fireBoot(config) {
 function fromHostInit(m) {
   const c = (m && m.config) || {};
   const media = normalizeMedia(c.media, !!c.remoteMedia);
+  // SPEECH BRIDGE feature-detect (see the block below). Only the desktop host
+  // sends this; the website and the RN host leave it absent => browser path.
+  if (c.speech && typeof c.speech === 'object' && c.speech.bridge === true) {
+    speechCaps = { bridge: true, available: c.speech.available !== false, reason: c.speech.reason || null };
+  }
   return defaultBootConfig({
     niche: NICHES.includes(c.niche) ? c.niche : Niche.Bambi,
     caps: Object.assign({}, DEFAULT_CAPS, c.caps || {}),
@@ -248,6 +255,70 @@ on('assets-append', (m) => {
 on('online-status', (m) => {
   remoteInFlight = false;
   if (m && m.ok === false) log('remote media: ' + ((m && m.error) || 'unavailable'));
+});
+
+/* ----------------------------------------------------------------------------
+ * SPEECH BRIDGE — the say-it (Mantra) beat's microphone, when the host has one.
+ *
+ * WHY: the beat used to ask the browser for window.SpeechRecognition. Inside
+ * WebView2 that API errors ('network' / 'not-allowed' — the Edge runtime has no
+ * cloud recognizer to lean on), so a desktop player could never advance a
+ * "repeat after me" item by speaking; it looped "didn't catch that" until they
+ * typed or skipped. The desktop app already owns an OFFLINE recognizer (Vosk, the
+ * same engine spoken mantras and She's Listening use), so the host lends it to
+ * the page over the bridge. Match leniency is the host's (the mantra threshold +
+ * loudness gate), so a phrase that satisfies a spoken mantra satisfies this.
+ *
+ * FEATURE-DETECT FIRST. `hostSpeech.bridge` is true ONLY when the host's init
+ * carried `config.speech.bridge === true`. The public website (same file, no
+ * host) and the RN host never set it, and render/beats.js keeps its browser
+ * SpeechRecognition path for them. Nothing here throws at import.
+ *
+ * Wire (additive; PROTOCOL unchanged):
+ *   page -> host  speech-start {id, phrase}   open the mic for this phrase
+ *                 speech-stop  {id}           close it (beat unmounted / typed / skipped)
+ *   host -> page  speech-event {id, kind, transcript?, matched?, score?, loudEnough?, reason?}
+ *     kind: listening · partial · final · silence · idle · unavailable · stopped
+ *     reason (unavailable): consent · no-mic · no-model · model-failed · busy · error
+ *
+ * `id` is minted by the page per start (see hostSpeech.start) so a late event
+ * from a superseded session can be dropped by the beat that did not ask for it.
+ * -------------------------------------------------------------------------- */
+let speechCaps = { bridge: false, available: false, reason: null };
+let speechSeq = 0;
+const speechListeners = new Set();
+
+on('speech-event', (m) => {
+  for (const fn of Array.from(speechListeners)) {
+    try { fn(m); } catch (_e) { /* never break the bridge */ }
+  }
+});
+
+export const hostSpeech = Object.freeze({
+  /** True when the host lent us its offline recognizer (desktop only). */
+  get bridge() { return speechCaps.bridge; },
+  /** Boot-time snapshot; the host re-checks on every start and answers `unavailable` if not. */
+  get available() { return speechCaps.available; },
+  /** Boot-time reason when not available (one of the wire strings above), else null. */
+  get reason() { return speechCaps.reason; },
+  /** Open the mic for `phrase`. Returns the session id events will carry, or 0 when there is no bridge. */
+  start(phrase) {
+    if (!speechCaps.bridge) return 0;
+    const id = ++speechSeq;
+    send({ type: 'speech-start', id, phrase: String(phrase == null ? '' : phrase) });
+    return id;
+  },
+  /** Close the session `id` (no-op for 0 / without a bridge). */
+  stop(id) {
+    if (!speechCaps.bridge || !id) return;
+    send({ type: 'speech-stop', id });
+  },
+  /** Subscribe to speech-event frames. Returns the unsubscribe function. */
+  listen(fn) {
+    if (typeof fn !== 'function') return () => {};
+    speechListeners.add(fn);
+    return () => { speechListeners.delete(fn); };
+  },
 });
 
 /* ----------------------------------------------------------------------------

--- a/ConditioningControlPanel/Services/Quiz/IntakeHostService.Speech.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeHostService.Speech.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Services.Speech;
+
+namespace ConditioningControlPanel.Services.Quiz
+{
+    /// <summary>
+    /// SPEECH BRIDGE for the Graded Intake's say-it (Mantra) beat.
+    ///
+    /// The page used to ask the browser for <c>window.SpeechRecognition</c>. Inside WebView2 that
+    /// API is either absent or errors (<c>network</c> / <c>not-allowed</c>) because the Edge runtime
+    /// has no cloud recognizer to lean on, so a T2 tester (Ashley, 2026-08-28) could never advance
+    /// a "repeat after me" item by speaking. Regular mantras and She's Listening work because they
+    /// go through the app's OFFLINE Vosk engine (<see cref="SpeechService"/>) — this bridge routes
+    /// the intake through the same engine, with the same match leniency
+    /// (<c>SpeechMatchThreshold</c> + the loudness gate), so a phrase that satisfies a spoken
+    /// mantra satisfies the intake too.
+    ///
+    /// Wire (additive to the protocol in web-shim.js; the page feature-detects
+    /// <c>init.config.speech.bridge</c> and keeps its browser path when absent, which is what the
+    /// public website still uses):
+    ///
+    ///   Page -&gt; Host:  speech-start { id, phrase }   open the mic for this phrase (auto on beat mount)
+    ///                  speech-stop  { id }           beat unmounted / typed instead / skipped
+    ///   Host -&gt; Page:  speech-event { id, kind, ... }
+    ///       kind = listening                        mic is open
+    ///              partial  { transcript }          streaming hypothesis ("I'm hearing…")
+    ///              final    { matched, transcript, score, loudEnough }
+    ///              silence                          a whole window with nothing said; host re-opens
+    ///              idle                             host stopped re-opening (silence/miss caps); re-tap
+    ///              unavailable { reason }           see <see cref="IntakeSpeechPolicy"/> reasons
+    ///              stopped                          ack of speech-stop / window closing
+    ///
+    /// ONE RULE: this never fights another mic owner. If the wake-word loop, push-to-talk, a lock
+    /// card or a spoken mantra already holds the mic, the page is told <c>busy</c> and drops the
+    /// item to typed input. (LockCardWindow and SpeakPromptSession evict the wake loop instead;
+    /// the intake is a 20-minute windowed tool and standing She's Listening down for its whole
+    /// length would be the bigger surprise.)
+    ///
+    /// Threading: page messages arrive on the UI thread; the listen loop runs on the pool and
+    /// every post back is marshalled onto the dispatcher because <c>CoreWebView2</c> is UI-affine.
+    /// </summary>
+    internal static partial class IntakeHostService
+    {
+        private static readonly object _speechGate = new();
+        private static CancellationTokenSource? _speechCts;
+        private static int _speechId;            // the page's id for the session we are running (0 = none)
+
+        /// <summary>The <c>speech</c> block that rides <c>init.config</c>. <c>bridge:true</c> is
+        /// the feature-detect; <c>available</c>/<c>reason</c> are a snapshot so the page can paint
+        /// the right note before its first start (availability is re-checked on every start).</summary>
+        private static object BuildSpeechCaps()
+        {
+            var reason = SpeechUnavailability();
+            return new { bridge = true, available = reason == null, reason };
+        }
+
+        /// <summary>Live availability check; null = the mic can open now.</summary>
+        private static string? SpeechUnavailability()
+        {
+            try
+            {
+                var speech = App.Speech;
+                var consent = App.Settings?.Current?.MicConsentGiven == true;
+                var hasMic = SpeechService.HasCaptureDevice;
+                // IsAvailable probes (and caches) the model; ask it first so ModelStatus is real.
+                var model = speech == null ? SpeechModelStatus.NoModelFound
+                          : (speech.IsAvailable ? SpeechModelStatus.Ok : speech.ModelStatus);
+                var held = speech?.IsListening == true
+                        || App.WakeWord?.IsListening == true;
+                return IntakeSpeechPolicy.Unavailability(consent, hasMic, model, held);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("IntakeHostService.speech: availability probe failed: {E}", ex.Message);
+                return IntakeSpeechPolicy.ReasonError;
+            }
+        }
+
+        // ============================ page -> host ============================
+
+        private static void OnSpeechStart(JObject o)
+        {
+            int id = (int?)o["id"] ?? 0;
+            var phrase = ((string?)o["phrase"] ?? "").Trim();
+            if (id <= 0 || phrase.Length == 0)
+            {
+                PostSpeechEvent(id, "unavailable", new { reason = IntakeSpeechPolicy.ReasonError });
+                return;
+            }
+
+            // A new start supersedes whatever was running (the page moved on to another beat, or
+            // re-tapped after an idle). Cancel it first so at most one loop ever touches the mic.
+            StopSpeechBridge("superseded", notifyPage: false);
+
+            var reason = SpeechUnavailability();
+            if (reason != null)
+            {
+                App.Logger?.Information("IntakeHostService: speech-start #{Id} refused ({Reason})", id, reason);
+                PostSpeechEvent(id, "unavailable", new { reason });
+                return;
+            }
+
+            var cts = new CancellationTokenSource();
+            lock (_speechGate)
+            {
+                _speechCts = cts;
+                _speechId = id;
+            }
+            App.Logger?.Information("IntakeHostService: speech-start #{Id} target='{Phrase}'", id, phrase);
+            _ = Task.Run(() => RunSpeechLoopAsync(id, phrase, cts.Token));
+        }
+
+        private static void OnSpeechStop(JObject o)
+        {
+            int id = (int?)o["id"] ?? 0;
+            lock (_speechGate)
+            {
+                // A stop for a session we already left behind is a no-op (the page's cleanup for the
+                // previous beat can race the start of the next one).
+                if (id != 0 && id != _speechId) return;
+            }
+            StopSpeechBridge("page", notifyPage: true);
+        }
+
+        /// <summary>Cancel the running listen loop, if any. Safe from any thread and idempotent.
+        /// Called from <see cref="DisposeAll"/> so a closed window never leaves the mic open.</summary>
+        private static void StopSpeechBridge(string why, bool notifyPage)
+        {
+            CancellationTokenSource? cts;
+            int id;
+            lock (_speechGate)
+            {
+                cts = _speechCts;
+                id = _speechId;
+                _speechCts = null;
+                _speechId = 0;
+            }
+            if (cts == null) return;
+            try { cts.Cancel(); } catch { }
+            // The loop's own finally disposes the cts; cancelling also cuts the in-flight
+            // RecognizePhraseAsync through the token it was handed, so the mic closes at once.
+            App.Logger?.Debug("IntakeHostService: speech #{Id} stopped ({Why})", id, why);
+            if (notifyPage) PostSpeechEvent(id, "stopped", null);
+        }
+
+        // ============================ the listen loop ============================
+
+        private static async Task RunSpeechLoopAsync(int id, string phrase, CancellationToken ct)
+        {
+            var speech = App.Speech;
+            if (speech == null) { PostSpeechEvent(id, "unavailable", new { reason = IntakeSpeechPolicy.ReasonNoModel }); return; }
+
+            string lastPartial = "";
+            void OnPartial(object? _, string text)
+            {
+                // Vosk re-emits the partial on every 50 ms buffer; only forward changes.
+                if (string.IsNullOrWhiteSpace(text) || text == lastPartial) return;
+                lastPartial = text;
+                PostSpeechEvent(id, "partial", new { transcript = text });
+            }
+
+            int silent = 0, misses = 0;
+            speech.PartialTranscript += OnPartial;
+            try
+            {
+                // The same window the spoken-mantra and lock-card paths use — long enough to get a
+                // whole sentence out without racing the recognizer.
+                var options = new RecognizeOptions { Timeout = TimeSpan.FromSeconds(10) };
+                bool announced = false;
+
+                while (!ct.IsCancellationRequested)
+                {
+                    // Re-check between windows: the engine can vanish (device unplugged) and another
+                    // feature can claim the mic mid-run. Neither is ours to argue with.
+                    var reason = SpeechUnavailability();
+                    if (reason != null)
+                    {
+                        PostSpeechEvent(id, "unavailable", new { reason });
+                        return;
+                    }
+                    if (!announced) { announced = true; PostSpeechEvent(id, "listening", null); }
+                    lastPartial = "";
+
+                    PhraseResult res;
+                    try { res = await speech.RecognizePhraseAsync(phrase, options, ct).ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Warning("IntakeHostService: speech #{Id} recognize threw: {E}", id, ex.Message);
+                        PostSpeechEvent(id, "unavailable", new { reason = IntakeSpeechPolicy.ReasonError });
+                        return;
+                    }
+                    if (ct.IsCancellationRequested) return;
+
+                    if (res.Unavailable)
+                    {
+                        // The single-session guard refused us: someone else grabbed the mic between
+                        // our probe and the open. Report busy rather than spin.
+                        PostSpeechEvent(id, "unavailable", new { reason = IntakeSpeechPolicy.ReasonBusy });
+                        return;
+                    }
+
+                    if (res.Matched)
+                    {
+                        App.Logger?.Information("IntakeHostService: speech #{Id} matched '{Phrase}' (score={S:0.00}, conf={C:0.00})",
+                            id, phrase, res.Score, res.Confidence);
+                        PostSpeechEvent(id, "final", new { matched = true, transcript = res.Transcript, score = res.Score, loudEnough = res.LoudEnough });
+                        return;
+                    }
+
+                    if (res.TimedOut && string.IsNullOrWhiteSpace(res.Transcript))
+                    {
+                        silent++;
+                        misses = 0;
+                        PostSpeechEvent(id, "silence", null);
+                    }
+                    else
+                    {
+                        misses++;
+                        silent = 0;
+                        App.Logger?.Information("IntakeHostService: speech #{Id} miss — heard '{Heard}' (score={S:0.00}, loud={L})",
+                            id, res.Transcript, res.Score, res.LoudEnough);
+                        PostSpeechEvent(id, "final", new { matched = false, transcript = res.Transcript, score = res.Score, loudEnough = res.LoudEnough });
+                        // A beat between windows so the page's "almost" can land before the mic reopens.
+                        try { await Task.Delay(350, ct).ConfigureAwait(false); } catch (OperationCanceledException) { return; }
+                    }
+
+                    if (IntakeSpeechPolicy.ShouldGoIdle(silent, misses))
+                    {
+                        PostSpeechEvent(id, "idle", null);
+                        return;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("IntakeHostService: speech #{Id} loop failed: {E}", id, ex.Message);
+                PostSpeechEvent(id, "unavailable", new { reason = IntakeSpeechPolicy.ReasonError });
+            }
+            finally
+            {
+                speech.PartialTranscript -= OnPartial;
+                CancellationTokenSource? mine = null;
+                lock (_speechGate)
+                {
+                    if (_speechId == id) { mine = _speechCts; _speechCts = null; _speechId = 0; }
+                }
+                try { mine?.Dispose(); } catch { }
+            }
+        }
+
+        // ============================ host -> page ============================
+
+        /// <summary>Post one <c>speech-event</c>. Marshals to the UI thread (CoreWebView2 is
+        /// UI-affine) and drops the frame silently once the window is gone.</summary>
+        private static void PostSpeechEvent(int id, string kind, object? extra)
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            void Send()
+            {
+                try
+                {
+                    if (_host == null) return;
+                    var frame = new JObject { ["type"] = "speech-event", ["id"] = id, ["kind"] = kind };
+                    if (extra != null) frame.Merge(JObject.FromObject(extra));
+                    _host.Post(frame);
+                }
+                catch (Exception ex) { App.Logger?.Debug("IntakeHostService.speech post: {E}", ex.Message); }
+            }
+            if (disp.CheckAccess()) Send();
+            else disp.BeginInvoke((Action)Send);
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
@@ -28,6 +28,8 @@ namespace ConditioningControlPanel.Services.Quiz
     ///                  quiz-result { result }         -&gt; C# QuizSessionGenerator drafts a session
     ///                  session-drafted { ok, name, path } &lt;- host's reply to quiz-result
     ///                  exit                           -&gt; graceful teardown
+    ///                  speech-start / speech-stop     -&gt; offline Vosk say-it bridge; the host
+    ///                  speech-event { id, kind, ... } &lt;- answers (IntakeHostService.Speech.cs)
     ///
     /// Unlike DtRH this is a windowed Lab tool, not a screen-owning game: it hosts nothing native
     /// (the effect layer is fully self-contained in-page) and needs no meta/loom/haptics plumbing.
@@ -37,7 +39,7 @@ namespace ConditioningControlPanel.Services.Quiz
     /// per-instance user-data folder, hardened settings (no devtools), navigation lockdown,
     /// queue-until-ready bridge, a heartbeat watchdog and a relaunch-once recovery ladder.
     /// </summary>
-    internal static class IntakeHostService
+    internal static partial class IntakeHostService
     {
         /// <summary>The fiction name — mirrors contracts.PRODUCT_NAME's single-constant intent
         /// so a rename is a one-line change on each side.</summary>
@@ -331,6 +333,12 @@ namespace ConditioningControlPanel.Services.Quiz
                         // see the WPF setting on its own. False => beats.js renders the
                         // button disabled rather than live (type-it stays available).
                         micEnabled = App.Settings?.Current?.MicConsentGiven == true,
+                        // SPEECH BRIDGE. `bridge:true` is the page's feature-detect: with it the
+                        // say-it beat routes through the app's offline Vosk engine over
+                        // speech-start / speech-event instead of the browser's SpeechRecognition,
+                        // which errors inside WebView2 (no cloud recognizer) and left the item
+                        // un-advanceable by voice. Absent (website / RN host) => browser path.
+                        speech = BuildSpeechCaps(),
                         // Reward media for the in-page effect layer (gif bursts / jackpot
                         // spotlights). Served through the ccp.assets virtual host mapped above;
                         // a small random sample per launch keeps the init message light.
@@ -408,6 +416,12 @@ namespace ConditioningControlPanel.Services.Quiz
                     break;
                 case "need-remote":    // the page's remote still pool is running low
                     ServeRemoteBatch();
+                    break;
+                case "speech-start":   // say-it beat mounted / re-tapped: open the offline mic for its phrase
+                    OnSpeechStart(o);
+                    break;
+                case "speech-stop":    // beat unmounted, typed instead, or skipped: close it
+                    OnSpeechStop(o);
                     break;
                 case "exit-done":
                     DisposeAll();
@@ -1335,6 +1349,7 @@ namespace ConditioningControlPanel.Services.Quiz
             {
                 CancelExitWatchdog();
                 StopHeartbeatWatch();
+                StopSpeechBridge("closed", notifyPage: false);   // never leave the mic open behind a closed window
                 try { _host?.Dispose(); } catch { }
                 _host = null;
                 _exiting = false;

--- a/ConditioningControlPanel/Services/Quiz/IntakeSpeechPolicy.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeSpeechPolicy.cs
@@ -1,0 +1,62 @@
+using ConditioningControlPanel.Services.Speech;
+
+namespace ConditioningControlPanel.Services.Quiz
+{
+    /// <summary>
+    /// The pure half of the Graded Intake speech bridge (see <c>IntakeHostService.Speech.cs</c>):
+    /// every decision that does not need a live mic, so the tests can pin the wire contract without
+    /// an <see cref="App"/>. The reason strings are PROTOCOL — <c>render/beats.js</c> maps each one
+    /// to the note it prints when it drops the say-it item to typed input, so renaming one here
+    /// silently turns that note into the generic "mic unavailable".
+    /// </summary>
+    internal static class IntakeSpeechPolicy
+    {
+        /// <summary>Reasons the bridge reports when it cannot open the mic. Wire strings.</summary>
+        public const string ReasonConsent = "consent";        // MicConsentGiven is false
+        public const string ReasonNoMic = "no-mic";           // no capture device
+        public const string ReasonNoModel = "no-model";       // nothing under Resources/Models/vosk
+        public const string ReasonModelFailed = "model-failed"; // a model is there and Vosk refused it
+        public const string ReasonBusy = "busy";              // the mic belongs to another feature
+        public const string ReasonError = "error";            // setup threw / engine vanished mid-run
+
+        /// <summary>
+        /// Consecutive EMPTY listen windows (the user said nothing at all) before the host stops
+        /// re-opening the mic on its own and tells the page to wait for a re-tap. Three 10 s windows
+        /// is long enough to read the phrase twice and long enough for a walk-away to cost nothing.
+        /// </summary>
+        public const int MaxSilentWindows = 3;
+
+        /// <summary>
+        /// Consecutive non-matching utterances before the host gives up and hands the page an
+        /// <c>idle</c>. The page surfaces the typed input alongside the mic well before this
+        /// (after <c>3</c>), so this is a backstop against a recognizer that keeps hearing wrong.
+        /// </summary>
+        public const int MaxMisses = 6;
+
+        /// <summary>
+        /// Why speech cannot start right now, or <c>null</c> when it can. Order matters and mirrors
+        /// how the rest of the app reports the mic (She's Listening, Takeover, the lock card):
+        /// consent first (the user's choice trumps hardware), then hardware, then the model, then
+        /// whether someone else already holds the mic. The bridge never evicts another mic owner —
+        /// the wake-word loop, push-to-talk and a running spoken mantra all keep what they have and
+        /// the page drops to typed input instead.
+        /// </summary>
+        public static string? Unavailability(bool consentGiven, bool hasCaptureDevice, SpeechModelStatus model, bool micHeldElsewhere)
+        {
+            if (!consentGiven) return ReasonConsent;
+            if (!hasCaptureDevice) return ReasonNoMic;
+            switch (model)
+            {
+                case SpeechModelStatus.NoModelFound: return ReasonNoModel;
+                case SpeechModelStatus.LoadFailed: return ReasonModelFailed;
+                case SpeechModelStatus.NotProbed: return ReasonNoModel; // the caller probes first; treat an unprobed engine as absent
+            }
+            if (micHeldElsewhere) return ReasonBusy;
+            return null;
+        }
+
+        /// <summary>True once the host should stop re-opening the mic on its own and send <c>idle</c>.</summary>
+        public static bool ShouldGoIdle(int consecutiveSilentWindows, int consecutiveMisses)
+            => consecutiveSilentWindows >= MaxSilentWindows || consecutiveMisses >= MaxMisses;
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/IntakeSpeechBridgeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/IntakeSpeechBridgeTests.cs
@@ -1,0 +1,226 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services.Quiz;
+using ConditioningControlPanel.Services.Speech;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Graded Intake speech bridge (T2 Ashley, 2026-08-28): say-it items never advanced on the
+/// desktop because the page asked the browser for <c>SpeechRecognition</c>, which errors inside
+/// WebView2. The fix routes the beat through the app's offline Vosk engine over a small
+/// host&lt;-&gt;page protocol, and hardens BOTH ears so any error drops to typed input.
+///
+/// <para>Two halves are pinned here. <see cref="IntakeSpeechPolicy"/> is pure and tested directly.
+/// The wire contract is textual across three files that cannot be loaded off a real app (the host
+/// service is static over <c>App.*</c>; the page is an ES module with a DOM), so it is asserted
+/// against the source — the same idiom as <c>Phase8RedirectContractTests</c> /
+/// <c>ArcademyDoorOpenTests</c>. A renamed message type or reason string on one side is a
+/// feature that silently never fires on the other.</para>
+/// </summary>
+public class IntakeSpeechBridgeTests
+{
+    // ---- source helpers ----
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string Read(params string[] parts) =>
+        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+
+    private static string Host() => Read("Services", "Quiz", "IntakeHostService.cs");
+    private static string HostSpeech() => Read("Services", "Quiz", "IntakeHostService.Speech.cs");
+    private static string Shim() => Read("Resources", "web", "intake", "web-shim.js");
+    private static string Beats() => Read("Resources", "web", "intake", "render", "beats.js");
+    private static string Boot() => Read("Resources", "web", "intake", "boot.js");
+
+    // ---- IntakeSpeechPolicy: availability reasons, in the app's reporting order ----
+
+    [Fact]
+    public void Unavailability_ConsentTrumpsEverything()
+    {
+        // Even with no mic and no model, the user's own "no" is the reason we report.
+        Assert.Equal(IntakeSpeechPolicy.ReasonConsent,
+            IntakeSpeechPolicy.Unavailability(consentGiven: false, hasCaptureDevice: false, SpeechModelStatus.NoModelFound, micHeldElsewhere: true));
+    }
+
+    [Fact]
+    public void Unavailability_HardwareBeforeModel()
+    {
+        Assert.Equal(IntakeSpeechPolicy.ReasonNoMic,
+            IntakeSpeechPolicy.Unavailability(true, hasCaptureDevice: false, SpeechModelStatus.LoadFailed, micHeldElsewhere: true));
+    }
+
+    [Theory]
+    [InlineData(SpeechModelStatus.NoModelFound, IntakeSpeechPolicy.ReasonNoModel)]
+    [InlineData(SpeechModelStatus.LoadFailed, IntakeSpeechPolicy.ReasonModelFailed)]
+    [InlineData(SpeechModelStatus.NotProbed, IntakeSpeechPolicy.ReasonNoModel)]
+    public void Unavailability_ModelStatesReadDifferently(SpeechModelStatus status, string expected)
+    {
+        // "no model" and "the model you installed refused to load" must not collapse into one line -
+        // the second sends users off to download a model they already have.
+        Assert.Equal(expected, IntakeSpeechPolicy.Unavailability(true, true, status, micHeldElsewhere: false));
+    }
+
+    [Fact]
+    public void Unavailability_BusyIsReportedNotFought()
+    {
+        Assert.Equal(IntakeSpeechPolicy.ReasonBusy,
+            IntakeSpeechPolicy.Unavailability(true, true, SpeechModelStatus.Ok, micHeldElsewhere: true));
+    }
+
+    [Fact]
+    public void Unavailability_NullWhenEverythingIsThere()
+    {
+        Assert.Null(IntakeSpeechPolicy.Unavailability(true, true, SpeechModelStatus.Ok, micHeldElsewhere: false));
+    }
+
+    [Theory]
+    [InlineData(0, 0, false)]
+    [InlineData(2, 0, false)]
+    [InlineData(3, 0, true)]    // three empty windows: stop re-opening the mic on our own
+    [InlineData(0, 5, false)]
+    [InlineData(0, 6, true)]    // six wrong utterances: backstop
+    public void ShouldGoIdle_CapsSilenceAndMisses(int silent, int misses, bool expected)
+    {
+        Assert.Equal(expected, IntakeSpeechPolicy.ShouldGoIdle(silent, misses));
+    }
+
+    // ---- wire contract: every message type exists on both sides ----
+
+    [Fact]
+    public void Host_RoutesBothPageMessages()
+    {
+        var host = Host();
+        Assert.Contains("case \"speech-start\":", host);
+        Assert.Contains("case \"speech-stop\":", host);
+        // The class had to become partial for the bridge file to attach.
+        Assert.Matches(new Regex(@"internal\s+static\s+partial\s+class\s+IntakeHostService"), host);
+    }
+
+    [Fact]
+    public void Host_AdvertisesTheBridgeOnInit()
+    {
+        // `speech = BuildSpeechCaps()` rides init.config; the page feature-detects `bridge:true`.
+        Assert.Contains("speech = BuildSpeechCaps()", Host());
+        Assert.Contains("bridge = true", HostSpeech());
+    }
+
+    [Fact]
+    public void Host_PostsEveryEventKindThePageHandles()
+    {
+        var hostSpeech = HostSpeech();
+        var beats = Beats();
+        foreach (var kind in new[] { "listening", "partial", "final", "silence", "idle", "unavailable", "stopped" })
+        {
+            Assert.Contains($"case '{kind}':", beats);
+            // Every kind the page handles is one the host can actually send (stopped rides StopSpeechBridge).
+            Assert.Contains($"\"{kind}\"", hostSpeech);
+        }
+        Assert.Contains("[\"type\"] = \"speech-event\"", hostSpeech);
+        Assert.Contains("on('speech-event'", Shim());
+    }
+
+    [Fact]
+    public void Host_ClosesTheMicWhenTheWindowGoes()
+    {
+        // DisposeAll is the single teardown funnel; a closed window must never leave Vosk capturing.
+        var host = Host();
+        var dispose = host.Substring(host.IndexOf("private static void DisposeAll()", StringComparison.Ordinal));
+        Assert.Contains("StopSpeechBridge(", dispose);
+    }
+
+    [Fact]
+    public void Host_ReasonStringsMatchThePageNotes()
+    {
+        // The page prints a per-reason note when it drops to typed input; a reason the page does not
+        // know falls to the generic line, which is legal but wrong for the user in front of it.
+        var beats = Beats();
+        foreach (var reason in new[]
+                 {
+                     IntakeSpeechPolicy.ReasonConsent, IntakeSpeechPolicy.ReasonNoMic, IntakeSpeechPolicy.ReasonNoModel,
+                     IntakeSpeechPolicy.ReasonModelFailed, IntakeSpeechPolicy.ReasonBusy, IntakeSpeechPolicy.ReasonError,
+                 })
+        {
+            Assert.Contains($"'{reason}':", beats);
+        }
+    }
+
+    [Fact]
+    public void Shim_ExportsHostSpeechAndSendsBothMessages()
+    {
+        var shim = Shim();
+        Assert.Contains("export const hostSpeech", shim);
+        Assert.Contains("type: 'speech-start'", shim);
+        Assert.Contains("type: 'speech-stop'", shim);
+        // Feature-detect is the host's explicit flag, never "hosted" (the RN host is hosted too).
+        Assert.Contains("c.speech.bridge === true", shim);
+    }
+
+    [Fact]
+    public void Boot_HandsTheBridgeToBeats()
+    {
+        Assert.Contains("speech: shim.hostSpeech", Boot());
+        Assert.Contains("micEnabled, speech }", Beats());
+    }
+
+    [Fact]
+    public void Beats_FeatureDetectsTheBridgeBeforeTheBrowserEar()
+    {
+        var beats = Beats();
+        var mantra = beats.Substring(beats.IndexOf("function renderMantra()", StringComparison.Ordinal));
+        var hostEar = mantra.IndexOf("if (speechBridge) { renderHostEar(); return; }", StringComparison.Ordinal);
+        var browserProbe = mantra.IndexOf("window.SpeechRecognition || window.webkitSpeechRecognition", StringComparison.Ordinal);
+        Assert.True(hostEar >= 0, "the host ear must be feature-detected");
+        Assert.True(browserProbe > hostEar, "the browser SpeechRecognition probe must come AFTER the bridge check");
+    }
+
+    [Fact]
+    public void Beats_BrowserEarNeverLoopsOnAHardError()
+    {
+        // The original bug: rec.onerror printed "didn't catch that" for a 'network' error and left the
+        // user with no way forward but skip. Now only the two soft errors are allowed to retry, and
+        // even those are capped.
+        var beats = Beats();
+        var browser = beats.Substring(beats.IndexOf("function renderBrowserEar()", StringComparison.Ordinal));
+        var onerror = browser.Substring(browser.IndexOf("rec.onerror", StringComparison.Ordinal));
+        onerror = onerror.Substring(0, onerror.IndexOf("rec.onend", StringComparison.Ordinal));
+        Assert.Contains("err === 'no-speech' || err === 'aborted'", onerror);
+        Assert.Contains("softErrors >= 3", onerror);
+        Assert.Equal(2, Regex.Matches(onerror, @"dropToTyped\(").Count);   // soft cap + hard error
+        Assert.DoesNotContain("status.textContent = 'didn’t catch that';", onerror);
+    }
+
+    [Fact]
+    public void Beats_HostEarAutoStartsAndStopsOnCleanup()
+    {
+        var beats = Beats();
+        var host = beats.Substring(beats.IndexOf("function renderHostEar()", StringComparison.Ordinal));
+        host = host.Substring(0, host.IndexOf("// =================== BROWSER EAR", StringComparison.Ordinal));
+        // Auto-open on mount (the way spoken mantras behave), the last statement of the ear.
+        Assert.Matches(new Regex(@"start\(\);\s*\}\s*$"), host.TrimEnd());
+        // Unmount closes the host session so the mic never outlives the card.
+        Assert.Contains("cleanups.push(() => {", host);
+        Assert.Contains("try { stop(); } catch (_e) {}", host);
+        // A stale session's events are dropped, not applied to the wrong beat.
+        Assert.Contains("m.id !== sid", host);
+    }
+
+    [Fact]
+    public void Shim_KeepsTheWebsiteSyncPatchTarget()
+    {
+        // cclabs-web/scripts/sync-intake.mjs asserts EXACTLY ONE occurrence of this literal when it
+        // vendors the intake; a second one (or none) fails the sync loudly.
+        var shim = Shim();
+        Assert.Equal(1, Regex.Matches(shim, Regex.Escape("location.href = 'about:blank'")).Count);
+    }
+}


### PR DESCRIPTION
## Bug

T2 tester Ashley (2026-08-28): in the Graded Intake, "repeat after me" (say-it) items never advance when spoken; you have to type or skip. The page used `window.SpeechRecognition`, which errors inside WebView2 (`network` / `not-allowed`, no cloud recognizer), and the error handler printed "didn't catch that" forever. Spoken mantras and She's Listening work because they run on the app's offline Vosk engine.

## Fix

**Host speech bridge** - the desktop lends the page its offline `SpeechService` (Vosk), with the same leniency spoken mantras get (`SpeechMatchThreshold` + loudness gate, grammar-constrained to the target phrase).

- `Services/Quiz/IntakeHostService.Speech.cs` (new, partial): `speech-start {id, phrase}` / `speech-stop {id}` from the page; `speech-event {id, kind, transcript?, matched?, score?, loudEnough?, reason?}` back, kinds `listening | partial | final | silence | idle | unavailable | stopped`. Listen loop on the pool, posts marshalled to the UI thread. `DisposeAll` closes the session.
- `Services/Quiz/IntakeSpeechPolicy.cs` (new, pure): availability reasons in the app's reporting order (`consent > no-mic > no-model / model-failed > busy`) and the idle caps (3 silent windows / 6 misses).
- `IntakeHostService.cs`: `init.config.speech = {bridge:true, available, reason}` feature-detect; routes the two page messages; teardown hook.
- `web-shim.js`: `hostSpeech` (`bridge`, `available`, `reason`, `start(phrase) -> id`, `stop(id)`, `listen(fn) -> unsubscribe`). Additive; PROTOCOL unchanged; the sync-intake patch target (`about:blank`, exactly one) is untouched.
- `boot.js`: passes `speech: shim.hostSpeech` into `createBeats`.
- `render/beats.js` `renderMantra`: feature-detects the bridge FIRST -> host ear (auto-opens the mic on mount like spoken mantras; button is a live indicator / re-tap after idle; partials shown; typed input appears alongside after 3 misses). Otherwise the browser ear (website) as before, but **any hard error drops to typed input immediately**; only `no-speech` / `aborted` may retry, capped at 3.

**Never fights another mic owner**: if the wake-word loop, push-to-talk, a lock card or a spoken mantra holds the mic, the host answers `busy` and the page goes typed. Mic consent off -> `consent` (button greyed as before). No model / model refused -> distinct notes.

## Tests

`Tests/.../IntakeSpeechBridgeTests.cs` (23): policy reasons + caps, and source-contract pins across host / shim / boot / beats (every event kind handled on both sides, reason strings match the page notes, browser ear no longer loops, sync patch target still exactly one). `dotnet test --filter Intake`: 70/70. Debug build: 0 errors. Shim bridge half also driven under node with a fake WebView2 transport (7 checks).

Not exercised live (no mic on the build box) - please play-test on the prerelease: say-it item with mic consent on (should auto-listen and advance on the phrase), with She's Listening armed (should say "mic is busy elsewhere - type it"), with consent off, and on the website after sync (typed fallback on the first error).

Primer `Resources/web/intake/CLAUDE.md` updated (section 6 + gotcha 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpGh5B86bg4UWAXCzuet2t
