### PR TITLE
fix(arcademy): EMI keeps off the phone chrome too (hint line, folded plaque)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -723,12 +723,23 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    * in (shell/mail.css, and the first-run standoff in widget.js is named after
    * it). A tap eaten by a mascot is a tap eaten by a mascot either way. */
   const KEEP_OFF_SEL = 'g.campus-room.facility, .arc-mailchip';
+  /* ...and on a PHONE, the two bits of campus chrome that share her band: the
+   * hint line (bottom, over the folded ID tag - upright campus re-homes it) and
+   * the folded plaque on the spine. Desktop keeps the doors-only list on purpose
+   * (the hint is inert there and folding it in only drags her over the Lecture
+   * Hall); on a 390px glass she covers the hint with her whole body. Only the
+   * COLLAPSED plaque: expanded, the wrap IS the full-screen scrim (styles.css
+   * UPRIGHT CAMPUS B) and a rect the size of the viewport has no way out, which
+   * the rule would answer by leaving her put - harmless, but a wasted turn. Read
+   * per call, never at mount: the plaque re-homes on every orientation flip. */
+  const KEEP_OFF_SEL_PHONE = KEEP_OFF_SEL + ', .campus-hint, .campus-boardwrap.collapsed';
+  const onPhone = () => { try { return document.documentElement.classList.contains('arc-mobile'); } catch (e) { return false; } };
   /** Everything on the quad she may not stand on, in viewport px. [] off-campus. */
   function campusDoorRects() {
     if (screen !== 'board' || !campus || !campus.root) return [];
     const out = [];
     try {
-      const nodes = campus.root.querySelectorAll(KEEP_OFF_SEL);
+      const nodes = campus.root.querySelectorAll(onPhone() ? KEEP_OFF_SEL_PHONE : KEEP_OFF_SEL);
       for (const n of nodes) {
         const b = n.getBoundingClientRect ? n.getBoundingClientRect() : null;
         if (b && b.width > 0 && b.height > 0) out.push(b);


### PR DESCRIPTION
Follow-up to #364 (stacked on its branch so the diff is just this commit; GitHub retargets to `main` when #364 merges). Merge AFTER #364.

## What

On a phone (`html.arc-mobile`, either orientation) `campusDoorRects()` also feeds EMI's keep-off rule the campus **hint line** and the **collapsed timetable plaque**, on top of #364's facility doors + mail chip. Desktop stays doors-only, per the Locker session's reasoning (hint is inert there; folding it in drags her over the Lecture Hall).

- Only the *collapsed* plaque: expanded, the wrap is the full-screen scrim (upright campus), a viewport-sized rect has no escape and would just waste the rule's turn.
- Read per call, never cached: the plaque re-homes on every orientation flip.

## Why

On an 844x390 phone in landscape she parked with her whole body on the hint (measured 502,292 86x87 over the hint band). Portrait was already clear at 390x844 after #364's first-run standoff, but persisted positions and other glass sizes are not guaranteed.

## Verified

Playwright rotate round-trip (portrait -> landscape -> portrait) at 390x844, 360x780, 430x932: `onHint / onPlaque / onDoorOrMail` all false in both orientations, 0 console errors; landscape she slides 27px up off the hint. Full portrait flow rig (rest, board, tap, walk, rotate) 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg9bPZycVwUEYHJUsZk5wR
