### PR TITLE
fix(arcademy): mail box letter titles no longer spill out of their card

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/mail.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/mail.css
@@ -144,8 +144,26 @@
 .arc-mail-paper { min-height:0; overflow:auto; padding-right:4px; }
 .arc-mail-hint, .arc-mail-empty { margin:14px 2px; }
 
-/* ---- one envelope on the wall ----------------------------------------- */
+/* ---- one envelope on the wall -----------------------------------------
+   THE CARD NEVER SHRINKS, AND THAT IS THE WHOLE OF IT (owner bug, 2026-08-28:
+   a two-line heading painting over the bottom border and into the next
+   envelope). `.arc-mail-list` is a flex COLUMN with `overflow:auto`, so every
+   card is a flex ITEM, and a flex item's default `flex-shrink:1` means a pile
+   taller than the pane is SQUEEZED before it is scrolled. What normally holds
+   the line is the automatic minimum size (`min-height:auto` resolving to the
+   content), and that protection is only owed to a box whose overflow is
+   visible - a `<button>` is a form control the engine may treat otherwise, so
+   it is not a floor to build on. Measured with the full 24-letter catalog at
+   1600x900 and that protection off: every card collapsed to the SAME 21.7px
+   (which is what "fixed-height card" means here) and the clamped 32.5px title
+   hung 34px below its own border. The sender line survived because it is one
+   nowrap ellipsised row - it had nothing to spill.
+   `flex:none` rather than a tighter clamp: the pane already scrolls (list
+   529px, content 1739px), so the honest answer is a card that grows to its two
+   lines and a wall that scrolls past them. The clamp below still caps a heading
+   at two lines; this is what makes the CARD follow it. */
 .arc-mail-item {
+  flex:none;
   position:relative; cursor:pointer; text-align:left;
   display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:10px;
   padding:10px 12px 10px 10px;


### PR DESCRIPTION
## The bug

In **THE MAIL BOX** (`shell/mailbox.js` + `shell/mail.css`), a letter whose
heading wraps to two lines spilled out of its card on the wall: the second line
painted over the card's own bottom border and into the next envelope. The sender
line was never affected - it is a single `nowrap` ellipsised row, so it had
nothing to spill.

## Root cause

`.arc-mail-list` (mail.css:139) is a **flex column** with `overflow:auto`, so
every `.arc-mail-item` is a flex item carrying the default `flex-shrink:1`.
When the pile of letters is taller than the pane, flex **squeezes the items
before the pane scrolls**. The only thing normally holding the line is the
automatic minimum size (`min-height:auto` resolving to the content size), and
that protection is owed only to a box whose overflow is `visible` - `.arc-mail-item`
is a `<button>`, a form control an engine is free to treat otherwise.

Measured headlessly against the real 24-letter catalog at 1600x900 with that
protection off: every card collapsed to the same **21.7px** (which is what the
"fixed-height card" in the report actually is) and the clamped **32.5px** title
hung **34px** below its own border - exactly the reported picture.

## The change

One declaration, `mail.css` - `flex:none` on `.arc-mail-item`, plus the comment
block that explains why (the file's house style).

The pane already scrolls (list 529px vs content 1739px), so the preferred fix
applies: the card **grows to fit its two lines** and the wall scrolls past them.
The existing 2-line `-webkit-line-clamp` on `.arc-mail-item-line` is untouched
and still caps a long heading; this is what makes the card *follow* it. The date
column (`.arc-mail-item-meta`) is a separate grid track and stays right-aligned.

## Before / after

| | before | after |
|---|---|---|
| card height (2-line heading) | 21.7px, identical for every card | 66.5px, 50.5px for a 1-line heading |
| title bottom vs card bottom | **+34px (outside)** | -10.8px (inside, padding + border) |
| list | did not scroll, cards squeezed | scrolls, cards intact |

Verified at 1600x900 and at the narrow (<=760px) two-row layout, in both cases
with the shrink protection forced off, driving the **real** `openMailbox()` over
the real `MAIL` catalog. `html.arc-mobile` needed nothing of its own - it styles
the same element, so it inherits the fix.

## Files

- `ConditioningControlPanel/Resources/web/arcademy/shell/mail.css`

`styles.css`, `campus.js`, `shell.js` and `mail.js` are untouched - the DOM
needed no wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBf8LcaDB642RCq1kCTEeo
