### PR TITLE
feat(arcademy): init.launchGame + the Discord command table (Activity contract §2/§6)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -948,6 +948,21 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     grades S is told 1. The whole-blob `meta` snapshot is pushed as well.
   - `complete:true` IS the permanent unlock: the shell offers Begin on that room every night
     through the same door path as `devDoor`. Nothing host-side gates which room may start.
+  - **AND IT IS THE DISCORD KEY TOO** (the Activity wave, 2026-08-28). A full card opens the
+    class as a Discord Activity: `/dailytrigger` and its nine siblings. `games/registry.js`
+    **`DISCORD_COMMAND`** is the key -> slash-command table and `discordCommand(key)` its
+    reader; `shell/enrollment.js` prints it as the unlock box's third row
+    (`punchcard_unlocked_discord`, `{cmd}` substituted) and `shell.js` appends the same
+    sentence to the quiet no-op-mint note. See trap 134 - that table is HALF of a contract.
+  - **`init.launchGame`** (string gameKey, or absent) is how a hosted shell says which room
+    it was opened for. `shell.js` reads it once beside `devDoor` (`launchRequest`), and
+    `maybeLaunchRequested()` fires ONCE per boot, immediately after the boot's `showBoard()`
+    - the campus has mounted and the cards have been known since `init.meta` reached the
+    store. Complete card -> `launchGraded(key)` (which starts tonight's board class if the
+    room is on it, else the free-swim twin); anything else -> stay on the campus and toast
+    `launch_card_locked`. **The C# host never sends it** and never should: the desktop opens
+    on a campus, so `BuildInit` has nothing to say here. The field is `cclabs-web`'s
+    (`scripts/arcademy-web-ext/host/index.js` reads the activity boot blob's `game`).
   - **The SHELL half** (2026-08-23): `core/store.js` lists the key in `HOST_OWNED_KEYS` and
     exposes `store.punchCard(gameKey)` / `store.unlockedGames()`, both of which RE-DERIVE
     `punches`, `house`, `complete` and `enrolled` off the two fields that are actually earned -
@@ -3038,6 +3053,25 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     of this is fixed by hand (`html.arc-mobile[data-arc-orient="landscape"] .campus-hint
     { right:170px }`). The general case is OPEN - it belongs to the widget, not to the
     campus chrome.
+134. **`DISCORD_COMMAND` IS HALF OF A TWO-REPO CONTRACT, AND THE OTHER HALF IS A BOT.**
+    `games/registry.js DISCORD_COMMAND` maps a game key to the slash command that opens
+    that class as a Discord Activity. CCP-Server `bot/arcademy-activity.js`
+    (`commandDefinitions()` / `handleCommand`) registers exactly those names against
+    exactly those keys, and the Activity link it hands back is
+    `custom_id=arcademy-<gameKey>`. Change one side alone and a command silently opens the
+    wrong room (or the campus): **both repos move in the same wave, or neither does.**
+    Three rules that fall out of it:
+    - **The command is derived from the KEY, never from `gameName()` or a lexicon row.** A
+      mod re-voices the SENTENCE (`punchcard_unlocked_discord`) and may never rename a
+      command, which is why `{cmd}` is a substituted token and not part of the copy.
+    - **A key with no row simply has no line.** `misdirection` is retired: no row, no
+      command, no launch, and the entitlement route answers `complete:false` for it anyway.
+      The ceremony omits the third row rather than printing an empty command.
+    - **`init.launchGame` is a request, not a grant.** It is gated by the page's own
+      `isUnlocked()` - the same read the campus door uses - so this door can never be wider
+      than the one on the quad, whatever a host sends. The hosted shells wall on the
+      server's `complete` before the page boots; the page's toast is the belt-and-braces
+      half, and it lands the player on a campus rather than on a dead end.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -299,6 +299,16 @@ export const DEFAULT_LEXICON = Object.freeze({
   punchcard_unlocked_chip: 'Unlocked',
   punchcard_unlocked_title: 'Assignment complete',
   punchcard_unlocked_line: 'This room is now open even when the course is not in session.',
+  /* THE DISCORD LINE (the Activity wave, 2026-08-28). Third row of the unlock
+     box, and the ONE place the page names a slash command. `{cmd}` is filled
+     from games/registry.js DISCORD_COMMAND - a key with no row there hides the
+     line rather than printing a hole. A mod may re-voice the sentence; it may
+     NOT rename the command, which is why the token is substituted and not
+     written into the copy. */
+  punchcard_unlocked_discord: 'Even in Discord: type {cmd} in the CCP server to play it anytime.',
+  /* An activity host asked for a room whose card is not full. The hosted shells
+     wall before the page ever boots, so this is the belt-and-braces toast. */
+  launch_card_locked: 'That card is not complete yet. Fill it first.',
   enroll_kicker: 'Enrollment',
   enroll_next: 'Next',
   enroll_begin: 'Begin class',

--- a/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
@@ -151,6 +151,42 @@ export const OPEN_SEMESTERS = new Set([1, 2, 3]);
  */
 export const RETIRED_GAMES = new Set(['misdirection']);
 
+/**
+ * SLASH COMMAND PER CLASS - THE TWO-REPO CONTRACT (Discord Activity, 2026-08-28).
+ *
+ * `/arcademy` opens the campus; one command per class opens THAT room directly,
+ * and only for a player whose punch card is complete. The command name is
+ * derived from the KEY and never from `gameName()` or a lexicon row - a mod
+ * that re-voices a class must not rename a Discord command.
+ *
+ * THIS TABLE IS HALF OF A CONTRACT. The other half is CCP-Server
+ * `bot/arcademy-activity.js` (`commandDefinitions()` / `handleCommand`), which
+ * registers exactly these names against exactly these keys. Change one side and
+ * you MUST change the other in the same wave, or a command opens the campus
+ * instead of the room the player asked for.
+ *
+ * RETIRED CLASSES ARE ABSENT (misdirection): no command, no launch, and the
+ * entitlement route answers complete=false for the key regardless. A key with
+ * no row here simply has no Discord line in the unlock ceremony.
+ */
+export const DISCORD_COMMAND = Object.freeze({
+  daily_trigger: '/dailytrigger',
+  lost_and_found: '/lostandfound',
+  deja_vu: '/dejavu',
+  impulse_control: '/impulsecontrol',
+  sort: '/sort',
+  echo: '/echo',
+  instant_recall: '/instantrecall',
+  anomaly: '/anomaly',
+  composure: '/composure',
+  the_deep_end: '/deepend',
+});
+
+/** The slash command that opens this class in Discord, or '' when it has none. */
+export function discordCommand(key) {
+  return DISCORD_COMMAND[key] || '';
+}
+
 /** True when a class's semester has opened (unknown keys are Semester I) AND
  *  the class has not been retired - this is the ONE gate the registry pool,
  *  the timetable and shell/campus.js all read, so they can never disagree. */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/enrollment.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/enrollment.js
@@ -37,6 +37,7 @@
 import { t } from '../core/lexicon.js';
 import { exitBar, sign as signExit } from './exits.js';
 import { cardFace, thud, THUD_PITCH, HOLES, ENROLL_PUNCHES } from './punchcard.js';
+import { DISCORD_COMMAND } from '../games/registry.js';
 
 /* ----------------------------------------------------------------------------
  * THE FLAVOUR COPY
@@ -435,6 +436,21 @@ export function createPunchCeremony(o) {
   unlockBox.appendChild(el('p', 'arc-pc-unlock-line',
     t('punchcard_unlocked_line',
       'This room is now open even when the course is not in session.')));
+  /* THE DISCORD ROW (the Activity wave, 2026-08-28). A full card opens the room
+   * on EVERY host, and one of them is the CCP Discord: `/dailytrigger` and its
+   * nine siblings open that class as an Activity for a player whose card is
+   * complete. The command comes from games/registry.js DISCORD_COMMAND - the
+   * two-repo contract with CCP-Server `bot/arcademy-activity.js` - so it is
+   * derived from the KEY and never from the class's (mod-skinnable) name. A key
+   * with NO row there (a retired class) simply has no third line: the row is
+   * never appended, rather than printing an empty command. */
+  const cmd = DISCORD_COMMAND[s.gameKey] || '';
+  if (cmd) {
+    unlockBox.appendChild(el('p', 'arc-pc-unlock-discord',
+      String(t('punchcard_unlocked_discord',
+        'Even in Discord: type {cmd} in the CCP server to play it anytime.'))
+        .replace('{cmd}', cmd)));
+  }
   box.appendChild(unlockBox);
 
   const done = el('button', 'btn primary', t('done', 'Done'));

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -34,6 +34,7 @@ import { gradeClass, capsRaised, isSPlus, gradeKey } from '../core/grades.js';
 import { createStore } from '../core/store.js';
 import {
   loadGames, descriptors, tierFor, tierForPromotions, advance, suspendedStub, MAX_TIER,
+  DISCORD_COMMAND,
 } from '../games/registry.js';
 import { createBoard } from './splitflap.js';
 import { createCampus, campusState, currentSemester } from './campus.js';
@@ -1003,6 +1004,21 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    * postman, and a delivered letter is persisted state a peek must not mint. */
   const annexPeek = src.devAnnex === true;
   if (annexPeek) say('ANNEX PEEK (owner dev): lab reachable, nothing stamped');
+
+  /* THE ACTIVITY LAUNCH (the Discord Activity wave, 2026-08-28). A hosted shell
+   * that was opened through one of the per-class slash commands names the room
+   * it was asked for; absent (the desktop host NEVER sends it, and does not
+   * need to - it has a campus) means "just open the campus".
+   *
+   * IT IS A REQUEST, NOT A GRANT. The gate is the player's own punch card, read
+   * from the SAME `isUnlocked` the campus door reads, so this door can never be
+   * wider than the one on the quad. The hosted shells wall on the server's
+   * `complete` before the page boots; this is the belt-and-braces half, and it
+   * refuses with a toast rather than a screen so the player lands on the campus
+   * they can actually use. Fired exactly ONCE per boot (see `launchFired`). */
+  const launchRequest = (typeof src.launchGame === 'string' && src.launchGame) ? src.launchGame : '';
+  let launchFired = false;
+  if (launchRequest) say('activity launch requested: ' + launchRequest);
 
   /* ---------------------- registry + timetable -------------------------- */
   const games = await loadGames(say);
@@ -3422,6 +3438,48 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     }
     setStage('arc-report-on');
     if (typeof lockerRoom.fit === 'function') lockerRoom.fit();
+  }
+
+  /**
+   * ONE SHOT, ONE BOOT. The host asked for a room by key (`init.launchGame`);
+   * open it if the card is full, otherwise stay on the campus and say why. An
+   * unknown or retired key has no card and therefore no grant, which is the
+   * same refusal by the same test - there is no second table to keep in step.
+   */
+  function maybeLaunchRequested() {
+    if (launchFired || destroyed) return;
+    launchFired = true;
+    if (!launchRequest) return;
+    if (isUnlocked(launchRequest)) {
+      say('activity launch: ' + launchRequest + ' - card complete, opening the room');
+      launchGraded(launchRequest);
+      return;
+    }
+    say('activity launch refused: ' + launchRequest + ' - card not complete');
+    try { shout(t('launch_card_locked', 'That card is not complete yet. Fill it first.')); }
+    catch (e) { /* a toast may never hold a door */ }
+  }
+
+  /**
+   * The unlock box's / end card's Discord sentence for a class, or '' when the
+   * class has no slash command (a retired key). `{cmd}` comes from the registry
+   * table - the two-repo contract with CCP-Server `bot/arcademy-activity.js` -
+   * so a mod may re-voice the sentence but can never rename the command.
+   */
+  function discordLine(gameKey) {
+    const cmd = DISCORD_COMMAND[gameKey] || '';
+    if (!cmd) return '';
+    return String(t('punchcard_unlocked_discord',
+      'Even in Discord: type {cmd} in the CCP server to play it anytime.'))
+      .replace('{cmd}', cmd);
+  }
+
+  /** Two sentences in one line, and one of them may be missing. */
+  function joinNote(a, b) {
+    const first = String(a || '').trim();
+    const second = String(b || '').trim();
+    if (!second) return first;
+    return first ? (first + ' ' + second) : second;
   }
 
   /* ---------------------- the graded launch ----------------------------
@@ -5931,8 +5989,15 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
           const full = !!(norm && (norm.complete || Number(norm.punches) >= cap));
           try {
             endCard.setPunchNote(full
-              ? t('punchcard_unlocked_line',
-                'This room is now open even when the course is not in session.')
+              /* A FULL CARD GETS THE DISCORD SENTENCE TOO. The ceremony is the
+               * loud half of this and it does not run on a no-op mint, so the
+               * quiet note is the only place a player who filled the card on an
+               * earlier night is told the room travels. Two sentences in one
+               * line - setPunchNote paints ONE <p> - and the second is dropped
+               * whole when the class has no command (a retired key). */
+              ? joinNote(t('punchcard_unlocked_line',
+                'This room is now open even when the course is not in session.'),
+                discordLine(m.gameKey))
               : t('punchcard_next_hole', 'Come back tomorrow for the next stamp.'));
           } catch (e) { say('punch note failed: ' + ((e && e.message) || e)); }
         }
@@ -6325,6 +6390,13 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   } catch (e) { say('first bell unavailable (the shell is unaffected): ' + ((e && e.message) || e)); }
 
   showBoard();
+  /* THE ACTIVITY LAUNCH, fired here and nowhere else: the campus has mounted
+   * (showBoard above) and the punch cards have been known since `init.meta`
+   * reached the store at construction, which are the ceremony's two
+   * preconditions. `launchGraded` sorts the rest out - a room tonight's board
+   * already deals starts as THAT class, a room off the board starts as a free
+   * swim's graded twin - so this hook only decides WHETHER. */
+  maybeLaunchRequested();
   return api;
 }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -3360,6 +3360,9 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
   text-transform:uppercase; color:var(--gold);
 }
 .arc-pc-unlock-line { margin:0; font-size:12.5px; color:var(--ink-dim); }
+/* The Discord row of the unlock box (the Activity wave). Same voice as the
+   line above it, one notch quieter - it names a command, not a promise. */
+.arc-pc-unlock-discord { margin:0; font-size:12px; color:var(--ink-dim); opacity:.85; }
 
 /* ---- the enrollment intro ----------------------------------------------- */
 /* Mounted on the class ROOT, not over the whole stage, so the proctor strip and

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1848,6 +1848,10 @@ internal static class ArcademyHostService
         ["punchcard_unlocked_chip"] = "Unlocked",
         ["punchcard_unlocked_title"] = "Assignment complete",
         ["punchcard_unlocked_line"] = "This room is now open even when the course is not in session.",
+        // THE DISCORD LINE (the Activity wave, 2026-08-28). `{cmd}` is filled by
+        // the page from games/registry.js DISCORD_COMMAND, never by the host.
+        ["punchcard_unlocked_discord"] = "Even in Discord: type {cmd} in the CCP server to play it anytime.",
+        ["launch_card_locked"] = "That card is not complete yet. Fill it first.",
         ["enroll_kicker"] = "Enrollment",
         ["enroll_next"] = "Next",
         ["enroll_begin"] = "Begin class",


### PR DESCRIPTION
The **app-repo half** of the three-repo "Arcademy as a Discord Activity" contract
(§2 and §6). Nothing here is armed by itself: the page simply learns how to be
opened at a room, and how to name the command that does it.

## `init.launchGame`

A hosted shell (the `/discord-arcademy` shell in `cclabs-web`) opens the vendored
page with the room the player asked for. `shell/shell.js` reads the field once
beside `devDoor` (`launchRequest`, line ~1019) and `maybeLaunchRequested()` fires
**exactly once per boot**, immediately after the boot's `showBoard()` — the campus
has mounted and the punch cards have been known since `init.meta` reached the
store at construction.

- card complete -> `launchGraded(key)`, which already sorts the rest out: a room
  tonight's board deals starts as *that* class, a room off the board starts as
  the free-swim twin (graded, timed, XP once per UTC day).
- not complete / unknown / retired -> stay on the campus and toast
  `t('launch_card_locked')`.

**It is a request, not a grant.** The gate is the page's own `isUnlocked()` — the
same read the campus door uses — so this door can never be wider than the one on
the quad, whatever a host sends. The hosted shells wall on the server's
`complete` before the page ever boots; this is the belt-and-braces half, and it
lands the player on a campus rather than on a dead end.

**The C# host does not send `launchGame` and must not start.** The desktop opens
on a campus; `BuildInit` is untouched.

## The ceremony line

`shell/enrollment.js`'s unlock box grows a third row, `p.arc-pc-unlock-discord`:

> Even in Discord: type `/dailytrigger` in the CCP server to play it anytime.

`{cmd}` is substituted from `DISCORD_COMMAND[gameKey]`; a key with no row (a
retired class) gets **no row at all** rather than an empty command. `unlockBeat`
stays idempotent — the row is built once at construction, and the beat only
un-hides the box. The same sentence is appended to the quiet no-op-mint path
(`endCard.setPunchNote`), which is the only place a player who filled the card on
an earlier night is told the room travels.

Two new lexicon rows in `core/lexicon.js` **and** the C# `NeutralLexicon` mirror
in `ArcademyHostService.cs`, both well under the 96-char mod-skin cap (trap 26),
no em-dashes. Three lines of CSS next to the existing `.arc-pc-unlock` rules.

## Two-repo contract note

`games/registry.js` **`DISCORD_COMMAND`** (10 open classes; `misdirection` is
retired and absent) is **half of a contract**. The other half is CCP-Server
`bot/arcademy-activity.js` — `commandDefinitions()` / `handleCommand()` — which
registers exactly these names against exactly these keys, and whose Activity link
is `custom_id=arcademy-<gameKey>`. **Change one side alone and a command silently
opens the wrong room.** Both repos move in the same wave, or neither does.
Commands are derived from the KEY, never from `gameName()` or a lexicon row, so a
mod re-voices the sentence and can never rename a command. Written up as
`Resources/web/arcademy/CLAUDE.md` **trap 134**, with the seam itself in §3.

## Verification

- `node --test` activity suite (scratch harness per CLAUDE.md §6): **16/16 pass** —
  the table verbatim against a hand-transcribed copy of contract §2, all ten open
  keys covered and only those, `misdirection` absent on all three tests, names
  legal under Discord's `^[a-z0-9_-]{1,32}$` and distinct, the frozen table, both
  lexicon rows present in **both** tables verbatim with the 96-char cap and the
  `{cmd}` token, plus source-shape tripwires for the ceremony row, the CSS rule
  (trap 27: no bare `display:`), the once-per-boot fire and its position after
  `showBoard()`, the quiet path, `launchGame` **absent** from the C# host, and the
  CLAUDE.md rows.
- `node --check` on every touched module.
- `dotnet build`: **0 errors**, 344 warnings (the usual CA1416/CS8602 baseline).

Not play-tested in the app — there is no host that sends `launchGame` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBf8LcaDB642RCq1kCTEeo
