### PR TITLE
fix(arcademy): pool room label + pill no longer clipped at the plan's bottom edge

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -107,11 +107,27 @@ export const ROOMS = Object.freeze({
    * runs down it to the water: `door` is still a corridor x, so doorFor(),
    * stopAnchor() and routeFor() need no change at all - the numbered stop lands in
    * the Main Hall like every other class. Because the building sits off the
-   * corridor, `neonY` / `nameY` pin the sign and the label inside it instead of
-   * taking the side-derived defaults (which assume a room bolted to the hall). */
+   * corridor, `neonX` / `neonY` / `nameY` pin the sign and the label inside it
+   * instead of taking the side-derived defaults (which assume a room bolted to
+   * the hall).
+   *
+   * THE SIGN IS ON THE ROOM'S OWN CENTRE LINE, NOT ON ITS DOOR. Every other room
+   * on the plan is entered through the middle of its own wall, so `door` IS the
+   * room's centre and the sign, the art and the plate all stack on one axis. The
+   * Pool is entered from the alley at x 450 and its centre is x 470, so taking
+   * the default left the status pill twenty units west of the wordmark and the
+   * plate under it - close enough to look like a mistake and far enough to read
+   * as a label belonging to something else. `neonX` puts it back on the stack.
+   *
+   * THE BOTTOM EDGE OF THE PLAN IS NOT SPARE. This is the ONE room below the
+   * corridor's south wall, which is why `styles.css` stops the plan growing past
+   * 16:9 (THE VERTICAL SAFE BAND, beside `svg.campus-plan`): under `slice` a
+   * window wider than 16:9 crops the top and the bottom, and everything it takes
+   * off the bottom is this room. A future room drawn below y 730 inherits the
+   * same dependency. */
   the_deep_end: {
     rect: [302, 738, 336, 114], side: 's', door: 450, rm: '105',
-    neonY: 742, nameY: 822,
+    neonX: 470, neonY: 742, nameY: 822,
     nameKey: 'campus_room_the_deep_end', nameEn: 'The Pool',
     descKey: 'campus_desc_the_deep_end',
     descEn: 'Sink tile into tile. The deeper you go, the harder the board is to read.',
@@ -1107,6 +1123,18 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
    * the plan always fills the frame, whatever the window - dead sky is cropped
    * instead of letterboxed. Content near the top/bottom edges is croppable
    * flavor only (tower cap, quad), never a room or a control.
+   *
+   * AND THAT SENTENCE STOPPED BEING TRUE WHEN THE POOL WAS BUILT. The Deep End
+   * sits on the south lawn at y 738..852, below every other room on the plan, so
+   * on a DESKTOP window wider than 16:9 the very first thing slice took was a
+   * room: at 1920x900 the crop is 67 units a side and the wordmark, the room
+   * name and the RM number all went under the bottom edge, leaving the sign
+   * hanging over nothing (tester shot, 2026-08-28). The cure is a CSS one and it
+   * is deliberately NOT here - `styles.css`'s VERTICAL SAFE BAND (beside
+   * `svg.campus-plan`) stops the plan growing past 16:9 and pillarboxes into the
+   * stage's own sky, which needs no measuring, no listener and no rebuild on a
+   * resize. This attribute keeps saying `slice`, because below 16:9 that is
+   * still exactly what the plan wants.
    *
    * ON A PHONE IT MEETS INSTEAD (the mobile pass, owner bugs A and B). Slice is
    * only ever right while the frame is CLOSE to 16:9, and a phone is not close

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -1411,6 +1411,30 @@ html.arc-campus-on body { overflow:hidden; }
 
 /* ---- SVG plan ---- */
 svg.campus-plan { position:absolute; inset:0; width:100%; height:100%; display:block; }
+/* THE PLAN STOPS GROWING AT 16:9 - THE VERTICAL SAFE BAND.
+   `slice` fills the frame and throws away whatever does not fit, and on a frame
+   WIDER than 16:9 what does not fit is the TOP AND THE BOTTOM of the plan: at
+   1920x900 that is 67 viewBox units off each edge, at 2560x1080 it is 105. That
+   was a fair trade for as long as the plan's bottom band was lawn - and it
+   stopped being true the night The Pool was built on the south lawn. The Deep
+   End is the one ROOM below the corridor's south wall (y 738..852 of an 810-unit
+   box, its plate on y 822/840), so a wide window ate the bottom half of its
+   wordmark, its room name and its RM number and left the IN SESSION sign
+   standing on its own over nothing - the exact shot a tester filed on
+   2026-08-28, and the exact bug the phone pass fixed for phones only.
+   So above 16:9 the plan keeps its ratio and PILLARBOXES into the stage's own
+   dusk sky instead: the same trade `meet` already makes on a phone, where the
+   bands read as sky and nothing looks broken. It is CONTINUOUS at the threshold
+   - at exactly 16:9 the box still fills the frame, so there is no jump - and it
+   is only ever the WIDE side. A frame TALLER than 16:9 still slices its left and
+   right edges into the horizontal SAFE BAND that campus.js's ROOMS table is
+   drawn against (x 72..1368); nothing about that changes. */
+@media (min-aspect-ratio:16/9) {
+  svg.campus-plan {
+    right:auto; width:auto; aspect-ratio:16/9;
+    left:50%; transform:translateX(-50%);
+  }
+}
 .campus-gfloor { fill:var(--campus-plan); stroke:var(--campus-line); stroke-width:2; }
 .campus-gfloor.striped { fill:var(--campus-hall); opacity:.6; }
 .campus-ghall { fill:var(--campus-hall); stroke:var(--campus-line); stroke-width:2; }


### PR DESCRIPTION
**Tester report (Mort, 2026-08-28):** _"this needs making more obvious too"_ — a shot of the campus floor plan in a wide window with a box drawn round the bottom-centre: THE POOL / DEEP END sitting on the very bottom edge, its name cut off, its RETAKE pill floating above it looking orphaned, with an arrow relating it to the IN SESSION pill on Impulse Control that reads clearly.

## Root cause

`svg.campus-plan` is `preserveAspectRatio="xMidYMid slice"` over a 16:9 viewBox (`0 55 1440 810`), so **any frame wider than 16:9 crops the top and the bottom** — 67 viewBox units a side at 1920x900, 105 at 2560x1080. The plan build comment says that band is "croppable flavor only (tower cap, quad), never a room or a control", and that stopped being true the night The Pool was built on the south lawn: `ROOMS.the_deep_end` (`shell/campus.js:112`) is `rect: [302, 738, 336, 114]` with its plate on `nameY: 822` — the one room below the corridor's south wall, and therefore the first thing the crop eats.

Reproduced headless at 1920x900 (Mort's aspect):

| | before | |
|---|---|---|
| room name | y **914** | outside a 900px viewport |
| RM 105 row | y **945** | outside |
| room `<g>` | bottom **973** | outside |
| status pill | y 826 | inside — hence "orphaned" |

The 2026-08-25 mobile pass fixed this exact shear **for phones** (`meet` on `html.arc-mobile`) and left the desktop window alone.

## The fix

**`styles.css`, beside `svg.campus-plan` — THE VERTICAL SAFE BAND.** Above 16:9 the plan stops growing and pillarboxes into the stage's own dusk sky instead of cropping. That is the same trade `meet` already makes on a phone ("the bands it leaves are the stage's own dusk-sky gradient, so nothing looks broken"), and it is **continuous at the threshold** — at exactly 16:9 the box still fills the frame, so nothing jumps. Below 16:9 nothing changes: the sides still slice into the horizontal safe band the `ROOMS` table is drawn against (x 72..1368). No listener, no measuring, no rebuild on a resize — `onDeviceChange` does not fire on a plain desktop resize, so a JS fit would have needed a new listener to tear down.

**`shell/campus.js`, `ROOMS.the_deep_end` — `neonX: 470`.** Every other room is entered through the middle of its own wall, so `door` *is* the room's centre and the sign, the art and the plate stack on one axis. The Pool is entered from the alley at x 450 while its centre is x 470, so the sign sat twenty units west of the wordmark and the plate under it — close enough to look like a mistake, far enough to read as a label belonging to something else. On the room's own axis the pill, the wordmark, THE POOL and RM 105 read as one stack, the way every other room's do.

Both hunks are away from the `locker` / `prizes` facility block and away from the end of `styles.css`, so the parallel locker wave merges clean. Nothing in `campus.js` was reordered or reformatted.

## Verification

CDP screenshot rig per `CLAUDE.md` §6 (Chrome headless, stub bridge, `?forcemobile=1` for the phone shots), **rect diffs before vs after**, not eyeballs:

| shot | result |
|---|---|
| **1600x900 (16:9)** | **ONE rect changed on the whole plan** — the Pool's pill, +22px onto its own centre line. Every other room, facility, plate, sign, the hall, the tower and the grounds are byte-identical. Desktop 16:9 did not move. |
| **1920x900** | room / name / RM row / pill **all inside** (all but the pill were outside before) |
| **2560x1080** | same — whole plan visible |
| **844x390 phone landscape** | every room rect unchanged; only the plan's own box now hugs the plan it was already letterboxing |
| **390x844 phone portrait** (upright campus) | **IDENTICAL**, rect for rect |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBf8LcaDB642RCq1kCTEeo
