### PR TITLE
fix(arcademy): SORT noise feeds stay in the sorting room

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1133,16 +1133,43 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
   ask again after every reply, MAX_ASKS **per tag** 8, RETRY_MS 1500, batch cap 24.
 - **THE DOOR'S OTHER FOUR VERBS** hang off the same object and are how SORT's setup screen
   draws itself: `catalog()` (the sanitized `init.settings` projection - `remoteCatalog`
-  `[{id,label,subs}]`, `subLibrary` `[{name,ok,videoCount,stillOnly}]`, `localFolders`
+  `[{id,label,subs}]`, `subLibrary` `[{name,ok,videoCount,stillOnly,selected}]`, `localFolders`
   `[{path,gifs,stills,videos}]`, `assetPresets` `[{id,name}]`, plus `remoteConsent`,
-  `remoteMediaEnabled`, `offlineMode`, `mediaSource`), `probeSub(name)` ->
-  `probe-sub {reqId,name}` / `sub-probe {reqId,name,ok,videoCount,stillOnly}`,
+  `remoteMediaEnabled`, `offlineMode`, `mediaSource`), `probeSub(name, {scope, pile})` ->
+  `probe-sub {reqId,name,scope?,pile?}` / `sub-probe {reqId,name,ok,videoCount,stillOnly}`,
   `removeLibrarySub(name)` -> `library-remove {name}`, and `onLibrary(cb)` for the host's
   `library {subLibrary:[...]}` push (which any surface can cause - the Assets tab, the FYP
   popover, another probe). `shell.js` passes the six new init fields into `createAssets`
   beside `settings`; a host that predates them ships nothing and the catalog is simply empty.
   **Neither probe nor library is media**, so they ride `remote.js`'s `sendRaw`/`subscribe`
   rather than the reqId mailbox.
+- **THE SORT SCOPE: A DECOY PILE IS NOT A TASTE** (2026-08-28, tester report - "the noise
+  reddit feeds (cat and pokemon) I added for the sorting room game seem to have followed me
+  through to all the other games"). The LIBRARY (subs the player has KEPT) and the FEED
+  SELECTION (what the app-wide, untagged `claim()` is answered from) are two lists, and the
+  split is the whole point: SORT's door adds to the first and must never add to the second.
+  `probeSub` therefore names the surface - `{scope:'sort', pile:'noise'|'target'}`, both
+  optional, the frame byte-for-byte the old one without them (the Media counter's own add
+  box sends neither).
+  - **The C# host honours it by construction and acts on it nowhere.**
+    `AppSettings.TryAddLibrarySub` never touches `FypOnlineCustomSubs`, and `RemoteChannels()`
+    resolves the app-wide pull from the niches plus that selection alone - so the desktop
+    never leaked. `OnProbeSub` reads `scope`/`pile` and logs one line; a second rule there
+    would be a second place for the same law to drift.
+  - **The web host shim is the one that has to act**, because its library row IS its feed
+    selection (`selected` defaults true on a probe add, and its app-wide sub set is "the
+    picked niches plus every selected library row" - `scripts/arcademy-web-ext/host/provider.js`
+    in the site repo). Until it does, `provider/index.js` **fences the row itself**: on an OK
+    `sort`/`noise` verdict that actually grew the library, and ONLY where
+    `init.settings.mediaControls === true` (the web-only media counter), it posts one
+    `set-setting {key:'media.librarySelect', value:{name, selected:false}}` - the counter's
+    own key, so this parks the sub exactly as un-ticking its box would and the player can
+    tick it back on there. It fires once, at the moment of the add, because the door never
+    re-probes a name the library already holds.
+  - **"The noise turns itself off after the class" is NOT built** (owner may want it). It
+    would hang off `shell/shell.js finishClass` / SORT's own `end`, reaching back into this
+    seam with the pile the class dealt. The fence is the smaller, safer claim: the decoy
+    never got enrolled in the first place.
 - **`engine/index.js` `createEngine(opts)` / `provider/index.js` `createAssets(opts)`** are
   loaded *optionally* (intake's `loadOptional`). Missing or throwing → null object, and the
   class still runs, silent. Never make either a hard import.
@@ -3173,6 +3200,16 @@ probe/library round trip, and `claim()` proven untouched - and `test-setuphook.m
 drives the real shell through the setup door (false -> campus, true/throw/reject -> beginPlay,
 the clock never armed, Esc = the leave confirm, the enrollment intro first) plus the registry /
 campus / lexicon rows. Both are node:test; `run.sh` copies the web root the same way.
+`test-sortscope.mjs` (2026-08-28, 10 cases) is the third half, and its subject is THE SORT
+SCOPE above: it drives the real provider against a fake host shaped like the WEB shim (a
+library row that IS the feed selection) and proves a noise-tagged sub never reaches an
+untagged `claim()` - with the unscoped add kept as the RED control, so the harness is known
+to be able to see the leak. Plus the frame's optional `scope`/`pile`, the target pile left
+alone, the app host never sent a `media.*` key, an already-kept sub never re-parked (the
+settings toggle wins), and `selected` carried through `catalog()`. Three cases in the two
+older files were ALREADY red before this work (`prewarm is capped at 12` predates the
+on-deck rail; the two `test-setuphook.mjs` rows predate SORT's 180s budget and the campus
+side field) and are untouched.
 
 `test-punchcard.mjs` (2026-08-23) is the punch-card half: the store's refusal + self-heal,
 the 96-char cap on every one of the 30 flavour rows AND the 8 rotating card lines AND their

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
@@ -754,7 +754,18 @@ export function createSetupDoor(o) {
 
   function runProbe(name, sideName, fromStarter) {
     let p = null;
-    try { p = assets.probeSub(name); } catch (e) { p = null; }
+    /* THE SCOPE (2026-08-28). This add is the SORTING ROOM's, and the side it
+     * lands on decides what it may become. A `noise` pick is the decoy heap:
+     * the provider keeps it on the library shelf so the door can offer it again
+     * tomorrow, and fences it out of the app-wide feed that every OTHER class's
+     * `claim()` draws from - "the cat and pokemon feeds I added for the sorting
+     * room followed me through to all the other games" is the bug that closes.
+     * A `target` pick is content the player chose, so it is added exactly the
+     * way the Media counter's own box adds one. Both fields are optional and a
+     * provider that predates them ignores them. */
+    try {
+      p = assets.probeSub(name, { scope: 'sort', pile: sideName === 'noise' ? 'noise' : 'target' });
+    } catch (e) { p = null; }
     Promise.resolve(p).then((res) => {
       if (destroyed) return;
       probingStarters.delete(lc(name));

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -22,7 +22,11 @@
  * `claim()` moves; every other class draws exactly the media it drew before.
  * Beside it ride the DOOR's four reads/writes: `catalog()` (the niches, the
  * player's sub library, their local folders and asset presets, projected on
- * init), `probeSub(name)`, `removeLibrarySub(name)` and `onLibrary(cb)`.
+ * init), `probeSub(name, {scope, pile})`, `removeLibrarySub(name)` and
+ * `onLibrary(cb)`. A `{scope:'sort', pile:'noise'}` probe is a DECOY pile pick:
+ * it joins the library and is fenced OUT of the app-wide feed, so it can never
+ * come back to the player through some other class's `claim()` - see THE SORT
+ * SCOPE below.
  *
  * LAWS
  *  - NEVER BLOCK A DRAW. A local candidate is always ready: the C#-supplied
@@ -893,6 +897,12 @@ export function createAssets(options = {}) {
         ok: e && typeof e === 'object' && e.ok != null ? !!e.ok : true,
         videoCount: Math.max(0, (e && e.videoCount) | 0),
         stillOnly: !!(e && e.stillOnly),
+        /* Whether the app-wide feed uses this row right now. The host has always
+         * shipped it (ArcademyHostService BuildSubLibrary, and the web shim's
+         * pushLibrary) and this sanitizer used to DROP it, which is why the door
+         * could not tell an enrolled sub from a parked one. Missing reads as
+         * enrolled, the same default `shell/settings.js cleanLibrary` uses. */
+        selected: e && typeof e === 'object' && e.selected != null ? !!e.selected : true,
       }));
     }
     return out;
@@ -938,6 +948,63 @@ export function createAssets(options = {}) {
   const PROBE_TIMEOUT_MS = 15000;    // a probe is a network round trip on the HOST
   const LIBRARY_ECHO_MS = 4000;      // how long a remove waits for the host's push
 
+  /* ==========================================================================
+   * THE SORT SCOPE (2026-08-28). Tester report: "the noise reddit feeds (cat
+   * and pokemon) I added for the sorting room game seem to have followed me
+   * through to all the other games".
+   *
+   * A sub picked at SORT's setup door is a PILE, not a taste. It belongs in the
+   * player's library - the door has to be able to offer it again tomorrow, and
+   * the X on its pill is the one way off - but the NOISE pile is the decoy
+   * heap, and a decoy heap has no business in the media every OTHER class
+   * draws. `claim()` names no subs (trap 54: that ask is byte-for-byte what it
+   * always was), so the host answers it from whatever it considers ENROLLED and
+   * the page cannot filter the leak out downstream. The only honest place to
+   * say so is the moment the sub is ADDED.
+   *
+   * Two halves, deliberately unequal, because the two hosts already differ:
+   *  - `scope`/`pile` ride the `probe-sub` frame. The C# host honours it BY
+   *    CONSTRUCTION - `AppSettings.TryAddLibrarySub` never touches
+   *    `FypOnlineCustomSubs`, the app-wide feed selection - so on the desktop
+   *    this is the contract catching up with the behaviour, and the host logs
+   *    it rather than acting on it.
+   *  - THE FENCE, for the WEB host, whose library row IS its feed selection: a
+   *    probe add there defaults `selected:true` and its app-wide sub set is
+   *    "the picked niches plus every selected library row", which is exactly
+   *    the leak. Where the media counter exists (`init.settings.mediaControls
+   *    === true`, the web-only flag - see settings.js MEDIA_KEYS) the page
+   *    posts ONE `media.librarySelect {name, selected:false}` for the row it
+   *    just caused. That key is the counter's own, so this parks the sub
+   *    exactly as un-ticking its box would, and the player can tick it back on
+   *    there whenever they like: nothing here ever un-ticks it twice, because
+   *    the door only probes a name the library does NOT already hold.
+   *
+   * NOT built, on purpose: "the noise turns itself off after the class". That
+   * would hang off `shell.js finishClass` (or SORT's own `end`) reaching back
+   * into this seam for the pile it dealt - the owner may want it, and the pile
+   * is knowable there. This fence is the smaller claim: it never got enrolled.
+   * ======================================================================= */
+  const mediaCounter = pickFirst(opts.mediaControls, bag.mediaControls) === true;
+  /** Lower-cased names this page asked for as a SORT noise pile. */
+  const sortNoiseScoped = new Set();
+
+  /**
+   * Park a library row so the app-wide feed does not draw it. A no-op on any
+   * host without the media counter - the C# host has no such key, and needs
+   * none. Returns whether the frame actually left.
+   */
+  function unenrolSub(name) {
+    if (!mediaCounter || !opts.bridge || disposed) return false;
+    const ok = channel.sendRaw('set-setting', {
+      key: 'media.librarySelect',
+      value: { name, selected: false },
+    });
+    log(ok
+      ? 'sort noise: r/' + name + ' kept out of the app-wide feed'
+      : 'sort noise: could not park r/' + name);
+    return ok;
+  }
+
   function emitLibrary() {
     const view = subLibrary.slice();
     for (const fn of [...libraryCbs]) { try { fn(view); } catch { /* a bad listener never kills the seam */ } }
@@ -969,9 +1036,15 @@ export function createAssets(options = {}) {
      * pushing the fresh list; folding it in here as well means the door can act
      * on the verdict without waiting for a second frame. */
     if (row.ok && !subLibrary.some((s) => s.name.toLowerCase() === row.name.toLowerCase())) {
-      subLibrary = subLibrary.concat([Object.freeze(row)]);
+      /* THE FENCE (see THE SORT SCOPE above). This add is the door's, and it is
+       * the noise pile: park it before the row is ever published, so no reader
+       * of the library sees an enrolled decoy even for a frame. */
+      const noise = sortNoiseScoped.has(row.name.toLowerCase());
+      if (noise) unenrolSub(row.name);
+      subLibrary = subLibrary.concat([Object.freeze(Object.assign({ selected: !noise }, row))]);
       emitLibrary();
     }
+    sortNoiseScoped.delete(row.name.toLowerCase());
     rec.resolve(row);
   }
 
@@ -1501,23 +1574,42 @@ export function createAssets(options = {}) {
      * Ask the host to verify a sub. NEVER rejects: a silent host resolves
      * `{ok:false, timeout:true}` after PROBE_TIMEOUT_MS, which the door shows as
      * "not found" - a spinner that never stops is worse than a wrong no.
+     *
+     * `opts2.scope` names the SURFACE that is adding it and `opts2.pile` the
+     * side it is being added to (SORT's door sends `{scope:'sort', pile:'noise'
+     * |'target'}`). Both are OPTIONAL and the frame stays byte-for-byte the old
+     * one without them - the Media counter's own add box sends neither. A
+     * `sort`/`noise` add is fenced out of the app-wide feed; see THE SORT SCOPE.
      */
-    probeSub(name) {
+    probeSub(name, opts2) {
       const clean = String(name == null ? '' : name).trim();
       if (!clean) return Promise.resolve({ name: '', ok: false, videoCount: 0, stillOnly: false });
       if (!opts.bridge || disposed) {
         return Promise.resolve({ name: clean, ok: false, videoCount: 0, stillOnly: false, offline: true });
       }
+      const o2 = (opts2 && typeof opts2 === 'object') ? opts2 : {};
+      const scope = typeof o2.scope === 'string' ? o2.scope : '';
+      const pile = typeof o2.pile === 'string' ? o2.pile : '';
+      const key = clean.toLowerCase();
+      /* Latched BEFORE the round trip: the verdict lands in onSubProbeFrame,
+       * which is the one place the fence is spent - and the only place that
+       * knows whether the library actually grew. */
+      if (scope === 'sort' && pile === 'noise') sortNoiseScoped.add(key);
       probeSeq += 1;
       const reqId = 'ae-probe-' + probeSeq + '-' + Math.floor(Date.now() % 1e7);
+      const frame = { reqId, name: clean };
+      if (scope) frame.scope = scope;
+      if (pile) frame.pile = pile;
       return new Promise((resolve) => {
         const timer = setTimeout(() => {
           probes.delete(reqId);
+          sortNoiseScoped.delete(key);
           resolve({ name: clean, ok: false, videoCount: 0, stillOnly: false, timeout: true });
         }, PROBE_TIMEOUT_MS);
         probes.set(reqId, { name: clean, resolve, timer });
-        if (!channel.sendRaw('probe-sub', { reqId, name: clean })) {
+        if (!channel.sendRaw('probe-sub', frame)) {
           probes.delete(reqId);
+          sortNoiseScoped.delete(key);
           try { clearTimeout(timer); } catch { /* noop */ }
           resolve({ name: clean, ok: false, videoCount: 0, stillOnly: false, offline: true });
         }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -4686,6 +4686,10 @@ internal static class ArcademyHostService
 
     private static readonly HashSet<string> ProbesInFlight = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>One line a session about the probe frame's optional scope, the way
+    /// <c>_nichesIgnoredLogged</c> guards the assets-request one.</summary>
+    private static bool _probeScopeLogged;
+
     /// <summary>
     /// The SORT door's search box: is r/&lt;name&gt; real, and how much video does it hold. Same
     /// upstream question the two shipped pickers ask (<c>FypHostService.ProbeCustomSub</c>), with
@@ -4694,6 +4698,15 @@ internal static class ArcademyHostService
     ///
     /// <para>It never touches <c>FypOnlineCustomSubs</c>: noise the player picked to sort against
     /// must not start flashing on their desktop. That split is the whole point of the library.</para>
+    ///
+    /// <para>THE SCOPE (2026-08-28). The frame may carry <c>scope</c> (the surface making the add -
+    /// SORT's door sends <c>"sort"</c>) and <c>pile</c> (<c>"noise"</c> | <c>"target"</c>). Both are
+    /// OPTIONAL and this host acts on NEITHER, deliberately: the law above already holds for every
+    /// add, whatever surface made it, so honouring a scope here would be a second way of saying the
+    /// same thing and a second place for it to drift. They are read and logged so the contract is
+    /// visible on both sides - the web host shim, whose library row IS its feed selection, is the
+    /// one that has to act on them (a decoy pile enrolled there followed the player into every
+    /// other class, tester report 2026-08-28).</para>
     ///
     /// <para>BRIGHT LINE, as everywhere on this path: the probe goes straight from this machine to
     /// the provider. Nothing routes through CC Labs infrastructure.</para>
@@ -4707,6 +4720,17 @@ internal static class ArcademyHostService
         {
             PostSubProbe(reqId, (raw ?? "").Trim(), false, null, "invalid");
             return;
+        }
+
+        // Read, logged once, acted on nowhere - see the scope paragraph above.
+        var scope = ((string?)o["scope"] ?? "").Trim();
+        var pile = ((string?)o["pile"] ?? "").Trim();
+        if (scope.Length > 0 && !_probeScopeLogged)
+        {
+            _probeScopeLogged = true;
+            App.Logger?.Information(
+                "ArcademyHost: probe-sub carried scope '{Scope}' / pile '{Pile}' - the library add never "
+                + "enrols a sub in the app-wide feed on this host, so there is nothing to honour", scope, pile);
         }
 
         var s = App.Settings?.Current;


### PR DESCRIPTION
Mort (web/phone, 2026-08-28):

> the 'noise' reddit feeds (cat and pokemon) I added for the sorting room game seem to have followed me through to all the other games, and there's no way of turning them off. they're not listed on the set up screen when you first open the Arcademy ... found them in settings so there is a way to turn them off - would be good if they turned themselves off after the relevant game though.

## The leak

Two lists, and they are not the same list:

- **the LIBRARY** - subs the player has KEPT, on any surface (Assets tab, FYP popover, SORT's door). A shelf.
- **the FEED SELECTION** - what the app-wide, *untagged* `claim()` that every other class makes is answered from.

SORT's setup door is only ever allowed to write the first. It had no way to say so.

`provider/index.js probeSub()` sent a bare `probe-sub {reqId, name}`, so no host could tell a *sorting room decoy pile* add from a *the player wants this everywhere* add:

- `Resources/web/arcademy/provider/index.js:1574` (pre-fix) - the frame, with no scope
- `Resources/web/arcademy/games/sort/setup.js:757` (pre-fix) - the door's one probe site, calling it that way

On the **desktop** that was harmless, because the C# host honours the split by construction: `AppSettings.TryAddLibrarySub` never touches `FypOnlineCustomSubs` (`Models/AppSettings.cs:3553`) and `ArcademyHostService.RemoteChannels()` resolves the app-wide pull from the niches plus that selection alone. The header on `OnProbeSub` already spells the law out: *"noise the player picked to sort against must not start flashing on their desktop"*.

On the **web** it is the bug Mort hit. The browser shim's library row **is** its feed selection - `cclabs-web scripts/arcademy-web-ext/host/provider.js`:

- `:842-845` - an OK probe verdict appends `{name, ok:true, ..., selected: true}`
- `:604` - `appWideSubs()` = the picked niches **plus every selected library row**

So every sub the SORT door verified was enrolled in the pull that dresses Instant Recall, Lost & Found, Deja Vu and the rest. The lobby's niche picker only lists catalogue niches, which is why they were invisible there; Settings -> Media -> "Subs on your list" was the only place they showed, which is where Mort found them.

`claim()` names no subs (trap 54 - that ask is byte-for-byte what it has always been) and the app-wide reply carries no `src` on either host, so the page cannot filter the leak out downstream. It has to be said at the moment the sub is **added**.

## The fix

- **`provider/index.js`** - `probeSub(name, {scope, pile})`. Both optional; without them the frame is byte-for-byte the old one, so the Media counter's own add box (`shell/settings.js:1346`) is untouched.
  - **THE FENCE.** On an OK `sort`/`noise` verdict that actually grew the library, and **only** where `init.settings.mediaControls === true` (the web-only media counter), the page posts one `set-setting {key:'media.librarySelect', value:{name, selected:false}}`. That is the counter's own key, so this parks the sub exactly as un-ticking its box would - **the settings toggle keeps working**, and nothing ever un-ticks it twice, because the door never re-probes a name the library already holds.
  - `sanitizeLibrary` now carries `selected` through instead of dropping it (the host has always shipped it).
- **`games/sort/setup.js`** - the door's one probe site sends `{scope:'sort', pile:'noise'|'target'}`. A **target** pick is content the player chose, so it is added exactly as the Media counter would add it; only the decoy heap is fenced.
- **`Services/Arcademy/ArcademyHostService.cs`** - reads `scope`/`pile`, logs one line a session, acts on neither **on purpose**: the law already holds for every add on this host, and a second rule there would be a second place for it to drift. Parity is a fact, not a new code path.
- **`Resources/web/arcademy/CLAUDE.md`** - THE SORT SCOPE, under §3's cross-agent seams.

### Follow-up for the web repo (not this PR)

`cclabs-web scripts/arcademy-web-ext/host/provider.js` should honour the scope at source - `selected: !(scope === 'sort' && pile === 'noise')` on the probe add - and then the page-side fence becomes belt to its braces. Until then the fence is what actually fixes it for web players, with no site deploy.

### Deliberately NOT built

"The noise turns itself off after the class" (Mort's own suggestion, owner may want it). It would hang off `shell/shell.js finishClass` / SORT's own `end`, reaching back into this seam with the pile the class dealt. This PR makes the smaller, safer claim: the decoy never got enrolled in the first place.

**Subs added before this change stay enrolled** until the player unticks them once in Settings -> Media (Mort already has). Nothing here retro-parks a row the player may since have ticked on deliberately.

## Tests

`scratchpad/suite-p/test-sortscope.mjs`, **10 new cases**, node:test driving the REAL `provider/index.js` against a fake host shaped like the web shim (library row = feed selection):

- **`A NOISE SUB NEVER APPEARS IN AN UNTAGGED CLAIM`** - the headline, and the RED control beside it (`...and without the fence it does leak`) proves the harness can see the leak at all
- SORT itself still deals the pile it picked from `claimTagged`
- a `target` pick is not parked; the app host is never sent a `media.*` key
- an already-kept sub is never re-parked (the settings toggle wins); a not-found verdict parks nothing and leaves no latch
- the frame's optional `scope`/`pile`, and `selected` carried through `catalog()`

Verified **red before / green after**: swapping `HEAD`'s `provider/index.js` under the same suite fails 4 of the 10.

**Runs:**

- `test-sortscope.mjs` - **10/10 pass**
- `test-tagged.mjs` - 25/26 (`prewarm is capped at 12 per tag` was ALREADY red on `origin/main`; it predates the on-deck rail rework)
- `test-setuphook.mjs` - 10/12 (both failures ALREADY red on `origin/main`; they predate SORT's 180s budget and the campus side field)
- `dotnet build` - **0 errors**, 344 pre-existing warnings

Not touched: `styles.css`, `campus.js`, `shell.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBf8LcaDB642RCq1kCTEeo
