### PR TITLE
perf(arcademy): phone fx diet - still plates for fullscreen gifs and spiral washes, one video decoder per phone

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -3039,6 +3039,29 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     { right:170px }`). The general case is OPEN - it belongs to the widget, not to the
     campus chrome.
 
+134. **AN ANIMATED GIF THAT COVERS THE STAGE IS THE ONE NODE A PHONE CANNOT PAY FOR (measured
+    2026-08-28).** Blink decodes every gif frame on the renderer main thread and then re-rasters
+    every device pixel the image covers, per frame advance; at DPR 3 the 150vmax spiral square is
+    ~14 Mpx and a full-bleed burst ~3 Mpx, PER FRAME. The 4x-throttled phone rig put ONE bundled
+    spiral gif painted as a url-string wash at 3.1s of GPU-process time per 8s (the CSS conic or
+    the live loom: 23-126ms), and Instant Recall at 33fps with three 500px spiral gifs animating
+    behind a SPIRAL question. The half-size-box-under-`transform:scale(2)` trick does NOT help
+    (Chrome rasters at the ideal scale). The cure is THE STILL PLATE (`engine/util.js plateEl`):
+    the gif's first frame drawn once into a small canvas (long side 640) that the stylesheet
+    stretches over the element, with an optional compositor-only spin (`.ae-wash-plate-spin`,
+    worn only while the hold is live and never under reduced motion). It is read by the touch
+    rung only - `sustained.js paintUrl` for a url-string spiral wash (IR gif-ring decoys, the
+    WebGL-lost floor), `oneshots.js` for a full-bleed .gif burst, `instant-recall/spirals.js
+    spiralStillThumb` for the SPIRAL option faces - and gates on `html.ae-touch` /
+    `ctx.platform.isTouch`, never UA. Desktop keeps the animated gif byte for byte (digest-
+    verified). Two rules that fall out of it: a url-string wash on touch must go through
+    `paintUrl`, never write `backgroundImage` itself (the plate would be orphaned under it);
+    and `plateMount` is idempotent per url because the decks re-trigger a held wash several
+    times a second and a re-decode per trigger is the bug it exists to cure. The related
+    decoder caps: `MONTAGE.VIDEO_TILE_CAP_TOUCH = 1` (two playing tiles measured p95 33ms, the
+    30Hz lock) and `PLAYTEST.VIDEO_TILE_CAP_TOUCH = 1` in Lost and Found (the LITE four were
+    EIGHT playing players with the wrap reps).
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -62,7 +62,7 @@ import {
   NODE_CAPS, DUCK, subFlashSpec, glitchSpec, gifBurstSpec,
   burstCountForHeat, burstOpacityForHeat,
 } from './curves.js';
-import { rand, pickFrom, hasDom, mediaEl, budgetedKind, isVideoUrl } from './util.js';
+import { rand, pickFrom, hasDom, mediaEl, budgetedKind, isVideoUrl, isGifUrl, plateEl } from './util.js';
 import { createEscapeGuard } from './escape.js';
 
 /** The ceiling on a lengthened sub_flash. A word that outlives this stops being
@@ -322,7 +322,17 @@ export function createOneshots(ctx) {
       }
       // mediaEl: <img>, or a muted looping <video> when the pool handed us a
       // webm/mp4 loop (the only animated shape a remote provider has)
-      const node = (url && mediaEl(url)) || document.createElement('div');
+      /* THE STILL PLATE (phone fx diet, measured 2026-08-28; util.js plateEl):
+       * a full-bleed GIF on touch is the plate of its first frame. touchStill
+       * pins the pool draw to a still, but an explicit opts.url, and a gif the
+       * still pool itself hands out (the mobile host's still pool and the web
+       * host's IMAGE_RE both admit .gif), still covered the stage with an
+       * animated <img>: ~3 Mpx re-rastered per gif frame, 700ms GPU + 340ms
+       * decode per 8s on the phone profile. A video keeps mediaEl (the
+       * decoder budget already owns it); a jpg/webp/png still is one raster
+       * and keeps its full resolution as an <img>. Desktop never comes here. */
+      const node = (url && (touchStill && isGifUrl(url) ? plateEl(url) : mediaEl(url)))
+        || document.createElement('div');
       node.className = 'ae-burst ae-burst-' + variant.name + (clickable ? ' ae-burst-clickable' : '')
         + (fullBleed ? ' ae-burst-cover' : '');
       node.style.setProperty('--ae-x', (atX == null ? Math.round(rand(ctx.rng, 12, 88)) : atX) + '%');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -269,6 +269,18 @@ img.ae-sub{width:min(38vw,38vh);aspect-ratio:1;object-fit:cover;border-radius:10
 .ae-touch .ae-glitch-rgbsplit{filter:none}
 .ae-touch .ae-glitch-vhsroll{animation:ae-shudder var(--ae-dur,600ms) steps(2,end) 1}
 .ae-touch .ae-burst{box-shadow:none}
+/* THE STILL PLATE (phone fx diet, measured 2026-08-28; util.js plateEl). On
+   touch a url-string spiral wash and a full-bleed gif burst paint the gif's
+   FIRST FRAME into a small canvas instead of running the animated gif, which
+   decoded every frame on the main thread and re-rastered every covered device
+   pixel per frame advance (3.1s of GPU per 8s for one bundled spiral). The
+   wash plate fills its element (the 150vmax square, held still by the rule
+   above) and takes over the slow spin the CSS conic gives up here: a transform
+   on the canvas is compositor-only - no decode, no raster - and it is only
+   worn while the hold is live (sustained.js plateActive), never parked at 0.
+   No will-change: the animation promotes on demand, like the wash opacity. */
+.ae-touch .ae-wash-plate{position:absolute;inset:0;width:100%;height:100%;display:block;object-fit:cover;pointer-events:none}
+.ae-touch .ae-wash-plate-spin{animation:ae-spin 18s linear infinite}
 /* .ae-mote stays animated on touch ON PURPOSE: ae-float is transform-only
    (compositor-cheap, no re-raster), and the phone cost of the ambient field is
    its NODE COUNT, which the lite ladder now caps (curves.js ambientLite). */
@@ -277,7 +289,7 @@ img.ae-sub{width:min(38vw,38vh);aspect-ratio:1;object-fit:cover;border-radius:10
 @media (prefers-reduced-motion: reduce){
   .ae-layer *{animation-duration:.01ms !important;animation-iteration-count:1 !important;
     transition-duration:.12s !important}
-  .ae-wash-spiral,.ae-crt-live,.ae-mote,.ae-drift-breathe{animation:none !important}
+  .ae-wash-spiral,.ae-wash-plate,.ae-crt-live,.ae-mote,.ae-drift-breathe{animation:none !important}
   .ae-sub,.ae-burst,.ae-rain,.ae-bubble,.ae-stamp{animation:none !important;opacity:var(--ae-alpha,.5) !important}
   /* the seep's animated tells are already retired at the director; this is the
      brace that survives a director nobody wired */

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -41,7 +41,7 @@
 
 import { clamp01 } from '../core/caps.js';
 import { NODE_CAPS, washSpec, gifRainSpec, ambientSpec, driftSpec, bubbleSpec } from './curves.js';
-import { rand, hasDom, mediaEl, budgetedKind, isVideoUrl } from './util.js';
+import { rand, hasDom, mediaEl, budgetedKind, isVideoUrl, plateEl } from './util.js';
 import { createEscapeGuard } from './escape.js';
 import { createLoomWash } from './loomWash.js';
 
@@ -103,7 +103,7 @@ export function createSustained(ctx) {
         if (oldKind != null) {
           const o = washHolds.get(oldKind);
           if (o.hideTimer) { ctx.timers.cancel(o.hideTimer); o.hideTimer = 0; }
-          loomDrop(o);
+          loomDrop(o); plateDrop(o);
           ctx.timers.release(o.el);
           washHolds.delete(oldKind);
         }
@@ -128,6 +128,7 @@ export function createSustained(ctx) {
    *  the wrapper's id while the canvas is live, the fallback gif url when the
    *  WebGL floor caught it, or null (the CSS conic kept the element). */
   function loomMount(h, wrap) {
+    plateDrop(h);   // the loom canvas and the still plate never share an element
     try {
       if (!h.loom) h.loom = createLoomWash({ log: ctx.log });
       if (h.loom.supported()) {
@@ -139,7 +140,7 @@ export function createSustained(ctx) {
            * every NEXT trigger answers the gif url, honestly.) */
           onLost: () => {
             try {
-              if (wrap.href) h.el.style.backgroundImage = 'url("' + wrap.href + '")';
+              if (wrap.href) paintUrl(h, String(wrap.href));
             } catch (e) { /* ignore */ }
           },
         });
@@ -152,7 +153,7 @@ export function createSustained(ctx) {
     // THE FLOOR: no WebGL -> the bundled gif IS what is shown, so it IS the answer.
     loomDrop(h);
     if (wrap.href && typeof wrap.href === 'string') {
-      h.el.style.backgroundImage = 'url("' + wrap.href + '")';
+      paintUrl(h, wrap.href);
       return String(wrap.href);
     }
     return null;
@@ -160,11 +161,67 @@ export function createSustained(ctx) {
   /** Tear the loom canvas off a hold entirely (a url string took the element,
    *  or the hold is being released). Safe on a hold that never had one. */
   function loomDrop(h) {
-    if (h && h.loom) { try { h.loom.dispose(); } catch (e) { /* ignore */ } h.loom = null; }
+    if (h && h.loom) {
+      try { h.loom.dispose(); } catch (e) { /* ignore */ }
+      h.loom = null;
+      // dispose restored the element's own backing; a standing plate keeps it off
+      if (h.plate && h.el) { try { h.el.style.backgroundImage = 'none'; } catch (e) { /* ignore */ } }
+    }
   }
-  /** The hold's opacity was driven to 0 (or back up): idle the loom's rAF. */
+  /** The hold's opacity was driven to 0 (or back up): idle the loom's rAF
+   *  (and the plate's compositor spin, which rides the same switch). */
   function loomActive(h, on) {
     if (h && h.loom) { try { h.loom.setActive(!!on); } catch (e) { /* ignore */ } }
+    plateActive(h, on);
+  }
+
+  /* ---- the still plate (phone fx diet, measured 2026-08-28; util.js) ------ */
+  /** TOUCH ONLY. A url STRING on a wash - the IR gif-ring decoys, the
+   *  WebGL-lost floor, a desktop user's own spiral gif - used to paint an
+   *  animated gif across the 150vmax square as an UNPROMOTED background (the
+   *  touch rung sets will-change:auto), so every frame advance decoded on the
+   *  main thread and re-rastered the root layer at DPR: 3.1s of GPU per 8s for
+   *  one bundled spiral on the throttled phone profile. The plate is that
+   *  gif's first frame in a small canvas child (plateEl); the element's own
+   *  backing goes to none while it stands, exactly as the loom does.
+   *  Idempotent per url: the decks re-trigger a held wash several times a
+   *  second and must not re-decode. Returns true when the plate took it;
+   *  false on desktop and without a canvas, and the caller paints the
+   *  background-image byte for byte as before. */
+  function plateMount(h, url) {
+    if (!h || !h.el || !touchClass()) return false;
+    if (h.plate && h.plateUrl === url) return true;
+    plateDrop(h);
+    const c = plateEl(url, 'ae-wash-plate', { square: true });
+    if (!c) return false;
+    h.plate = c; h.plateUrl = url;
+    h.el.appendChild(c);
+    h.el.style.backgroundImage = 'none';
+    return true;
+  }
+  function plateDrop(h) {
+    if (!h || !h.plate) return;
+    try { h.plate.remove(); } catch (e) { /* ignore */ }
+    h.plate = null; h.plateUrl = null;
+    try { if (h.el && h.el.style.backgroundImage === 'none') h.el.style.backgroundImage = ''; } catch (e) { /* ignore */ }
+  }
+  /** The plate's slow spin (a transform on the canvas: compositor-only, no
+   *  decode, no raster - measured 0 decode / 0 raster, ~350ms GPU + ~360ms
+   *  main per 6s on the throttled phone profile against a static plate's
+   *  ~idle) rides the hold's activity like the loom's rAF: never while the
+   *  wash is parked at 0, never under reduced motion, and only on the FULL
+   *  motion rung - the motion knob is the phone's way to a still plate. */
+  function plateActive(h, on) {
+    if (!h || !h.plate) return;
+    const spin = !!on && !ctx.reduced() && ctx.motion() >= 2;
+    try { h.plate.classList.toggle('ae-wash-plate-spin', spin); } catch (e) { /* ignore */ }
+  }
+  /** Paint a url string on a hold: the plate on touch, the element's own
+   *  background-image everywhere else (the pre-diet path, unchanged). */
+  function paintUrl(h, url) {
+    if (plateMount(h, url)) return;
+    plateDrop(h);
+    h.el.style.backgroundImage = 'url("' + url + '")';
   }
 
   /**
@@ -233,7 +290,7 @@ export function createSustained(ctx) {
         loomTook = typeof wroteUrl === 'string' && wroteUrl.indexOf('loom:') === 0;
       } else if (url) {
         loomDrop(h);   // a url string takes the element back; no-op when no canvas
-        h.el.style.backgroundImage = 'url("' + url + '")'; wroteUrl = String(url);
+        paintUrl(h, String(url)); wroteUrl = String(url);
       }
     }
     /* Was this wash already on screen? Read BEFORE the opacity is written: it
@@ -242,6 +299,7 @@ export function createSustained(ctx) {
     const wasUp = parseFloat(h.el.style.opacity || '0') > 0.001;
     if (h.hideTimer) { ctx.timers.cancel(h.hideTimer); h.hideTimer = 0; }
     h.el.style.opacity = String(alpha);
+    plateActive(h, true);   // touch plate spin wakes with the wash (no-op elsewhere)
     /* THE HELD WASH. sustainForever HOLDS the element at alpha until a later
        trigger says otherwise. A later trigger that is NOT forever is one of
        two things: a FLARE (a higher alpha - a jackpot's forced garnish, a
@@ -611,7 +669,7 @@ export function createSustained(ctx) {
         h.forever = false; h.heldAlpha = 0;
         h.el.style.opacity = '0';
         loomActive(h, false);
-        if (immediate) { loomDrop(h); ctx.timers.release(h.el); }
+        if (immediate) { loomDrop(h); plateDrop(h); ctx.timers.release(h.el); }
       }
       if (immediate) washHolds.clear();
       return true;

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
@@ -82,6 +82,76 @@ function forgetVideo(node) {
   liveVideos = liveVideos > 0 ? liveVideos - 1 : 0;
 }
 
+/* ---- THE STILL PLATE (phone fx diet, measured 2026-08-28) -----------------
+ * An animated gif that covers the stage is the one node a phone cannot pay
+ * for. Blink decodes every gif frame on the renderer main thread at native
+ * size and then re-rasters every device pixel the image covers, per frame
+ * advance: at DPR 3 a 390x844 stage is ~3 Mpx of raster per gif frame and the
+ * 150vmax spiral square is ~14 Mpx. The 4x-throttled phone profile put one
+ * bundled spiral gif (sp5, 500x375, 60 frames) at 3.1s of GPU-process time per
+ * 8s where the CSS conic or the live loom cost 23-126ms, and a full-bleed gif
+ * burst at 700ms GPU + 340ms decode per 8s. The scale trick (a half-size box
+ * under transform:scale(2)) does NOT help - Chrome rasters at the ideal scale.
+ *
+ * The plate is the one technique that removes BOTH costs: the gif's FIRST
+ * FRAME drawn once into a small canvas (long side PLATE_BACK_LONG, or the
+ * gif's own size when smaller) that the stylesheet stretches over the stage.
+ * No decoder runs, no per-frame raster, one texture. Read by the touch rung
+ * only (sustained.js and oneshots.js branch on html.ae-touch, armed by
+ * core/device.js from the arc-mobile decision); desktop keeps the animated
+ * gif byte for byte. A plate that never loads is a transparent canvas over the
+ * element's own backing - a dimmer wash, never a hole. */
+export const PLATE_BACK_LONG = 640;
+/** A url the plate stands in for: a .gif is decoded frame by frame, still or not. */
+export const GIF_URL_RE = /\.gif(\?|#|$)/i;
+export const isGifUrl = (u) => typeof u === 'string' && GIF_URL_RE.test(u);
+/**
+ * @param {string} url
+ * @param {string} [cls]
+ * @param {{backLong?:number, square?:boolean, onReady?:Function}} [o]
+ *   square: a rotating plate must never bare a corner, so it is cover-cropped
+ *   to a square; otherwise the canvas keeps the image's aspect and the
+ *   stylesheet's object-fit does the covering.
+ * @returns {HTMLCanvasElement|null} null without a DOM (callers fall back to mediaEl)
+ */
+export function plateEl(url, cls, o = {}) {
+  if (!hasDom() || typeof Image !== 'function' || typeof url !== 'string' || !url) return null;
+  let c = null;
+  try {
+    c = document.createElement('canvas');
+    if (!c || typeof c.getContext !== 'function') return null;
+  } catch { return null; }
+  const cap = Math.max(64, (o.backLong | 0) || PLATE_BACK_LONG);
+  const square = o.square === true;
+  c.width = cap; c.height = cap;
+  if (cls) c.className = cls;
+  try { c.__aePlate = true; } catch { /* ignore */ }
+  const src = new Image();
+  try { src.decoding = 'async'; } catch { /* ignore */ }
+  src.onload = () => {
+    try {
+      const nw = src.naturalWidth || cap, nh = src.naturalHeight || cap;
+      const long = Math.min(cap, Math.max(nw, nh));
+      let w, h;
+      if (square) { w = long; h = long; }
+      else if (nw >= nh) { w = long; h = Math.max(1, Math.round(long * nh / nw)); }
+      else { h = long; w = Math.max(1, Math.round(long * nw / nh)); }
+      c.width = w; c.height = h;
+      const g = c.getContext('2d');
+      if (!g) return;
+      // a detached Image draws its FIRST frame; cover so nothing letterboxes
+      const s = Math.max(w / nw, h / nh);
+      const dw = nw * s, dh = nh * s;
+      g.drawImage(src, (w - dw) / 2, (h - dh) / 2, dw, dh);
+      try { c.__aePlateReady = true; } catch { /* ignore */ }
+      if (typeof o.onReady === 'function') o.onReady(c);
+    } catch { /* a plate that cannot draw stays transparent; never a throw */ }
+  };
+  src.src = url;
+  try { c.__aePlateSrc = src; } catch { /* ignore */ }
+  return c;
+}
+
 /** The media node for a pool url: <img> for stills/gifs, a muted, looping,
  *  inline-autoplaying <video> for mp4/webm. Same class, same `src`, same
  *  object-fit rules - callers never branch. Returns null with no DOM; never

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
@@ -1620,7 +1620,18 @@ export default {
       box.setAttribute('aria-hidden', 'true');
       if (kind) box.setAttribute('data-media', kind);
       try {
-        const m = mediaElFor(url);
+        /* THE STILL THUMB (phone fx diet, measured 2026-08-28): a spiral
+         * option's face on touch is the gif's first frame in a small canvas
+         * (spirals.js spiralStillThumb), not the animated <img> - three 500px
+         * gifs decoding behind the question were a third of what held the
+         * phone profile at 33fps. Same seam as the montage's coarse grid
+         * (ctx.platform.isTouch); the loom's data-url thumbs, every other
+         * face, and desktop keep mediaElFor byte for byte. */
+        const touch = !!(ctx.platform && ctx.platform.isTouch);
+        const still = (touch && kind === 'spiral' && typeof url === 'string' && url.indexOf('data:') !== 0
+          && spirals && typeof spirals.spiralStillThumb === 'function')
+          ? spirals.spiralStillThumb(url, 192) : null;
+        const m = still || mediaElFor(url);
         if (m) box.appendChild(m);
       } catch (e) { /* a broken preview is an empty box, never a dead class */ }
       return box;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/montage.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/montage.js
@@ -122,6 +122,12 @@ export const MONTAGE = Object.freeze({
   /** <video>: 2+ playing lock the page to 30Hz. Gifs carry this wall. */
   VIDEO_TILE_CAP: 4,
   VIDEO_TILE_CAP_LITE: 2,
+  /** Touch (phone fx diet, measured 2026-08-28): the LITE two held the
+   *  4x-throttled phone profile at p95 33ms - the 30Hz lock, in the numbers -
+   *  and a phone gets ONE decoration decoder everywhere else in the school
+   *  (engine VIDEO_BUDGET_TOUCH). Read on `coarse`, the same seam the grid
+   *  solves on; desktop keeps its two rungs untouched. */
+  VIDEO_TILE_CAP_TOUCH: 1,
 
   /** THE DWELL: how long a tile holds a face, band 0 (cold) -> band 1 (dense).
    *  Reduced motion gets a longer, plainer beat and never a live loop. */
@@ -466,7 +472,7 @@ export function createMontage(o = {}) {
       Math.max(MONTAGE.LIVE_LOOP_MIN, Math.round(count * MONTAGE.LIVE_LOOP_SHARE)),
     ));
   const videoCap = Math.max(0, Math.min(
-    lite ? MONTAGE.VIDEO_TILE_CAP_LITE : MONTAGE.VIDEO_TILE_CAP,
+    coarse ? MONTAGE.VIDEO_TILE_CAP_TOUCH : (lite ? MONTAGE.VIDEO_TILE_CAP_LITE : MONTAGE.VIDEO_TILE_CAP),
     liveCap,
   ));
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/spirals.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/spirals.js
@@ -246,6 +246,42 @@ export function preloadSpirals(urls) {
   return n;
 }
 
+/**
+ * THE STILL THUMB (phone fx diet, measured 2026-08-28). A spiral option's
+ * preview face on touch: the gif's FIRST FRAME drawn once into a small square
+ * canvas, in place of the animated <img> the montage mints. Three 500px spiral
+ * gifs decoding behind a SPIRAL question (frame by frame, on the main thread)
+ * were a third of what held the 4x-throttled phone profile at 33fps in this
+ * class; a still face reads the same spiral - the answer is the shape, not the
+ * motion. Desktop and the loom's data-url thumbs never come here.
+ * @param {string} url
+ * @param {number} [size=192]  canvas backing in px (a face is ~96-160 css px)
+ * @returns {HTMLCanvasElement|null} null without a DOM; the caller keeps its <img>
+ */
+export function spiralStillThumb(url, size = 192) {
+  if (typeof document === 'undefined' || typeof Image !== 'function') return null;
+  if (typeof url !== 'string' || !url) return null;
+  try {
+    const c = document.createElement('canvas');
+    if (!c || typeof c.getContext !== 'function') return null;
+    const s = Math.max(32, size | 0);
+    c.width = s; c.height = s; c.className = 'g-ir-media';
+    const img = new Image();
+    try { img.decoding = 'async'; } catch (e) { /* not everywhere */ }
+    img.onload = () => {
+      try {
+        const g = c.getContext('2d');
+        if (!g) return;
+        const nw = img.naturalWidth || s, nh = img.naturalHeight || s;
+        const k = Math.max(s / nw, s / nh);   // cover, centred - a detached Image draws frame 1
+        g.drawImage(img, (s - nw * k) / 2, (s - nh * k) / 2, nw * k, nh * k);
+      } catch (e) { /* a blank face, never a dead class */ }
+    };
+    img.src = url;
+    return c;
+  } catch (e) { return null; }
+}
+
 /* ============================================================================
  * THE GENERATED-LOOM HELPERS (2026-08-25)
  * ==========================================================================*/
@@ -354,6 +390,6 @@ export function loomThumbDataUrl(params, size = 96) {
 }
 
 export default {
-  SPIRAL_KIN, kinOf, buildSpiralSet, spiralDecoys, preloadSpirals,
+  SPIRAL_KIN, kinOf, buildSpiralSet, spiralDecoys, preloadSpirals, spiralStillThumb,
   loomRowsOf, loomDecoyParams, loomThumbDataUrl,
 };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
@@ -243,6 +243,7 @@ export function signaturePool(rng) {
  * @param {Function} o.rng          the class's seeded rng
  * @param {number} o.drift          0..1 drift dial (period only - see header)
  * @param {boolean} o.lite          coarse pointer / low quality tier
+ * @param {boolean} o.touch         a phone (ctx.platform.isTouch / coarse probe): one video url
  * @param {boolean} o.reduced       reduced motion
  * @param {Function} o.onTileClick  (tile, event) => void
  * @param {Function=} o.onTileHover (tile, event) => void - THE HOVER TELL. The
@@ -257,6 +258,7 @@ export function createBoard(o) {
   const density = Math.max(4, opts.density | 0);
   const reduced = !!opts.reduced;
   const lite = !!opts.lite;
+  const touch = !!opts.touch;
   const say = typeof opts.log === 'function' ? opts.log : () => {};
 
   const mosaic = el('div', 'g-lf-mosaic');
@@ -337,7 +339,7 @@ export function createBoard(o) {
    *  scarcer page resource than an image decoder, and the wrap clones are real
    *  players too. (The 0821 "40% of density" rule shipped ~156 of them.) */
   const videoCap = Math.max(0, Math.min(
-    lite ? PLAYTEST.VIDEO_TILE_CAP_LITE : PLAYTEST.VIDEO_TILE_CAP,
+    touch ? PLAYTEST.VIDEO_TILE_CAP_TOUCH : (lite ? PLAYTEST.VIDEO_TILE_CAP_LITE : PLAYTEST.VIDEO_TILE_CAP),
     Math.floor(PLAYTEST.VIDEO_ELEMENT_CEIL / maxReps),
     liveCap,
   ));

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
@@ -144,6 +144,12 @@ export const PLAYTEST = Object.freeze({
    *  almost never reaches them (gifs win the draw). */
   VIDEO_TILE_CAP: 6,
   VIDEO_TILE_CAP_LITE: 4,
+  /** Touch (phone fx diet, measured 2026-08-28): the LITE four became EIGHT
+   *  playing <video> elements on the phone profile (x2 wrap reps), against an
+   *  iOS hardware-decode ceiling of three or four sessions and the school's
+   *  one-decoder rule for a phone (engine VIDEO_BUDGET_TOUCH). One distinct
+   *  url = two players with the wrap. Gifs keep the LITE live cap. */
+  VIDEO_TILE_CAP_TOUCH: 1,
   /** Simultaneous <video> ELEMENTS, wrap clones included. Chromium's per-page
    *  media-player budget is the wall we hit; stay well under it. */
   VIDEO_ELEMENT_CEIL: 32,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -1633,7 +1633,7 @@ export default {
         });
         board = createBoard({
           mount: hud.view, density, rng, drift: dials.drift,
-          lite: coarse, reduced, log: say, onTileClick, onTileHover,
+          lite: coarse, touch, reduced, log: say, onTileClick, onTileHover,
         });
         // Somebody has to be the target before any media exists, so the class is
         // playable even if the provider never answers.


### PR DESCRIPTION
## Why

Owner report (2026-08-28): on the phone (app.cclabs.app/arcademy in a mobile browser, and the vendored copy in the CCP-Mobile WebView) the fullscreen gifs and the spirals slow everything down.

Measured, not guessed. Rig: headless Chrome over raw CDP, 390x844 @ DPR 3, touch emulation, CPU throttle 4x, `?forcemobile=1`, 8s trace samples (renderer main / compositor / GPU-process main busy ms, decode, raster, draw frames, layers, network bytes) plus a 14s scripted play of all ten classes with the same instrumentation. The desktop profile (1600x900 @ DPR 1, no throttle, no forcemobile) ran the same matrix as the control.

**The finding.** An animated gif that covers the stage is the one node a phone cannot pay for: Blink decodes every gif frame on the renderer main thread at native size and then re-rasters every device pixel the image covers, per frame advance. At DPR 3 the 150vmax spiral square is ~14 Mpx and a full-bleed burst ~3 Mpx, PER FRAME. One bundled spiral gif (sp5.gif, 500x375, 60 frames, 5.3 MB) painted as a url-string wash cost **3147 ms of GPU-process time per 8.6 s** where the CSS conic cost 23 ms and the live loom 126 ms. A full-bleed gif burst: 700 ms GPU + 342 ms decode. Instant Recall ran at **32.7 fps (p95 50 ms)** with three 500px spiral gifs animating behind a SPIRAL question and two montage `<video>`s (the 30Hz lock). Lost and Found had **8 playing `<video>` elements** on a phone (LITE cap 4 x 2 wrap reps) against an iOS ceiling of three or four hardware decode sessions. The half-size-box-under-`transform:scale(2)` trick was tried and does NOT help (Chrome rasters at the ideal scale).

## What

**THE STILL PLATE** (`engine/util.js plateEl`): the gif's first frame drawn once into a small canvas (long side 640, or the gif's own size when smaller) that the stylesheet stretches over the element. No decoder runs, no per-frame raster, one texture. The cut is graceful: the spiral still reads as a spiral wash (first frame, alpha unchanged) and keeps a slow compositor-only spin; a fullscreen gif is still a fullscreen image with the same fade.

Touch rung only. Every branch reads `html.ae-touch` (armed by `core/device.js` from the `arc-mobile` decision; `?forcemobile=1/0` honoured) or `ctx.platform.isTouch` (the montage's existing coarse seam), never UA. The spin additionally honours `reducedMotion` and the motion knob (FULL rung only).

- `engine/sustained.js`: a url-string spiral wash (IR gif-ring decoys, the WebGL-lost floor, a user's own spiral gif) goes through `paintUrl -> plateMount` on touch, idempotent per url (the decks re-trigger a held wash several times a second); `plateActive` toggles `.ae-wash-plate-spin` with the hold, like the loom's rAF; `plateDrop` on eviction and immediate stop; the loom canvas and the plate never share an element.
- `engine/oneshots.js`: a full-bleed `.gif` burst on touch is the plate (`touchStill` already pinned the pool draw to a still, but an explicit `opts.url` or a gif the still pool hands out still covered the stage with an animated `<img>`). Video keeps `mediaEl`; jpg/webp/png stills keep their `<img>` at full resolution.
- `engine/style.js`: `.ae-touch .ae-wash-plate` / `.ae-wash-plate-spin` (18s, no `will-change`, promoted on demand); the plate joins the reduced-motion `animation:none` list.
- `games/instant-recall/montage.js`: `MONTAGE.VIDEO_TILE_CAP_TOUCH = 1` read on `coarse` (LITE 2 = the 30Hz lock, measured p95 33.5 ms).
- `games/instant-recall/index.js` + `spirals.js`: SPIRAL option faces on touch are first-frame canvas thumbs (`spiralStillThumb`, 192px) instead of animated gif `<img>`s; loom data-url thumbs and every other face untouched.
- `games/lost-and-found/constants.js` + `board.js` + `index.js`: `PLAYTEST.VIDEO_TILE_CAP_TOUCH = 1` via a new board `touch` option (one url = two players with the wrap).
- `Resources/web/arcademy/CLAUDE.md`: trap 134.

Not cut: corner gif bursts (`gif_burst` without `fullBleed`) and `gif_rain` gifs keep animating on touch (measured ~800-900 ms GPU per 8 s each, mostly decode; they are the visible "gif pops" and the diet did not need them). The Deep End's own animated gif tiles and CSS filters, Echo's main-thread saturation, and the remaining game-minted `<video>` sites (anomaly, composure, deja-vu, echo, IC, sort) are noted below, not touched.

## Numbers (same rig before and after)

Run-to-run noise on this rig is real: untouched classes moved by 5-10 fps between the before and after play runs (anomaly 49 -> 60, echo 24 -> 30, IC 48 -> 59). Read the structural counters (decode ms, raster ms, playing videos, canvases) as the proof and the fps as the direction.

### Phone (390x844 @ DPR 3, touch, CPU 4x) isolated engine scenarios, 8s samples (before -> after)

| scn | fps | p95 ms | frames >32ms | long tasks | renderer main ms | compositor ms | GPU main ms | decode ms | raster ms | draw frames | net KB | census after |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| idle | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 987 -> 1272 | 99 -> 114 | 84 -> 100 | 0 -> 0 | 1 -> 0 | 1 -> 1 | 250 -> 259 | canv -; vids 0; gif imgs - |
| spiral-loom | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 1464 -> 1591 | 169 -> 183 | 126 -> 152 | 0 -> 0 | 1 -> 1 | 81 -> 80 | 250 -> 258 | canv 148x320; vids 0; gif imgs -; wash spiral |
| spiral-gif | 59.6 -> 59.8 | 16.8 -> 16.8 | 0/477 -> 0/478 | 0 -> 0 | 1339 -> 2389 | 365 -> 287 | 3147 -> 756 | 158 -> 0 | 160 -> 1 | 250 -> 480 | 5391 -> 5399 | canv 500x500; vids 0; gif imgs -; wash spiral |
| spiral-css | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 1343 -> 1507 | 131 -> 132 | 23 -> 21 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 258 | canv -; vids 0; gif imgs -; wash spiral |
| pink | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 1501 -> 1443 | 146 -> 132 | 32 -> 27 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 258 | canv -; vids 0; gif imgs -; wash pink |
| drain | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 1234 -> 1256 | 130 -> 126 | 24 -> 24 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 258 | canv -; vids 0; gif imgs -; wash drain |
| full-video | 59.6 -> 59.8 | 16.8 -> 16.8 | 0/477 -> 0/478 | 0 -> 0 | 3509 -> 4195 | 379 -> 424 | 1246 -> 1325 | 0 -> 0 | 31 -> 34 | 307 -> 309 | 907 -> 915 | canv -; vids 1; gif imgs - |
| full-gif | 59.8 -> 59.6 | 16.8 -> 16.8 | 0/478 -> 0/477 | 0 -> 0 | 1858 -> 2226 | 309 -> 184 | 700 -> 228 | 342 -> 0 | 43 -> 1 | 293 -> 160 | 5391 -> 5399 | canv 500x375; vids 0; gif imgs - |
| full-gif2 | 59.8 -> 59.6 | 16.8 -> 16.8 | 0/478 -> 0/477 | 0 -> 0 | 1539 -> 2325 | 250 -> 186 | 510 -> 250 | 2 -> 0 | 29 -> 1 | 246 -> 160 | 1336 -> 1344 | canv 500x281; vids 0; gif imgs - |
| corner-video | 59.8 -> 58.1 | 16.8 -> 16.8 | 0/478 -> 11/465 | 0 -> 1 | 4308 -> 6403 | 578 -> 690 | 1623 -> 1937 | 0 -> 0 | 38 -> 42 | 408 -> 411 | 907 -> 915 | canv -; vids 1; gif imgs - |
| corner-gif | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 2142 -> 2448 | 356 -> 376 | 799 -> 838 | 315 -> 305 | 35 -> 36 | 406 -> 407 | 5391 -> 5399 | canv -; vids 0; gif imgs 500x375 |
| rain-video | 59.6 -> 59.8 | 16.8 -> 16.8 | 0/477 -> 0/478 | 0 -> 0 | 4085 -> 4754 | 510 -> 580 | 1343 -> 1609 | 0 -> 0 | 21 -> 23 | 479 -> 480 | 907 -> 915 | canv -; vids 1; gif imgs - |
| rain-gif | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 2209 -> 2824 | 333 -> 395 | 932 -> 1107 | 14 -> 13 | 45 -> 51 | 480 -> 480 | 1336 -> 1344 | canv -; vids 0; gif imgs 500x281/500x281/500x281/500x281/500x281 |
| spiral-loom+full-video | 59.8 -> 59.6 | 16.8 -> 16.8 | 0/478 -> 1/477 | 0 -> 0 | 3526 -> 4537 | 406 -> 456 | 1216 -> 1321 | 0 -> 0 | 32 -> 33 | 337 -> 334 | 907 -> 915 | canv 148x320; vids 1; gif imgs -; wash spiral |
| spiral-loom+full-gif | 59.3 -> 59.3 | 16.8 -> 16.8 | 3/474 -> 2/474 | 0 -> 0 | 2261 -> 3607 | 354 -> 276 | 741 -> 398 | 236 -> 0 | 44 -> 2 | 340 -> 212 | 5391 -> 5399 | canv 148x320/500x375/500x375; vids 0; gif imgs -; wash spiral |
| crt | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 1020 -> 1492 | 102 -> 135 | 25 -> 23 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 258 | canv -; vids 0; gif imgs - |

### Phone whole-class play, 14s scripted (before -> after)

| game | fps | p95 ms | frames >32ms | long tasks | renderer main ms | compositor ms | GPU main ms | decode ms | raster ms | draw frames | net KB | census after |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| daily_trigger | 59.6 -> 59.6 | 16.8 -> 16.8 | 2/834 -> 1/835 | 1 -> 1 | 8076 -> 8596 | 962 -> 952 | 5916 -> 6327 | 22 -> 0 | 309 -> 313 | 0 -> 0 | 12 -> 0 | canv -; vids 0/0; gif imgs - |
| lost_and_found | 59.5 -> 59.2 | 16.8 -> 16.8 | 4/833 -> 7/829 | 0 -> 0 | 12149 -> 11794 | 1190 -> 1207 | 4012 -> 3603 | 147 -> 337 | 296 -> 328 | 0 -> 0 | 0 -> 0 | canv -; vids 2/2; gif imgs 360x360/360x360/500x375/500x375/500x281/500x281/360x360/500x281/500x281/360x360/360x360/360x360 |
| deja_vu | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/837 -> 0/837 | 0 -> 0 | 5762 -> 6704 | 751 -> 836 | 1156 -> 1310 | 0 -> 0 | 86 -> 97 | 0 -> 0 | 0 -> 0 | canv -; vids 0/12; gif imgs - |
| impulse_control | 47.5 -> 58.9 | 33.5 -> 16.8 | 164/665 -> 11/824 | 1 -> 0 | 13912 -> 12244 | 1079 -> 1025 | 2514 -> 2218 | 19 -> 11 | 336 -> 322 | 0 -> 0 | 1376 -> 1376 | canv 130x265; vids 0/0; gif imgs - |
| the_deep_end | 22.8 -> 32.6 | 116.9 -> 66.8 | 205/319 -> 222/456 | 55 -> 39 | 13376 -> 13469 | 1202 -> 1032 | 4422 -> 4062 | 1310 -> 1080 | 361 -> 332 | 0 -> 0 | 10900 -> 10243 | canv -; vids 1/1; gif imgs 500x375/360x360/360x360/360x360; wash drain pink |
| sort | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/837 -> 0/837 | 0 -> 0 | 2858 -> 2581 | 287 -> 265 | 317 -> 300 | 0 -> 4 | 4 -> 4 | 0 -> 0 | 0 -> 0 | canv -; vids 0/0; gif imgs - |
| echo | 23.9 -> 29.6 | 66.9 -> 50.2 | 294/335 -> 313/414 | 46 -> 16 | 13940 -> 13853 | 1014 -> 982 | 2627 -> 2572 | 11 -> 8 | 476 -> 507 | 0 -> 0 | 0 -> 0 | canv -; vids 0/0; gif imgs - |
| instant_recall | 32.7 -> 54.1 | 50.1 -> 33.4 | 313/458 -> 66/757 | 14 -> 2 | 10657 -> 10190 | 856 -> 978 | 2959 -> 2643 | 950 -> 58 | 184 -> 156 | 0 -> 0 | 12768 -> 14082 | canv 192x192/192x192/192x192/192x192; vids 0/1; gif imgs -; wash pink drain |
| anomaly | 49.4 -> 59.8 | 33.5 -> 16.8 | 102/692 -> 0/837 | 8 -> 0 | 11806 -> 8192 | 1055 -> 922 | 1863 -> 1549 | 10 -> 5 | 145 -> 119 | 0 -> 0 | 0 -> 0 | canv -; vids 0/0; gif imgs - |
| composure | 55 -> 57.2 | 33.4 -> 16.8 | 47/770 -> 26/801 | 2 -> 2 | 12161 -> 10885 | 1078 -> 1039 | 2939 -> 2757 | 49 -> 47 | 237 -> 228 | 0 -> 0 | 1791 -> 1791 | canv 148x320; vids 0/0; gif imgs -; wash drain spiral |

### Desktop control (1600x900 @ DPR 1, no throttle) isolated scenarios (before -> after)

| scn | fps | p95 ms | frames >32ms | long tasks | renderer main ms | compositor ms | GPU main ms | decode ms | raster ms | draw frames | net KB | census after |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| idle | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/478 -> 0/478 | 0 -> 0 | 231 -> 319 | 105 -> 139 | 157 -> 66 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 259 | canv -; vids 0; gif imgs - |
| spiral-loom | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 581 -> 644 | 467 -> 504 | 934 -> 855 | 0 -> 0 | 1 -> 1 | 479 -> 479 | 250 -> 258 | canv 512x288; vids 0; gif imgs -; wash spiral |
| spiral-gif | 59.8 -> 59.6 | 16.8 -> 16.8 | 0/478 -> 0/477 | 0 -> 0 | 558 -> 539 | 432 -> 449 | 1019 -> 1015 | 203 -> 282 | 31 -> 31 | 480 -> 479 | 5391 -> 5399 | canv -; vids 0; gif imgs -; wash spiral(gif) |
| spiral-css | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 537 -> 506 | 387 -> 392 | 1002 -> 944 | 0 -> 0 | 1 -> 1 | 479 -> 479 | 250 -> 258 | canv -; vids 0; gif imgs -; wash spiral |
| pink | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 363 -> 296 | 146 -> 130 | 55 -> 46 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 258 | canv -; vids 0; gif imgs -; wash pink |
| drain | 59.6 -> 59.8 | 16.8 -> 16.8 | 0/477 -> 0/478 | 0 -> 0 | 310 -> 319 | 131 -> 133 | 36 -> 54 | 0 -> 0 | 1 -> 1 | 1 -> 1 | 250 -> 258 | canv -; vids 0; gif imgs -; wash drain |
| full-video | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 725 -> 832 | 414 -> 472 | 1222 -> 1401 | 0 -> 0 | 37 -> 43 | 305 -> 305 | 907 -> 915 | canv -; vids 1; gif imgs - |
| full-gif | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 413 -> 493 | 320 -> 341 | 727 -> 756 | 235 -> 413 | 45 -> 51 | 292 -> 286 | 5391 -> 5399 | canv -; vids 0; gif imgs 500x375 |
| full-gif2 | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 362 -> 682 | 252 -> 326 | 502 -> 612 | 0 -> 3 | 27 -> 35 | 240 -> 242 | 1336 -> 1344 | canv -; vids 0; gif imgs 500x281/500x281 |
| corner-video | 59.6 -> 59.8 | 16.8 -> 16.8 | 0/477 -> 0/478 | 0 -> 0 | 982 -> 1075 | 638 -> 656 | 1484 -> 1599 | 0 -> 0 | 37 -> 38 | 410 -> 410 | 907 -> 915 | canv -; vids 1; gif imgs - |
| corner-gif | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 549 -> 540 | 380 -> 345 | 844 -> 676 | 374 -> 118 | 28 -> 25 | 409 -> 407 | 5391 -> 5399 | canv -; vids 0; gif imgs 500x375 |
| rain-video | 29.6 -> 29.8 | 33.5 -> 33.5 | 237/237 -> 238/238 | 0 -> 0 | 741 -> 788 | 400 -> 423 | 2541 -> 2703 | 0 -> 0 | 34 -> 36 | 240 -> 240 | 907 -> 915 | canv -; vids 5; gif imgs - |
| rain-gif | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 565 -> 730 | 394 -> 467 | 1050 -> 1275 | 8 -> 9 | 49 -> 60 | 480 -> 479 | 1336 -> 1344 | canv -; vids 0; gif imgs 500x281/500x281/500x281/500x281/500x281/500x281/500x281 |
| spiral-loom+full-video | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 894 -> 1163 | 623 -> 697 | 1702 -> 2081 | 0 -> 0 | 38 -> 46 | 479 -> 479 | 907 -> 915 | canv 512x288; vids 1; gif imgs -; wash spiral |
| spiral-loom+full-gif | 59.5 -> 59.6 | 16.8 -> 16.8 | 1/476 -> 0/477 | 0 -> 0 | 710 -> 786 | 631 -> 723 | 1205 -> 1491 | 484 -> 286 | 42 -> 48 | 478 -> 478 | 5391 -> 5399 | canv 512x288; vids 0; gif imgs 500x375; wash spiral |
| crt | 59.6 -> 59.6 | 16.8 -> 16.8 | 0/477 -> 0/477 | 0 -> 0 | 540 -> 786 | 541 -> 671 | 1612 -> 2085 | 0 -> 0 | 83 -> 103 | 479 -> 480 | 250 -> 258 | canv -; vids 0; gif imgs - |

### Desktop control whole-class play (before -> after)

| game | fps | p95 ms | frames >32ms | long tasks | renderer main ms | compositor ms | GPU main ms | decode ms | raster ms | draw frames | net KB | census after |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| daily_trigger | 59.8 -> 59.8 | 16.8 -> 16.8 | 0/837 -> 0/837 | 0 -> 0 | 1843 -> 2152 | 1071 -> 1207 | 6642 -> 7565 | 0 -> 20 | 291 -> 354 | 0 -> 0 | 0 -> 0 | canv -; vids 0/0; gif imgs - |
| lost_and_found | 37.6 -> 37.9 | 33.5 -> 33.5 | 292/526 -> 292/530 | 0 -> 0 | 3304 -> 3967 | 1496 -> 1797 | 5648 -> 6306 | 606 -> 1010 | 299 -> 350 | 0 -> 0 | 2980 -> 2275 | canv -; vids 2/2; gif imgs 360x360/500x281/360x360/500x281/360x360/360x360/360x360/500x375/500x375/500x375/500x375/500x281/500x375/500x375/500x281/500x281/360x360/500x281/360x360 |
| deja_vu | 44.7 -> 44.6 | 33.5 -> 33.5 | 207/626 -> 210/624 | 0 -> 0 | 1867 -> 1989 | 876 -> 1044 | 3646 -> 3750 | 9 -> 7 | 158 -> 163 | 0 -> 0 | 0 -> 0 | canv -; vids 2/12; gif imgs - |
| impulse_control | 59.7 -> 59.6 | 16.8 -> 16.8 | 1/836 -> 1/835 | 0 -> 0 | 4040 -> 3043 | 1542 -> 1189 | 3497 -> 2706 | 16 -> 13 | 451 -> 334 | 0 -> 0 | 2744 -> 2731 | canv 533x300; vids 1/2; gif imgs - |
| the_deep_end | 39.9 -> 41.1 | 33.5 -> 33.5 | 268/559 -> 253/575 | 0 -> 0 | 8029 -> 6623 | 2530 -> 2101 | 8833 -> 7316 | 329 -> 283 | 382 -> 335 | 0 -> 0 | 12726 -> 12294 | canv -; vids 2/2; gif imgs 360x360/360x360/360x360; wash drain pink |
| sort | 59.8 -> 59.7 | 16.8 -> 16.8 | 0/837 -> 0/836 | 0 -> 0 | 969 -> 751 | 362 -> 296 | 341 -> 283 | 0 -> 16 | 5 -> 4 | 0 -> 0 | 0 -> 0 | canv -; vids 0/0; gif imgs - |
| echo | 59 -> 59.7 | 16.8 -> 16.8 | 7/826 -> 1/836 | 1 -> 0 | 7999 -> 6284 | 2482 -> 2091 | 9599 -> 7794 | 47 -> 27 | 2512 -> 2082 | 0 -> 0 | 0 -> 0 | canv -; vids 0/0; gif imgs - |
| instant_recall | 36.3 -> 36.6 | 33.5 -> 33.5 | 326/508 -> 324/513 | 1 -> 0 | 2330 -> 1735 | 962 -> 740 | 3308 -> 2561 | 705 -> 614 | 160 -> 137 | 0 -> 0 | 12401 -> 12401 | canv 512x288; vids 0/4; gif imgs 500x500/640x480/500x375; wash spiral pink drain |
| anomaly | 33.4 -> 33.9 | 33.5 -> 33.5 | 363/468 -> 356/475 | 0 -> 0 | 2041 -> 1522 | 962 -> 750 | 4032 -> 3166 | 8 -> 6 | 103 -> 78 | 0 -> 0 | 12905 -> 12905 | canv -; vids 9/9; gif imgs - |
| composure | 59.4 -> 59.7 | 16.8 -> 16.8 | 4/832 -> 1/836 | 1 -> 0 | 3276 -> 2728 | 1656 -> 1405 | 7293 -> 5651 | 68 -> 71 | 656 -> 587 | 0 -> 0 | 1791 -> 1791 | canv 512x288; vids 0/0; gif imgs -; wash drain spiral |

### Desktop unchanged

- DOM + computed-style + layout digest (`digest.mjs`: `<html>` class, every stage node's tag/class/inline style/offset box and 31 static computed properties, canvas backing, media src) on the desktop profile for all 16 engine scenarios: **15 of 16 MATCH byte for byte**; the 16th (`crt`) differs only in the scanline roll's animated `background-position` (63.5095px vs 63.5077px, sampling phase). The same digest on the phone profile differs on exactly `spiral-gif` and `full-gif` (the plate) and matches everywhere else.
- Desktop bench and desktop play numbers above are within the rig's noise; no desktop scenario gained or lost a node, a video, a canvas or a layer.
- Every new CSS rule is `.ae-touch`-prefixed; the one shared list touched (reduced-motion `animation:none`) gains a selector that matches no desktop node.

### Not measurable here

- Real phone GPU cost: the rig's GPU is a desktop RTX 3060 Ti via ANGLE D3D11; the GPU-process numbers show the raster/upload WORK removed, not phone frame times. The spin's compositor cost on a phone GPU is a ~3 Mpx fill per frame (trivial) plus tiling of a 3798px layer.
- Headless Chrome paints `<video>` on the renderer main thread (`full-video` / `corner-video` renderer ms are an artifact); the decoder-count problem on iOS is a hardware session ceiling that no desktop trace shows.
- Animated webp (sp2/sp4 in the bundled spiral set) is not plated by the burst branch (`isGifUrl` is `.gif` only; a webp url cannot be told still from animated); the wash branch plates every url string.
- `preloadSpirals` still warms the whole bundled spiral pool on touch (22.6 MB of gif bytes in an IR class): bytes only, no decode, left alone.

### CCP-Mobile

The WebView vendors `origin/main` through `scripts/sync-arcademy-web.mjs` (cclabs-web `sync-arcademy.mjs`), so this rides the next `npm run sync:arcademy` after merge. `init.ts` sets `platform.isTouch: true` and `reducedMotion: motionLevel !== 2`; `provider.ts` admits gifs into the still pool, which is exactly the case the burst plate covers. Nothing host-specific was needed.

Do not merge yet: owner phone pass first (spiral wash reads as a still spiral with a slow spin; IR SPIRAL faces are still frames; L&F shows two playing tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145PcYKP62biKiogetX1WMz
