### PR TITLE
feat(arcademy): wallet banks on the server, shared across devices

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -600,6 +600,8 @@ export const DEFAULT_LEXICON = Object.freeze({
   prize_full: 'Your pockets are full of those. Use one first.',
   prize_locked_msg: 'That one stays in the case for now.',
   prize_unknown: 'The counter does not know that one. Odd.',
+  prize_offline: 'The counter cannot reach the bank right now. Nothing was charged.',
+  prize_busy: 'Somebody is already at the drawer. Give it a second and ask again.',
   prize_quiet: 'The counter went quiet on that one. Try again in a moment.',
   prize_empty: 'Shelf is bare tonight. Come back when the truck has been.',
   prize_payday_label: 'Hot room tonight',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
@@ -62,6 +62,14 @@ export const REFUSALS = Object.freeze({
   full: ['prize_full', 'Your pockets are full of those. Use one first.'],
   locked: ['prize_locked_msg', 'That one stays in the case for now.'],
   unknown: ['prize_unknown', 'The counter does not know that one. Odd.'],
+  /* THE SHARED WALLET (2026-08-28). The wallet is on the account now, so two
+   * refusals arrive that no local till could ever have produced: `offline` when
+   * the host could not reach the bank, and `busy` when one of your OWN other
+   * devices is mid-write on the same wallet. Neither is a refusal the player did
+   * anything to earn, and in both cases nothing was charged - which is the half
+   * worth saying out loud. Without these rows both fell to the unknown shrug. */
+  offline: ['prize_offline', 'The counter cannot reach the bank right now. Nothing was charged.'],
+  busy: ['prize_busy', 'Somebody is already at the drawer. Give it a second and ask again.'],
 });
 
 /** The glyph each sku wears on its little drawn box. Text, not art: a sku the

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -206,6 +206,12 @@ internal static class ArcademyHostService
             // exactly the same, on the cards this machine already holds.
             ArcademySyncService.Attach(_meta, OnMirrorCardsChanged);
 
+            // THE SHARED WALLET (wallet contract, "Client behaviour"). Same posture, one shelf
+            // over: fetch the ACCOUNT's wallet, carry this machine's up if it never has been, and
+            // drain anything a night offline left unpaid. Signed out, this does nothing at all and
+            // the money path below stays exactly the local-authority one it has always been.
+            ArcademyWalletSyncService.Attach(_meta, OnWalletBanked);
+
             // CAMPUS PRESENCE (PRESENCE.md §3). Two independent halves behind one Attach: the
             // EMITTER announces `campus_enter` (only if the player has opted in - the rung is read
             // inside), and the SNAPSHOT PUSHER starts polling the public feed and handing it to
@@ -753,7 +759,12 @@ internal static class ArcademyHostService
     {
         try
         {
-            var payday = ArcademyEconomy.PickPayday(
+            // THE SERVER'S DRAW WINS WHEN THERE IS ONE. Both sides run the same seeded pick over
+            // the same roster, so they normally agree to the letter; where they can differ is a
+            // roster that has not finished mirroring, and on that night the account's answer is the
+            // one every OTHER device is also showing. The local pick is the fallback, and it is
+            // what a signed-out player (and an early `init` that beat the reply home) gets.
+            var payday = ArcademyWalletSyncService.ServerPayday ?? ArcademyEconomy.PickPayday(
                 DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
                 _meta?.EnrolledGameKeys());
             var (extra, honors) = _meta?.LeverUnlocks() ?? (false, false);
@@ -1592,15 +1603,22 @@ internal static class ArcademyHostService
         ["prize_buy"] = "Trade",
         ["prize_soon"] = "Arriving soon",
         ["prize_wait"] = "Asking the counter",
-        // What the counter says back. The five refusals line up one for one with the reason
-        // strings on `wallet-result` (unknown / poor / owned / full / locked); the last two are
-        // what the page says on its own when no answer came back at all.
+        // What the counter says back. The refusals line up one for one with the reason strings on
+        // `wallet-result` (unknown / poor / owned / full / locked, plus `offline` and `busy` since
+        // the wallet moved to the account); the last two are what the page says on its own when no
+        // answer came back at all.
         ["prize_bought"] = "Wrapped up and yours.",
         ["prize_poor"] = "Not quite enough on you for that one yet.",
         ["prize_owned_msg"] = "You have that one already.",
         ["prize_full"] = "Your pockets are full of those. Use one first.",
         ["prize_locked_msg"] = "That one stays in the case for now.",
         ["prize_unknown"] = "The counter does not know that one. Odd.",
+        // The shared wallet's two new refusals. The till is on the account now, so a purchase with
+        // no line out is a thing the counter cannot do rather than a thing you cannot afford, and
+        // the account lock is another of your own devices at the same drawer. Both are worded so
+        // they never sound like a scolding and never mention a network.
+        ["prize_offline"] = "The counter cannot reach the bank right now. Nothing was charged.",
+        ["prize_busy"] = "Somebody is already at the drawer. Give it a second and ask again.",
         ["prize_quiet"] = "The counter went quiet on that one. Try again in a moment.",
         ["prize_empty"] = "Shelf is bare tonight. Come back when the truck has been.",
         // Tonight's hot room, painted from the seeded draw `init` already handed down.
@@ -3504,7 +3522,18 @@ internal static class ArcademyHostService
             // Tickets and tokens, wrapped on their own: the attendance credit above is the thing we
             // must not lose, and the money must never become a second way to lose it. Everything
             // here is host-decided - the frame carries a grade and a room, and nothing else.
-            var till = MintCurrency(gameKey, grade, zen, streak, localDate, lever);
+            //
+            // AND SINCE THE SHARED WALLET, WHO DECIDES DEPENDS ON THE DOOR. With an account
+            // attached the money is the SERVER's to mint (one wallet, every device), so this frame
+            // goes up and the answer comes back on its own beat. Signed out, nothing has changed:
+            // MintCurrency runs here, in this order, exactly as it always has.
+            var mintFrame = ArcademyWalletSyncService.DoorOpen
+                ? ArcademyWalletSyncService.BuildMintFrame(
+                    gameKey, grade, zen, streak, localDate, lever, lateSlipUsed, dayUtc)
+                : null;
+            var till = mintFrame == null
+                ? MintCurrency(gameKey, grade, zen, streak, localDate, lever)
+                : default;
 
             // THE PUNCH CARD RIDES THE ATTENDANCE CREDIT (PUNCHCARD §2.1). Same frame, same local
             // date, same idempotence - a graded finish is exactly the event that stamps, so there
@@ -3541,46 +3570,32 @@ internal static class ArcademyHostService
             // letter. Own try/catch: nothing about company may cost the payout frame below.
             try { ArcademyPresenceService.NoteClassEnd(gameKey, grade); } catch { }
 
-            if (_meta != null) _host?.Post(_meta.SnapshotMessage());
+            // Everything the debrief needs that is NOT money, gathered once so both endings below
+            // send the same frame and there is only one place to change the wording of a payout.
+            var report = new PayoutReport(gameKey, tier, xp, levelAfter > levelBefore, streak,
+                perfect, classesToday, !firstToday, darePaid ? DareBonusXp : 0, grade,
+                darePaid ? dareWon : "", dayUtc);
 
-            _host?.Post(new
+            if (mintFrame == null)
             {
-                type = "payout-result",
-                gameKey,
-                xp,
-                levelUp = levelAfter > levelBefore,
-                streak,
-                perfectAttendance = perfect,
-                classesToday,
-                // Additive: the report card reads it to explain a 0 XP line. Older pages ignore it.
-                retake = !firstToday,
-                // Additive (EMI ASKS): what the dare bonus actually paid, so the page never has
-                // to guess. 0 on every class that carried no dare, and on a retake.
-                dareXp = darePaid ? DareBonusXp : 0,
-                // Additive (economy): the till, already counted. `tickets` is what was minted,
-                // `ticketBase`/`ticketMult` are its working so the debrief can show the lever and
-                // the payday doing their jobs, and `wallet` is the POST-mint balance, so the page
-                // never adds anything up itself.
-                grade,
-                tickets = till.Tickets,
-                ticketBase = till.Base,
-                ticketMult = till.Mult,
-                tokenMinted = till.TokenMinted,
-                payday = till.Payday,
-                lever = till.Lever,
-                lateSlipUsed,
-                wallet = till.Wallet,
-            });
+                // SIGNED OUT. Byte for byte the old ending: the snapshot, the payout, the card.
+                if (_meta != null) _host?.Post(_meta.SnapshotMessage());
+                PostPayout(report, till, lateSlipUsed);
+                PostPunchCard(gameKey, "daily", punch);
+                LogClassComplete(report, till, lever, banked: false);
+                return;
+            }
+
+            // BANKED. The punch card goes out NOW rather than behind the request: the ceremony is
+            // the page's own beat and it must never sit waiting on a network that might be down.
+            // The money follows on `payout-result` whenever the bank answers, which is exactly the
+            // fill-in-later the report card was already built for (it repaints on arrival).
+            if (_meta != null) _host?.Post(_meta.SnapshotMessage());
             PostPunchCard(gameKey, "daily", punch);
-            App.Logger?.Information(
-                "ArcademyHost: class complete ({Game}, tier {Tier}, grade {Grade}) = {Xp:0} XP{Dare}{Retake}, {Tickets} tickets (x{Mult}{Lever}){Token}, streak {Streak}, {Today}/4 today",
-                gameKey, tier, grade, xp,
-                darePaid ? " +" + DareBonusXp.ToString("0", CultureInfo.InvariantCulture) + " dare (" + dareWon + ")" : "",
-                firstToday ? "" : " (retake - already paid for " + dayUtc + ")",
-                till.Tickets, till.Mult.ToString("0.##", CultureInfo.InvariantCulture),
-                lever == "standard" ? "" : ", " + lever,
-                till.TokenMinted ? " +1 TOKEN" : "",
-                streak, classesToday);
+
+            int epoch = Volatile.Read(ref _generation);
+            ArcademyWalletSyncService.Bank(mintFrame,
+                outcome => SettleMint(epoch, report, mintFrame, lever, lateSlipUsed, zen, localDate, outcome));
         }
         catch (Exception ex) { App.Logger?.Warning("ArcademyHost.OnClassEnded: {E}", ex.Message); }
     }
@@ -3591,6 +3606,170 @@ internal static class ArcademyHostService
     private readonly record struct TillResult(
         int Tickets, int Base, double Mult, bool TokenMinted,
         int Payday, string Lever, JObject Wallet);
+
+    /// <summary>Everything on <c>payout-result</c> that is NOT money. Gathered once in
+    /// <see cref="OnClassEnded"/> so the local ending and the banked one send the same frame.</summary>
+    private readonly record struct PayoutReport(
+        string GameKey, int Tier, double Xp, bool LevelUp, int Streak, int Perfect,
+        int ClassesToday, bool Retake, double DareXp, string Grade, string DareWon, string DayUtc);
+
+    /// <summary>
+    /// The <c>payout-result</c> frame. Every field is what it always was; what changed is that the
+    /// money half can now arrive from the account's wallet instead of this machine's, and the page
+    /// cannot tell (and must not be able to tell) which.
+    /// </summary>
+    private static void PostPayout(in PayoutReport r, in TillResult till, bool lateSlipUsed)
+    {
+        _host?.Post(new
+        {
+            type = "payout-result",
+            gameKey = r.GameKey,
+            xp = r.Xp,
+            levelUp = r.LevelUp,
+            streak = r.Streak,
+            perfectAttendance = r.Perfect,
+            classesToday = r.ClassesToday,
+            // Additive: the report card reads it to explain a 0 XP line. Older pages ignore it.
+            retake = r.Retake,
+            // Additive (EMI ASKS): what the dare bonus actually paid, so the page never has
+            // to guess. 0 on every class that carried no dare, and on a retake.
+            dareXp = r.DareXp,
+            // Additive (economy): the till, already counted. `tickets` is what was minted,
+            // `ticketBase`/`ticketMult` are its working so the debrief can show the lever and
+            // the payday doing their jobs, and `wallet` is the POST-mint balance, so the page
+            // never adds anything up itself.
+            grade = r.Grade,
+            tickets = till.Tickets,
+            ticketBase = till.Base,
+            ticketMult = till.Mult,
+            tokenMinted = till.TokenMinted,
+            payday = till.Payday,
+            lever = till.Lever,
+            lateSlipUsed,
+            wallet = till.Wallet ?? new JObject { ["t"] = 0, ["k"] = 0 },
+        });
+    }
+
+    /// <summary>The owner's one line per class. <paramref name="banked"/> is the only new word in
+    /// it, and it is the word that tells a support thread apart: money on the account, or money
+    /// still sitting on this desk waiting for a wire.</summary>
+    private static void LogClassComplete(in PayoutReport r, in TillResult till, string lever, bool banked)
+    {
+        App.Logger?.Information(
+            "ArcademyHost: class complete ({Game}, tier {Tier}, grade {Grade}) = {Xp:0} XP{Dare}{Retake}, {Tickets} tickets (x{Mult}{Lever}){Token}, streak {Streak}, {Today}/4 today{Banked}",
+            r.GameKey, r.Tier, r.Grade, r.Xp,
+            r.DareWon.Length > 0
+                ? " +" + r.DareXp.ToString("0", CultureInfo.InvariantCulture) + " dare (" + r.DareWon + ")"
+                : "",
+            r.Retake ? " (retake - already paid for " + r.DayUtc + ")" : "",
+            till.Tickets, till.Mult.ToString("0.##", CultureInfo.InvariantCulture),
+            lever == "standard" ? "" : ", " + lever,
+            till.TokenMinted ? " +1 TOKEN" : "",
+            r.Streak, r.ClassesToday,
+            banked ? " (banked)" : "");
+    }
+
+    /// <summary>
+    /// The bank answered (or did not). Runs on a background thread, so it hops the dispatcher and
+    /// checks the window generation the way every other async continuation here does - a reply that
+    /// arrives after the Arcademy closed must not paint a payout into the NEXT session's report.
+    ///
+    /// <para>THE THREE ENDINGS. Banked: adopt what came back and report it. Nobody answered: mint
+    /// locally so the debrief still has a number, park the frame under the same <c>mintId</c>, and
+    /// let the next launch carry it up - the server's answer will REPLACE this preview, so nothing
+    /// is ever counted twice. Refused (the tier gate, mostly): mint locally and park nothing,
+    /// because a frame this account can never bank is a queue that can never drain.</para>
+    /// </summary>
+    private static void SettleMint(int epoch, PayoutReport report, JObject frame, string lever,
+        bool lateSlipUsed, bool zen, string localDate, ArcademyWalletSyncService.MintOutcome outcome)
+    {
+        try
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            if (Volatile.Read(ref _generation) != epoch) return;
+            disp.BeginInvoke(() =>
+            {
+                try
+                {
+                    if (_meta == null || _host == null) return;
+                    if (Volatile.Read(ref _generation) != epoch) return;
+
+                    TillResult till;
+                    bool slip = lateSlipUsed;
+                    if (outcome.Verdict == ArcademyWalletSyncService.MintVerdict.Banked
+                        && outcome.Economy != null)
+                    {
+                        till = TillFromEconomy(outcome.Economy, lever);
+                        // The server consumes the late slip itself and echoes what actually
+                        // happened, so its word beats the local read that went up on the frame.
+                        slip = (bool?)outcome.Economy["lateSlipUsed"] ?? lateSlipUsed;
+                    }
+                    else
+                    {
+                        // THE PREVIEW. Worth saying plainly: this writes the local wallet, and the
+                        // next successful pull or replay overwrites it with the account's copy.
+                        till = MintCurrency(report.GameKey, report.Grade, zen, report.Streak,
+                            localDate, lever);
+                        if (outcome.Verdict == ArcademyWalletSyncService.MintVerdict.Queue)
+                            ArcademyWalletSyncService.Park(frame);
+                    }
+
+                    _host.Post(_meta.SnapshotMessage());
+                    PostPayout(report, till, slip);
+                    LogClassComplete(report, till, lever,
+                        banked: outcome.Verdict == ArcademyWalletSyncService.MintVerdict.Banked);
+                }
+                catch (Exception ex) { App.Logger?.Warning("ArcademyHost.SettleMint: {E}", ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.SettleMint dispatch: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// The server's <c>economy</c> block, read into the same shape the local till has. The page's
+    /// <c>payday</c> field is the MULTIPLIER (an int) and always has been; the wire carries the
+    /// draw as an object, so the room name is dropped here rather than changing a frame the shell
+    /// already reads.
+    /// </summary>
+    private static TillResult TillFromEconomy(JObject economy, string fallbackLever)
+    {
+        int tickets = Math.Max(0, (int?)economy["tickets"] ?? 0);
+        int b = Math.Max(0, (int?)economy["ticketBase"] ?? 0);
+        double mult = (double?)economy["ticketMult"] ?? 1.0;
+        if (!(mult > 0)) mult = 1.0;
+        bool token = (bool?)economy["tokenMinted"] ?? false;
+        int payday = Math.Max(1, (int?)economy["payday"]?["mult"] ?? 1);
+        var lever = (string?)economy["lever"];
+        if (string.IsNullOrWhiteSpace(lever)) lever = fallbackLever;
+        var wallet = economy["wallet"] as JObject;
+        return new TillResult(tickets, b, mult, token, payday, lever,
+            ArcademyEconomy.BalanceJson(ArcademyEconomy.EnsureShape(wallet)));
+    }
+
+    /// <summary>
+    /// The account's wallet landed (or a parked mint drained into it). Same shape as
+    /// <see cref="OnMirrorCardsChanged"/>: hop the dispatcher, push the whole-blob meta snapshot,
+    /// and let the shell repaint its chips off it. Nothing here decides anything.
+    /// </summary>
+    private static void OnWalletBanked()
+    {
+        try
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            disp.BeginInvoke(() =>
+            {
+                try
+                {
+                    if (_meta == null || _host == null) return;
+                    _host.Post(_meta.SnapshotMessage());
+                }
+                catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnWalletBanked: {E}", ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnWalletBanked dispatch: {E}", ex.Message); }
+    }
 
     /// <summary>
     /// TICKETS AND TOKENS for one graded finish. The whole sum lives in
@@ -3661,12 +3840,60 @@ internal static class ArcademyHostService
                 return;
             }
 
+            // WITH AN ACCOUNT ATTACHED, THE COUNTER IS ON THE SERVER. It has to be: the wallet is
+            // shared, so a spend settled here would be overwritten by the next pull and the player
+            // would watch a prize they bought turn back into tickets. ONLINE ONLY by contract - a
+            // press that cannot reach the till is a refusal, and the room says so.
+            if (ArcademyWalletSyncService.DoorOpen)
+            {
+                int epoch = Volatile.Read(ref _generation);
+                ArcademyWalletSyncService.Buy(sku, outcome => SettleBuy(epoch, sku, outcome));
+                return;
+            }
+
             var localDate = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var result = _meta.Buy(sku, localDate);
             if (result.Ok) _host?.Post(_meta.SnapshotMessage());
             PostWalletResult(sku, result.Ok, result.Reason, _meta.WalletSnapshot());
         }
         catch (Exception ex) { App.Logger?.Warning("ArcademyHost.OnPrizeBuy: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// The counter answered (or did not). Same dispatcher-and-generation hop <see cref="SettleMint"/>
+    /// takes, and the same rule about a stale reply.
+    ///
+    /// <para>A refusal the SERVER named rides back verbatim - the room already has a line for each
+    /// of them. Nobody answering is <c>offline</c>, which is the one new word on this frame, and it
+    /// carries the wallet UNCHANGED: the page treats a missing bag as "unchanged" but there is no
+    /// reason to make it guess, and no reason for a failed purchase to move a number.</para>
+    /// </summary>
+    private static void SettleBuy(int epoch, string sku, ArcademyWalletSyncService.BuyOutcome outcome)
+    {
+        try
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            if (Volatile.Read(ref _generation) != epoch) return;
+            disp.BeginInvoke(() =>
+            {
+                try
+                {
+                    if (_meta == null || _host == null) return;
+                    if (Volatile.Read(ref _generation) != epoch) return;
+
+                    if (!outcome.Answered)
+                    {
+                        PostWalletResult(sku, false, "offline", _meta.WalletSnapshot());
+                        return;
+                    }
+                    if (outcome.Ok) _host.Post(_meta.SnapshotMessage());
+                    PostWalletResult(sku, outcome.Ok, outcome.Reason, _meta.WalletSnapshot());
+                }
+                catch (Exception ex) { App.Logger?.Warning("ArcademyHost.SettleBuy: {E}", ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.SettleBuy dispatch: {E}", ex.Message); }
     }
 
     /// <summary>The <c>wallet-result</c> frame: same-frame truth for the counter, on the same
@@ -5390,6 +5617,9 @@ internal static class ArcademyHostService
             // sent now (payload taken first, so the request outlives this window without touching
             // anything being disposed) and every reply still in the air is dropped by generation.
             try { ArcademySyncService.Detach(); } catch { }
+            // And the wallet with it. Nothing to flush here: a frame the server never took is
+            // already on disk in `pendingMints`, and the next launch is what carries it up.
+            try { ArcademyWalletSyncService.Detach(); } catch { }
             // Stop the presence poll BEFORE the host goes: the timer must never outlive the window
             // that armed it, and Detach also sends this session's one best-effort `campus_leave`.
             try { ArcademyPresenceService.Detach(); } catch { }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -3674,11 +3674,13 @@ internal static class ArcademyHostService
     /// checks the window generation the way every other async continuation here does - a reply that
     /// arrives after the Arcademy closed must not paint a payout into the NEXT session's report.
     ///
-    /// <para>THE THREE ENDINGS. Banked: adopt what came back and report it. Nobody answered: mint
-    /// locally so the debrief still has a number, park the frame under the same <c>mintId</c>, and
-    /// let the next launch carry it up - the server's answer will REPLACE this preview, so nothing
-    /// is ever counted twice. Refused (the tier gate, mostly): mint locally and park nothing,
-    /// because a frame this account can never bank is a queue that can never drain.</para>
+    /// <para>THE THREE ENDINGS. Banked: adopt what came back and report it. Nobody answered YET -
+    /// the wire, or the TIER GATE, which on this desk is a 14-day cached-entitlement grace the
+    /// server does not keep, so an account can legitimately be playing here and not yet bankable
+    /// there: mint locally so the debrief still has a number, park the frame under the same
+    /// <c>mintId</c>, and let the next launch carry it up - the server's answer will REPLACE this
+    /// preview, so nothing is ever counted twice. Refused: mint locally and park nothing, because a
+    /// frame this account can never bank is a queue that can never drain.</para>
     /// </summary>
     private static void SettleMint(int epoch, PayoutReport report, JObject frame, string lever,
         bool lateSlipUsed, bool zen, string localDate, ArcademyWalletSyncService.MintOutcome outcome)

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
@@ -58,6 +58,24 @@ internal sealed class ArcademyMetaStore
     /// could print it. Shape and every rule about it live in <see cref="ArcademyEconomy"/>.</summary>
     public const string WalletKey = "wallet";
 
+    /// <summary>Host-owned: this install's stable id, minted once and never changed. The server
+    /// keys its once-per-device wallet import on it (wallet contract §2).</summary>
+    public const string WalletDeviceKey = "walletDeviceId";
+
+    /// <summary>Host-owned: when this machine carried its wallet up to the account, absent until it
+    /// has. Present means the local <see cref="WalletKey"/> is a CACHE of the account's copy rather
+    /// than the record, and it is what decides whether an unpaid mint may be parked at all.</summary>
+    public const string WalletImportedKey = "walletImported";
+
+    /// <summary>Host-owned: class-ended frames the server never took, oldest first. Money the
+    /// player has earned and nobody has banked yet, so it is the one region here that is worth more
+    /// than the file it sits in.</summary>
+    public const string PendingMintsKey = "pendingMints";
+
+    /// <summary>How many unpaid frames are kept. See <see cref="QueueMint"/> for why the cap drops
+    /// the oldest rather than refusing the newest.</summary>
+    private const int PendingMintCap = 60;
+
     /// <summary>Classes in a day — the timetable's fixed size (GROUND-RULES §4).</summary>
     private const int ClassesPerDay = 4;
 
@@ -94,6 +112,7 @@ internal sealed class ArcademyMetaStore
     private static readonly HashSet<string> HostOwnedKeys = new(StringComparer.Ordinal)
     {
         AttendanceKey, StreakKey, PerfectKey, TodayClassesKey, XpPaidKey, PunchCardsKey, WalletKey,
+        WalletDeviceKey, WalletImportedKey, PendingMintsKey,
     };
 
     private readonly object _lock = new();
@@ -534,6 +553,153 @@ internal sealed class ArcademyMetaStore
                     result.Item?.Sku, result.Item?.Cost, result.Item?.Cur);
             }
             return result;
+        }
+    }
+
+    // ============================ the wallet, banked on the server ============================
+
+    /// <summary>
+    /// This install's stable id, minted once and kept forever. The server records which devices
+    /// have handed their wallet over (<c>imports[deviceId]</c>), so a second import from the same
+    /// machine is a no-op there as well as here - two independent guards on the one operation that
+    /// could ever add money twice.
+    /// </summary>
+    public string WalletDeviceId()
+    {
+        lock (_lock)
+        {
+            var existing = (string?)_state[WalletDeviceKey];
+            if (!string.IsNullOrWhiteSpace(existing) && existing.Length is >= 8 and <= 64) return existing;
+            var minted = Guid.NewGuid().ToString("N");
+            _state[WalletDeviceKey] = minted;
+            Touch();
+            App.Logger?.Information("ArcademyMetaStore: minted this install's wallet device id");
+            return minted;
+        }
+    }
+
+    /// <summary>When this machine carried its wallet up to the account, or null if it never has.
+    /// The flag lives out here rather than inside the wallet object because it is a fact about this
+    /// INSTALL, and the wallet object is about to become a cache of the account's copy.</summary>
+    public string? WalletImportedAt()
+    {
+        lock (_lock) return (string?)_state[WalletImportedKey];
+    }
+
+    /// <summary>Record the import. Written on any answer at all, the server's own no-op included:
+    /// what it records is "this device has been offered", not "this device paid in".</summary>
+    public void MarkWalletImported()
+    {
+        lock (_lock)
+        {
+            _state[WalletImportedKey] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+            Touch();
+        }
+    }
+
+    /// <summary>Is there anything on this machine worth carrying up? Balances, what was ever
+    /// earned, the shelf and the two lever rungs - the same regions the contract's import rule
+    /// names.</summary>
+    public bool WalletHasEarnings()
+    {
+        lock (_lock)
+        {
+            var w = WalletUnlocked();
+            if (((int?)w["t"] ?? 0) > 0 || ((int?)w["k"] ?? 0) > 0) return true;
+            if (((int?)w["earnedT"] ?? 0) > 0 || ((int?)w["earnedK"] ?? 0) > 0) return true;
+            if (w["inv"] is JObject inv && inv.Count > 0) return true;
+            return ArcademyEconomy.ExtraUnlocked(w) || ArcademyEconomy.HonorsUnlocked(w);
+        }
+    }
+
+    /// <summary>
+    /// Take the account's wallet whole. REPLACE, never merge: the server is the authority once the
+    /// import has run, and a local merge here would be this machine quietly arguing with it - which
+    /// is exactly how a balance ends up different on two desks. Anything the server carries that
+    /// this build does not know about rides along untouched.
+    /// </summary>
+    public void AdoptServerWallet(JObject? wallet)
+    {
+        if (wallet == null) return;
+        lock (_lock)
+        {
+            _state[WalletKey] = ArcademyEconomy.EnsureShape((JObject)wallet.DeepClone());
+            Touch();
+        }
+    }
+
+    /// <summary>The parked mint frames, oldest first - a clone, and only the rows still carrying a
+    /// <c>mintId</c> (a frame without one cannot be paid idempotently, so it is not a frame).</summary>
+    public JArray PendingMints()
+    {
+        lock (_lock)
+        {
+            var queue = new JArray();
+            if (_state[PendingMintsKey] is not JArray parked) return queue;
+            foreach (var row in parked)
+            {
+                if (row is JObject f && !string.IsNullOrWhiteSpace((string?)f["mintId"]))
+                    queue.Add(f.DeepClone());
+            }
+            return queue;
+        }
+    }
+
+    /// <summary>How many frames are still waiting - the number the log line quotes.</summary>
+    public int PendingMintCount()
+    {
+        lock (_lock) return (_state[PendingMintsKey] as JArray)?.Count ?? 0;
+    }
+
+    /// <summary>
+    /// Park one frame the server never took. Idempotent on <c>mintId</c>, so a retry that queues
+    /// the same night twice still only owes one mint.
+    ///
+    /// <para>Capped, and the cap drops the OLDEST. A queue this long means months offline with an
+    /// account attached, and the server's own replay wall is fourteen days anyway - so the frames
+    /// falling off the front were already past being payable, and the alternative (refusing new
+    /// ones) would lose tonight instead of a night nobody can bank any more.</para>
+    /// </summary>
+    public void QueueMint(JObject frame)
+    {
+        var mintId = (string?)frame["mintId"];
+        if (string.IsNullOrWhiteSpace(mintId)) return;
+        lock (_lock)
+        {
+            if (_state[PendingMintsKey] is not JArray parked)
+            {
+                parked = new JArray();
+                _state[PendingMintsKey] = parked;
+            }
+            if (parked.Any(r => r is JObject f
+                                && string.Equals((string?)f["mintId"], mintId, StringComparison.Ordinal))) return;
+
+            parked.Add(frame.DeepClone());
+            while (parked.Count > PendingMintCap) parked.RemoveAt(0);
+            Touch();
+            App.Logger?.Information("ArcademyMetaStore: parked a mint for {Game} on {Day} ({N} waiting)",
+                (string?)frame["game"], (string?)frame["localDay"], parked.Count);
+        }
+    }
+
+    /// <summary>Drop one parked frame once the server has answered for it, one way or the other.
+    /// Anything malformed sharing the ride is swept out with it.</summary>
+    public void DropMint(string mintId)
+    {
+        lock (_lock)
+        {
+            if (_state[PendingMintsKey] is not JArray parked || parked.Count == 0) return;
+            var keep = new JArray();
+            foreach (var row in parked)
+            {
+                if (row is not JObject f) continue;
+                var id = (string?)f["mintId"];
+                if (string.IsNullOrWhiteSpace(id) || string.Equals(id, mintId, StringComparison.Ordinal)) continue;
+                keep.Add(f);
+            }
+            if (keep.Count == parked.Count) return;
+            _state[PendingMintsKey] = keep;
+            Touch();
         }
     }
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyMetaStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Threading;
 using Newtonsoft.Json;
@@ -75,6 +76,10 @@ internal sealed class ArcademyMetaStore
     /// <summary>How many unpaid frames are kept. See <see cref="QueueMint"/> for why the cap drops
     /// the oldest rather than refusing the newest.</summary>
     private const int PendingMintCap = 60;
+
+    /// <summary>The shape the wallet routes demand of <c>deviceId</c>, spelled here so an id this
+    /// machine hands over can never be one the server will only ever answer with a 400.</summary>
+    private static readonly Regex DeviceIdShape = new("^[A-Za-z0-9_-]{8,64}$", RegexOptions.Compiled);
 
     /// <summary>Classes in a day — the timetable's fixed size (GROUND-RULES §4).</summary>
     private const int ClassesPerDay = 4;
@@ -569,7 +574,14 @@ internal sealed class ArcademyMetaStore
         lock (_lock)
         {
             var existing = (string?)_state[WalletDeviceKey];
-            if (!string.IsNullOrWhiteSpace(existing) && existing.Length is >= 8 and <= 64) return existing;
+            // THE WIRE'S SHAPE, NOT JUST A LENGTH. The server refuses anything outside
+            // `^[A-Za-z0-9_-]{8,64}$` with a 400, so an id that is the right length but the wrong
+            // alphabet - a hand-edited file, a braced GUID somebody pasted in - would fail on EVERY
+            // launch, for ever, with no way out. The import is the one call that cannot simply be
+            // skipped and retried later, because the balance it carries is real. Minting a fresh one
+            // costs nothing: the local `walletImported` flag is what stops a second import, and it
+            // is still absent on a machine that has never managed a first.
+            if (!string.IsNullOrWhiteSpace(existing) && DeviceIdShape.IsMatch(existing)) return existing;
             var minted = Guid.NewGuid().ToString("N");
             _state[WalletDeviceKey] = minted;
             Touch();

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
@@ -366,8 +366,13 @@ internal static class ArcademyWalletSyncService
             }
 
             store.MarkWalletImported();
-            App.Logger?.Information("[ArcademyWallet] this machine's wallet has been carried up ({Imported})",
-                (bool?)reply?["imported"] == true ? "merged" : "already known");
+            // THREE OUTCOMES, NOT TWO, and the third is the one that is easy to miss: `adopted`
+            // says the account had no wallet at all and this machine's became it. Worth telling
+            // apart in a support thread, because "adopted whole" and "merged" answer two different
+            // questions about where a balance came from.
+            App.Logger?.Information("[ArcademyWallet] this machine's wallet has been carried up ({How})",
+                (bool?)reply?["imported"] != true ? "already known"
+                    : (bool?)reply?["adopted"] == true ? "adopted whole" : "merged");
             return reply?["wallet"] as JObject;
         }
         catch (Exception ex)
@@ -524,6 +529,17 @@ internal static class ArcademyWalletSyncService
                     (string?)frame["mintId"]);
             }
 
+            // THE CLAMPS, AND ONE OF THEM IS WORTH FINDING IN A LOG. `<game>:queued_stamp_walled`
+            // says the money paid and the STAMP was dropped, because a replayed frame's local day
+            // fell outside the attendance wall. That answer carries `minted: 0`, and reading a 0
+            // there as "nothing happened" is exactly the mistake to avoid - the tickets are real,
+            // and this machine's own punch card already holds the hole the server declined to add.
+            if (reply?["clamps"] is JArray mintClamps && mintClamps.Count > 0)
+            {
+                App.Logger?.Information("[ArcademyWallet] the mint was clamped: {Clamps}",
+                    string.Join(", ", mintClamps.Select(c => (string?)c ?? "?")));
+            }
+
             if (!Retired(generation) && economy["wallet"] is JObject wallet)
             {
                 Store(generation)?.AdoptServerWallet(wallet);
@@ -612,7 +628,17 @@ internal static class ArcademyWalletSyncService
         using var cts = new CancellationTokenSource(PageWait);
         try
         {
-            var payload = JsonConvert.SerializeObject(new { unified_id = unifiedId, sku });
+            // THE PLAYER'S DAY, NOT THE SERVER'S. `localDay` is optional and an absent one falls
+            // back to the proxy's UTC day rather than being refused, which is why it is easy to
+            // leave off - but it is the date that lands on the receipt in the roll and on the
+            // inventory row, and both of those are read back on this desk. A player west of UTC
+            // buying after dinner would see tomorrow on a prize they bought tonight.
+            var payload = JsonConvert.SerializeObject(new
+            {
+                unified_id = unifiedId,
+                sku,
+                localDay = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            });
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{ProxyBaseUrl}{PrizeBuyPath}")
             {
                 Content = new StringContent(payload, Encoding.UTF8, "application/json"),

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
@@ -1,0 +1,751 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Arcademy;
+
+/// <summary>
+/// THE SHARED WALLET, host side (wallet CONTRACT v1, wire contract
+/// <c>proxy/docs/arcademy-wallet-api.md</c>). One wallet per ACCOUNT, held by the proxy, mutated
+/// only by the server. This class is the desktop's half of that: it reads the account's wallet at
+/// launch, imports this machine's wallet into it once, and from then on asks the server to mint
+/// every graded finish and to settle every purchase.
+///
+/// <para>THE SAME POSTURE AS <see cref="ArcademySyncService"/>, AND FOR THE SAME REASON. The
+/// Arcademy runs offline inside the WebView2 and a player with no account never touches this file
+/// at all: with the door shut, the local wallet stays the authority and the money path is byte for
+/// byte what it was. Nothing here blocks, nothing here opens a dialog, and a failure is one log
+/// line plus a frame parked on disk. Offline forever is still a working feature.</para>
+///
+/// <para>WHAT THE SERVER OWNS vs WHAT THIS MACHINE OWNS. The server owns the MONEY: balances, the
+/// token ledger, the replay counters the decay ladder reads, the shelf inventory and the two lever
+/// rungs. This machine keeps owning ATTENDANCE - the streak, perfect attendance, the punch cards -
+/// because those are local-day facts about a person sitting at this desk, and they already have
+/// their own mirror. The local <c>wallet</c> meta key becomes a CACHE of the last answer, which is
+/// what lets the Prize Counter, the Locker and the chips render with the network down.</para>
+///
+/// <para>NEVER SUBTRACT, NEVER DOUBLE-PAY. Two rules carry that. First, every mint frame carries a
+/// <c>mintId</c> and the server is idempotent on it, so a frame that timed out on the wire and got
+/// replayed tomorrow pays exactly once. Second, a frame is only ever QUEUED once this account has
+/// imported (<see cref="ArcademyMetaStore.WalletImportedKey"/>): before that the local wallet is
+/// still the record and the import itself is what carries the night's earnings up, so queueing as
+/// well would bank the same tickets twice.</para>
+///
+/// <para>THE LOCAL MINT IS A PREVIEW. When a class ends and the server cannot be reached, the host
+/// still mints locally so the debrief has a number to show, then parks the frame. The server's
+/// answer REPLACES the local wallet when the queue drains, so the preview is never added to
+/// anything - it is only ever the page's benefit.</para>
+/// </summary>
+internal static class ArcademyWalletSyncService
+{
+    /// <summary>The proxy, spelled the way every other service here spells it (there is no shared
+    /// constant in this codebase - see <see cref="ArcademySyncService"/>).</summary>
+    private const string ProxyBaseUrl = "https://codebambi-proxy.vercel.app";
+
+    private const string WalletPath = "/v2/arcademy/wallet";
+    private const string ImportPath = "/v2/arcademy/wallet/import";
+    private const string ClassEndedPath = "/v2/arcademy/class-ended";
+    private const string PrizeBuyPath = "/v2/arcademy/prize-buy";
+
+    /// <summary>How long a call the PAGE is waiting on may take. The Prize Counter puts its own
+    /// watchdog down at 6s (<c>shell/prizecounter.js</c> ECHO_WAIT_MS) and answers "the counter
+    /// went quiet" when it fires, so a request that has not landed by 5s has to be turned into a
+    /// refusal here while there is still a second left to say so. The report card has no watchdog
+    /// - a late <c>payout-result</c> simply repaints it - but it reads as a stall all the same, so
+    /// the mint is timed the same way.</summary>
+    private static readonly TimeSpan PageWait = TimeSpan.FromSeconds(5);
+
+    /// <summary>Bodies are truncated in the log the way <see cref="ArcademySyncService"/> does.</summary>
+    private const int MaxLoggedBody = 200;
+
+    /// <summary>The wire's id shape for both <c>deviceId</c> and <c>mintId</c>. A GUID in "N" form
+    /// is 32 hex characters, comfortably inside it.</summary>
+    private static readonly Regex IdShape = new("^[A-Za-z0-9_-]{8,64}$", RegexOptions.Compiled);
+
+    /// <summary>The launch pull can take its time (nobody is watching it); the two page-facing
+    /// calls carry their own shorter cancellation instead.</summary>
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(20) };
+
+    static ArcademyWalletSyncService()
+    {
+        try
+        {
+            Http.DefaultRequestHeaders.Add("X-Client-Version", UpdateService.AppVersion);
+            Http.DefaultRequestHeaders.UserAgent.ParseAdd($"ConditioningControlPanel/{UpdateService.AppVersion}");
+        }
+        catch { /* a header we could not set is not worth failing a static ctor over */ }
+    }
+
+    private static readonly object Gate = new();
+    private static ArcademyMetaStore? _store;
+    private static Action? _onWalletChanged;
+
+    /// <summary>Bumped by <see cref="Detach"/>, read by every continuation - same generation guard
+    /// <see cref="ArcademySyncService"/> and <see cref="ArcademyHostService"/> use, so a reply that
+    /// lands after the window closed cannot write into the next session's store.</summary>
+    private static int _generation;
+
+    /// <summary>Tonight's payday as the SERVER drew it, or null when this launch never got an
+    /// answer. <c>init.economy.payday</c> prefers it and falls back to the local draw; the two
+    /// agree whenever the mirrored roster and the enrolled roster do.</summary>
+    private static ArcademyEconomy.Payday? _serverPayday;
+
+    /// <summary>One hard refusal is worth a line; a hundred are worth none. Covers the tier gate and
+    /// the credential door alike - either way it is the same launch-long condition. Reset per launch.</summary>
+    private static bool _refusalLogged;
+
+    /// <summary>One request at a time. The server takes a 5s account lock on every write, so two
+    /// of ours racing would only 409 each other.</summary>
+    private static readonly SemaphoreSlim InFlight = new(1, 1);
+
+    // ============================ lifecycle ============================
+
+    /// <summary>
+    /// Bind to the store the Arcademy just opened and go and fetch the account's wallet. Called
+    /// from <see cref="ArcademyHostService"/>'s launch beside the punch-card mirror's own Attach,
+    /// and like that one it is not awaited: the reply usually lands while the WebView2 is still
+    /// booting and rides out in <c>init</c>, and when it is slower
+    /// <paramref name="onWalletChanged"/> pushes the ordinary whole-blob meta snapshot instead.
+    /// </summary>
+    public static void Attach(ArcademyMetaStore store, Action onWalletChanged)
+    {
+        lock (Gate)
+        {
+            _store = store;
+            _onWalletChanged = onWalletChanged;
+            _serverPayday = null;
+            _refusalLogged = false;
+        }
+        int generation = Volatile.Read(ref _generation);
+        Run(() => LaunchAsync(generation), "launch");
+    }
+
+    /// <summary>Unbind at teardown. Nothing is flushed because nothing is buffered: a frame that
+    /// did not get out lives in <c>pendingMints</c> on disk and the next launch replays it.</summary>
+    public static void Detach()
+    {
+        lock (Gate)
+        {
+            _store = null;
+            _onWalletChanged = null;
+            _serverPayday = null;
+        }
+        Interlocked.Increment(ref _generation);
+    }
+
+    /// <summary>Is there an account to bank into? The same door <see cref="ArcademySyncService"/>
+    /// pushes cards through, asked the same way and just as quietly.</summary>
+    public static bool DoorOpen => Identity(out _, out _);
+
+    /// <inheritdoc cref="_serverPayday"/>
+    public static ArcademyEconomy.Payday? ServerPayday
+    {
+        get { lock (Gate) return _serverPayday; }
+    }
+
+    // ============================ what the host calls ============================
+
+    /// <summary>What became of one graded finish.</summary>
+    internal enum MintVerdict
+    {
+        /// <summary>The server minted it. <c>Economy</c> is its answer and the wallet is adopted.</summary>
+        Banked,
+
+        /// <summary>Nobody answered (network, 5xx, 409, 429, a timeout). Mint locally for the page
+        /// and park the frame.</summary>
+        Queue,
+
+        /// <summary>The server said no and will say no again (403 tier, 400 body). Mint locally and
+        /// park nothing - a queue of frames that can never land is just a leak.</summary>
+        Refused,
+    }
+
+    internal readonly record struct MintOutcome(MintVerdict Verdict, JObject? Economy);
+
+    /// <summary>What became of one press of Buy. <c>Answered</c> false is the offline case: the
+    /// counter refuses and the local wallet is left exactly as it was.</summary>
+    internal readonly record struct BuyOutcome(bool Answered, bool Ok, string? Reason, JObject? Wallet);
+
+    /// <summary>
+    /// Bank one graded finish. Fire-and-forget with a guaranteed single callback on a background
+    /// thread - the caller owns marshalling it to the dispatcher, exactly like the mirror's
+    /// <c>onCardsChanged</c>.
+    /// </summary>
+    public static void Bank(JObject frame, Action<MintOutcome> settled)
+    {
+        int generation = Volatile.Read(ref _generation);
+        Run(async () =>
+        {
+            MintOutcome outcome;
+            try { outcome = await PostMintAsync(frame, generation).ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                App.Logger?.Information("[ArcademyWallet] mint failed: {E}", ex.Message);
+                outcome = new MintOutcome(MintVerdict.Queue, null);
+            }
+            try { settled(outcome); }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.Bank callback: {E}", ex.Message); }
+
+            // A mint that landed is proof the wire is up: anything parked from an earlier night
+            // can go out now rather than waiting for the next launch.
+            if (outcome.Verdict == MintVerdict.Banked) await ReplayAsync(generation).ConfigureAwait(false);
+        }, "mint");
+    }
+
+    /// <summary>Settle one press of Buy at the counter. Same shape as <see cref="Bank"/>.</summary>
+    public static void Buy(string sku, Action<BuyOutcome> settled)
+    {
+        int generation = Volatile.Read(ref _generation);
+        Run(async () =>
+        {
+            BuyOutcome outcome;
+            try { outcome = await PostBuyAsync(sku, generation).ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                App.Logger?.Information("[ArcademyWallet] buy failed: {E}", ex.Message);
+                outcome = new BuyOutcome(false, false, "offline", null);
+            }
+            try { settled(outcome); }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.Buy callback: {E}", ex.Message); }
+        }, "buy");
+    }
+
+    // ============================ launch ============================
+
+    /// <summary>
+    /// THE LAUNCH PULL, and the only place the import rule runs. Read the account's wallet, adopt
+    /// it, carry this machine's wallet up if it has never been carried, then drain anything that
+    /// was parked while the wire was down.
+    /// </summary>
+    private static async Task LaunchAsync(int generation)
+    {
+        if (!Identity(out var unifiedId, out var token)) return;
+
+        // Wait our turn rather than give up. Sign out and back in, or close the Arcademy and open
+        // it again, and this runs while the previous pull is still on the wire; dropping the new
+        // one would leave the fresh window reading a stale cache until the next launch. Bounded so
+        // a wedged request cannot hold a launch here for ever, and the epoch is asked again on the
+        // way in because the wait is long enough for the window to have moved on.
+        if (!await InFlight.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false)) return;
+        try
+        {
+            if (Retired(generation)) return;
+
+            var url = $"{ProxyBaseUrl}{WalletPath}?unified_id={Uri.EscapeDataString(unifiedId)}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Auth-Token", token);
+
+            using var response = await Http.SendAsync(request).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                App.Logger?.Information("[ArcademyWallet] pull failed: {Status} {Body}",
+                    (int)response.StatusCode, Truncate(body));
+                return;
+            }
+
+            var reply = Parse(body);
+            if (reply == null || Retired(generation)) return;
+            var store = Store(generation);
+            if (store == null) return;
+
+            NotePayday(reply["payday"] as JObject);
+            NoteCatalogWave(reply["catalogWave"]);
+
+            bool exists = (bool?)reply["exists"] ?? false;
+            var serverWallet = reply["wallet"] as JObject;
+            bool imported = store.WalletImportedAt() != null;
+
+            // THE IMPORT RULE (contract, "Client behaviour"). Two doors into the same call: a
+            // server with nothing on this account takes whatever this machine has earned, and a
+            // server that already holds a wallet MERGES a machine that has never handed its own
+            // over. Both are once-per-device forever after - the server remembers the deviceId, and
+            // so do we, so a lost answer costs a wasted round trip rather than a second import.
+            if (!imported && (exists || store.WalletHasEarnings()))
+            {
+                var answer = await PostImportAsync(store, unifiedId, token, generation).ConfigureAwait(false);
+                if (answer != null) serverWallet = answer;
+            }
+            else if (!imported)
+            {
+                // Nothing here and nothing there. Not an import, and deliberately not marked as one
+                // either: the day this machine does earn something is the day it should carry it up.
+                App.Logger?.Information("[ArcademyWallet] no wallet on either side yet - nothing to import");
+            }
+
+            if (Retired(generation)) return;
+            if (serverWallet != null)
+            {
+                store.AdoptServerWallet(serverWallet);
+                App.Logger?.Information("[ArcademyWallet] adopted the account wallet: {T} tickets, {K} tokens (rev {Rev})",
+                    (int?)serverWallet["t"] ?? 0, (int?)serverWallet["k"] ?? 0, (int?)serverWallet["rev"] ?? 0);
+            }
+
+            await ReplayAsync(generation).ConfigureAwait(false);
+            RaiseChanged(generation);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyWallet] pull failed: {E}", ex.Message);
+        }
+        finally { try { InFlight.Release(); } catch { } }
+    }
+
+    /// <summary>
+    /// Hand this machine's wallet over, once. The answer is the merged wallet and it is what gets
+    /// adopted; the flag is written on any answer at all, including the server's own no-op, because
+    /// what it records is "this device has been offered", not "this device paid in".
+    /// </summary>
+    private static async Task<JObject?> PostImportAsync(ArcademyMetaStore store, string unifiedId,
+        string token, int generation)
+    {
+        try
+        {
+            var deviceId = store.WalletDeviceId();
+            if (!IdShape.IsMatch(deviceId))
+            {
+                App.Logger?.Warning("[ArcademyWallet] refusing to import with a malformed device id");
+                return null;
+            }
+
+            var payload = JsonConvert.SerializeObject(new
+            {
+                unified_id = unifiedId,
+                deviceId,
+                wallet = store.WalletSnapshot(),
+            });
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{ProxyBaseUrl}{ImportPath}")
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Add("X-Auth-Token", token);
+
+            using var response = await Http.SendAsync(request).ConfigureAwait(false);
+            var text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                App.Logger?.Information("[ArcademyWallet] import refused: {Status} {Body} - trying again next launch",
+                    (int)response.StatusCode, Truncate(text));
+                return null;
+            }
+
+            var reply = Parse(text);
+            if (Retired(generation)) return null;
+
+            // A clamp is the server refusing an impossible delta, not a failed request - the same
+            // reading the punch-card mirror's clamps get. Worth a line, worth nothing else.
+            if (reply?["clamps"] is JArray clamps && clamps.Count > 0)
+            {
+                App.Logger?.Information("[ArcademyWallet] the import was clamped: {Clamps}",
+                    string.Join(", ", clamps.Select(c => (string?)c ?? "?")));
+            }
+
+            store.MarkWalletImported();
+            App.Logger?.Information("[ArcademyWallet] this machine's wallet has been carried up ({Imported})",
+                (bool?)reply?["imported"] == true ? "merged" : "already known");
+            return reply?["wallet"] as JObject;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyWallet] import failed: {E}", ex.Message);
+            return null;
+        }
+    }
+
+    // ============================ the mint ============================
+
+    /// <summary>
+    /// POST one class-ended frame. Timed at <see cref="PageWait"/> because the debrief is sitting
+    /// there waiting for the number.
+    /// </summary>
+    private static async Task<MintOutcome> PostMintAsync(JObject frame, int generation)
+    {
+        if (!Identity(out var unifiedId, out var token)) return new MintOutcome(MintVerdict.Refused, null);
+
+        using var cts = new CancellationTokenSource(PageWait);
+        try
+        {
+            var body = (JObject)frame.DeepClone();
+            body["unified_id"] = unifiedId;
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{ProxyBaseUrl}{ClassEndedPath}")
+            {
+                Content = new StringContent(body.ToString(Formatting.None), Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Add("X-Auth-Token", token);
+
+            using var response = await Http.SendAsync(request, cts.Token).ConfigureAwait(false);
+            var text = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                int status = (int)response.StatusCode;
+
+                // 403 IS THE TIER GATE, and it is not a failure to retry. The desktop opens the
+                // Arcademy on a slightly wider bar than the server mints on (the 14-day offline
+                // grace, mainly), so an account can legitimately be playing here and unable to bank
+                // there. Its money simply stays on this machine, and it is worth exactly one line.
+                if (status == 403)
+                {
+                    lock (Gate)
+                    {
+                        if (!_refusalLogged)
+                        {
+                            _refusalLogged = true;
+                            App.Logger?.Information(
+                                "[ArcademyWallet] the server will not bank for this account: {Body}. Tickets stay on this machine.",
+                                Truncate(text));
+                        }
+                    }
+                    return new MintOutcome(MintVerdict.Refused, null);
+                }
+
+                // A 400 is this client speaking a contract the server has not learned (or a frame
+                // built out of something unreadable). Replaying it forever would never fix it.
+                if (status == 400)
+                {
+                    App.Logger?.Warning("[ArcademyWallet] the server refused the frame: {Body}", Truncate(text));
+                    return new MintOutcome(MintVerdict.Refused, null);
+                }
+
+                // A 401 IS PARKED, NOT DROPPED, and the distinction is worth a line of its own.
+                // It is what a token caught mid-refresh looks like, and it is also what this route
+                // would answer if it had not yet learned the desktop's own door - and in both cases
+                // the money is real and the frame will pay the moment the credential works. Parking
+                // is the side that cannot lose a night; the queue's own cap is what bounds it.
+                if (status == 401)
+                {
+                    lock (Gate)
+                    {
+                        if (!_refusalLogged)
+                        {
+                            _refusalLogged = true;
+                            App.Logger?.Warning(
+                                "[ArcademyWallet] the mint would not take this account's credential: {Body}. Frames are being parked until it does.",
+                                Truncate(text));
+                        }
+                    }
+                    return new MintOutcome(MintVerdict.Queue, null);
+                }
+
+                App.Logger?.Information("[ArcademyWallet] mint refused: {Status} {Body} - parking the frame",
+                    status, Truncate(text));
+                return new MintOutcome(MintVerdict.Queue, null);
+            }
+
+            var reply = Parse(text);
+            var economy = reply?["economy"] as JObject;
+            if (economy == null)
+            {
+                // A 200 with no economy block is an older server that only stamped the card. The
+                // money never left this machine, so mint locally and park it for the day the route
+                // learns to pay.
+                App.Logger?.Information("[ArcademyWallet] the server stamped the card but paid nothing - parking the frame");
+                return new MintOutcome(MintVerdict.Queue, null);
+            }
+
+            if ((bool?)economy["duplicate"] == true)
+            {
+                App.Logger?.Information("[ArcademyWallet] mint {Mint} was already banked - the server paid it once",
+                    (string?)frame["mintId"]);
+            }
+
+            if (!Retired(generation) && economy["wallet"] is JObject wallet)
+            {
+                Store(generation)?.AdoptServerWallet(wallet);
+            }
+            return new MintOutcome(MintVerdict.Banked, economy);
+        }
+        catch (OperationCanceledException)
+        {
+            App.Logger?.Information("[ArcademyWallet] the mint did not answer inside {S}s - parking the frame",
+                PageWait.TotalSeconds);
+            return new MintOutcome(MintVerdict.Queue, null);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyWallet] mint failed: {E} - parking the frame", ex.Message);
+            return new MintOutcome(MintVerdict.Queue, null);
+        }
+    }
+
+    /// <summary>
+    /// Drain <c>pendingMints</c>, oldest first. Each frame goes up carrying the SAME mintId it was
+    /// parked with, so a frame that in fact reached the server the first time (and only lost its
+    /// answer on the way back) is recognised and paid once.
+    ///
+    /// <para>Stops at the first frame nobody answers rather than working down the list: the wire is
+    /// down, and the rest of the queue would only be a row of timeouts. A frame the server actively
+    /// refuses is dropped instead, because a queue that can never drain is just a leak.</para>
+    /// </summary>
+    private static async Task ReplayAsync(int generation)
+    {
+        var store = Store(generation);
+        if (store == null) return;
+        JArray pending;
+        try { pending = store.PendingMints(); }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.Replay read: {E}", ex.Message); return; }
+        if (pending.Count == 0) return;
+
+        App.Logger?.Information("[ArcademyWallet] {N} parked mint(s) to replay", pending.Count);
+        foreach (var token in pending.ToList())
+        {
+            if (Retired(generation)) return;
+            // PendingMints() hands back only frames that still carry a mintId, so there is nothing
+            // malformed to step over here.
+            if (token is not JObject frame) continue;
+            var mintId = (string?)frame["mintId"] ?? "";
+
+            frame["queued"] = true;
+            var outcome = await PostMintAsync(frame, generation).ConfigureAwait(false);
+            if (outcome.Verdict == MintVerdict.Queue)
+            {
+                App.Logger?.Information("[ArcademyWallet] the wire is still down - {N} frame(s) stay parked",
+                    store.PendingMintCount());
+                return;
+            }
+
+            store.DropMint(mintId);
+            if (outcome.Verdict == MintVerdict.Banked)
+            {
+                App.Logger?.Information("[ArcademyWallet] banked a parked mint for {Game} on {Day}",
+                    (string?)frame["game"], (string?)frame["localDay"]);
+            }
+        }
+    }
+
+    // ============================ the counter ============================
+
+    /// <summary>
+    /// POST one purchase. ONLINE ONLY by contract: the wallet lives on the server, so a press of
+    /// Buy that cannot reach it is a refusal rather than a local spend that would be overwritten by
+    /// the next pull anyway.
+    /// </summary>
+    private static async Task<BuyOutcome> PostBuyAsync(string sku, int generation)
+    {
+        if (!Identity(out var unifiedId, out var token)) return new BuyOutcome(false, false, "offline", null);
+
+        using var cts = new CancellationTokenSource(PageWait);
+        try
+        {
+            var payload = JsonConvert.SerializeObject(new { unified_id = unifiedId, sku });
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{ProxyBaseUrl}{PrizeBuyPath}")
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Add("X-Auth-Token", token);
+
+            using var response = await Http.SendAsync(request, cts.Token).ConfigureAwait(false);
+            var text = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+            var reply = Parse(text);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // THE ACCOUNT LOCK. Another device is mid-write on this same wallet - a phone that
+                // finished a class a second ago, most likely. It is the one status code here that
+                // is genuinely momentary, and the counter has its own line for it so it never reads
+                // as "you cannot afford that".
+                if (response.StatusCode == HttpStatusCode.Conflict)
+                {
+                    App.Logger?.Information("[ArcademyWallet] the wallet was busy - the counter says so");
+                    return new BuyOutcome(true, false, "busy", null);
+                }
+
+                // Every refusal the counter has a line for arrives as a 200 with `ok:false`. A
+                // status code instead means the account, not the purchase, was the problem, and the
+                // room says the same thing it says when nobody answers.
+                App.Logger?.Information("[ArcademyWallet] buy refused: {Status} {Body}",
+                    (int)response.StatusCode, Truncate(text));
+                return new BuyOutcome(false, false, "offline", null);
+            }
+
+            var wallet = reply?["wallet"] as JObject;
+            bool ok = (bool?)reply?["ok"] == true;
+            if (ok && wallet != null && !Retired(generation)) Store(generation)?.AdoptServerWallet(wallet);
+
+            var reason = (string?)reply?["reason"];
+            App.Logger?.Information("[ArcademyWallet] the counter answered '{Sku}': {Verdict}",
+                sku, ok ? "sold" : reason ?? "refused");
+            return new BuyOutcome(true, ok, reason, wallet);
+        }
+        catch (OperationCanceledException)
+        {
+            App.Logger?.Information("[ArcademyWallet] the counter did not answer inside {S}s", PageWait.TotalSeconds);
+            return new BuyOutcome(false, false, "offline", null);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyWallet] buy failed: {E}", ex.Message);
+            return new BuyOutcome(false, false, "offline", null);
+        }
+    }
+
+    // ============================ small guards ============================
+
+    /// <summary>Take the server's draw for tonight, when it sent one worth having.</summary>
+    private static void NotePayday(JObject? payday)
+    {
+        if (payday == null) return;
+        var gameKey = (string?)payday["gameKey"];
+        int mult = (int?)payday["mult"] ?? 1;
+        if (mult < 1) mult = 1;
+        lock (Gate) _serverPayday = new ArcademyEconomy.Payday(gameKey, mult);
+    }
+
+    /// <summary>The server ships its own copy of the shelf, generated from
+    /// <see cref="ArcademyEconomy"/>. A wave that has drifted from this build's is not something
+    /// this class can fix, but it IS the first thing to look at when a sku starts coming back
+    /// unknown, so it goes in the log where the owner will find it.</summary>
+    private static void NoteCatalogWave(JToken? wave)
+    {
+        int w = (int?)wave ?? 0;
+        if (w == 0 || w == ArcademyEconomy.CurrentWave) return;
+        App.Logger?.Information("[ArcademyWallet] the server's shelf is wave {Server}, this build is wave {Local}",
+            w, ArcademyEconomy.CurrentWave);
+    }
+
+    /// <summary>
+    /// The token door: <c>X-Auth-Token</c> plus this account's own <c>unified_id</c>, exactly the
+    /// door <see cref="ArcademySyncService"/> pushes cards through. No identity, no traffic - and
+    /// silently so: a player who has never logged in is not a problem to report, they are simply
+    /// someone whose wallet lives on their own machine.
+    /// </summary>
+    private static bool Identity(out string unifiedId, out string token)
+    {
+        unifiedId = string.Empty;
+        token = string.Empty;
+        try
+        {
+            if (App.Settings?.Current?.OfflineMode == true) return false;
+            var id = App.Settings?.Current?.UnifiedId;
+            var auth = App.Settings?.Current?.AuthToken;
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(auth)) return false;
+            unifiedId = id;
+            token = auth;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyWallet.Identity: {E}", ex.Message);
+            return false;
+        }
+    }
+
+    private static ArcademyMetaStore? Store(int generation)
+    {
+        if (Retired(generation)) return null;
+        lock (Gate) return _store;
+    }
+
+    private static bool Retired(int generation) =>
+        generation >= 0 && Volatile.Read(ref _generation) != generation;
+
+    private static void RaiseChanged(int generation)
+    {
+        Action? cb;
+        lock (Gate) cb = _onWalletChanged;
+        if (cb == null || Retired(generation)) return;
+        try { cb(); }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.RaiseChanged: {E}", ex.Message); }
+    }
+
+    /// <summary>Fire-and-forget onto the thread pool with a catch-all: every entry point here is
+    /// called from a UI-thread handler and none of them may pay for the network or die of it
+    /// (CLAUDE.md async rules 6-8).</summary>
+    private static void Run(Func<Task> work, string what)
+    {
+        try
+        {
+            _ = Task.Run(async () =>
+            {
+                try { await work().ConfigureAwait(false); }
+                catch (Exception ex) { App.Logger?.Information("[ArcademyWallet] {What} failed: {E}", what, ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyWallet.Run({What}): {E}", what, ex.Message); }
+    }
+
+    private static JObject? Parse(string body)
+    {
+        try { return string.IsNullOrWhiteSpace(body) ? null : JObject.Parse(body); }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyWallet] unreadable reply: {E}", ex.Message);
+            return null;
+        }
+    }
+
+    private static string Truncate(string? s)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        return s.Length <= MaxLoggedBody ? s : s[..MaxLoggedBody] + "...";
+    }
+
+    // ============================ the frame ============================
+
+    /// <summary>
+    /// Build the mint frame for one graded finish. Everything on it is host-decided: the page
+    /// reports what happened and every number here has already been clamped by the caller, so the
+    /// server is being told the same story the local mint would have been told.
+    ///
+    /// <para><c>tzOffsetMinutes</c> is the wire's convention, not .NET's - minutes to ADD to local
+    /// to reach UTC, so a player at UTC+2 sends -120.</para>
+    /// </summary>
+    public static JObject BuildMintFrame(string gameKey, string grade, bool zen, int streak,
+        string localDay, string lever, bool lateSlipUsed, string seed)
+    {
+        int tz;
+        try { tz = -(int)Math.Round(TimeZoneInfo.Local.GetUtcOffset(DateTime.Now).TotalMinutes); }
+        catch { tz = 0; }
+
+        return new JObject
+        {
+            ["kind"] = "class-ended",
+            ["game"] = gameKey,
+            ["grade"] = grade,
+            ["zen"] = zen,
+            ["localDay"] = localDay,
+            ["tzOffsetMinutes"] = Math.Clamp(tz, -840, 840),
+            ["streak"] = Math.Clamp(streak, 0, 3650),
+            ["lateSlipUsed"] = lateSlipUsed,
+            ["lever"] = lever,
+            ["mintId"] = Guid.NewGuid().ToString("N"),
+            ["seed"] = seed.Length <= 64 ? seed : seed[..64],
+        };
+    }
+
+    /// <summary>
+    /// Park a frame the server never took, so the next launch can carry it up.
+    ///
+    /// <para>ONLY ONCE THIS ACCOUNT HAS IMPORTED, and that condition is the whole double-pay guard.
+    /// Before the import, the local wallet still IS the record and the import is what carries the
+    /// night's earnings to the server; parking the frame as well would bank the same tickets twice,
+    /// once as a balance and once as a mint. After the import the local wallet is only a cache, so
+    /// the frame is the only copy of that night's money and it has to be kept.</para>
+    /// </summary>
+    public static void Park(JObject frame)
+    {
+        try
+        {
+            var store = Store(Volatile.Read(ref _generation));
+            if (store == null) return;
+            if (store.WalletImportedAt() == null)
+            {
+                App.Logger?.Information(
+                    "[ArcademyWallet] this machine has not carried its wallet up yet - the local mint is the record, nothing parked");
+                return;
+            }
+            store.QueueMint(frame);
+        }
+        catch (Exception ex) { App.Logger?.Warning("ArcademyWallet.Park: {E}", ex.Message); }
+    }
+}

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
@@ -44,6 +44,15 @@ namespace ConditioningControlPanel.Services.Arcademy;
 /// still mints locally so the debrief has a number to show, then parks the frame. The server's
 /// answer REPLACES the local wallet when the queue drains, so the preview is never added to
 /// anything - it is only ever the page's benefit.</para>
+///
+/// <para>THE TIER GATE IS PARKED, NOT DROPPED, AND THAT IS A DESKTOP RULE. The server reads the
+/// live tier on every call; this app grants a 14-day cached-entitlement grace it does not, so
+/// inside that grace an account playing here is answered <c>403 arcademy_locked</c> there. The
+/// import can only ever carry what was on this machine when it ran, never a night earned after it,
+/// so a dropped frame is the one way the grace could cost somebody money they watched themselves
+/// earn. Parked frames wait for the pledge, and the server pays a queued one even when its stamp
+/// falls outside the attendance wall. A 403 that names no tier is the identity door, which is a
+/// different refusal and keeps its own ending.</para>
 /// </summary>
 internal static class ArcademyWalletSyncService
 {
@@ -103,6 +112,11 @@ internal static class ArcademyWalletSyncService
     /// the credential door alike - either way it is the same launch-long condition. Reset per launch.</summary>
     private static bool _refusalLogged;
 
+    /// <summary>Set the first time the tier gate turns a mint away this launch. It changes nothing
+    /// about what happens to the frame (it parks, like any other unanswered one); it only stops the
+    /// replay reporting a wall as "the wire is down", which is the wrong thing to go looking for.</summary>
+    private static bool _tierWalled;
+
     /// <summary>One request at a time. The server takes a 5s account lock on every write, so two
     /// of ours racing would only 409 each other.</summary>
     private static readonly SemaphoreSlim InFlight = new(1, 1);
@@ -124,6 +138,7 @@ internal static class ArcademyWalletSyncService
             _onWalletChanged = onWalletChanged;
             _serverPayday = null;
             _refusalLogged = false;
+            _tierWalled = false;
         }
         int generation = Volatile.Read(ref _generation);
         Run(() => LaunchAsync(generation), "launch");
@@ -160,12 +175,13 @@ internal static class ArcademyWalletSyncService
         /// <summary>The server minted it. <c>Economy</c> is its answer and the wallet is adopted.</summary>
         Banked,
 
-        /// <summary>Nobody answered (network, 5xx, 409, 429, a timeout). Mint locally for the page
-        /// and park the frame.</summary>
+        /// <summary>Nobody answered, or nobody may answer YET (network, 5xx, 409, 429, a timeout,
+        /// and the tier gate). Mint locally for the page and park the frame.</summary>
         Queue,
 
-        /// <summary>The server said no and will say no again (403 tier, 400 body). Mint locally and
-        /// park nothing - a queue of frames that can never land is just a leak.</summary>
+        /// <summary>The server said no and will say no to this frame for ever (a malformed body, a
+        /// credential that names no account at all). Mint locally and park nothing - a queue of
+        /// frames that can never land is just a leak.</summary>
         Refused,
     }
 
@@ -390,19 +406,51 @@ internal static class ArcademyWalletSyncService
             {
                 int status = (int)response.StatusCode;
 
-                // 403 IS THE TIER GATE, and it is not a failure to retry. The desktop opens the
-                // Arcademy on a slightly wider bar than the server mints on (the 14-day offline
-                // grace, mainly), so an account can legitimately be playing here and unable to bank
-                // there. Its money simply stays on this machine, and it is worth exactly one line.
                 if (status == 403)
                 {
+                    var refusal = Parse(text);
+
+                    // THE TIER GATE IS THE ONE REFUSAL THIS LANE PARKS, and it is worth saying why
+                    // at length because the server's own contract advises the opposite.
+                    //
+                    // The desktop grants a 14-day CACHED-ENTITLEMENT GRACE that the server does not
+                    // keep: the proxy reads the live tier on every call, so inside that grace an
+                    // account that is legitimately playing here is answered 403 there. Dropping the
+                    // frame is the one way that grace could cost somebody real money, because the
+                    // once-per-device import can only ever carry what was on the machine when it
+                    // ran - never a night earned after it. The queue CAN carry that night, and the
+                    // server pays a queued frame even when its stamp falls outside the attendance
+                    // wall (it answers `<game>:queued_stamp_walled` and pays anyway).
+                    //
+                    // Replayed on the NEXT LAUNCH and no sooner, which is also the only cadence
+                    // that means anything: a pledge does not come back mid-session.
+                    if (IsTierRefusal(refusal))
+                    {
+                        lock (Gate)
+                        {
+                            _tierWalled = true;
+                            if (!_refusalLogged)
+                            {
+                                _refusalLogged = true;
+                                App.Logger?.Information(
+                                    "[ArcademyWallet] the server will not bank for this account yet: {Body}. Frames are being parked until it does.",
+                                    Truncate(text));
+                            }
+                        }
+                        return new MintOutcome(MintVerdict.Queue, null);
+                    }
+
+                    // THE OTHER 403 IS `arcademy_identity_unknown`, and it is a different animal:
+                    // this credential resolves to no account at all, so there is no wallet for a
+                    // queue to drain into and a parked frame would be waiting on something that is
+                    // not coming. The money stays on this machine, where it already is.
                     lock (Gate)
                     {
                         if (!_refusalLogged)
                         {
                             _refusalLogged = true;
                             App.Logger?.Information(
-                                "[ArcademyWallet] the server will not bank for this account: {Body}. Tickets stay on this machine.",
+                                "[ArcademyWallet] the server cannot name an account for this credential: {Body}. Tickets stay on this machine.",
                                 Truncate(text));
                         }
                     }
@@ -411,8 +459,25 @@ internal static class ArcademyWalletSyncService
 
                 // A 400 is this client speaking a contract the server has not learned (or a frame
                 // built out of something unreadable). Replaying it forever would never fix it.
+                //
+                // ONE REASON IS DIFFERENT AND IT IS WORTH THE EXTRA BRANCH. `local_day_out_of_range`
+                // on a frame that did NOT go up marked `queued` is the ATTENDANCE wall, which is
+                // deliberately the tighter of the server's two: it asks whether somebody really was
+                // at this desk on that day. The queue's wall is fourteen days wide, so the very same
+                // frame replayed as a queued one is a frame the server will pay. Parking it is
+                // therefore not a retry of a hopeless request, it is asking a different question.
                 if (status == 400)
                 {
+                    var refusal = Parse(text);
+                    if ((string?)refusal?["reason"] == "local_day_out_of_range"
+                        && (bool?)frame["queued"] != true)
+                    {
+                        App.Logger?.Information(
+                            "[ArcademyWallet] the attendance wall would not take {Day} - parking it for the queue's wider window",
+                            (string?)frame["localDay"]);
+                        return new MintOutcome(MintVerdict.Queue, null);
+                    }
+
                     App.Logger?.Warning("[ArcademyWallet] the server refused the frame: {Body}", Truncate(text));
                     return new MintOutcome(MintVerdict.Refused, null);
                 }
@@ -484,8 +549,13 @@ internal static class ArcademyWalletSyncService
     /// answer on the way back) is recognised and paid once.
     ///
     /// <para>Stops at the first frame nobody answers rather than working down the list: the wire is
-    /// down, and the rest of the queue would only be a row of timeouts. A frame the server actively
-    /// refuses is dropped instead, because a queue that can never drain is just a leak.</para>
+    /// down, and the rest of the queue would only be a row of timeouts. THE TIER GATE STOPS IT THE
+    /// SAME WAY and for a better reason - it is one condition for the whole launch, so the second
+    /// frame would only be told what the first one already was. A frame the server refuses outright
+    /// is dropped instead, because a queue that can never drain is just a leak.</para>
+    ///
+    /// <para>Called at launch, and again after any mint that landed (a mint landing is proof the
+    /// wire and the gate are both open). Nothing here retries inside a session on its own.</para>
     /// </summary>
     private static async Task ReplayAsync(int generation)
     {
@@ -509,7 +579,12 @@ internal static class ArcademyWalletSyncService
             var outcome = await PostMintAsync(frame, generation).ConfigureAwait(false);
             if (outcome.Verdict == MintVerdict.Queue)
             {
-                App.Logger?.Information("[ArcademyWallet] the wire is still down - {N} frame(s) stay parked",
+                bool walled;
+                lock (Gate) walled = _tierWalled;
+                App.Logger?.Information(
+                    walled
+                        ? "[ArcademyWallet] the account cannot bank yet - {N} frame(s) stay parked"
+                        : "[ArcademyWallet] the wire is still down - {N} frame(s) stay parked",
                     store.PendingMintCount());
                 return;
             }
@@ -590,6 +665,21 @@ internal static class ArcademyWalletSyncService
     }
 
     // ============================ small guards ============================
+
+    /// <summary>
+    /// Is this 403 the TIER gate rather than the identity door? The two send a player to two
+    /// different places and this lane treats them differently, so it reads the machine-readable
+    /// fields rather than the status code: the tier body is <c>code:'arcademy_locked'</c> and
+    /// carries <c>min_tier</c>, the identity body is <c>code:'arcademy_identity_unknown'</c> and
+    /// carries neither. An unreadable body is treated as the identity refusal, which is the side
+    /// that parks nothing - a queue is the thing to be careful about growing.
+    /// </summary>
+    private static bool IsTierRefusal(JObject? refusal)
+    {
+        if (refusal == null) return false;
+        if (string.Equals((string?)refusal["code"], "arcademy_locked", StringComparison.Ordinal)) return true;
+        return refusal["min_tier"] != null && refusal["min_tier"]!.Type != JTokenType.Null;
+    }
 
     /// <summary>Take the server's draw for tonight, when it sent one worth having.</summary>
     private static void NotePayday(JObject? payday)


### PR DESCRIPTION
## What this is

The desktop half of the shared Arcademy wallet. Today every platform mints and spends locally, so
the balance on the PC and the balance on the phone are two different piles of tickets. This puts the
wallet on the account: the server owns it, the desktop keeps its local copy as a cache of the last
answer, and a second device sees the same balance on its next launch.

Implements the "Client behaviour" section of the wallet contract. The server lane is
`CC-Labs-llc/CCP-Server` branch `feat/arcademy-wallet`; the web and mobile lanes are being built to
the same contract in parallel.

## Why it is shaped like this

`Services/Arcademy/ArcademyWalletSyncService.cs` is deliberately the punch-card mirror's twin: same
proxy, same `X-Auth-Token` + `unified_id` door, same fire-and-forget `Run` wrapper, same generation
counter so a late reply cannot write into the next window, same quiet logging (`[ArcademyWallet]`).
Nothing here blocks the page and nothing here puts a dialog in front of anybody.

Two rules held the design:

**Never subtract locally.** No failure path ever takes tickets away. The server is the only thing
that can spend.

**Never double-pay.** Every graded finish carries a client-minted `mintId`, the server keeps those
for 30 days, and a replay of the same frame returns the stored result rather than paying again.

## Offline queue

- Signed out: today's local-authority path, byte for byte. Nothing was touched.
- Server answers: adopt `economy.wallet`, post `payout-result` from the server's numbers.
- 5xx / 409 / timeout / network / 401: mint LOCALLY so the debrief still shows a number, then park
  the frame in `pendingMints` with `queued:true` and the SAME `mintId`. The next launch, or the next
  mint that lands, replays the queue oldest first and the server's answer replaces the local wallet.
  The local mint was only ever a preview.
- 403 tier: mint locally, park NOTHING, log once per launch. A queue of frames that can never land
  is just a leak.
- One extra guard the contract does not name: `Park` refuses to queue anything before this machine
  has imported. Until the import runs the local wallet is still the record, and the import itself
  carries that night's money up. Parking as well would bank it twice.

## Import rule

On launch, with an account behind it, GET the wallet. If this install has never imported and either
the server has a wallet or the local one has earnings, POST the import once (server merges, keyed on
a per-install `walletDeviceId`), then adopt. From then on local is a cache. If neither side has
anything yet, nothing is sent. `walletImported` and `walletDeviceId` live in host-owned meta, not in
the wallet object.

`init.economy.payday` shows the server's draw when the launch pull got through, and the local
`PickPayday` otherwise.

## Two reasons the Prize Counter had no words for

`Resources/web/arcademy/shell/prizecounter.js`'s REFUSALS map had no row for `offline` or `busy`, so
both fell to the unknown shrug line. Once the wallet is on the account those are the two refusals a
purely local till could never produce, and neither is anything the player did:

- `offline` - the counter cannot reach the bank right now. Nothing was charged.
- `busy` - somebody is already at the drawer (one of the player's OWN other devices, mid-write).

Added to the map, to `core/lexicon.js`, and to the host lexicon in `ArcademyHostService` alongside
`prize_poor` / `prize_locked`. Web and mobile vendor this page byte for byte, so the rows land on
every platform from this one branch. Nothing else in `Resources/web` was touched.

Failure never zeroes the chip either: an unanswered Buy echoes the current local wallet back with
`ok:false`, never a null one.

## What was verified

- `dotnet build`: 0 errors, 344 warnings, all pre-existing (CA1416 and friends). No warning in any
  Arcademy file.
- An offline harness in the scratchpad compiles the REAL `ArcademyWalletSyncService`,
  `ArcademyMetaStore`, `ArcademyEconomy` and `ArcademyPunchCards` (one edit: the proxy base URL
  points at a local `HttpListener`) and drives them against a fake proxy. 18 checks over 6 scenarios,
  all passing:
  - launch adopts the account wallet whole (1234t / 9k), stamps `walletImported`, sends this
    install's `deviceId` in the import body, and takes the server's payday (sort x5)
  - a 500 comes back as "queue", the frame is parked under the same `mintId`, and the frame carries
    the wire's field names
  - a 200 with an `economy` block is banked and 184t / 2k is adopted
  - the replay drains the queue, re-sending the original `mintId` with `queued:true`
  - a 403 comes back Refused and parks nothing
  - before the import, nothing is parked at all
- Field names read against the live server branch: GET wallet (`exists`, `wallet`,
  `payday{gameKey,mult}`, `catalogWave`, `serverDay`), import body and its `{imported, wallet,
  clamps}` answer, class-ended's nested `economy.wallet`, prize-buy's 409 `{reason:'busy'}` and its
  200 `{ok, sku, reason, wallet}`. All match.
- Not verified by a play-test: this has not been run against the real proxy, because the server
  branch is not deployed.

## REPORT: which tier the desktop lets into the Arcademy

The door is `TierGate.DemandLab` -> `App.Patreon.HasLabAccess`, which is true when ANY of these
hold:

- Patreon `CurrentTier >= Level2`
- Patreon `IsWhitelisted`
- SubscribeStar tier >= 2
- SubscribeStar `IsWhitelisted`
- `HasCachedLabAccess` - a 14 day offline grace on the last good validation

The server's class-ended gate is strictly tier >= 2 (whitelist included, same arithmetic minus the
grace). So the two are the same set EXCEPT for the grace window: an account whose subscription
lapsed, or whose validation cannot reach the server, can still play locally for up to 14 days and
will 403 on the mint. That case is handled - local mint, nothing queued, one log line - but it is
worth an owner decision: the player keeps earning on that machine and those tickets never reach the
account.

## Open question for the server lane

`/v2/arcademy/class-ended` still resolves through `resolveBearerCaller`, which wants an
`Authorization: Bearer` header. The desktop sends none - it carries `X-Auth-Token` + `unified_id`,
the pair `resolveAccessCaller` already handles for `/access` and the pair the new wallet routes
accept. Until that route moves to `resolveAccessCaller`, every desktop mint 401s. The client treats
a 401 as "queue it, do not lose the money" with its own once-per-launch warning, so nothing breaks
today; the tickets simply stay parked until the door opens. Raised with the server lane.

Do not merge this ahead of the server branch. Signed-out players are unaffected either way.
