### PR TITLE
fix(avatar): the tube lands beside main after the DPI-settle refit, not on it

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
@@ -570,7 +570,19 @@ namespace ConditioningControlPanel
             {
                 _clampScreenValid = false;   // monitor may have changed under the cached clamp bounds
                 CalculateScaleFactor();
-                if (_isAttached) UpdatePosition();
+                if (_isAttached)
+                {
+                    // CalculateScaleFactor only writes ContentViewbox.Width/Height; the WINDOW follows on the
+                    // NEXT layout pass (the ContentViewbox.SizeChanged handler wired in OnLoaded). UpdatePosition
+                    // measures the tube with GetWindowRect, so without forcing layout here it hangs the NEW
+                    // offsets off the OLD footprint and plants her (newW-oldW) px too far right and
+                    // (newH-oldH)/2 px too low: on top of main's left rail until the next parent move. A cold
+                    // boot on a mixed-DPI pair hits this every launch (born on the primary, the first
+                    // UpdatePosition carries her onto main's monitor, WM_DPICHANGED is swallowed, and this
+                    // refit runs 450 ms later). Same force-layout Attach() does, for the same reason.
+                    UpdateLayout();
+                    UpdatePosition();
+                }
                 App.Logger?.Information("AvatarTube DPI settle refit: scale {Scale:F2}", _scaleFactor);
             }
             catch (Exception ex)


### PR DESCRIPTION
**Symptom:** on a cold launch with a mixed-DPI two-monitor pair, the avatar tube lands ON TOP of the main window's left rail instead of docked outside its left edge. She snaps home on the next parent move, so it only ever looks like a startup glitch.

**Root cause:** `RefitAfterDpiSettle()` did `CalculateScaleFactor(); if (_isAttached) UpdatePosition();`. `CalculateScaleFactor()` only writes `ContentViewbox.Width/Height`; the HWND follows on the NEXT layout pass, via the `ContentViewbox.SizeChanged` handler wired in `OnLoaded`. `UpdatePosition()` measures the tube with `GetWindowRect`, so it hung the NEW scale's offsets off the OLD window footprint: `(newW-oldW)` px too far right and `(newH-oldH)/2` px too low. At 0.65 -> 0.98 that is +257 px, +168 px, i.e. straight onto the rail. Regressed in 3f24c020b (mixed-DPI deadlock fix, 2026-08-23), which introduced the refit.

**Fix:** force the layout pass before measuring, exactly as `Attach()` already does for the same reason (`UpdateLayout(); // Force layout update so ActualWidth/Height reflect new size`). Everything else in the method is unchanged. WPF's `Window` pushes `Width`/`Height` to the HWND synchronously from its DP callbacks, so one `UpdateLayout()` is enough for `GetWindowRect` to see the grown footprint.

**Tests:** 4515 passed, 0 failed. Debug build clean (0 errors).

**Play-test ask:** cold boot with main on the 125% monitor and confirm she starts docked outside main's left edge, not over the rail; then drag main across monitors both ways. Also one single-monitor sanity boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SpGh5B86bg4UWAXCzuet2t
