### PR TITLE
fix(arcademy): Prize Counter and the service alley tappable again on short portrait phones (Discord Activity)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -5655,6 +5655,33 @@ html.arc-mobile[data-arc-orient="portrait"] .campus-hint {
   font-size:9px; letter-spacing:.14em;
 }
 
+/* ---- SHORT PORTRAIT FRAMES: the band only exists while the frame is TALLER
+   than 9:16, because `meet` letterboxes then. At or below 9:16 the plan is
+   height limited, the band collapses to nothing and the service alley
+   (Records / Front Office / Prize Counter / The Locker, plan y 72..181) rises
+   under the bell cluster and the post-row, which are the two pointer-catching
+   slabs above it - so every tap on those four windows died. Discord's Activity
+   takes 44px plus both safe-area insets off the iframe, which is exactly what
+   drops most phones under the line (iPhone SE and every 16:9 Android in the
+   Activity; a 390x844 tab never hits it). Measured break: campus height below
+   ~663px at phone width.
+
+   Two rules. First, the two chrome containers stop catching pointers in the
+   gaps between their chips (each chip keeps its own tap target). Second, on a
+   frame short enough to lose the band, the plan is pushed down to reserve the
+   78px the rules above already assume (58px for the cluster, 74px for the
+   post-row), so the alley never rises under either. Tall phones are
+   untouched: the media query does not apply to them. */
+html.arc-mobile[data-arc-orient="portrait"] .campus-topright,
+html.arc-mobile[data-arc-orient="portrait"] .campus-postrow { pointer-events:none; }
+html.arc-mobile[data-arc-orient="portrait"] .campus-topright > *,
+html.arc-mobile[data-arc-orient="portrait"] .campus-postrow > * { pointer-events:auto; }
+@media (max-height:700px) {
+  html.arc-mobile[data-arc-orient="portrait"] svg.campus-plan {
+    top:78px; height:calc(100% - 78px);
+  }
+}
+
 /* ---- LANDSCAPE PHONE: the hint stops standing under EMI ----------------
    Measured at 844x390: the hint ran x 558..767 and EMI's first-run spot is
    x 686..772 - she stood on "STEP INSIDE" (owner-visible in the reference


### PR DESCRIPTION
## Owner report
"I can't seem to access the prize counter from mobile" (web campus inside the Discord Activity).

## Root cause
Not the economy, not the bank, not the Discord URL mapping (all verified live: catalog 18 rows on the wire inside the Activity, wallet routes answering, counter lit with the bank ok / 401 / 404).

The upright portrait plan uses `preserveAspectRatio: meet` on a 9:16 viewBox. Taller-than-9:16 frames letterbox and produce the empty top band the portrait CSS is written against (the comments say "the top band (y 0..75)"). At or below 9:16 the plan is height limited, the band collapses to zero, and the service alley (Records / Front Office / Prize Counter / The Locker, plan y 72..181) rises to y ~28..55, straight under `.campus-topright` (332x44 at y 14..58, z 20) and `.campus-postrow` (144x70 at 12,4). Both containers catch pointers, so every tap on the four windows died, or landed on the gear / wallet chip instead, which is why it felt random.

Discord's Activity subtracts 44px plus both safe-area insets from the iframe, so iPhone SE (375x603), every 16:9 Android and any un-expanded activity sheet fall under the ~663px break; a 390x844 browser tab never does.

## Fix (styles.css only, portrait phone scoped)
1. `.campus-topright` / `.campus-postrow` get `pointer-events:none`, their children `auto`: the gaps between chips stop eating taps over live architecture.
2. `@media (max-height:700px)` pushes `svg.campus-plan` down 78px so the band the rules already assume exists on short frames too.

Verified by injecting exactly this CSS into the live production page at 375x603, 360x596, 360x640, 390x620: the Prize Counter plate moves to y ~104 and the booth opens. 390x844 and 390x707 are byte-for-byte unchanged (query does not apply).

## After merge
The sync-arcademy workflow re-vendors it to app.cclabs.app; the Discord Activity picks it up on next launch. The phone app takes it on the next sync:arcademy.

## Secondary (not this PR)
- cclabs-web `host/init.js` fetches `../catalog.json` with `cache:'force-cache'` while the sibling sfx fetch uses `no-cache` for the stated reason; a phone that cached a pre-economy miss keeps an empty shelf. Worth flipping.
- `shell/scene.js` `onPhone()` still returns true only in landscape ("portrait is behind the rotate gate"), stale since the upright campus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145PcYKP62biKiogetX1WMz