### PR TITLE
fix(arcademy): warm + vet the Discord Activity's proxied media (own page, not own origin)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -3140,6 +3140,22 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     decoder caps: `MONTAGE.VIDEO_TILE_CAP_TOUCH = 1` (two playing tiles measured p95 33ms, the
     30Hz lock) and `PLAYTEST.VIDEO_TILE_CAP_TOUCH = 1` in Lost and Found (the LITE four were
     EIGHT playing players with the wrap reps).
+136. **A SAME-ORIGIN URL IS NOT OUR OWN FILE, AND A BARE PATH IS NOT REMOTE (Discord Activity,
+    2026-08-28).** Inside the E.M.I. Activity the frame lives on `<app_id>.discordsays.com` and
+    the web shim rewrites every Scrolller row to the portal mapping `/scrolller-media/<sub>/...`
+    - our origin on paper, a proxied CDN in fact. Two page laws misread that shape: (1)
+    `inventory.js isLocalUrl` calls a RELATIVE url local, so when the shim handed over the bare
+    path `absorbRemote()` `continue`d on every row, `absorbLocal()` (blob:/data: only) took none,
+    and every ordinary `claim()` - Anomaly, Impulse Control, Composure, Deja Vu, Echo, Instant
+    Recall - dealt the six `ae-ph-N.svg` tiles all class (the owner's striped Anomaly board).
+    Cure = the shim now hands ABSOLUTE same-origin urls (cclabs-web #112). (2) `warmable()`,
+    `instantUrl()` and `vet.js instant()` called anything on OUR ORIGIN "ready now", so inside
+    the Activity nothing was ever prefetched or probed: a LAN desktop never noticed, a phone on
+    5G met every card cold (striped back while it buffered, dead index posts dealt unvetted).
+    Cure = `inventory.js isOwnPageUrl`: same origin AND under the document's own directory
+    (`/arcademy/` on the web, `/arcademy/v/<stamp>/` in the Activity) is ours; same origin
+    elsewhere travels. `isLocalUrl` is unchanged on purpose - it is the canvas-taint law, and a
+    proxied row must stay OUT of `canvasSafe` pools.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -75,7 +75,7 @@
  *     network, not the player's own disk (remote.js request(), trap 54).
  * ==========================================================================*/
 
-import { buildLocalPools, isLocalUrl, formatOk, kindOf, wantRemote } from './inventory.js';
+import { buildLocalPools, isLocalUrl, isOwnPageUrl, formatOk, kindOf, wantRemote } from './inventory.js';
 import { createRemoteChannel } from './remote.js';
 import { createTaggedPool, TAGGED } from './tagged.js';
 import { createVetter } from './vet.js';
@@ -587,30 +587,29 @@ export function createAssets(options = {}) {
     if (n < WARM_RETRY_MAX) prewarmed.delete(s);
   }
 
-  /** Only bytes that actually travel: remote http(s), not our own origin. */
+  /** Only bytes that actually travel: remote http(s), not our own PAGE. Our own
+   *  ORIGIN is not the test any more (trap 136): inside the Discord Activity a
+   *  remote row is '<frame origin>/scrolller-media/...' - same origin, proxied
+   *  CDN - and it warms like any other remote url. */
   function warmable(url) {
     const s = String(url || '');
     if (!s || prewarmed.has(s)) return false;
     if (isBrokenUrl(s)) return false;            // a dead url is never re-asked for
     if (isLocalUrl(s)) return false;             // ccp.* / relative / data: / blob:
     if (!/^https?:\/\//i.test(s)) return false;
-    try {
-      if (typeof location !== 'undefined' && location.origin && new URL(s).origin === location.origin) return false;
-    } catch { return false; }
+    try { new URL(s); } catch { return false; }  // an unparsable url warms nothing
+    if (isOwnPageUrl(s)) return false;           // the campus's own bundled files
     return true;
   }
 
-  /** A url whose warm cannot help: local disk, our own origin, data:/blob:.
+  /** A url whose warm cannot help: local disk, our own page, data:/blob:.
    *  These are ready the instant an element asks - ready() answers true NOW. */
   function instantUrl(url) {
     const s = String(url || '');
     if (!s) return false;
     if (isLocalUrl(s)) return true;
     if (!/^https?:\/\//i.test(s)) return true;
-    try {
-      if (typeof location !== 'undefined' && location.origin && new URL(s).origin === location.origin) return true;
-    } catch { /* an unparsable url is not instant */ }
-    return false;
+    return isOwnPageUrl(s);
   }
 
   /* Warm OUTCOMES, for ready(): which urls finished (bytes + decode for a
@@ -844,7 +843,7 @@ export function createAssets(options = {}) {
   /* THE VET (0827, see ./vet.js): liveness proof for a list of rows before a
    * game deals off them. Its dead verdicts land in the blacklist above as
    * PERMANENT strikes, so a tagged serve / a substitute pick skips them. */
-  const vetter = createVetter({ markBroken, isBroken: isBrokenUrl, isLocal: isLocalUrl, log });
+  const vetter = createVetter({ markBroken, isBroken: isBrokenUrl, isLocal: isLocalUrl, isOwnPage: isOwnPageUrl, log });
   const mediaSeam = {
     warmManifest: (entries, opts) => { void opts; return warmManifest(entries); },
     warmCursor: (i) => warmCursor(i),

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/inventory.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/inventory.js
@@ -39,6 +39,33 @@ export function isLocalUrl(url) {
   return true;                    // relative -> our own document origin
 }
 
+/**
+ * OUR OWN PAGE, as opposed to our own ORIGIN (2026-08-28). Same origin AND under
+ * the document's own directory: the campus's bundled files (the ae-ph-N.svg
+ * floor, a game's ./assets), which no warm or probe can make any readier. A
+ * same-origin url OUTSIDE that directory is bytes that TRAVEL - inside the
+ * Discord Activity the web shim rewrites every Scrolller row to
+ * '<frame origin>/scrolller-media/<sub>/<path>', our origin on paper and a
+ * proxied CDN in fact - and the warm rail and the vet must treat it exactly as
+ * they treat images.scrolller.com. Local by isLocalUrl() is own-page by
+ * definition (ccp.*, relative, data:, blob:). Without a `location` (a node
+ * harness) nothing same-origin exists, so the answer is false and the callers
+ * fall back to their old http(s)-only tests.
+ */
+export function isOwnPageUrl(url) {
+  const s = String(url || '');
+  if (!s) return false;
+  if (isLocalUrl(s)) return true;
+  try {
+    if (typeof location === 'undefined' || !location || !location.origin) return false;
+    const u = new URL(s);
+    if (u.origin !== location.origin) return false;
+    const p = String(location.pathname || '/');
+    const dir = p.slice(0, p.lastIndexOf('/') + 1) || '/';
+    return u.pathname.indexOf(dir) === 0;
+  } catch (e) { return false; }
+}
+
 /** Turn a manifest entry into an absolute url. Accepts a bare relative path
  *  ("images/foo.gif"), an already-absolute url, or {url|path, kind, mime}. */
 export function toAssetUrl(entry) {
@@ -104,4 +131,4 @@ export function wantRemote(ratio, rand, haveRemote, canvasSafe) {
   return rand < Math.min(1, r);
 }
 
-export default { buildLocalPools, isLocalUrl, formatOk, kindOf, toAssetUrl, wantRemote };
+export default { buildLocalPools, isLocalUrl, isOwnPageUrl, formatOk, kindOf, toAssetUrl, wantRemote };

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/vet.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/vet.js
@@ -81,6 +81,12 @@ const verdicts = new Map();
  * @param {Function} o.markBroken (url, permanent) -> the provider's blacklist verb
  * @param {Function} o.isBroken   (url) -> boolean
  * @param {Function} o.isLocal    (url) -> boolean (inventory.js isLocalUrl)
+ * @param {Function} [o.isOwnPage] (url) -> boolean (inventory.js isOwnPageUrl): same
+ *                                origin AND under the document's directory. Absent,
+ *                                the old same-origin test stands. Injected because a
+ *                                same-origin url is NOT proof of life any more: inside
+ *                                the Discord Activity a remote row is
+ *                                '<frame origin>/scrolller-media/...' (trap 136).
  * @param {Function} [o.log]
  */
 export function createVetter(o = {}) {
@@ -88,6 +94,7 @@ export function createVetter(o = {}) {
   const markBroken = typeof o.markBroken === 'function' ? o.markBroken : () => {};
   const isBroken = typeof o.isBroken === 'function' ? o.isBroken : () => false;
   const isLocal = typeof o.isLocal === 'function' ? o.isLocal : () => false;
+  const isOwnPage = typeof o.isOwnPage === 'function' ? o.isOwnPage : null;
 
   const canProbe = (() => {
     try {
@@ -96,12 +103,15 @@ export function createVetter(o = {}) {
     } catch (e) { return false; }
   })();
 
-  /** Alive without asking: the host's own disk, our origin, inline data. */
+  /** Alive without asking: the host's own disk, our own page, inline data. */
   function instant(url) {
     const s = String(url || '');
     if (!s) return false;
     try { if (isLocal(s)) return true; } catch (e) { /* fall through */ }
     if (!/^https?:\/\//i.test(s)) return true;
+    if (isOwnPage) {
+      try { return !!isOwnPage(s); } catch (e) { return false; }
+    }
     try {
       if (typeof location !== 'undefined' && location.origin && new URL(s).origin === location.origin) return true;
     } catch (e) { /* an unparsable url is not instant */ }


### PR DESCRIPTION
## What

Inside the E.M.I. Discord Activity every Scrolller row reaches the campus page as `<frame origin>/scrolller-media/<sub>/<path>` (the dev-portal URL mapping): **our origin on paper, a proxied CDN in fact.** Three page laws treated any same-origin url as "ready now":

- `provider/index.js warmable()` refused it (never prefetched)
- `provider/index.js instantUrl()` answered ready immediately
- `provider/vet.js instant()` recorded `ok` without a probe

So inside the Activity **nothing was ever warmed or vetted**. On a LAN desktop nobody notices (the card arrives cold but fast). On a phone over 5G every SORT card is met cold: striped back while it buffers past `DECODER_CEILING`, and dead index posts are dealt unjudged. That is the owner's "SORT misses a beat on mobile, never on desktop".

## Fix

- `provider/inventory.js`: new `isOwnPageUrl(url)` = `isLocalUrl` OR (same origin AND pathname under the document's own directory: `/arcademy/` on the web, `/arcademy/v/<stamp>/` in the Activity). Placeholders (`ae-ph-N.svg`) and game `./assets` stay instant; `/scrolller-media/...` travels.
- `provider/index.js`: `warmable` / `instantUrl` use it; `createVetter` is handed `isOwnPage`.
- `provider/vet.js`: `instant()` uses the injected `isOwnPage` when present, old origin test otherwise (node harness parity).
- `isLocalUrl` is **unchanged on purpose**: it is the canvas-taint law and a proxied row must stay out of `canvasSafe` pools.
- `CLAUDE.md` trap 136.

Web tab (app.cclabs.app/arcademy) and desktop WebView2 (`ccp.*` hosts / relative urls) behave exactly as before: their remote rows were never same-origin.

## Pairs with

cclabs-web **#112** (https://github.com/CodeBambi/cclabs-web/pull/112): the shim now hands the page ABSOLUTE `/scrolller-media/...` urls. That PR alone brings Anomaly / Impulse Control back from the placeholder floor (the bare relative path was read as *local* by `isLocalUrl`, so `absorbRemote` dropped every row). This PR only matters once those urls are absolute, so **merge #112 first**, then this, then dispatch `sync-arcademy`.

No Discord dev-portal URL-mapping changes needed: `/scrolller-media/{subdomain}` already covers every Scrolller host (live-probed 206 for images/gamma/quark/atto/zetta).

## Checks

- `node --check` on all three provider files
- scratch node test (isOwnPageUrl cases for no-location / Activity frame / web tab; vet instant split with and without the injection): 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg9bPZycVwUEYHJUsZk5wR
