### PR TITLE
fix(arcademy): portrait room scene - lever row and BEGIN CLASS stop overlapping, art sits under the header

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
@@ -58,6 +58,18 @@ const APRON_MIN = 110;
  * off --arm-band-h and clamps each one at 44) and hands the painting back the
  * 38px it was eating. Desktop keeps 110 exactly. */
 const APRON_MIN_MOBILE = 72;
+/* AND THE PORTRAIT FLOOR, which is a different number again because portrait
+ * stands the apron's contents up in THREE rows instead of one: the knobs, the
+ * lever rail, then Back beside the verb. Measured on the narrowest phone in
+ * range (360px): 48 + 34 + 60 for the rows, 8 + 8 between them, 12 + 12 of
+ * padding = 182. 170 is that with the knobs row allowed to sit on the tape,
+ * which is ugly but readable; below it the verb would leave the screen. It
+ * almost never binds - a 9:19.5 frame fitting a 16:9 plate by WIDTH leaves
+ * ~400px under the painting - but a freak short portrait must not clip the one
+ * button the room exists for. */
+const APRON_MIN_PORTRAIT = 170;
+/** Air between the portrait header card and the top of the painting (px). */
+const HEAD_GAP = 8;
 
 /**
  * The fan-out table. Rects are [x, y, w, h] in stage pixels. Rects must keep
@@ -165,18 +177,31 @@ const SCENES = Object.freeze({
  * both to agree: the apron's floor and the stage's anchor are computed here and
  * the box they move is styled there.
  *
- * LANDSCAPE ONLY, and that is the half that matters. Portrait is behind the
- * rotate gate (shell/orientgate.js), so it is not designed for - but a room
- * left standing while the phone is turned still has to render something sane,
- * and top-anchoring a 9:19.5 frame would hand the apron two thirds of the
- * screen. Portrait keeps the centred stage and the 110px floor it always had.
- * rooms.css carries the SAME `[data-arc-orient="landscape"]` qualifier on the
- * two rules that move with this flag; drift and the scale walks off-axis.
+ * BOTH AXES NOW, and the history is the reason it reads like this. This used to
+ * be `isMobile() && orientation() === 'landscape'`, because the campus asked for
+ * the phone sideways (`requireOrientation('landscape', { reason: 'campus' })`)
+ * and portrait was therefore a screen nobody could reach. The upright wave
+ * (2026-08-28) took that gate down - the plan turns with the glass now - so a
+ * portrait phone walks all the way to a painted door, and the room it opened
+ * was the DESKTOP layout on 390px of glass: the plate centred its letterbox, so
+ * a third of the frame above the painting was void, and the apron's one flex
+ * row put the lever rail down on top of the BEGIN slab (owner report, Lost &
+ * Found 104).
  *
- * Wrapped because a suite's DOM double has no matchMedia and must get `false`
- * rather than a throw at fit() time. */
-function onPhone() {
-  try { return !!isMobile() && orientation() === 'landscape'; } catch (e) { return false; }
+ * So the answer is now three-valued and every caller says which axis it means:
+ *   ''           desktop, untouched, and the whole mobile block is dead code
+ *   'landscape'  exactly what it did before, to the pixel
+ *   'portrait'   top-anchored UNDER the header card, three-row apron
+ * rooms.css carries the SAME `[data-arc-orient]` qualifiers on the rules that
+ * move with each value; drift and the scale walks off-axis (lab.css's lesson).
+ *
+ * Wrapped because a suite's DOM double has no matchMedia and must get '' rather
+ * than a throw at fit() time. */
+function phoneAxis() {
+  try {
+    if (!isMobile()) return '';
+    return orientation() === 'portrait' ? 'portrait' : 'landscape';
+  } catch (e) { return ''; }
 }
 
 /** Does this game have a painted room? The shell's decline test. */
@@ -486,17 +511,35 @@ export function createRoomScene(opts) {
      * letterbox above and below; above is the ceiling of the room, which is the
      * half a player reads the set from, and below is the calm floor the apron
      * was going to cover anyway. So on a phone the whole void goes to the
-     * bottom, under the band. rooms.css moves the box (`top:0`) and the origin
-     * (`50% 0`) under the same class - the two have to agree or the scale walks
-     * the plane off-axis (lab.css's lesson). Desktop is untouched. */
-    const phone = onPhone();
+     * bottom, under the band. rooms.css moves the box (`top`) and the origin
+     * (`50% 0`) under the same qualifier - the two have to agree or the scale
+     * walks the plane off-axis (lab.css's lesson). Desktop is untouched. */
+    const axis = phoneAxis();
+    const phone = axis !== '';
+    /* PORTRAIT PUTS THE HEADER ABOVE THE PAINTING RATHER THAN ON IT. Landscape
+     * can afford a room sign pinned into the corner of a 699x390 plate; the
+     * same card on a 390x218 one covers the furniture it is naming. So in
+     * portrait rooms.css runs the plate full width at the top of the frame and
+     * the plane starts under it - MEASURED, never guessed, because the card is
+     * two lines in English and four in German. Published as `--arm-head-h` and
+     * read back by the `[data-arc-orient="portrait"] .arm-stage` rule; it is 0
+     * everywhere else, which is what keeps `top:0` landscape's exact number. */
+    let headH = 0;
+    if (axis === 'portrait' && typeof plate.getBoundingClientRect === 'function') {
+      const pb = plate.getBoundingClientRect();
+      if (pb && pb.height) headH = Math.round(pb.bottom) + HEAD_GAP;
+    }
+    root.style.setProperty('--arm-head-h', headH + 'px');
     stage.style.transform = 'translate(-50%,' + (phone ? '0' : '-50%') + ') scale(' + s + ')';
     /* The apron hugs the painting's floor line and swallows the letterbox:
      * top = the APRON_STAGE_TOP row of the scaled stage; bottom = the viewport.
-     * Never thinner than the floor for this frame (APRON_MIN / _MOBILE). */
-    const artTop = phone ? 0 : (h - STAGE_H * s) / 2;
+     * Never thinner than the floor for this frame (APRON_MIN / _MOBILE /
+     * _PORTRAIT - portrait's is the tallest because its apron is three rows). */
+    const floor = axis === 'portrait' ? APRON_MIN_PORTRAIT
+      : (phone ? APRON_MIN_MOBILE : APRON_MIN);
+    const artTop = phone ? headH : (h - STAGE_H * s) / 2;
     let apronTop = artTop + APRON_STAGE_TOP * s;
-    if (h - apronTop < (phone ? APRON_MIN_MOBILE : APRON_MIN)) apronTop = h - (phone ? APRON_MIN_MOBILE : APRON_MIN);
+    if (h - apronTop < floor) apronTop = h - floor;
     if (apronTop < 0) apronTop = 0;
     bar.style.top = apronTop + 'px';
     /* Published on both: the bar is a body-level sibling, so it cannot

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
@@ -544,14 +544,16 @@
  *   `transform-origin` move together here or the scale walks the plane
  *   off-axis (rooms.css header, lab.css's lesson).
  *
- * PORTRAIT IS BEHIND THE ROTATE GATE (shell/orientgate.js) and is not designed
- * for - these rules simply must not throw or hide anything there, which they
- * cannot: they are three sizes and an anchor. */
+ * PORTRAIT HAS ITS OWN BLOCK NOW, at the bottom of this file. It used to be
+ * behind the rotate gate and got nothing but these three sizes and an anchor;
+ * the upright wave took the gate down and the anchor was landscape-only, which
+ * is the whole of the owner's Lost & Found report. Nothing in THIS block is
+ * qualified by axis unless it already was, so landscape keeps every number. */
 
-/* LANDSCAPE ONLY, and room.js's `onPhone()` carries the SAME qualifier - the
+/* LANDSCAPE ONLY, and room.js's `phoneAxis()` carries the SAME qualifier - the
    box and the origin move together with the JS that writes the transform, or
-   the scale walks the plane off-axis. Portrait is behind the rotate gate and
-   keeps the centred stage. */
+   the scale walks the plane off-axis. Portrait's own anchor is at the bottom of
+   this file; it differs only in starting under the header card. */
 html.arc-mobile[data-arc-orient="landscape"] .arm-stage { top: 0; transform-origin: 50% 0; }
 
 /* A HOVER-ONLY AFFORDANCE IS NOT AN AFFORDANCE ON A PHONE (owner report
@@ -662,3 +664,156 @@ html.arc-mobile .arm-plate-name { font-size: 15px; }
 html.arc-mobile .arm-plate-room { font-size: 9px; }
 html.arc-mobile .arm-plate-status { font-size: 10px; margin-top: 4px; }
 html.arc-mobile .arm-plate-xp { font-size: 10.5px; margin-top: 5px; }
+
+/* ======================= THE ROOM HELD UPRIGHT ===========================
+ * PORTRAIT, and every rule in here is qualified `[data-arc-orient="portrait"]`
+ * so landscape and desktop are byte-for-byte what they were. Prove it, do not
+ * trust it: the harness reads `.arm-bar`, `.arm-hero` and `.arm-slab-back` at
+ * 844x390 and 1600x900 before and after and the rects must be identical.
+ *
+ * WHY THIS BLOCK EXISTS. Until the upright wave (2026-08-28) the campus asked
+ * for the phone sideways, so a portrait phone could not reach a painted door at
+ * all and the room wore the DESKTOP layout by default. It does not survive
+ * 390px of glass:
+ *   - the plate centred its letterbox, so 313 of 844px was void ABOVE the
+ *     painting and the apron's contents sat 108px BELOW it;
+ *   - `.arm-bar` is one flex row and `.arm-hero-group` is `flex: 0 0 auto`, so
+ *     the two `flex: 1 1 0` sides shrank to nothing and the lever rail (208px,
+ *     `justify-content: flex-end`, which overflows towards the START) was drawn
+ *     straight over the BEGIN slab;
+ *   - `Back to campus` measured 127px into an 8px box and read "BACK TO...".
+ * Owner report, Lost & Found 104, phone held upright.
+ *
+ * THE SHAPE PORTRAIT WANTS is a column, so this is the one place the apron
+ * stops being a row: header, painting, then a THREE-ROW stack under the tape.
+ * `align-content: start` is what pins that stack to the top of the band - the
+ * band still runs to the bottom of the glass (it is the painted floor of the
+ * room, not a toolbar) but its furniture stands at the front edge, where the
+ * painting leaves it, instead of floating in the middle of 560px of carpet.
+ * ==========================================================================*/
+
+/* THE ANCHOR, portrait's own. Same origin as landscape - the box and the origin
+   must move together or the scale walks the plane off-axis - but the box starts
+   under the header rather than at 0. room.js publishes `--arm-head-h` from the
+   plate's MEASURED bottom (fit()); the 0px fallback is landscape's number, so a
+   frame that somehow gets here before the first fit is merely top-anchored. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-stage {
+  top: var(--arm-head-h, 0px);
+  transform-origin: 50% 0;
+}
+
+/* THE ROOM SIGN BECOMES A HEADER. Landscape pins a card into the corner of a
+   699x390 plate and the painting is still legible around it; the same card on a
+   390x218 plate covers the furniture it is naming. So it runs the full width
+   and the painting starts below it - which is also why `max-width` has to go,
+   not just widen: `min(260px, 46vw)` would leave a 54vw hole beside a header. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-plate {
+  right: calc(10px + env(safe-area-inset-right, 0px));
+  max-width: none;
+}
+
+/* ------------------------- the apron, stood up --------------------------- */
+
+/* TWO COLUMNS, TWO ROWS. `ctl` spans both so the knobs and the lever rail get a
+   full-width line of their own; `back` takes only the width its label needs and
+   `hero` takes the rest, which is what stops the verb from being the thing that
+   gets cut when a language spends more words on "Back to campus".
+   12px of top padding clears the 6px route tape without pushing the stack down
+   into the carpet; the bottom padding is the phone rule's safe-area, kept. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-bar {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  grid-template-areas:
+    "ctl  ctl"
+    "back hero";
+  align-content: start;
+  align-items: center;
+  gap: 8px 10px;
+  padding-top: 12px;
+}
+
+/* THE CONTROL PLATE, first line. `flex-end` was the landscape justification and
+   it is what aimed the overflow at the hero; centred, the row cannot reach the
+   verb even when it is wider than the glass. The rail is forced onto its OWN
+   line (`flex: 0 0 100%`) rather than left to wrap: at 390px the knobs slab and
+   the rail together measure 370 against 370 of usable width, so wrapping would
+   be a coin toss between one line and two, and a layout that changes shape
+   between two phones 30px apart is a layout nobody can screenshot. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-bar-right {
+  grid-area: ctl;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+html.arc-mobile[data-arc-orient="portrait"] .arm-lever {
+  flex: 0 0 100%;
+  align-items: center;
+  max-width: none;
+}
+
+/* THE WAY OUT AND THE VERB, second line. `align-self: start` keeps Back level
+   with the top of the hero in the pool, where the hero column is two slabs tall
+   (Begin over Free Swim) because the two cannot fit side by side at 360px. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-bar-left {
+  grid-area: back;
+  align-self: start;
+}
+html.arc-mobile[data-arc-orient="portrait"] .arm-hero-group {
+  grid-area: hero;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ----------------------- what has to be restated ------------------------- */
+
+/* THE SIZES DO NOT RIDE `--arm-band-h` HERE, and that is the whole reason this
+   half of the block exists. Landscape's band IS the strip the slabs live in
+   (72px), so sizing off it is honest. Portrait's band is the painted floor -
+   ~560px on a 390x844 phone - and `calc(var(--arm-band-h) * 0.26)` off that is
+   a 24px BEGIN CLASS in a 175px face, which is the clipped verb again by a
+   different road. The band variable is still published (scene.css's overlay
+   reads it); it is simply not a type scale in portrait. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-hero {
+  height: 60px;
+  min-width: 0;
+  width: 100%;
+  flex: 1 1 140px;
+}
+html.arc-mobile[data-arc-orient="portrait"] .arm-hero .arm-hero-face {
+  font-size: clamp(13px, 4vw, 18px);
+}
+html.arc-mobile[data-arc-orient="portrait"] .arm-hero-alt {
+  height: 52px;
+  min-width: 0;
+  flex: 1 1 104px;
+}
+html.arc-mobile[data-arc-orient="portrait"] .arm-hero-alt .arm-hero-face {
+  font-size: clamp(11px, 3.2vw, 14px);
+}
+
+/* 11px, not the phone block's 13px, and it buys 17px of the hero's column back
+   on a 360px screen: `Back to campus` is 14 characters of tracked display caps
+   and it is the widest label either slab can carry in English. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-bar-ghost {
+  height: 48px;
+  padding: 0 10px;
+  font-size: 11px;
+}
+
+/* THE RUNGS BECOME THUMB TARGETS, and the measurement is the argument. The
+   phone media query above sets `5px 8px` at 10px type for a LANDSCAPE apron
+   72px tall, where a taller rung would not fit; the rig read those rungs at
+   80x22 once portrait stopped wrapping `Extra Credit` onto a second line, and
+   22px is half the 44px floor every other slab in this room clears. Portrait
+   has 560px of band and no such excuse. 44 tall at 11px type measures the three
+   labels at 88 + 119 + 72 = 279px on one rail, which clears the narrowest phone
+   in range (360px, 340 usable) with 61px to spare - so the height is bought
+   without ever putting a label back on two lines. `inline-flex` is what centres
+   the word once the box is taller than the text. */
+html.arc-mobile[data-arc-orient="portrait"] .arm-lever .arc-lever-pos {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 12px;
+  font-size: 11px;
+}


### PR DESCRIPTION
Owner report, phone portrait in the Discord Activity (Lost & Found, RM 104): the lever pills sit **on top of** BEGIN CLASS, "BEGIN CLASS" reads "BE...SS", "Back to campus" reads "BACK T...", and the painting floats in the middle of the frame with a black band above it.

## Root cause

The upright campus wave (2026-08-28) removed `requireOrientation('landscape', { reason: 'campus' })` from `showBoard()` - the plan turns with the glass now. **The room chassis was never told.**

`shell/room.js` had:

```js
function onPhone() {
  try { return !!isMobile() && orientation() === 'landscape'; } catch (e) { return false; }
}
```

and `shell/rooms.css` carried the matching `[data-arc-orient="landscape"]` qualifier on the stage anchor. Both were written when portrait was a screen nobody could reach. So a portrait phone now walks all the way to a painted door and opens the room in the **desktop** layout on 390px of glass. That is all three reported bugs at once:

| what the owner saw | the number behind it (390x844, before) |
|---|---|
| black band above the art | the plate centres its letterbox: `voidAbove = 313` of 844px |
| pills over BEGIN CLASS | `.arm-hero-group` is `flex: 0 0 auto` and the two `flex: 1 1 0` sides shrank to nothing, so the 208px rail with `justify-content: flex-end` overflowed towards the **start**, over the slab: `pillOverHero = true` |
| "BACK T..." | `Back to campus` measures 127px of text into an 8px box: `backClip.cut = true` |

A fourth one fell out of the rig: the landscape `@media (max-width:720px),(max-height:520px)` rule sizes the lever rungs for a 72px apron, giving **22px** tall pills in portrait - half the house's 44px thumb floor - and only measuring 34 in the screenshot because "Extra Credit" was wrapping to two lines.

## What changed (two files, both in `Resources/web/arcademy/shell/`)

**`room.js`** - `onPhone()` becomes the three-valued `phoneAxis()` (`'' | 'landscape' | 'portrait'`). Portrait measures the header card and publishes `--arm-head-h` so the plane starts under it rather than behind it, and takes its own apron floor (`APRON_MIN_PORTRAIT = 170`, because portrait stands the apron up in three rows instead of one). `'landscape'` returns exactly what `onPhone()` returned; `''` is desktop and the whole mobile branch stays dead code.

**`rooms.css`** - a new **THE ROOM HELD UPRIGHT** block. Every rule in it is scoped to `html.arc-mobile[data-arc-orient="portrait"]`, the same hook the campus uses. The rotate gate is **not** resurrected. The apron becomes a two-column grid: knobs + lever rail on their own centred line (`grid-area: ctl`), then BACK TO CAMPUS beside BEGIN (`back` / `hero`), full labels, and the lever rungs get `min-height: 44px` back. Sizes are restated rather than ridden off `--arm-band-h` because `calc(var(--arm-band-h) * 0.26)` off a ~560px portrait band is a 24px BEGIN CLASS in a 175px face; the arithmetic is in the comments.

The landscape declaration itself is byte-identical:

```css
html.arc-mobile[data-arc-orient="landscape"] .arm-stage { top: 0; transform-origin: 50% 0; }
```

All ten class rooms share this one chassis, so the fix lands once for all of them.

## Screenshots

Headless-Chrome CDP rig, both trees served side by side (`/before` = `origin/main`, `/after` = this branch), the real `boot.js` / `shell.js` / `room.js` running behind the host shim, entered through the campus door like a player. `lost_and_found` renders dark in the shim's seed (not on tonight's timetable), so the shots use `daily_trigger` (same control set as the owner's) and `the_deep_end` (worst case: it carries the Free Swim alt slab, four controls).

**BEFORE, 390x844** - header card floating top-left, the painting centred with 313px of void over it, "BACK T..." in a clipped box, and the three pills laid across the BEGIN slab with "Extra Credit" wrapped onto two lines.

**AFTER, 390x844** - header card full width at the top, the painting directly beneath it, route tape, then CLASS OPTIONS centred on its own line, the three-pill rail on its own line with one-line labels at 44px, then BACK TO CAMPUS beside a wide BEGIN.

**AFTER, 360x640** (narrowest Android) and **375x603** (Discord Activity iPhone SE) hold the same stack; `the_deep_end` stacks BEGIN over FREE SWIM in the right column.

## The proof

Numbers from the rig's `survey()` probe, before vs after:

| viewport | voidAbove | pillOverHero | backClip.cut | lever rail | rungs |
|---|---|---|---|---|---|
| 390x844 before | 313 | **true** | **true** | 208x36 | Extra Credit wrapped, 22px tall |
| 390x844 after | 107 | false | false | 294x46 | `Standard 94x44 / Extra Credit 120x44 / Honors 78x44` |
| 375x603 before / after | 197 / 107 | true / false | true / false | | |
| 360x640 before / after | 220 / 107 | true / false | true / false | 279px of rungs on 340px usable | |

`overflowRight = []` and `errs = []` on every portrait shot after.

**Unchanged proof.** Every rect identical before and after:

* **844x390 landscape** - `art = 73,0 699x390 | hero = 302,331 240x54 | back = 22,334 152x48 | rail = 615,340 208x36`
* **1600x900 desktop** - `art = 0,3 1600x893 | hero = 608,786 384x88 | back = 44,799 226x61 | rail = 1305,801 251x38`, and the Deep End variant `hero = 504,786 | rail = 1315,801 241x38 | alt = 904,796 192x67`

**Still works.** Latch: `pullLever('Extra') -> {"found":true,"on":"Extra Credit"}`. Verb: `begin() -> {"began":true,"roomGone":true,"started":{"type":"class-started","gameKey":"daily_trigger","gradeTier":1,"lever":"extra"}}` - the class-started frame still carries `lever`.

## Known sibling, deliberately not touched

`shell/scene.js` + `shell/scene.css` (the separate `.asc-` facility-scene chassis behind the Prize Booth and the Records Office) carries the identical landscape-only anchor and its own `onPhone()` with the same stale "portrait is behind the rotate gate" comment. Different shell, no lever and no hero group, so it wants its own layout rather than a copy of this one. Out of scope here; worth its own ticket.
