### PR TITLE
fix(arcademy): portrait facilities - Prize Counter, Records, Locker laid out for an upright phone

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -181,7 +181,17 @@ shell/scene.js     THE SCENE CHASSIS: a generalised point-and-click ROOM (the
                    time, the apron's back slab on <body>, the inward-out Esc
                    fold that answers FALSE at home). Dumb by construction - it
                    renders a table it was handed and calls back; it owns no
-                   store, no bridge, no key and no lexicon row. + scene.css
+                   store, no bridge, no key and no lexicon row.
+                   THREE AXES (portrait wave 0828): `phoneAxis()` answers
+                   '' | 'landscape' | 'portrait' and scene.css carries the
+                   SAME `[data-arc-orient]` qualifiers - box and origin must
+                   travel together or the scale walks off-axis. Portrait
+                   top-anchors the plate and the band becomes the painted
+                   FLOOR, so `apronWanted()` steps the carpet off for an open
+                   panel (an upright phone's panel IS a close-up) and the
+                   panel is sized off `--asc-art-line` rather than
+                   `--arm-band-h`; `publishBand()` writes 0 to <html> while it
+                   is away. Laws 138 + 139. + scene.css
                    THE ALIVE LAYER (W2 0825): a DECLARATIVE `fx` table, the
                    same grammar as `hotspots` and `patches` and the same stage
                    pixels - `[{kind, view, rect:[x,y,w,h] | circle:{cx,cy,r},
@@ -3206,6 +3216,31 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     The Locker WEAR tile composites it too. Do NOT reach for z-index on the body sprite: the face
     must stay over the body for every other outfit. Follow-up: the script should emit over-*.png
     itself.
+
+138. **A BAND SIZED FOR A 72px STRIP IS A BAND THAT EATS THE SCREEN WHEN IT BECOMES A FLOOR
+    (portrait facilities, 0828).** `.asc-panel` clears `--arm-band-h` because it rises out of
+    the carpet, which is honest while the carpet IS a 72px action strip. In portrait it is not:
+    fit() hangs the apron off the painting's floor line and runs it to the bottom of the glass,
+    so a 390x844 phone fitting the 1376x768 plate by WIDTH puts that line at y=181 and hands the
+    band 663px. `100% - var(--arm-band-h) - 16px` is then 165px of panel for a shop whose content
+    measures 1790px. The cure is not a shorter band (that leaves a 550px dark void on the wide
+    shot): on an upright phone **an open panel IS a close-up**, so `apronWanted()` in `scene.js`
+    steps the carpet off for it through the same `.asc-bar-away` the zoom already uses, and the
+    panel is sized off `--asc-art-line` - the floor line in SCREEN pixels, published by the same
+    fit() - instead of off the band. The catch that is easy to miss: `publishBand()` must write
+    **zero** to `<html>`'s `--arm-band-h` while the carpet is away, because `.arc-rs-stage`
+    (styles.css) pads its bottom by it and a body-level spotlight would otherwise reserve four
+    fifths of the phone for a carpet that is not on screen. Landscape and desktop publish the
+    real number in every state, which is what keeps their rects identical.
+139. **THE TWO CHASSIS SHARE `rooms.css`, SO HALF OF A PORTRAIT FIX ARRIVES FOR FREE AND THE
+    OTHER HALF NEVER DOES.** `.asc-bar` wears `.arm-bar`: PR #382's portrait apron block (the
+    grid, `align-content:start`, the 12px top padding, the 48px/11px ghost slab) applied itself
+    to the facilities the moment it merged, which is why the back slab was already at the top of
+    the band and reading `Back to campus` in full before this branch touched anything. What did
+    NOT come across is everything keyed on the chassis's own prefix - the stage anchor
+    (`.asc-stage` vs `.arm-stage`) and the overlay - because room.js has no `.asc-panel` and the
+    scene had no header card. Read the sibling's diff before writing the same fix twice, and
+    check which half is `.arm-`.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/locker.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/locker.css
@@ -427,3 +427,24 @@
 }
 /* Worn outranks new: if you put it on the moment it arrived, the rim is pink. */
 .lk-tile.is-new.is-on { border-color: var(--pink); }
+
+/* ================= THE LOCKER ON AN UPRIGHT PHONE =========================
+ * PORTRAIT ONLY. `isRailViewport()` in locker.js is already landscape-only, so
+ * portrait gets the stacked page rather than the rail and the tiles (108x140)
+ * wrap on their own. What is left is the two small controls the rig found
+ * under the 44px floor at every portrait width: "Ring it", the bell's one
+ * poke, at 95x23, and "4 more at the counter", the footer link out to the
+ * Prize Counter, at 145x32.
+ *
+ * `inline-flex` is what centres the label once the box is taller than the
+ * text - both are styled as pills, not as blocks, so a bare `min-height`
+ * would leave the word sitting on the top edge. Landscape keeps 23 and 32:
+ * its rail is 102px tall and a 44px poke would push the tiles off it.
+ * ==========================================================================*/
+html.arc-mobile[data-arc-orient="portrait"] .lk-poke,
+html.arc-mobile[data-arc-orient="portrait"] .lk-morelink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.css
@@ -638,3 +638,21 @@ html.arc-reduced .pc-buy.is-breath { animation:none; }
    The scrim lifts a little so the shelf stays legible behind a beat that is
    only passing through. */
 .pc-beat.is-compact { background:color-mix(in srgb, var(--ground) 48%, transparent); }
+
+/* ================= THE SHELF ON AN UPRIGHT PHONE ==========================
+ * PORTRAIT ONLY, so landscape and desktop keep every number they had. The
+ * `max-width:520px` query above already stacks `.pc-goods` into one column
+ * here, and the landscape compaction block is qualified away, so a portrait
+ * row is a wide row with room to spare - the only thing wrong with it is the
+ * size of the one control that spends money.
+ * ==========================================================================*/
+
+/* 74x28 IS NOT A THUMB TARGET, and Trade is the button this whole screen
+   exists for. It inherits `.btn`'s 28px box, which is a mouse number: the rig
+   read it at 74x28 on every viewport, against the 44px floor the back slab,
+   the exit bar and the locker tiles all clear. A `<button>` centres its own
+   label vertically, so the floor is the whole edit - the label does not move
+   and the row does not reflow, the hit box just grows to meet the thumb.
+   Landscape keeps 28 deliberately: its apron is 72px and its rows are 99px
+   tall in three columns, and 44 there costs a row of goods. */
+html.arc-mobile[data-arc-orient="portrait"] .pc-buy { min-height: 44px; }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.css
@@ -470,3 +470,17 @@ html.arc-mobile .rr-cards .arc-records-docket { min-height: 0; }
 /* The cut: deskbook.js does not even arm the leaf under reduced motion, and
    this is the second floor under that decision. */
 .arc-reduced .rdb-flip { animation: none; opacity: 0; }
+
+/* ================ THE CARD WALL ON AN UPRIGHT PHONE =======================
+ * PORTRAIT ONLY. The four-up wall above was written for a phone in LANDSCAPE,
+ * where 774px of desk divides into four 186px columns and a card reads. The
+ * upright wave made portrait reachable and the same rule divides 338px into
+ * four 77px columns: `.arc-pc` is `--pc-w:100%` so the card obediently shrinks
+ * to 77px wide, and "NOT ENROLLED - ATTEND THE CLASS" wraps onto four lines
+ * inside it. Two columns at 164px is the nearest thing to landscape's 186 that
+ * an upright phone can hold, and it is the same number the 360px screen gets
+ * (150) rather than a third size. The desktop three-up is untouched.
+ * ==========================================================================*/
+html.arc-mobile[data-arc-orient="portrait"] .rr-cards .arc-records-wall {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.css
@@ -447,3 +447,63 @@ html.arc-mobile .asc-panel {
   margin-bottom: calc(var(--arm-band-h, 72px) + 8px);
   max-height: calc(100% - var(--arm-band-h, 72px) - 16px);
 }
+
+/* ==================== THE FACILITY HELD UPRIGHT ==========================
+ * PORTRAIT, and every rule in here is qualified `[data-arc-orient="portrait"]`
+ * so landscape and desktop are byte-for-byte what they were. Prove it, do not
+ * trust it: the harness reads `.asc-art`, `.arm-bar`, `.arm-slab-back` and
+ * `.asc-panel` at 844x390 and 1600x900 before and after and every rect must be
+ * identical.
+ *
+ * WHY THIS BLOCK EXISTS. The upright wave (2026-08-28) took the rotate gate
+ * down and rooms.css grew a portrait block for the CLASSROOM chassis. This is
+ * the sibling: the same apron, a different stage, and it was still answering
+ * "not a phone" in portrait, so the Prize Counter, the Records Office and the
+ * Locker each opened in the DESKTOP layout on 390px of glass. Measured on
+ * origin/main at 390x844: the plate centred its letterbox so 313 of 844px was
+ * dead frame ABOVE the painting, the band under it was 349px, and the back
+ * slab floated 112px BELOW the painting in the middle of the carpet.
+ *
+ * The apron's own portrait rules are rooms.css's, as they have always been -
+ * `.asc-bar` wears `.arm-bar`, so the grid, `align-content: start`, the 12px
+ * top padding and the 48px/11px ghost slab all arrive from there for free.
+ * What is left is what only a SCENE has: the anchor, and the overlay.
+ * ==========================================================================*/
+
+/* THE ANCHOR, portrait's own, and it is deliberately the SAME pair of numbers
+   as landscape rather than a shared selector. room.js's portrait anchor starts
+   at `var(--arm-head-h)` because a classroom hangs a room-sign card over the
+   top of the plate and the card would cover the furniture it names. This
+   chassis has no header: the only chrome over the painting is `.asc-back`, a
+   44px pill in the top-left corner that is up ONLY on a close-up. So the
+   painting starts at 0 on both axes. Two rules, not one selector list, because
+   the day a facility grows a header this is the line that has to move and
+   landscape must not move with it. The box and the origin travel together or
+   the scale walks the plane off-axis (this file's header, lab.css's lesson). */
+html.arc-mobile[data-arc-orient="portrait"] .asc-stage { top: 0; transform-origin: 50% 0; }
+
+/* THE OVERLAY IS THE ROOM ON AN UPRIGHT PHONE, and the arithmetic is the whole
+   argument. `.asc-panel` clears the band (it rises out of the carpet, see the
+   overlay block above) and portrait's band is not a 72px strip - it is the
+   painted floor, running from the painting's floor line to the bottom of the
+   glass. A 390x844 phone fits the 1376x768 plate by WIDTH at 0.283, so that
+   line is at y=181 and the carpet under it is 663px. `100% - var(--arm-band-h)
+   - 16px` is then 165px of panel: one row of goods and an exit bar, for a shop
+   whose content measures 1790px tall.
+
+   So portrait sizes the panel off the PAINTING'S FLOOR LINE instead
+   (`--asc-art-line`, published by fit() in screen pixels) and scene.js steps
+   the carpet off underneath it for the duration - the same `.asc-bar-away`
+   class and the same ~200ms the band already uses for a close-up, because on
+   390px of glass an open panel IS a close-up. 844 - 181 - 20 = 643px of shelf
+   with the painting still readable above it, against 479 before. See
+   apronWanted() for the level and publishBand() for why `--arm-band-h` goes to
+   zero while the carpet is away.
+
+   The bottom margin is the safe-area only: there is no band left to clear. */
+html.arc-mobile[data-arc-orient="portrait"] .asc-panel {
+  width: min(920px, 96%);
+  padding: 14px 16px 16px;
+  margin-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+  max-height: calc(100% - var(--asc-art-line, 0px) - 20px - env(safe-area-inset-bottom, 0px));
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
@@ -120,13 +120,30 @@ import { t as lexT } from '../core/lexicon.js';
 import { isMobile, orientation } from '../core/device.js';
 
 /* THE ONE MOBILE DECISION (core/device.js), asked the way room.js asks it, and
- * LANDSCAPE ONLY for room.js's reason: portrait is behind the rotate gate, and
- * top-anchoring a 9:19.5 frame would hand the apron two thirds of the screen.
- * The apron floor and the stage anchor are computed here, the box they move is
- * styled from `html.arc-mobile[data-arc-orient="landscape"]` in scene.css, and
- * the two must not drift. The wrapper is for the DOM double, no matchMedia. */
-function onPhone() {
-  try { return !!isMobile() && orientation() === 'landscape'; } catch (e) { return false; }
+ * THREE-VALUED now for the reason room.js's is. It used to be
+ * `isMobile() && orientation() === 'landscape'`, because the campus asked for
+ * the phone sideways (`requireOrientation('landscape')`) and portrait was a
+ * screen nobody could reach. The upright wave (2026-08-28) took that gate down
+ * and room.js followed it; this is the SIBLING chassis and it was still
+ * answering "not a phone" in portrait, so the Prize Counter, the Records Office
+ * and the Locker each opened in the DESKTOP layout on 390px of glass.
+ *
+ * Every caller says which axis it means:
+ *   ''           desktop, untouched, and the whole mobile block is dead code
+ *   'landscape'  exactly what it did before, to the pixel
+ *   'portrait'   top-anchored painting, the apron at the painting's floor line,
+ *                and the band STEPS OFF for a panel (see apronWanted below)
+ * scene.css carries the SAME `[data-arc-orient]` qualifier on the rules that
+ * move with each value; the box and the origin must not drift or the scale
+ * walks the plane off-axis (this file's own header, lab.css's lesson).
+ *
+ * The wrapper is for the DOM double, which has no matchMedia and must get ''
+ * rather than a throw at fit() time. */
+function phoneAxis() {
+  try {
+    if (!isMobile()) return '';
+    return orientation() === 'portrait' ? 'portrait' : 'landscape';
+  } catch (e) { return ''; }
 }
 
 /** The plane the VN art was authored on. Overridable, rarely overridden. */
@@ -142,6 +159,17 @@ const APRON_MIN = 110;
 /** The phone's floor. room.js's number and room.js's reasons - the two chassis
  *  share rooms.css's slab sizing, so they must share the band it sizes off. */
 const APRON_MIN_MOBILE = 72;
+/* AND THE PORTRAIT FLOOR, its own number for the same reason room.js has one,
+ * and a much smaller one because a FACILITY apron is not a classroom apron.
+ * room.js needs 170: portrait stands its contents up in three rows (knobs,
+ * lever rail, then Back beside BEGIN CLASS). This chassis carries the back
+ * slab and nothing else - `.arm-bar-right` is built empty here - so the whole
+ * stack is rooms.css's 12px portrait top padding over the 6px route tape, a
+ * 48px slab, and 12px under it: 72, rounded to 80 for the 3px bottom border
+ * and the shadow it throws. It is a FLOOR and almost never binds - a 9:19.5
+ * frame fitting a 16:9 plate by WIDTH leaves ~660px under the painting's floor
+ * line - but a freak short portrait must not clip the one button it carries. */
+const APRON_MIN_PORTRAIT = 80;
 
 /** The zoom between slides. One number, mirrored in scene.css. */
 const ZOOM_MS = 320;
@@ -397,6 +425,10 @@ export function createScene(opts) {
     if (doc.body) doc.body.appendChild(bar); else root.appendChild(bar);
   }
 
+  /** Is the band on screen right now? Read by publishBand(), which has to tell
+   *  a body-level modal how much carpet it is actually clearing. */
+  let apronShown = true;
+
   /**
    * THE BAND STEPS OFF FOR A CLOSE-UP. One class, and the sheet owns both the
    * ~200ms fade and the `.arc-reduced` cut - the JS is one path, exactly the
@@ -409,6 +441,7 @@ export function createScene(opts) {
    * off-screen at the wide shot.
    */
   function apronVisible(show) {
+    apronShown = !!show;
     if (!bar) return;
     try {
       if (bar.classList && typeof bar.classList.toggle === 'function') { bar.classList.toggle('asc-bar-away', !show); return; }
@@ -419,6 +452,42 @@ export function createScene(opts) {
       if (!show && !has && bar.classList && bar.classList.add) bar.classList.add('asc-bar-away');
       else if (show && has && bar.classList && bar.classList.remove) bar.classList.remove('asc-bar-away');
     } catch (e) { /* noop */ }
+  }
+
+  /**
+   * WHO IS ALLOWED THE FRONT EDGE, and there are two claimants now.
+   *
+   * The old answer was the whole of "a zoom is a zoom": the band belongs to the
+   * WIDE shot and steps off for every close-up. That still stands on both other
+   * axes. PORTRAIT ADDS ONE MORE, and the arithmetic is the argument. On a
+   * 390x844 phone the plate fits by WIDTH at 0.283, so the painting's floor
+   * line lands at y=181 and the band under it is 663px - four fifths of the
+   * glass. `.asc-panel` clears the band (it rises out of the carpet, scene.css)
+   * so the shelf would get 844 - 663 - 16 = 165px to show a catalog in, which
+   * is one row of goods and an exit bar. Measured on origin/main: 479px before
+   * the painting was even top-anchored, and 165 after.
+   *
+   * So on an upright phone A PANEL IS THE ROOM: the carpet steps off for it the
+   * same way it steps off for a close-up, by the same class and the same 200ms,
+   * and the panel takes the glass under the painting. This file already says
+   * why - "a sheet of paper behind an opaque slab is a sheet of paper nobody
+   * can read" - it simply had never had to apply it to a band this tall.
+   *
+   * LANDSCAPE AND DESKTOP ARE UNTOUCHED and must stay so: their band is 72px
+   * and 110-152px, the panel clears it comfortably, and the carpet under an
+   * open panel is a big part of what makes the room a room.
+   */
+  function apronWanted() {
+    if (viewName && viewName !== 'wide') return false;
+    if (overlay && phoneAxis() === 'portrait') return false;
+    return true;
+  }
+
+  /** Write the level and republish the band, in that order - publishBand()
+   *  reads `apronShown`. Every caller that can move either one calls this. */
+  function syncApron() {
+    apronVisible(apronWanted());
+    publishBand();
   }
 
   /* ---------------------------------------------------- the step-back pill */
@@ -1078,8 +1147,10 @@ export function createScene(opts) {
     applyFlags();
     /* A ZOOM IS A ZOOM: the band belongs to the wide shot and steps off for
      * every close-up. Written on EVERY move, not just the ones that change it,
-     * so the level always matches the view that is actually up. */
-    apronVisible(name === 'wide');
+     * so the level always matches the view that is actually up. apronWanted()
+     * owns the rule now, because an upright phone has a second claimant on the
+     * front edge (an open panel) and the level is the AND of both. */
+    syncApron();
     /* ...and the pill is the other half of the same law: the band and the pill
      * are never both up, and never both away. */
     backVisible(name !== 'wide');
@@ -1178,6 +1249,10 @@ export function createScene(opts) {
     layer.appendChild(panel);
     root.appendChild(layer);
     overlay = { name: name, layer: layer, token: token };
+    /* AFTER `overlay` is set and BEFORE the panel is filled: apronWanted()
+     * reads `overlay`, and mountFn measures itself against a `--arm-band-h`
+     * that must already say what the carpet is about to do. */
+    syncApron();
     sfx('paper', 0.24);
     if (typeof mountFn === 'function') {
       try { mountFn(panel); } catch (e) { log('scene overlay mount threw: ' + ((e && e.message) || e)); }
@@ -1191,6 +1266,12 @@ export function createScene(opts) {
     const layer = overlay.layer;
     overlay = null;
     try { layer.remove(); } catch (e) { /* noop */ }
+    /* The carpet comes back the moment the panel is off the DOM, not one
+     * animation later: `overlay` is already null, so this is the whole of it.
+     * openOverlay() closes an existing panel before opening the next, which
+     * would flick the band on and off in portrait between two panels - the
+     * ~200ms fade is a transition, so a same-frame off/on is not painted. */
+    syncApron();
     sfx('paper', 0.18);
   }
 
@@ -1234,14 +1315,19 @@ export function createScene(opts) {
      * the plane off-axis (this file's own header). The ZOOM is untouched: it
      * lives on `.asc-slide`, one level down, and still turns about its own
      * centre. */
-    const phone = onPhone();
+    const axis = phoneAxis();
+    const phone = !!axis;
     stage.style.transform = 'translate(-50%,' + (phone ? '0' : '-50%') + ') scale(' + s + ')';
 
     let bandH = 0;
+    let apronTop = h;
     if (bar) {
-      const floor = phone ? APRON_MIN_MOBILE : APRON_MIN;
+      /* Three floors for three axes now, and the portrait one is its own
+       * number because portrait's apron is padded differently: 14px over the
+       * route tape, a 48px slab, 12px under it. See the constants up top. */
+      const floor = axis === 'portrait' ? APRON_MIN_PORTRAIT : (phone ? APRON_MIN_MOBILE : APRON_MIN);
       const artTop = phone ? 0 : (h - stageH * s) / 2;
-      let apronTop = artTop + apronStageTop * s;
+      apronTop = artTop + apronStageTop * s;
       if (h - apronTop < floor) apronTop = h - floor;
       if (apronTop < 0) apronTop = 0;
       bandH = h - apronTop;
@@ -1249,15 +1335,55 @@ export function createScene(opts) {
       bar.style.setProperty('--arm-band-h', bandH + 'px');
     }
     root.style.setProperty('--arm-band-h', bandH + 'px');
-    /* ...AND ON <html>, because a viewport-level modal cannot inherit it.
-     * `position:fixed` inside this room is contained by the room (root is
-     * fixed, and an overlay panel carries a transform), so anything that has
-     * to be measured against the WINDOW - the Records spotlight, a notice
-     * reader - is mounted on <body> and has no ancestor of ours to read the
-     * band off. One page-level custom property is the seam; destroy() clears
-     * it, so a screen after this one never inherits a carpet that left. */
-    setBandVar(bandH);
+    /* THE PAINTING'S FLOOR LINE, IN SCREEN PIXELS, and it is a SECOND fact
+     * because in portrait the panel can no longer be sized off the band. A
+     * 390x844 phone fits the 1376x768 plate by WIDTH at 0.283, so the floor
+     * line lands at y=181 and the carpet under it is 663px: the old ceiling,
+     * `100% - band - 16`, leaves 165px of shelf, which is one row of goods and
+     * an exit bar. Portrait sizes the panel off THIS instead (`100% - artLine
+     * - 16` = 647px) and lets the carpet step off underneath it, which is what
+     * apronWanted() is for. Landscape and desktop never read it: their band is
+     * 72px and 110-152px, the panel clears it, and nothing moves. */
+    lastBand = bandH;
+    lastArtLine = apronTop;
+    root.style.setProperty('--asc-art-line', apronTop + 'px');
+    if (bar) bar.style.setProperty('--asc-art-line', apronTop + 'px');
+    publishBand();
     return s;
+  }
+
+  /** What the last fit() worked out, in screen px, for publishBand() to echo
+   *  onto <html> whenever the carpet comes or goes without a resize. */
+  let lastBand = 0;
+  let lastArtLine = 0;
+
+  /**
+   * THE BAND AS A PAGE FACT, because a viewport-level modal cannot inherit it.
+   * `position:fixed` inside this room is contained by the room (root is fixed,
+   * and an overlay panel carries a transform), so anything that has to be
+   * measured against the WINDOW - the Records spotlight, a notice reader - is
+   * mounted on <body> and has no ancestor of ours to read the band off. One
+   * page-level custom property is the seam; destroy() clears it, so a screen
+   * after this one never inherits a carpet that left.
+   *
+   * AND IT PUBLISHES ZERO WHILE THE CARPET IS AWAY IN PORTRAIT, because away
+   * is a thing that only happens there and only for a panel. `.arc-rs-stage`
+   * pads its bottom by this number (styles.css); a spotlight opened over a
+   * stepped-off 663px band would reserve four fifths of a 844px phone for a
+   * carpet that is not on screen. Landscape and desktop publish the real
+   * number in every state, which is exactly what they did before this line
+   * existed: their carpet never steps off for a panel, so there is nothing to
+   * correct for and their measurements are unchanged to the pixel.
+   */
+  function publishBand() {
+    const away = !apronShown && phoneAxis() === 'portrait';
+    setBandVar(away ? 0 : lastBand);
+    try {
+      const de = doc.documentElement;
+      if (de && de.style && typeof de.style.setProperty === 'function') {
+        de.style.setProperty('--asc-art-line', lastArtLine + 'px');
+      }
+    } catch (e) { /* noop */ }
   }
 
   /** The band height as a page fact. Defensive: the node double has no
@@ -1309,8 +1435,13 @@ export function createScene(opts) {
     if (sheetRooms && sheetRooms.removeEventListener) { try { sheetRooms.removeEventListener('load', onResize); } catch (e) { /* noop */ } }
     if (overlay) { try { overlay.layer.remove(); } catch (e) { /* noop */ } overlay = null; }
     if (bar) { try { bar.remove(); } catch (e) { /* noop */ } }
-    /* The carpet goes with the room: the next screen has no band. */
+    /* The carpet goes with the room: the next screen has no band, and no
+     * painting either, so the floor line goes out with it. */
     setBandVar(0);
+    try {
+      const de = doc.documentElement;
+      if (de && de.style && typeof de.style.removeProperty === 'function') de.style.removeProperty('--asc-art-line');
+    } catch (e) { /* noop */ }
     try { root.remove(); } catch (e) { /* noop */ }
     live.length = 0;
     /* The props go with the room, but they are NOT ours to destroy - the


### PR DESCRIPTION
Follow-up to #382. That PR gave the CLASSROOM chassis (`shell/room.js` + `rooms.css`) a real
portrait layout after the upright wave took the rotate gate down. The SIBLING chassis
(`shell/scene.js` + `scene.css`, the `.asc-` facility rooms) still carried the landscape-only
anchor and the same "portrait is behind the rotate gate" reasoning, so on an upright phone the
three facilities opened in the DESKTOP layout on 390px of glass.

**Three screens use the chassis** and that is the whole list, verified by grep on `createScene`:
the **Prize Counter** (`prizebooth.js`, which opens `prizecounter.js` in the overlay), the
**Records Office** (`recordsroom.js` -> `records.js`) and **The Locker** (`locker.js`, whose panel
auto-opens 380ms after mount). There is no Front Office and the Annex is a different chassis.

## What was wrong, measured on `origin/main` at 390x844

| | before | after |
|---|---|---|
| dead frame above the painting | 313px | **0** |
| back slab | 112px BELOW the painting, mid-carpet | at the top of the band, under the plate |
| panel the shop scrolls inside | 378x**479**, for 1790px of goods | 374x**643**, for 1870px |
| `--arm-band-h` published to a body-level modal while a panel is up | 349px of carpet that is not there | **0** |
| `Trade`, the one button that spends money | 74x**28** | 74x**44** |
| `Ring it` / `4 more at the counter` | 95x23 / 145x32 | **44** tall |
| the card wall | **4** columns x 77px | **2** x 164px |

## What changed

**The chassis, once.**
- `onPhone()` -> `phoneAxis()`, three-valued (`'' | 'landscape' | 'portrait'`), exactly as room.js
  now asks it. `scene.css` carries the same `[data-arc-orient]` qualifiers.
- `APRON_MIN_PORTRAIT = 80`. Smaller than room.js's 170 because a facility apron is one back slab,
  not three rows.
- **The band steps off for a panel, in portrait only.** Sizing `.asc-panel` off `--arm-band-h` is
  honest while the band is a 72px strip; in portrait it is the painted FLOOR (663px on a 390x844
  phone), and `100% - band - 16` is 165px of shelf. So `apronWanted()` says the carpet belongs to
  the wide shot AND to no open panel: an upright phone's panel IS a close-up, and it leaves by the
  same `.asc-bar-away` and the same 200ms the zoom already uses.
- `fit()` publishes `--asc-art-line` (the painting's floor line, in screen px) and portrait sizes
  the panel off that instead. `publishBand()` writes **0** to `<html>`'s `--arm-band-h` while the
  carpet is away, because `.arc-rs-stage` pads its bottom by it and the Records spotlight would
  otherwise reserve four fifths of the phone for a carpet nobody can see.

**Half of it arrived free.** `.asc-bar` wears `.arm-bar`, so #382's portrait apron block (the grid,
`align-content:start`, the 12px top padding, the 48px/11px ghost slab) applied itself to the
facilities on merge. That is why `Back to campus` was already unclipped here. What did not come
across is everything keyed on `.asc-`.

**Each consumer's own controls**, portrait-qualified so landscape and desktop keep every number:
`.pc-buy` to a 44px floor, `.lk-poke` and `.lk-morelink` to 44px inline-flex pills, and the card
wall from four columns to two.

## Verification

Headless Chrome over raw CDP, both trees on one port, 17 shots per side at 390x844 / 375x603 /
360x640 / 844x390 / 1600x900.

- **Identical-rect proof**: every `.asc-art`, `.arm-bar`, `.arm-slab-back` and `.asc-panel` rect at
  844x390 and 1600x900 is byte-identical before and after (`proof.sh`). The one line that moved is
  `.arc-sign-lamps`'s scrollWidth, a CSS-animated marquee strip that disagrees with itself between
  two shots of the same tree; nothing on this branch names it.
- **A buy still settles from the portrait shelf** (and it is a 700ms charge-hold, not a tap):
  `{"sent":1,"settled":true,"echo":{"sku":"emi_cheer","cur":"t","cost":1200,"t":3800,"k":500},"owned":true}`
- **The Locker equip still persists**: `{"name":"Varsity jacket","stuck":true,"wrote":true,"cmd":{"op":"set","key":"lockerOutfit","value":"varsity"}}`
- No off-glass controls and no sub-44px targets left in portrait on any of the three screens.

`CLAUDE.md` gains laws 138 and 139 and a note on the `shell/scene.js` index entry.

Left for the owner: the phone pass inside the Discord Activity.
