### PR TITLE
fix(gaze): Focus Gaze toggle now actually gates bubble popping

### DIFF
--- a/ConditioningControlPanel/Services/Tracking/GazeFocusService.cs
+++ b/ConditioningControlPanel/Services/Tracking/GazeFocusService.cs
@@ -480,8 +480,14 @@ public class GazeFocusService : IDisposable
 
             if (hit.Value.Bubble is Bubble b)
             {
-                try { b.Pop(); GazePopped?.Invoke(); }
-                catch (Exception ex) { App.Logger?.Debug("Gaze blink-pop bubble failed: {Error}", ex.Message); }
+                // Same master gate as FindBestTarget/AdvanceBubbleDwell:
+                // bubbles only react to gaze while the Lab "Focus Gaze"
+                // toggle is armed.
+                if (_masterEnabled)
+                {
+                    try { b.Pop(); GazePopped?.Invoke(); }
+                    catch (Exception ex) { App.Logger?.Debug("Gaze blink-pop bubble failed: {Error}", ex.Message); }
+                }
             }
             else if (hit.Value.Flash is FlashWindow fw)
             {
@@ -950,7 +956,13 @@ public class GazeFocusService : IDisposable
             }
         }
 
-        var bubbles = App.Bubbles?.GetGazeTargets();
+        // Bubbles are gated on the Lab "Focus Gaze" master toggle. Unlike
+        // flashes (FlashGazePopEnabled) and video targets
+        // (VideoGazeClickEnabled), bubbles have no per-feature gaze flag, so
+        // when a consumer flag keeps the engine alive with the master off,
+        // enumerating them here would make gaze pop bubbles the user never
+        // opted into.
+        var bubbles = _masterEnabled ? App.Bubbles?.GetGazeTargets() : null;
         if (bubbles != null)
         {
             for (int i = bubbles.Count - 1; i >= 0; i--)
@@ -1143,6 +1155,16 @@ public class GazeFocusService : IDisposable
 
     private void AdvanceBubbleDwell(Bubble b)
     {
+        // Belt-and-braces gate: FindBestTarget already skips bubbles when the
+        // Focus Gaze master is off, but if one slips through (e.g. the toggle
+        // flips mid-tick) release any in-progress bubble dwell instead of
+        // popping something the user turned off.
+        if (!_masterEnabled)
+        {
+            ClearTarget();
+            return;
+        }
+
         if (!ReferenceEquals(_currentBubble, b))
         {
             ClearTarget();


### PR DESCRIPTION
## Root cause
The Lab "Focus Gaze" toggle only sets `GazeFocusService.MasterEnabled`, but the shared dwell engine runs whenever `_masterEnabled || AnyConsumerOn()`, and the three consumer flags (FlashGazePopEnabled, FlashGazeLingerEnabled, VideoGazeClickEnabled) default to true. Flashes gate their pop on FlashGazePopEnabled and video targets gate in VideoService.GetGazeTargets, but bubbles had no gate anywhere: FindBestTarget enumerated `App.Bubbles?.GetGazeTargets()` unconditionally, AdvanceBubbleDwell popped at dwell threshold with no check, and HandleBlink popped unconditionally. So with eye tracking on for any reason (Webcam Triggers, debug cursor, flash gaze features), gaze popped bubbles even with Focus Gaze off. User report: "Focus Gaze can't actually be turned off... if I have eye tracking on for any reason, it'll pop bubbles."

## Fix
- FindBestTarget only enumerates bubble targets when `_masterEnabled`.
- AdvanceBubbleDwell gets a defensive guard: with the master off it releases any in-progress bubble dwell state and returns (covers a mid-tick toggle flip).
- HandleBlink's bubble-pop path is gated on `_masterEnabled` the same way.

`EvaluateDesiredState` is deliberately untouched: flash and video consumers legitimately keep the engine alive with the master off, and that behavior stays.

## Risk
Low. Three small guards in one file, all keyed on an existing field. Flash gaze-pop, flash linger, video gaze-click, the refine overlay, and the calibration flow are unchanged. Bubbles also can no longer appear as refine candidates while the master is off, since candidates come from the same enumeration, which is the correct side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFhG5U6L4yaHmZq3CAUp3C