### PR TITLE
fix(wallet): Prize Counter no longer calls the tier gate an outage

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizecounter.js
@@ -184,6 +184,10 @@ export const REFUSALS = Object.freeze({
    * worth saying out loud. Without these rows both fell to the unknown shrug. */
   offline: ['prize_offline', 'The counter cannot reach the bank right now. Nothing was charged.'],
   busy: ['prize_busy', 'Somebody is already at the drawer. Give it a second and ask again.'],
+  /* The tier gate, told apart from the wire being down (2026-08-29): the bank
+   * DID answer, and the answer was that this account cannot bank here yet.
+   * Without this row the tier refusal wore the offline line. */
+  tier: ['prize_tier', 'The bank does not serve this account yet. Nothing was charged.'],
 });
 
 /** The glyph each sku wears on its little drawn box. Text, not art: a sku the

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyWalletSyncService.cs
@@ -661,6 +661,23 @@ internal static class ArcademyWalletSyncService
                     return new BuyOutcome(true, false, "busy", null);
                 }
 
+                // THE TIER GATE. A 403 naming the tier wall is not the wire being down: the
+                // account cannot bank here, and the counter has its own line for that instead of
+                // the offline shrug - the same mapping the web host makes. Any other 403 (the
+                // identity door) and a 401 keep the offline answer, but the log tells them apart.
+                if (response.StatusCode == HttpStatusCode.Forbidden && IsTierRefusal(reply))
+                {
+                    App.Logger?.Information("[ArcademyWallet] buy refused by the tier gate: {Body}", Truncate(text));
+                    return new BuyOutcome(true, false, "tier", null);
+                }
+                if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                {
+                    App.Logger?.Information("[ArcademyWallet] buy refused at the {Door} door: {Status} {Body}",
+                        response.StatusCode == HttpStatusCode.Unauthorized ? "token" : "identity",
+                        (int)response.StatusCode, Truncate(text));
+                    return new BuyOutcome(false, false, "offline", null);
+                }
+
                 // Every refusal the counter has a line for arrives as a 200 with `ok:false`. A
                 // status code instead means the account, not the purchase, was the problem, and the
                 // room says the same thing it says when nobody answers.


### PR DESCRIPTION
## Root cause
`ArcademyWalletSyncService.PostBuyAsync` collapsed every non-2xx status except 409 into reason "offline". A 403 with code `arcademy_locked` (the tier gate) and a 401 invalid_token therefore both made the Prize Counter say "The counter cannot reach the bank right now", which is factually wrong (the bank answered) and hides the actual reason from the player. The file already had an `IsTierRefusal` helper, used only by the class-ended mint path. The web host already maps the tier 403 to its own reason; this mirrors that for parity.

## Fix
- In PostBuyAsync, a 403 now parses the body and routes through the existing `IsTierRefusal` helper. A tier refusal returns `BuyOutcome(answered: true, ok: false, reason: "tier")`, and SettleBuy already forwards a server-named reason verbatim to the page.
- Added a `tier` row to the REFUSALS map in Resources/web/arcademy/shell/prizecounter.js: "The bank does not serve this account yet. Nothing was charged." Note: the spec assumed the counter already knew how to phrase "tier", but on origin/main the map has no such row and the reason would have fallen to the "unknown" shrug ("The counter does not know that one. Odd."), so this one-line row was added. The map is documented as degrade-gracefully for unknown reasons, so this is additive.
- 401 and the identity 403 keep the current offline behavior, but a new log line in the existing [ArcademyWallet] style says which door refused (token vs identity) instead of a bare status dump.

## Risk
Low. Only the buy path changes; mint, replay, pull, and DoorOpen semantics are untouched. All other statuses behave exactly as before. Worst case for an older web bundle paired with a newer host: reason "tier" falls through to the unknown line, which the map was already designed to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFhG5U6L4yaHmZq3CAUp3C