### PR TITLE
feat(quests): capture per-day quest ids for the Spiral

### DIFF
--- a/ConditioningControlPanel/Models/QuestProgress.cs
+++ b/ConditioningControlPanel/Models/QuestProgress.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace ConditioningControlPanel.Models;
 
@@ -50,6 +52,16 @@ public class QuestProgress
 
     // Streak calendar - dates when daily quests were completed (last 30 days)
     public List<DateTime> DailyQuestCompletionDates { get; set; } = new();
+
+    // Spiral W1: which quests were finished on which day. DailyQuestCompletionDates above answers
+    // "was anything done that day"; this answers "what". Written only by QuestService.CompleteQuest
+    // (the one place that holds a quest id) and trimmed on the same 90 day window. Default
+    // initialised so a quests.json written before this list existed still loads.
+    // quests.json goes through System.Text.Json, so both attributes are here to keep the wire
+    // name identical whichever serializer touches this type.
+    [JsonProperty("quest_completion_log")]
+    [JsonPropertyName("quest_completion_log")]
+    public List<QuestLogEntry> QuestCompletionLog { get; set; } = new();
 
     // #889: a slot rolled while the Patreon/SubscribeStar entitlement was still unresolved drew
     // from the free-only pool and must be re-rolled once the answer lands. Persisted rather than
@@ -205,5 +217,29 @@ public class ActiveQuest
         CurrentProgress = 0;
         IsCompleted = false;
         CompletedAt = null;
+    }
+}
+
+/// <summary>
+/// One quest finished on one day. <c>D</c> is the day key (yyyy-MM-dd, invariant) for the same
+/// calendar day <see cref="QuestProgress.DailyQuestCompletionDates"/> records; <c>Q</c> is the
+/// quest definition id, which is also the name of its art file.
+/// </summary>
+public class QuestLogEntry
+{
+    [JsonProperty("d")]
+    [JsonPropertyName("d")]
+    public string D { get; set; } = "";
+
+    [JsonProperty("q")]
+    [JsonPropertyName("q")]
+    public string Q { get; set; } = "";
+
+    public QuestLogEntry() { }
+
+    public QuestLogEntry(string day, string questId)
+    {
+        D = day;
+        Q = questId;
     }
 }

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -1437,6 +1437,29 @@ public class QuestService : IDisposable
     public bool AreAllDailyQuestsCompleted() => Progress.AreAllDailyQuestsCompleted();
 
     /// <summary>
+    /// The day key used by the quest completion log: the same calendar day
+    /// <see cref="QuestProgress.DailyQuestCompletionDates"/> stores, as yyyy-MM-dd invariant
+    /// (the format the cloud sync already sends those dates in).
+    /// </summary>
+    private static string DayKey(DateTime day) =>
+        day.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Append (day, questId) to the quest completion log, de-duped on the pair. Only ever called
+    /// from <see cref="CompleteQuest"/>, which is the only path that knows a quest id: the streak
+    /// shield and the manual day fix stamp the calendar with no quest behind them and must not
+    /// invent one here.
+    /// </summary>
+    private void RecordQuestInLog(DateTime day, string questId)
+    {
+        if (string.IsNullOrWhiteSpace(questId)) return;
+        var key = DayKey(day);
+        Progress.QuestCompletionLog ??= new List<QuestLogEntry>();
+        if (Progress.QuestCompletionLog.Any(e => e.D == key && e.Q == questId)) return;
+        Progress.QuestCompletionLog.Add(new QuestLogEntry(key, questId));
+    }
+
+    /// <summary>
     /// Complete a quest and award rewards
     /// </summary>
     private void CompleteQuest(ActiveQuest quest, QuestDefinition def, QuestType type)
@@ -1445,6 +1468,11 @@ public class QuestService : IDisposable
 
         quest.IsCompleted = true;
         quest.CompletedAt = DateTime.Now;
+
+        // Spiral W1: remember WHICH quest was finished today, not just that one was. Daily and
+        // weekly both, and here at the top because this is the last place that still holds the
+        // definition id. Keyed on the same calendar day the streak calendar uses.
+        RecordQuestInLog(DateTime.Today, def.Id);
 
         // Update statistics
         if (type == QuestType.Daily)
@@ -1466,6 +1494,8 @@ public class QuestService : IDisposable
             // Trim entries older than 90 days (matches cloud sync window)
             var cutoff = today.AddDays(-90);
             Progress.DailyQuestCompletionDates.RemoveAll(d => d.Date < cutoff);
+            var logCutoff = DayKey(cutoff);
+            Progress.QuestCompletionLog.RemoveAll(e => string.CompareOrdinal(e.D, logCutoff) < 0);
             App.Settings?.Current?.StreakShieldUsedDates?.RemoveAll(d => d.Date < cutoff);
 
             // Apply streak shield if yesterday is missing (would break streak)

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1341,6 +1341,9 @@ namespace ConditioningControlPanel.Services
                             ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? "",
                             ["quest_completion_dates"] = questProgress?.DailyQuestCompletionDates?
                                 .Select(d => d.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)).ToList() ?? new List<string>(),
+                            // Spiral W1: the same days, but with the quest ids that filled them.
+                            // Rides beside the dates and gets the same union merge coming back.
+                            ["quest_completion_log"] = BuildQuestCompletionLogPayload(questProgress),
                             ["total_daily_quests_completed"] = questProgress?.TotalDailyQuestsCompleted ?? 0,
                             ["total_weekly_quests_completed"] = questProgress?.TotalWeeklyQuestsCompleted ?? 0,
                             ["total_xp_from_quests"] = questProgress?.TotalXPFromQuests ?? 0,
@@ -2122,6 +2125,7 @@ namespace ConditioningControlPanel.Services
                         ["last_daily_quest_date"] = settings.LastDailyQuestDate?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture) ?? "",
                         ["quest_completion_dates"] = legacyQuestProgress?.DailyQuestCompletionDates?
                             .Select(d => d.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)).ToList() ?? new List<string>(),
+                        ["quest_completion_log"] = BuildQuestCompletionLogPayload(legacyQuestProgress),
                         ["total_daily_quests_completed"] = legacyQuestProgress?.TotalDailyQuestsCompleted ?? 0,
                         ["total_weekly_quests_completed"] = legacyQuestProgress?.TotalWeeklyQuestsCompleted ?? 0,
                         ["total_xp_from_quests"] = legacyQuestProgress?.TotalXPFromQuests ?? 0
@@ -2709,6 +2713,10 @@ namespace ConditioningControlPanel.Services
                     }
                 }
 
+                // Spiral W1: same union merge for the per-day quest ids.
+                if (questProgress != null && MergeCloudQuestLog(cloudProfile.Stats, questProgress))
+                    needsSave = true;
+
                 // Take higher quest totals
                 if (questProgress != null)
                 {
@@ -2975,6 +2983,73 @@ namespace ConditioningControlPanel.Services
             return date <= DateTime.Today.AddDays(1);
         }
 
+        /// <summary>Newest entries the quest completion log may carry over the wire.</summary>
+        private const int QuestCompletionLogWireCap = 400;
+
+        /// <summary>
+        /// Spiral W1: the outbound stats.quest_completion_log, newest 400 entries. The day key is
+        /// already yyyy-MM-dd in the local store, so this is a straight copy with a cap.
+        /// </summary>
+        private static List<Dictionary<string, string>> BuildQuestCompletionLogPayload(QuestProgress? questProgress)
+        {
+            var log = questProgress?.QuestCompletionLog;
+            if (log == null || log.Count == 0) return new List<Dictionary<string, string>>();
+            return log
+                .Where(e => e != null && !string.IsNullOrEmpty(e.D) && !string.IsNullOrEmpty(e.Q))
+                .OrderBy(e => e.D, StringComparer.Ordinal)
+                .Reverse()
+                .Take(QuestCompletionLogWireCap)
+                .Reverse()
+                .Select(e => new Dictionary<string, string> { ["d"] = e.D, ["q"] = e.Q })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Union merge stats.quest_completion_log from the cloud into the local log, exactly the
+        /// way quest_completion_dates is merged: the server never removes an entry, it only adds
+        /// days another device knew about. De-duped on (d, q) and trimmed on the same 90 day
+        /// window the dates list uses. Returns true when something was added.
+        /// </summary>
+        private static bool MergeCloudQuestLog(Dictionary<string, object>? cloudStats, QuestProgress questProgress)
+        {
+            if (cloudStats == null) return false;
+            if (!cloudStats.TryGetValue("quest_completion_log", out var cloudLogObj)) return false;
+            try
+            {
+                var cloudLog = JsonConvert.DeserializeObject<List<QuestLogEntry>>(cloudLogObj?.ToString() ?? "[]");
+                if (cloudLog == null || cloudLog.Count == 0) return false;
+
+                questProgress.QuestCompletionLog ??= new List<QuestLogEntry>();
+                var seen = new HashSet<string>(questProgress.QuestCompletionLog
+                    .Where(e => e != null)
+                    .Select(e => e.D + "|" + e.Q), StringComparer.Ordinal);
+
+                var cutoff = DateTime.Today.AddDays(-90).ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+                bool changed = false;
+                foreach (var entry in cloudLog)
+                {
+                    if (entry == null || string.IsNullOrEmpty(entry.D) || string.IsNullOrEmpty(entry.Q)) continue;
+                    if (string.CompareOrdinal(entry.D, cutoff) < 0) continue;
+                    if (!seen.Add(entry.D + "|" + entry.Q)) continue;
+                    questProgress.QuestCompletionLog.Add(new QuestLogEntry(entry.D, entry.Q));
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    questProgress.QuestCompletionLog.RemoveAll(e => e == null || string.CompareOrdinal(e.D, cutoff) < 0);
+                    App.Logger?.Debug("Quest sync: Merged quest completion log from cloud ({Count} total entries)",
+                        questProgress.QuestCompletionLog.Count);
+                }
+                return changed;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Quest sync: Failed to parse cloud quest completion log: {Error}", ex.Message);
+                return false;
+            }
+        }
+
         private bool MergeV2CloudStatsIntoLocalProgress(Dictionary<string, object>? cloudStats, bool forceStreakOverride)
         {
             if (cloudStats == null) return false;
@@ -3198,6 +3273,10 @@ namespace ConditioningControlPanel.Services
                         App.Logger?.Debug("V2 Quest sync: Failed to parse cloud completion dates: {Error}", ex.Message);
                     }
                 }
+
+                // Spiral W1: same union merge for the per-day quest ids.
+                if (questProgress != null && MergeCloudQuestLog(cloudStats, questProgress))
+                    needsSave = true;
 
                 if (questProgress != null)
                 {


### PR DESCRIPTION
Spiral W1 wire contract, sections 1 and 2 (desktop half). Additive everywhere: old clients and old save files ignore the new keys.

## What lands

**Models/QuestProgress.cs**
- `QuestLogEntry { d, q }` and `List<QuestLogEntry> QuestCompletionLog` (JSON name `quest_completion_log`), default initialised so a `quests.json` written before this list existed still loads.
- `d` = day key, `q` = the quest definition id, which is also the name of its art file (`daily_devotion_d`, `pavlov_w`).
- Note: `quests.json` is serialized with `System.Text.Json`, not Newtonsoft, so the new members carry both `[JsonProperty]` and `[JsonPropertyName]` to keep the contract's names identical whichever serializer touches the type.

**Services/Progression/QuestService.cs**
- `CompleteQuest` records `(day, def.Id)` right after the completion is stamped, for daily and weekly alike, de-duped on the pair. It sits at the top of the method because that is the last point that certainly holds the definition id.
- Trimmed to 90 days on the same line the dates list is trimmed (ordinal string compare against the same `today.AddDays(-90)` cutoff).
- The save that already follows in `CompleteQuest` (`_isDirty = true; Save();`) persists it, so no new write path.
- Confirmed the streak shield (inside `CompleteQuest`, fills yesterday) and the Oopsie / streak-fix path (`MainWindow.QuestsTab.cs`, adds `fixDate`) touch only `DailyQuestCompletionDates`. Neither knows a quest id and neither writes the log.

**Services/Settings/ProfileSyncService.cs** (the file lives under `Services/Settings/`, not `Services/Sync/`)
- `stats.quest_completion_log` goes out beside `stats.quest_completion_dates` on the V2 push and on the legacy V1 push, as `[{ "d": "...", "q": "..." }]`, capped at the newest 400 entries.
- Union-merged on pull in both merge paths, `MergeCloudQuestLog`.

## The date convention

`quest_completion_dates` stores `DateTime.Today` locally and is sent as `yyyy-MM-dd` invariant:

```
["quest_completion_dates"] = questProgress?.DailyQuestCompletionDates?
    .Select(d => d.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)).ToList()
```

So `d` is the `yyyy-MM-dd` invariant key for the same `DateTime.Today` value the calendar records. Nothing new was invented, and ordinal string ordering on that key is the same ordering as the dates, which is what the 90 day trim and the 400 entry cap rely on.

## Pull / echo behaviour

Union-merged, because the dates are union-merged. Both merge paths (V1 `cloudProfile.Stats` and V2 `cloudStats`) add cloud dates the local calendar lacks and never remove a local one, so the log gets the identical treatment: entries are added, never dropped by the server, de-duped on (d, q), and trimmed to the same 90 day window.

One deliberate exception: `ApplyForceStreakOverride` (admin `/admin/set-streak`, typed `V2StreakStats`) hard-replaces the dates list. The log is not touched there, since that admin payload has no notion of quest ids and there is no server field to feed it. The extra ids for days the override drops are harmless, and the web reads ids only for days the block already ticks.

## Not in this PR

Contract sections 3 to 6: the server archive (`quest_day_ids:<uid>` in ccp-server), the descent block v3 keys, the quest art on cclabs-site, and the web card.

## Verification

`dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj -c Debug` succeeds: `344 Warning(s), 0 Error(s)`, with zero warnings from any of the three touched files (the warning count is unchanged, pre-existing CA1416 / CS8602 noise). The app was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiWb7w3m8XsJfR6YZZH5je
