### PR TITLE
fix(arcademy): flash guard slider says which way is gentler

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
@@ -206,6 +206,16 @@ function el(tag, cls, text) {
 }
 function pct(v) { return Math.round((Number(v) || 0) * 100) + '%'; }
 function mult(v) { return (Math.round((Number(v) || 0) * 100) / 100).toFixed(2) + 'x'; }
+/* THE GUARD READS ITSELF (player feedback, 2026-08-29). "0.85x" alone never
+ * said which way was safer, so the readout carries the word too. 1.00x is the
+ * hinge - the strength the class was authored at - and 0.85x is only where the
+ * school starts you, which is why the word below is measured against 1, not
+ * against the default. */
+function guardMult(v) {
+  const n = Math.round((Number(v) || 0) * 100) / 100;
+  const side = n < 1 ? ' gentler' : n > 1 ? ' harsher' : ' as designed';
+  return n.toFixed(2) + 'x' + side;
+}
 
 /**
  * @param {Object} o
@@ -284,7 +294,16 @@ export function createSettingsPage({ init, bridge, games, keybinds, assets, onCl
   }
 
   /* ---------------------- row builders --------------------------------- */
-  function sliderRow({ key, label, hint, value, min, max, step, fmt }) {
+  /**
+   * `ends` is OPTIONAL and generic: two short words, painted under the two ends
+   * of this row's own track ("gentler" / "harsher"). A range input is mute about
+   * direction - a percentage carries its own, but a multiplier does not, and a
+   * player who cannot tell which way is safer leaves the row alone. The captions
+   * are decoration for the eye only (`aria-hidden`); the direction that a screen
+   * reader gets is the hint, which lives inside the label and is announced with
+   * it. Anything but a two-item array renders the row exactly as before.
+   */
+  function sliderRow({ key, label, hint, value, min, max, step, fmt, ends }) {
     const row = el('div', 'arc-row');
     const lab = el('label', null, label);
     const input = el('input');
@@ -295,12 +314,25 @@ export function createSettingsPage({ init, bridge, games, keybinds, assets, onCl
     lab.htmlFor = input.id = 'arc-' + String(key).replace(/[^\w]+/g, '-');
     if (hint) lab.appendChild(el('span', 'arc-hint', hint));
 
+    /* The wrapper takes the track's place on the row's flex line, so no other
+     * row on the page moves and no other row's layout is touched. */
+    let control = input;
+    if (Array.isArray(ends) && ends.length === 2) {
+      const wrap = el('div', 'arc-slider');
+      const caps = el('span', 'arc-ends');
+      caps.setAttribute('aria-hidden', 'true');
+      caps.appendChild(el('span', null, String(ends[0])));
+      caps.appendChild(el('span', null, String(ends[1])));
+      wrap.appendChild(input); wrap.appendChild(caps);
+      control = wrap;
+    }
+
     // Paint the drag live (an input that fights your thumb feels broken) but the
     // MODEL only moves on the echo - see applyEcho.
     input.addEventListener('input', () => { out.textContent = (fmt || pct)(input.value); });
     input.addEventListener('change', () => write(key, Number(input.value), row));
 
-    row.appendChild(lab); row.appendChild(input); row.appendChild(out);
+    row.appendChild(lab); row.appendChild(control); row.appendChild(out);
     rows.set(key, {
       node: row,
       apply(v) {
@@ -488,9 +520,12 @@ export function createSettingsPage({ init, bridge, games, keybinds, assets, onCl
     g.appendChild(sliderRow({
       key: SETTING_KEYS.effectIntensity,
       label: 'Flash strength guard',
-      hint: 'Photosensitivity guard - every strobe-class effect routes through it.',
+      hint: 'Photosensitivity guard - it scales every strobe-class flash. '
+        + 'Left is gentler (0.20x, nearly off), right is harsher (1.50x). '
+        + '1.00x is full designed strength. The school starts you at 0.85x.',
       value: src.effectIntensity == null ? 0.85 : src.effectIntensity,
-      min: 0.2, max: 1.5, step: 0.05, fmt: mult,
+      min: 0.2, max: 1.5, step: 0.05, fmt: guardMult,
+      ends: ['gentler', 'harsher'],
     }));
 
     const caps = (src.caps && typeof src.caps === 'object') ? src.caps : {};

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -713,6 +713,22 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
 }
 .arc-row .arc-hint { display:block; font-size:11px; color:var(--ink-faint); }
 .arc-row input[type=range] { flex:1 1 180px; accent-color:var(--pink); min-width:120px; }
+/* END CAPTIONS (player feedback, 2026-08-29). A range input is mute about
+   direction, so a row may hand sliderRow two words and get them under the ends
+   of its own track. The wrapper takes the track's flex line, which is why the
+   input inside it must drop the row-level basis: in a COLUMN, `flex:1 1 180px`
+   would be sizing its HEIGHT, not its width. Captions stay tiny and may shrink
+   to nothing on a narrow phone rather than push the track below its min-width. */
+.arc-row .arc-slider {
+  flex:1 1 180px; min-width:120px; display:flex; flex-direction:column; gap:3px;
+}
+.arc-row .arc-slider input[type=range] { flex:0 0 auto; width:100%; min-width:0; }
+.arc-row .arc-ends {
+  display:flex; justify-content:space-between; gap:8px;
+  font-size:10px; line-height:1.2; color:var(--ink-faint); letter-spacing:.05em;
+}
+.arc-row .arc-ends > span { min-width:0; overflow-wrap:anywhere; }
+.arc-row .arc-ends > span + span { text-align:right; }
 .arc-row select, .arc-row input[type=text] {
   background:var(--panel); color:var(--ink); border:var(--hairline);
   border-radius:8px; padding:5px 8px; font:inherit; font-size:13px;


### PR DESCRIPTION
### The report

Discord, "New UI Feedback" thread, **Wobberjockey**, on the Arcademy settings sheet:

> master intensity is self explanatory, but i dont know if Left is more intense or less intense flashes from the flash guard. i know some of us are going to want to turn it off, and others will want to max it out, so it'd be niche to make it clear in the UI

He is right, and it is worse than "unlabelled": a percentage carries its own direction, a multiplier does not, and a row named a **guard** showing `0.85x` reads like guard strength (more = safer) when it is a strobe multiplier (more = harsher). So the one row on the page a photosensitive player most needs to move is the one they leave alone.

### What changed

`Resources/web/arcademy/shell/settings.js`

- **The hint** now states the direction, both ends, the hinge and the default:

  > Photosensitivity guard - it scales every strobe-class flash. Left is gentler (0.20x, nearly off), right is harsher (1.50x). 1.00x is full designed strength. The school starts you at 0.85x.

- **`sliderRow` takes an optional `ends`** - `ends: ['gentler','harsher']`, two tiny muted captions painted under that row's own track. Generic and opt-in: anything but a two-item array renders the row exactly as before, and the wrapper takes the track's place on the row's flex line so no other row's layout moves. The captions are `aria-hidden` - a screen reader gets the direction from the hint, which lives inside the label and is announced with it.
- **The readout says the side too**, via a `guardMult` formatter: `0.85x gentler`, `1.20x harsher`, `1.00x as designed`. Measured against 1.00x (full designed strength), not against the 0.85x default.

`Resources/web/arcademy/styles.css` - `.arc-slider` / `.arc-ends`, 10px `--ink-faint` captions on the existing muted token. The input inside the column wrapper drops the row-level `flex:1 1 180px`, which in a column would have been sizing its **height**.

Master intensity is deliberately left alone - the reporter says it already reads, and captions there would be noise.

The DISTRACTION header summary (`Guard 0.85x`) is untouched.

### Verify

No JS test harness exists for the Arcademy shell in this repo, so: `node --check` on the edited module (clean), a CSS brace-balance check (clean), and a headless render of the real `createSettingsPage` (puppeteer-core, already a dependency) at 1100px desktop and at 390px with `html.arc-mobile`, at 0.20x, 1.00x and 1.20x. Captions land on the ends of the track, the value stays on the slider's line at phone width, nothing wraps badly, no console errors.

Screenshots (local, not committed):
- before: `C:/Users/PC/.claude/jobs/e0a906b1/tmp/flashguard.png`
- after, desktop: `C:/Users/PC/.claude/jobs/e0a906b1/tmp/flashguard-after-desktop.png`
- after, phone at 0.20x: `C:/Users/PC/.claude/jobs/e0a906b1/tmp/flashguard-after-phone.png`

### After merge

The Arcademy web build in `cclabs-web` syncs from this repo via the dispatched workflow - the web/mobile sheet only picks this up once that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UD77cQe9nFEH1tiu2waPiG
