### PR TITLE
fix(arcademy): ID card photo never encoded, frame reskins never painted

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1343,9 +1343,12 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     rung, so photo on means the campus ghost wears it too, and turning it off
     drops to `username` (the name stays). There is no second private flag.
   - **THE SNOWFLAKE RULE HOLDS** (PRESENCE.md §10): the Discord CDN url and the
-    Discord user id NEVER reach the page. Desktop caches a 128px PNG and ships
-    it as a `data:` URI inside init; the web build sends the first-party proxy
-    url. Anything else is a leak, and `<img>` onerror falls back to the drawn
+    Discord user id NEVER reach the page. Desktop caches a 128px still and ships
+    it as a `data:` URI inside init (JPEG since the photo-pending fix - WPF's
+    PNG encoder INFLATED every real avatar past the size cap, so the card had
+    never once worn a photo; the page was only ever promised a `data:` URI and
+    `<img>` does not care which codec is inside it); the web build sends the
+    first-party proxy url. Anything else is a leak, and `<img>` onerror falls back to the drawn
     portrait rather than retrying.
   - **ONE CLICK IS THE CONSENT** (owner ruling): when a link-up started from the
     chip succeeds, the HOST applies `presenceShare:'discord'` itself and pushes

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -43,7 +43,7 @@ import { isMobile, orientation, onDeviceChange } from '../core/device.js';
  * furniture card and the big card can never disagree about what your card says
  * (shell/idcard.js's header). Nothing here mounts anything. */
 import { genericPortrait, portraitSrc, portraitLabel, chipRung, paintChip, runPhotoDay,
-  studentNumber } from './idcard.js';
+  studentNumber, paintCardFrame } from './idcard.js';
 import { thud as punchThud } from './punchcard.js';
 import { createAccountChip } from './accountchip.js';
 import { mountMailChip } from './mailbox.js';
@@ -985,12 +985,20 @@ function idCrestGlyph() {
  *   chip, the Prize Counter's window and the Extra Credit lever on the door
  *   card all live entirely on these getters. Absent = none of the three is
  *   mounted, and the campus is byte-for-byte the campus it was.
+ * @param {Function=} o.idFrame  THE FRAME THE CARD WEARS. A GETTER answering
+ *   'gold' | 'navy' | '' (shell.js's `idFrame()`), and a getter for the same
+ *   reason `seep` is one: the campus is torn down and rebuilt under it, and the
+ *   Locker can change the answer while neither card is on screen. The class map
+ *   itself is shell/idcard.js's `FRAMES`, imported - the corner card and the
+ *   spotlight's big card read ONE map, never two copies of it. Absent = a card
+ *   that wears no frame, which is exactly what it did before the counter sold
+ *   any.
  * @param {Function=} o.log
  * @returns {{root, boardMount, footMount, update, closeCard, destroy}}
  */
 export function createCampus({ state, gameName, banner, stats, reducedMotion, on, log,
   dateSeed, attractIdleMs, boardPulse, idCardMode, holdAttract, post, seep, annex,
-  account, economy } = {}) {
+  account, economy, idFrame } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const handlers = on || {};
   /* THE ACCOUNT CHIP (shell/accountchip.js): a host slot in the top-right
@@ -2526,6 +2534,11 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   idFoil.setAttribute('aria-hidden', 'true');
   id.appendChild(idFoil);
   paintIdChip('link');
+  /* THE FRAME, on the card the player is actually looking at. Painted at build
+   * because the campus is re-minted on every visit, and again on every repaint
+   * below - a frame equipped in the Locker has to be on this card by the time
+   * the player walks back out to the quad. */
+  paintIdFrame();
   /* THE CARD IS A DOOR NOW. It opens the ID spotlight (shell/idcard.js) through
    * the shell, which owns the overlay exactly as it owns the Records one. The
    * press is REFUSED while the card is withheld and while Orientation Day has
@@ -2555,6 +2568,20 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   }
 
   /**
+   * THE FRAME THE COUNTER SOLD, on the laminated corner card. The word comes
+   * from the `idFrame` getter (the shell owns the ownership ladder and the
+   * Locker's pick) and the CLASS comes from idcard.js's exported FRAMES through
+   * `paintCardFrame`, so this card and the spotlight's big card can never drift
+   * apart the way they did when only one of them knew about frames at all.
+   */
+  function paintIdFrame() {
+    let want = '';
+    try { want = String((typeof idFrame === 'function' ? idFrame() : '') || ''); }
+    catch (e) { want = ''; }
+    try { paintCardFrame(id, want); } catch (e) { /* a frame may never hold a card */ }
+  }
+
+  /**
    * THE PROFILE LANDED. Everything the card says about YOU repaints from this
    * one object and from nothing else: the photo, the name, the number and the
    * chip's resting rung. A host that has never heard of `profile` simply never
@@ -2580,6 +2607,10 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       idNum.textContent = t('id_no', 'Student no.').toUpperCase() + ' ' + num.no;
     }
     paintIdChip(chipRung(prof));
+    /* A frame equipped while the campus was off screen lands on the SAME
+     * repaint the profile echo takes - the spotlight's setProfile() ends in its
+     * own paintFrame() for exactly this reason. */
+    paintIdFrame();
   }
 
   /** PHOTO DAY on the furniture card: the shutter, the well-only flash and the
@@ -3129,6 +3160,9 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     idLastTier = tierNow;
     /* The card's edge warms as the streak climbs: a colour, never a bulb ring. */
     try { id.classList.toggle('is-warm', (stats2.streak | 0) >= 7); } catch (e) { /* noop */ }
+    /* ...and the frame rides the same update(), so a Locker equip is on the
+     * corner card by the next tick even on a host that sends no profile echo. */
+    paintIdFrame();
   }
 
   /* enrich class-card state with descriptor detail the shell passes on stops */
@@ -3499,6 +3533,10 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
      * the stand-in portrait and the unlinked chip it was built with.
      */
     setProfile: setIdProfile,
+    /** A FRAME WAS EQUIPPED OR SOLD BACK. The Locker's toast fires this from a
+     *  screen the quad is not on, so the corner card re-reads the `idFrame`
+     *  getter now rather than waiting for the next visit. */
+    refreshFrame: paintIdFrame,
     /** THE ACCOUNT CHIP's seam: a later `account` repaints the chip, or mints
      *  it when init shipped without one. Nothing on a host that sent none. */
     setAccount(a) {

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/idcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/idcard.js
@@ -203,6 +203,41 @@ export function hasPhoto(profile) {
 }
 
 /* ----------------------------------------------------------------------------
+ * THE FRAME, and there is ONE of it.
+ *
+ * A frame the counter sold has to land on BOTH cards - the 560px card under the
+ * Records spotlight AND the laminated one leaning in the corner of the quad
+ * (campus.js's `.campus-idcard`). It landed on only the big one for two waves,
+ * which is why a 300-ticket frame read as "does nothing": the card the player
+ * actually looks at while walking around never changed.
+ *
+ * So the map and the painter live HERE, at module scope, exported, and campus.js
+ * imports them the way it already imports `genericPortrait` and `paintChip`.
+ * Two copies of this map is exactly the drift the parts helpers exist to stop.
+ * -------------------------------------------------------------------------- */
+
+/** The frames the counter stocks, sku word -> class. An unknown word paints
+ *  nothing rather than a broken class, so a catalog that grows a third frame
+ *  tomorrow cannot make either card render as a mystery. */
+export const FRAMES = { gold: 'is-frame-gold', navy: 'is-frame-navy' };
+
+/**
+ * Put the bought frame on a card node, or take a sold-back one off. Every class
+ * in FRAMES is toggled on every call, so this is also the way a frame is
+ * REMOVED - there is no separate clear verb to forget to call.
+ * @param {?Element} node  the card element (`.arc-id-big` or `.campus-idcard`)
+ * @param {?string} name   'gold' | 'navy' | '' (anything unknown reads as none)
+ */
+export function paintCardFrame(node, name) {
+  if (!node || !node.classList) return;
+  let want = '';
+  try { want = String(name || ''); } catch (e) { want = ''; }
+  for (const key of Object.keys(FRAMES)) {
+    try { node.classList.toggle(FRAMES[key], key === want); } catch (e) { /* noop */ }
+  }
+}
+
+/* ----------------------------------------------------------------------------
  * THE CHIP
  *
  * ONE switch with three resting rungs and one in-flight look. The rung is
@@ -471,23 +506,17 @@ export function createIdSpotlight({ t, reducedMotion, lite, isMobile, profile, s
 
   function nameFor(p) { return (p && p.name) ? String(p.name) : tr('student', 'Student'); }
 
-  /** The frames the counter stocks. An unknown word paints nothing rather than
-   *  a broken class, so a catalog that grows a third frame tomorrow cannot make
-   *  the card render as a mystery. */
-  const FRAMES = { gold: 'is-frame-gold', navy: 'is-frame-navy' };
-
   /** Put the bought frame on the card, or take a sold-back one off. The node
    *  arrives by hand at build time (`spot` does not exist yet) and is read off
-   *  the live refs on every repaint after that. */
+   *  the live refs on every repaint after that. The MAP and the class-toggling
+   *  are `paintCardFrame`'s, at module scope, because the corner card wears the
+   *  same frame off the same one map. */
   function paintFrame(node) {
     const big = node || (spot && spot.refs ? spot.refs.big : null);
-    if (!big || !big.classList) return;
     let want = '';
     try { want = String((typeof frame === 'function' ? frame() : '') || ''); }
     catch (e) { want = ''; }
-    for (const key of Object.keys(FRAMES)) {
-      try { big.classList.toggle(FRAMES[key], key === want); } catch (e) { /* noop */ }
-    }
+    paintCardFrame(big, want);
   }
 
   /** Repaint the parts a `profile` frame or a `setting` echo can move. */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -2111,6 +2111,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
           onOpenCard: () => showIdCard(),
           onAction: postAccountAction,
         },
+        /* THE FRAME, on the card in the corner of the quad. The SAME getter the
+         * spotlight takes, so the 560px card and the laminated one can never
+         * show different frames - and it is the getter and not a value because
+         * the campus outlives an equip made in the Locker. */
+        idFrame,
         log: say,
       });
       campus.noteDescriptors(campusDescriptors());
@@ -3613,11 +3618,18 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
        * it, and the `set_bell` bus message stays unused (it writes the
        * ownership slot, which a preview must never touch). */
       bellOwned: () => ownsSku('brass_bell'),
-      /* A FRAME CHANGED WHILE THE CARD IS UP. setProfile() is the card's own
-       * repaint and it ends in paintFrame(), so this is the whole of it. In
-       * practice the spotlight is never up while the Locker is (clearScreen
-       * dismisses it), but the toast's equip verb can fire from anywhere. */
+      /* A FRAME CHANGED. BOTH CARDS WEAR IT, and for two waves only one did -
+       * the spotlight's 560px card repainted and the laminated card in the
+       * corner of the quad never heard about it, so a 300-ticket frame read as
+       * "does nothing" to anyone who bought one and walked back outside.
+       * The spotlight is never up while the Locker is (clearScreen dismisses
+       * it) but the toast's equip verb can fire from anywhere, and the campus
+       * IS still mounted underneath - so it is the one that actually needs
+       * telling. setProfile() is the spotlight's own repaint and it ends in
+       * paintFrame(); refreshFrame() is the campus's. */
       refreshIdCard: () => {
+        try { if (campus && campus.refreshFrame) campus.refreshFrame(); }
+        catch (e) { /* the corner card repaints on the next update() regardless */ }
         try { if (idSpotlight && idSpotlight.isOpen && idSpotlight.isOpen()) idSpotlight.setProfile(); }
         catch (e) { /* the card repaints on its next open regardless */ }
       },

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -57,6 +57,14 @@
   /* the student ID's chip LED on its unlinked rung - the ONE place a brand
      colour appears in this school, and it is a 6px dot (shell/idcard.js) */
   --discord:#5865F2;
+  /* THE NAVY VARSITY FRAME's edge (id_frame_navy). It is a token because the
+     purchase reveal PROMISES this exact blue - shell/reveal.css paints
+     `[data-frame="navy"]` #6C8BE0 the instant the frame is bought - and for two
+     waves the card it landed on only nudged its own lavender hairline instead,
+     which is most of why a 300-ticket frame read as "does nothing". The reveal
+     is the spec; this is the reveal's colour, named once so the two cards and
+     the reveal cannot drift. */
+  --varsity:#6C8BE0;
 
   /* --- semantic --- */
   --gS:var(--gold); --gA:var(--pink); --gB:var(--lav); --gC:var(--slate);
@@ -2014,7 +2022,15 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
   width:236px; transform:rotate(-2.6deg);
   background:linear-gradient(160deg, var(--panel), var(--navy));
   border:var(--hairline); border-radius:12px;
-  box-shadow:0 16px 44px rgba(0,0,0,.7), inset 0 1px 0 rgba(255,255,255,.08);
+  /* --id-ring IS THE BOUGHT FRAME'S INSET, and it is a custom property rather
+     than a fourth shadow in the frame rules because :hover below re-declares
+     the whole box-shadow. A frame that vanished the moment you pointed at your
+     own card would be a worse bug than the one this fixes. Transparent by
+     default, so an unframed card is byte-for-byte the card it always was. */
+  --id-ring:transparent;
+  box-shadow:0 16px 44px rgba(0,0,0,.7),
+    inset 0 0 0 2px var(--id-ring),
+    inset 0 1px 0 rgba(255,255,255,.08);
   padding:12px 14px; overflow:hidden; transition:transform .3s;
 }
 /* THE CARD IS A DOOR NOW: it lifts under the pointer AND under the keyboard,
@@ -2025,12 +2041,52 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
   transform:rotate(-1deg) translateY(-4px); outline:none;
   box-shadow:0 22px 54px rgba(0,0,0,.75),
     0 0 22px color-mix(in srgb, var(--pink), transparent 62%),
+    inset 0 0 0 2px var(--id-ring),
     inset 0 1px 0 rgba(255,255,255,.1);
 }
 .campus-idcard:active { transform:rotate(-1deg) translateY(-2px) scale(.985); }
 /* ATTENDANCE HEAT: the hairline warms from lavender to gold as the streak
    climbs past a week. A colour, not a bulb ring - and it survives motion 0. */
 .campus-idcard.is-warm { border-color:color-mix(in srgb, var(--gold), transparent 55%); }
+
+/* THE FRAMES THE COUNTER SELLS, ON THE CARD THE PLAYER ACTUALLY LOOKS AT.
+   ======================================================================
+   This block is the other half of owner bug "the reskins do nothing", and it is
+   the half that hurt: the frame classes were painted ONLY on `.arc-id-big`, the
+   560px card inside the Records spotlight. The laminated card leaning in the
+   corner of the quad - the one on screen the whole time you are walking around
+   the school - was pixel-identical before and after a 300-ticket purchase.
+   shell/campus.js now toggles the SAME class off the SAME exported map
+   (idcard.js's FRAMES, through `paintCardFrame`), so these rules are the
+   spotlight's rules at furniture scale: one stripe pitch down, one inset ring
+   instead of two, everything else the same idea.
+
+   AFTER `.is-warm` ON PURPOSE. Equal specificity, so source order decides, and
+   a frame the player chose and paid for outranks a streak the card is still
+   reporting in its own numbers two lines below.
+   Nothing here animates, so `html.arc-reduced` needs no opinion about it. */
+.campus-idcard.is-frame-gold {
+  background:
+    repeating-linear-gradient(115deg,
+      color-mix(in srgb, var(--gold), transparent 87%) 0 1px,
+      transparent 1px 7px),
+    linear-gradient(160deg, var(--panel), var(--navy));
+  border-color:color-mix(in srgb, var(--gold), transparent 34%);
+  --id-ring:color-mix(in srgb, var(--gold), transparent 66%);
+}
+/* the blurb's "around your ID photo", at 58px. An outline, so the well keeps
+   the pink rim that says the photo is real. */
+.campus-idcard.is-frame-gold .id-photo {
+  outline:1px solid color-mix(in srgb, var(--gold), transparent 45%);
+  outline-offset:2px;
+}
+.campus-idcard.is-frame-navy {
+  background:linear-gradient(160deg,
+    color-mix(in srgb, var(--varsity), var(--navy) 76%),
+    color-mix(in srgb, var(--navy), #000 28%));
+  border-color:var(--varsity);
+  --id-ring:color-mix(in srgb, var(--varsity), transparent 62%);
+}
 .campus-idcard::after {
   content:""; position:absolute; top:0; left:-70%; width:45%; height:100%;
   transform:skewX(-18deg);
@@ -4172,24 +4228,67 @@ html.ae-lite .arc-rs-name .arc-rs-l { animation-play-state:running, paused; }
 }
 .arc-id-face.is-back { transform:rotateY(180deg); }
 
-/* THE FRAMES THE COUNTER SELLS. Border and glow ONLY - the face keeps its own
-   gradient, its photo, its foil and every inset it had, because a frame is a
-   thing you put a card in, not a different card. Both faces take it so the
-   frame survives the flip, and nothing here touches layout, so a framed card
-   and a bare one are the same card at the same size on the same three-line
-   layout that the 330px note above spent so long earning. */
+/* THE FRAMES THE COUNTER SELLS.
+   ============================
+   THEY CHANGE THE GROUND, NOT JUST THE HAIRLINE, and that is the whole of owner
+   bug "the reskins do nothing". Border-and-glow was the old rule here, and it
+   left navy nudging the SAME lavender border from 28% to 58% alpha over one
+   pixel: the 2px inset resolved to roughly #504A6D painted onto the face's own
+   #2b2b52 gradient, which is inside the noise of the default card. Meanwhile
+   shell/reveal.css had already SHOWN the buyer an unmistakable blue at the
+   moment of purchase. The reveal is the spec (--varsity is its colour, in the
+   palette above), so navy now gets a navy GROUND and a varsity edge, and gold
+   gets the pinstripe its catalog name has promised since day one - the sku is
+   literally "Gold Pinstripe Frame" and there was not one stripe anywhere in
+   this sheet.
+
+   WHAT IS STILL TRUE: no layout moves. Every rule below paints `background`,
+   `border-color`, `box-shadow` and one photo-well outline, so a framed card and
+   a bare one are the same card at the same size on the same three-line layout
+   the 330px note above spent so long earning. Both faces take the frame so it
+   survives the flip, and nothing here animates, so `html.arc-reduced` needs no
+   opinion about any of it. */
+
+/* GOLD PINSTRIPE. A real repeating stripe, laid OVER the face's own gradient as
+   a second background layer rather than replacing it - the card is still the
+   card, wearing a pinstripe suit. 9px pitch at 115deg reads as cloth at 560px
+   and as a warm sheen at thumbnail size, which is the right way round. */
 .arc-id-big.is-frame-gold .arc-id-face {
-  border-color:color-mix(in srgb, var(--gold), transparent 30%);
+  background:
+    repeating-linear-gradient(115deg,
+      color-mix(in srgb, var(--gold), transparent 86%) 0 1px,
+      transparent 1px 9px),
+    linear-gradient(160deg, #342f45 0%, var(--panel) 40%, #1b1729 100%);
+  border-color:color-mix(in srgb, var(--gold), transparent 24%);
   box-shadow:0 34px 84px rgba(0,0,0,.72),
     0 0 52px color-mix(in srgb, var(--gold), transparent 70%),
-    inset 0 0 0 2px color-mix(in srgb, var(--gold), transparent 52%),
+    inset 0 0 0 2px color-mix(in srgb, var(--gold), transparent 46%),
+    inset 0 0 0 5px color-mix(in srgb, var(--gold), transparent 88%),
     inset 0 1px 0 rgba(255,255,255,.10);
 }
+/* "A thin gold pinstripe AROUND YOUR ID PHOTO" - the blurb's own words, and the
+   one place the old rules never went. An OUTLINE and not the border, so the
+   well keeps the pink rim that says the photo is real. */
+.arc-id-big.is-frame-gold .arc-id-photo {
+  outline:1px solid color-mix(in srgb, var(--gold), transparent 42%);
+  outline-offset:3px;
+}
+
+/* NAVY VARSITY. A deep navy GROUND (the default card is purple-lavender, so
+   this is the difference you can see across the room) and a varsity edge: the
+   letterman double stripe, drawn as two insets with the card's own dark between
+   them rather than as one thicker line. */
 .arc-id-big.is-frame-navy .arc-id-face {
-  border-color:color-mix(in srgb, var(--lav), transparent 42%);
+  background:linear-gradient(160deg,
+    color-mix(in srgb, var(--varsity), var(--navy) 76%) 0%,
+    var(--navy) 46%,
+    color-mix(in srgb, var(--navy), #000 34%) 100%);
+  border-color:var(--varsity);
   box-shadow:0 34px 84px rgba(0,0,0,.78),
-    0 0 40px color-mix(in srgb, var(--lav), transparent 74%),
-    inset 0 0 0 2px color-mix(in srgb, var(--navy), var(--lav) 34%),
+    0 0 46px color-mix(in srgb, var(--varsity), transparent 68%),
+    inset 0 0 0 2px color-mix(in srgb, var(--varsity), transparent 58%),
+    inset 0 0 0 5px color-mix(in srgb, var(--navy), #000 20%),
+    inset 0 0 0 6px color-mix(in srgb, var(--varsity), transparent 76%),
     inset 0 1px 0 rgba(255,255,255,.06);
 }
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyAvatarCache.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyAvatarCache.cs
@@ -9,12 +9,21 @@ namespace ConditioningControlPanel.Services.Arcademy;
 
 /// <summary>
 /// THE STUDENT ID PHOTO, on disk. One file and one sidecar, both fixed names:
-/// <c>%LOCALAPPDATA%/ConditioningControlPanel/arcademy/avatar.png</c> plus
-/// <c>avatar.hash</c>, which records the Discord avatar hash those bytes were fetched for.
+/// <c>%LOCALAPPDATA%/ConditioningControlPanel/arcademy/avatar.jpg</c> plus
+/// <c>avatar.hash</c>, which records the Discord avatar hash those bytes were fetched for AND the
+/// encode recipe they were made with.
+///
+/// <para>JPEG, NOT PNG, AND THAT IS THE WHOLE OF BUG "PHOTO PENDING FOREVER". WPF's
+/// <c>PngBitmapEncoder</c> re-encodes an already-optimised CDN avatar LARGER than it arrived:
+/// measured against a real 128x128 Discord avatar, a 128px PNG round-trip came back at 33,713
+/// bytes and the 96px retry at 19,860 - both over the old 18,414-byte ceiling, so
+/// <see cref="Encode"/> returned null on EVERY avatar and the card had never once worn a photo on
+/// desktop. <c>JpegBitmapEncoder</c> at <see cref="JpegQuality"/> puts the same 128px frame at
+/// about 6 KB. The page was only ever promised "a <c>data:</c> URI"; the format is ours.</para>
 ///
 /// <para>THE SNOWFLAKE RULE (STUDENT ID contract, "Snowflake rule"). The Discord CDN url and the
 /// Discord user id NEVER reach the page: the CDN url embeds the snowflake, so this class is the
-/// only thing that ever sees it, and what crosses the bridge is a <c>data:image/png;base64,...</c>
+/// only thing that ever sees it, and what crosses the bridge is a <c>data:image/jpeg;base64,...</c>
 /// string of at most <see cref="MaxDataUriChars"/> characters. Nothing here is ever logged with a
 /// url in it, for the same reason <c>GoonAvatarCache</c> refuses to.</para>
 ///
@@ -26,31 +35,56 @@ namespace ConditioningControlPanel.Services.Arcademy;
 /// <para>OFFLINE MODE NEVER LEAVES THE MACHINE. <see cref="EnsureCachedAsync"/> short-circuits with
 /// no request at all when <c>OfflineMode</c> is set; the file already on disk stays readable, so an
 /// offline player keeps the photo they last had.</para>
+///
+/// <para><see cref="Dir"/> IS SHARED AND IS NEVER DELETED. WebView2 keeps its <c>EBWebView</c>
+/// profile folder in the same directory, so nothing here may ever remove the directory itself -
+/// only the two (three, counting the retired PNG) fixed file names below.</para>
 /// </summary>
 internal static class ArcademyAvatarCache
 {
     /// <summary>Fixed names. No page string, no server string and no hash ever reaches
     /// <c>Path.Combine</c> here, so traversal is not a thing that can be attempted.</summary>
-    private const string AvatarFile = "avatar.png";
+    private const string AvatarFile = "avatar.jpg";
     private const string HashFile = "avatar.hash";
 
-    /// <summary>The contract's ceiling for the data URI that rides the bridge (24 KB). It is a cap
-    /// on the STRING, not on the file, because the string is what the page is promised.</summary>
-    public const int MaxDataUriChars = 24 * 1024;
+    /// <summary>The PNG this cache wrote before the encoder switch. It never once existed in the
+    /// wild (the PNG re-encode could not fit the cap), but a machine that somehow has one should
+    /// not keep an orphan next to the JPEG - so a successful write sweeps it, BY NAME.</summary>
+    private const string LegacyAvatarFile = "avatar.png";
 
-    /// <summary>The prefix costs 22 of those characters and base64 costs 4 per 3 bytes, so this is
-    /// the largest PNG whose data URI still fits under the cap.</summary>
-    private static readonly int MaxPngBytes = (MaxDataUriChars - DataUriPrefix.Length) / 4 * 3;
+    /// <summary>The contract's ceiling for the data URI that rides the bridge (48 KB). It is a cap
+    /// on the STRING, not on the file, because the string is what the page is promised.
+    ///
+    /// <para>It was 24 KB, which the PNG encoder could not meet on any real avatar. JPEG clears the
+    /// old figure eight times over, so this doubling is not what fixes the bug - it is the headroom
+    /// that stops the next busy avatar from re-opening it.</para></summary>
+    public const int MaxDataUriChars = 48 * 1024;
 
-    private const string DataUriPrefix = "data:image/png;base64,";
+    /// <summary>The prefix costs 23 of those characters and base64 costs 4 per 3 bytes, so this is
+    /// the largest image whose data URI still fits under the cap.</summary>
+    private static readonly int MaxImageBytes = (MaxDataUriChars - DataUriPrefix.Length) / 4 * 3;
+
+    private const string DataUriPrefix = "data:image/jpeg;base64,";
+
+    /// <summary>What <see cref="Encode"/> asks the JPEG encoder for. 85 is the usual "you cannot
+    /// see the difference at 128px" figure and lands a Discord avatar around 6 KB.</summary>
+    private const int JpegQuality = 85;
+
+    /// <summary>THE RECIPE STAMP, and it is in the sidecar for one reason: the sidecar now records
+    /// FAILURES too (see <see cref="EnsureCachedAsync"/>'s negative cache), and a failure recorded
+    /// under the old PNG encoder must not outlive the encoder that caused it. Bump this string
+    /// whenever the encode changes and every sidecar on every machine - success and failure alike -
+    /// reads as stale on the next open, which re-fetches exactly once.</summary>
+    private const string EncodeRecipe = "j85-48k-1";
 
     /// <summary>What the CDN is allowed to hand back before we stop reading. An avatar is tens of
     /// KB; anything past this is not the picture we asked for.</summary>
     private const int MaxFetchBytes = 512 * 1024;
 
     /// <summary>The two decode widths, in order. 128 is the card's photo well at 2x; 96 is the one
-    /// retry for an avatar whose 128px PNG will not fit the 24 KB cap (a busy animated frame). A
-    /// third rung would be a smaller picture than the well deserves, so there is not one.</summary>
+    /// retry for an avatar whose 128px JPEG will not fit the cap. Since the encoder switch the
+    /// first rung lands around 6 KB against a 36 KB ceiling, so the second is a rung nothing is
+    /// expected to reach. A third would be a smaller picture than the well deserves.</summary>
     private static readonly int[] DecodeWidths = { 128, 96 };
 
     /// <summary>An avatar may never be on the critical path of anything (the Goon cache's rule,
@@ -81,7 +115,9 @@ internal static class ArcademyAvatarCache
         }
         catch (Exception ex)
         {
-            App.Logger?.Debug("ArcademyAvatarCache.PathFor({F}): {E}", bare, ex.Message);
+            // WARNING, not Debug: a directory we cannot make is a card that will never have a
+            // photo, and a permanent no-photo state has to be audible at the default level.
+            App.Logger?.Warning("ArcademyAvatarCache.PathFor({F}): {E}", bare, ex.Message);
             return null;
         }
     }
@@ -101,6 +137,25 @@ internal static class ArcademyAvatarCache
         return null;   // a default avatar is not a picture we can fetch
     }
 
+    /// <summary>Said once per launch and no more. A player on a default Discord avatar would
+    /// otherwise earn a Warning on every single window open, and a line that cries every time is
+    /// a line nobody reads.</summary>
+    private static int _noTagWarned;
+
+    /// <summary>
+    /// WHAT THE SIDECAR SAYS, in one line: <c>&lt;recipe&gt;|&lt;ok|no&gt;|&lt;tag&gt;</c>.
+    ///
+    /// <para><c>ok</c> means "these bytes are on disk for this hash"; <c>no</c> is THE NEGATIVE
+    /// CACHE - "this exact picture was fetched and would not encode, do not fetch it again". Before
+    /// it existed, <c>KickAvatarRefresh</c> re-downloaded and re-failed on the hopeless avatar every
+    /// time the window opened. Three things still invalidate it, which is the whole point of writing
+    /// the recipe and the tag INTO the line rather than keeping a bare hash: a different avatar (the
+    /// tag moves), a different encoder (<see cref="EncodeRecipe"/> moves) and a deleted sidecar.</para>
+    /// </summary>
+    private static string Sidecar(string tag, bool ok) => EncodeRecipe + (ok ? "|ok|" : "|no|") + tag;
+
+    /// <summary>The sidecar line as written, or null. A line from an older build is simply a line
+    /// that matches neither <see cref="Sidecar"/> form, so it re-fetches exactly once.</summary>
     private static string? ReadTag()
     {
         try
@@ -108,9 +163,21 @@ internal static class ArcademyAvatarCache
             var p = PathFor(HashFile);
             if (p == null || !File.Exists(p)) return null;
             var tag = File.ReadAllText(p).Trim();
-            return tag.Length == 0 || tag.Length > 128 ? null : tag;
+            return tag.Length == 0 || tag.Length > 160 ? null : tag;
         }
         catch { return null; }
+    }
+
+    /// <summary>Best-effort sidecar write. A sidecar we could not write only costs the next open a
+    /// re-fetch, so this never fails anything above it.</summary>
+    private static void WriteSidecar(string tag, bool ok)
+    {
+        try
+        {
+            var hp = PathFor(HashFile);
+            if (hp != null) WriteAtomic(hp, System.Text.Encoding.UTF8.GetBytes(Sidecar(tag, ok)));
+        }
+        catch { /* a missing sidecar only costs the next open a re-fetch */ }
     }
 
     /// <summary>
@@ -128,9 +195,9 @@ internal static class ArcademyAvatarCache
             var p = PathFor(AvatarFile);
             if (p == null || !File.Exists(p)) return null;
             var fi = new FileInfo(p);
-            if (fi.Length == 0 || fi.Length > MaxPngBytes) return null;
+            if (fi.Length == 0 || fi.Length > MaxImageBytes) return null;
             var bytes = File.ReadAllBytes(p);
-            if (!IsPng(bytes)) return null;
+            if (!IsJpeg(bytes)) return null;
             var uri = DataUriPrefix + Convert.ToBase64String(bytes);
             return uri.Length > MaxDataUriChars ? null : uri;
         }
@@ -143,11 +210,16 @@ internal static class ArcademyAvatarCache
 
     /// <summary>
     /// Fetch the player's Discord avatar when the cache is missing or belongs to a different hash,
-    /// re-encode it to a small PNG and store it atomically. Returns <c>true</c> only when the bytes
+    /// re-encode it to a small JPEG and store it atomically. Returns <c>true</c> only when the bytes
     /// on disk CHANGED, which is the caller's cue to push a <c>profile</c> frame.
     ///
     /// <para>Never throws and never blocks a UI thread: the decode and the encode run on whatever
     /// thread the continuation lands on, against a frozen <see cref="BitmapImage"/>.</para>
+    ///
+    /// <para>TWO EARLY-OUTS ARE NOW DISTINGUISHABLE IN THE LOG, because for five days they were not
+    /// and the wrong one was blamed: no fetchable avatar hash warns once per launch, and an avatar
+    /// that will not encode warns once per hash (see the negative cache in <see cref="Sidecar"/>).
+    /// Anything that leaves the card without a photo says so at the default level.</para>
     /// </summary>
     public static async Task<bool> EnsureCachedAsync()
     {
@@ -156,10 +228,29 @@ internal static class ArcademyAvatarCache
             var d = App.Discord;
             if (d == null || !d.IsAuthenticated) return false;
             var tag = CurrentTag();
-            if (tag == null) return false;                       // default avatar: nothing to fetch
+            if (tag == null)
+            {
+                // A DEFAULT DISCORD AVATAR HAS NO HASH, so there is genuinely nothing to fetch -
+                // but "nothing to fetch" and "fetched and could not encode" are the two ways this
+                // card ends up with PHOTO PENDING forever, and the log has to name which.
+                if (Interlocked.Exchange(ref _noTagWarned, 1) == 0)
+                {
+                    App.Logger?.Warning(
+                        "ArcademyAvatarCache: no fetchable Discord avatar hash (default avatar?) - student photo stays pending");
+                }
+                return false;
+            }
             var file = PathFor(AvatarFile);
             if (file == null) return false;
-            if (File.Exists(file) && string.Equals(ReadTag(), tag, StringComparison.Ordinal)) return false;
+            var side = ReadTag();
+            if (File.Exists(file) && string.Equals(side, Sidecar(tag, true), StringComparison.Ordinal)) return false;
+            // THE NEGATIVE CACHE. This exact picture, under this exact encoder, has already been
+            // fetched and rejected once; re-downloading it on every window open only re-fails.
+            if (string.Equals(side, Sidecar(tag, false), StringComparison.Ordinal))
+            {
+                App.Logger?.Debug("ArcademyAvatarCache: this avatar is already known not to fit - no re-fetch");
+                return false;
+            }
 
             // OFFLINE MODE: no request at all. The file already on disk stays usable.
             if (App.Settings?.Current?.OfflineMode == true)
@@ -170,15 +261,18 @@ internal static class ArcademyAvatarCache
 
             var url = d.GetAvatarUrl(128);
             if (string.IsNullOrEmpty(url)) return false;
-            // An animated avatar comes back as .gif; the card wants the still, and the contract's
-            // data URI is specified as image/png either way.
+            // An animated avatar comes back as .gif; the card wants the still, and the CDN will
+            // serve any avatar as .png. What WE re-encode it to afterwards is a separate question.
             url = url!.Replace(".gif?", ".png?");
 
             if (!await FetchGate.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false)) return false;
             try
             {
-                // Re-check under the gate: the other caller may have just fetched this exact hash.
-                if (File.Exists(file) && string.Equals(ReadTag(), tag, StringComparison.Ordinal)) return false;
+                // Re-check under the gate: the other caller may have just fetched this exact hash,
+                // or just recorded it as hopeless.
+                var side2 = ReadTag();
+                if (File.Exists(file) && string.Equals(side2, Sidecar(tag, true), StringComparison.Ordinal)) return false;
+                if (string.Equals(side2, Sidecar(tag, false), StringComparison.Ordinal)) return false;
 
                 byte[] raw;
                 using (var resp = await Http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead,
@@ -193,23 +287,29 @@ internal static class ArcademyAvatarCache
                 }
                 if (raw.Length == 0 || raw.Length > MaxFetchBytes) return false;
 
-                var png = Encode(raw);
-                if (png == null)
+                var img = Encode(raw);
+                if (img == null)
                 {
-                    App.Logger?.Debug("ArcademyAvatarCache: avatar would not fit {Cap} chars - no photo",
+                    // WARNING, not Debug. This exact line at Debug is why a card that had never once
+                    // shown a photo looked, from the logs, like a card that was working.
+                    App.Logger?.Warning(
+                        "ArcademyAvatarCache: avatar would not fit {Cap} chars at any decode width - no student photo",
                         MaxDataUriChars);
+                    WriteSidecar(tag, false);        // do not come back for this one until it changes
                     return false;
                 }
 
-                if (!WriteAtomic(file, png)) return false;
+                if (!WriteAtomic(file, img)) return false;
+                WriteSidecar(tag, true);
+                // The retired PNG, BY NAME. Never the directory - WebView2 lives in it (see Dir).
                 try
                 {
-                    var hp = PathFor(HashFile);
-                    if (hp != null) WriteAtomic(hp, System.Text.Encoding.UTF8.GetBytes(tag));
+                    var legacy = PathFor(LegacyAvatarFile);
+                    if (legacy != null && File.Exists(legacy)) File.Delete(legacy);
                 }
-                catch { /* a missing sidecar only costs the next open a re-fetch */ }
+                catch { /* an orphan we could not sweep is not worth failing a cached photo over */ }
 
-                App.Logger?.Information("ArcademyAvatarCache: student photo cached ({N} bytes)", png.Length);
+                App.Logger?.Information("ArcademyAvatarCache: student photo cached ({N} bytes)", img.Length);
                 return true;
             }
             finally { FetchGate.Release(); }
@@ -222,8 +322,14 @@ internal static class ArcademyAvatarCache
         }
     }
 
-    /// <summary>Decode whatever the CDN sent and re-encode it as a PNG small enough for the cap,
-    /// trying <see cref="DecodeWidths"/> in order. Null when even the smallest will not fit.</summary>
+    /// <summary>Decode whatever the CDN sent and re-encode it as a JPEG small enough for the cap,
+    /// trying <see cref="DecodeWidths"/> in order. Null when even the smallest will not fit.
+    ///
+    /// <para>THE ENCODER IS THE FIX. <c>PngBitmapEncoder</c> was here and it INFLATED every real
+    /// avatar past the ceiling - a lossless re-encode of an already-optimised PNG is bigger than
+    /// what it started with, so the 128px rung and the 96px rung both failed and the card had never
+    /// worn a photo. A photo is a photo; JPEG at <see cref="JpegQuality"/> is what it wanted all
+    /// along, and the 96px rung below is now a rung nothing is expected to reach.</para></summary>
     private static byte[]? Encode(byte[] raw)
     {
         foreach (var width in DecodeWidths)
@@ -239,12 +345,24 @@ internal static class ArcademyAvatarCache
                 bmp.EndInit();
                 bmp.Freeze();                                    // usable off the UI thread
 
-                var enc = new PngBitmapEncoder();
-                enc.Frames.Add(BitmapFrame.Create(bmp));
+                // JPEG HAS NO ALPHA, so say what happens to it here rather than leaving it to the
+                // encoder. Discord serves an OPAQUE square (measured: 0 of 16,384 pixels on a real
+                // avatar carry alpha - the circle is the page's crop, not the picture's), so in
+                // practice this converts nothing; it is here so a transparent avatar degrades to a
+                // defined dark corner instead of an encoder's opinion. NOT a RenderTargetBitmap:
+                // this runs on whatever pool thread the continuation landed on, and this conversion
+                // needs no dispatcher.
+                var flat = new FormatConvertedBitmap(bmp, System.Windows.Media.PixelFormats.Bgr24, null, 0);
+                flat.Freeze();
+
+                var enc = new JpegBitmapEncoder { QualityLevel = JpegQuality };
+                enc.Frames.Add(BitmapFrame.Create(flat));
                 using var ms = new MemoryStream();
                 enc.Save(ms);
                 var bytes = ms.ToArray();
-                if (bytes.Length > 0 && bytes.Length <= MaxPngBytes) return bytes;
+                if (bytes.Length > 0 && bytes.Length <= MaxImageBytes) return bytes;
+                App.Logger?.Debug("ArcademyAvatarCache.Encode({W}): {N} bytes is over {Cap}",
+                    width, bytes.Length, MaxImageBytes);
             }
             catch (Exception ex)
             {
@@ -254,7 +372,7 @@ internal static class ArcademyAvatarCache
         return null;
     }
 
-    /// <summary>Temp file then <c>File.Move(overwrite)</c>: a half-written avatar.png read by the
+    /// <summary>Temp file then <c>File.Move(overwrite)</c>: a half-written avatar.jpg read by the
     /// next <c>init</c> is exactly the corruption the self-healing read would have to eat.</summary>
     private static bool WriteAtomic(string path, byte[] bytes)
     {
@@ -267,13 +385,15 @@ internal static class ArcademyAvatarCache
         }
         catch (Exception ex)
         {
-            App.Logger?.Debug("ArcademyAvatarCache.WriteAtomic: {E}", ex.Message);
+            // WARNING, not Debug: a write we cannot land is the other permanent no-photo state.
+            App.Logger?.Warning("ArcademyAvatarCache.WriteAtomic: {E}", ex.Message);
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { }
             return false;
         }
     }
 
-    /// <summary>The bytes decide what they are, never the label they arrived with.</summary>
-    private static bool IsPng(byte[] b) =>
-        b.Length >= 8 && b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47;
+    /// <summary>The bytes decide what they are, never the label they arrived with. JPEG's SOI
+    /// marker, plus the 0xFF that opens whichever marker follows it.</summary>
+    private static bool IsJpeg(byte[] b) =>
+        b.Length >= 3 && b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF;
 }


### PR DESCRIPTION
Two separate silent failures on the student ID card. Both reported success while doing nothing, which is why no play-test ever caught them.

## 1. Photo stuck on "pending"

`ArcademyAvatarCache.cs:43` computed its cap as `(24KB - 22) / 4 * 3` = **18,414 bytes**, then `Encode()` re-encoded Discord's already-optimised PNG with `PngBitmapEncoder` — which *inflates* it. Measured against a real avatar (33,906 B on disk):

| path | 128px | 96px |
|---|---|---|
| PNG re-encode (old) | 33,713 | 19,860 |
| **JPEG q85 via Bgr24 (new)** | **5,965** | 3,871 |

Both old outputs fell off the cap, so the cache gave up every time without a word in the log.

Now JPEG q85 through an explicit `Bgr24` `FormatConvertedBitmap`, cap raised to 48KB, file is `avatar.jpg`, sniff is the JPEG SOI marker. Every downscale and every rejection now logs at **Warning**, including a distinct line for a null `CurrentTag()`. A negative-result sidecar (`<recipe>|ok|<tag>` / `<recipe>|no|<tag>`) stops us re-encoding a picture we already know will not fit, keyed by encode recipe so a future dial change invalidates it.

The cache **directory** is never deleted, only named files — it is shared with the WebView2 `EBWebView` profile.

**This is not a regression.** The file has one commit ever (`4ec1ae6fc`), HEAD is byte-identical to `origin/main`, `avatar.png` never existed, and the success log line appears **zero** times in every log from Aug 24–30. The desktop path has never worked. What worked "a couple of days ago" was the web Arcademy, which fetches avatars through a first-party proxy and never touches this cache — this bug cannot occur there.

## 2. Frame reskins doing nothing

`FRAMES` was function-local to `idcard.js`, so the string `is-frame-` appeared **exactly once in the entire JS tree** and the campus card was never painted at all. Hoisted to module scope with a shared `paintCardFrame()`, imported by `campus.js`, applied on build, on profile echo, on `update()` and on the refresh seam.

While there, the two frames now look like what they promise: navy gets a real deep-navy ground and a letterman double-stripe on a new `--varsity` token taken from its own purchase copy; gold gets an actual `repeating-linear-gradient` pinstripe plus a gold `outline` on the photo well — `outline` rather than `border-color`, so the pink "this photo is real" rim survives underneath. An `--id-ring` custom property was needed because `.campus-idcard:hover` re-declares the whole `box-shadow`.

## Testing

`dotnet build` 0 Errors, `node --check` clean on every touched file. The encode sizes above are real measurements against the owner's own cached avatar, not estimates.

**Not play-tested in the live WebView2 host.** The photo path in particular wants a real run.

## Notes for the reviewer

- Touches `shell.js` and `styles.css`, which the other three arcade branches also touch. See the conflict note on the wave.
- The web half of this needs the `cclabs-web` CI sync after merge; the C# avatar fix is desktop-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bSqKBafSV6HB2YNg8YrXX