### PR TITLE
feat(arcademy): prize counter door on the report card, plus a holdings tray

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -633,6 +633,21 @@ export const DEFAULT_LEXICON = Object.freeze({
   booth_alley_hint: 'The lit window is down at the end of the row.',
   booth_put_it_on: 'Put it on',
   booth_hang_it: 'Hang it up',
+  /* THE HOLDINGS TRAY (counter shortcut wave, 2026-08-30). The tray on the sill
+   * answered what is in your purse and which room is hot, and never the third
+   * thing a shopper wants to know: what am I already carrying. `booth_hold_n`
+   * is deliberately absent - the count reads `2/3` by concatenation, the way
+   * `prize_held` and `prize_short` already do, because a number baked into a
+   * translated string is a number a translator has to be trusted to keep.
+   *
+   * THE PASSIVE LINES ARE THE HONEST PART. There is exactly one consumable on
+   * this shelf and it has no press: a late slip is spent by the HOST, on the
+   * night you are not here, inside the attendance credit. So the row says so
+   * rather than growing a button that would have nowhere to send you. */
+  booth_holdings: 'What you are holding',
+  booth_hold_none: 'Nothing in your pockets tonight. The shelf is through the window.',
+  booth_hold_late_slip: 'It spends itself the night you miss one. Nothing to press.',
+  booth_hold_passive: 'It spends itself the moment it is needed.',
   /* THE TWO SIGNS IN THE ALLEY (shell/alleysign.js). One pair, one alley: the
    * plate on the booth's right-hand wall points at RM 004 and the plate on the
    * Locker's left-hand wall points back at the counter, so neither room is a

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizebooth.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizebooth.css
@@ -8,8 +8,10 @@
  * here and nothing generic could know about either:
  *   .pb-shut   the word over a shutter that has come down, and the one hall
  *              line under it
- *   .pb-till   the ticket tray's little panel: what is on you, and which room
- *              is paying over the odds tonight
+ *   .pb-till   the ticket tray's little panel: what is on you, which room is
+ *              paying over the odds tonight, and - since the counter shortcut
+ *              wave, 2026-08-30 - .pb-hold-*, the third question a shopper
+ *              asks at a counter: what am I already carrying
  *
  * NO RULE BELOW MAY PAINT A HOTSPOT. When the counter is shut, prizebooth.js
  * does not build the rects at all (scene.js's `when` gate), which is the only
@@ -162,6 +164,147 @@
 .pb-payday-none {
   max-width: 34em;
   opacity: .78;
+}
+
+/* ---------------------------------------------------- THE HOLDINGS TRAY ----
+   What you are carrying, under the purse and the payday line (prizebooth.js,
+   counter shortcut wave 2026-08-30). Read left to right like a receipt: the
+   sprite the shelf sold it under, then its name and `2/3`, then either the one
+   press that spends it or the sentence saying why there is no press.
+
+   NOTHING HERE PAINTS A HOTSPOT and nothing here is a second till - the rows
+   are a reading of a wallet, exactly like the purse two rules up. */
+.pb-hold-tray {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: var(--hairline);
+  text-align: left;
+}
+
+.pb-hold-head {
+  margin: 0 0 10px;
+  text-align: center;
+  font-family: var(--disp);
+  font-size: clamp(11px, 1.8vh, 13px);
+  font-weight: 700;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  opacity: .78;
+}
+
+/* An empty pocket is a sentence, never a blank box - `.pb-payday-none`'s rule,
+   for the same reason it has one. */
+.pb-hold-none {
+  margin: 0 auto;
+  max-width: 34em;
+  text-align: center;
+  font-size: clamp(12px, 2vh, 14px);
+  line-height: 1.5;
+  opacity: .74;
+}
+
+.pb-hold-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.pb-hold {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border: var(--hairline);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, .22);
+}
+
+.pb-hold-art {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  image-rendering: auto;
+}
+
+/* The stand-in for a sku whose png has not been drawn yet. Same box as the
+   sprite so a row never changes height when the art lands. */
+.pb-hold-glyph {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  font-style: normal;
+  font-size: 22px;
+  line-height: 1;
+  opacity: .6;
+}
+
+.pb-hold-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pb-hold-line {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pb-hold-name {
+  font-size: clamp(12px, 2vh, 15px);
+  color: var(--ink);
+}
+
+/* `2/3`. Tabular so two rows of different counts line up, and never a
+   translated sentence with a number baked into it. */
+.pb-hold-n {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--pink);
+}
+
+/* WHY THERE IS NO PRESS. The one thing a player did not know about a late slip
+   before this tray existed, so it is the row's own line and not a tooltip. */
+.pb-hold-passive {
+  margin: 4px 0 0;
+  font-size: clamp(11px, 1.8vh, 13px);
+  line-height: 1.45;
+  opacity: .74;
+}
+
+/* THE VERB, for the day a sku declares one (prizebooth.js USE_VERBS is empty
+   today and the shell passes no `onUse`, so nothing renders this yet). Sized
+   at the thumb floor from the start: this panel is read on a phone. */
+.pb-hold-use {
+  flex: none;
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0;
+  min-height: 44px;
+  padding: 8px 16px;
+  border: var(--hairline);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  cursor: pointer;
+}
+
+.pb-hold-use:hover, .pb-hold-use:focus-visible {
+  border-color: var(--gold);
+  color: var(--gold);
 }
 
 /* ============================================================================

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/prizebooth.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/prizebooth.js
@@ -86,7 +86,7 @@
 
 import { t as lexT } from '../core/lexicon.js';
 import { createScene } from './scene.js';
-import { paydayParts, TOKEN_MARK } from './prizecounter.js';
+import { paydayParts, TOKEN_MARK, heldCount, spriteUrl } from './prizecounter.js';
 /* THE SIGN DOWN THE ALLEY. One module, two rooms: the Locker mounts the mirror
  * of this at its own end, and shell/alleysign.js's header says why there are
  * two of them. It imports the lexicon and exits.js and nothing else, so the
@@ -172,6 +172,66 @@ export function boothFx() {
     { kind: 'lamp', view: 'wide', rect: FX_LAMP, when: '!closed' },
     { kind: 'tilt', view: 'wide', amp: 2 },
   ];
+}
+
+/* ----------------------------------------------------------------------------
+ * THE HOLDINGS TRAY'S TWO TABLES (counter shortcut wave, 2026-08-30)
+ *
+ * The tray answered two questions - what is in your purse, and which room is
+ * paying over the odds - and never the third one a shopper actually asks at a
+ * counter: what am I already carrying. A consumable is invisible the moment it
+ * is bought; the shelf turns the row gold and nothing anywhere says you have
+ * two late slips in your pocket. That is what these rows are for.
+ *
+ * BE HONEST ABOUT THE STATE OF THE WORLD. There is exactly ONE consumable on
+ * this shelf and it has NO manual verb: `late_slip` is spent by the HOST, by
+ * itself, inside the attendance credit on the night a day is missed
+ * (ArcademyEconomy.ConsumeLateSlip). So the tray is a WHAT YOU HOLD view with
+ * room for a verb, not a verb pretending to have somewhere to go.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * WHICH CONSUMABLES CAN BE SPENT BY HAND. Deliberately EMPTY, and it is empty
+ * because nothing in the school can be. The shape is EQUIP_VERBS's, one row per
+ * sku - `sku: ['lexicon_key', 'English']` - so the night a manually-spendable
+ * thing lands on the shelf it is one line here and one `onUse` cap in shell.js.
+ *
+ * A VERB WITH NO `onUse` BEHIND IT IS NOT A BUTTON. The cap is asked at render
+ * as well as the table, and a row that names a verb the host cannot answer
+ * falls back to the passive line: a control that cannot do the thing it is
+ * lettered with is a worse lie than no control at all.
+ */
+export const USE_VERBS = Object.freeze({});
+
+/** The stand-in for a sku whose sprite has not been drawn yet. A filled block,
+ *  not a picture of anything - prizecounter.js's GLYPHS make the same choice
+ *  for the same reason: a wrong picture is worse than an obvious placeholder. */
+export const HOLD_GLYPH = '▤';
+
+/**
+ * WHAT A THING YOU HOLD BUT CANNOT PRESS SAYS. Per sku where the school has
+ * something specific to say about how it spends itself, and one general line
+ * underneath for anything that arrives later without its own.
+ */
+export const PASSIVE_LINES = Object.freeze({
+  late_slip: ['booth_hold_late_slip', 'It spends itself the night you miss one. Nothing to press.'],
+});
+
+/** The floor under PASSIVE_LINES. */
+export const PASSIVE_DEFAULT = Object.freeze(
+  ['booth_hold_passive', 'It spends itself the moment it is needed.']
+);
+
+/** The verb pair for a sku, or null. Own-property only - a sku called
+ *  'constructor' may not inherit a verb off Object.prototype. */
+export function useVerbFor(sku) {
+  return Object.prototype.hasOwnProperty.call(USE_VERBS, sku) ? USE_VERBS[sku] : null;
+}
+
+/** The passive line for a sku - its own, or the floor. Never null. */
+export function passiveLineFor(sku) {
+  return Object.prototype.hasOwnProperty.call(PASSIVE_LINES, sku)
+    ? PASSIVE_LINES[sku] : PASSIVE_DEFAULT;
 }
 
 /* ----------------------------------------------------------------------------
@@ -272,6 +332,18 @@ export function findCls(node, cls) {
  *              file only draws the answer and re-draws it on setClosed().
  *  balance   - () -> {t, k}, read fresh every time the tray is opened.
  *  payday    - optional () -> {gameKey, mult} for tonight's hot room, or null.
+ *  catalog   - optional () -> the host's catalog rows. THE HOLDINGS TRAY reads
+ *              it for the consumable rows and their names; omit it and the
+ *              tray simply has nothing to list, which is the honest answer
+ *              for a host with no shelf.
+ *  inv       - optional () -> the wallet's `inv` bag, for how many are held.
+ *  stackMax  - optional (sku) -> how many may be held at once. Display only;
+ *              the host is what refuses the third late slip, reason `full`.
+ *  onUse     - optional (sku) -> spend one, by hand. THERE IS NO SUCH SKU
+ *              TODAY - the one consumable on the shelf burns itself in the
+ *              host's attendance path - so the shell does not pass this and
+ *              every row draws its passive line instead. It is named here so
+ *              the day one arrives the tray already knows what to do with it.
  *  gameName  - optional (key) -> that room's display name.
  *  alley     - play the arrival beat? Default true. The purse chip in the
  *              chrome passes false: it did not walk anywhere, so it does not
@@ -534,7 +606,12 @@ export function createPrizeBooth(caps) {
    * thing in this school that may move a balance is the shop's settle().
    */
   function openTill() {
-    if (dead) return;
+    /* THE SAME PAIR openShop() KEEPS. `onAction` already refuses while the
+     * shutter is down and the rects are not even built (scene.js's `when`
+     * gate), so this is the belt behind those braces: the tray is a reading
+     * of a wallet at a counter, and a counter that is shut is not reading
+     * anything out. */
+    if (dead || closed) return;
     /* ONE PANEL AT A TIME is the chassis's rule, not ours: opening this takes
      * the shelf down without asking. Saying so first is what keeps the shell's
      * counter from outliving the box it was mounted in. */
@@ -560,7 +637,140 @@ export function createPrizeBooth(caps) {
           'No room is paying over the odds tonight. Every graded class still pays tickets.')));
       }
       panel.appendChild(line);
+
+      /* WHAT YOU ARE CARRYING. The third question, answered under the other
+       * two and read at OPEN like both of them - the panel is built fresh
+       * every time the tray comes out, so there is nothing here to keep in
+       * step with a wallet that moved while it was shut. */
+      panel.appendChild(holdings());
     });
+  }
+
+  /* ------------------------------------------------------ THE HOLDINGS TRAY */
+
+  /**
+   * One row per consumable on you, and an honest sentence when there are none.
+   *
+   * STILL NOT A SECOND TILL. Every number in here is READ, nothing proposes a
+   * purchase, and the only press a row can ever grow is `onUse` - which the
+   * shell does not pass, because there is no sku in this school a player
+   * spends by hand. See the two tables at the top of the file.
+   */
+  function holdings() {
+    const box = el('section', 'pb-hold-tray');
+    box.appendChild(el('h4', 'pb-hold-head', t('booth_holdings', 'What you are holding')));
+    const rows = holdingRows();
+    if (!rows.length) {
+      /* AN EMPTY POCKET IS AN ANSWER. A blank panel reads as a thing that
+       * failed to load, exactly the way `prize_no_payday` reads above it. */
+      box.appendChild(el('p', 'pb-hold-none', t('booth_hold_none',
+        'Nothing in your pockets tonight. The shelf is through the window.')));
+      return box;
+    }
+    const list = el('ul', 'pb-hold-list');
+    for (const row of rows) list.appendChild(holdingNode(row));
+    box.appendChild(list);
+    return box;
+  }
+
+  /** The consumables the player actually holds, in the catalog's own order. */
+  function holdingRows() {
+    const inv = readInv();
+    const out = [];
+    for (const item of readCatalog()) {
+      if (!item || item.kind !== 'consumable') continue;
+      let n = 0;
+      try { n = heldCount(inv, item.sku); } catch (e) { n = 0; }
+      if (n <= 0) continue;
+      out.push({ item: item, n: n, cap: stackCapFor(item) });
+    }
+    return out;
+  }
+
+  function readInv() {
+    try {
+      const v = (typeof c.inv === 'function') ? c.inv() : null;
+      return (v && typeof v === 'object') ? v : {};
+    } catch (e) { return {}; }
+  }
+
+  function readCatalog() {
+    try {
+      const v = (typeof c.catalog === 'function') ? c.catalog() : null;
+      return Array.isArray(v) ? v.filter(function (r) { return r && r.sku; }) : [];
+    } catch (e) { log('prize booth catalog read threw'); return []; }
+  }
+
+  /** The shell's cap first, then the row's own `max` off the wire. Zero means
+   *  the tray shows a bare count instead of `n/max`. */
+  function stackCapFor(item) {
+    let n = NaN;
+    try { if (typeof c.stackMax === 'function') n = Number(c.stackMax(item.sku)); }
+    catch (e) { n = NaN; }
+    if (!Number.isFinite(n) || n <= 0) n = Number(item && item.max);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+  }
+
+  /**
+   * ONE THING IN YOUR POCKET: the sprite the shelf sells it under, its name,
+   * how many of how many, and then either the one press that spends it or the
+   * sentence that says why there is no press.
+   */
+  function holdingNode(row) {
+    const item = row.item;
+    const li = el('li', 'pb-hold');
+    attr(li, 'data-sku', item.sku);
+
+    /* THE SHELF'S OWN ART, so a thing looks the same in your pocket as it did
+     * in the window. A sku with no png yet leaves the glyph standing, which is
+     * prizecounter.js's own rule for the same table. */
+    let art = null;
+    try { art = spriteUrl(item.sku); } catch (e) { art = null; }
+    if (art) {
+      const img = el('img', 'pb-hold-art');
+      try { img.src = art; img.alt = ''; } catch (e) { /* noop */ }
+      attr(img, 'aria-hidden', 'true');
+      attr(img, 'loading', 'lazy');
+      li.appendChild(img);
+    } else {
+      const glyph = el('i', 'pb-hold-glyph', HOLD_GLYPH);
+      attr(glyph, 'aria-hidden', 'true');
+      li.appendChild(glyph);
+    }
+
+    const text = el('div', 'pb-hold-text');
+    const head = el('p', 'pb-hold-line');
+    head.appendChild(el('b', 'pb-hold-name', t(item.nameKey, item.nameEn || item.sku)));
+    /* `2/3`, never a translated sentence with a number baked into it - the
+     * same ruling `prize_held` and `prize_short` are already built on. */
+    head.appendChild(el('span', 'pb-hold-n',
+      row.cap > 0 ? (row.n + '/' + row.cap) : String(row.n)));
+    text.appendChild(head);
+
+    const verb = useVerbFor(item.sku);
+    if (verb && typeof c.onUse === 'function') {
+      const btn = el('button', 'pb-hold-use', t(verb[0], verb[1]));
+      attr(btn, 'type', 'button');
+      try {
+        if (typeof btn.addEventListener === 'function') {
+          btn.addEventListener('click', function () {
+            try { c.onUse(item.sku); }
+            catch (e) { log('prize booth use threw: ' + ((e && e.message) || e)); }
+          });
+        }
+      } catch (e) { /* a verb that cannot be wired is not offered */ }
+      li.appendChild(text);
+      li.appendChild(btn);
+      return li;
+    }
+
+    /* NO VERB, SO SAY WHY. This is the whole of what a player is missing
+     * today: a late slip is not a thing you take out and hand over, it is a
+     * thing that gets handed over for you on the night you are not here. */
+    const passive = passiveLineFor(item.sku);
+    text.appendChild(el('p', 'pb-hold-passive', t(passive[0], passive[1])));
+    li.appendChild(text);
+    return li;
   }
 
   /** One currency reading, the counter's own two marks. `cur` is 't' or 'k'. */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
@@ -146,10 +146,24 @@ async function copyText(text) {
  *                                 shell always rendered.
  * @param {Function=} o.toast
  * @param {Function=} o.log
+ * @param {Function=} o.onCounter  THE TILL IS A DOOR (counter shortcut wave,
+ *                                 2026-08-30). Absent = the card the shell
+ *                                 always rendered, down to the byte: the
+ *                                 ticket chip stays the inert <span> it has
+ *                                 always been. Present = that same chip is a
+ *                                 <button> and this is what it presses. The
+ *                                 card never decides whether there IS a
+ *                                 counter to walk to - the shell owns the
+ *                                 catalog, the shutter and the walk, and this
+ *                                 is one callback out.
  */
-export function createReportCard({ ceremonies, seep, toast, log } = {}) {
+export function createReportCard({ ceremonies, seep, toast, log, onCounter } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const shout = typeof toast === 'function' ? toast : () => {};
+  /* THE ONE DOOR THIS CARD OFFERS BESIDES 'done'. Captured once, asked at
+   * render: a card built without it is not a card with a dead button on it,
+   * it is the card that has no button at all (see the chip below). */
+  const toCounter = typeof onCounter === 'function' ? onCounter : null;
   // The report is a fullscreen beat now (shell marks <html> arc-report-on):
   // the stage is the night ground under a desk lamp, and everything the card
   // used to box sits on one graded PAPER laid on it. Same DOM order, same
@@ -172,6 +186,19 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
   function sweep() {
     for (const id of Array.from(timers)) { try { clearTimeout(id); } catch (e) { /* noop */ } }
     timers.clear();
+  }
+
+  /** Shut a chip's door, or open it again. `disabled` is the real property on a
+   *  real <button> and the class is only what the sheet paints; both are
+   *  wrapped because the node double carries neither. */
+  function setBusy(node, on) {
+    if (!node) return;
+    try { node.disabled = !!on; } catch (e) { /* noop */ }
+    try {
+      if (node.classList && typeof node.classList.toggle === 'function') {
+        node.classList.toggle('is-busy', !!on);
+      }
+    } catch (e) { /* noop */ }
   }
 
   /**
@@ -287,7 +314,42 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
     }
     if (till.tickets > 0 || till.token) {
       const row = el('div', 'arc-classbar arc-till');
-      const tChip = el('span', 'chip arc-till-t');
+      /* THE TILL IS A DOOR (counter shortcut wave, 2026-08-30). This is the one
+       * screen in the school where you are TOLD you just earned tickets and had
+       * no road to spend them on: the campus chip is two screens back behind a
+       * Done. So the ticket chip is the same press the campus chip already is -
+       * `campus.js`'s pattern copied, not a second one invented. Same label off
+       * the same key, glyph still `aria-hidden`, and the count-up below writes
+       * `tNum.textContent` exactly as it did: the parent changing tag changes
+       * nothing about the number inside it.
+       *
+       * NO DOOR, NO BUTTON. Without `onCounter` the chip is emitted as the inert
+       * <span> it has always been, byte for byte, so every other caller of this
+       * card and every suite that reads it are untouched.
+       *
+       * NO `returnTo`. report -> prizebooth is a lateral swap `screenCue()`
+       * already knows how to sound; the card's Back and Esc still mean the
+       * campus, and a variable exit on a screen with three call sites is trap
+       * 48's warning with the serial numbers filed off. */
+      const tChip = toCounter
+        ? el('button', 'chip arc-till-t arc-till-go')
+        : el('span', 'chip arc-till-t');
+      if (toCounter) {
+        const lbl = t('campus_room_prizes', 'Prize Counter');
+        try {
+          tChip.setAttribute('type', 'button');
+          tChip.setAttribute('aria-label', lbl);
+          tChip.setAttribute('title', lbl);
+        } catch (e) { /* the node double may not carry attributes */ }
+        try {
+          if (typeof tChip.addEventListener === 'function') {
+            tChip.addEventListener('click', () => {
+              try { toCounter(); }
+              catch (e2) { say('the till door threw: ' + ((e2 && e2.message) || e2)); }
+            });
+          }
+        } catch (e) { /* a chip that cannot be wired is the chip it was */ }
+      }
       const tIco = el('i', 'arc-tick');
       try { tIco.setAttribute('aria-hidden', 'true'); } catch (e) { /* noop */ }
       tChip.appendChild(tIco);
@@ -343,6 +405,27 @@ export function createReportCard({ ceremonies, seep, toast, log } = {}) {
               });
             } catch (e) { say('token mint beat failed: ' + ((e && e.message) || e)); }
           }, till.tickets > 0 ? 820 : 120);
+        }
+      }
+
+      /* THE DOOR IS SHUT WHILE THE MONEY IS STILL BEING COUNTED. Walking to the
+       * counter tears this screen down (`showPrizeBooth` calls dismissEndCard,
+       * dismissPunchStage and dismissAnnexStage on its way in), so a press
+       * landing mid-beat stomps the very beat that is telling you what you have
+       * to spend. The count-up runs 720ms and the jackpot lands at 820; the
+       * chip wakes up on the far side of whichever of the two is playing. A
+       * REPAINT has no beats at all, so it never shuts.
+       *
+       * The shell keeps its own rung on the same question - a punch card or the
+       * annex reveal can still be up over this paper - and refuses there. Two
+       * guards because they are two different facts. */
+      if (toCounter && s.arrived) {
+        const ends = till.token
+          ? (till.tickets > 0 ? 820 : 120) + 1400
+          : (till.tickets > 0 ? 780 : 0);
+        if (ends > 0) {
+          setBusy(tChip, true);
+          later(() => setBusy(tChip, false), ends);
         }
       }
     }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -1222,7 +1222,35 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     try { return seep ? seep.misprintFor(rows) : null; } catch (e) { return null; }
   };
 
-  reportCard = createReportCard({ ceremonies, seep, toast: shout, log: say });
+  /* THE TILL IS A DOOR (counter shortcut wave, 2026-08-30). The report card is
+   * the one screen that TELLS you what you just earned and, until now, had no
+   * road to spend it on - the campus wallet chip is two screens back behind a
+   * Done. So the night's ticket chip presses through to the same place the
+   * campus chip does, and the card is handed the verb rather than the reason:
+   * the catalog, the shutter and the ceremonies are all the shell's business.
+   *
+   * OFFERED ONLY WHEN THERE IS A SHELF AT ALL. `init.economy.catalog` is fixed
+   * for the life of the page, so this is asked once here; a host that projects
+   * no economy gets the card it always got, with an inert <span> on the till.
+   *
+   * IT REFUSES, IT NEVER TRAVELS BADLY. Two rungs, and they are two different
+   * facts: a shut counter (a suspend, a lapsed entitlement) is answered with
+   * the shutter's own line exactly as the campus chip answers it, and a
+   * ceremony still on screen is answered with silence - `showPrizeBooth` calls
+   * dismissEndCard/dismissPunchStage/dismissAnnexStage on its way in, so a
+   * press mid-beat would stomp the beat that is doing the telling. */
+  const counterFromReport = economyCatalog().length ? () => {
+    if (endCard || punchStage || annexStage) return;
+    if (counterClosed()) {
+      shout(t('prize_closed_line',
+        'The shutter is down and the sign above it has been switched off at the wall.'));
+      return;
+    }
+    showPrizes();
+  } : null;
+  reportCard = createReportCard({
+    ceremonies, seep, toast: shout, log: say, onCounter: counterFromReport,
+  });
 
   /* ---------------------- helpers --------------------------------------- */
   function gameName(key) {
@@ -2085,8 +2113,25 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
            * IT LANDS AT THE WINDOW WITH THE SHELF ALREADY OPEN (Locker wave).
            * The shop is a panel over the booth's plate now, so "straight to the
            * shelf" means the plate is there under it - what the chip skips is
-           * the walk and the arrival down the alley, never the room. */
-          prizesShelf: () => showPrizes(),
+           * the walk and the arrival down the alley, never the room.
+           *
+           * IT REFUSES IN PLACE WHEN THE SHUTTER IS DOWN (counter shortcut
+           * wave, 2026-08-30). `applySuspend` re-shows the board and leaves
+           * this chip live and pressable, so a press during a suspend used to
+           * BUILD the booth with `closed:true` - the shelf no-ops on the way in
+           * (prizebooth.js openShop) and the player is left standing in an
+           * unusable dark room they then have to find their way back out of. A
+           * toast is the whole answer: `screen` never moves, no dialog is
+           * minted, and the sentence is the one the shutter itself is lettered
+           * with one screen further in, so the school says it in one voice. */
+          prizesShelf: () => {
+            if (counterClosed()) {
+              shout(t('prize_closed_line',
+                'The shutter is down and the sign above it has been switched off at the wall.'));
+              return;
+            }
+            showPrizes();
+          },
           annex: () => walkThen('annex', () => showAnnex()),
           /* THE DOOR walks; THE GEAR does not. campus.js calls `registrarRoom`
            * for the Front Office room and falls back to `registrar` for the
@@ -3355,10 +3400,21 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       reduced: reducedMotion,
       closed: counterClosed(),
       alley: !opt.skipWalk,
-      /* The same two getters the shelf takes, and for the same reason: the tray
-       * on the sill reads a wallet, it never moves one. */
+      /* The same getters the shelf takes, and for the same reason: the tray on
+       * the sill READS a wallet, it never moves one. `catalog`/`inv`/`stackMax`
+       * joined the list for the holdings tray (counter shortcut wave,
+       * 2026-08-30) - what you are holding is three reads of the same three
+       * facts the shelf already reads, and not one of them is a proposal.
+       *
+       * NO `onUse`. Nothing on this shelf can be spent by hand: the one
+       * consumable, `late_slip`, is burned by the HOST inside the attendance
+       * credit (ArcademyEconomy.ConsumeLateSlip), so there is no press to wire
+       * and the tray says so in words instead of growing a button that lies. */
       balance: () => walletBalance(),
       payday: () => economyPayday(),
+      catalog: () => economyCatalog(),
+      inv: () => walletInv(),
+      stackMax: (sku) => stackMaxFor(sku),
       gameName,
       /* THE BOOTH OWNS THE BOX, THE SHELL OWNS WHAT IS IN IT. The room hands
        * over a panel and the way out of it; the counter and every cap it reads

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -581,6 +581,40 @@ html.arc-reduced .arc-endcard-actions .arc-retake { animation:none; box-shadow:0
   background:color-mix(in srgb, var(--gold), transparent 90%);
 }
 
+/* THE TILL IS A DOOR (counter shortcut wave, 2026-08-30). When the shell hands
+   the report card a way to the counter, the ticket chip is emitted as a
+   <button> wearing this class as well as `.chip` - so everything below is one
+   job: undo what a user agent does to a <button> that `.chip` does not already
+   overwrite (its own font, its margin, its centred text, its native skin), and
+   then borrow `.campus-wallet`'s manners so the two presses that lead to the
+   same room feel like the same verb. Without the class the chip is a <span>
+   and none of this applies to anything. */
+.arc-till-go {
+  appearance:none; -webkit-appearance:none;
+  margin:0; text-align:left;
+  font-family:inherit; font-size:11px; font-weight:600; letter-spacing:.04em;
+  line-height:inherit;
+  border:var(--hairline); background:var(--panel); color:var(--ink-dim);
+  cursor:pointer;
+}
+/* `:not()` on both marks rather than a second rule undoing this one: a door
+   that is shut may not light up under the cursor. */
+.arc-till-go:not([disabled]):not(.is-busy):hover,
+.arc-till-go:not([disabled]):not(.is-busy):focus-visible {
+  border-color:var(--pink-deep);
+  color:var(--ink);
+}
+/* SHUT WHILE THE MONEY IS BEING COUNTED. reportcard.js holds the door for the
+   length of the count-up (and the token jackpot behind it) because walking to
+   the counter tears this screen down mid-beat. Both marks, because `disabled`
+   is the real one and the class is what the node double can be read for. */
+.arc-till-go[disabled], .arc-till-go.is-busy {
+  cursor:default; opacity:.5;
+}
+/* 44px is the floor for anything a thumb has to find, and this one sits in the
+   middle of a paper the player is already scrolling. */
+html.arc-mobile .arc-till-go { min-height:44px; padding:6px 14px; }
+
 /* THE CAMPUS WALLET CHIP. It rides the top-right cluster beside the account
    chip, it is READ-ONLY, and pressing it walks to the Prize Counter. */
 .campus-wallet {

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -3047,6 +3047,17 @@ internal static class ArcademyHostService
         ["booth_alley_hint"] = "The lit window is down at the end of the row.",
         ["booth_put_it_on"] = "Put it on",
         ["booth_hang_it"] = "Hang it up",
+        // THE HOLDINGS TRAY (counter shortcut wave, 2026-08-30). The tray on the booth's sill
+        // lists the consumables the player is carrying. There is no "2 of 3" row: the count is
+        // built as "2/3" by concatenation, the way prize_held and prize_short already are.
+        // The two passive lines are the honest half of the feature - the one consumable on the
+        // shelf, late_slip, has no manual verb at all (ArcademyEconomy.ConsumeLateSlip burns it
+        // inside the attendance credit), so the row says so instead of growing a dead button.
+        // All four are well inside MergeModTable's 96-char skin cap (trap 26).
+        ["booth_holdings"] = "What you are holding",
+        ["booth_hold_none"] = "Nothing in your pockets tonight. The shelf is through the window.",
+        ["booth_hold_late_slip"] = "It spends itself the night you miss one. Nothing to press.",
+        ["booth_hold_passive"] = "It spends itself the moment it is needed.",
         // The two wayfinding plates in the alley (shell/alleysign.js): the booth's
         // right-hand wall points at RM 004 and the Locker's left wall points back.
         // Rows of their own, not a re-use of the room cards, because a sign names a


### PR DESCRIPTION
Buying a consumable meant remembering where the counter was.

The campus ticket chip already opened the shelf in one click. The **report card** — where you actually sit and look at your ticket count — did not.

## The door

The ticket chip on the report card becomes a real `button` when a counter route exists, and stays the exact prior `span` when it does not. The route is built only when the economy catalogue is non-empty, and refuses outright while an end card, a punch stage or the annex stage is up. The door shuts for the arrival beats (780ms on tickets, +1400 past a jackpot) so it cannot be double-fired mid-animation.

## A real bug found on the way

Hitting the prize shelf while the counter was **shut** teleported you into a dark shuttered room with no explanation. It now calls `counterClosed()` and says so out loud.

## Holdings tray

The booth grows a tray so you can see what you are carrying.

`USE_VERBS` is **deliberately empty**. `late_slip` is the only consumable that exists and it is passive, so the tray reports holdings honestly rather than growing buttons that do nothing. Wire a verb here when a consumable earns one — I did not invent SKUs to fill the space.

## Lexicon

Four new keys — `booth_holdings`, `booth_hold_none`, `booth_hold_late_slip`, `booth_hold_passive` — each present in all three required locations (call site, `core/lexicon.js` `DEFAULT_LEXICON`, `ArcademyHostService` `NeutralLexicon`), all within the 96-character host cap. Verified 4 × 3 by grep, since a key the host does not ship fails silently in English and play-tests never catch it (trap 123).

## Testing

`node --check` clean, `dotnet build` 0 Errors.

**Not play-tested in the live WebView2 host.** The door's behaviour across the arrival animation is the part that wants a real run.

## Notes for the reviewer

- Touches `shell.js`, `styles.css` and `ArcademyHostService.cs`, which other arcade branches in this wave also touch. See the conflict note on the wave.
- Needs the `cclabs-web` CI sync after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bSqKBafSV6HB2YNg8YrXX