### PR TITLE
fix(quests): rerolling a daily seat can no longer hand back the same quest (#1085)

### DIFF
--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -1038,9 +1038,16 @@ public class QuestService : IDisposable
             return false;
         }
 
-        // The whole board is excluded, not just this seat: spending a reroll to be handed a
-        // duplicate of the card next to it would be the worst possible outcome of pressing it.
-        var replacement = RollDailyQuest(DailyBoardIds(skipIndex: slot));
+        // The whole board is excluded, THIS SEAT INCLUDED (#1085 - it used to pass
+        // skipIndex: slot, which excluded the two cards the player did NOT touch and left the
+        // one they just rerolled as the only id that could come back). Being handed a duplicate
+        // of the card next to it, or the very card just paid to be rid of, are the two worst
+        // possible outcomes of pressing this button; neither is reachable from here.
+        //
+        // Costs nothing in reachability: RollDailyQuest's last-resort pass drops the exclusion
+        // set entirely, so it returns null only when the pool is empty with NO exclusions at
+        // all - one more excluded id cannot turn a successful reroll into a refused one.
+        var replacement = RollDailyQuest(DailyBoardIds());
         if (replacement == null)
         {
             App.Logger?.Warning("Daily reroll found no replacement quest - the pool is empty, keeping '{QuestId}' and NOT spending the reroll",


### PR DESCRIPTION
Closes #1085.

## The bug

Rerolling a daily quest could hand back the **same quest you just paid to be rid of**. Live regression in the 6.8.6 three-up board (`6bde3f418`).

`QuestService.cs` passed `DailyBoardIds(skipIndex: slot)`, and `skipIndex` **omits that seat's own id from the exclusion set**. So the two cards you did not touch were correctly excluded, and the one you rerolled was the only id that could come back. The comment directly above stated the opposite intent.

## The fix

One argument: `DailyBoardIds(skipIndex: slot)` -> `DailyBoardIds()`. Comment corrected to match.

## Why this is safe

**Reachability-neutral, not merely low-risk.** `RollDailyQuest` has a documented last-resort pass that re-filters with `excludeIds = null`, so it returns null only when the pool is empty with *no* exclusions applied - a condition independent of what the caller passes. One more excluded id cannot turn a successful reroll into a refused one.

Pool headroom after the change: **premium 15 candidates, free 7** (from 18 and 10 rollable, minus the 3-card board). The existing `replacement == null` guard still returns before `DailyRerollsUsed++`, so a failed roll never spends the reroll.

## Other callers left alone

There are **five** `skipIndex` callers, four remaining. All are correct as-is: two cannot return the outgoing id anyway, and two are automatic re-roll passes where nothing is spent. This seat was the only one where the player spends a finite currency on the outcome - which is exactly why the duplicate was worth a report here and is benign elsewhere.

## Follow-up (not in this PR)

`RollDailyQuest`'s last-resort pass ignores exclusions, so a server-published daily set of <=3 quests could resurrect the symptom via `App.QuestDefinitions`. That wants a floor check server-side, not more client code.

## Verification

`dotnet build`: 0 errors, 350 warnings (unchanged baseline), none from `QuestService.cs`. Not play-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
