### PR TITLE
fix(video): video trigger bubbles no longer vanish into the For You feed (#1073)

### DIFF
--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1585,6 +1585,10 @@ namespace ConditioningControlPanel.Services
             _cascadeDeferPending = false;
             _cascadeDeferDeadlineUtc = DateTime.MinValue;
 
+            // Same for the #1073 For You defer — identical latch, identical failure mode.
+            _feedDeferPending = false;
+            _feedDeferDeadlineUtc = DateTime.MinValue;
+
             try { Microsoft.Win32.SystemEvents.SessionSwitch -= OnSessionSwitch; }
             catch { }
             try { Microsoft.Win32.SystemEvents.PowerModeChanged -= OnPowerModeChanged; }
@@ -1752,6 +1756,146 @@ namespace ConditioningControlPanel.Services
                 });
         }
 
+        /// <summary>True while the For You feed is actually on the user's screen. A GHOSTED feed is
+        /// deliberately NOT included (#1073): ghost mode parks the real window off-screen and leaves
+        /// a see-through, click-through DWM mirror, so nothing is competing for the screen and there
+        /// is no reason to stand a mandatory video down.</summary>
+        private static bool FeedOwnsTheScreen =>
+            Fyp.FypHostService.IsActive && !Fyp.FypHostService.IsGhosted;
+
+        /// <summary>True while a trigger is parked waiting for the For You feed to leave the screen
+        /// (#1073). One pending replay at a time, exactly like the cascade defer — a feed session that
+        /// swallows several triggers replays one video, not a backlog. Cleared by <see cref="Stop"/>
+        /// so a defer that outlived the service cannot coalesce (and so swallow) every future trigger.</summary>
+        private bool _feedDeferPending;
+
+        /// <summary>Longest a trigger will wait out an on-screen feed. Deliberately short, and
+        /// deliberately the same ceiling as the cascade defer: the feed can stay open for hours (which
+        /// is why the original guard refused to queue behind it at all), and a mandatory video that
+        /// fires many minutes after the bubble that earned it is a surprise, not a reward. Past this,
+        /// the trigger is given up on — never accumulated.</summary>
+        private static readonly TimeSpan FeedDeferMaxWait = TimeSpan.FromSeconds(90);
+
+        /// <summary>Absolute expiry of the CURRENT feed-defer chain, set on its first defer.
+        /// <see cref="DateTime.MinValue"/> = no chain in flight.</summary>
+        private DateTime _feedDeferDeadlineUtc = DateTime.MinValue;
+
+        /// <summary>#1073: hold a trigger the For You guard refused and replay it once the feed leaves
+        /// the screen (closed, or ghosted away).</summary>
+        private void DeferTriggerPastFeed(bool silentIfEmpty, bool? strictOverride)
+        {
+            if (_feedDeferPending)
+            {
+                App.Logger?.Information("VideoService: For You replay already pending - trigger coalesced");
+                return;
+            }
+
+            // Ceiling measured from the FIRST defer of the chain, not per-hop — same reasoning as the
+            // cascade version: a replay that lands back in front of the feed must not restart the clock.
+            var now = DateTime.UtcNow;
+            if (_feedDeferDeadlineUtc == DateTime.MinValue)
+                _feedDeferDeadlineUtc = now + FeedDeferMaxWait;
+
+            var remaining = _feedDeferDeadlineUtc - now;
+            if (remaining <= TimeSpan.Zero)
+            {
+                App.Logger?.Information("VideoService: For You replay dropped - past the {Sec:F0}s defer ceiling",
+                    FeedDeferMaxWait.TotalSeconds);
+                _feedDeferDeadlineUtc = DateTime.MinValue;
+                return;
+            }
+
+            _feedDeferPending = true;
+            RunWhenFeedClear(
+                () =>
+                {
+                    _feedDeferPending = false;
+
+                    // Re-assert the preconditions at FIRE time. The defer can easily outlive the thing
+                    // that justified it — the engine stopped, the user turned mandatory videos off —
+                    // and replaying then pops a fullscreen video out of a feature that is switched off.
+                    // Same guard the cascade replay and the scheduler use.
+                    if (!_isRunning || App.Settings?.Current?.MandatoryVideosEnabled != true)
+                    {
+                        App.Logger?.Information("VideoService: For You replay abandoned - mandatory videos no longer running");
+                        _feedDeferDeadlineUtc = DateTime.MinValue;
+                        return;
+                    }
+
+                    TriggerVideo(silentIfEmpty, strictOverride);
+
+                    // TriggerVideo may have parked itself again (the feed came back, or a cascade
+                    // started). Only release the ceiling when the chain really ended, so a re-defer
+                    // inherits it instead of buying itself another full window.
+                    if (!_feedDeferPending) _feedDeferDeadlineUtc = DateTime.MinValue;
+                },
+                remaining,
+                onExpired: () =>
+                {
+                    _feedDeferPending = false;
+                    _feedDeferDeadlineUtc = DateTime.MinValue;
+                });
+        }
+
+        /// <summary>
+        /// Run <paramref name="action"/> as soon as the For You feed is off the screen, and give up
+        /// after <paramref name="maxWait"/> so nothing can be held forever. Shaped like
+        /// ChaosGifCascadeOverlay.RunWhenClear and for the same reason: there is no "feed closed" event
+        /// to hang off, and ghost mode enters and leaves without one either, so the UI dispatcher is
+        /// polled twice a second. Callers only reach here while the feed IS on screen, so there is no
+        /// fire-immediately branch — the first tick handles the case where it has already gone.
+        ///
+        /// <para><paramref name="onExpired"/> is the UNCONDITIONAL give-up callback: it runs on every
+        /// path where <paramref name="action"/> will not, including the "there is no dispatcher to poll
+        /// on" early return. The caller latches a "defer pending" flag before calling in, and a silent
+        /// early return here would latch it forever.</para>
+        /// </summary>
+        private static void RunWhenFeedClear(Action action, TimeSpan maxWait, Action? onExpired = null)
+        {
+            if (action == null) return;
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted)
+            {
+                // No dispatcher to poll on, so the action can never run — release the caller's latch.
+                try { onExpired?.Invoke(); } catch { }
+                return;
+            }
+
+            var deadline = DateTime.UtcNow + maxWait;
+            // Normal, not Background: this project has a documented starvation issue where Background /
+            // Loaded priority work is starved out under load, which would stall the poll that releases
+            // the parked trigger.
+            var timer = new DispatcherTimer(DispatcherPriority.Normal, dispatcher)
+            {
+                Interval = TimeSpan.FromMilliseconds(500)
+            };
+            timer.Tick += (_, _) =>
+            {
+                try
+                {
+                    if (FeedOwnsTheScreen && DateTime.UtcNow < deadline) return;   // still on screen, still within the window
+                    timer.Stop();
+                    if (FeedOwnsTheScreen)
+                    {
+                        App.Logger?.Information("VideoService: deferred video expired - For You feed still on screen after {Sec:F0}s",
+                            maxWait.TotalSeconds);
+                        onExpired?.Invoke();
+                        return;
+                    }
+                    App.Logger?.Information("VideoService: For You feed left the screen - firing deferred video");
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    try { timer.Stop(); } catch { }
+                    try { onExpired?.Invoke(); } catch { }
+                    App.Logger?.Debug("VideoService.RunWhenFeedClear: {E}", ex.Message);
+                }
+            };
+            timer.Start();
+            App.Logger?.Information("VideoService: deferring mandatory video until the For You feed leaves the screen");
+        }
+
         /// <param name="silentIfEmpty">
         /// When true, an empty videos folder is logged and ignored instead of popping the
         /// "no videos found" dialog. Used for the auto-played startup video (#333) so a user
@@ -1811,18 +1955,38 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
-            // For You feed open: the feed IS the video experience — a mandatory video over it
-            // would fight the feed's own players for audio and attention. Drop outright (never
-            // queue: the feed can stay open far longer than the queue's stuck window), releasing
-            // a dequeued claim the same way the cascade guard above does.
-            if (Fyp.FypHostService.IsActive)
+            // For You feed ON SCREEN: the feed IS the video experience — a mandatory video over it
+            // would fight the feed's own players for audio and attention. Two things this guard
+            // used to get wrong (#1073, reported as "60% of my video bubbles do nothing"):
+            //
+            //  1. It gated on IsActive alone, and a GHOSTED feed is still "active". Ghost mode parks
+            //     the real window off-screen and leaves a see-through, click-through DWM mirror —
+            //     there is no feed competing for the screen, so a mandatory video is exactly as
+            //     appropriate as it would be with the feed closed. A user browsing ghosted had every
+            //     video silently eaten while seeing no feed at all. Hence FeedOwnsTheScreen.
+            //  2. It DROPPED. Bubble payloads reach this method too (the same wrong assumption that
+            //     cost #871 above), and a video the user popped a bubble to earn must not evaporate.
+            //     So the trigger is held and replayed once the feed leaves the screen — closed, or
+            //     ghosted away — exactly like the cascade guard.
+            //
+            // The old comment's concern ("never queue: the feed can stay open far longer than the
+            // queue's stuck window") is still honoured, twice over: the queue slot is RELEASED here
+            // rather than held across the wait, and the wait itself is capped at FeedDeferMaxWait,
+            // so nothing parks behind an all-evening feed session.
+            if (FeedOwnsTheScreen)
             {
-                App.Logger?.Information("VideoService: TriggerVideo dropped - For You feed active");
+                App.Logger?.Information("VideoService: TriggerVideo deferred - For You feed on screen");
+                // Same release as the cascade guard: when this trigger was DEQUEUED the queue already
+                // claimed the Video slot for us, and holding it across the wait would block every
+                // interaction for the 5-minute stuck window. The replay re-enters the queue normally.
+                // Safe on non-dequeue paths: current==Video with no video playing only happens right
+                // after a dequeue.
                 if (!_videoPlaying &&
                     App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.Video)
                 {
                     App.InteractionQueue.Complete(InteractionQueueService.InteractionType.Video);
                 }
+                DeferTriggerPastFeed(silentIfEmpty, strictOverride);
                 return;
             }
 


### PR DESCRIPTION
Closes #1073.

Reported as *"About 60% of the time my video trigger bubbles don't actually trigger a video. Seems to be within the last 2 updates."*

## The bug

`TriggerVideo` dropped outright whenever `FypHostService.IsActive` - which is just `_host != null`. **Ghosting does not clear it**: ghost mode only parks the real window off-screen behind a see-through, click-through DWM mirror. So a user with a ghosted feed had every video bubble silently eaten while no feed was visible at all. Present since v6.6.3 (`b743be12f`), matching the reporter's "last 2 updates".

## The fix

Two parts.

1. **`FeedOwnsTheScreen` = `IsActive && !IsGhosted`** - a ghosted feed no longer suppresses anything. This is the reported bug.
2. **A visible feed now defers-and-replays instead of dropping.** A bubble the user popped is earned input. Dropping it repeats the exact mistake #871 already corrected two guards higher in this same method - including the same wrong premise ("bubble payloads are gated upstream"), which #871's own comment records as false.

## This is not the queueing the old comment warned about

The old comment objected to *queueing* - parking a claim in the InteractionQueue behind a feed that can outlive the queue's 5-minute stuck window. This defers **outside** the queue: it releases the queue slot first (the same three lines the drop already ran), then waits with a **90s ceiling anchored at the first defer of a chain**, so a replay landing back in front of the feed inherits the deadline rather than buying a fresh window. One latch, coalesce-not-append - nothing accumulates.

90s is deliberate: a strict-lock mandatory video firing minutes after the bubble that earned it is a surprise, not a reward.

`Stop()` clears the latch alongside the cascade pair - omitting that is the documented failure where a stale latch coalesces every future trigger forever.

## InteractionQueue

Claim release happens **before** the defer, so it is correct on every sub-path (coalesce, over-ceiling, expiry). All 11 exit paths traced: no path holds a claim across the wait, and no path releases a claim that is not its own. `onExpired` runs unconditionally so the latch can never strand, including on shutdown.

Polling (shaped on `ChaosGifCascadeOverlay.RunWhenClear`, `DispatcherPriority.Normal` per the documented Background-starvation issue) is the only option - `FypHostService.Close`/`ExitGhost` raise no events.

## Follow-up (not in this PR)

`Services/BubbleCountService.cs:157` has the **identical** `if (Fyp.FypHostService.IsActive)` drop, with a comment copied from this one. Bubble count is also user-popped earned input, so a ghosted feed eats it too. `AutonomyService.cs:1083` also gates on `IsActive` but only as a candidate filter - harmless, intentionally left alone.

## Verification

`dotnet build`: 0 errors, 350 warnings (unchanged baseline), **none from `VideoService.cs`**. No test asserted the old drop behaviour. Not play-tested - wants a real bubble pop against both a visible and a ghosted feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
