### PR TITLE
fix(achievements): stop achievement progress being lost to a truncated save (#1071, #1074)

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2434,13 +2434,38 @@ namespace ConditioningControlPanel
             // Wire up achievement popup BEFORE checking any achievements
             Achievements.AchievementUnlocked += OnAchievementUnlocked;
             
-            // Now check initial achievements (so popup can show)
-            Achievements.CheckLevelAchievements(Settings.Current.PlayerLevel);
-            Logger.Information("Checked level achievements for level {Level}", Settings.Current.PlayerLevel);
-            
-            // Check daily maintenance achievement (7 days streak)
-            Achievements.CheckDailyMaintenance();
-            Logger.Information("Checked daily maintenance achievement");
+            // Both checks below REPAIR unlocks the user already earned - they reconstruct them from
+            // state that outlived achievements.json (PlayerLevel and the launch streak both live in
+            // settings.json) rather than witnessing a fresh earn - so they run SILENTLY, exactly as
+            // the post-login cloud restore and GamificationBridge's own retroactive pass do, and for
+            // the identical reason spelled out there.
+            //
+            // #1074: when a truncated achievements.json loaded as empty, TryUnlock stopped
+            // early-returning on IsUnlocked and EVERY level achievement the user had ever earned
+            // popped again, one after another, on the next launch - and re-posted to Discord with
+            // them. The cloud restore that refills the unlocked set lands asynchronously a few
+            // seconds later, far too late to stop a storm these synchronous lines already started.
+            // The unlocks are still recorded, saved and cloud-synced; only the popup/sound/webhook
+            // are skipped. A genuine level-up still celebrates: that fires through
+            // ProgressionService's own CheckLevelAchievements call, which is not suppressed.
+            //
+            // The prior flag value is saved rather than assumed false so an in-flight cloud restore
+            // that is already suppressing cannot be un-suppressed on the way out.
+            var achWasSuppressed = Achievements.SuppressPopups;
+            Achievements.SuppressPopups = true;
+            try
+            {
+                Achievements.CheckLevelAchievements(Settings.Current.PlayerLevel);
+                Logger.Information("Checked level achievements for level {Level} (retroactive, popups suppressed)", Settings.Current.PlayerLevel);
+
+                // Check daily maintenance achievement (7 days streak)
+                Achievements.CheckDailyMaintenance();
+                Logger.Information("Checked daily maintenance achievement (retroactive, popups suppressed)");
+            }
+            finally
+            {
+                Achievements.SuppressPopups = achWasSuppressed;
+            }
 
             // Start the gamification bridge now that all feature services it subscribes
             // to (Mods, Companion, KeywordTriggers, RemoteControl, Webcam, BlinkTrainer,
@@ -4697,14 +4722,18 @@ Application State:
             // as well as from MainWindow.Closing, since a Shutdown() that bypasses the main
             // window's close path would otherwise leave them alive.
             try { CornerGif?.StopAll(); } catch { }
-            Bubbles?.Dispose();
-            LockCard?.Dispose();
-            PopQuiz?.Dispose();
-            BubbleCount?.Dispose();
-            BouncingText?.Dispose();
-            MindWipe?.Dispose();
-            BrainDrain?.Dispose();
-            Achievements?.Dispose();
+            // Each guarded individually (#1071). These were a bare unguarded run of calls, so a
+            // throw in ANY of them skipped every line after it - including the achievement flush,
+            // which is the last write of the user's progress before OnExit reaches TerminateProcess.
+            // A minigame failing to tear down must not cost the session's XP, counters and unlocks.
+            try { Bubbles?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "Bubbles dispose failed"); }
+            try { LockCard?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "LockCard dispose failed"); }
+            try { PopQuiz?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "PopQuiz dispose failed"); }
+            try { BubbleCount?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "BubbleCount dispose failed"); }
+            try { BouncingText?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "BouncingText dispose failed"); }
+            try { MindWipe?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "MindWipe dispose failed"); }
+            try { BrainDrain?.Dispose(); } catch (Exception ex) { Logger?.Debug(ex, "BrainDrain dispose failed"); }
+            try { Achievements?.Dispose(); } catch (Exception ex) { Logger?.Error(ex, "Achievement progress flush on shutdown FAILED"); }
             // Before WindowAwareness: its Dispose runs Stop(), which also stops the observer — and the
             // observer's own Stop is what closes the open visit and flushes the ledger to disk.
             // Detach first so nothing can route a line into a half-disposed arbiter on the way down.

--- a/ConditioningControlPanel/Services/Progression/AchievementService.cs
+++ b/ConditioningControlPanel/Services/Progression/AchievementService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Threading;
@@ -19,6 +20,29 @@ public class AchievementService : IDisposable
     private readonly DispatcherTimer _saveTimer;
     private readonly DispatcherTimer _trackingTimer;
     private bool _isDirty;
+
+    /// <summary>
+    /// Serialises every writer of <see cref="_progressPath"/>. Before this existed the 30s autosave
+    /// timer's fire-and-forget <c>Task.Run</c> and the synchronous <see cref="Save"/> that
+    /// TryUnlock / lock cards / video minutes call could both be inside <c>File.WriteAllText</c> on
+    /// the SAME path at the same time. See <see cref="WriteProgress"/>.
+    /// </summary>
+    private readonly object _saveLock = new();
+
+    /// <summary>Identical for every write - build them once, not once per save.</summary>
+    private static readonly JsonSerializerOptions SaveOptions = new() { WriteIndented = true };
+
+    /// <summary>
+    /// Flush <see cref="TrackBubblePopped"/> to disk every this many pops (#1071).
+    ///
+    /// <para>Pops are a hot path - click-spam and a Rabbit Hole run fire them many times a second -
+    /// so they cannot call <see cref="Save"/> inline the way lock cards and video minutes do. But
+    /// leaving them to the 30s timer alone is what lost the count. 50 is the middle ground: the
+    /// worst case is losing the last 49 pops, and even at a sustained 10 pops/second it is one
+    /// small write every 5 seconds. It also divides 100, so every sparkle-point milestone is
+    /// banked by the same flush.</para>
+    /// </summary>
+    private const int BubbleSaveEveryNPops = 50;
     private DateTime _lastPinkFilterCheck = DateTime.Now;
     private DateTime _lastSpiralCheck = DateTime.Now;
     private DateTime _lastBrainDrainCheck = DateTime.Now;
@@ -92,26 +116,11 @@ public class AchievementService : IDisposable
         _saveTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(30) };
         _saveTimer.Tick += (s, e) =>
         {
-            if (_isDirty)
-            {
-                _isDirty = false;
-                var json = JsonSerializer.Serialize(_progress, new JsonSerializerOptions { WriteIndented = true });
-                var path = _progressPath;
-                _ = Task.Run(() =>
-                {
-                    try
-                    {
-                        var dir = Path.GetDirectoryName(path);
-                        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                            Directory.CreateDirectory(dir);
-                        File.WriteAllText(path, json);
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Error(ex, "Failed to save achievement progress");
-                    }
-                });
-            }
+            if (!_isDirty) return;
+            _isDirty = false;
+            // Still off the UI thread, but through the one writer that holds _saveLock and lands
+            // the bytes atomically - this tick used to race the synchronous Save() below.
+            _ = Task.Run(WriteProgress);
         };
         _saveTimer.Start();
         
@@ -135,41 +144,134 @@ public class AchievementService : IDisposable
             _progress.UnlockedAchievements.Count);
     }
     
+    /// <summary>
+    /// Loads achievements.json, falling back to the <c>.bak</c> sibling
+    /// <see cref="WriteProgress"/> leaves behind.
+    ///
+    /// <para>A file that EXISTS but will not parse is now logged at Error, loudly and by name. The
+    /// old behaviour - swallow the JsonException and hand back a fresh, empty
+    /// <see cref="AchievementProgress"/> - is what turned a single truncated write into permanent,
+    /// unexplained total loss: every counter reset and, because <see cref="TryUnlock"/> early-returns
+    /// on <c>IsUnlocked</c>, every already-earned achievement popped again on the next launch
+    /// (#1071 / #1074). "No file yet" (a first launch) and "the file is corrupt" look like the same
+    /// silence to the user, so they must not be the same silence in the log.</para>
+    /// </summary>
     private AchievementProgress LoadProgress()
     {
-        try
+        var backupPath = _progressPath + ".bak";
+
+        foreach (var (path, label) in new[] { (_progressPath, "achievements.json"), (backupPath, "achievements.json.bak") })
         {
-            if (File.Exists(_progressPath))
+            if (!File.Exists(path)) continue;
+
+            try
             {
-                var json = File.ReadAllText(_progressPath);
-                return JsonSerializer.Deserialize<AchievementProgress>(json) ?? new AchievementProgress();
+                var json = File.ReadAllText(path);
+                var loaded = JsonSerializer.Deserialize<AchievementProgress>(json);
+                if (loaded == null)
+                {
+                    App.Logger?.Error("Achievement progress {File} parsed to null - treating it as corrupt", label);
+                    continue;
+                }
+
+                if (!string.Equals(path, _progressPath, StringComparison.Ordinal))
+                {
+                    App.Logger?.Warning(
+                        "RECOVERED achievement progress from {File} after the main file failed to load. {Count} unlock(s) preserved.",
+                        label, loaded.UnlockedAchievements?.Count ?? 0);
+                }
+
+                return loaded;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex,
+                    "Achievement progress {File} EXISTS but failed to parse - this is data loss unless the backup loads", label);
             }
         }
-        catch (Exception ex)
+
+        if (File.Exists(_progressPath) || File.Exists(backupPath))
         {
-            App.Logger?.Error(ex, "Failed to load achievement progress");
+            App.Logger?.Error(
+                "Achievement progress could not be read from achievements.json OR its backup - starting EMPTY. Cloud sync will restore what it holds.");
         }
-        
+
         return new AchievementProgress();
     }
-    
+
+    /// <summary>
+    /// The ONE writer of achievements.json: serialised under <see cref="_saveLock"/>, and the bytes
+    /// land atomically.
+    ///
+    /// <para>This is the #1071 / #1074 root cause. Every previous writer was a bare
+    /// <c>File.WriteAllText</c>, which opens <c>FileMode.Create</c> and truncates the file BEFORE the
+    /// new bytes land. Two of them ran unsynchronised - the 30s autosave timer's fire-and-forget
+    /// <c>Task.Run</c> and the synchronous <see cref="Save"/> that TryUnlock, lock cards and video
+    /// minutes call - and <c>App.OnExit</c> ends in <c>TerminateProcess</c>, which kills an
+    /// in-flight background write outright. Either way the document left on disk was truncated,
+    /// <see cref="LoadProgress"/> read it as "empty", and the user lost every counter and every
+    /// unlock: the bubble total fell back to whatever last reached the cloud (the sync merge is
+    /// take-higher, so the cloud value is a floor, not a repair) and the emptied unlocked set
+    /// stopped <see cref="TryUnlock"/> early-returning, so earned achievements popped all over
+    /// again on the next launch.</para>
+    ///
+    /// <para>Mirrors <see cref="Companion.Brain.MemoryStore.AtomicWrite"/> - temp file, then an
+    /// atomic replace - and additionally keeps the previous good document as a <c>.bak</c> sibling,
+    /// because this file is the only local record of progress that cannot be recomputed.
+    /// <c>File.Replace</c> does the swap and the backup in one atomic NTFS operation.</para>
+    /// </summary>
+    private void WriteProgress()
+    {
+        lock (_saveLock)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_progressPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                // Serialise INSIDE the lock. _progress is mutated on the UI thread, so a background
+                // write that serialised outside it could capture a half-updated object graph.
+                var json = JsonSerializer.Serialize(_progress, SaveOptions);
+
+                var tmp = _progressPath + ".tmp";
+                File.WriteAllText(tmp, json, Encoding.UTF8);
+
+                if (File.Exists(_progressPath))
+                {
+                    try
+                    {
+                        File.Replace(tmp, _progressPath, _progressPath + ".bak", ignoreMetadataErrors: true);
+                    }
+                    catch (Exception ex) when (ex is PlatformNotSupportedException or IOException or UnauthorizedAccessException)
+                    {
+                        // File.Replace is not supported everywhere (FAT32 media, some network
+                        // redirectors). Losing the .bak is survivable; losing the save is not.
+                        App.Logger?.Debug(ex, "File.Replace unavailable for achievements.json, falling back to move");
+                        File.Move(tmp, _progressPath, overwrite: true);
+                    }
+                }
+                else
+                {
+                    File.Move(tmp, _progressPath, overwrite: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Re-arm the dirty flag so the next tick retries. The old timer cleared it BEFORE
+                // the write, so a failed write silently discarded everything since the last good one.
+                _isDirty = true;
+                App.Logger?.Error(ex, "Failed to save achievement progress");
+            }
+        }
+    }
+
     public void Save()
     {
-        try
-        {
-            var dir = Path.GetDirectoryName(_progressPath);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-            {
-                Directory.CreateDirectory(dir);
-            }
-            
-            var json = JsonSerializer.Serialize(_progress, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(_progressPath, json);
-        }
-        catch (Exception ex)
-        {
-            App.Logger?.Error(ex, "Failed to save achievement progress");
-        }
+        _isDirty = false;
+        WriteProgress();
     }
     
     /// <summary>
@@ -491,6 +593,17 @@ public class AchievementService : IDisposable
             }
         }
 
+        // #1071: a pop used to set _isDirty and nothing else, leaving the entire run's count to the
+        // 30s autosave timer - a DispatcherTimer running at DispatcherPriority.Background (its
+        // default), whose write App.OnExit's TerminateProcess can kill outright. Lock cards and
+        // video minutes have always called Save() inline for exactly this reason. Pops cannot: they
+        // are a hot path and a disk write per pop would be felt. So the flush is counted, not timed
+        // - bounded by POPS rather than by wall clock or by shutdown timing.
+        if (_progress.TotalBubblesPopped % BubbleSaveEveryNPops == 0)
+        {
+            Save();
+        }
+
         // Track for quests
         App.Quests?.TrackBubblePopped();
     }
@@ -532,6 +645,9 @@ public class AchievementService : IDisposable
                 ShowBubbleMilestoneNotification(after - after % 100);
             }
         }
+
+        // Called once at run-end, not per pop, so an inline flush costs nothing here (#1071).
+        Save();
 
         // Track for quests (advance by the full batch, not one)
         App.Quests?.TrackBubblesPopped(count);
@@ -1121,10 +1237,19 @@ public class AchievementService : IDisposable
         return TryUnlock(achievementId);
     }
     
+    /// <summary>
+    /// Last chance the process gets to persist progress: App.OnExit calls this and then ends in
+    /// <c>TerminateProcess</c>, which skips finalizers and ProcessExit handlers entirely. Each step
+    /// is guarded individually so a throw while stopping a timer cannot skip the flush that follows
+    /// it - that flush is the whole point of being here.
+    /// </summary>
     public void Dispose()
     {
-        _saveTimer.Stop();
-        _trackingTimer.Stop();
+        try { _saveTimer.Stop(); } catch (Exception ex) { App.Logger?.Debug(ex, "AchievementService: save timer stop failed"); }
+        try { _trackingTimer.Stop(); } catch (Exception ex) { App.Logger?.Debug(ex, "AchievementService: tracking timer stop failed"); }
+
+        // Synchronous by design: WriteProgress takes _saveLock, so this also waits out any autosave
+        // Task.Run still in flight instead of racing it into a truncated file.
         Save();
     }
 }


### PR DESCRIPTION
Closes #1071. Closes #1074.

One root cause, two symptoms - and the only **data loss** item in the 6.8.7 wave.

- #1071: *"Every time I close the app and reopen it goes back to 2.6k popped."*
- #1074: already-unlocked achievements re-pop their popups at startup.

## Root cause: two unsynchronised writers on one file

Both writers used bare `File.WriteAllText` with **no lock between them**. `WriteAllText` opens `FileMode.Create` and **truncates before writing**, so the 30s background `Task.Run` and the synchronous `Save()` (called by `TryUnlock`, lock cards, video minutes) could be inside it on the same path simultaneously. That is the corruption engine.

Three contributing defects found alongside it:

1. `TrackBubblePopped` only set `_isDirty`, leaving an entire run's count to a Background-priority `DispatcherTimer` whose fire-and-forget write `App.OnExit`'s `TerminateProcess` can kill. Lock cards and video minutes both `Save()` inline; bubbles did not.
2. The timer set `_isDirty = false` **before** the write, so a failed write silently discarded everything since the last success.
3. `Dispose()` *did* flush synchronously - but `App.xaml.cs` reached it through a bare unguarded run of `Dispose()` calls, so a throw in `Bubbles`, `LockCard`, `PopQuiz`, `BubbleCount`, `BouncingText`, `MindWipe` or `BrainDrain` skipped the achievement flush entirely.

## Why a truncated file re-pops achievements (#1071 leads to #1074)

`TryUnlock` early-returns on `_progress.IsUnlocked(id)`. Empty that set and the guard is gone. Critically, `CheckLevelAchievements` reads `PlayerLevel` from `Settings.Current` - **a different file that survives**. So a level-100 user whose `achievements.json` was truncated re-unlocks and re-pops every level achievement on the next launch, **and re-posts them to Discord**. The cloud restore that would refill the set lands ~3s later, far too late.

## The fix

- **One writer**, serialised under `_saveLock`.
- **Atomic**: temp file + `File.Replace`, which performs the swap *and* keeps the previous good document as a `.bak` in one NTFS operation. Falls back to `File.Move` where unsupported (FAT32, some network redirectors) - losing the `.bak` is survivable, losing the save is not.
- **`LoadProgress` recovers from the `.bak`**, and now logs at **Error** when a file exists but will not parse. Previously "first launch" and "your save is corrupt" were the same silence.
- `_isDirty` is restored to `true` if a write throws.
- Flush cadence: **every 50 pops** - bounded by pops, not wall clock or shutdown timing, which are the two things that actually failed. Worst case is 49 lost pops instead of thousands; at a sustained 10 pops/sec that is one small write per 5s, no worse than the existing 30s timer, and it stays off the hot path. 50 divides 100 so sparkle-point milestones always bank.
- Each `Dispose()` in the shutdown chain is individually guarded.
- Startup retroactive re-checks run under `SuppressPopups`, following the precedent already documented in `GamificationBridge.cs`.

Save format is unchanged; existing files load.

## Not touched

Cloud merge is take-higher with no clamp (`ProfileSyncService.cs`), so the cloud value is a floor, not a repair. Confirmed as designed and deliberately left alone - it is not the bug.

## Verification

`dotnet build`: 0 errors, 350 warnings (unchanged baseline); a filtered rebuild confirms **zero** warnings from either touched file.

**Caveat:** the corruption could not be reproduced on disk, so the causal chain is verified by code reading rather than observation. The new `.bak` recovery plus the loud Error log means the next user to hit it leaves a definitive breadcrumb in `crash.log` either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
