### PR TITLE
fix(ollama): drain ollama serve pipes so local AI stops wedging (#1079)

### DIFF
--- a/ConditioningControlPanel/Services/AIService/LocalAiService.cs
+++ b/ConditioningControlPanel/Services/AIService/LocalAiService.cs
@@ -264,6 +264,21 @@ namespace ConditioningControlPanel.Services.AIService
             var model = GetConfiguredModel();
             if (string.IsNullOrWhiteSpace(model)) return;
 
+            // #1079: the `ollama serve` we spawn is our child and gets killed on app exit, so a
+            // user who onboarded through the setup wizard starts every later session with
+            // nothing listening. Warm-up is the first thing that touches Ollama each session,
+            // which makes it the natural place to bring the server back. Best-effort and
+            // loopback-only; a false return just means we fall through to the warm-up attempt
+            // below and let the normal "can't reach Ollama" diagnostics speak.
+            try
+            {
+                await OllamaSetupService.EnsureServerRunningAsync(_activeHost).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Information("LocalAiService: ensure-server-running failed: {Error}", ex.Message);
+            }
+
             try
             {
                 var sw = System.Diagnostics.Stopwatch.StartNew();

--- a/ConditioningControlPanel/Services/AIService/OllamaSetupService.cs
+++ b/ConditioningControlPanel/Services/AIService/OllamaSetupService.cs
@@ -31,6 +31,29 @@ namespace ConditioningControlPanel.Services.AIService
         private static Process? _spawnedServer;
         private static readonly object _spawnedServerLock = new();
 
+        // #1079: `ollama serve` writes its startup banner, GPU discovery and one access-log
+        // line per HTTP request to stderr. We redirect both pipes (those logs are the single
+        // most useful artefact when local AI misbehaves), which means we MUST drain them —
+        // an undrained redirected pipe fills its ~4KB OS buffer, the child then blocks
+        // forever on its next write, and the server stops servicing HTTP mid-flight. That
+        // produced the exact reported symptom: /api/tags answers while the buffer is still
+        // short (the connection test goes green) and then the first real inference, which is
+        // by far the chattiest thing the server logs, wedges and never returns.
+        //
+        // The drain keeps a bounded tail for diagnostics. Both caps are hard: at most
+        // ServerLogTailMax lines of at most ServerLogLineMax chars, so the tail cannot grow
+        // past ~18KB no matter how long the server runs.
+        private static readonly Queue<string> _serverLogTail = new();
+        private static readonly object _serverLogLock = new();
+        private const int ServerLogTailMax = 60;
+        private const int ServerLogLineMax = 300;
+
+        // Only the first N lines of a given spawn reach Serilog. Startup output is what
+        // matters for triage; the per-request access log after that would bloat crash.log
+        // for every user who leaves the app open all day.
+        private const int ServerLogLinesToLog = 40;
+        private static int _serverLogLinesLogged;
+
         public enum InstallStatus
         {
             NotInstalled,
@@ -336,34 +359,63 @@ namespace ConditioningControlPanel.Services.AIService
             var cliPath = FindOllamaCli();
             if (string.IsNullOrEmpty(cliPath)) return false;
 
+            Process? started = null;
+            Process? candidate = null;
             try
             {
-                var proc = Process.Start(new ProcessStartInfo
+                var proc = new Process
                 {
-                    FileName = cliPath,
-                    Arguments = "serve",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                });
-
-                if (proc != null)
-                {
-                    lock (_spawnedServerLock)
+                    StartInfo = new ProcessStartInfo
                     {
-                        // If we somehow already had one, drop the old handle —
-                        // the new spawn supersedes it. Don't kill the old; if it
-                        // was orphaned the new one will fail-bind anyway.
-                        _spawnedServer?.Dispose();
-                        _spawnedServer = proc;
-                    }
+                        FileName = cliPath,
+                        Arguments = "serve",
+                        // Redirection requires UseShellExecute=false; CreateNoWindow keeps the
+                        // console off screen. (WindowStyle is ignored once CreateNoWindow is set,
+                        // but is left in place as belt-and-braces for any future shell-exec path.)
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true
+                    },
+                    EnableRaisingEvents = false
+                };
+                candidate = proc;
+
+                // Handlers must be attached BEFORE Start so no output is missed, and the
+                // Begin*ReadLine calls immediately after are what actually drain the pipes.
+                // Without them the redirection above is a deadlock (#1079).
+                proc.OutputDataReceived += OnServerOutput;
+                proc.ErrorDataReceived += OnServerOutput;
+
+                Interlocked.Exchange(ref _serverLogLinesLogged, 0);
+                ClearServerLogTail();
+
+                proc.Start();
+                proc.BeginOutputReadLine();
+                proc.BeginErrorReadLine();
+                started = proc;
+
+                Process? superseded = null;
+                lock (_spawnedServerLock)
+                {
+                    // We only get here when nothing was answering on the host, so any handle
+                    // we still hold is a dead or wedged server. Kill it rather than dropping
+                    // the handle: an abandoned-but-alive process would hold port 11434, make
+                    // this new spawn fail-bind, and then outlive the app as an orphan because
+                    // StopSpawnedServer no longer knows about it.
+                    superseded = _spawnedServer;
+                    _spawnedServer = proc;
                 }
+                KillQuietly(superseded, "superseded `ollama serve`");
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "Failed to spawn `ollama serve`");
+                // Start() (or a Begin*ReadLine) can throw after the Process object exists.
+                // If it never became the tracked server, tear it down here so we neither
+                // leak the handle nor orphan a process that did in fact start.
+                if (started == null) KillQuietly(candidate, "half-started `ollama serve`");
                 return false;
             }
 
@@ -371,11 +423,108 @@ namespace ConditioningControlPanel.Services.AIService
             while (DateTime.UtcNow < deadline)
             {
                 ct.ThrowIfCancellationRequested();
+
                 var (ok, _) = await TryListModelsAsync(host, ct);
                 if (ok) return true;
+
+                // A server that died (usually "address already in use", or a broken install)
+                // will never answer. Bail immediately with the reason instead of burning the
+                // full 30s and reporting a bare timeout.
+                try
+                {
+                    if (started.HasExited)
+                    {
+                        App.Logger?.Warning(
+                            "`ollama serve` exited with code {Code} before binding {Host}. Server output:{Nl}{Tail}",
+                            started.ExitCode, host, Environment.NewLine, GetServerLogTail());
+                        return false;
+                    }
+                }
+                catch { /* HasExited/ExitCode can throw on a disposed handle — keep waiting */ }
+
                 await Task.Delay(1000, ct);
             }
+
+            App.Logger?.Warning(
+                "`ollama serve` did not answer {Host} within 30s. Server output:{Nl}{Tail}",
+                host, Environment.NewLine, GetServerLogTail());
             return false;
+        }
+
+        /// <summary>
+        /// Drain handler for both of the spawned server's pipes. Runs on a thread-pool thread
+        /// that is actively emptying the pipe, so it must be cheap and must never throw —
+        /// a slow or throwing handler re-creates the very deadlock it exists to prevent.
+        /// </summary>
+        private static void OnServerOutput(object? sender, DataReceivedEventArgs e)
+        {
+            // e.Data is null when the stream closes; blank lines are not worth keeping.
+            var line = e.Data;
+            if (string.IsNullOrWhiteSpace(line)) return;
+
+            try
+            {
+                if (line.Length > ServerLogLineMax) line = line.Substring(0, ServerLogLineMax);
+
+                lock (_serverLogLock)
+                {
+                    _serverLogTail.Enqueue(line);
+                    while (_serverLogTail.Count > ServerLogTailMax) _serverLogTail.Dequeue();
+                }
+
+                if (Interlocked.Increment(ref _serverLogLinesLogged) <= ServerLogLinesToLog)
+                    App.Logger?.Debug("[ollama serve] {Line}", line);
+            }
+            catch
+            {
+                // Never let a logging failure propagate into the pipe reader.
+            }
+        }
+
+        private static void ClearServerLogTail()
+        {
+            lock (_serverLogLock) { _serverLogTail.Clear(); }
+        }
+
+        /// <summary>
+        /// The last few lines the spawned server wrote, newest last. Empty when we never
+        /// spawned one. Purely diagnostic — safe to call from anywhere.
+        /// </summary>
+        internal static string GetServerLogTail()
+        {
+            lock (_serverLogLock)
+            {
+                return _serverLogTail.Count == 0
+                    ? "(no output captured)"
+                    : string.Join(Environment.NewLine, _serverLogTail);
+            }
+        }
+
+        /// <summary>
+        /// Kill + dispose a process handle, tolerating every state it can be in (already
+        /// exited, never started, handle disposed). Used wherever we drop a server handle.
+        /// </summary>
+        private static void KillQuietly(Process? proc, string context = "spawned `ollama serve`")
+        {
+            if (proc == null) return;
+            try
+            {
+                if (!proc.HasExited)
+                {
+                    proc.Kill(entireProcessTree: true);
+                    proc.WaitForExit(2000);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Already gone, never started, or the handle is disposed — all expected.
+                // Logged rather than silent so a genuinely stuck process leaves a trace.
+                App.Logger?.Debug("Could not stop {Context}: {Error}", context, ex.Message);
+            }
+            finally
+            {
+                try { proc.Dispose(); } catch { }
+            }
         }
 
         /// <summary>
@@ -407,22 +556,61 @@ namespace ConditioningControlPanel.Services.AIService
 
             if (proc == null) return;
 
+            // Kills the tree and waits briefly so the OS releases port 11434 before we exit;
+            // tolerates a process that already died on its own.
+            KillQuietly(proc);
+        }
+
+        /// <summary>
+        /// Best-effort "is the local server actually there?" check used before we lean on it.
+        /// If <paramref name="host"/> already answers, does nothing. If it doesn't, and the
+        /// host is loopback, and the Ollama CLI is installed, brings the headless server back
+        /// up and waits for it to bind.
+        ///
+        /// <para>#1079 (second half): the server we spawn is our child and
+        /// <see cref="StopSpawnedServer"/> kills it on app exit, so the next launch starts with
+        /// nothing listening and nothing was restarting it. This closes that gap at the one
+        /// point where it matters — just before the first request of the session — without
+        /// standing up a supervisor.</para>
+        ///
+        /// <para>Deliberately refuses non-loopback hosts: if the user pointed the app at a
+        /// remote Ollama, spawning a local one would bind the wrong box's work to this
+        /// machine and mask the real connection problem.</para>
+        /// </summary>
+        public static async Task<bool> EnsureServerRunningAsync(string? host = null, CancellationToken ct = default)
+        {
+            host ??= DefaultHost;
+
+            var (reachable, _) = await TryListModelsAsync(host, ct);
+            if (reachable) return true;
+
+            if (!IsLoopbackHost(host))
+            {
+                App.Logger?.Information(
+                    "Ollama host {Host} is not reachable and is not local — not spawning a server for it", host);
+                return false;
+            }
+
+            if (FindOllamaCli() == null)
+            {
+                App.Logger?.Information("Ollama is not reachable at {Host} and no CLI is installed to start", host);
+                return false;
+            }
+
+            App.Logger?.Information("Ollama not reachable at {Host} — starting the headless server", host);
+            return await TryStartHeadlessServerAsync(host, ct);
+        }
+
+        private static bool IsLoopbackHost(string host)
+        {
             try
             {
-                if (!proc.HasExited)
-                {
-                    proc.Kill(entireProcessTree: true);
-                    // Brief wait so the OS can release the port before we exit.
-                    proc.WaitForExit(2000);
-                }
+                var uri = new Uri(NormalizeHost(host));
+                return uri.IsLoopback;
             }
-            catch (Exception ex)
+            catch
             {
-                App.Logger?.Warning(ex, "Failed to stop spawned `ollama serve`");
-            }
-            finally
-            {
-                try { proc.Dispose(); } catch { }
+                return false;
             }
         }
 


### PR DESCRIPTION
Closes #1079.

Two users hit this independently in Discord and neither filed a report: *"i downloaded the Ollama AI bot and it still only works on cloud"* / *"never was able to get Ollama to work properly, despite having the connection confirmed."*

## Root cause: redirected pipes that nobody drains

`OllamaSetupService.cs` spawned `ollama serve` with **both** `RedirectStandardOutput` and `RedirectStandardError` set true - and a grep for `BeginOutputReadLine|BeginErrorReadLine|ReadToEnd` across all 570 lines of the file returns **nothing**.

`ollama serve` is chatty on stderr. Once the ~4KB OS pipe buffer fills, the child **blocks on write** and stops servicing HTTP. That is a classic Win32 pipe hazard and it explains the symptom precisely, including why the setup wizard lies: `/api/tags` is tiny and early (one access-log line) so it answers while the buffer is still short and the connection test goes green - then the first real inference, by far the chattiest thing the server logs, wedges.

**Ruled out first:** port (`localhost:11434`, same constant in `OllamaSetupService` and `LocalAiService`), model (`qwen3.5:latest`, consistent across `LocalAiService` and `LocalAiSetupWizard`, with the wizard writing `_targetModel` back to the `CompanionPrompt.AiModel` that `GetConfiguredModel()` reads - no drift), and timeouts (chat 5 min, `/api/tags` 3-4s, pull infinite). None changed.

## The fix: drain, not un-redirect

Handlers attached **before** `Start()`, then `BeginOutputReadLine()`/`BeginErrorReadLine()`. Ollama's startup banner and GPU discovery are the single most useful triage artefact for this class of bug, so keeping the streams is worth it - and the risk is containable:

- handler does a length-truncate, a lock-guarded enqueue and an interlocked counter, all inside a blanket `catch`
- memory hard-bounded at **60 lines x 300 chars (~18KB)** regardless of uptime
- only the first 40 lines of a spawn reach Serilog, so a long-running server cannot bloat `crash.log`

`UseShellExecute = false` / `CreateNoWindow = true` were already correct and are unchanged - no console pops.

## Restart gap

The spawned server is CCP's child and is killed on app exit, so a wizard-onboarded user started every later session with nothing listening. Added `EnsureServerRunningAsync`, called from `LocalAiService.WarmUpAsync` (the first thing that touches Ollama each session). It no-ops when the host already answers.

**Loopback-only by design**: if the user has pointed the app at a remote Ollama, spawning a local one would mask the real connection problem.

No supervisor was built. `DescribeChatException` already names Ollama for refused/DNS/timeout, so failure modes stay legible; the pre-existing hole was that a *wedged* server produced 5 minutes of dead air first, which the drain removes at the source.

## Process lifetime hardening

- superseding a tracked handle now **kills** the old process instead of dropping it (the old comment assumed the new spawn would fail-bind, which would orphan a live server past app exit)
- a throw after the `Process` object exists tears it down instead of leaking
- the 30s bind wait breaks early on child exit and logs exit code + captured output instead of a bare timeout
- one `KillQuietly` helper tolerates every handle state, shared by all teardown paths

## Verification

`dotnet build`: 0 errors, 350 warnings (unchanged baseline); filtered log confirms **zero** warnings from either touched file.

**Not runtime-tested - there is no Ollama install on the build machine.** Needs a human with Ollama to confirm: (1) chats complete past the first inference, (2) `EnsureServerRunningAsync` relaunches cleanly on a second app launch, and (3) **no `ollama.exe` is orphaned after CCP exits** - item 3 is the one to watch hardest, since the supersede path changed from drop-handle to kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
