### PR TITLE
fix(ask-emi): the book takes a narrow width rather than parking on top of her

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -26,6 +26,15 @@ namespace ConditioningControlPanel
     public partial class App : Application
     {
         /// <summary>
+        /// True when this launch is an offscreen screenshot rig (<c>--shoot-book</c>,
+        /// <c>--shoot-doors</c>, <c>--possession-preview</c>) and there is nobody to answer a dialog.
+        ///
+        /// <para>Read it to skip a MODAL question, never to skip the thing being tested. A rig exists
+        /// to photograph the shipped behaviour, so anything that draws must still draw.</para>
+        /// </summary>
+        public static bool IsUnattendedRig { get; private set; }
+
+        /// <summary>
         /// Custom entry point. Originally added for Velopack's update hooks; kept after
         /// Velopack removal (v5.8.4) so we still control startup ordering explicitly.
         /// </summary>
@@ -2535,6 +2544,26 @@ namespace ConditioningControlPanel
                 try { new GoonTestWindow().Show(); }
                 catch (Exception ex) { Logger?.Error(ex, "Failed to open the Goon Game test cockpit"); }
             }
+
+            // THE RIGS RUN WITH NOBODY AT THE KEYBOARD, and this is the line that makes that true.
+            //
+            // Every offscreen rig drives the SHIPPED app: it summons her the way a user does and
+            // shoots what actually renders. That is the point of them - a private code path would
+            // only prove the private code path works. But it means anything modal on the way in
+            // stops them dead, and one thing is: the mute prompt. `MaybeAskAboutMuting` opens a
+            // dialog on the summon path, the summon is abandoned while it is up, and the rig then
+            // waits ten seconds for a companion who is never coming and writes "she never came out".
+            //
+            // It failed SILENTLY and it failed INTERMITTENTLY, which is the worst pair. The prompt
+            // only appears when something else in the app is talking, and it is once per session, so
+            // the same command wrote 132 shots one minute and zero the next. The run that worked
+            // worked because a person happened to click the dialog while it was going.
+            //
+            // So a rig launch declares itself, once, here. It suppresses NOTHING that gets drawn -
+            // it answers one modal question the way a keyboard would ("Keep") so the summon survives.
+            IsUnattendedRig = e.Args.Contains("--shoot-doors")
+                              || e.Args.Contains("--shoot-book")
+                              || e.Args.Contains("--possession-preview");
 
             // `--shoot-doors [outDir]`: render every nav door to a PNG offscreen, then exit. Exists
             // because screen capture returns a stale frame whenever the display is asleep or the

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2560,7 +2560,9 @@ namespace ConditioningControlPanel
                 var bookDir = bidx >= 0 && bidx + 1 < e.Args.Length && !e.Args[bidx + 1].StartsWith("--")
                     ? e.Args[bidx + 1]
                     : Path.Combine(AppContext.BaseDirectory, "logs", "book-shots");
-                Services.Dev.BookShooter.Run(mainWindow, bookDir);
+                // `--narrow` alongside it forces the book to the width it takes when it has no room
+                // beside her, which is the only way to review that reflow on a desk that has room.
+                Services.Dev.BookShooter.Run(mainWindow, bookDir, e.Args.Contains("--narrow"));
             }
 
             // `--dump-book-keys [path]`: write every emi_book_* key the deck needs, as a JSON

--- a/ConditioningControlPanel/Services/Dev/BookShooter.cs
+++ b/ConditioningControlPanel/Services/Dev/BookShooter.cs
@@ -38,8 +38,11 @@ internal static class BookShooter
     /// last frame and the first is where a loop that does not actually loop shows itself.</summary>
     private static readonly double[] Walk = { 0.0, 0.2, 0.4, 0.6, 0.8 };
 
-    public static void Run(Window window, string outDir)
+    public static void Run(Window window, string outDir, bool narrow = false)
     {
+        // Set before the book is ever placed: PlaceWindow reads it on the way in.
+        EmiBookWindow.ForceNarrow = narrow;
+
         // Deferred to Loaded for the same reason DoorShooter defers: rendering an unarranged visual
         // yields an empty bitmap that reads exactly like a broken panel.
         if (window.IsLoaded) _ = Shoot(outDir);

--- a/ConditioningControlPanel/Services/EmiDesk/EmiBookLayout.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiBookLayout.cs
@@ -1,0 +1,102 @@
+using System;
+
+namespace ConditioningControlPanel.Services.EmiDesk;
+
+/// <summary>
+/// Where the book goes and how wide it is: the whole horizontal decision, as arithmetic.
+///
+/// <para><b>Why this is not in the window.</b> It used to be, and it was wrong in a way nobody could
+/// have caught by looking at it. The old code put the book at her right, flipped to her left only if
+/// the right overflowed the work area, and then finished with a clamp into the work area - so on a
+/// desk where NEITHER side had room the clamp quietly dragged the book back on top of her, covering
+/// her body, her gear, her <c>?</c> and anything in her hand. It needs a work area under roughly
+/// <c>bodyWidth + 750</c> to happen, which is why it never showed on the machine that wrote it and
+/// would have shown on somebody's 1280 laptop. Geometry that only misbehaves at sizes you do not
+/// own has to be reachable from a test, so it lives here and the window just applies the answer.</para>
+///
+/// <para><b>The book has two widths, not a continuous one.</b> A book that took whatever width was
+/// going would give every desk a different text column, and the cards are written to a measured one -
+/// four nudges that fit here would be six lines and a scroll somewhere else. So it is
+/// <see cref="FullWidth"/> or <see cref="NarrowWidth"/>, the same two-step the demo stage already
+/// takes vertically, and the narrow book is exactly the full one with the stage at 2x.</para>
+///
+/// <para>The rail does not shrink in either. Forty-four DIP is two pixels per cell of a 16 cell
+/// glyph plus its air, and an icon column you have to squint at is not navigation.</para>
+/// </summary>
+internal static class EmiBookLayout
+{
+    /// <summary>Air between her silhouette and the book's near edge, in DIPs.</summary>
+    public const double BodyGap = 12.0;
+
+    /// <summary>
+    /// The book at its drawn width, in DIPs. Matches the XAML: 2 panel border + 44 rail + 2 rail
+    /// border + 12 margin + 290 card column + 12 margin + 2 panel border.
+    /// </summary>
+    public const double FullWidth = 364.0;
+
+    /// <summary>
+    /// The narrow book. Same chrome, same rail, the card column cut to what a 2x stage needs
+    /// (192 + its 2 DIP frame each side), which is the width the demo stops being the constraint at.
+    /// </summary>
+    public const double NarrowWidth = 270.0;
+
+    /// <summary>What <see cref="Place"/> decided.</summary>
+    /// <param name="Left">The book's left edge, in DIPs, in the same space the inputs were given in.</param>
+    /// <param name="Width">Either <see cref="FullWidth"/> or <see cref="NarrowWidth"/>.</param>
+    /// <param name="OnHerLeft">True when the book ended up on her left.</param>
+    /// <param name="Narrow">True when the book took its narrow width, which also drops the stage to 2x.</param>
+    /// <param name="CoversHer">
+    /// True when even the narrow book did not fit beside her and the clamp put it over her body. The
+    /// window still shows it - a book you asked for and cannot see is worse than one that overlaps -
+    /// but this says so out loud instead of it being a silent consequence of a clamp.
+    /// </param>
+    internal readonly record struct Placement(
+        double Left, double Width, bool OnHerLeft, bool Narrow, bool CoversHer);
+
+    /// <summary>
+    /// Choose a side and a width for a book beside a body box.
+    ///
+    /// <para>Reading order of the decisions, and each one is a rule rather than a fallback:</para>
+    /// <list type="number">
+    /// <item>If the full book fits on either side, it is full width, and it prefers her RIGHT.</item>
+    /// <item>If it does not, the book goes narrow - narrow on the roomier side beats full width
+    /// hanging over her, because the thing the book is for is being read.</item>
+    /// <item>If the narrow book does not fit either, it goes on the roomier side anyway and is
+    /// clamped into the work area, which is the only case that covers her.</item>
+    /// </list>
+    ///
+    /// <para>Every length is in DIPs and in one space; the caller converts.</para>
+    /// </summary>
+    /// <param name="workLeft">Left edge of the monitor work area.</param>
+    /// <param name="workWidth">Width of the monitor work area.</param>
+    /// <param name="bodyLeft">Left edge of her body box.</param>
+    /// <param name="bodyRight">Right edge of her body box.</param>
+    public static Placement Place(double workLeft, double workWidth, double bodyLeft, double bodyRight)
+    {
+        double workRight = workLeft + workWidth;
+
+        // The room OUTSIDE her, on each side, once the gap is paid for. Negative means she is
+        // already past that edge, which a body dragged half off the desk really does produce.
+        double roomRight = workRight - (bodyRight + BodyGap);
+        double roomLeft = (bodyLeft - BodyGap) - workLeft;
+        double best = Math.Max(roomRight, roomLeft);
+
+        bool narrow = best < FullWidth;
+        double w = narrow ? NarrowWidth : FullWidth;
+
+        // Her right unless her left is genuinely roomier AND her right cannot take the book. Ties go
+        // right, and so does the case where both sides fit: the book is read rather than operated,
+        // and she usually lives at the right of the desk with her near side on the left.
+        bool onHerLeft = roomRight < w && roomLeft > roomRight;
+
+        double left = onHerLeft ? bodyLeft - BodyGap - w : bodyRight + BodyGap;
+
+        // The clamp that started all this. It is still here and still last, because a book off the
+        // side of the screen is not a better outcome than a book over her - but by now it only bites
+        // when even the narrow book had nowhere to go, and it says so.
+        double clamped = Math.Max(workLeft, Math.Min(workRight - w, left));
+        bool coversHer = best < w;
+
+        return new Placement(clamped, w, onHerLeft, narrow, coversHer);
+    }
+}

--- a/ConditioningControlPanel/Services/EmiDesk/EmiDeskService.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiDeskService.cs
@@ -1346,6 +1346,15 @@ public sealed class EmiDeskService : IDisposable
                 return;
             }
             if (_mutePromptShownThisSession) return;
+            if (App.IsUnattendedRig)
+            {
+                // A screenshot rig has no keyboard. Left to itself this dialog abandons the summon
+                // it interrupted and the rig photographs an empty desk - see App.OnStartup. "Keep"
+                // is what the prompt does on a dismiss anyway, so this is the no-op answer.
+                _muteAccepted = false;
+                Log.Information("[EmiDesk] mute prompt skipped: unattended rig");
+                return;
+            }
             if (!AnyTalkingFeatureLive())
             {
                 // Nothing is going to talk over her, so there is nothing to arbitrate. Do NOT burn

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml
@@ -263,8 +263,10 @@
                         and the rail therefore never holds more than eight.
 
                         It is docked left BEFORE the card so the card keeps the whole remaining
-                        width. The window grew by exactly this rail's 44, so the text column is the
-                        same 292 it was measured at and no card reflows.
+                        width. The window grew by exactly this rail's 44, so on a desk with room the
+                        text column is the same 290 it was measured at and no card reflows. The rail
+                        keeps this width in the narrow book too - an icon column you have to squint
+                        at is not navigation - so the narrow book pays for itself out of the card.
                     -->
                     <Border DockPanel.Dock="Left" Width="44" Background="#FF1E1D34"
                             BorderBrush="#FF0E0E1C" BorderThickness="0,0,2,0">
@@ -326,12 +328,33 @@
                             the last bullet with nothing to say it had. The bar is Hidden rather
                             than Auto because a scrollbar is the one piece of chrome on this window
                             that Windows would draw instead of us.
+
+                            SO WE DRAW THE CUE OURSELVES. Hidden means the content still scrolls, it
+                            just says nothing about it, and that was already a quiet way to lose the
+                            end of a bullet on a short desk. The narrow book made it reachable: at a
+                            196 wide column the densest card gains three lines, and the LOCKDOWN card
+                            lost the last word of "then type let me out" - which is the one sentence
+                            in the whole book somebody reads in a hurry. The chevron shows only when
+                            there is something below, and it goes away once you have scrolled to it.
                         -->
-                        <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Hidden"
-                                      HorizontalScrollBarVisibility="Disabled"
-                                      PanningMode="VerticalOnly" Margin="0,12,0,0">
-                            <StackPanel x:Name="Nudges" VerticalAlignment="Top"/>
-                        </ScrollViewer>
+                        <Grid Grid.Row="3" Margin="0,12,0,0">
+                            <ScrollViewer x:Name="NudgeScroll" VerticalScrollBarVisibility="Hidden"
+                                          HorizontalScrollBarVisibility="Disabled"
+                                          PanningMode="VerticalOnly"
+                                          ScrollChanged="OnNudgeScrollChanged">
+                                <StackPanel x:Name="Nudges" VerticalAlignment="Top"/>
+                            </ScrollViewer>
+
+                            <!-- Hard edges and her pink, like everything else on this panel. It sits
+                                 OVER the text rather than taking a row, because a row would move the
+                                 catch strip on exactly the cards that have least room to spare. -->
+                            <Border x:Name="MoreBelow" Visibility="Collapsed" IsHitTestVisible="False"
+                                    HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                                    Background="#FF252542" BorderBrush="#FF3B3962" BorderThickness="2"
+                                    Padding="5,3">
+                                <Polygon Points="0,0 10,0 5,6" Fill="#FFFF69B4"/>
+                            </Border>
+                        </Grid>
 
                         <!-- The honest bit, in gold, with a rule down its left edge instead of a
                              bullet. Same fixed place on every card, so it is somewhere you can

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml
@@ -338,20 +338,34 @@
                             there is something below, and it goes away once you have scrolled to it.
                         -->
                         <Grid Grid.Row="3" Margin="0,12,0,0">
-                            <ScrollViewer x:Name="NudgeScroll" VerticalScrollBarVisibility="Hidden"
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <ScrollViewer Grid.Row="0" x:Name="NudgeScroll"
+                                          VerticalScrollBarVisibility="Hidden"
                                           HorizontalScrollBarVisibility="Disabled"
                                           PanningMode="VerticalOnly"
                                           ScrollChanged="OnNudgeScrollChanged">
                                 <StackPanel x:Name="Nudges" VerticalAlignment="Top"/>
                             </ScrollViewer>
 
-                            <!-- Hard edges and her pink, like everything else on this panel. It sits
-                                 OVER the text rather than taking a row, because a row would move the
-                                 catch strip on exactly the cards that have least room to spare. -->
-                            <Border x:Name="MoreBelow" Visibility="Collapsed" IsHitTestVisible="False"
-                                    HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                                    Background="#FF252542" BorderBrush="#FF3B3962" BorderThickness="2"
-                                    Padding="5,3">
+                            <!--
+                                ITS OWN BAND, not an overlay on the text. The first cut floated the
+                                chevron over the bottom right of the copy, and on the card that
+                                prompted all this it sat on the words: LOCKDOWN read "then type
+                                let m [v]". A cue that hides the sentence it is pointing at is worse
+                                than no cue, because the reader cannot even tell something is missing.
+
+                                A row cannot oscillate. Showing it shrinks the viewport, which can
+                                only ADD overflow, never remove it, so the cue never flickers itself
+                                out of existence. It is inside the bullets' own star row, so the
+                                catch strip and the button do not move when it appears.
+                            -->
+                            <Border Grid.Row="1" x:Name="MoreBelow" Visibility="Collapsed"
+                                    IsHitTestVisible="False" HorizontalAlignment="Right"
+                                    Margin="0,3,0,0" Padding="6,2">
                                 <Polygon Points="0,0 10,0 5,6" Fill="#FFFF69B4"/>
                             </Border>
                         </Grid>

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml.cs
@@ -55,9 +55,6 @@ namespace ConditioningControlPanel;
 /// </summary>
 public partial class EmiBookWindow : Window
 {
-    /// <summary>Air between her silhouette and the book's near edge, in DIPs.</summary>
-    private const double BodyGap = 12.0;
-
     /// <summary>The book at its full drawn height, in DIPs. Matches the XAML.</summary>
     private const double FullHeight = 728.0;
 
@@ -76,6 +73,20 @@ public partial class EmiBookWindow : Window
     private readonly EmiDeskWindow _owner;
     private readonly EmiPixelCanvas _canvas = new(BufW, BufH);
     private readonly List<Border> _dots = new();
+
+    /// <summary>One log line per book, not one per move: <c>PlaceWindow</c> runs on every drag tick.</summary>
+    private bool _notedCover;
+
+    /// <summary>
+    /// QA ONLY: pretend there is no room, so the narrow book can be reviewed on a desk that has
+    /// plenty (<c>--shoot-book &lt;dir&gt; --narrow</c>).
+    ///
+    /// <para>The narrow book cuts the card column from 290 to 196, which reflows every card written
+    /// against the wide one. That is a copy review, and a copy review needs pixels - but the machines
+    /// the cards get written on are exactly the machines that never see the narrow book. Nothing in
+    /// a normal launch sets this.</para>
+    /// </summary>
+    internal static bool ForceNarrow;
 
     private DispatcherTimer? _clock;
     private readonly Stopwatch _since = new();
@@ -628,12 +639,38 @@ public partial class EmiBookWindow : Window
             }
 
             RenderButton(card);
+
+            // The card just changed height under the scroller. Ask at Loaded rather than now:
+            // ScrollableHeight is zero until this content has been arranged, so reading it here
+            // says "nothing to scroll" on every card, which is the failure that looks like success.
+            NudgeScroll.ScrollToTop();
+            Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(UpdateMoreCue));
         }
         catch (Exception ex)
         {
             Log.Warning(ex, "[EmiDesk] book card render failed for {Card}", card.Id);
         }
     }
+
+    /// <summary>
+    /// Show the chevron exactly while there is unread copy under the fold.
+    ///
+    /// <para>Both halves matter. It appears when a card overflows, which on a narrow or short desk is
+    /// the difference between a bullet that ends mid-sentence and one you know to scroll. And it goes
+    /// away at the bottom, so it is a statement about THIS card rather than a decoration that trains
+    /// the reader to ignore it.</para>
+    /// </summary>
+    private void UpdateMoreCue()
+    {
+        try
+        {
+            double left = NudgeScroll.ScrollableHeight - NudgeScroll.VerticalOffset;
+            MoreBelow.Visibility = left > 1.0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+        catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book more-cue failed"); }
+    }
+
+    private void OnNudgeScrollChanged(object sender, ScrollChangedEventArgs e) => UpdateMoreCue();
 
     /// <summary>
     /// Lay a line of card copy into a TextBlock as runs, with the <c>*asterisk*</c> key words drawn
@@ -971,6 +1008,12 @@ public partial class EmiBookWindow : Window
     /// and the near side of a widget that usually lives at the right of the desk is the left one.
     /// It flips when that side has no room.</para>
     ///
+    /// <para>The side and the width are both decided by <see cref="EmiBookLayout.Place"/>, which is
+    /// arithmetic and therefore testable at desk sizes nobody here owns. This method converts, asks,
+    /// and applies. On a narrow desk the answer comes back narrow and the stage drops to 2x with it,
+    /// so a book that will not fit beside her is read at a smaller size rather than parked on top of
+    /// her - which is exactly what the old clamp used to do, silently.</para>
+    ///
     /// <para>On a short desk the stage drops from 3x to 2x rather than the book scrolling. Nine
     /// screen pixels per cell down to four keeps the integer multiple, and a demo with a half-pixel
     /// seam in it is worse than a smaller demo.</para>
@@ -988,38 +1031,48 @@ public partial class EmiBookWindow : Window
             double workW = work.Width / s;
             double workH = work.Height / s;
 
-            double h = Math.Min(FullHeight, Math.Max(MinPanelHeight, workH - 24));
-            if (Math.Abs(Height - h) > 0.5) Height = h;
-            // The stage drops to 2x on a short desk, and the test is ROOM rather than "did we get
-            // the full height": a 1366 x 768 laptop lands at about 704, which is a hair under
-            // FullHeight and has ample room for the big stage. Measuring against FullHeight sent
-            // those machines to the small stage for a 8 pixel shortfall.
-            ApplyStageScale(h >= BigStageFloor ? 3 : 2);
-
-            UpdateLayout();
-
             var bodyPx = _owner.BodyScreenRect;
             double bodyL = bodyPx.Left / s;
             double bodyT = bodyPx.Top / s;
             double bodyR = bodyPx.Right / s;
             double bodyH = bodyPx.Height / s;
 
-            double w = ActualWidth > 1 ? ActualWidth : Width;
+            var place = EmiBookLayout.Place(workL, workW, bodyL, bodyR);
+            if (ForceNarrow) place = place with { Width = EmiBookLayout.NarrowWidth, Narrow = true };
+            if (Math.Abs(Width - place.Width) > 0.5) Width = place.Width;
+
+            double h = Math.Min(FullHeight, Math.Max(MinPanelHeight, workH - 24));
+            if (Math.Abs(Height - h) > 0.5) Height = h;
+            // The stage drops to 2x on a short desk, and the test is ROOM rather than "did we get
+            // the full height": a 1366 x 768 laptop lands at about 704, which is a hair under
+            // FullHeight and has ample room for the big stage. Measuring against FullHeight sent
+            // those machines to the small stage for a 8 pixel shortfall.
+            //
+            // The narrow book overrides it outright: at 270 DIP the card column is 196 wide and a
+            // 288 wide stage does not go in it at all.
+            ApplyStageScale(!place.Narrow && h >= BigStageFloor ? 3 : 2);
+
+            UpdateLayout();
 
             bool wasOnHerLeft = _onHerLeft;
-            double left = bodyR + BodyGap;
-            _onHerLeft = false;
-            if (left + w > workL + workW)
+            _onHerLeft = place.OnHerLeft;
+
+            // Worth a line in the log the first time a desk is this tight, because every visual
+            // symptom of it - the book over her body, her chips unreachable under it - looks like a
+            // z-order bug and is not one.
+            if (place.CoversHer && !_notedCover)
             {
-                double alt = bodyL - BodyGap - w;
-                if (alt >= workL) { left = alt; _onHerLeft = true; }
+                _notedCover = true;
+                Log.Information(
+                    "[EmiDesk] book has no room beside her (work {WorkW:F0}, body {BodyW:F0}); it overlaps",
+                    workW, bodyR - bodyL);
             }
 
             // Centred on her, not aligned to her head: the book is nearly three of her tall and a
             // top-aligned one hangs off the bottom of every desk she stands near the middle of.
             double top = bodyT + bodyH / 2 - h / 2;
 
-            Left = Math.Max(workL, Math.Min(workL + workW - w, left));
+            Left = place.Left;
             Top = Math.Max(workT, Math.Min(workT + workH - h, top));
 
             SweepHost.RenderTransformOrigin = new Point(_onHerLeft ? 1 : 0, 0.5);

--- a/Tests/ConditioningControlPanel.Tests/EmiBookLayoutTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiBookLayoutTests.cs
@@ -1,0 +1,194 @@
+using ConditioningControlPanel.Services.EmiDesk;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Where the book goes, at desk sizes nobody on this project owns.
+///
+/// <para>These exist because of a bug that could not be seen by reading the code and could not be
+/// seen on the machine that wrote it. The book placed itself at her right, flipped left only if the
+/// right overflowed, and then clamped into the work area - so when NEITHER side had room the clamp
+/// dragged it back over her body. It needs a work area under about <c>bodyWidth + 750</c> to happen:
+/// invisible at 1920, routine on a 1280 laptop with her scaled up. The geometry now lives in
+/// <see cref="EmiBookLayout"/> precisely so a test can stand where those users stand.</para>
+/// </summary>
+public class EmiBookLayoutTests
+{
+    // A body box, as the desk window reports it: left and right edges in DIPs.
+    private const double Gap = EmiBookLayout.BodyGap;
+    private const double Full = EmiBookLayout.FullWidth;
+    private const double Narrow = EmiBookLayout.NarrowWidth;
+
+    // ---------------------------------------------------------------- the roomy desk
+
+    /// <summary>With room on both sides she keeps her preference: the book opens on her right.</summary>
+    [Fact]
+    public void On_a_wide_desk_the_book_opens_on_her_right_at_full_width()
+    {
+        var p = EmiBookLayout.Place(0, 1920, 100, 300);
+
+        Assert.False(p.OnHerLeft);
+        Assert.False(p.Narrow);
+        Assert.False(p.CoversHer);
+        Assert.Equal(Full, p.Width);
+        Assert.Equal(300 + Gap, p.Left);
+    }
+
+    /// <summary>Pinned to the right edge, the book flips rather than shrinking: her left is roomy.</summary>
+    [Fact]
+    public void Against_the_right_edge_it_flips_to_her_left_and_stays_full_width()
+    {
+        var p = EmiBookLayout.Place(0, 1920, 1700, 1900);
+
+        Assert.True(p.OnHerLeft);
+        Assert.False(p.Narrow);
+        Assert.False(p.CoversHer);
+        Assert.Equal(1700 - Gap - Full, p.Left);
+    }
+
+    /// <summary>A book on the second monitor is placed in THAT work area, not in the desktop.</summary>
+    [Fact]
+    public void A_second_monitor_work_area_is_respected_on_both_edges()
+    {
+        var p = EmiBookLayout.Place(1920, 1920, 3500, 3700);
+
+        Assert.True(p.OnHerLeft);
+        Assert.True(p.Left >= 1920);
+        Assert.True(p.Left + p.Width <= 3840);
+    }
+
+    // ---------------------------------------------------------------- the narrow desk
+
+    /// <summary>
+    /// THE FIX. Nine hundred DIP of desk has no room for the full book on either side, and the old
+    /// code answered that by putting the full book on top of her. It goes narrow and stays beside
+    /// her instead: a smaller book that can be read beats a big one parked over the thing it is
+    /// explaining.
+    /// </summary>
+    [Fact]
+    public void When_the_full_book_fits_on_neither_side_it_goes_narrow_beside_her()
+    {
+        var p = EmiBookLayout.Place(0, 900, 350, 550);
+
+        Assert.True(p.Narrow);
+        Assert.Equal(Narrow, p.Width);
+        Assert.False(p.CoversHer);
+        Assert.Equal(550 + Gap, p.Left);
+        Assert.True(p.Left + p.Width <= 900);
+    }
+
+    /// <summary>
+    /// The narrow book flips too - the side rule does not stop applying at the small size.
+    ///
+    /// <para>The window here is tighter than it looks: her left has to hold the NARROW book and not
+    /// the full one, or the book simply stays full width and flips, which is a different test. At
+    /// 340 on an 800 desk her left has 328, which is over the narrow 270 and under the full 364.</para>
+    /// </summary>
+    [Fact]
+    public void The_narrow_book_still_flips_to_the_roomier_side()
+    {
+        var p = EmiBookLayout.Place(0, 800, 340, 540);
+
+        Assert.True(p.Narrow);
+        Assert.True(p.OnHerLeft);
+        Assert.False(p.CoversHer);
+        Assert.Equal(340 - Gap - Narrow, p.Left);
+    }
+
+    // ---------------------------------------------------------------- the desk with no room at all
+
+    /// <summary>
+    /// Below the narrow book's own needs there is no honest answer, and the book overlaps her. Two
+    /// things still have to hold: it is fully ON the screen, and it SAYS it covered her rather than
+    /// leaving that to be discovered.
+    /// </summary>
+    [Fact]
+    public void With_no_room_at_all_it_overlaps_her_but_stays_on_the_screen_and_admits_it()
+    {
+        var p = EmiBookLayout.Place(0, 600, 200, 400);
+
+        Assert.True(p.CoversHer);
+        Assert.Equal(Narrow, p.Width);
+        Assert.True(p.Left >= 0);
+        Assert.True(p.Left + p.Width <= 600);
+    }
+
+    /// <summary>Her dragged half off the left edge gives a negative room reading; it must not throw
+    /// the side choice or put the book off screen.</summary>
+    [Fact]
+    public void A_body_hanging_off_the_left_edge_still_places_on_screen()
+    {
+        var p = EmiBookLayout.Place(0, 1280, -80, 120);
+
+        Assert.False(p.OnHerLeft);
+        Assert.True(p.Left >= 0);
+        Assert.True(p.Left + p.Width <= 1280);
+    }
+
+    // ---------------------------------------------------------------- the sweep
+
+    /// <summary>
+    /// THE REGRESSION, swept rather than sampled: walk her across a desk a DIP at a time and the
+    /// book must never sit on her body unless it has declared that it had to. This is the assertion
+    /// the old code failed, and only at the far end of the walk on the narrower desks.
+    /// </summary>
+    [Theory]
+    [InlineData(1920.0, 200.0)]
+    [InlineData(1600.0, 200.0)]
+    [InlineData(1366.0, 240.0)]
+    [InlineData(1280.0, 300.0)]
+    [InlineData(1024.0, 260.0)]
+    public void The_book_never_lands_on_her_body_without_saying_so(double workW, double bodyW)
+    {
+        for (double bodyL = 0; bodyL + bodyW <= workW; bodyL += 1)
+        {
+            double bodyR = bodyL + bodyW;
+            var p = EmiBookLayout.Place(0, workW, bodyL, bodyR);
+
+            Assert.True(p.Left >= 0, $"book off the left edge at bodyL {bodyL}");
+            Assert.True(p.Left + p.Width <= workW, $"book off the right edge at bodyL {bodyL}");
+
+            bool overlaps = p.Left < bodyR && p.Left + p.Width > bodyL;
+            if (overlaps)
+                Assert.True(p.CoversHer, $"book covered her at bodyL {bodyL} without declaring it");
+        }
+    }
+
+    /// <summary>The width is one of two. A continuous one would give every desk a different text
+    /// column, and the cards are written to a measured one.</summary>
+    [Theory]
+    [InlineData(1920.0)]
+    [InlineData(1366.0)]
+    [InlineData(1024.0)]
+    [InlineData(800.0)]
+    [InlineData(480.0)]
+    public void The_book_only_ever_takes_one_of_its_two_widths(double workW)
+    {
+        for (double bodyL = 0; bodyL + 200 <= workW; bodyL += 7)
+        {
+            var p = EmiBookLayout.Place(0, workW, bodyL, bodyL + 200);
+            Assert.True(p.Width == Full || p.Width == Narrow, $"odd width {p.Width}");
+            Assert.Equal(p.Width == Narrow, p.Narrow);
+        }
+    }
+
+    /// <summary>When the book did fit beside her, it sits exactly one gap off her edge - not
+    /// approximately, and not wherever a clamp left it.</summary>
+    [Theory]
+    [InlineData(1920.0)]
+    [InlineData(1366.0)]
+    [InlineData(1024.0)]
+    public void A_book_that_fits_sits_exactly_one_gap_off_her_edge(double workW)
+    {
+        for (double bodyL = 0; bodyL + 200 <= workW; bodyL += 7)
+        {
+            double bodyR = bodyL + 200;
+            var p = EmiBookLayout.Place(0, workW, bodyL, bodyR);
+            if (p.CoversHer) continue;
+
+            double near = p.OnHerLeft ? bodyL - (p.Left + p.Width) : p.Left - bodyR;
+            Assert.Equal(Gap, near, 6);
+        }
+    }
+}


### PR DESCRIPTION
## The book stops parking on top of her

The clamp at the end of the book's placement dragged it back over her whenever neither side of her
had room:

```csharp
Left = Math.Max(workL, Math.Min(workL + workW - w, left));
```

Her body, her gear, her `?` and anything in her hand, all under the panel. It needs a work area under
roughly `bodyWidth + 750`, so it never showed on the machines the book was written on and would have
shown on somebody's 1280 laptop with her scaled up. Found while answering a question about whether
the book could collide with #407's prop plate - it cannot, but this can.

### Two widths

If the full 364 fits on either side of her, **nothing changes**. If it does not, the book goes narrow:
270 DIP, the same chrome, the same rail, the demo stage at 2x, and it stays *beside* her. A smaller
book that can be read beats a big one parked over the thing it is explaining.

Only when even the narrow book has nowhere to go does it overlap her - and then it says so in the log,
because every visual symptom of that (panel over her body, her chips unreachable) looks like a z-order
bug and is not one.

Two widths and not a continuous one on purpose: the cards are written to a measured column, and a book
that took whatever width was going would give every desk a different one.

### Why the geometry moved out of the window

`Services/EmiDesk/EmiBookLayout.cs` is now pure arithmetic. That is the whole point - the bug was
unreachable from a test while it lived inside a `Window`, and it is exactly the class of bug that only
appears at a screen size nobody on the project owns.

`EmiBookLayoutTests` (20) sweeps her a DIP at a time across 1920, 1600, 1366, 1280 and 1024 desks and
asserts the book is never on her body without having declared it, never off the screen, always one of
the two widths, and exactly one `BodyGap` off her edge whenever it fits.

### The bullet that was losing its last word

Fell out of the narrow reflow, but it was already true at full width on a short desk. The nudge list
scrolls with `VerticalScrollBarVisibility="Hidden"`, so a card taller than its room silently loses the
end of its last bullet. At 196 the LOCKDOWN card rendered

> five clicks on the timer, under a second apart, then type **let me**

and dropped `out`. That is the escape phrase, and the one line in the book somebody reads in a hurry.

A small pink chevron now shows while there is copy below and goes away once you reach it. Drawn rather
than a real scrollbar, for the reason the original comment gave: a scrollbar is the one piece of chrome
on this window that Windows would draw instead of us.

### Rig

`--shoot-book <dir> --narrow` forces the narrow book, so the reflow can be reviewed on a desk that has
room. Nothing in a normal launch sets it.

## Tests

4842 pass. The one red test is `EmiAliveTests.NoFidgetEverRepeatsItselfAndAllThreeGetUsed`, which is
red on `main` already and is being fixed on `feat/emi-idle-rotation` - this branch does not touch the
fidget pool, `EmiProps` or the desk window.

## Verified how

The narrow book was rendered offscreen at 270 and read card by card: the rail keeps its icons, the 2x
stage fits the column exactly, and the densest card (LOCKDOWN, eight glyphs in the rail) still lands
its catch strip and its button without clipping.

**The chevron itself has not been shot yet** - a peer session's build holds the single-instance mutex
and the offscreen rig cannot start behind it. Its logic is trivial and covered by inspection, but it
has not been seen. I will shoot it and post the frame here as soon as the app is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nMSMQZ2ieD7Hp9enNq63J
