### PR TITLE
feat(emi): fold the glass channels into the idle wheel, pull the props in

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
@@ -420,7 +420,10 @@
  * ======================================================================== */
 .arc-emi .emi .emi-prop {
   position: absolute;
-  right: 3.5%;
+  /* 6.5%, not the 3.5% this shipped at: flush to the edge of the box the plate
+     read as taped to the frame rather than held (owner, 2026-08-30). Twin of
+     EmiProps.RightFrac = 0.935. */
+  right: 6.5%;
   bottom: 9.5%;
   z-index: 2;
   pointer-events: none;

--- a/ConditioningControlPanel/Services/EmiDesk/EmiAlive.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiAlive.cs
@@ -22,7 +22,18 @@ public enum EmiFidget
     /// away again. The only fidget that puts ART on the screen rather than moving her, and so the
     /// only one that can no-op because a file is missing (see <c>EmiProps</c>).
     /// </summary>
-    Prop
+    Prop,
+
+    /// <summary>
+    /// She puts something on her own glass: pong, a spiral, a burst, gif rain, a film strip. The
+    /// channels already existed behind a 90 second stillness gate of their own
+    /// (<c>EmiChannels.IdleBeforeFlip</c>); this is the same flip, reached from the fidget wheel so
+    /// that the screen takes its turn among the small body moves instead of being a separate
+    /// clock. Like <see cref="Prop"/> it can no-op - a channel needs a library to draw from and the
+    /// desk has to have been left alone - which is why <c>RunFidget</c> reports whether it did
+    /// anything.
+    /// </summary>
+    Screen
 }
 
 /// <summary>What a completed pat on her body means once the poke ladder has looked at it.</summary>
@@ -225,6 +236,17 @@ public static class EmiAlive
     /// <summary>...and no later than this, in ms.</summary>
     public const int FidgetMaxMs = 50_000;
 
+    /// <summary>
+    /// How long the desk has to have gone untouched before the <see cref="EmiFidget.Screen"/> beat
+    /// will take its turn, in ms. The glass's own clock (<c>EmiChannels.IdleBeforeFlip</c>, 90 s)
+    /// is an owner lock and stays exactly where it is - it is what makes an ABANDONED desk drift
+    /// off to a channel. This is the shorter floor for the same flip arriving off the fidget
+    /// wheel, and it is deliberately longer than one fidget gap: she does not put a show on the
+    /// second you look away, but a minute of quiet is enough that a channel is one of the things
+    /// she might do next rather than something that only happens if you leave the room.
+    /// </summary>
+    public const int ScreenBeatRestMs = 30_000;
+
     /// <summary>The antenna twitch's travel, in DIPs.</summary>
     public const double TwitchDip = 2.0;
 
@@ -285,14 +307,15 @@ public static class EmiAlive
         /// </summary>
         public EmiFidget Next()
         {
-            Span<EmiFidget> all = stackalloc EmiFidget[4]
+            Span<EmiFidget> all = stackalloc EmiFidget[5]
             {
-                EmiFidget.Twitch, EmiFidget.WeightShift, EmiFidget.Glance, EmiFidget.Prop
+                EmiFidget.Twitch, EmiFidget.WeightShift, EmiFidget.Glance, EmiFidget.Prop,
+                EmiFidget.Screen
             };
 
             // Draw from the kinds that are NOT the last one, so the rule costs one roll, never a
             // retry loop that could in principle spin.
-            Span<EmiFidget> pool = stackalloc EmiFidget[4];
+            Span<EmiFidget> pool = stackalloc EmiFidget[5];
             int n = 0;
             for (int i = 0; i < all.Length; i++)
             {

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -7,6 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using ConditioningControlPanel.Models;
 using Serilog;
 
 namespace ConditioningControlPanel.Services.EmiDesk;
@@ -28,7 +29,22 @@ namespace ConditioningControlPanel.Services.EmiDesk;
 public static class EmiChannels
 {
     /// <summary>The channel ids, in the order the ambient rotation offers them.</summary>
-    public static readonly IReadOnlyList<string> All = new[] { "spiral", "video", "burst", "rain" };
+    public static readonly IReadOnlyList<string> All = new[] { "pong", "spiral", "video", "burst", "rain" };
+
+    /// <summary>
+    /// The channels that are a SCREEN SAVER rather than an offer: she is watching them and a tap
+    /// only puts her face back. Everything else on the glass is a thing she is holding out to you,
+    /// and <see cref="Fire"/> is what taking it does.
+    ///
+    /// <para>Pong is the first, and it is why this distinction had to exist: the campus has had a
+    /// whole deck of savers (<c>emi/channels.js</c>) since the takeover work and the desk had none,
+    /// so every flip of the desk's glass was an offer of an EFFECT. Now the wheel can also just
+    /// find her playing something.</para>
+    /// </summary>
+    private static readonly HashSet<string> Savers = new(StringComparer.Ordinal) { "pong" };
+
+    /// <summary>True when a tap on this channel fires nothing - see <see cref="Savers"/>.</summary>
+    public static bool IsSaver(string? id) => id != null && Savers.Contains(id);
 
     /// <summary>How long a channel sits on the glass before she gives up on it (BRIEF 6).</summary>
     public static readonly TimeSpan ChannelLife = TimeSpan.FromSeconds(10);
@@ -88,12 +104,23 @@ public static class EmiChannels
     /// <summary>Can this channel be painted and fired right now?</summary>
     public static bool Feasible(string? id) => id switch
     {
+        // The only channel with no library behind it: she can always play herself. A MOVING BALL
+        // IS THE WHOLE CHANNEL, so reduced motion refuses it outright rather than parking a still
+        // of a pong board on her face - the campus's plan() makes the same call.
+        "pong" => MotionOk(),
         "spiral" => App.Overlay != null,
         "video" => EmiOffers.HasVideos(),
         "burst" => EmiOffers.HasImages(),
         "rain" => EmiOffers.HasImages(),
         _ => false
     };
+
+    /// <summary>The app-wide motion setting, the same one the wave-A fidgets read. Never throws.</summary>
+    private static bool MotionOk()
+    {
+        try { return MotionFx.Level == MotionLevel.Full; }
+        catch { return true; }
+    }
 
     /// <summary>Build the painter for a channel, or null when the channel is unknown or unusable.</summary>
     public static EmiChannelPainter? Build(string? id, double w, double h)
@@ -103,6 +130,7 @@ public static class EmiChannels
             if (w <= 4 || h <= 4) return null;
             return id switch
             {
+                "pong" => new PongPainter(w, h),
                 "spiral" => new SpiralPainter(w, h),
                 "video" => VideoPainter.TryBuild(w, h),
                 "burst" => BurstPainter.TryBuild(w, h),
@@ -124,6 +152,9 @@ public static class EmiChannels
         {
             switch (id)
             {
+                case "pong":
+                    // A saver. She was playing; you looked; that is the whole transaction.
+                    return;
                 case "spiral":
                     EmiOffers.FireSpiral(fromAsk: false);
                     return;
@@ -164,6 +195,157 @@ public static class EmiChannels
     // ============================================================================================
     // the painters
     // ============================================================================================
+
+    /// <summary>
+    /// CHANNEL PONG. She plays both sides, imperfectly. A port of the campus saver
+    /// (<c>Resources/web/arcademy/emi/channels.js</c>, CH1) onto four rectangles and two numbers,
+    /// so the desk and the campus show the same game.
+    ///
+    /// <para>The campus's dials are quoted for a 60 px glass; the desk's glass is anywhere from
+    /// about 60 to 175 DIPs across as the user resizes her, so every length here is scaled by
+    /// <c>w / 60</c>. Scaling the SPEED too is deliberate: a ball that crosses a small screen in
+    /// two seconds and a big one in six is two different games.</para>
+    ///
+    /// <para>THE FUMBLE IS THE POINT. Both paddles track the ball, and at a seeded moment one of
+    /// them starts tracking it slackly and lets a point through. A pong board where nobody ever
+    /// misses is a screensaver; one where a side loses is her playing.</para>
+    /// </summary>
+    private sealed class PongPainter : EmiChannelPainter
+    {
+        private const double RefGlass = 60.0;   // the width the campus numbers are quoted at
+        private const double SpeedRef = 55.0;   // CAMPUS PONG_SPEED, virtual px/s
+        private const double PaddleHRef = 10.0; // CAMPUS PADDLE_H
+        private const double PaddleWRef = 2.0;  // CAMPUS PADDLE_W
+
+        private readonly double _w, _h, _k;
+        private readonly double _paddleH, _paddleW, _speed, _ballSize, _inset;
+        private readonly Random _rng = new();
+
+        private readonly Rectangle _padL = new();
+        private readonly Rectangle _padR = new();
+        private readonly Rectangle _ball = new();
+        private readonly TextBlock _scoreL = new();
+        private readonly TextBlock _scoreR = new();
+
+        private double _x, _y, _vx, _vy, _pl, _pr, _last;
+        private int _left, _right;              // the score, left side first
+        private readonly int _missSide;
+        private readonly double _missAtMs;
+
+        public PongPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            _k = Math.Max(0.5, w / RefGlass);
+            _paddleH = PaddleHRef * _k;
+            _paddleW = Math.Max(1.0, PaddleWRef * _k);
+            _speed = SpeedRef * _k;
+            _ballSize = Math.Max(1.5, 3 * _k);
+            _inset = 6 * _k;
+
+            _missSide = _rng.Next(2);
+            _missAtMs = 3200 + _rng.NextDouble() * 4200;   // inside the ten second life, always
+
+            _x = _w / 2; _y = _h / 2;
+            _vx = _speed * (_rng.Next(2) == 0 ? 1 : -1);
+            _vy = _speed * (_rng.NextDouble() * 0.9 - 0.45);
+            _pl = _h / 2; _pr = _h / 2;
+        }
+
+        public override string Id => "pong";
+
+        public override void Attach(Panel host)
+        {
+            AddBackdrop(host, _w, _h);
+
+            // the dashed centre line, drawn once and never touched again
+            double dash = Math.Max(2, 4 * _k);
+            for (double y = 2 * _k; y < _h; y += dash * 2)
+            {
+                host.Children.Add(Box(Math.Round(_w / 2), y, Math.Max(1, _k), dash, PinkBrush, 0.45));
+            }
+
+            foreach (var pad in new[] { _padL, _padR })
+            {
+                pad.Width = _paddleW;
+                pad.Height = _paddleH;
+                pad.Fill = PinkBrush;
+                pad.IsHitTestVisible = false;
+                host.Children.Add(pad);
+            }
+            Canvas.SetLeft(_padL, _inset);
+            Canvas.SetLeft(_padR, _w - _inset - _paddleW);
+
+            _ball.Width = _ball.Height = _ballSize;
+            _ball.Fill = PinkBrush;
+            _ball.IsHitTestVisible = false;
+            host.Children.Add(_ball);
+
+            double size = Math.Max(5, _h * 0.14);
+            foreach (var (tb, leftEdge) in new[] { (_scoreL, _w / 2 - 14 * _k), (_scoreR, _w / 2 + 5 * _k) })
+            {
+                tb.Text = "0";
+                tb.FontFamily = EmiFace.PixelFont;
+                tb.FontSize = size;
+                tb.Foreground = PinkBrush;
+                tb.Opacity = 0.75;
+                tb.IsHitTestVisible = false;
+                Canvas.SetLeft(tb, leftEdge);
+                Canvas.SetTop(tb, 2 * _k);
+                host.Children.Add(tb);
+            }
+        }
+
+        public override void Tick(double tMs)
+        {
+            // Clamped, like the campus's: a dropped frame must not teleport the ball through a
+            // paddle, and the glass timer is a Background-priority DispatcherTimer that WILL be
+            // late under load.
+            double dt = Math.Min(80.0, tMs - _last) / 1000.0;
+            _last = tMs;
+
+            _x += _vx * dt;
+            _y += _vy * dt;
+            if (_y < _k) { _y = _k; _vy = Math.Abs(_vy); }
+            if (_y > _h - 4 * _k) { _y = _h - 4 * _k; _vy = -Math.Abs(_vy); }
+
+            double left = _inset, right = _w - _inset - _paddleW;
+            _pl = Track(_pl, Fumbling(0, tMs) ? 0.02 : 0.16);
+            _pr = Track(_pr, Fumbling(1, tMs) ? 0.02 : 0.16);
+            _pl = Math.Clamp(_pl, _paddleH / 2, _h - _paddleH / 2);
+            _pr = Math.Clamp(_pr, _paddleH / 2, _h - _paddleH / 2);
+
+            if (_vx < 0 && _x <= left + _paddleW && Math.Abs(_y - _pl) < _paddleH / 2 + 2 * _k)
+            {
+                _x = left + _paddleW; _vx = Math.Abs(_vx);
+                _vy += (_y - _pl) * 1.6;
+            }
+            if (_vx > 0 && _x + _ballSize >= right && Math.Abs(_y - _pr) < _paddleH / 2 + 2 * _k)
+            {
+                _x = right - _ballSize; _vx = -Math.Abs(_vx);
+                _vy += (_y - _pr) * 1.6;
+            }
+
+            if (_x < -4 * _k) { _right++; _scoreR.Text = _right.ToString(CultureInfo.InvariantCulture); Serve(1); }
+            if (_x > _w + 4 * _k) { _left++; _scoreL.Text = _left.ToString(CultureInfo.InvariantCulture); Serve(-1); }
+
+            Canvas.SetTop(_padL, _pl - _paddleH / 2);
+            Canvas.SetTop(_padR, _pr - _paddleH / 2);
+            Canvas.SetLeft(_ball, _x);
+            Canvas.SetTop(_ball, _y);
+        }
+
+        /// <summary>Is it this side's turn to be losing? One side, from one moment, for the rest.</summary>
+        private bool Fumbling(int side, double tMs) => tMs > _missAtMs && _missSide == side;
+
+        private double Track(double cur, double gain) => cur + (_y + 1.5 * _k - cur) * gain;
+
+        private void Serve(int dir)
+        {
+            _x = _w / 2; _y = _h / 2;
+            _vx = _speed * dir;
+            _vy = _speed * (_rng.NextDouble() * 0.9 - 0.45);
+        }
+    }
 
     /// <summary>
     /// A five-arm spiral, rotating. One <see cref="System.Windows.Shapes.Path"/> whose geometry is

--- a/ConditioningControlPanel/Services/EmiDesk/EmiDebug.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiDebug.cs
@@ -91,11 +91,13 @@ public static class EmiDebug
 
             ResetKnock = IsOn(Environment.GetEnvironmentVariable("EMI_DESK_RESET_KNOCK"));
 
-            if (IdleMs != null || Enabled || ResetOnboarding || ResetKnock)
+            if (IdleMs != null || FidgetMs != null || Enabled || ResetOnboarding || ResetKnock)
             {
                 Log.Information(
-                    "[EmiDesk] DEBUG overrides active: idleMs={Idle}, qaCadence={Qa}, resetOnboarding={Reset}, resetKnock={Knock}",
-                    IdleMs?.ToString(CultureInfo.InvariantCulture) ?? "default", Enabled, ResetOnboarding, ResetKnock);
+                    "[EmiDesk] DEBUG overrides active: idleMs={Idle}, fidgetMs={Fidget}, qaCadence={Qa}, resetOnboarding={Reset}, resetKnock={Knock}",
+                    IdleMs?.ToString(CultureInfo.InvariantCulture) ?? "default",
+                    FidgetMs?.ToString(CultureInfo.InvariantCulture) ?? "default",
+                    Enabled, ResetOnboarding, ResetKnock);
             }
         }
         catch (Exception ex)
@@ -104,6 +106,7 @@ public static class EmiDebug
             // this one cannot be allowed to: a bad environment variable simply means no override.
             try { Log.Debug(ex, "[EmiDesk] debug override probe failed"); } catch { }
             IdleMs = null;
+            FidgetMs = null;
             Enabled = false;
             ResetOnboarding = false;
             ResetKnock = false;

--- a/ConditioningControlPanel/Services/EmiDesk/EmiProps.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiProps.cs
@@ -61,8 +61,13 @@ public static class EmiProps
     // Her right hand, in body-box fractions. Both numbers were set by compositing all three plates
     // over body-idle and body-sway2 and looking at them; they are not derived from anything.
 
-    /// <summary>The prop's RIGHT edge, as a fraction of the body box width.</summary>
-    public const double RightFrac = 0.965;
+    /// <summary>
+    /// The prop's RIGHT edge, as a fraction of the body box width. Pulled in from 0.965 on the
+    /// owner's first look at it running (2026-08-30): flush against the edge of the box the plate
+    /// read as taped to the frame rather than held, and three percent buys the hand some air on
+    /// its outside without the plate starting to cover her sneaker.
+    /// </summary>
+    public const double RightFrac = 0.935;
 
     /// <summary>The prop's BOTTOM edge, as a fraction of the body box height.</summary>
     public const double BottomFrac = 0.905;

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Alive.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Alive.cs
@@ -471,12 +471,41 @@ public partial class EmiDeskWindow
             if (now < _fidgetDue) return;
             if (!CanPerk()) return;
             _fidgetDue = now.AddMilliseconds(FidgetDelayMs());
-            RunFidget(_fidgets.Next());
+
+            // Two of the five can decline: the prop beat when its art is missing, the screen beat
+            // when there is no library to draw from or the desk was touched a moment ago. A
+            // declined beat hands its slot straight to another kind rather than costing the user a
+            // whole quiet minute of nothing - one retry only, because the scheduler never repeats
+            // itself and a second refusal means the pool really has nothing to give right now.
+            var kind = _fidgets.Next();
+            if (RunFidget(kind)) { NoteFidget("[EmiDesk] fidget {Kind}", kind, null); return; }
+
+            var alt = _fidgets.Next();
+            NoteFidget("[EmiDesk] fidget {Kind} declined, {Alt} instead", kind, alt);
+            RunFidget(alt);
         }
         catch (Exception ex)
         {
             Log.Debug(ex, "[EmiDesk] fidget step failed");
         }
+    }
+
+    /// <summary>
+    /// Say which fidget just ran. DEBUG in a normal launch, because at 25-50 s apart this is a line
+    /// every half minute for the life of the process and it tells the user's log nothing; INFO
+    /// under the QA cadence (EMI_DESK_DEBUG), where reading the rotation back off the log IS the
+    /// play-test.
+    /// </summary>
+    private static void NoteFidget(string template, EmiFidget kind, EmiFidget? alt)
+    {
+        if (EmiDebug.Enabled)
+        {
+            if (alt is EmiFidget a) Log.Information(template, kind, a);
+            else Log.Information(template, kind);
+            return;
+        }
+        if (alt is EmiFidget b) Log.Debug(template, kind, b);
+        else Log.Debug(template, kind);
     }
 
     /// <summary>
@@ -491,48 +520,75 @@ public partial class EmiDeskWindow
         return EmiDebug.FidgetMs is int ms ? ms : authored;
     }
 
-    private void RunFidget(EmiFidget kind)
+    /// <summary>
+    /// Do one micro-fidget. Returns FALSE when the kind declined - reduced motion has taken the
+    /// two that move her, the prop beat found no art, the screen beat found nothing to show - so
+    /// that <see cref="StepFidgets"/> can spend the slot on something else instead of leaving the
+    /// desk still for another minute. Never throws.
+    /// </summary>
+    private bool RunFidget(EmiFidget kind)
     {
         try
         {
             switch (kind)
             {
                 case EmiFidget.Twitch:
-                    if (!AliveMotionOk) return;
+                    if (!AliveMotionOk) return false;
                     PlayChain(TwitchChain);
                     AnimateOffset(MoveShift, EmiAlive.TwitchDip, 0, 0.22, 1);
-                    break;
+                    return true;
 
                 case EmiFidget.WeightShift:
                     // No chain and no face: she just leans on the other foot for a moment. It is the
                     // one fidget that can happen without claiming the glass at all.
-                    if (!AliveMotionOk) return;
+                    if (!AliveMotionOk) return false;
                     RunWeightShift();
-                    break;
+                    return true;
 
                 case EmiFidget.Glance:
                     // The canon glance, plus a small standing look to the side she glanced at, so
                     // the two halves of "she looked over there" agree.
                     PlayChain("glance", bodyFrameOverride: "idle");
                     NudgeGaze(Rng.Next(2) == 0 ? -1 : 1, 0, 900);
-                    break;
+                    return true;
 
                 case EmiFidget.Prop:
-                    // She checks something. The longest of the four by a distance, which is why it
-                    // is one of four rather than one of two: at 25-50 s apart a 3 s beat is rare.
+                    // She checks something. The longest of the five by a distance, which is why it
+                    // is one of five rather than one of two: at 25-50 s apart a 3 s beat is rare.
                     // EmiDeskWindow.Props.cs owns the plate and takes it off again.
-                    RunPropBeat();
+                    if (!RunPropBeat()) return false;
                     // She is looking DOWN at the thing in her hand, so the standing look goes with
                     // it - a reading face over a level gaze reads as her reading the middle
                     // distance. Right and down, because the prop is at her right hand.
                     NudgeGaze(1, 1, EmiProps.HoldMs);
-                    break;
+                    return true;
+
+                case EmiFidget.Screen:
+                    // She puts something on her own glass. EmiDeskWindow.Glass.cs owns the flip and
+                    // its ten second life; all this does is reach the same door from the wheel.
+                    return RunScreenBeat();
             }
+
+            return false;
         }
         catch (Exception ex)
         {
             Log.Debug(ex, "[EmiDesk] fidget {Kind} failed", kind);
+            return false;
         }
+    }
+
+    /// <summary>
+    /// THE SCREEN'S TURN ON THE WHEEL. Everything that says "not now" about a channel already lives
+    /// in <c>GlassMayFlip</c> and is asked here unchanged, plus one floor of its own: the desk has
+    /// to have gone <see cref="EmiAlive.ScreenBeatRestMs"/> untouched. Without that the wheel would
+    /// hand her a channel while the user is still moving the mouse over her, and the first thing
+    /// <c>NoteGlassActivity</c> would do is tear it back down.
+    /// </summary>
+    private bool RunScreenBeat()
+    {
+        if (!GlassRestedFor(EmiAlive.ScreenBeatRestMs)) return false;
+        return TryFlipGlassNow();
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Glass.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Glass.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -45,6 +45,19 @@ public partial class EmiDeskWindow
     private DateTime _lastActivityUtc = DateTime.UtcNow;
     private DateTime _channelUpUtc;
     private bool _glassLive;
+
+    /// <summary>
+    /// SET WHILE A CHANNEL IS ANNOUNCING ITSELF, and the reason it has to exist:
+    /// <see cref="LandChannel"/> fires the <c>glassOffer</c> moment, the engine answers it
+    /// SYNCHRONOUSLY with an ask, and <see cref="ShowAsk"/> closes any live channel - correctly,
+    /// because an ask arriving from anywhere else must not leave a channel running behind it.
+    ///
+    /// <para>The channel's OWN offer is the one exception. Without this flag every channel tore
+    /// itself down 69 ms after it landed: one glitch, then her face again, then a question about a
+    /// thing nobody ever saw. It was invisible until the fidget wheel started flipping the glass
+    /// on a 30 s floor instead of only on an abandoned desk (found on the desk, 2026-08-30).</para>
+    /// </summary>
+    private bool _offering;
     private bool _channelTapped;
     private bool _emiOwnsTheVideo;
     private bool _glassHooked;
@@ -90,8 +103,9 @@ public partial class EmiDeskWindow
             CloseChannel(declined: false);
 
             // effectFired (with the channel) is raised by EmiChannels/EmiOffers, so there is one
-            // place a fired effect is announced no matter which door it came through.
-            EmiChannels.Fire(id, payload);
+            // place a fired effect is announced no matter which door it came through. A SAVER fires
+            // nothing: she was playing, you looked, and the glass goes back to her face.
+            if (!EmiChannels.IsSaver(id)) EmiChannels.Fire(id, payload);
         }
         catch (Exception ex)
         {
@@ -193,6 +207,35 @@ public partial class EmiDeskWindow
     }
 
     /// <summary>
+    /// Has the desk been left alone at least this long? The idle watch reads
+    /// <c>EmiChannels.IdleBeforeFlip</c> off the same clock; the fidget wheel's screen beat
+    /// (<c>EmiAlive.ScreenBeatRestMs</c>) reads a shorter one. Both are the same "nobody has
+    /// touched her" stamp, which <see cref="NoteGlassActivity"/> owns.
+    /// </summary>
+    internal bool GlassRestedFor(int ms)
+        => (DateTime.UtcNow - _lastActivityUtc).TotalMilliseconds >= ms;
+
+    /// <summary>
+    /// Put a channel on the glass RIGHT NOW if every gate allows it, and say whether one went up.
+    /// The fidget wheel's door to the flip: same gate, same painter, same ten second life as the
+    /// idle watch's, only reached from the rotation instead of from the 90 second clock.
+    /// </summary>
+    internal bool TryFlipGlassNow()
+    {
+        try
+        {
+            if (_glassLive) return false;
+            if (!GlassMayFlip()) return false;
+            return BeginFlip();
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "[EmiDesk] glass beat failed");
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Every reason she must NOT wander off to a channel. All of them are "something is already
     /// happening": the glass is the quietest thing she does and it never goes first.
     /// </summary>
@@ -234,17 +277,18 @@ public partial class EmiDeskWindow
 
     // ---------------------------------------------------------------- the flip
 
-    private void BeginFlip()
+    /// <summary>Start the glitch into a channel. False when there was nothing to show.</summary>
+    private bool BeginFlip()
     {
         string? id = EmiChannels.Pick();
-        if (id == null) return;
+        if (id == null) return false;
 
         var rect = GlassRect;
         var painter = EmiChannels.Build(id, rect.Width, rect.Height);
         if (painter == null)
         {
             Log.Debug("[EmiDesk] channel {Channel} had nothing to draw, skipped", id);
-            return;
+            return false;
         }
 
         _channel = id;
@@ -254,7 +298,7 @@ public partial class EmiDeskWindow
         StopIdleBeats();
 
         EnsureGlassLayers();
-        if (_glitchLayer == null || _glassLayer == null) { CloseChannel(false, silent: true); return; }
+        if (_glitchLayer == null || _glassLayer == null) { CloseChannel(false, silent: true); return false; }
 
         _glitchLayer.Children.Clear();
         _glitchLayer.Visibility = Visibility.Visible;
@@ -282,6 +326,7 @@ public partial class EmiDeskWindow
             }
         };
         _glitch.Start();
+        return true;
     }
 
     /// <summary>
@@ -353,7 +398,10 @@ public partial class EmiDeskWindow
             () => CloseChannel(declined: true));
 
         Log.Information("[EmiDesk] glass channel up: {Channel}", _channel);
-        App.EmiDesk?.Fire("glassOffer", new { channel = _channel });
+
+        _offering = true;
+        try { App.EmiDesk?.Fire("glassOffer", new { channel = _channel }); }
+        finally { _offering = false; }
     }
 
     private void OnChannelFrame(object? sender, EventArgs e)
@@ -377,6 +425,9 @@ public partial class EmiDeskWindow
     /// </summary>
     private void CloseChannel(bool declined, bool silent = false)
     {
+        // Her own offer may not close the channel it is offering. See _offering.
+        if (_offering) return;
+
         bool wasLive = _glassLive;
         string? id = _channel;
 

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Props.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Props.cs
@@ -291,12 +291,16 @@ public partial class EmiDeskWindow
     ///
     /// <para>Which prop is a plain roll, minus the one she did last, for the reason the fidget
     /// scheduler never repeats itself: the same object twice running reads as a loop.</para>
+    ///
+    /// <para>Returns FALSE when it could not run - no plates installed, or the chosen plate's art
+    /// is missing - so the fidget wheel can spend the slot on a different kind rather than leaving
+    /// the desk still.</para>
     /// </summary>
-    private void RunPropBeat()
+    private bool RunPropBeat()
     {
         try
         {
-            if (EmiProps.All.Count == 0) return;
+            if (EmiProps.All.Count == 0) return false;
 
             string key = _lastPropKey;
             for (int guard = 0; guard < 8 && key == _lastPropKey; guard++)
@@ -304,7 +308,7 @@ public partial class EmiDeskWindow
             _lastPropKey = key;
 
             ShowProp(key);
-            if (!PropUp) return;               // art missing: do not put the reading face on nothing
+            if (!PropUp) return false;         // art missing: do not put the reading face on nothing
 
             PlayChain(new EmiChain(
                 "prop", "IDLE BEAT (checks something)",
@@ -314,10 +318,13 @@ public partial class EmiDeskWindow
                     new EmiFrame(EmiProps.DoneFace, 420)
                 },
                 BodyFrame: "idle"), done: () => HideProp());
+            Log.Debug("[EmiDesk] prop beat: {Prop}", key);
+            return true;
         }
         catch (Exception ex)
         {
             Log.Debug(ex, "[EmiDesk] prop beat failed");
+            return false;
         }
     }
 

--- a/Tests/ConditioningControlPanel.Tests/EmiAliveTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiAliveTests.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using ConditioningControlPanel.Services.EmiDesk;
 using Xunit;
@@ -197,7 +198,7 @@ public class EmiAliveTests
     }
 
     [Fact]
-    public void NoFidgetEverRepeatsItselfAndAllThreeGetUsed()
+    public void NoFidgetEverRepeatsItselfAndEveryKindGetsUsed()
     {
         var s = new EmiAlive.FidgetScheduler(new Random(99));
         var seen = new HashSet<EmiFidget>();
@@ -213,7 +214,12 @@ public class EmiAliveTests
             last = next;
         }
 
-        Assert.Equal(3, seen.Count);
+        // EVERY kind in the enum except None, counted from the enum rather than written down: the
+        // pool has grown twice already (the prop beat, then the screen beat) and a hard 3 here is
+        // what turned main red both times.
+        var kinds = Enum.GetValues<EmiFidget>().Where(k => k != EmiFidget.None).ToArray();
+        Assert.Equal(kinds.Length, seen.Count);
+        Assert.All(kinds, k => Assert.Contains(k, seen));
     }
 
     // ---------------------------------------------------------------- the poke ladder


### PR DESCRIPTION
Three things, all watched running on the desk before this was opened.

## 1. The props sit slightly further in

`EmiProps.RightFrac` 0.965 -> 0.935, and the web twin `.arc-emi .emi .emi-prop { right: 6.5% }`
to match. Flush against the edge of her body box the plate read as taped to the frame rather
than held.

## 2. The idle wheel gained a fifth beat: `Screen`

`EmiAlive.FidgetScheduler` now picks between `WeightShift`, `Glance`, `Twitch`, `Prop` and
`Screen`. `Screen` flips her glass to one of the channels the desk already owned - spiral,
video, burst, gif rain - plus a **pong** ported from the campus saver deck
(`Resources/web/arcademy/emi/channels.js` CH1).

Pong is the desk's first SAVER: `EmiChannels.IsSaver("pong")` is true, so a tap on it fires no
effect. It is something to watch, not an offer.

Two of the five kinds may now *decline* a turn (no prop art installed; glass not rested long
enough), so `StepFidgets` retries once rather than spending a whole quiet minute on a beat that
could not run. The live log reads `fidget "Screen" declined, "Prop" instead`.

The 90 s owner lock on channel flips (`EmiChannels.IdleBeforeFlip`) is untouched. The beat reads
its own shorter 30 s floor (`EmiAlive.ScreenBeatRestMs`) for a desk that is merely quiet rather
than abandoned.

## 3. A real desk bug this exposed: every glass channel tore itself down 69 ms after it landed

`LandChannel()` fires the `glassOffer` moment. `EmiDeskService.Speak` answers it
**synchronously**, and `ShowAsk` closes any live channel - correct for an ask arriving from
anywhere else, fatal for the channel's own offer:

```
CloseChannel (Glass.cs) <- ShowAsk (Bubble.cs) <- EmiDeskService.Speak <- Fire
  <- LandChannel (Glass.cs) <- BeginFlip glitch tick
```

On screen that was one glitch frame, her face back, and then a question about a thing nobody
ever saw. It predates this branch and stayed hidden because channels only ever fired on a 90 s
abandoned desk, where nobody was looking. The new beat's shorter floor made it reproducible.

Fix is a scoped `_offering` flag set around the `Fire` in `LandChannel` and honoured at the top
of `CloseChannel`. `SpeakLine` and `HoldFace` reach `CloseChannel` the same way and are covered
by the same guard.

## Play-tested

Live on the desk, 2026-08-30. `WeightShift`, `Glance`, `Twitch`, `Prop`, `Screen` and the
decline-and-retry path all fired. `glass channel up: pong` stayed up its full `ChannelLife`
instead of dying at 69 ms, and a per-frame diff of the glass rect showed the ball and paddles
moving. Spiral landed too, and held while her ask was up.

Build clean, 4823/4823 green.
