### PR TITLE
perf(arcademy): mobile dig - shell lite rung, video registration door, split-flap twin

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/emi/channels.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/channels.js
@@ -664,6 +664,17 @@ export const saver = {
   uncapped: true,
   plan(ctx) {
     if (ctx.reducedMotion) return null;    // the deep-idle slot falls to OFF AIR
+    /* THE PHONE REFUSAL (perf/arcademy-mobile-dig): the one uncapped channel is
+     * a canvas repainting every column of every frame until input, and on a
+     * phone "deep idle" usually means the screen is burning in a pocket. The
+     * global GPU-ceiling marker (core/device.js - never set on desktop) sends
+     * the deep-idle slot to OFF AIR instead. pickDeepIdle consumed its seeded
+     * roll before asking, so the session stays deterministic either way. */
+    try {
+      const h = typeof document !== 'undefined' ? document.documentElement : null;
+      if (h && typeof h.getAttribute === 'function'
+        && h.getAttribute('data-ae-touch-global') === '1') return null;
+    } catch (e) { /* a probe must never cost the channel */ }
     return { seed: ctx.seed + '|rain' };
   },
   start(g, spec) {

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/takeover.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/takeover.js
@@ -38,6 +38,7 @@
  * ==========================================================================*/
 
 import { SL_DIALS, GLASS_W, GLASS_H, CHANNELS, rollChannel, pickDeepIdle, rollWrong, titleOf } from './channels.js';
+import { adoptVideo } from '../engine/util.js';
 
 const VIDEO_RE = /\.(mp4|webm|mov|m4v)(\?|#|$)/i;
 
@@ -124,6 +125,7 @@ export function createMediaBroker({ assets, settings, rand, doc, log } = {}) {
       try {
         if (VIDEO_RE.test(url)) {
           const v = d.createElement('video');
+          adoptVideo(v);
           v.muted = true; v.loop = true; v.autoplay = true; v.playsInline = true;
           if (v.setAttribute) { v.setAttribute('muted', ''); v.setAttribute('playsinline', ''); }
           v.addEventListener('loadeddata', () => { try { v.play(); } catch (e) { /* noop */ } settle(v); });

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
@@ -68,14 +68,63 @@ export function videoBudget() {
   } catch { /* ignore */ }
   return budget;
 }
+/* ---- ADOPTED VIDEOS (the registration door, 2026-08-30) -------------------
+ * Games mint their own <video> nodes (SORT faces and ghost cards, Deja Vu
+ * card faces, Instant Recall's montage, EMI's television) and those decoders
+ * were invisible here - decoration could still claim its budget while a game
+ * already held the phone's whole decode capacity. `adoptVideo()` lets any
+ * owner report a node the moment it mints one; the count folds into
+ * `budgetedKind()` ON THE GLOBAL TOUCH ARM ONLY (`data-ae-touch-global`,
+ * core/device.js's mobile verdict - NOT the bare ae-touch class, which The
+ * Deep End arms per-class on desktop), so desktop arithmetic is untouched
+ * byte for byte, The Deep End's desktop runs included.
+ *
+ * Nobody owes a release call. A node is counted while it is CONNECTED and
+ * PLAYING; one that has lived in the DOM and left is dropped on the next ask,
+ * and one that never mounted at all (a probe that lost its race) is dropped
+ * after a grace window, so the map cannot grow without bound. */
+const ADOPT_ORPHAN_MS = 30000;
+const adoptedVideos = new Map(); // node -> { at, live }
+export function adoptVideo(node) {
+  if (!node || typeof node !== 'object') return node;
+  try { adoptedVideos.set(node, { at: nowMs(), live: false }); } catch { /* ignore */ }
+  return node;
+}
+/** Playing, connected, game-owned decoders right now. Prunes as it counts. */
+export function adoptedVideoCount() {
+  let n = 0;
+  const now = nowMs();
+  for (const [v, s] of adoptedVideos) {
+    let conn = false;
+    try { conn = v.isConnected === true; } catch { conn = false; }
+    if (conn) {
+      s.live = true;
+      try { if (v.paused !== true && !v.error) n += 1; } catch { n += 1; }
+      continue;
+    }
+    if (s.live || (now - s.at) > ADOPT_ORPHAN_MS) adoptedVideos.delete(v);
+  }
+  return n;
+}
+const touchArmIsGlobal = () => {
+  try {
+    const html = hasDom() ? document.documentElement : null;
+    return !!(html && typeof html.getAttribute === 'function'
+      && html.getAttribute('data-ae-touch-global') === '1');
+  } catch { return false; }
+};
+
 /** The asset kind decoration may actually ask for. 'loop' until the budget is
- *  spent, then 'still' - every other kind passes straight through. */
+ *  spent, then 'still' - every other kind passes straight through. On the
+ *  global touch arm the game's own adopted decoders spend the budget too. */
 export function budgetedKind(want) {
   if (want !== 'loop') return want;
-  return liveVideos >= videoBudget() ? 'still' : 'loop';
+  let held = liveVideos;
+  if (touchArmIsGlobal()) held += adoptedVideoCount();
+  return held >= videoBudget() ? 'still' : 'loop';
 }
 /** Test seam only: the harness runs many cases in one process. */
-export function resetVideoBudget() { liveVideos = 0; }
+export function resetVideoBudget() { liveVideos = 0; try { adoptedVideos.clear(); } catch { /* ignore */ } }
 function forgetVideo(node) {
   if (!node || node.__aeVideo !== true) return;
   try { node.__aeVideo = false; } catch { /* ignore */ }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/casino.js
@@ -164,6 +164,13 @@ const STYLE_TEXT = `
 @keyframes g-cp-mqxr{to{background-position-x:-16px}}
 @keyframes g-cp-mqy{to{background-position-y:16px}}
 @keyframes g-cp-mqyr{to{background-position-y:-16px}}
+/* THE PHONE CEILING (html.ae-touch): the crawl repaints four dotted strips on
+   every frame for as long as the frame is up (background-position is a paint,
+   trap 36's whole point). steps() keeps the chase and pays for it three times
+   a second instead of sixty; the zen breathe rides the same clock. Desktop is
+   untouched - the class never lands there. */
+html.ae-touch .g-cp-mq .mq-t,html.ae-touch .g-cp-mq .mq-r,
+html.ae-touch .g-cp-mq .mq-b,html.ae-touch .g-cp-mq .mq-l{animation-timing-function:steps(6)}
 .g-cp-mq.g-cp-mq-zen i{animation:g-cp-mqbreathe calc(var(--cp-breath) * 1.2) ease-in-out infinite alternate}
 @keyframes g-cp-mqbreathe{from{opacity:.4;filter:none}to{opacity:1;filter:drop-shadow(0 0 4px var(--cp-n-mq, hsl(var(--cp-hue-a),80%,74%)))}}
 .g-cp-mq.g-cp-mq-bell{--cp-n-mq:var(--gold);filter:drop-shadow(0 0 6px rgba(240,194,75,.75))}

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
@@ -458,6 +458,10 @@ html.ae-touch .g-dt-neonbleed{filter:blur(12px);animation:none;opacity:1}
 /* the marquee's gold drop-shadow re-rasterised every frame of the crawl */
 html.ae-touch .g-dt-mq.g-dt-mq-gold{filter:none}
 html.ae-touch .g-dt-mq.g-dt-mq-flash{animation:g-dt-mqflash-t .6s ease-out 1}
+/* the crawl itself: background-position repaints all four strips every frame;
+   steps() keeps the chase at three paints a second on the phone */
+html.ae-touch .g-dt-mq .mq-t,html.ae-touch .g-dt-mq .mq-r,
+html.ae-touch .g-dt-mq .mq-b,html.ae-touch .g-dt-mq .mq-l{animation-timing-function:steps(6)}
 @keyframes g-dt-mqflash-t{0%{opacity:1}100%{opacity:var(--g-dt-mqa,.25)}}
 /* HUD chips: no live blur behind glass, so the glass turns solid instead */
 html.ae-touch .g-dt-hud .chip{backdrop-filter:none;-webkit-backdrop-filter:none;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -60,6 +60,7 @@ import {
 import { createDvCasino } from './casino.js';
 import { createDvTrickster, DV_TRICKSTER } from './trickster.js';
 import { makeTaggedRoll, makeRng, shuffled } from '../../core/rng.js';
+import { adoptVideo } from '../../engine/util.js';
 
 /** Distinct glyphs so a class is fully playable with ZERO media (the floor
  *  under the poster-frame-only floor). Deliberately font-safe, no emoji.
@@ -582,6 +583,7 @@ export default {
       let node;
       if (url && isVideoUrl(url) && !posterOnly) {
         node = el('video', 'g-dv-face');
+        adoptVideo(node);
         node.muted = true; node.loop = true; node.autoplay = false;
         node.setAttribute('muted', 'true');
         node.setAttribute('playsinline', 'true');

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
@@ -575,6 +575,13 @@ html.ae-touch .g-dv-almost{animation:g-dv-almost-t .62s ease-out both}
 html.ae-touch .g-dv-mq.g-dv-mq-bell{filter:none}
 html.ae-touch .g-dv-mq.g-dv-mq-flash{animation:g-dv-mqflash-t .6s ease-out 1}
 @keyframes g-dv-mqflash-t{0%{opacity:1}100%{opacity:var(--g-dv-mqa,.26)}}
+/* the crawl itself repaints four dotted strips every frame (background-position
+   is a paint); steps() keeps the chase at three paints a second on the phone */
+html.ae-touch .g-dv-mq .mq-t,html.ae-touch .g-dv-mq .mq-r,
+html.ae-touch .g-dv-mq .mq-b,html.ae-touch .g-dv-mq .mq-l{animation-timing-function:steps(6)}
+/* the preview beam: the sweep stays - it IS the telegraph - but its 18px+44px
+   glow smear was a grid-wide repaint riding every frame of it */
+html.ae-touch .g-dv-grid.scanning::after{box-shadow:none}
 /* the twins carry new names, so the reduced gate has to say its kills again */
 html.arc-reduced.ae-touch .g-dv-card.tell{animation:none;border-color:var(--gold);
   box-shadow:0 0 0 2px rgba(240,194,75,.55)}

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/montage.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/montage.js
@@ -94,6 +94,7 @@
  * ==========================================================================*/
 
 import { makeTaggedRoll } from '../../core/rng.js';
+import { adoptVideo } from '../../engine/util.js';
 
 export const MONTAGE = Object.freeze({
   /** Target CELL count by tier, before the density multiplier and before the
@@ -225,6 +226,7 @@ export function mediaElFor(url) {
   if (isVideoUrl(url)) {
     const v = el('video', 'g-ir-media');
     if (!v) return null;
+    adoptVideo(v);
     v.muted = true; v.loop = true; v.autoplay = true; v.playsInline = true;
     try {
       v.setAttribute('muted', '');

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -62,6 +62,7 @@
  * ==========================================================================*/
 
 import { makeRng, hash01, shuffled } from '../../core/rng.js';
+import { adoptVideo } from '../../engine/util.js';
 import {
   buildDeck, deckFromRows, rowsFromCards, cacheUsable, wrapQuickPool,
   judge, DECK,
@@ -1299,6 +1300,7 @@ export default {
       if (wantVideo && videoCount < DECODER_CEILING) {
         const v = el('video', 'g-sort-face');
         if (!v) return null;
+        adoptVideo(v);
         videoCount += 1;
         v.muted = true; v.loop = true; v.autoplay = isTop; v.playsInline = true;
         try {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
@@ -41,6 +41,7 @@
  * ==========================================================================*/
 
 import { SETUP_LEX } from './setup-lex.js';
+import { adoptVideo } from '../../engine/util.js';
 
 /* ---------------------------------------------------------------- data --- */
 
@@ -934,6 +935,7 @@ export function createSetupDoor(o) {
         let media;
         if (isVideoRow(row)) {
           media = el('video', 'g-sort-gmedia');
+          adoptVideo(media);
           media.muted = true; media.loop = true; media.autoplay = true;
           attr(media, 'muted', 'true'); attr(media, 'loop', 'true');
           attr(media, 'playsinline', 'true'); attr(media, 'autoplay', 'true');

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -545,6 +545,27 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   const shout = typeof toast === 'function' ? toast : () => {};
   const src = init || {};
 
+  /* THE LITE RUNG'S DEVICE HALF (mobile dig 2026-08-30). Every shell surface
+   * ships a diet twin (`.arm-lite`, `is-lite`, `asc-lite`: rooms.css holds the
+   * breath, alleysign.css stops the bloom and the chase, prizecounter.css
+   * drops the lamps, scene.js skips the dust canvas, reveal/walk thin their
+   * particles) - but `lite` only ever read `performanceMode`, a desktop dial
+   * the phone never sets, so every one of those twins was dead code exactly
+   * where it was written for. The device half reads core/device.js's GLOBAL
+   * arm marker (`data-ae-touch-global`), NOT the bare `ae-touch` class: The
+   * Deep End arms that class per-class on desktop too, and a desktop that
+   * enters The Deep End must not walk out into a lit-down school. The marker
+   * is stamped once, at boot, on the mobile verdict only - desktop WebView2
+   * never carries it, so this reads false there on every ask. */
+  const shellLite = () => {
+    if (src.performanceMode) return true;
+    try {
+      const html = typeof document !== 'undefined' ? document.documentElement : null;
+      return !!(html && typeof html.getAttribute === 'function'
+        && html.getAttribute('data-ae-touch-global') === '1');
+    } catch (e) { return false; }
+  };
+
   /* ---------------------- look & lexicon -------------------------------- */
   setLexicon(src.lexicon);
   applyPalette(src.palette, say);
@@ -2236,7 +2257,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
            * THINS the spark pool rather than dropping it, house doctrine:
            * lite keeps the move and drops the particle count). Only
            * reducedMotion deletes the sparks outright. */
-          lite: !!src.performanceMode,
+          lite: shellLite(),
           cosmetics: {
             awayColors: ownsSku('away_colors'),
             sparklerSteps: ownsSku('sparkler_steps'),
@@ -2715,7 +2736,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         idSpotlight = createIdSpotlight({
           t,
           reducedMotion: () => reducedMotion || idReducedMotion(),
-          lite: !!src.performanceMode,
+          lite: shellLite(),
           isMobile,
           profile: idProfile,
           stats: idStats,
@@ -3022,7 +3043,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    */
   function syncThemeFx(id) {
     const kind = themeFxFor(id == null ? themePick() : id, ownsSku);
-    if (!kind || reducedMotion || src.performanceMode) {
+    if (!kind || reducedMotion || shellLite()) {
       if (themeFx) { try { themeFx.destroy(); } catch (e) { /* noop */ } themeFx = null; }
       return;
     }
@@ -3030,7 +3051,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       try {
         themeFx = createThemeFx({
           reduced: reducedMotion,
-          lite: !!src.performanceMode,
+          lite: shellLite(),
           mobile: isMobile(),
           seed: utcDateSeed,
           log: say,
@@ -3150,7 +3171,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     installReveal({
       t,
       log: say,
-      lite: () => !!src.performanceMode,
+      lite: () => shellLite(),
       reduced: () => reducedMotion,
       isMobile,
       /* The same seed the corkboard deals tonight's poster from and the same
@@ -3178,7 +3199,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       owned: () => ownsSku('pa_pack'),
       t,
       log: say,
-      lite: () => !!src.performanceMode,
+      lite: () => shellLite(),
       reduced: () => reducedMotion,
       inClass: () => !!active,
       /* THE DUCK CAP. pa.js scales LINE_DUCK by this exactly the way
@@ -3202,7 +3223,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     paCaption = installPaCaption({
       t,
       log: say,
-      lite: () => !!src.performanceMode,
+      lite: () => shellLite(),
       reduced: () => reducedMotion,
       /* SHE STEPS ASIDE WHILE THE SCHOOL TALKS. campusDoorRects() already hands
        * the caption's box to her keep-off rule, but a rule is only read when
@@ -3304,7 +3325,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       beatMount: () => (prizeBooth && prizeBooth.root) || null,
       t,
       log: say,
-      lite: !!src.performanceMode,
+      lite: shellLite(),
       reduced: reducedMotion,
       catalog: () => economyCatalog(),
       balance: () => walletBalance(),
@@ -3403,7 +3424,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       mount: dom && dom.screen,
       t,
       log: say,
-      lite: !!src.performanceMode,
+      lite: shellLite(),
       reduced: reducedMotion,
       closed: counterClosed(),
       alley: !opt.skipWalk,
@@ -3588,7 +3609,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       mount: dom && dom.screen,
       t,
       log: say,
-      lite: !!src.performanceMode,
+      lite: shellLite(),
       reduced: reducedMotion,
       // Registry order, every registered class - including the ones never
       // played. An unattended card on the wall IS the advertisement (§6).
@@ -3643,7 +3664,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       mount: dom && dom.screen,
       t,
       log: say,
-      lite: !!src.performanceMode,
+      lite: shellLite(),
       reduced: reducedMotion,
       isMobile,
       /* THE OWNERSHIP WITNESS, and the only one. Law 1 in locker.js hangs off
@@ -3846,7 +3867,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     roomPage = createRoomScene({
       gameKey,
       t,
-      lite: !!src.performanceMode,
+      lite: shellLite(),
       log: say,
       name: gameName(gameKey),
       plate: (info && info.plate) || '',
@@ -3916,7 +3937,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     } catch (e) { /* noop */ }
     annexPage = createAnnexLab({
       t,
-      lite: !!src.performanceMode,
+      lite: shellLite(),
       log: say,
       subject: src.subject || {},
       gamesList: games.list.map((e) => e.key),

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -5983,3 +5983,24 @@ html.arc-mobile[data-arc-orient="portrait"] .campus-clockhand {
   transform-box:fill-box;
   transform-origin:50% 100%;
 }
+
+/* ===================== THE FLAP'S TOUCH TWIN (2026-08-30) ====================
+   Phase 4b, the deliberately-deferred one: arc-flap repaints every vane's
+   BACKGROUND GRADIENT (and its ink) per frame, across a whole board of
+   characters, r/i-staggered - on a phone the timetable deal is a paint storm
+   right on the first screen. Same length, same delays, the same letter-reveal
+   color timing to the stop (splitflap.js's CHAR_STEP_MS math is coupled to the
+   .95s and reads nothing else), but the material never changes: the vane flips
+   on transform alone and keeps the resting face gradient it was born with.
+   Desktop keeps arc-flap byte for byte - this selector cannot win there. */
+html.ae-touch .board.play .fl { animation-name:arc-flap-touch; }
+@keyframes arc-flap-touch {
+  0%   { color:transparent; }
+  14%  { transform:rotateX(-72deg); }
+  28%  { transform:rotateX(0); color:transparent; }
+  42%  { transform:rotateX(-72deg); }
+  56%  { transform:rotateX(0); color:transparent; }
+  68%  { transform:rotateX(-40deg); color:var(--ink); }
+  80%  { transform:rotateX(0); }
+  100% { transform:rotateX(0); color:var(--ink); }
+}


### PR DESCRIPTION
## What this is

Owner asked for a continued dig into Arcademy mobile perf beyond the Lost & Found fix (separate branch). Audit of everything shipped since the echo-diet wave (bc3b868f1): ~24.6K new arcademy lines, and the biggest new surfaces carried zero touch discipline.

## The three fixes

**1. Shell lite rung finally fires on phones** (the headline). Every shell surface already ships a diet twin (`.arm-lite`/`is-lite`/`asc-lite`: rooms breath, records solo ring, alley sign bloom+chase, prize-counter lamps, scene dust canvas, reveal/walk particle pools, themefx weather canvas, idcard, pa, locker, annex lab) - but all 13 `lite:` sites in shell.js read only `performanceMode`, a desktop dial the phone never sets. Every twin was dead code on the device it was written for. `shellLite()` ORs in the GLOBAL arm marker `data-ae-touch-global` (core/device.js mobile verdict) - deliberately NOT the bare `ae-touch` class, which The Deep End arms per-class on desktop.

**2. Video registration door.** Game-minted `<video>`s (SORT faces + ghost cards, Deja Vu faces, IR montage, EMI television) were invisible to engine/util.js's decoder budget - decoration could still claim its loop while a game held the phone's whole decode capacity (iOS caps ~3-4 hw sessions). `adoptVideo()` registers at mint; folds into `budgetedKind()` only under the global touch arm, only while connected+playing; liveness-pruned so no game owes a release path. **Lost & Found wiring left to its branch** - seam: `board.js` `mediaElFor` video branch -> `adoptVideo(v)`.

**3. Split-flap touch twin** (Phase 4b's deferred item). `arc-flap` animates every vane's background gradient + ink per frame across a staggered board - a paint storm on the phone's first screen. `html.ae-touch` swaps `animation-name` to a transform-only twin; same duration/delays/letter-reveal stops, splitflap.js timing math untouched.

## Desktop-identical proof

- All CSS additions live under `html.ae-touch` selectors (cannot match on desktop WebView2).
- `shellLite()` / `budgetedKind()` fold both key off `data-ae-touch-global`, stamped only by the mobile verdict - proven by a DOM-double unit run: desktop-no-fold / phone-under-budget / phone-over-budget / desktop-again-after / paused-stops-counting all pass.
- `node --check` green on all 7 touched JS files; headless import smoke green on all touched modules (incl. shell.js).

## Audit verdicts (no change needed)

- rAF hygiene across new shell/annex/emi files: all one-shot next-frame stagers or throttled+suppressed loops - clean.
- EMI widget timers: already guarded (document.hidden, reduced, busy) - untouched per house feel rules.
- New shell keyframes are overwhelmingly transform/opacity (compositor-cheap); the expensive box-shadow/filter breathers all had lite twins already - fix 1 arms them.
- deja-vu landscape chrome reserve: already fixed on main (style.js mobile fit rework).
- corkboard flutter uses the composited `rotate` property - cheap, left alone.

## Not proven here

- Real-iPhone decode-session behavior, safe-area, and actual frame-time A/B on hardware (no rig rebuilt this wave; changes are additive + statically proven desktop-inert instead).
- The adopted-video fold's effect during live Scrolller pools (sim only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YU23oXbzvGrFVxZeL5dM4q


---

## Round 2: the coordinator's 10-item audit, verified line by line (d185bf64f)

A second static audit (run against the dirty main cwd) handed over 10 ranked offenders. Every file:line was re-verified against clean origin/main before acting. **Most of the list describes pre-0825 code** - the big-ticket items were already shipped in the 0825/0826 waves:

| Audit claim | Verdict on clean origin/main |
|---|---|
| `.ae-touch` has NO global writer; ~19 CSS diets dead on phones | **REFUTED** - `core/device.js` `armTouchClass()` does `classList.add('ae-touch')` + stamps `data-ae-touch-global`, called from `paintRoot()` on the `isMobile()` verdict, wired at `boot.js:651`. Every `html.ae-touch` rule is live on phones. |
| deja-vu plays 12-20 videos at once | **REFUTED** - `TOUCH_PLAY_CAP = 2` + rotating touch preview window shipped (index.js:97-111). |
| impulse-control `perf: false` hardcoded; blur(14px) ungated; tube3d rAF never bails | **REFUTED** - `perf: touch` (index.js:462); `html.ae-touch` kills the depth/break backdrop-filters (style.js:569/591); tube3d has a full visibility guard (:1368+). |
| instant-recall `lite` bound to motionLevel only | **REFUTED** - `lite: motionLevel<=1 || isTouch` (index.js:2624). Montage govTick already skips hidden frames. |
| engine `createTimers().loop` has no hidden bail | **NO CHANGE NEEDED** - the loop is rAF-driven (util.js:275); browsers freeze rAF on hidden/occluded tabs, so it pauses for free. The `after(33)` fallback only runs headless. |
| echo `fitWords` forced-layout storm | **NO CHANGE NEEDED** - already memoized on (pad width, dealt hand) and coalesced through a 16ms `scheduleFit`. |
| campus attract 20Hz with no visibility handling | **NO CHANGE NEEDED** - phone half-rate shipped (campus.js:559); hidden-tab cost is handled by the web host's visibilitychange->suspend (host layer, not campus's job); fog blur was already flattened (styles.css:5660 GPU-diet block). |
| annex lab mask-image pipeline + resize thrash | **REFUTED** - the mask is a one-time canvas->dataURL at load; resize is a single listener calling a transform-only `fitStage()`. (The audit read the dirty cwd's stale annex duplicates, as suspected.) |
| EMI widget: no visibility handling, pointermove rect on every move | **REFUTED at the cited lines** - toy loop has a visibilitychange guard (widget.js:1275), sway bails on `hidden` inside `startSway()`; widget.js:1489 is the renderer-injection block, no pointermove there. |
| composure motes/inset, anomaly layoutMarquee, IR/shell bg-position marquees | **Mostly shipped/clean** - motes killed under ae-touch (:679); anomaly marquee only rebuilds when bulb count changes and is resize/timer-driven, not per-frame; IR casino + shell bugle/corkboard are trap-36 compliant (transform chase, never background-position). |

### What actually survived, and shipped in d185bf64f

- **Border-marquee crawls** (composure casino, daily-trigger, deja-vu): four dotted strips animating `background-position` at 60fps for the whole class, ungated. Now `animation-timing-function:steps(6)` under `html.ae-touch` - ~3 paints/s, chase kept, desktop untouched.
- **Deja-vu preview beam**: keeps its sweep (it IS the telegraph) but drops the 18px+44px box-shadow glow that repainted the grid on every frame of it (`html.ae-touch` only).
- **EMI saver (code rain)**: the one uncapped channel now declines deep idle when `data-ae-touch-global` is armed; the slot falls to OFF AIR exactly as the reduced-motion path does. Proven by a DOM-double run that found a saver-first seed: desktop=saver, phone=offair, desktop-again=saver; four-seed determinism pass; `pickDeepIdle` consumes its seeded roll before asking, so RNG streams are byte-identical.

### Deliberately left for the owner

- **EMI sway cadence / blink / chains**: ALIVE-pillar feel, explicitly out of scope.
- **Misdirection shuffle** animates `left:calc(var(--x)*100%)`: converting to transform needs a JS refactor of the shell walk (per-frame layout, but shuffles are short bursts, not idle cost). Flagged, not touched.
- **Campus roompulse** (blur(22px) SVG glow breathing at 3.2s/5s): a feel call - it is the campus's heartbeat; steps()-ing it reads as flicker on the room glows.
- **Punchcard art** is 15MB on disk (not the audit's 38MB) - webp siblings would be an asset-pipeline change, not a code diet.
- Dependabot reports 2 high vulnerabilities on the default branch (unrelated to this PR, surfaced for visibility).