### PR TITLE
feat(arcademy): direct game launch splash for Discord activity commands

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -3408,6 +3408,23 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     scene had no header card. Read the sibling's diff before writing the same fix twice, and
     check which half is `.arm-`.
 
+143. **A TOAST FIRED WHILE THE BOOT SPLASH IS UP IS A TOAST NOBODY EVER SEES.** `#arc-toast`
+    is z 60 and `.arc-loader` is z 70, and the toast's own life is 2.2s while the splash's
+    floor is longer than that - so `shout()` called from anywhere inside `createShell`'s
+    construction (the `launch_card_locked` refusal had done this since the day it was written)
+    plays out and expires behind the splash. The cure in shell.js is `shoutOnScreen()`: say it
+    now if `#arc-loader` is not on screen, otherwise park the one line in `pendingShout` and let
+    `onSplashDone`'s `flushPendingShout()` speak it when there is a screen to land on. A page
+    with no loader node (every headless suite) answers "not up" and behaves exactly as before.
+144. **`node --check` DOES NOT CATCH A BLOCK COMMENT YOU CLOSED EARLY, UNLESS THE FILE IS
+    CHECKED AS A MODULE.** A doc comment containing a literal `games/*/index.js` ends at that
+    `*/`; the rest of the sentence then parses as loose statements, which is legal script and
+    `node --check games/registry.js` in a plain directory says nothing. It only became
+    `SyntaxError: Unexpected identifier 'shell'` when the same file was checked from a directory
+    whose `package.json` carries `"type":"module"`. Run the §6 syntax pass against the rig's
+    COPY (which sits under a `module` package.json), never against a bare path, and never write
+    `*/` inside a comment - say "of every game module" instead.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -26,6 +26,11 @@
 
 import * as bridge from './bridge.js';
 import { installDeviceClass } from './core/device.js';
+/* THE DIRECT LAUNCH's two reads, and they are the only reason boot.js knows the
+ * registry exists. Both are STATIC data (a frozen table and two Sets) - the game
+ * modules themselves are dynamic imports inside `loadGames`, so this costs the
+ * boot nothing it was not already paying. */
+import { GAME_PATHS, isOpenSemester, gameTitle } from './games/registry.js';
 
 const doc = (typeof document !== 'undefined') ? document : null;
 const win = (typeof window !== 'undefined') ? window : null;
@@ -118,6 +123,78 @@ function armBootDeadline() {
 }
 
 /* ----------------------------------------------------------------------------
+ * THE DIRECT LAUNCH (the Discord per-class commands, 2026-08-30).
+ *
+ * `/deepend` and its nine siblings open this page with `init.launchGame` set to
+ * ONE room. The player asked for a game, not for a school, so the boot they get
+ * is the school's opening beat WITH THAT ROOM'S NAME UNDER IT and then the room
+ * itself - the campus is never built, never revealed and never walked (shell.js
+ * owns that half; see THE DIRECT LAUNCH there).
+ *
+ * boot.js owns the splash, so boot.js letters the plate, and it does it from
+ * `init` alone: the title comes off the registry's static table (or the mod's
+ * own `game_<key>` lexicon row), so the line is on screen from the first paint
+ * rather than whenever the ten game modules finish importing.
+ *
+ * THREE THINGS THE DIRECT SPLASH DOES DIFFERENTLY, and all three are "brief":
+ *   1. it leaves at DIRECT_MIN_MS instead of INTRO_MIN_MS,
+ *   2. it never holds for the knock (the jingle is the campus's welcome, and a
+ *      player who typed a command is not being welcomed; the mixer still arms
+ *      itself on the first pointer inside the class, as it always has), and
+ *   3. it never strikes the 4s intro bed for the same reason.
+ * An UNKNOWN or RETIRED key is not a direct launch at all: the page boots the
+ * ordinary campus and shell.js toasts the refusal, which is the same answer the
+ * campus door gives.
+ * -------------------------------------------------------------------------- */
+/** The class this boot was asked for, or '' - resolved once, in the init handler. */
+let directGame = '';
+
+/** The requested room, IF it is a room this build actually has. */
+function directLaunchKey(src) {
+  const key = (src && typeof src.launchGame === 'string') ? src.launchGame : '';
+  if (!key || !GAME_PATHS[key]) return '';
+  try { if (!isOpenSemester(key)) return ''; } catch (e) { return ''; }
+  return key;
+}
+
+/** Letter the plate. Idempotent, guarded, and never worth a boot. */
+function dressDirectLaunch() {
+  if (!directGame || !dom.loader || !doc) return;
+  try {
+    const line = dom.loader.querySelector('.arc-intro-class');
+    const name = line && line.querySelector('.arc-intro-class-name');
+    if (!line || !name) return;
+    name.textContent = gameTitle(directGame, initMsg && initMsg.lexicon);
+    line.hidden = false;
+    dom.loader.classList.add('is-direct');
+  } catch (e) { /* a plate may never cost the boot */ }
+}
+
+/** ...and take it off again when the shell refused the launch (a card that is
+ *  not full, or a suspend): the player is landing on the campus, so the splash
+ *  must not still be promising a room. shell.js fires the event; the ordinary
+ *  boot never does. */
+function undressDirectLaunch() {
+  directGame = '';
+  if (!dom.loader) return;
+  try {
+    dom.loader.classList.remove('is-direct');
+    const line = dom.loader.querySelector('.arc-intro-class');
+    if (line) line.hidden = true;
+  } catch (e) { /* noop */ }
+}
+
+if (doc && doc.addEventListener) {
+  doc.addEventListener('arcademy-direct-launch', (e) => {
+    try {
+      const d = (e && e.detail) || {};
+      log('direct launch: ' + (d.gameKey || '?') + ' ' + (d.ok ? 'opening the room' : 'refused - campus'));
+      if (!d.ok) undressDirectLaunch();
+    } catch (_e) { /* noop */ }
+  });
+}
+
+/* ----------------------------------------------------------------------------
  * THE SPLASH DISMISSAL. The loader doubles as the ~3s intro splash (see
  * index.html): a boot that lands early WAITS OUT the beat instead of cutting
  * it, a boot that lands late dismisses on arrival. `.is-done` plays the CSS
@@ -146,6 +223,10 @@ function armBootDeadline() {
  * loader comes down whatever the shell does with the news.
  * -------------------------------------------------------------------------- */
 const INTRO_MIN_MS = 2950;
+/** A DIRECT LAUNCH's floor. Short on purpose (the owner's word was "brief"):
+ *  past the CRT power-on, the wordmark thud and the glint, and out before the
+ *  sparkle tail - which `.is-direct` hides rather than cut in half. */
+const DIRECT_MIN_MS = 1900;
 const INTRO_EXIT_MS = 320;
 const introT0 = Date.now();
 
@@ -240,6 +321,7 @@ function onKnock() {
 
 function armKnockGate() {
   const src = initMsg || {};
+  if (directGame) return;                                    // a direct launch is not welcomed in
   if (src.autoplayOk === true) return;                       // the host's promise stands
   if (!!src.reducedMotion || src.motionLevel === 0) return;  // no cues, no hold (trap 66)
   if (!audio || typeof audio.hasSample !== 'function' || !audio.hasSample('intro_bed')) return;
@@ -518,6 +600,9 @@ let cancelSlate = null;
 
 function armFeedSlate() {
   if (cancelSlate || !dom.loader) return;
+  /* ...and never on a DIRECT LAUNCH: that splash leaves at 1.9s, which is half
+   * a slate, and half a haunting is a glitch rather than a beat. */
+  if (directGame) return;
   const src = initMsg || {};
   try {
     import('./shell/seep.js').then((m) => {
@@ -558,7 +643,7 @@ function scheduleIntroCues() {
     const elapsed = Date.now() - introT0;
     // hasSample is feature-detected: an older consumer simply stitches.
     const hasBed = !!(audio && typeof audio.hasSample === 'function' && audio.hasSample('intro_bed'));
-    if (hasBed && src.autoplayOk === true && elapsed < INTRO_BED_WINDOW_MS) {
+    if (hasBed && !directGame && src.autoplayOk === true && elapsed < INTRO_BED_WINDOW_MS) {
       strikeBed();
       return;
     }
@@ -598,7 +683,7 @@ function dismissLoader() {
   /* And the jingle outranks both: settleBed() re-calls us the moment the bed is
    * over, or the moment the cap says it is (THE SPLASH WAITS FOR THE JINGLE). */
   if (bedHolding) { bedDismissQueued = true; return; }
-  const wait = Math.max(0, INTRO_MIN_MS - (Date.now() - introT0));
+  const wait = Math.max(0, (directGame ? DIRECT_MIN_MS : INTRO_MIN_MS) - (Date.now() - introT0));
   const id = setTimeout(() => {
     exitTimers.delete(id);
     try {
@@ -720,6 +805,8 @@ bridge.on('init', guard('init', (m) => {
     return;
   }
   initMsg = m;
+  directGame = directLaunchKey(m);
+  dressDirectLaunch();            // THE DIRECT LAUNCH: name the room on the splash
   bridge.markInitialized();       // flush anything the page queued pre-init
   armBootDeadline();              // progress milestone
   armFeedSlate();                 // THE SEEP, tell 10 - fire and forget

--- a/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
@@ -152,6 +152,51 @@ export const OPEN_SEMESTERS = new Set([1, 2, 3]);
 export const RETIRED_GAMES = new Set(['misdirection']);
 
 /**
+ * THE PLATE ON THE DOOR, AND IT IS A PARACHUTE (the direct-launch wave, 2026-08-30).
+ *
+ * Every class module exports its own `title` and that module IS the source of
+ * truth - `shell.js gameName()` reads it, and a mod re-voices it through the
+ * `game_<key>` lexicon row. This table is the copy for the ONE reader that has
+ * neither: `boot.js`, which paints the class name onto the boot splash for a
+ * direct launch BEFORE a single game module has been imported (the whole point
+ * of that splash is that it is up from the first paint).
+ *
+ * KEEP IT IN STEP WITH THE MODULES. The direct-launch rig (CLAUDE.md §6 - it
+ * lives in the session scratchpad, not the repo) reads every `title:` line out
+ * of every game module and asserts this table agrees with all of them, so a
+ * drift is a failed case rather than a wrong plate. A key with no row falls back
+ * to the key with its underscores knocked out, which is a plate nobody wants to
+ * read - so add the row when a class ships.
+ */
+export const GAME_TITLE = Object.freeze({
+  daily_trigger: 'Daily Trigger',
+  lost_and_found: 'Lost & Found',
+  deja_vu: 'Deja Vu',
+  impulse_control: 'Impulse Control',
+  misdirection: 'Misdirection',
+  sort: 'Sort',
+  echo: 'Echo',
+  instant_recall: 'Instant Recall',
+  anomaly: 'Anomaly',
+  composure: 'Composure',
+  the_deep_end: 'The Deep End',
+});
+
+/**
+ * The display name for a class, resolved the way `shell.js gameName()` resolves
+ * it (lexicon row first, module title second) but WITHOUT the module - so a
+ * caller that has only `init.lexicon` can still letter a door plate.
+ * @param {string} key
+ * @param {Object=} lexicon  init.lexicon, or absent
+ */
+export function gameTitle(key, lexicon) {
+  const k = String(key || '');
+  const row = lexicon && typeof lexicon === 'object' ? lexicon['game_' + k] : null;
+  if (typeof row === 'string' && row) return row;
+  return GAME_TITLE[k] || k.replace(/_/g, ' ');
+}
+
+/**
  * SLASH COMMAND PER CLASS - THE TWO-REPO CONTRACT (Discord Activity, 2026-08-28).
  *
  * `/arcademy` opens the campus; one command per class opens THAT room directly,

--- a/ConditioningControlPanel/Resources/web/arcademy/index.html
+++ b/ConditioningControlPanel/Resources/web/arcademy/index.html
@@ -69,6 +69,11 @@
         </div>
         <div class="arc-intro-rail" aria-hidden="true"></div>
         <p class="arc-intro-caption">Opening <span class="arc-loader-name">The Arcademy</span>&#8230;</p>
+        <!-- THE DIRECT LAUNCH's door plate (boot.js dressDirectLaunch). Empty and
+             hidden on every ordinary boot; a Discord per-class command fills the
+             span with that class's own name and unhides it, so the splash the
+             player is already watching says which room it is opening. -->
+        <p class="arc-intro-class" hidden><span class="arc-intro-class-name"></span></p>
         <div class="arc-intro-scan" aria-hidden="true"></div>
         <div class="arc-intro-flash" aria-hidden="true"></div>
         <div class="arc-intro-crt" aria-hidden="true"></div>

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -1073,6 +1073,25 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     + timetable.classes.map((c) => c.gameKey).join(', ')
     + (timetable.relaxed.length ? ' (relaxed: ' + timetable.relaxed.join(',') + ')' : ''));
 
+  /* THE DIRECT LAUNCH (the Discord per-class commands, 2026-08-30). A request
+   * for a room this build actually HAS is opened without a campus: no board, no
+   * entry reveal, no ghosts, no walk and no Orientation Day - boot.js keeps its
+   * own splash up over the whole thing and letters the room's name on it, so the
+   * player who typed `/deepend` sees the school's opening and then the pool.
+   *
+   * IT IS STILL ONLY A REQUEST. The gate has not moved: `maybeLaunchRequested`
+   * is the one thing that ever fires a launch and it still asks `isUnlocked`.
+   * This flag decides whether the CAMPUS is built first, and nothing else.
+   *
+   * An unknown or retired key is NOT a direct launch (`games.byKey` is the same
+   * open-semester pool the board deals from): that boot opens the ordinary
+   * campus and the refusal lands on it as a toast, which is the answer the quad
+   * door would give. */
+  const directLaunch = !!launchRequest && !!games.byKey[launchRequest];
+  if (launchRequest && !directLaunch) {
+    say('activity launch: ' + launchRequest + ' is not a room in this build - campus');
+  }
+
   /* ---------------------- engine + provider ----------------------------- */
   /* THE CARD FACES. Optional, guarded, once: art/punchcard/faces.json says
    * where the stamps, the crest and the live text sit on each class's face
@@ -3730,11 +3749,46 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     docEvent('arcademy-locker-opened', { from: from === 'prizebooth' ? 'counter' : from });
   }
 
+  /* IS THE BOOT SPLASH STILL THE THING ON SCREEN? `#arc-toast` is z 60 and
+   * `.arc-loader` is z 70, so a toast fired during construction is a toast
+   * nobody ever sees - it expires (2.2s) under a splash whose own floor is
+   * longer than that. boot.js owns the loader, so this is a READ of its node
+   * and nothing more; a page without one (every headless suite) answers false
+   * and every toast is spoken the moment it is asked for, exactly as before. */
+  function splashUp() {
+    try {
+      if (typeof document === 'undefined' || !document.getElementById) return false;
+      const node = document.getElementById('arc-loader');
+      return !!(node && !node.hidden);
+    } catch (e) { return false; }
+  }
+  /** The one line parked behind the splash, or '' (see splashUp). */
+  let pendingShout = '';
+  /** Say it now, or on the splash edge - whichever the player can actually read. */
+  function shoutOnScreen(msg) {
+    const line = String(msg || '');
+    if (!line) return;
+    if (!splashUp()) { try { shout(line); } catch (e) { /* noop */ } return; }
+    pendingShout = line;
+  }
+  /** Called by `onSplashDone`, once, and only ever on the happy path. */
+  function flushPendingShout() {
+    if (!pendingShout) return;
+    const line = pendingShout;
+    pendingShout = '';
+    try { shout(line); } catch (e) { /* a toast may never hold a door */ }
+  }
+
   /**
    * ONE SHOT, ONE BOOT. The host asked for a room by key (`init.launchGame`);
    * open it if the card is full, otherwise stay on the campus and say why. An
    * unknown or retired key has no card and therefore no grant, which is the
    * same refusal by the same test - there is no second table to keep in step.
+   *
+   * STILL THE ONLY THING THAT FIRES A LAUNCH, and still exactly once per boot:
+   * the direct-launch road below does not launch anything itself, it decides
+   * WHEN this is called and whether a campus is built around it (see the tail
+   * of createShell). `launchFired` is the whole guard and it is spent here.
    */
   function maybeLaunchRequested() {
     if (launchFired || destroyed) return;
@@ -3743,11 +3797,61 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     if (isUnlocked(launchRequest)) {
       say('activity launch: ' + launchRequest + ' - card complete, opening the room');
       launchGraded(launchRequest);
+      /* THE SPLASH IS TOLD (boot.js listens). Fired AFTER `launchGraded` and
+       * read off `screen` rather than off the intent, so a class the suspend
+       * gate turned away is reported as the refusal it actually is and the
+       * splash takes the room's name back off. */
+      docEvent('arcademy-direct-launch', { gameKey: launchRequest, ok: screen === 'class' });
       return;
     }
     say('activity launch refused: ' + launchRequest + ' - card not complete');
-    try { shout(t('launch_card_locked', 'That card is not complete yet. Fill it first.')); }
-    catch (e) { /* a toast may never hold a door */ }
+    docEvent('arcademy-direct-launch', { gameKey: launchRequest, ok: false });
+    shoutOnScreen(t('launch_card_locked', 'That card is not complete yet. Fill it first.'));
+  }
+
+  /** How long a DIRECT LAUNCH waits for the host to say anything at all about
+   *  punch cards before it gives up and opens the campus instead. The hosted
+   *  shells send `meta` with `init`, so this is the never-arrives parachute and
+   *  not a step anybody is expected to stand on. */
+  const DIRECT_LAUNCH_WAIT_MS = 10000;
+
+  /** Has the host spoken about punch cards at all? `undefined` is "not yet";
+   *  an empty object is a real answer (a player who has never filled one). */
+  function cardsKnown() { return store.get('punchCards') !== undefined; }
+
+  /**
+   * THE DIRECT LAUNCH's ONE WAIT, and the only thing between a `/deepend` and
+   * the pool. It resolves as soon as the requested card reads complete, or as
+   * soon as the host has said anything about cards at all (a real "no"), or on
+   * the parachute above.
+   *
+   * `store.onChange` is the seam because the store subscribes to `meta` frames
+   * ITSELF, at construction - a snapshot that lands while the shell is still
+   * being built reaches the cache, where boot.js's own `if (shell)` handler
+   * would have dropped it.
+   */
+  function awaitDirectLaunchCards() {
+    if (isUnlocked(launchRequest) || cardsKnown()) return Promise.resolve();
+    say('direct launch: no punch cards yet - holding the splash for them');
+    return new Promise((resolve) => {
+      let spent = false;
+      let off = () => {};
+      const finish = (why) => {
+        if (spent) return;
+        spent = true;
+        clearTimeout(timer);
+        try { off(); } catch (e) { /* noop */ }
+        say('direct launch: ' + why);
+        resolve();
+      };
+      const timer = setTimeout(
+        () => finish('the cards never arrived - opening the campus'),
+        DIRECT_LAUNCH_WAIT_MS
+      );
+      off = store.onChange(() => {
+        if (isUnlocked(launchRequest) || cardsKnown()) finish('cards arrived');
+      });
+    });
   }
 
   /**
@@ -6510,6 +6614,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         bellSplashCleared = true; maybeFirstBell();
         stageClear = true; maybeStartOrientation();
       };
+      /* ...and anything said UNDER the splash is said again now that there is
+       * something to say it on (see shoutOnScreen). Before the continuation, so
+       * a parked refusal is already up as the campus finishes arriving. */
+      flushPendingShout();
       try { if (vn) { vn.splashDone(cleared); return; } }
       catch (e) { say('first bell cold open skipped (' + ((e && e.message) || e) + ')'); }
       cleared();
@@ -6866,14 +6974,46 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     if (vn) say('first bell: ' + (vn.armed ? 'armed' : 'nothing left to play'));
   } catch (e) { say('first bell unavailable (the shell is unaffected): ' + ((e && e.message) || e)); }
 
-  showBoard();
-  /* THE ACTIVITY LAUNCH, fired here and nowhere else: the campus has mounted
-   * (showBoard above) and the punch cards have been known since `init.meta`
-   * reached the store at construction, which are the ceremony's two
-   * preconditions. `launchGraded` sorts the rest out - a room tonight's board
-   * already deals starts as THAT class, a room off the board starts as a free
-   * swim's graded twin - so this hook only decides WHETHER. */
-  maybeLaunchRequested();
+  /* ================= THE OPENING, AND THERE ARE TWO OF THEM ==============
+   * THE ORDINARY BOOT builds the campus and then asks the activity hook whether
+   * a room was requested: the campus has mounted (showBoard) and the punch cards
+   * have been known since `init.meta` reached the store at construction, which
+   * are the launch's two preconditions. `launchGraded` sorts the rest out - a
+   * room tonight's board already deals starts as THAT class, a room off the
+   * board starts as a free swim's graded twin - so the hook only decides
+   * WHETHER.
+   *
+   * THE DIRECT LAUNCH turns that round. A `/deepend` boot is not a visit to a
+   * school, it is a visit to ONE ROOM, so the campus is not built at all:
+   * boot.js's splash (lettered with that room's name) is the only thing on
+   * screen, the cards are waited for when the host has not sent them yet, and
+   * the class starts straight into it. The quad's arrival rituals are not lost,
+   * they are DEFERRED - the greet, the postman, the streak reading and
+   * Orientation Day all belong to ARRIVING on the campus, and the player does
+   * that for real when the class ends and `showBoard()` runs its first time.
+   *
+   * THE REFUSAL NEVER STRANDS ANYBODY: a card that is not full (or a class the
+   * suspend gate turned away) falls through to exactly the ordinary opening one
+   * beat later, with the toast the quad door would have given.
+   * `maybeLaunchRequested` is spent exactly once on both roads.
+   * ==================================================================== */
+  if (directLaunch) {
+    await awaitDirectLaunchCards();
+    if (!destroyed) {
+      if (isUnlocked(launchRequest)) {
+        maybeLaunchRequested();
+        // startClass refuses under a global suspend: that boot is a campus after all.
+        if (screen !== 'class') showBoard();
+      } else {
+        // Campus FIRST, so the refusal has a screen to land on.
+        showBoard();
+        maybeLaunchRequested();
+      }
+    }
+  } else {
+    showBoard();
+    maybeLaunchRequested();
+  }
   return api;
 }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -1365,6 +1365,31 @@ html.ae-touch .arc-intro-burst { animation:arc-intro-burst-in .6s ease-out .5s b
 .arc-intro-caption .arc-loader-name { font-family:inherit; color:var(--pink); letter-spacing:inherit; }
 @keyframes arc-intro-caption-in { from { opacity:0; transform:translateY(5px); } to { opacity:1; transform:none; } }
 
+/* ---- THE DIRECT LAUNCH's door plate (the Discord per-class commands) -------
+   A player who typed /deepend asked for ONE room, so the splash they are
+   already watching says which one: the school's own opening, and the class
+   name under it. House display face (never the pixel one - this is a plate on
+   a door, not a status line), house pink, and it lands with the caption rather
+   than on a beat of its own. `hidden` in the markup is the ground truth: an
+   ordinary boot never has this line at all.
+   THE TAIL IS TRADED FOR SPEED on `.is-direct`: the sparkle burst and its
+   flash are the 2.35-2.65s close of a ~3s beat and a direct launch leaves at
+   ~1.9s, so they would only ever be cut in half - hidden outright instead,
+   which is also six fewer animated nodes on a phone (the FX diet). */
+.arc-intro-class {
+  position:relative; z-index:1; margin-top:-8px;
+  animation:arc-intro-caption-in .3s ease-out .95s both;
+}
+.arc-intro-class-name {
+  font-family:var(--disp); font-size:21px; letter-spacing:.14em;
+  text-transform:uppercase; color:var(--ink);
+  text-shadow:0 0 16px color-mix(in srgb, var(--pink) 45%, transparent);
+}
+.arc-loader.is-direct .arc-intro-spark,
+.arc-loader.is-direct .arc-intro-flash { display:none; }
+.arc-loader.is-done .arc-intro-class { opacity:0; transition:opacity .16s ease-in; }
+html.arc-mobile .arc-intro-class-name { font-size:17px; letter-spacing:.1em; }
+
 /* ---- full-frame layers --------------------------------------------------- */
 .arc-intro-scan {
   position:absolute; inset:0; z-index:4; pointer-events:none; opacity:.4;


### PR DESCRIPTION
Owner report (2026-08-30): the per-game slash commands (`/dailytrigger`, `/deepend`, ...) open the Arcademy Activity, which boots the **whole campus** first - board, ghosts, walker, orientation gate, the 4.5s entry reveal, plus the splash's knock gate and its ~4s jingle bed - and only then does `maybeLaunchRequested()` start the class and tear all of that back down. The ask: **open the game directly**, behind "a brief arcademy animation with under it the game name".

## What this does

When `init.launchGame` names a room that exists in the registry:

* **The splash is the whole opening.** `boot.js` letters the existing `#arc-loader` with the room's display name from **first paint** (a new hidden `<p class="arc-intro-class">` in `index.html`), adds `.is-direct`, and shortens the floor from `INTRO_MIN_MS` 2950 to `DIRECT_MIN_MS` **1900**. It also **skips the knock gate** (a direct launch is not welcomed in) and **skips the intro bed** wait, so the splash is exactly as long as it looks. No new art, no new audio - the wordmark, the ground and the caption animation already shipped.
* **The campus is never built.** `createShell` no longer calls `showBoard()` on this road. `applyTheme`, seep, PA, OST, themeFx, mail, ceremonies, VN and EMI are all constructed independently of it, and `renderTopbar()` already runs with `campus === null` on the ordinary class-start path, so nothing new is exercised.
* **The quad's rituals are deferred, not lost.** `fireMoment('greet')`, `mail.deliver()`, `noteStreakTurn()`, the annex-reveal probe and Orientation Day all belong to *arriving at the campus* - and the player does that for real when the class ends and `showBoard()` runs its first time.
* **One wait, and only when needed.** If the host has not sent punch cards yet, `awaitDirectLaunchCards()` holds the splash on `store.onChange` until the card reads complete, or until any card data lands (a real "no"), or on a **10s** parachute. `store` subscribes to `meta` itself at construction, so a snapshot landing mid-construction reaches the cache; boot.js's own `if (shell)` handler would have dropped it. 10s sits well inside the existing 45s boot deadline.

### Gates preserved

* Card not complete, unknown/retired key, or a class the global suspend gate turned away -> falls through to the **ordinary opening** one beat later (campus + `launch_card_locked` toast). The splash is told via a `arcademy-direct-launch` document event and takes the room's name back off.
* **Bug found and fixed on the way:** that toast has never been visible. `#arc-toast` is z 60, `.arc-loader` is z 70, and the toast's 2.2s life expires *behind* a splash whose floor is longer than that. New `shoutOnScreen()` parks the line and `onSplashDone()`'s `flushPendingShout()` speaks it when there is a screen to land on.
* **No double launch.** `maybeLaunchRequested()` is still the one and only launch site and still spends its `launchFired` latch exactly once per boot. The direct road decides *when* it is called and whether a campus is built around it - it launches nothing itself.
* **Reduced motion / phone diet.** Every added rule is a new selector; `@media (prefers-reduced-motion: reduce)` already nulls all `.arc-loader *` animation, so the plate is static there. `.is-direct` hides the spark and flash layers, and `html.arc-mobile` drops the plate to 17px. Net: a direct launch is *cheaper* than today's boot - one fewer full campus mount.
* **Desktop (WebView2) and plain web are untouched.** With no `launchGame`, `directGame` is `''`, every new guard is inert, `dressDirectLaunch()` returns immediately, the HTML addition stays `hidden`, `flushPendingShout()` is a no-op, and the tail runs the identical `showBoard(); maybeLaunchRequested();`.

## Files

| File | Lines | What |
|---|---|---|
| `Resources/web/arcademy/games/registry.js` | +45 | `GAME_TITLE` table + `gameTitle(key, lexicon)` - the plate on the door, readable before any game module is imported |
| `Resources/web/arcademy/index.html` | +5 | the hidden `.arc-intro-class` plate under the caption |
| `Resources/web/arcademy/styles.css` | +25 | `.arc-intro-class{-name}`, `.is-direct` suppressions, mobile size - all new selectors |
| `Resources/web/arcademy/boot.js` | +89/-2 | `directLaunchKey()`, `dressDirectLaunch()`/`undress`, `DIRECT_MIN_MS`, knock/bed/feed-slate guards, the `arcademy-direct-launch` listener |
| `Resources/web/arcademy/shell/shell.js` | +150/-10 | `directLaunch`, `splashUp()`/`shoutOnScreen()`/`flushPendingShout()`, `awaitDirectLaunchCards()`, the two-road tail of `createShell` |
| `Resources/web/arcademy/CLAUDE.md` | +17 | traps 143 (toast under the splash) and 144 (`node --check` and an early-closed comment) |

## Test evidence

`dotnet build` from the worktree root: **0 errors** (352 pre-existing warnings). `node --check` clean on all three JS files *checked as modules* (see trap 144).

Per `arcademy/CLAUDE.md` §6 the harness is rebuilt in the session scratchpad from a **copy** of the web root plus a DOM double and a fake bridge; the repo tree grows no test seam. **47 assertions, 0 failures**, across two suites:

* **(a) `launchGame` + unlocked** -> `createCampus` call count **0**, a `class-start` bracket sent, `arcademy-direct-launch {ok:true}`, no toast. The campus board is never shown.
* **(b) `launchGame` + locked** -> campus built exactly once, `{ok:false}`, the `launch_card_locked` line **parked** while the splash is up and spoken on `onSplashDone()`.
* **(b2) unknown key** -> same as (b): campus once, `{ok:false}`.
* **(c) no `launchGame`** -> campus once, zero direct-launch events, zero toasts - identical to before, and argued at diff level above.
* **(d) late cards** -> the shell holds, no campus, and launches on the `meta` frame.
* **(e) the 10s parachute** -> campus + refusal toast.
* **(f) `escapeStep()` out of a directly-launched class** -> builds the campus exactly once, so XP payout and the graded once/day path land on a normal board.
* **boot.js driven for real** (fake WebView2 transport installed before the import, one real `init` frame): the plate reads "The Deep End", is unhidden, the loader carries `.is-direct`, no knock hint is hung, and a `{ok:false}` event takes the plate back off.

**Not play-tested by a human** - no eyes on the actual splash yet.

Do not merge, do not run the web sync Action until the owner has looked at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
