### PR TITLE
perf(lost-and-found): phone smoothness + honest tap resolution (press road, tile floor, sheen diet)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
@@ -88,6 +88,16 @@ export function isAnimatedUrl(url) { return isVideoUrl(url) || isGifUrl(url); }
 
 /** Build the media element for a url. Never throws; broken media self-removes.
  *  `o.low` marks a wrap clone: same pixels, lower fetch priority. */
+/* THE SHARED VIDEO DOOR (0830 seam). The engine budgets its own <video>
+ * elements but could not see ours; engine/util.js adoptVideo() (perf wave,
+ * merge-order independent) registers a game-minted player with that budget.
+ * engine/ is an OPTIONAL layer by contract, so this is a dynamic import that
+ * may never resolve - and adoptVideo itself is a no-op off the touch arm. */
+let engUtil = null;
+try {
+  import('../../engine/util.js').then((m) => { engUtil = m; }).catch(() => {});
+} catch (e) { /* a missing engine costs the seam, never the class */ }
+
 export function mediaElFor(url, o) {
   if (!url) return null;
   const low = !!(o && o.low);
@@ -109,6 +119,7 @@ export function mediaElFor(url, o) {
       });
     }
     v.src = url;
+    try { if (engUtil && typeof engUtil.adoptVideo === 'function') engUtil.adoptVideo(v); } catch (e) { /* seam only */ }
     if (typeof v.play === 'function') {
       try { const p = v.play(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* autoplay policy */ }
     }
@@ -320,6 +331,98 @@ export function createBoard(o) {
     rows.push({ el: rowEl, strip, tiles: rowTiles, reps, durSec, dir: r % 2 ? 'r' : 'l' });
   });
 
+  /* ---------------------------------------------------------- press road */
+  /* TOUCH TAP RESOLUTION (0830). Two measured mis-tap mechanisms on phones:
+   *   1. `click` fires at finger-UP plus synthesis delay, and the strip keeps
+   *      drifting under the finger the whole time - a press that landed ON the
+   *      target resolved 200-350ms later on the neighbour (rig: 0/5 honest
+   *      presses survived a 320ms dwell).
+   *   2. Under jank the compositor-driven marquee runs ahead of the last
+   *      painted frame, so hit-testing resolves against a position the player
+   *      never saw.
+   * So on touch the MOSAIC resolves the gesture at pointerdown, and rewinds
+   * the hit-test by exactly the animation-timeline advance since the last rAF
+   * stamp. The timeline is the honest clock: it holds still while the wall is
+   * frozen (ceremony, pause) and while a stall stops the clock with us, so the
+   * rewind self-calibrates to zero everywhere except the one case it exists
+   * for. The resolved tile goes down the SAME onTileClick road - target, warm,
+   * miss and the ledger are untouched, and a press that resolves on a wrong
+   * tile is still a miss. Never a forgiveness radius, never a fake hit.
+   * Desktop (`touch` false) installs none of this and keeps the click road. */
+  let pressRafId = 0;
+  let pressStamp = null;   // animation-timeline ms at the last painted frame
+  let refStripAnim = null;
+
+  function refAnimTime() {
+    try {
+      if (refStripAnim && refStripAnim.playState !== 'idle') {
+        const ct = Number(refStripAnim.currentTime);
+        if (Number.isFinite(ct)) return ct;
+      }
+      refStripAnim = null;
+      for (const r of rows) {
+        if (!r.strip || typeof r.strip.getAnimations !== 'function') continue;
+        const list = r.strip.getAnimations();
+        if (list && list.length) {
+          refStripAnim = list[0];
+          const ct = Number(refStripAnim.currentTime);
+          if (Number.isFinite(ct)) return ct;
+        }
+      }
+    } catch (e) { /* no timeline, no rewind */ }
+    return null;
+  }
+  function pressStampLoop() {
+    if (destroyed || !touch) return;
+    pressStamp = { at: refAnimTime() };
+    pressRafId = requestAnimationFrame(pressStampLoop);
+  }
+  /** byEl only knows tile roots; a press usually lands on the skin or media. */
+  function tileFromNode(n) {
+    let node = n;
+    for (let hops = 0; node && hops < 6; hops++) {
+      const t = byEl.get(node);
+      if (t) return t;
+      node = node.parentNode || null;
+    }
+    return null;
+  }
+  function pressResolve(e) {
+    if (destroyed || !e || e.isPrimary === false) return;
+    const rawTile = tileFromNode(e.target);
+    if (!rawTile) return;                     // gaps stay dead, like the click road
+    let resolved = rawTile;
+    try {
+      const at = refAnimTime();
+      const dt = (pressStamp && Number.isFinite(pressStamp.at) && Number.isFinite(at))
+        ? at - pressStamp.at : 0;
+      if (dt > 24 && dt < 1200 && Number.isFinite(e.clientX)
+        && typeof document !== 'undefined' && document.elementFromPoint) {
+        const row = rows[rawTile.row];
+        const strip = row && row.strip;
+        if (strip) {
+          const dur = parseFloat(strip.style && strip.style.getPropertyValue
+            ? strip.style.getPropertyValue('--g-lf-dur') : '') || row.durSec || 30;
+          const reps = (row.reps | 0) || 2;
+          const w = strip.scrollWidth || 0;
+          if (w > 0 && dur > 0) {
+            // driftL translates -x, so content seen at clientX now sits at
+            // clientX - v*dt; the reversed strip mirrors the sign.
+            const v = (w / reps) / dur;
+            const shift = (row.dir === 'r' ? 1 : -1) * v * (dt / 1000);
+            const t2 = tileFromNode(document.elementFromPoint(e.clientX + shift, e.clientY));
+            if (t2 && t2.row === rawTile.row) resolved = t2;   // never jump rows
+          }
+        }
+      }
+    } catch (err) { /* the raw tile still stands */ }
+    try { if (opts.onTileClick) opts.onTileClick(resolved, e); } catch (err) { say('tile press: ' + ((err && err.message) || err)); }
+  }
+  if (touch && mosaic && mosaic.addEventListener) {
+    mosaic.addEventListener('pointerdown', pressResolve);
+    if (typeof requestAnimationFrame === 'function') pressRafId = requestAnimationFrame(pressStampLoop);
+  }
+
   /* ------------------------------------------------------------- budgets */
   /* Every budget here counts what Chromium actually pays for. `maxReps` is the
      multiplier the toroidal wrap applies to every live element, so it has to be
@@ -379,6 +482,9 @@ export function createBoard(o) {
     // click-precision board wants (engine bursts over it are pointer-events:none).
     node.addEventListener('click', (e) => {
       if (destroyed) return;
+      // On touch the press road below already resolved this gesture at
+      // pointerdown; letting the late click land too would double-count it.
+      if (touch) return;
       try { if (opts.onTileClick) opts.onTileClick(tile, e); } catch (err) { say('tile click: ' + ((err && err.message) || err)); }
     });
     // THE HOVER TELL rides the same per-element wiring as the click, and for
@@ -717,6 +823,10 @@ export function createBoard(o) {
 
     destroy() {
       destroyed = true;
+      if (pressRafId && typeof cancelAnimationFrame === 'function') {
+        try { cancelAnimationFrame(pressRafId); } catch (e) { /* ignore */ }
+      }
+      pressRafId = 0;
       byEl.clear();
       for (const t of desyncTimers) clearTimeout(t);
       desyncTimers.clear();

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
@@ -271,6 +271,15 @@ export const DENSITY_HARD_CAP = 200;
 /** Coarse pointers stop being honest input well before the wall does. */
 export const DENSITY_COARSE_CAP = 72;
 
+/* THE TOUCH TILE FLOOR (0830 phone wave). A landscape phone is ~390 CSS px
+ * tall; t3 medium dealt 53 tiles into that and the rows came out ~38px - under
+ * every touch-target floor, so a fingertip covered two tiles and the drift
+ * decided which one the press meant. effectiveDensity() caps the deal so a row
+ * is never shorter than this (including the row gap), by asking rowsFor() in
+ * reverse. Shrink-only, touch-only; par follows density (grade.js
+ * PAR_PER_TILE_SEC), so a smaller deal grades exactly as fair. */
+export const TOUCH_MIN_TILE_H = 48;
+
 /** Within-class breathing: each find starts the band a little higher (DTRH). */
 export const HEAT_BAND = 0.10;
 /** The find-3 modifier: one step hotter for the rest of the class. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -48,7 +48,7 @@ import {
   findsForTier, modifierFindForTier, finalBellFindForTier, PLAYTEST, TIERS,
   MOBILE_DENSITY, HEAT_BAND, MODIFIER_HEAT_STEP, BEAT_MS, TICK_MS,
   ASSEMBLE_STAGGER_MS, CLAIM_TIMEOUT_MS, POOL_OVERPROVISION, DISCRETE_STEP_MS,
-  DENSITY_LEVELS, DENSITY_HARD_CAP, DENSITY_COARSE_CAP,
+  DENSITY_LEVELS, DENSITY_HARD_CAP, DENSITY_COARSE_CAP, TOUCH_MIN_TILE_H,
 } from './constants.js';
 import { makeRng } from '../../core/rng.js';
 import { createBoard, paintLook, isVideoUrl, isAnimatedUrl } from './board.js';
@@ -273,11 +273,24 @@ export default {
 
     /** The board size we actually deal: tier density scaled by the player's
      *  lf_density level, then capped by device and player boardSize. */
-    function effectiveDensity() {
+    function effectiveDensity(viewH) {
       const lvl = String((ctx.settings && ctx.settings.lf_density) || 'medium');
       const mult = DENSITY_LEVELS[lvl] || DENSITY_LEVELS.medium;
       let d = Math.round(dials.density * mult);
       if (coarse) d = Math.min(DENSITY_COARSE_CAP, Math.min(d, Math.round((MOBILE_DENSITY[tier] || d) * mult)));
+      // THE TOUCH TILE FLOOR (constants.js TOUCH_MIN_TILE_H): cap the deal so
+      // a row is never shorter than a fingertip. rowsFor() is
+      // round(sqrt(d/1.75)) clamped 3..12, so the largest deal that still fits
+      // maxRows rows is 1.75*(maxRows+.5)^2 - 1. Shrink-only, touch-only, and
+      // par follows density (grade.js), so the grade stays exactly as fair.
+      if (touch && Number.isFinite(viewH) && viewH > 120) {
+        const gap = 5;                                   // styles.js --g-lf-gap
+        const maxRows = Math.floor((viewH + gap) / (TOUCH_MIN_TILE_H + gap));
+        if (maxRows < 12) {
+          const dMax = Math.ceil(1.75 * (maxRows + 0.5) * (maxRows + 0.5)) - 1;
+          d = Math.min(d, Math.max(8, dMax));
+        }
+      }
       const cap = Number(ctx.settings && ctx.settings.boardSize);
       if (Number.isFinite(cap) && cap > 0) d = Math.min(d, cap);
       return clamp(d, 8, DENSITY_HARD_CAP);
@@ -557,6 +570,7 @@ export default {
       shedVideos: 0, shedGifs: 0, regrown: 0,
     };
     const govGaps = [];
+    const govScratch = new Array(96);   // reused by govTick's median (no per-frame allocs)
     let govLast = 0;
 
     /** Rest a seat on something that costs no decoder and no player: a real
@@ -630,8 +644,18 @@ export default {
       }
       govLast = ts;
       if (govGaps.length < 48) return;
-      const s = govGaps.slice().sort((x, y) => x - y);
-      const med = s[s.length >> 1];
+      // Alloc-free median (0830 audit): slice().sort() here ran EVERY FRAME for
+      // the life of the class, feeding the GC on exactly the devices the
+      // governor exists to protect. Insertion into a reused scratch buffer
+      // yields the identical median with zero garbage (window is <= 90 wide).
+      const gn = govGaps.length;
+      for (let gi = 0; gi < gn; gi++) {
+        const gx = govGaps[gi];
+        let gj = gi - 1;
+        while (gj >= 0 && govScratch[gj] > gx) { govScratch[gj + 1] = govScratch[gj]; gj -= 1; }
+        govScratch[gj + 1] = gx;
+      }
+      const med = govScratch[gn >> 1];
       gov.med = med;
       if (med < gov.base) gov.base = med;
       const locked = med >= gov.base * PLAYTEST.GOV_LOCK_X;
@@ -1623,7 +1647,6 @@ export default {
         coarse = probeCoarse();
         touch = coarse || !!(ctx.platform && ctx.platform.isTouch);
         classSeed = String(spec.seed || 'lf');
-        density = effectiveDensity();
 
         injectStyles();
         hud = createHud({
@@ -1631,6 +1654,19 @@ export default {
           // the chrome vocabulary rides the game's clamped helper, never the engine
           cue,
         });
+        // The press-road diet (styles.js) is gated on a class THIS game arms -
+        // html.ae-touch's global arming belongs to the shell and is under
+        // audit (0830); a diet the phone may never wear is no diet.
+        try {
+          if (touch && hud.root && hud.root.classList) hud.root.classList.add('g-lf-touch');
+        } catch (e) { /* cosmetic only */ }
+        // Deliberately AFTER createHud: on touch the deal is capped by the
+        // view's real height (the touch tile floor), and only the mounted view
+        // knows it. Nothing before this line reads density, and createHud
+        // draws no rng, so the seeded stream is byte-identical either way.
+        density = effectiveDensity(hud.view && hud.view.clientHeight
+          ? hud.view.clientHeight
+          : (typeof window !== 'undefined' && window.innerHeight ? window.innerHeight - 100 : NaN));
         board = createBoard({
           mount: hud.view, density, rng, drift: dials.drift,
           lite: coarse, touch, reduced, log: say, onTileClick, onTileHover,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -1654,12 +1654,6 @@ export default {
           // the chrome vocabulary rides the game's clamped helper, never the engine
           cue,
         });
-        // The press-road diet (styles.js) is gated on a class THIS game arms -
-        // html.ae-touch's global arming belongs to the shell and is under
-        // audit (0830); a diet the phone may never wear is no diet.
-        try {
-          if (touch && hud.root && hud.root.classList) hud.root.classList.add('g-lf-touch');
-        } catch (e) { /* cosmetic only */ }
         // Deliberately AFTER createHud: on touch the deal is capped by the
         // view's real height (the touch tile floor), and only the mounted view
         // knows it. Nothing before this line reads density, and createHud

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
@@ -460,6 +460,11 @@ export const CSS = [
      the sheet's two hint loops freeze at their LIT frame. Desktop untouched. */
   /* The hue skin: one filtered render surface per seat, x2-3 wrap clones. */
   'html.ae-touch .g-lf-skin { filter:none; }',
+  /* The sheen: one compositor animation per tile ELEMENT - 106 of them on a
+     t3 phone board (measured 0830). The dense wall already drops it past
+     SHEEN_MAX_DENSITY; a phone board is always the dense wall in spirit. */
+  'html.ae-touch .g-lf-tile::after { display:none; }',
+  'html.ae-touch .g-lf-tile { contain:paint; }',
   /* Frosted chrome turns solid - a live blur behind glass is the phone tax. */
   'html.ae-touch .g-lf-hud .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
   '  background:rgba(20,20,43,.94); }',
@@ -492,30 +497,6 @@ export const CSS = [
   '  html.ae-touch .g-lf-ghost.g-lf-ghost-lure,',
   '  html.ae-touch .g-lf-mq.g-lf-mq-flash { animation:none !important; } }',
 
-  /* --------------- THE PRESS-ROAD DIET (.g-lf-touch, game-armed) -----------
-     Gated on OUR OWN class: index.js puts .g-lf-touch on the wrap from the
-     same `touch` probe the board's press road uses. The html.ae-touch ceiling
-     above stays as-is, but its GLOBAL arming belongs to the shell/device
-     layer and is under audit (0830) - a diet the phone may never wear is no
-     diet, so everything the phone must not pay for is said again on a class
-     this game provably arms. Desktop never carries it: nothing below exists
-     there, and the rules repeat the shipped ae-touch values verbatim wherever
-     both fire, so double-arming changes nothing. */
-  /* The sheen is one compositor animation per tile ELEMENT - 106 of them on a
-     t3 phone board (measured 0830). The dense wall already drops it past
-     SHEEN_MAX_DENSITY; a phone board is always the dense wall in spirit. */
-  '.g-lf-touch .g-lf-tile::after { display:none; }',
-  '.g-lf-touch .g-lf-tile { contain:paint; }',
-  /* Twins of the ae-touch ceiling, same values (see that block above). */
-  '.g-lf-touch .g-lf-skin { filter:none; }',
-  '.g-lf-touch .g-lf-hud .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
-  '  background:rgba(20,20,43,.94); }',
-  '.g-lf-touch .g-lf-foot .arc-peekbtn { backdrop-filter:none; -webkit-backdrop-filter:none;',
-  '  background:rgba(37,37,66,.97); }',
-  '.g-lf-touch .g-lf-foot .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
-  '  background:rgba(20,20,43,.94); }',
-  '.g-lf-touch .g-lf-dim { backdrop-filter:none; -webkit-backdrop-filter:none;',
-  '  background:rgba(20,20,43,.78); }',
 ].join('\n');
 
 /** Inject once per document. Idempotent - re-entering the class is free. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
@@ -491,6 +491,31 @@ export const CSS = [
   '@media (prefers-reduced-motion: reduce) {',
   '  html.ae-touch .g-lf-ghost.g-lf-ghost-lure,',
   '  html.ae-touch .g-lf-mq.g-lf-mq-flash { animation:none !important; } }',
+
+  /* --------------- THE PRESS-ROAD DIET (.g-lf-touch, game-armed) -----------
+     Gated on OUR OWN class: index.js puts .g-lf-touch on the wrap from the
+     same `touch` probe the board's press road uses. The html.ae-touch ceiling
+     above stays as-is, but its GLOBAL arming belongs to the shell/device
+     layer and is under audit (0830) - a diet the phone may never wear is no
+     diet, so everything the phone must not pay for is said again on a class
+     this game provably arms. Desktop never carries it: nothing below exists
+     there, and the rules repeat the shipped ae-touch values verbatim wherever
+     both fire, so double-arming changes nothing. */
+  /* The sheen is one compositor animation per tile ELEMENT - 106 of them on a
+     t3 phone board (measured 0830). The dense wall already drops it past
+     SHEEN_MAX_DENSITY; a phone board is always the dense wall in spirit. */
+  '.g-lf-touch .g-lf-tile::after { display:none; }',
+  '.g-lf-touch .g-lf-tile { contain:paint; }',
+  /* Twins of the ae-touch ceiling, same values (see that block above). */
+  '.g-lf-touch .g-lf-skin { filter:none; }',
+  '.g-lf-touch .g-lf-hud .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(20,20,43,.94); }',
+  '.g-lf-touch .g-lf-foot .arc-peekbtn { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(37,37,66,.97); }',
+  '.g-lf-touch .g-lf-foot .chip { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(20,20,43,.94); }',
+  '.g-lf-touch .g-lf-dim { backdrop-filter:none; -webkit-backdrop-filter:none;',
+  '  background:rgba(20,20,43,.78); }',
 ].join('\n');
 
 /** Inject once per document. Idempotent - re-entering the class is free. */


### PR DESCRIPTION
Owner report: "The Lost & Found game on phone is super laggy, sometimes even clicking the right picture gets it wrong."

Scope: `Resources/web/arcademy/games/lost-and-found/**` only. Desktop WebView2 behavior is unchanged - every change is behind the game's own `touch` probe / a game-armed CSS class, plus two shared-path changes that are provably output-identical (below).

## Root causes (rig-measured, headless Edge 844x390, seed `abc`)

1. **Mis-taps are the click road, not the player.** Taps resolved via `click` (finger-up + synthesis delay) while the CSS marquee keeps drifting; hit-testing then resolves against the *current* animation time, not the frame the player pressed on. Probe: **0/5** honest presses on the target survived a 320ms dwell - every one scored a misclick.
2. **106 infinite compositor animations on the phone board.** The per-tile sheen is density-gated (>64) but was not device-gated: desktop's density-92 board drops it, the phone's density-53 board kept all 106.
3. **38px tiles.** t3 medium dealt 53 tiles into a landscape-phone view; rows came out 38px - under any touch-target floor, so a fingertip covered two tiles.
4. Governor `govTick` ran `slice().sort()` per frame once warm (GC pressure on exactly the devices it protects).

## Changes

- **Touch press road** (board.js): on touch the mosaic resolves the gesture at `pointerdown`, rewinding the hit-test by the **animation-timeline advance** since the last rAF stamp (`anim.currentTime` delta - self-calibrating: zero when the wall is frozen, paused, or the clock stalled with the main thread). Resolved tile goes down the same `onTileClick` road: wrong tile is still a miss, ledger untouched, never a forgiveness radius, no fake hits. Per-tile `click` yields on touch (no double-fire). Desktop installs none of it.
- **Touch tile floor** (constants.js `TOUCH_MIN_TILE_H` 48 + index.js): deal capped so rows are never shorter than a fingertip; shrink-only, and par follows density (grade.js) so grading stays fair. Density now resolves after `createHud` (needs real view height; `createHud` draws no rng - seeded stream unchanged, retake deals the same board).
- **Sheen kill on the phone ceiling** (styles.js): `html.ae-touch .g-lf-tile::after { display:none }` + `contain:paint`, added to the existing PHONE CEILING section (ae-touch global arming was audited and verified live at boot - core/device.js `armTouchClass()`).
- **Alloc-free governor median** (index.js): reused scratch insertion sort, identical median, zero per-frame garbage. Shared path, output-identical.
- **Shared video door seam** (board.js): `adoptVideo()` from `engine/util.js` via optional dynamic import (engine is an optional layer; call is a typeof-guarded no-op until the perf-wave PR lands and off the touch arm after it) - game-minted `<video>` players become visible to the engine decoder budget.

## A/B (same seed, same driver)

| metric | base touch | after touch | base desktop | after desktop |
|---|---|---|---|---|
| running animations | **119** (106 sheen) | **11** (0 sheen) | 12 | 12 |
| tiles dealt / rows | 53 / 6 | 35 / 4 | 92 / 7 | 92 / 7 |
| tile size (rig view) | 38x38px | 60x59px | 36x31 | 36x31 |
| video tiles/cap | 1/1 | 1/1 | 6/6 | 6/6 |
| probe fingerDelay (320ms) | 0/5 hits | **3/3 hits** | - | - |
| probe jankStale (650ms stall) | 2/2* | 4/4 | - | - |
| honest-press misclicks | 4 | **0** | - | - |

*In headless the animation clock froze with the stalled main thread, so baseline "passed" trivially; the timeline-delta rewind is exactly zero in that case (cannot overcorrect) and covers the real-phone case where the compositor runs ahead.

Desktop A/B: identical dials, budgets, board and animation census; flat 16.7ms frames both sides. `node --check` clean on all four files; no in-repo L&F suite exists.

## Not provable in the rig (owner play-test wanted)

- Real-iPhone decode sessions, Safari URL-bar dynamics, actual Scrolller media weights (rig used local webm + svg stills).
- The headless rig cannot reproduce iPhone main-thread jank (desktop CPU, flat 60Hz) - the perf case rests on the structural counts above, not on rig frame times.
- Real-finger feel of press-at-pointerdown selection.

## Seam notes for the engine/shell wave

- `adoptVideo` call is in place (guarded); merge-order independent.
- Full-res remote stills still arrive undownscaled (texture memory on iOS) - provider/shim-side, out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YU23oXbzvGrFVxZeL5dM4q
