### PR TITLE
feat(emi-desk): port the campus channel deck to the glass + 10s rotation

### DIFF
--- a/ConditioningControlPanel/Services/EmiDesk/EmiAlive.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiAlive.cs
@@ -26,8 +26,8 @@ public enum EmiFidget
 
     /// <summary>
     /// She puts something on her own glass: pong, a spiral, a burst, gif rain, a film strip. The
-    /// channels already existed behind a 90 second stillness gate of their own
-    /// (<c>EmiChannels.IdleBeforeFlip</c>); this is the same flip, reached from the fidget wheel so
+    /// channels already existed behind a stillness gate of their own
+    /// (<c>EmiChannels.IdleBeforeFlip</c>, ~10 s since the 2026-08-30 campus port); this is the same flip, reached from the fidget wheel so
     /// that the screen takes its turn among the small body moves instead of being a separate
     /// clock. Like <see cref="Prop"/> it can no-op - a channel needs a library to draw from and the
     /// desk has to have been left alone - which is why <c>RunFidget</c> reports whether it did
@@ -238,14 +238,12 @@ public static class EmiAlive
 
     /// <summary>
     /// How long the desk has to have gone untouched before the <see cref="EmiFidget.Screen"/> beat
-    /// will take its turn, in ms. The glass's own clock (<c>EmiChannels.IdleBeforeFlip</c>, 90 s)
-    /// is an owner lock and stays exactly where it is - it is what makes an ABANDONED desk drift
-    /// off to a channel. This is the shorter floor for the same flip arriving off the fidget
-    /// wheel, and it is deliberately longer than one fidget gap: she does not put a show on the
-    /// second you look away, but a minute of quiet is enough that a channel is one of the things
-    /// she might do next rather than something that only happens if you leave the room.
+    /// will take its turn, in ms. This sat at 30 s against the glass's 90 s owner lock; on
+    /// 2026-08-30 the owner unlocked the rotation to ~10 s for the campus channel port, and the
+    /// wheel's floor drops with it - the two clocks are the same statement (an untouched desk
+    /// drifts off to a channel) arriving down different wires, and they should agree.
     /// </summary>
-    public const int ScreenBeatRestMs = 30_000;
+    public const int ScreenBeatRestMs = 10_000;
 
     /// <summary>The antenna twitch's travel, in DIPs.</summary>
     public const double TwitchDip = 2.0;

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Browsing.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Browsing.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace ConditioningControlPanel.Services.EmiDesk;
+
+public static partial class EmiChannels
+{
+    /// <summary>
+    /// CHANNEL BROWSING. Caught with tabs open. A port of the campus saver
+    /// (<c>Resources/web/arcademy/emi/channels.js</c>, CH2 "LATE NIGHT BROWSING") onto WPF shapes:
+    /// six wireframe pages of in-universe apps, one accent per app, flipped every 2500 ms.
+    ///
+    /// <para>NOTHING HERE IS A REAL BRAND. The parody is the LAYOUT - a title bar, chunky blocks,
+    /// a three to six character name - so each page reads as a different place at a glance without
+    /// a single word of anybody else's copy. Every page is somewhere the base already knows: her
+    /// mail, the board, the bank, the counter's now-serving card, the hole, the records room.</para>
+    ///
+    /// <para>SIZING. The campus numbers for this channel are quoted on the LOCKED FACE GRID, the
+    /// 152 x 137 virtual glass <c>face.js</c> paints, not on pong's quoted 60 - so the scaling law
+    /// is the same idea with a different reference, <c>k = w / 152</c>. The desk glass runs about
+    /// 60 to 175 DIPs across at the same 0.91 aspect, so the grid maps over almost exactly. The one
+    /// place literal offsets had to go is COPY: a title bar of 13 * k is 5 px on a small glass and
+    /// Press Start 2P cannot live in 5 px, so every font size has a legibility floor and the rows
+    /// are laid out in whatever body height is left over. Port the look, not the canvas calls.</para>
+    ///
+    /// <para>THE CHANNEL OUTLIVES THE CYCLE. Ten seconds of life is about four pages, and the
+    /// campus's plan() only ever deals two to four, so the order here is a full shuffle of all six
+    /// read round-robin: nobody sees the wrap, and two airings running are two different sittings.</para>
+    /// </summary>
+    internal sealed class BrowsingPainter : EmiChannelPainter
+    {
+        private const double RefGlass = 152.0;  // the locked face grid these numbers are written at
+        private const double PageMs = 2500.0;   // CAMPUS PAGE_MS
+        private const double BlinkMs = 500.0;   // CAMPUS blink, floor(t / 500) % 2
+        private const double DropAtMs = 1400.0; // the bank's bad news, measured in page dwell
+        private const double DeepRollMs = 1000.0;
+
+        private const int Mail = 0, Board = 1, Bank = 2, Cards = 3, Deep = 4, Rec = 5;
+        private const int PageCount = 6;
+
+        // ---- the palette, straight off CH2 -----------------------------------------------------
+        private static readonly SolidColorBrush DarkBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)));   // CAMPUS DARK
+        private static readonly SolidColorBrush RowBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x44)));   // an unread row
+        private static readonly SolidColorBrush BarBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x43, 0x43, 0x6A)));   // the fake subject line
+        private static readonly SolidColorBrush BlockBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x26, 0x26, 0x3F)));   // a dead tile
+        private static readonly SolidColorBrush LabelBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x5A, 0x5A, 0x7A)));   // small grey caption
+        private static readonly SolidColorBrush DropBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0xE8, 0x83, 0x6F)));   // the minus, in REC orange
+
+        /// <summary>One accent per app. The same six, in the same order, as CAMPUS BROWSE_PAGES.</summary>
+        private static readonly SolidColorBrush[] Accents =
+        {
+            Freeze(new SolidColorBrush(Color.FromRgb(0x7F, 0xD4, 0xC1))),   // MAIL
+            Freeze(new SolidColorBrush(Color.FromRgb(0xF2, 0xC1, 0x4E))),   // BOARD
+            Freeze(new SolidColorBrush(Color.FromRgb(0x8C, 0xC6, 0x3F))),   // BANK
+            Freeze(new SolidColorBrush(Color.FromRgb(0xC9, 0xA0, 0xDC))),   // CARDS
+            Freeze(new SolidColorBrush(Color.FromRgb(0x6F, 0xA8, 0xDC))),   // DEEP
+            Freeze(new SolidColorBrush(Color.FromRgb(0xE8, 0x83, 0x6F)))    // REC
+        };
+
+        /// <summary>The app names. Three to six characters, and shouted, exactly as on campus.</summary>
+        private static readonly string[] Titles = { "MAIL", "BOARD", "BANK", "CARDS", "DEEP", "REC" };
+
+        /// <summary>
+        /// The CRT rake, as ONE tiled brush under ONE rectangle. The campus fills a 1 px bar every
+        /// 2 px, which on the tallest desk glass is eighty shapes per page and six pages of them; a
+        /// frozen 2 px tile is the same picture for one node.
+        /// </summary>
+        private static readonly DrawingBrush ScanlineBrush = BuildScanlines();
+
+        // ---- geometry ---------------------------------------------------------------------------
+        private readonly double _w, _h, _k;
+        private readonly double _font, _small, _big, _barH, _body, _pad;
+        private readonly Random _rng = new();
+
+        // ---- the built pages --------------------------------------------------------------------
+        private readonly Canvas[] _pages = new Canvas[PageCount];
+        private readonly int[] _order = new int[PageCount];
+
+        // the bits Tick is allowed to touch, and nothing else
+        private readonly List<Rectangle> _mailBars = new();
+        private readonly List<Rectangle> _boardBars = new();
+        private readonly Rectangle _litRow = new();
+        private readonly Rectangle _litDot = new();
+        private readonly Rectangle _litBar = new();
+        private readonly TextBlock _bankNum = new();
+        private readonly TextBlock _bankDrop = new();
+        private readonly Polyline _deepTrace = new();
+        private readonly PointCollection _deepPts = new();
+
+        private double _mailBarMax, _boardBarMax, _deepStep, _deepTop;
+        private int _live = -1, _litState = -1, _bankN = -1;
+        private double _pageUpMs, _deepRolledMs;
+
+        public BrowsingPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            _k = Math.Max(0.5, w / RefGlass);
+
+            // The floors are the whole reason this is not a straight multiply: at the small end of
+            // the glass a literal 8 px cell lands under 4 px and the page turns into grey mush.
+            _font = Math.Max(5.0, 8.0 * _k);
+            _small = Math.Max(5.0, 7.0 * _k);
+            _big = Math.Max(9.0, 16.0 * _k);
+            _barH = Math.Max(_font + 3.0, 13.0 * _k);
+            _pad = Math.Max(2.0, 6.0 * _k);
+            _body = Math.Max(8.0, _h - _barH);
+
+            for (int i = 0; i < PageCount; i++) _order[i] = i;
+            for (int i = PageCount - 1; i > 0; i--)
+            {
+                int j = _rng.Next(i + 1);
+                (_order[i], _order[j]) = (_order[j], _order[i]);
+            }
+        }
+
+        public override string Id => "browsing";
+
+        public override void Attach(Panel host)
+        {
+            // CAMPUS clears to #0d0d18; the house dead-screen navy is #0E0E1C, the same colour to
+            // within a rounding error, so the shared backdrop stands in for it.
+            AddBackdrop(host, _w, _h);
+
+            for (int i = 0; i < PageCount; i++)
+            {
+                var page = new Canvas
+                {
+                    Width = _w,
+                    Height = _h,
+                    ClipToBounds = true,
+                    IsHitTestVisible = false,
+                    Visibility = Visibility.Collapsed
+                };
+
+                // the title bar, one accent per app, name in the dark ink so it reads as chrome
+                page.Children.Add(Box(0, 0, _w, _barH, Accents[i], 1.0));
+                page.Children.Add(LeftText(new TextBlock(), Titles[i], Math.Max(2, 4 * _k),
+                    Math.Max(0, (_barH - _font * 1.3) / 2), _font, DarkBrush));
+
+                switch (i)
+                {
+                    case Mail: BuildMail(page); break;
+                    case Board: BuildBoard(page); break;
+                    case Bank: BuildBank(page, Accents[i]); break;
+                    case Cards: BuildCards(page, Accents[i]); break;
+                    case Deep: BuildDeep(page, Accents[i]); break;
+                    default: BuildRec(page, Accents[i]); break;
+                }
+
+                _pages[i] = page;
+                host.Children.Add(page);
+            }
+
+            // the rake goes on last so it lies over every page at once
+            host.Children.Add(new Rectangle
+            {
+                Width = _w,
+                Height = _h,
+                Fill = ScanlineBrush,
+                IsHitTestVisible = false
+            });
+        }
+
+        public override void Tick(double tMs)
+        {
+            int slot = tMs <= 0 ? 0 : (int)(tMs / PageMs);
+            int page = _order[slot % PageCount];
+
+            if (page != _live)
+            {
+                if (_live >= 0) _pages[_live].Visibility = Visibility.Collapsed;
+                _live = page;
+                _pageUpMs = tMs;
+                _bankN = -1;
+                _litState = -1;
+                _pages[page].Visibility = Visibility.Visible;
+                Reroll(page, tMs);
+            }
+
+            double dwell = tMs - _pageUpMs;
+
+            switch (page)
+            {
+                case Board:
+                    Blink(tMs);
+                    break;
+
+                case Bank:
+                    // The balance climbs, which is the joke: she is being paid to sit there. The
+                    // string is only rebuilt when the number actually moves (about 25 times a
+                    // second at the campus rate), never once per frame for its own sake.
+                    int n = 1200 + (int)(tMs / 40.0);
+                    if (n != _bankN)
+                    {
+                        _bankN = n;
+                        _bankNum.Text = n.ToString(CultureInfo.InvariantCulture);
+                    }
+
+                    // CAMPUS quotes this beat off airing time (t > 6000). On the desk the page up at
+                    // six seconds is whichever one the shuffle dealt third, so the minus is quoted
+                    // off PAGE DWELL instead: it lands every time the bank is on, which is the only
+                    // way anybody ever sees it.
+                    var want = dwell > DropAtMs ? Visibility.Visible : Visibility.Collapsed;
+                    if (_bankDrop.Visibility != want) _bankDrop.Visibility = want;
+                    break;
+
+                case Deep:
+                    // A sounding, not a static chart. The campus re-rolls this trace every frame,
+                    // which on a canvas reads as a live instrument and in WPF would just be thirty
+                    // frames a second of noise, so it takes a fresh reading once a second instead.
+                    if (tMs - _deepRolledMs >= DeepRollMs) RollDeep(tMs);
+                    break;
+            }
+        }
+
+        // ---------------------------------------------------------------- the pages
+
+        /// <summary>
+        /// MAIL. Five rows, and the second one is FROM HER - the only pink on the page and the only
+        /// lower case word in the whole channel, because a subject line is not chrome.
+        /// </summary>
+        private void BuildMail(Canvas page)
+        {
+            double top = _barH + _pad;
+            double pitch = Math.Max(3.0, (_h - top - _pad * 0.5) / 5.0);
+            double rowH = Math.Max(_small + 1.0, pitch * 0.78);
+            double x = _pad, w = Math.Max(4.0, _w - _pad * 2);
+            _mailBarMax = Math.Max(3.0, w - _pad * 1.2);
+
+            for (int r = 0; r < 5; r++)
+            {
+                double y = top + r * pitch;
+                if (r == 1)
+                {
+                    page.Children.Add(Box(x, y, w, rowH, PinkBrush, 1.0));
+                    page.Children.Add(LeftText(new TextBlock(), "re: emi", x + _pad * 0.6,
+                        y + Math.Max(0, (rowH - _small * 1.3) / 2), _small, DarkBrush));
+                }
+                else
+                {
+                    page.Children.Add(Box(x, y, w, rowH, RowBrush, 1.0));
+                    var bar = Box(x + _pad * 0.6, y + rowH * 0.42, _mailBarMax * 0.5,
+                        Math.Max(1.5, 4 * _k), BarBrush, 1.0);
+                    _mailBars.Add(bar);
+                    page.Children.Add(bar);
+                }
+            }
+        }
+
+        /// <summary>
+        /// BOARD. Four threads, and the third one keeps lighting up. Only that row animates, so only
+        /// that row's three shapes are held; the rest are drawn once and never looked at again.
+        /// </summary>
+        private void BuildBoard(Canvas page)
+        {
+            double top = _barH + _pad;
+            double pitch = Math.Max(4.0, (_h - top - _pad * 0.5) / 4.0);
+            double rowH = Math.Max(3.0, pitch * 0.72);
+            double x = _pad, w = Math.Max(4.0, _w - _pad * 2);
+            double dot = Math.Max(2.0, 4 * _k);
+            double barH = Math.Max(1.5, 4 * _k);
+            _boardBarMax = Math.Max(3.0, w - _pad * 1.6 - dot * 2);
+
+            for (int r = 0; r < 4; r++)
+            {
+                double y = top + r * pitch;
+                bool tracked = r == 2;
+
+                var row = tracked ? _litRow : new Rectangle();
+                Place(row, w, rowH, BlockBrush, x, y);
+                page.Children.Add(row);
+
+                var pip = tracked ? _litDot : new Rectangle();
+                Place(pip, dot, dot, Accents[Board], x + _pad * 0.6, y + rowH * 0.16);
+                page.Children.Add(pip);
+
+                var bar = tracked ? _litBar : new Rectangle();
+                Place(bar, _boardBarMax * 0.6, barH, BarBrush, x + _pad * 0.6 + dot * 2, y + rowH * 0.42);
+                if (!tracked) _boardBars.Add(bar);
+                page.Children.Add(bar);
+            }
+        }
+
+        /// <summary>
+        /// BANK. A number going up, a caption, and a small red thing that turns up late. The block
+        /// at the bottom is a transactions list nobody gets to read.
+        /// </summary>
+        private void BuildBank(Canvas page, Brush accent)
+        {
+            page.Children.Add(Centered(new TextBlock(), "BALANCE", _barH + _body * 0.09, _small, LabelBrush));
+            page.Children.Add(Centered(_bankNum, "1200", _barH + _body * 0.22, _big, accent));
+
+            _bankDrop.Visibility = Visibility.Collapsed;
+            page.Children.Add(Centered(_bankDrop, "-14", _barH + _body * 0.50, Math.Max(6, 10 * _k), DropBrush));
+
+            page.Children.Add(Box(_pad * 1.5, _barH + _body * 0.72,
+                Math.Max(4.0, _w - _pad * 3), Math.Max(3.0, _body * 0.16), BlockBrush, 1.0));
+        }
+
+        /// <summary>
+        /// CARDS. The counter's now-serving card, on cream, with the number in pink. Still 004, and
+        /// still not yours.
+        /// </summary>
+        private void BuildCards(Canvas page, Brush accent)
+        {
+            double cardX = _w * 0.13, cardW = Math.Max(6.0, _w * 0.74);
+            double cardY = _barH + _body * 0.11, cardH = Math.Max(6.0, _body * 0.49);
+            page.Children.Add(Box(cardX, cardY, cardW, cardH, CreamBrush, 1.0));
+
+            page.Children.Add(Centered(new TextBlock(), "NOW", cardY + cardH * 0.08, _font, DarkBrush));
+            page.Children.Add(Centered(new TextBlock(), "SERVING", cardY + cardH * 0.36, _font, DarkBrush));
+            page.Children.Add(Centered(new TextBlock(), "004", cardY + cardH * 0.64,
+                Math.Max(7, 12 * _k), PinkBrush));
+
+            page.Children.Add(Box(cardX, _barH + _body * 0.72, cardW, Math.Max(2.0, 8 * _k), accent, 1.0));
+        }
+
+        /// <summary>
+        /// DEEP. One line that only ever goes down, and off the bottom of the glass. That is the
+        /// whole page, and it is the funniest one.
+        /// </summary>
+        private void BuildDeep(Canvas page, Brush accent)
+        {
+            _deepStep = Math.Max(3.0, 9 * _k);
+            _deepTop = _barH + _body * 0.07;
+
+            int count = Math.Max(4, (int)((_w - _pad * 2) / _deepStep) + 1);
+            for (int i = 0; i < count; i++) _deepPts.Add(new Point(_pad + i * _deepStep, _deepTop));
+
+            _deepTrace.Points = _deepPts;
+            _deepTrace.Stroke = accent;
+            _deepTrace.StrokeThickness = Math.Max(1.0, 2 * _k);
+            _deepTrace.StrokeLineJoin = PenLineJoin.Round;
+            _deepTrace.IsHitTestVisible = false;
+            page.Children.Add(_deepTrace);
+
+            page.Children.Add(LeftText(new TextBlock(), "DEPTH", _pad,
+                _barH + Math.Max(1.0, 2 * _k), _small, LabelBrush));
+        }
+
+        /// <summary>
+        /// REC. A twelve tile shelf with exactly one tile lit, the same one every time. Drawn once
+        /// and never touched again: the records room does not move for anybody.
+        /// </summary>
+        private void BuildRec(Canvas page, Brush accent)
+        {
+            double x0 = _w * 0.053, pitchX = _w * 0.224, tileW = Math.Max(3.0, _w * 0.184);
+            double y0 = _barH + _body * 0.07, pitchY = _body * 0.29, tileH = Math.Max(3.0, _body * 0.24);
+
+            for (int r = 0; r < 3; r++)
+            {
+                for (int c = 0; c < 4; c++)
+                {
+                    bool lit = r == 1 && c == 2;
+                    page.Children.Add(Box(x0 + c * pitchX, y0 + r * pitchY, tileW, tileH,
+                        lit ? accent : BlockBrush, 1.0));
+                }
+            }
+        }
+
+        // ---------------------------------------------------------------- the beats
+
+        /// <summary>
+        /// Fresh nonsense for the page that just came up. The campus re-randomises its bar widths
+        /// every frame; on a page of fake TEXT that reads as static rather than as writing, so the
+        /// dice are rolled once per page turn - a different sitting each time it comes back around.
+        /// </summary>
+        private void Reroll(int page, double tMs)
+        {
+            switch (page)
+            {
+                case Mail:
+                    foreach (var bar in _mailBars) bar.Width = _mailBarMax * (0.30 + _rng.NextDouble() * 0.36);
+                    break;
+                case Board:
+                    foreach (var bar in _boardBars) bar.Width = _boardBarMax * (0.42 + _rng.NextDouble() * 0.29);
+                    _litBar.Width = _boardBarMax * (0.42 + _rng.NextDouble() * 0.29);
+                    Blink(tMs);
+                    break;
+                case Deep:
+                    RollDeep(tMs);
+                    break;
+            }
+        }
+
+        /// <summary>The third thread, lighting. The brushes only swap on the half second they change.</summary>
+        private void Blink(double tMs)
+        {
+            int lit = (int)(tMs / BlinkMs) % 2 == 0 ? 1 : 0;
+            if (lit == _litState) return;
+            _litState = lit;
+
+            _litRow.Fill = lit == 1 ? Accents[Board] : BlockBrush;
+            _litDot.Fill = lit == 1 ? DarkBrush : Accents[Board];
+            _litBar.Fill = lit == 1 ? DarkBrush : BarBrush;
+        }
+
+        /// <summary>
+        /// One sounding of the hole. Points are assigned in place, never re-collected: the trace
+        /// only ever descends, and it is meant to run off the bottom edge and get clipped.
+        /// </summary>
+        private void RollDeep(double tMs)
+        {
+            _deepRolledMs = tMs;
+            double y = _deepTop;
+            for (int i = 0; i < _deepPts.Count; i++)
+            {
+                _deepPts[i] = new Point(_pad + i * _deepStep, Math.Min(y, _h + 20 * _k));
+                y += (4 + _rng.NextDouble() * 10) * _k;
+            }
+        }
+
+        // ---------------------------------------------------------------- small builders
+
+        private static void Place(Rectangle r, double w, double h, Brush fill, double x, double y)
+        {
+            r.Width = Math.Max(0.5, w);
+            r.Height = Math.Max(0.5, h);
+            r.Fill = fill;
+            r.IsHitTestVisible = false;
+            Canvas.SetLeft(r, x);
+            Canvas.SetTop(r, y);
+        }
+
+        /// <summary>Copy centred the way the campus's align 'center' does, without measuring text.</summary>
+        private TextBlock Centered(TextBlock tb, string s, double top, double size, Brush ink)
+        {
+            tb.Text = s;
+            tb.FontFamily = EmiFace.PixelFont;
+            tb.FontSize = size;
+            tb.Foreground = ink;
+            tb.Width = _w;
+            tb.TextAlignment = TextAlignment.Center;
+            tb.IsHitTestVisible = false;
+            Canvas.SetLeft(tb, 0);
+            Canvas.SetTop(tb, top);
+            return tb;
+        }
+
+        private TextBlock LeftText(TextBlock tb, string s, double x, double top, double size, Brush ink)
+        {
+            tb.Text = s;
+            tb.FontFamily = EmiFace.PixelFont;
+            tb.FontSize = size;
+            tb.Foreground = ink;
+            tb.IsHitTestVisible = false;
+            Canvas.SetLeft(tb, x);
+            Canvas.SetTop(tb, top);
+            return tb;
+        }
+
+        private static DrawingBrush BuildScanlines()
+        {
+            // 0x33 alpha is the campus's rgba(0,0,0,0.2), and the 2 x 2 tile with a 2 x 1 bar in the
+            // top of it is its "a 1 px line every 2 px" loop.
+            var ink = Freeze(new SolidColorBrush(Color.FromArgb(0x33, 0, 0, 0)));
+            var drawing = new GeometryDrawing(ink, null, new RectangleGeometry(new Rect(0, 0, 2, 1)));
+            return Freeze(new DrawingBrush(drawing)
+            {
+                TileMode = TileMode.Tile,
+                Viewbox = new Rect(0, 0, 2, 2),
+                ViewboxUnits = BrushMappingMode.Absolute,
+                Viewport = new Rect(0, 0, 2, 2),
+                ViewportUnits = BrushMappingMode.Absolute,
+                Stretch = Stretch.Fill
+            });
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Reruns.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Reruns.cs
@@ -1,0 +1,404 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using Newtonsoft.Json.Linq;
+using Serilog;
+
+namespace ConditioningControlPanel.Services.EmiDesk;
+
+/// <summary>
+/// CHANNEL RERUNS. The one channel on the glass that is ABOUT THE PLAYER: she digs the best class
+/// you ever graded out of the Arcademy's own day ledger and airs it back at you as a tape.
+///
+/// <para>Ported from the campus saver (<c>Resources/web/arcademy/emi/channels.js</c>, CH4) together
+/// with its two helpers, <c>bestRerun</c> and <c>flapName</c>. The campus reads the region straight
+/// out of page memory; the desk has no page, so the same region is read off the same file the page
+/// writes it to (<c>arcademy_meta.json</c>) - which is why this is the only channel here with a
+/// data dependency, and the only one that can refuse for want of MATERIAL rather than for want of a
+/// library.</para>
+/// </summary>
+public static partial class EmiChannels
+{
+    /// <summary>
+    /// The rerun tape. Static paint, four moving things: the OSD word, its blink, the timecode and
+    /// the tracking band rolling up the frame.
+    ///
+    /// <para>SCALE. Every campus number below is quoted at the 152 x 137 virtual glass
+    /// (<c>GLASS_W</c>/<c>GLASS_H</c> in channels.js) and is scaled by <c>w / 152</c> across and
+    /// <c>h / 137</c> down, the same law <see cref="PongPainter"/> applies with its own reference.
+    /// Pong references 60 because the numbers IT was ported from are the pitch demo's; these are the
+    /// campus painter's, so 152 is the only reference that keeps the card centred - at <c>w / 60</c>
+    /// the date line would land two glass-heights below the glass.</para>
+    ///
+    /// <para>SHE IS NOT EMBARRASSED HERE (campus <c>caught</c> table). The desk's caught beat is the
+    /// orchestrator's business, but the paint has to agree with it: this is a tape she keeps on
+    /// purpose, so nothing here reads as a channel she got stuck on.</para>
+    /// </summary>
+    internal sealed class RerunsPainter : EmiChannelPainter
+    {
+        private const double RefW = 152.0;   // CAMPUS GLASS_W - what every number here is quoted at
+        private const double RefH = 137.0;   // CAMPUS GLASS_H
+
+        /// <summary>The tape black. Deeper than <see cref="ScreenBrush"/> on purpose: the campus
+        /// clears this one channel to #07070f so the band and the scanlines have somewhere to be.</summary>
+        private static readonly SolidColorBrush TapeBlack =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x07, 0x07, 0x0F)));
+
+        private static readonly SolidColorBrush FlapInk =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x8D, 0x8D, 0xB0)));   // CAMPUS #8d8db0
+        private static readonly SolidColorBrush DateInk =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x4D, 0x4D, 0x6A)));   // CAMPUS #4d4d6a
+        private static readonly SolidColorBrush DimInk =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x5A, 0x5A, 0x7A)));   // CAMPUS #5a5a7a, the REW off-beat
+        private static readonly SolidColorBrush BandInk =
+            Freeze(new SolidColorBrush(Color.FromArgb(0x29, 0xE6, 0xE6, 0xFF)));  // rgba(230,230,255,0.16)
+        private static readonly SolidColorBrush BandUnderInk =
+            Freeze(new SolidColorBrush(Color.FromArgb(0x1A, 0xFF, 0x69, 0xB4)));  // rgba(255,105,180,0.10)
+
+        private readonly double _w, _h, _k, _ky;
+        private readonly Tape? _tape;
+
+        private readonly TextBlock _osd = new();
+        private readonly TextBlock _time = new();
+        private readonly Rectangle _band = new();
+        private readonly Rectangle _bandUnder = new();
+
+        private double _bandH, _bandUnderH, _bandSpan;
+        private int _lastOsd = -1;      // 0 = REW dim, 1 = REW lit, 2 = PLAY; -1 = nothing written yet
+        private int _lastSecond = -1;   // the timecode only ever changes once a second
+
+        internal RerunsPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            _k = Math.Max(0.25, w / RefW);
+            _ky = Math.Max(0.25, h / RefH);
+
+            // The tape is chosen HERE, not in Tick and not in Attach's hot path: one cached read at
+            // build time, so the ten seconds this channel lives never touch the disk.
+            _tape = HasMaterial() ? CachedTape() : null;
+        }
+
+        /// <summary>
+        /// The house <c>TryBuild</c> shape, for whichever door the orchestrator uses. NO TAPE, NO
+        /// CHANNEL - the campus's plan() returns null rather than airing a stub, and so does this.
+        /// </summary>
+        internal static RerunsPainter? TryBuild(double w, double h)
+        {
+            if (!HasMaterial()) return null;
+            return new RerunsPainter(w, h);
+        }
+
+        public override string Id => "reruns";
+
+        public override void Attach(Panel host)
+        {
+            // Not AddBackdrop: that one paints the shared dead-screen navy, and this channel is a
+            // tape rather than a dead screen.
+            host.Children.Add(Box(0, 0, _w, _h, TapeBlack, 1.0));
+
+            var tape = _tape;
+
+            // THE CARD. Grade huge, class under it, date under that - the campus's three lines at
+            // 40 / 7 / 7 px, top-anchored at y 36 / 88 / 102.
+            if (tape != null)
+            {
+                host.Children.Add(Centred(tape.Grade, 40, 36, PinkBrush));
+                host.Children.Add(Centred(FlapName(tape.GameKey), 7, 88, FlapInk));
+                host.Children.Add(Centred(tape.Date, 7, 102, DateInk));
+            }
+            // A null tape can only happen when the blob changed between the feasibility check and
+            // the build. The tape still rolls, blank: a dead ten seconds is recoverable, a throw
+            // into the glass is not.
+
+            // THE OSD, top left. Text and colour are the only things Tick writes here.
+            _osd.FontFamily = EmiFace.PixelFont;
+            _osd.FontSize = Px(8);
+            _osd.Foreground = PinkBrush;
+            _osd.Text = "<< REW";
+            _osd.IsHitTestVisible = false;
+            Canvas.SetLeft(_osd, 5 * _k);
+            Canvas.SetTop(_osd, 5 * _ky);
+            host.Children.Add(_osd);
+
+            // The fake timecode, bottom right. Right-aligned by giving the block the glass's width
+            // less the campus's 5 px margin: WPF has no draw-from-the-right anchor, and measuring a
+            // pixel-font string per frame to place it by hand would be the one allocation this
+            // painter cannot afford.
+            _time.FontFamily = EmiFace.PixelFont;
+            _time.FontSize = Px(8);
+            _time.Foreground = PinkBrush;
+            _time.Text = "0:00";
+            _time.TextAlignment = TextAlignment.Right;
+            _time.Width = Math.Max(1, _w - 5 * _k);
+            _time.IsHitTestVisible = false;
+            Canvas.SetLeft(_time, 0);
+            Canvas.SetTop(_time, Math.Max(0, _h - 14 * _ky));
+            host.Children.Add(_time);
+
+            // THE TRACKING BAND, over the card and under the scanlines - the campus's paint order.
+            _bandH = Math.Max(1.0, 9 * _ky);
+            _bandUnderH = Math.Max(0.5, 3 * _ky);
+            _bandSpan = _h + 18 * _ky;
+            Dress(_band, _bandH, BandInk);
+            Dress(_bandUnder, _bandUnderH, BandUnderInk);
+            host.Children.Add(_band);
+            host.Children.Add(_bandUnder);
+
+            // The scanline mask every channel wears. ONE tiled brush rather than sixty-eight
+            // rectangles: at the small end of the glass a 2 px campus row is under half a DIP, and
+            // sixty-eight sub-pixel bars antialias into a flat grey wash instead of a rhythm.
+            host.Children.Add(new Rectangle
+            {
+                Width = _w,
+                Height = _h,
+                Fill = Scanlines(_w, _ky),
+                IsHitTestVisible = false
+            });
+        }
+
+        public override void Tick(double tMs)
+        {
+            // THE FIRST SECOND IS A REWIND. She is not showing you the tape yet, she is finding it.
+            bool rew = tMs < 1000;
+            int state = !rew ? 2 : ((int)Math.Floor(tMs / 160.0) % 2 == 0 ? 0 : 1);
+            if (state != _lastOsd)
+            {
+                _lastOsd = state;
+                _osd.Text = state == 2 ? "> PLAY" : "<< REW";
+                _osd.Foreground = state == 0 ? DimInk : PinkBrush;
+            }
+
+            // One string a second, never one a frame.
+            int seconds = (int)Math.Max(0, Math.Floor(tMs / 1000.0));
+            if (seconds != _lastSecond)
+            {
+                _lastSecond = seconds;
+                _time.Text = Timecode(seconds);
+            }
+
+            // The band rolls UP, once every two seconds, and runs off the top before it comes back
+            // on at the bottom - hence the span overshoot.
+            double y = _h - (tMs % 2000.0) / 2000.0 * _bandSpan;
+            Canvas.SetTop(_band, y);
+            Canvas.SetTop(_bandUnder, y + _bandH);
+        }
+
+        // ------------------------------------------------------------ paint helpers
+
+        /// <summary>A campus font size in glass px, at whole DIPs: Press Start 2P has an 8 x 8 cell
+        /// and smears when it is asked to land between device pixels (see <see cref="EmiFace"/>).
+        /// The floor of 4 breaks the scaling law on purpose at the narrow end of the glass: strictly
+        /// proportional, the class name would round to three DIPs and read as texture, not a word.</summary>
+        private double Px(double campusSize) => Math.Max(4, Math.Round(campusSize * _k));
+
+        /// <summary>One centred line of the card. Centred by spanning the glass rather than by
+        /// measuring: the block is built once and never moves again.</summary>
+        private TextBlock Centred(string s, double campusSize, double campusTop, Brush ink)
+        {
+            var tb = new TextBlock
+            {
+                Text = s,
+                FontFamily = EmiFace.PixelFont,
+                FontSize = Px(campusSize),
+                Foreground = ink,
+                Width = _w,
+                TextAlignment = TextAlignment.Center,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(tb, 0);
+            Canvas.SetTop(tb, campusTop * _ky);
+            return tb;
+        }
+
+        private void Dress(Rectangle r, double height, Brush fill)
+        {
+            r.Width = _w;
+            r.Height = height;
+            r.Fill = fill;
+            r.IsHitTestVisible = false;
+            Canvas.SetLeft(r, 0);
+            Canvas.SetTop(r, -height);   // parked off the top until the first tick places it
+        }
+
+        /// <summary>The campus's <c>scanlines(g, 0.2)</c> as a frozen tile: one dark row every two
+        /// glass px, at least two DIPs apart so the rhythm survives the small glass.</summary>
+        private static Brush Scanlines(double w, double ky)
+        {
+            double step = Math.Max(2.0, Math.Round(2 * ky));
+            double tileW = Math.Max(1.0, w);
+            var drawing = new GeometryDrawing(
+                Freeze(new SolidColorBrush(Color.FromArgb(0x33, 0, 0, 0))),   // rgba(0,0,0,0.2)
+                null,
+                new RectangleGeometry(new Rect(0, 0, tileW, step / 2.0)));
+            // The tile is the full width of the glass, so this repeats DOWN and never across: a one
+            // DIP wide tile would have the compositor stamping the same column a hundred and fifty
+            // times per frame for an identical result.
+            var brush = new DrawingBrush(drawing)
+            {
+                TileMode = TileMode.Tile,
+                ViewportUnits = BrushMappingMode.Absolute,
+                Viewport = new Rect(0, 0, tileW, step),
+                ViewboxUnits = BrushMappingMode.Absolute,
+                Viewbox = new Rect(0, 0, tileW, step),
+                Stretch = Stretch.Fill
+            };
+            return Freeze(brush);
+        }
+
+        /// <summary><c>0:07</c> - the fake timecode every playback channel wears.</summary>
+        private static string Timecode(int seconds)
+        {
+            int m = seconds / 60, s = seconds % 60;
+            return m.ToString(CultureInfo.InvariantCulture) + ":" +
+                   s.ToString("00", CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>The split-flap short name for a class key, a straight port of the campus's
+        /// <c>flapName</c>. NO LEXICON REACHES EMI: she reads the raw key off the ledger and shouts
+        /// it, which is why a key nobody named still airs as something.</summary>
+        internal static string FlapName(string? gameKey)
+        {
+            var raw = gameKey ?? string.Empty;
+            // /[_-]+/g -> ' ': a RUN of underscores and hyphens collapses to one space, and nothing
+            // else does. Spaces the key already had are left alone, exactly as the regex leaves them.
+            var sb = new System.Text.StringBuilder(raw.Length);
+            bool inRun = false;
+            foreach (var c in raw)
+            {
+                bool sep = c == '_' || c == '-';
+                if (sep) { if (!inRun) sb.Append(' '); }
+                else sb.Append(c);
+                inRun = sep;
+            }
+            var s = sb.ToString().ToUpperInvariant().Trim();
+            // Faithful to the campus, cut first and only THEN fall back: a 14 char cut can end on a
+            // space, and the empty string is the only thing that becomes CLASS.
+            return s.Length > 14 ? s.Substring(0, 14) : (s.Length == 0 ? "CLASS" : s);
+        }
+
+        // ------------------------------------------------------------ the material
+
+        private sealed record Tape(string Date, string GameKey, string Grade);
+
+        /// <summary>The grades a rerun is worth airing. CAMPUS <c>GRADE_OK</c>, exactly: S or A, and
+        /// the comparison is done lowered so a ledger that ever wrote "a" still counts.</summary>
+        private static readonly HashSet<string> GradeOk =
+            new(StringComparer.Ordinal) { "s", "a" };
+
+        /// <summary>An <c>arcademy_meta.json</c> bigger than this is a corrupt save, not a ledger -
+        /// the store's own write cap is half a megabyte.</summary>
+        private const long MaxBlobBytes = 2 * 1024 * 1024;
+
+        private static readonly object MatLock = new();
+        private static long _matStamp = -1;   // ticks ^ length, the house stamp; -1 = never read
+        private static Tape? _matTape;
+
+        /// <summary>
+        /// IS THERE A TAPE? True when the Arcademy's day ledger holds a class this channel would
+        /// air. Read at most once per change to the file (the same <c>LastWriteTimeUtc.Ticks ^
+        /// Length</c> stamp <see cref="Services.Arcademy.ArcademyHostService"/> caches its wallet
+        /// against), so the wheel asking this every ten seconds costs one <c>FileInfo</c>.
+        ///
+        /// <para>NEVER THROWS AND ALWAYS FAILS CLOSED. A missing file, a half-written blob, a
+        /// <c>days</c> region that is an array this week - every one of them is "no tape", because
+        /// the alternative is a broken save reaching the mascot's face.</para>
+        /// </summary>
+        internal static bool HasMaterial()
+        {
+            try
+            {
+                var path = System.IO.Path.Combine(App.UserDataPath, "arcademy_meta.json");
+                long stamp;
+                long length;
+                try
+                {
+                    var info = new FileInfo(path);
+                    length = info.Exists ? info.Length : 0L;
+                    stamp = info.Exists ? (info.LastWriteTimeUtc.Ticks ^ length) : 0L;
+                }
+                catch { stamp = 0L; length = 0L; }
+
+                lock (MatLock)
+                {
+                    if (_matStamp != stamp)
+                    {
+                        _matStamp = stamp;
+                        _matTape = (stamp == 0L || length > MaxBlobBytes) ? null : ReadTape(path);
+                    }
+                    return _matTape != null;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] rerun material check failed");
+                return false;
+            }
+        }
+
+        /// <summary>The cached tape, without re-reading. Null until <see cref="HasMaterial"/> has
+        /// said yes at least once for the current stamp.</summary>
+        private static Tape? CachedTape()
+        {
+            lock (MatLock) { return _matTape; }
+        }
+
+        /// <summary>One read of the ledger. Called only when the stamp moved.</summary>
+        private static Tape? ReadTape(string path)
+        {
+            try
+            {
+                if (!File.Exists(path)) return null;
+                var blob = JObject.Parse(File.ReadAllText(path));
+                return BestRerun(blob["days"] as JObject);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] rerun ledger read failed");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// THE MOST RECENT S-OR-BETTER DAY ON RECORD, or null. A straight port of the campus's
+        /// <c>bestRerun</c> against the same region: <c>days</c> is keyed by LOCAL date
+        /// (<c>yyyy-MM-dd</c>, regression #978), so ordinal order IS chronological order and
+        /// newest-first is a reversed ordinal sort - no date parsing, and a key that is not a date
+        /// simply sorts somewhere and never throws.
+        ///
+        /// <para>Inside a day the classes are walked in the order the page wrote them, which is the
+        /// order they were sat, and the FIRST graded one wins. That is the campus's behaviour and
+        /// not an accident to be tidied: the rule is "the newest day that went well", not "the best
+        /// class of that day".</para>
+        /// </summary>
+        private static Tape? BestRerun(JObject? days)
+        {
+            if (days == null) return null;
+            foreach (var date in days.Properties().Select(p => p.Name)
+                         .OrderByDescending(n => n, StringComparer.Ordinal))
+            {
+                if (days[date] is not JObject row) continue;
+                if (row["classes"] is not JObject classes) continue;
+                foreach (var cls in classes.Properties())
+                {
+                    if (cls.Value is not JObject entry) continue;
+                    var grade = (entry["grade"]?.Type == JTokenType.String
+                        ? (string?)entry["grade"]
+                        : entry["grade"]?.ToString()) ?? string.Empty;
+                    grade = grade.ToLowerInvariant();
+                    if (GradeOk.Contains(grade))
+                    {
+                        return new Tape(date, cls.Name, grade.ToUpperInvariant());
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Screensavers.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Screensavers.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace ConditioningControlPanel.Services.EmiDesk;
+
+/// <summary>
+/// THE TWO DEEP-IDLE SAVERS, ported off the campus deck.
+///
+/// <para>The campus glass (<c>Resources/web/arcademy/emi/channels.js</c>) keeps a pair of channels
+/// that are not offers at all: CH7 SCREENSAVER, the code rain, and CH8 OFF AIR, the test card. They
+/// are the two things her screen does when it has been left alone, and the desk had neither. Both
+/// land here as WPF painters so the desk and the campus show the same appliance.</para>
+///
+/// <para>The campus quotes its numbers for a 152 x 137 virtual-px glass (<c>GLASS_W/GLASS_H</c>),
+/// where the desk's glass is anywhere from about 60 to 175 DIPs across as the user resizes her, so
+/// every length below is scaled by <c>w / 152</c> and then floored. The floors matter more here
+/// than they did for pong: pong scaled a ball, and these two scale TYPE, which stops being type
+/// somewhere around five pixels.</para>
+/// </summary>
+public static partial class EmiChannels
+{
+    /// <summary>
+    /// Bits both savers wear. Kept as a nested holder rather than as loose members on
+    /// <see cref="EmiChannels"/> because the partial is split across several files and a name like
+    /// "Scanlines" is exactly the one two ports would both reach for.
+    /// </summary>
+    private static class SaverGlass
+    {
+        /// <summary>
+        /// True black, shared. Both savers want it and neither wants the house navy: the rain
+        /// clears to it and the test card dims with it.
+        ///
+        /// <para>DECLARED FIRST ON PURPOSE. Static initialisers run in textual order and
+        /// <see cref="BuildScanTile"/> paints with this one, so a tidier alphabetical ordering here
+        /// would hand the tile a null brush and the scanlines would silently never draw.</para>
+        /// </summary>
+        internal static readonly SolidColorBrush Black = Freeze(new SolidColorBrush(Colors.Black));
+
+        /// <summary>
+        /// The scanline mask every campus channel wears (its <c>scanlines()</c>: one dark row every
+        /// two px) as ONE tiling brush instead of one Rectangle per row. A 137 DIP glass would be
+        /// sixty-eight rectangles otherwise, all of them static, all of them re-measured on every
+        /// layout pass the window does.
+        ///
+        /// <para>The tile is in ABSOLUTE units, so the mask stays two DIPs no matter how far the
+        /// user has dragged her out. A scanline that scales with the window is a stripe.</para>
+        /// </summary>
+        private static readonly DrawingBrush ScanTile = BuildScanTile();
+
+        private static DrawingBrush BuildScanTile()
+        {
+            // The drawing fills the top half of a 1 x 2 source box, so the tile is line, gap, line.
+            var cell = new GeometryDrawing
+            {
+                Brush = Black,
+                Geometry = new RectangleGeometry(new Rect(0, 0, 1, 1))
+            };
+            var b = new DrawingBrush(cell)
+            {
+                TileMode = TileMode.Tile,
+                Viewbox = new Rect(0, 0, 1, 2),
+                ViewboxUnits = BrushMappingMode.Absolute,
+                Viewport = new Rect(0, 0, 1, 2),
+                ViewportUnits = BrushMappingMode.Absolute,
+                Stretch = Stretch.Fill
+            };
+            return Freeze(b);
+        }
+
+        /// <summary>One element, drawn once, never touched by a tick.</summary>
+        internal static Rectangle ScanVeil(double w, double h, double alpha) => new()
+        {
+            Width = w,
+            Height = h,
+            Fill = ScanTile,
+            Opacity = alpha,
+            IsHitTestVisible = false
+        };
+    }
+
+    /// <summary>
+    /// CHANNEL CODE RAIN. The campus CH7 saver, falling down the desk's glass: green columns of
+    /// glyphs, a bright head, a fading tail, and about one column in twenty in her pink - which is
+    /// the tell under the costume, and the only reason this is HER screensaver rather than a stock
+    /// one.
+    ///
+    /// <para>Renamed from the campus id <c>saver</c> on purpose: the desk already ships a
+    /// <c>rain</c> channel (the user's own images falling), and two ids one letter apart in the
+    /// same wheel is a bug waiting for a typo.</para>
+    ///
+    /// <para>ONE TEXTBLOCK PER COLUMN, NOT PER GLYPH. The campus repaints every cell of every
+    /// column every frame, which a canvas does not mind and WPF very much does: a hundred and fifty
+    /// TextBlocks re-measuring at 30 fps is the phone FX diet's own bug again. A column is a
+    /// vertical strip whose brightness only ever falls off upward, so the whole tail fade is one
+    /// frozen vertical gradient on one block, and a frame is then just moving each block down.</para>
+    /// </summary>
+    internal sealed class CodeRainPainter : EmiChannelPainter
+    {
+        private const double RefGlass = 152.0;  // CAMPUS GLASS_W, the width its numbers are quoted at
+        private const double StepRef = 4.0;     // CAMPUS RAIN_STEP, a column every four virtual px
+        private const double CellRef = 6.0;     // CAMPUS RAIN_CELL, 4 x 6 glyph cells
+        private const int MaxTail = 9;          // CAMPUS 5 + floor(rand * 5), so nine at the top
+
+        /// <summary>
+        /// CAMPUS RAIN_GLYPHS, character for character. Written as escapes so this file stays pure
+        /// ASCII and cannot be broken by a tool that guesses an encoding; the tail is the katakana
+        /// A KA SA TA NA HA MA YA RA WA. Note the missing I and O in the latin run - that is the
+        /// campus list, and they are out because they read as 1 and 0 at six pixels.
+        /// </summary>
+        private const string Glyphs =
+            "ABCDEFGHJKLMNPQRSTUVWXYZ0123456789" +
+            "\u30A2\u30AB\u30B5\u30BF\u30CA\u30CF\u30DE\u30E4\u30E9\u30EF";
+
+        /// <summary>
+        /// The terminal ladder. A latin monospace leads so the letters and digits get a real
+        /// terminal face, and the Japanese system faces sit behind it purely to catch the katakana:
+        /// neither Press Start 2P nor Consolas has a single one of them, and WPF falls back per
+        /// glyph across a comma list (the same trick <see cref="EmiFace.FaceFont"/> uses for the
+        /// exotic kaomoji). The katakana come back full width, a touch wider than their column,
+        /// which is what they do on the campus too.
+        /// </summary>
+        private static readonly FontFamily RainFont = new(
+            "Cascadia Mono, Consolas, Noto Sans Mono, MS Gothic, Yu Gothic UI, Meiryo, " +
+            "Courier New, Global Monospace");
+
+        private static readonly Color RainGreen = Color.FromRgb(0x00, 0xFF, 0x41);  // CAMPUS RAIN_GREEN
+
+        private readonly double _w, _h, _cell, _step, _rows;
+        private readonly Random _rng = new();
+
+        private readonly List<TextBlock> _cols = new();
+        private readonly List<double> _y = new();       // head position, in CELLS, like the campus
+        private readonly List<double> _speed = new();   // cells per second
+        private readonly List<int> _tail = new();
+
+        private readonly char[] _buf = new char[(MaxTail + 1) * 2];
+        private double _last;
+        private int _churn;
+
+        public CodeRainPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            double k = Math.Max(0.1, w / RefGlass);
+
+            // FLOORED, NOT JUST SCALED. Six times a sixty-DIP glass's k is 2.4, and a 2.4 px glyph
+            // is a smear: the pink column and the katakana both stop being visible below about
+            // five, and they are the two things that make this rain hers rather than stock.
+            _cell = Math.Max(5.0, CellRef * k);
+            _step = Math.Max(3.0, StepRef * k);
+            _rows = Math.Ceiling(_h / _cell) + 2;
+        }
+
+        public override string Id => "coderain";
+
+        public override void Attach(Panel host)
+        {
+            // BLACK, not the house navy every other channel clears to. Phosphor green only reads as
+            // a CRT over true black; over #0E0E1C it reads as a highlighter.
+            host.Children.Add(new Rectangle
+            {
+                Width = _w,
+                Height = _h,
+                Fill = SaverGlass.Black,
+                IsHitTestVisible = false
+            });
+
+            int cols = Math.Max(1, (int)Math.Ceiling(_w / _step));
+            for (int i = 0; i < cols; i++)
+            {
+                int tail = 5 + _rng.Next(5);                    // CAMPUS 5 + floor(rand * 5)
+                bool pink = _rng.NextDouble() < 0.05;           // CAMPUS: about one column in twenty is hers
+
+                var tb = new TextBlock
+                {
+                    Text = Roll(tail),
+                    FontFamily = RainFont,
+                    FontSize = _cell,
+                    // The line box is forced down to the cell height so the column packs the way
+                    // the campus grid does. Left alone, WPF adds a comfortable reading leading and
+                    // the rain falls as a dotted line.
+                    LineHeight = _cell,
+                    LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+                    TextAlignment = TextAlignment.Center,
+                    Width = _cell * 2,
+                    Foreground = TailBrush(pink ? Pink : RainGreen, tail),
+                    IsHitTestVisible = false
+                };
+                // Half a cell of slack either side, so a full-width katakana bleeds symmetrically
+                // instead of shoving its whole column right.
+                Canvas.SetLeft(tb, i * _step - _cell * 0.5);
+
+                _cols.Add(tb);
+                _tail.Add(tail);
+                _y.Add(-Math.Floor(_rng.NextDouble() * 40));    // CAMPUS: they start well above the glass
+                _speed.Add(12 + _rng.NextDouble() * 26);        // CAMPUS 12 + rand * 26 cells/s
+                host.Children.Add(tb);
+            }
+
+            host.Children.Add(SaverGlass.ScanVeil(_w, _h, 0.14));   // CAMPUS scanlines(g, 0.14)
+        }
+
+        public override void Tick(double tMs)
+        {
+            // Clamped exactly like the campus frame(): the glass timer is a Background-priority
+            // DispatcherTimer and WILL be late under load, and an unclamped dt drops whole columns
+            // off the bottom in a single step.
+            double dt = Math.Min(120.0, tMs - _last) / 1000.0;
+            _last = tMs;
+
+            for (int i = 0; i < _cols.Count; i++)
+            {
+                double y = _y[i] + _speed[i] * dt;
+                if (y - _tail[i] > _rows)
+                {
+                    y = -2;                                  // CAMPUS: back to just above the glass
+                    _cols[i].Text = Roll(_tail[i]);          // and a fresh run of letters with it
+                }
+                _y[i] = y;
+
+                // SNAPPED TO WHOLE CELLS. The campus draws on integer rows, so the fall is stepped
+                // rather than smooth, and copying that is also the cheap choice here: text parked
+                // on a fractional offset re-rasterises with different hinting every frame and the
+                // whole column shimmers.
+                Canvas.SetTop(_cols[i], (Math.Floor(y) - _tail[i]) * _cell);
+            }
+
+            // THE CHURN, at a fraction of the price. The campus derives each glyph from its
+            // ABSOLUTE row, so a falling column's letters change under it; a per-column block
+            // cannot do that for free. One column re-rolls per frame instead, round robin, so each
+            // one turns over about once a second and the rain still crawls.
+            if (_cols.Count > 0)
+            {
+                _churn = (_churn + 1) % _cols.Count;
+                _cols[_churn].Text = Roll(_tail[_churn]);
+            }
+        }
+
+        /// <summary>A column's run of glyphs, one per line, built into the shared buffer.</summary>
+        private string Roll(int tail)
+        {
+            int len = 0;
+            for (int j = 0; j <= tail; j++)
+            {
+                if (j > 0) _buf[len++] = '\n';
+                _buf[len++] = Glyphs[_rng.Next(Glyphs.Length)];
+            }
+            return new string(_buf, 0, len);
+        }
+
+        /// <summary>
+        /// The tail fade as a frozen gradient: the campus's per-cell alpha (1 at the head, then
+        /// <c>max(0, 1 - k / tail) * 0.7</c> going up) written as two stops per line, so the bands
+        /// are hard-edged like drawn cells rather than a soft wash.
+        /// </summary>
+        private static LinearGradientBrush TailBrush(Color c, int tail)
+        {
+            int n = tail + 1;
+            var stops = new GradientStopCollection(n * 2);
+            for (int j = 0; j < n; j++)
+            {
+                int k = n - 1 - j;                            // 0 is the bottom line, and the head
+                double a = k == 0 ? 1.0 : Math.Max(0.0, 1.0 - (double)k / tail) * 0.7;
+                var band = Color.FromArgb((byte)Math.Round(a * 255.0), c.R, c.G, c.B);
+                stops.Add(new GradientStop(band, (double)j / n));
+                stops.Add(new GradientStop(band, (double)(j + 1) / n));
+            }
+            return Freeze(new LinearGradientBrush(stops, new Point(0, 0), new Point(0, 1)));
+        }
+    }
+
+    /// <summary>
+    /// CHANNEL OFF AIR. The campus CH8 test card: six colour bars, a dark plate with "brb" on it,
+    /// and NO SIGNAL along the bottom. She has stopped broadcasting.
+    ///
+    /// <para>THIS IS THE ONE THAT HAS TO SURVIVE A STARVED CLOCK. Everything else on the glass is a
+    /// thing in motion, so when the tick is throttled they degrade into a still of a half-drawn
+    /// animation. A test card is a still by nature, so this is the deep-idle look that still reads
+    /// when nothing moves - and that only holds if <see cref="Attach"/> alone leaves a FINISHED
+    /// card behind. It does: bars, dim, plate, "brb" and NO SIGNAL all land at once, and
+    /// <see cref="Tick"/> may do nothing at all forever without the picture looking unfinished.</para>
+    ///
+    /// <para>Which is the one deliberate break from the campus. There the dim and the NO SIGNAL
+    /// line both arrive at four seconds, on a channel that runs until you touch it. A desk channel
+    /// airs for ten (<see cref="ChannelLife"/>), so a bottom line that only shows up at second four
+    /// is a bottom line that never shows up on a throttled clock. Both are baked in at zero and the
+    /// tick is left holding a hum.</para>
+    /// </summary>
+    internal sealed class OffAirPainter : EmiChannelPainter
+    {
+        private const double RefGlass = 152.0;  // CAMPUS GLASS_W again
+
+        /// <summary>
+        /// CAMPUS BAR_COLOURS, in order. The third is the house cream, so it reuses the shared
+        /// brush rather than minting a second one of the same colour.
+        /// </summary>
+        private static readonly SolidColorBrush[] Bars =
+        {
+            Freeze(new SolidColorBrush(Color.FromRgb(0xB3, 0x6A, 0x75))),
+            Freeze(new SolidColorBrush(Color.FromRgb(0x5A, 0x6B, 0x84))),
+            CreamBrush,
+            Freeze(new SolidColorBrush(Color.FromRgb(0x4E, 0x8C, 0x86))),
+            Freeze(new SolidColorBrush(Color.FromRgb(0x7A, 0x5C, 0x87))),
+            Freeze(new SolidColorBrush(Color.FromRgb(0x2F, 0x2F, 0x3D)))
+        };
+
+        /// <summary>CAMPUS DARK, the plate the "brb" sits on. Not the screen navy.</summary>
+        private static readonly SolidColorBrush PlateBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)));
+
+        /// <summary>
+        /// The baked dim. The campus lands on 0.55 after its fade; this sits a little under it,
+        /// because there the bars have had four bright seconds first and here they never do, and a
+        /// card that opens at 0.55 opens looking switched off rather than signed off.
+        /// </summary>
+        private const double DimBase = 0.45;
+
+        private readonly double _w, _h, _k, _drift, _noSignalLeft;
+        private readonly bool _motion;
+
+        private readonly Rectangle _dim = new();
+        private readonly TextBlock _noSignal = new();
+
+        public OffAirPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            _k = Math.Max(0.1, w / RefGlass);
+            _drift = 4 * _k;                    // CAMPUS: NO SIGNAL steps four virtual px a second
+            _noSignalLeft = 10 * _k;
+
+            // Read once, not per frame. An airing is ten seconds long and nobody flips the motion
+            // setting inside one; the alternative is a guarded static property read at 30 fps.
+            _motion = MotionOk();
+        }
+
+        public override string Id => "offair";
+
+        public override void Attach(Panel host)
+        {
+            // The bars, edge to edge. The +1 on the width is the campus's own seam guard: six exact
+            // sixths of an odd width leave hairlines of backdrop showing between them.
+            double bw = _w / Bars.Length;
+            for (int i = 0; i < Bars.Length; i++)
+            {
+                host.Children.Add(Box(i * bw, 0, bw + 1, _h, Bars[i], 1.0));
+            }
+
+            _dim.Width = _w;
+            _dim.Height = _h;
+            _dim.Fill = SaverGlass.Black;
+            _dim.Opacity = DimBase;
+            _dim.IsHitTestVisible = false;
+            host.Children.Add(_dim);
+
+            // the centre plate
+            double r = 30 * _k;
+            var plate = new Ellipse
+            {
+                Width = r * 2,
+                Height = r * 2,
+                Fill = PlateBrush,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(plate, _w / 2 - r);
+            Canvas.SetTop(plate, _h / 2 - 6 * _k - r);
+            host.Children.Add(plate);
+
+            // "brb", lowercase, exactly as the campus says it. Centred by handing the block the
+            // full width and letting WPF centre inside it: the alternative is measuring pixel type,
+            // and Press Start 2P seen through a fallback chain is not a width this can predict.
+            double brbSize = Math.Max(6, 12 * _k);
+            var brb = new TextBlock
+            {
+                Text = "brb",
+                FontFamily = EmiFace.PixelFont,
+                FontSize = brbSize,
+                Foreground = CreamBrush,
+                Width = _w,
+                TextAlignment = TextAlignment.Center,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(brb, 0);
+            Canvas.SetTop(brb, _h / 2 - brbSize);
+            host.Children.Add(brb);
+
+            _noSignal.Text = "NO SIGNAL";
+            _noSignal.FontFamily = EmiFace.PixelFont;
+            _noSignal.FontSize = Math.Max(5, 7 * _k);
+            _noSignal.Foreground = CreamBrush;
+            _noSignal.Opacity = 0.85;
+            _noSignal.IsHitTestVisible = false;
+            Canvas.SetLeft(_noSignal, _noSignalLeft);
+            Canvas.SetTop(_noSignal, _h - Math.Max(9, 16 * _k));
+            host.Children.Add(_noSignal);
+
+            host.Children.Add(SaverGlass.ScanVeil(_w, _h, 0.16));    // CAMPUS scanlines(g, 0.16)
+        }
+
+        public override void Tick(double tMs)
+        {
+            // Nothing below is load bearing. Under reduced motion the card simply sits, which is
+            // the entire reason this channel exists.
+            if (!_motion) return;
+
+            // NO SIGNAL walks one step a second and wraps at six. That is the campus's whole
+            // animation, and it is why this look is the reduced-motion-safe one.
+            int step = (int)(tMs / 1000.0) % 6;
+            Canvas.SetLeft(_noSignal, _noSignalLeft + step * _drift);
+
+            // The hum: a tube that has been left on, not a fade. Two hundredths of opacity on a
+            // slow sine, plus one dropped frame about every three seconds - enough that a watching
+            // eye knows the set is still powered, small enough that a still of it is the same
+            // picture.
+            double flicker = tMs % 3300.0 < 60.0 ? -0.06 : 0.0;
+            _dim.Opacity = DimBase + 0.02 * Math.Sin(tMs / 900.0) + flicker;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Shop.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Shop.cs
@@ -1,0 +1,353 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace ConditioningControlPanel.Services.EmiDesk;
+
+public static partial class EmiChannels
+{
+    /// <summary>
+    /// CHANNEL SHOP AT HOME. The campus's CH5 (<c>Resources/web/arcademy/emi/channels.js</c>) on
+    /// the desk glass: one piece of in-universe merchandise turning on a pedestal, a price that
+    /// only ever falls, and a CALL NOW bar blinking at nobody.
+    ///
+    /// <para>THE JOKE IS THE LAYOUT, NOT THE ITEM. Every beat here is a shopping channel's tell -
+    /// the gold header, the plum product name, the price in a size nothing else on the glass gets,
+    /// the coral call bar. She is not selling anything (nothing on this channel is buyable, and a
+    /// tap on it just puts her face back, same as the pong board), she is doing the format.</para>
+    ///
+    /// <para>SIZING. Pong's numbers were quoted against a 60 px campus board, so its scalar is
+    /// <c>w / 60</c>; this channel's were written against the 152 x 137 campus GLASS, so the same
+    /// law with a different reference gives <c>w / 152</c>. One scalar covers both axes because the
+    /// desk glass keeps the campus aspect (137/152 and the desk's 0.903 are the same ratio).</para>
+    ///
+    /// <para>The desk glass is 60 to 175 DIPs across, which is a quarter of the campus width at the
+    /// bottom end, so the vertical stack is NOT the campus's literal y ladder. Bands and type are
+    /// floored at readable pixel sizes first and the pedestal takes what is left over. At 152 that
+    /// arithmetic lands within a few px of the campus frame, and at 60 it still reads as the same
+    /// appliance instead of overlapping into mush.</para>
+    /// </summary>
+    private sealed class ShopPainter : EmiChannelPainter
+    {
+        private const double RefGlass = 152.0;  // the campus GLASS_W the CH5 numbers are quoted at
+        private const double SpinStepMs = 220;  // CAMPUS: floor(t / 220) % 4
+        private const double PriceTickMs = 90;  // CAMPUS: floor(t / 90), one markdown per tick
+        private const double BlinkMs = 500;     // CAMPUS: floor(t / 500) % 2, the CALL NOW bar
+        private const double FloorBlinkMs = 250;
+        private const int FloorPrice = 9;       // CAMPUS: Math.max(9, ...). It never reaches zero.
+
+        /// <summary>
+        /// The price has to hit the floor while the channel is still up. <see cref="ChannelLife"/>
+        /// is ten seconds and the glitch flip eats the front of it, so aim the landing at seven and
+        /// a bit and leave the rest of the life for the floored bar to scream.
+        /// </summary>
+        private const double FallMs = 7300;
+
+        /// <summary>CAMPUS: the four step squeeze that reads as a turn. Frame 2 is edge on.</summary>
+        private static readonly double[] Squeeze = { 1.0, 0.6, 0.15, 0.6 };
+
+        private static readonly SolidColorBrush BgBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x12, 0x04, 0x0F)));   // CAMPUS #12040f
+        private static readonly SolidColorBrush BandBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x2A, 0x0A, 0x20)));   // CAMPUS #2a0a20
+        private static readonly SolidColorBrush GoldBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0xF2, 0xC1, 0x4E)));   // CAMPUS #F2C14E
+        private static readonly SolidColorBrush PlumBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0xC9, 0xA0, 0xDC)));   // CAMPUS #c9a0dc
+        private static readonly SolidColorBrush CoralBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0xE8, 0x83, 0x6F)));   // CAMPUS #E8836F, lit
+        private static readonly SolidColorBrush DeadBarBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x3A, 0x14, 0x20)));   // CAMPUS #3a1420, unlit
+        private static readonly SolidColorBrush DeadInkBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x7A, 0x40, 0x50)));   // CAMPUS #7a4050
+        private static readonly SolidColorBrush DarkInkBrush =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)));   // CAMPUS DARK, on coral
+
+        /// <summary>What is on the pedestal tonight. CAMPUS SHOP_ITEMS, prices included.</summary>
+        private enum Kind { Card, Watch, Disc }
+
+        private readonly Kind _kind;
+        private readonly string _label;
+        private readonly int _start;
+        private readonly int _drop;
+
+        private readonly double _w, _h, _k;
+        private double _ks;                     // the pedestal cluster's own scale, see Attach
+        private double _cx, _cy, _bodyW;
+
+        private readonly Rectangle _body = new();
+        private readonly Rectangle _base = new();
+        private readonly List<Rectangle> _detail = new(4);
+        private readonly Rectangle _foot = new();
+        private readonly TextBlock _price = new();
+        private readonly TextBlock _call = new();
+
+        private double _lastW = -1;
+        private int _shownPrice = -1;
+        private bool _lit = true;
+
+        public ShopPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            _k = Math.Max(0.35, w / RefGlass);
+
+            // Rng rather than a private Random: every painter is built on the dispatcher, and the
+            // shop has no per-instance stream to keep the way pong's fumble does.
+            switch (Rng.Next(3))
+            {
+                case 0: _kind = Kind.Card; _label = "CARD"; _start = 480; break;
+                case 1: _kind = Kind.Watch; _label = "WATCH"; _start = 1290; break;
+                default: _kind = Kind.Disc; _label = "DISC"; _start = 760; break;
+            }
+
+            // CAMPUS drops a flat 7 per tick, which lands CARD (480) on the floor at about six
+            // seconds and strands WATCH (1290) at four figures forever. On a page that sits there
+            // all evening that is fine; on a ten second channel a price that never arrives is a
+            // beat that never pays, so the slope is per item and 7 stays the minimum. CARD keeps
+            // the literal campus number; only the two that could not land get steeper.
+            int ticksToFloor = Math.Max(1, (int)(FallMs / PriceTickMs));
+            _drop = Math.Max(7, (int)Math.Ceiling((_start - FloorPrice) / (double)ticksToFloor));
+        }
+
+        public override string Id => "shop";
+
+        public override void Attach(Panel host)
+        {
+            // NOT the shared ScreenBrush. Every other channel sits on the dead navy the glass is
+            // when it is off; the shopping channel is a different appliance broadcasting into her,
+            // and the campus gives it its own maroon black to say so.
+            host.Children.Add(new Rectangle
+            {
+                Width = _w,
+                Height = _h,
+                Fill = BgBrush,
+                IsHitTestVisible = false
+            });
+
+            // ---- the stack, floored from the type outward ------------------------------------
+            // Press Start 2P is an 8 x 8 cell and smears between device pixels at fractional
+            // sizes, so every size here is a whole number. The per line divisors are the longest
+            // string that line can hold (the cell advance is one em), which is what keeps
+            // "SHOP AT HOME" inside a 60 DIP glass instead of running off both ends.
+            double titleSize = PixelSize(7 * _k, _w / 13.5, 4);
+            double callSize = PixelSize(7 * _k, _w / 8.5, 4);
+            double labelSize = PixelSize(7 * _k, _w / 6.0, 4);
+            double priceSize = PixelSize(12 * _k, _w / 7.5, 6);
+
+            double headH = Math.Max(titleSize * 1.6, 16 * _k);
+            double footH = Math.Max(callSize * 1.6, 14 * _k);
+            double priceTop = _h - footH - priceSize * 1.45 - _k;
+            double labelTop = priceTop - labelSize * 1.55;
+
+            host.Children.Add(Box(0, 0, _w, headH, BandBrush, 1.0));
+            host.Children.Add(CopyLine("SHOP AT HOME", titleSize, GoldBrush, Math.Max(0, (headH - titleSize * 1.35) / 2)));
+
+            // ---- the pedestal ------------------------------------------------------------------
+            // The campus cluster (item top at cy - 20 through the base bar's bottom at cy + 30) is
+            // 50 tall. Fit that block into whatever the bands and the type left behind and centre
+            // it, so the item shrinks rather than the copy when the user drags her small.
+            double stageTop = headH + _k;
+            double stageH = Math.Max(6 * _k, labelTop - stageTop - _k);
+            _ks = Math.Min(_k, stageH / 52.0);
+            _cx = _w / 2;
+            _cy = stageTop + (stageH - 50 * _ks) / 2 + 20 * _ks;
+
+            _base.Width = Math.Max(2, 52 * _ks);
+            _base.Height = Math.Max(1.5, 6 * _ks);
+            _base.Fill = BandBrush;
+            _base.IsHitTestVisible = false;
+            Canvas.SetLeft(_base, _cx - _base.Width / 2);
+            Canvas.SetTop(_base, _cy + 24 * _ks);
+            host.Children.Add(_base);
+
+            // The body and its cut-outs are built once and only ever resized: the spin is four
+            // widths on the same rectangles, never four rectangles.
+            double bodyH;
+            switch (_kind)
+            {
+                case Kind.Card: _bodyW = 34 * _ks; bodyH = 40 * _ks; _body.Fill = CreamInk; break;
+                case Kind.Watch: _bodyW = 30 * _ks; bodyH = 32 * _ks; _body.Fill = GoldBrush; break;
+                default: _bodyW = 36 * _ks; bodyH = 36 * _ks; _body.Fill = PinkBrush; break;
+            }
+            _body.Height = Math.Max(2, bodyH);
+            _body.Width = Math.Max(1, _bodyW);
+            _body.IsHitTestVisible = false;
+            Canvas.SetTop(_body, _cy - _body.Height / 2);
+            Canvas.SetLeft(_body, _cx - _body.Width / 2);
+            host.Children.Add(_body);
+
+            int details = _kind == Kind.Card ? 4 : 1;
+            for (int i = 0; i < details; i++)
+            {
+                // The card's pips read as a punched loyalty card; the watch's and the disc's single
+                // cut-out is the face and the hole. Both are the item's own dark, so the shape reads
+                // as one object rather than as two stacked blocks.
+                var cut = Box(0, 0, 1, 1, _kind == Kind.Disc ? BgBrush : BandBrush, 1.0);
+                _detail.Add(cut);
+                host.Children.Add(cut);
+            }
+
+            host.Children.Add(CopyLine(_label, labelSize, PlumBrush, labelTop));
+
+            _price.Text = _start.ToString(CultureInfo.InvariantCulture) + " SP";
+            _shownPrice = _start;
+            StyleLine(_price, priceSize, GoldBrush, priceTop);
+            host.Children.Add(_price);
+
+            // ---- CALL NOW ----------------------------------------------------------------------
+            _foot.Width = _w;
+            _foot.Height = footH;
+            _foot.Fill = CoralBrush;
+            _foot.IsHitTestVisible = false;
+            Canvas.SetLeft(_foot, 0);
+            Canvas.SetTop(_foot, _h - footH);
+            host.Children.Add(_foot);
+
+            _call.Text = "CALL NOW";
+            StyleLine(_call, callSize, DarkInkBrush, _h - footH + Math.Max(0, (footH - callSize * 1.35) / 2));
+            host.Children.Add(_call);
+
+            // The scanline mask every campus channel wears, as ONE tiled brush instead of seventy
+            // rectangles: the glass is short enough that a per line loop is affordable, but this
+            // painter already mutates a rectangle a frame and the mask never moves.
+            host.Children.Add(new Rectangle
+            {
+                Width = _w,
+                Height = _h,
+                Fill = ScanMask(Math.Max(2.0, 2 * _k)),
+                IsHitTestVisible = false
+            });
+
+            Paint(0);
+        }
+
+        public override void Tick(double tMs) => Paint(tMs);
+
+        private void Paint(double tMs)
+        {
+            // THE SPIN. The campus turns the item by squeezing it horizontally through four frames
+            // rather than by rotating it, because an 8 px pixel object that rotates smoothly stops
+            // looking like a pixel object. Frames 1 and 3 share a width, so the guard in SetWidth
+            // makes half the frames free.
+            SetWidth(Squeeze[(int)(tMs / SpinStepMs) & 3]);
+
+            int price = Math.Max(FloorPrice, _start - (int)(tMs / PriceTickMs) * _drop);
+            if (price != _shownPrice)
+            {
+                // Only on a change: at 30 fps the price moves about every third frame, and a string
+                // per frame for a number that did not move is the allocation storm the painter laws
+                // are about.
+                _shownPrice = price;
+                _price.Text = price.ToString(CultureInfo.InvariantCulture) + " SP";
+            }
+
+            // THE FLOOR IS THE PAYOFF. Once the price cannot fall any further the bar doubles its
+            // blink and takes the price with it, so the ten seconds end on a beat rather than on a
+            // number that simply stopped. The campus never needed this: its shop sits on the glass
+            // as long as the takeover lasts and the price is still falling when it goes.
+            bool floored = price <= FloorPrice;
+            bool lit = ((int)(tMs / (floored ? FloorBlinkMs : BlinkMs)) & 1) == 0;
+            if (lit == _lit && tMs > 0) return;
+            _lit = lit;
+            _foot.Fill = lit ? CoralBrush : DeadBarBrush;
+            _call.Foreground = lit ? DarkInkBrush : DeadInkBrush;
+            _price.Opacity = floored && !lit ? 0.45 : 1.0;
+        }
+
+        /// <summary>Resize the item and its cut-outs to this frame of the turn.</summary>
+        private void SetWidth(double squeeze)
+        {
+            double w = Math.Max(2 * _ks, _bodyW * squeeze);
+            if (Math.Abs(w - _lastW) < 0.05) return;
+            _lastW = w;
+
+            _body.Width = w;
+            Canvas.SetLeft(_body, _cx - w / 2);
+            double left = _cx - w / 2;
+
+            switch (_kind)
+            {
+                case Kind.Card:
+                    for (int i = 0; i < _detail.Count; i++)
+                    {
+                        // CAMPUS draws all four pips whenever the card is wider than 8, which spills
+                        // the last of them off a squeezed card. Per pip fitting instead: they vanish
+                        // into the edge as it turns, which is what a punched card actually does.
+                        double px = (4 + i * 7) * _ks;
+                        Show(_detail[i], px + 3 * _ks <= w, left + px, _cy - 12 * _ks, 3 * _ks, 3 * _ks);
+                    }
+                    break;
+                case Kind.Watch:
+                    Show(_detail[0], w > 10 * _ks, left + 4 * _ks, _cy - 12 * _ks, w - 8 * _ks, 24 * _ks);
+                    break;
+                default:
+                    Show(_detail[0], w > 12 * _ks, _cx - w / 4, _cy - 9 * _ks, w / 2, 18 * _ks);
+                    break;
+            }
+        }
+
+        private static void Show(Rectangle r, bool on, double x, double y, double w, double h)
+        {
+            r.Visibility = on ? Visibility.Visible : Visibility.Collapsed;
+            if (!on) return;
+            r.Width = Math.Max(0.5, w);
+            r.Height = Math.Max(0.5, h);
+            Canvas.SetLeft(r, x);
+            Canvas.SetTop(r, y);
+        }
+
+        /// <summary>A whole pixel size that both scales and fits the longest string on its line.</summary>
+        private static double PixelSize(double wanted, double fits, double floor) =>
+            Math.Max(floor, Math.Round(Math.Min(wanted, fits)));
+
+        /// <summary>
+        /// One centred line of TV copy. Centring is a full width TextBlock with
+        /// <see cref="TextAlignment.Center"/> rather than a measured offset, so the price can change
+        /// its digit count mid channel without a Measure pass per frame.
+        /// </summary>
+        private TextBlock CopyLine(string text, double size, Brush ink, double top)
+        {
+            var tb = new TextBlock { Text = text };
+            StyleLine(tb, size, ink, top);
+            return tb;
+        }
+
+        private void StyleLine(TextBlock tb, double size, Brush ink, double top)
+        {
+            tb.FontFamily = EmiFace.PixelFont;
+            tb.FontSize = size;
+            tb.Foreground = ink;
+            tb.Width = _w;
+            tb.TextAlignment = TextAlignment.Center;
+            tb.IsHitTestVisible = false;
+            Canvas.SetLeft(tb, 0);
+            Canvas.SetTop(tb, top);
+        }
+
+        /// <summary>
+        /// CAMPUS scanlines(g, 0.18): a one px black line every two px. 0x2E is that alpha, and the
+        /// tile is stretched with the glass so the pitch stays a scanline rather than becoming a
+        /// grille on a big window.
+        /// </summary>
+        private static DrawingBrush ScanMask(double pitch)
+        {
+            var line = new GeometryDrawing(
+                Freeze(new SolidColorBrush(Color.FromArgb(0x2E, 0, 0, 0))),
+                null,
+                new RectangleGeometry(new Rect(0, 0, 2, 1)));
+            return Freeze(new DrawingBrush(line)
+            {
+                TileMode = TileMode.Tile,
+                Viewbox = new Rect(0, 0, 2, 2),
+                ViewboxUnits = BrushMappingMode.Absolute,
+                Viewport = new Rect(0, 0, pitch, pitch),
+                ViewportUnits = BrushMappingMode.Absolute,
+                Stretch = Stretch.Fill
+            });
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Wrong.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Wrong.cs
@@ -1,0 +1,398 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace ConditioningControlPanel.Services.EmiDesk;
+
+public static partial class EmiChannels
+{
+    /// <summary>
+    /// THE WRONG CHANNEL. A port of the campus intrusion (<c>Resources/web/arcademy/emi/channels.js</c>,
+    /// CH6) onto the desk glass: for a beat, the tube shows a feed that is not hers.
+    ///
+    /// <para>It is not a channel in the way the others are. Pong and spiral and video are things she
+    /// puts on; this one arrives. On the campus it rides another channel's EXIT rather than sitting
+    /// on the wheel, because the moment a signal ghost is most believable is the moment the real
+    /// picture goes away. The desk keeps that shape: the ORCHESTRATOR lands this painter off its
+    /// exit hook, so the once-per-session lock and the 1-in-40 roll are not this file's business.
+    /// All this file owes is the look, and an arc short enough to be over before anyone decides
+    /// what they saw.</para>
+    ///
+    /// <para>NEVER ACKNOWLEDGED. <see cref="EmiChannelPainter.Payload"/> stays null (the base's), so
+    /// a tap fires nothing, and there is no line, no blip and no caught beat anywhere in here. The
+    /// campus comment is the whole design note: it is never explained.</para>
+    ///
+    /// <para>Deliberately NOT wearing the scanline mask the other channels wear. That mask is what
+    /// makes the deck read as one appliance, and this is not that appliance.</para>
+    /// </summary>
+    internal sealed class WrongPainter : EmiChannelPainter
+    {
+        /// <summary>Which of the campus's two intrusions this landing is. Chosen once, in the ctor.</summary>
+        private enum Wrongness
+        {
+            /// <summary>The glass floods pink and her face is punched out of it in dark, twice.</summary>
+            Negative,
+
+            /// <summary>Snow, with one word in it that is almost too faint to have been there.</summary>
+            Word
+        }
+
+        // The campus quotes this channel against its OWN glass, 152 x 137 virtual px (GLASS_W and
+        // GLASS_H in channels.js), not against the 60 px reference pong's dials come from. Same
+        // scaling law as pong, different divisor, so read every number below as campus px.
+        private const double RefW = 152.0;
+
+        // ---- the arc, in ms of Tick time -------------------------------------------------------
+        // The orchestrator tears this down after roughly 1200 to 1500 ms, and a teardown that is a
+        // frame late must never catch a live frame. So the whole thing is finished by 1150 and
+        // everything after that is a held black screen: worst case the user gets a few extra ms of
+        // dead tube, which is the correct ending anyway.
+        private const double FlashMs = 90;      // the break-in: one white hit, no warning
+        private const double CoreEndMs = 950;   // the wrongness itself
+        private const double DecayEndMs = 1150; // the collapse, and then dead
+
+        private const double ScrambleMs = 66;   // ~15 Hz. Snow, not a strobe, and a third of the churn
+        private const double RollMs = 700;      // one pass of the vertical-hold bar
+
+        // Campus densities times its 240 run budget: static_(0.55) under the word, static_r(0.12)
+        // over it.
+        private const int BaseGrains = 132;
+        private const int TopGrains = 29;
+
+        // Snow ink, verbatim from the campus helpers. The base pass is a dull grey pair so it reads
+        // as a dead carrier; the pass ON TOP of the word is half-alpha white and black, which is
+        // what buries the word without hiding it.
+        private static readonly SolidColorBrush GrainLight =
+            Freeze(new SolidColorBrush(Color.FromRgb(0xC9, 0xC9, 0xD6)));
+        private static readonly SolidColorBrush GrainDark =
+            Freeze(new SolidColorBrush(Color.FromRgb(0x4A, 0x4A, 0x58)));
+        private static readonly SolidColorBrush TopLight =
+            Freeze(new SolidColorBrush(Color.FromArgb(0x80, 0xFF, 0xFF, 0xFF)));
+        private static readonly SolidColorBrush TopDark =
+            Freeze(new SolidColorBrush(Color.FromArgb(0x80, 0x00, 0x00, 0x00)));
+
+        /// <summary>Campus <c>#e8e8f2</c>: the word is not cream and not pink, which is the point.</summary>
+        private static readonly SolidColorBrush WordInk =
+            Freeze(new SolidColorBrush(Color.FromRgb(0xE8, 0xE8, 0xF2)));
+
+        /// <summary>
+        /// The vertical-hold bar: a soft white band, transparent at both edges, that walks down the
+        /// glass. It is the one thing in here that says TUBE rather than says GLITCH, and it is what
+        /// keeps the snow from reading as a decoration.
+        /// </summary>
+        private static readonly LinearGradientBrush RollBrush = Freeze(new LinearGradientBrush(
+            new GradientStopCollection
+            {
+                new GradientStop(Color.FromArgb(0x00, 0xFF, 0xFF, 0xFF), 0.0),
+                new GradientStop(Color.FromArgb(0x2E, 0xFF, 0xFF, 0xFF), 0.5),
+                new GradientStop(Color.FromArgb(0x00, 0xFF, 0xFF, 0xFF), 1.0)
+            },
+            90.0));
+
+        /// <summary>
+        /// The campus word list (<c>WRONG_WORDS</c>), lowercase as written. Single innocent words,
+        /// never explained: the campus-side QA note is that the eeriness is the timing and not the
+        /// vocabulary, so do not make these cleverer.
+        /// </summary>
+        private static readonly string[] Words = { "soon", "hi", "again" };
+
+        // The face the negative is cut out of. The desk has no handle on what the locked face
+        // renderer is showing this instant, so this takes the campus's own fallback (its plan()
+        // ends with the literal 0_0) as a constant: a flat wide-eyed stare, the one that reads worst.
+        private const string NegativeFace = "0_0";
+
+        private readonly double _w, _h, _k;
+        private readonly Random _rng = new();
+        private readonly Wrongness _variant;
+
+        private readonly Rectangle _flash = new();   // the break-in hit
+        private readonly Rectangle _flood = new();   // negative: the pink ground
+        private readonly Rectangle _roll = new();    // the vertical-hold band
+        private readonly Rectangle _dead = new();    // black, over everything, the safe final frame
+        private readonly Rectangle _tear = new();    // the line the picture collapses into and dies
+        private readonly TextBlock _ghost = new();   // negative: the smaller one standing behind her
+        private readonly TextBlock _face = new();    // negative: her own face, punched dark
+        private readonly TextBlock _word = new();    // word: the thing that should not be legible
+
+        private readonly List<Rectangle> _snow = new();
+        private readonly List<Rectangle> _snowTop = new();
+
+        private double _faceX, _faceY;   // the face's resting corner; the twitch offsets from here
+        private double _rollH;
+        private double _lastScramble = double.NegativeInfinity;
+        private bool _ended;
+
+        // Two dropouts: the carrier goes entirely for a handful of frames. Seeded once so they land
+        // on different beats in different sessions, and both sit inside the core, never on the
+        // decay, where they would only look like the collapse stuttering.
+        private readonly double _dropAt0, _dropAt1, _dropFor0, _dropFor1;
+
+        public WrongPainter(double w, double h)
+        {
+            _w = w; _h = h;
+            _k = Math.Max(0.5, w / RefW);
+
+            _variant = _rng.NextDouble() > 0.5 ? Wrongness.Negative : Wrongness.Word;
+
+            _dropAt0 = 240 + _rng.NextDouble() * 180;
+            _dropAt1 = 620 + _rng.NextDouble() * 220;
+            _dropFor0 = 50 + _rng.NextDouble() * 30;
+            _dropFor1 = 50 + _rng.NextDouble() * 30;
+        }
+
+        public override string Id => "wrong";
+
+        public override void Attach(Panel host)
+        {
+            // The campus clears its snow to #0b0b12; the shared dead-screen navy is that colour to
+            // within a couple of levels, so the deck's own backdrop does the job.
+            AddBackdrop(host, _w, _h);
+
+            if (_variant == Wrongness.Negative) AttachNegative(host);
+            else AttachWord(host);
+
+            _rollH = Math.Max(2, _h * 0.16);
+            _roll.Width = _w;
+            _roll.Height = _rollH;
+            _roll.Fill = RollBrush;
+            _roll.IsHitTestVisible = false;
+            host.Children.Add(_roll);
+
+            // Order from here down is load bearing. The dead frame has to sit UNDER the collapsing
+            // line (a picture dying into a bright hairline on black) and under the break-in flash,
+            // and over everything else, so that raising one opacity is a guaranteed safe frame no
+            // matter what the variant left on screen.
+            _dead.Width = _w;
+            _dead.Height = _h;
+            _dead.Fill = ScreenBrush;
+            _dead.Opacity = 0;
+            _dead.IsHitTestVisible = false;
+            host.Children.Add(_dead);
+
+            _tear.Width = _w;
+            _tear.Height = _h;
+            _tear.Fill = CreamInk;
+            _tear.Opacity = 0;
+            _tear.IsHitTestVisible = false;
+            host.Children.Add(_tear);
+
+            _flash.Width = _w;
+            _flash.Height = _h;
+            _flash.Fill = CreamInk;
+            _flash.Opacity = 1;
+            _flash.IsHitTestVisible = false;
+            host.Children.Add(_flash);
+        }
+
+        /// <summary>
+        /// THE NEGATIVE. The glass floods pink and her face is the hole in it, with a second,
+        /// smaller one standing a few px behind and above it. Campus geometry: the ghost at 22 px
+        /// offset (+3, -6), her own at 30 px dead centre, both in the face font, because the shape
+        /// that unsettles is HER face rendered wrong and not some new drawing.
+        /// </summary>
+        private void AttachNegative(Panel host)
+        {
+            _flood.Width = _w;
+            _flood.Height = _h;
+            _flood.Fill = PinkBrush;
+            _flood.IsHitTestVisible = false;
+            host.Children.Add(_flood);
+
+            // Both faces take the shared dead-screen navy rather than a fresh dark brush: the hole
+            // punched in the pink should be the same nothing the tube shows when it is off.
+            _ghost.Text = NegativeFace;
+            _ghost.FontFamily = EmiFace.FaceFont;
+            _ghost.FontSize = Math.Max(5, 22 * _k);
+            _ghost.Foreground = ScreenBrush;
+            _ghost.Opacity = 0.55;
+            _ghost.IsHitTestVisible = false;
+            host.Children.Add(_ghost);
+            Centre(_ghost, 3 * _k, -6 * _k);
+
+            _face.Text = NegativeFace;
+            _face.FontFamily = EmiFace.FaceFont;
+            _face.FontSize = Math.Max(6, 30 * _k);
+            _face.Foreground = ScreenBrush;
+            _face.IsHitTestVisible = false;
+            host.Children.Add(_face);
+            var rest = Centre(_face, 0, 0);
+            _faceX = rest.X;
+            _faceY = rest.Y;
+        }
+
+        /// <summary>
+        /// THE WORD. Two thicknesses of snow with one word between them. The word sits UNDER the top
+        /// pass on purpose: legible enough to be read, buried enough that reading it feels like a
+        /// decision you made rather than something you were shown.
+        /// </summary>
+        private void AttachWord(Panel host)
+        {
+            // Grain COUNT is fixed and grain SIZE scales with the glass. The other way round (an
+            // area-scaled count) makes a 60 DIP glass read as dust on a dark screen instead of as a
+            // dead channel, because snow reads by grain density, not by grain count.
+            Snow(host, _snow, BaseGrains, GrainLight, GrainDark);
+
+            _word.Text = Words[_rng.Next(Words.Length)];
+            _word.FontFamily = EmiFace.PixelFont;
+            _word.FontSize = Math.Max(5, 14 * _k);
+            _word.Foreground = WordInk;
+            _word.Opacity = 0;
+            _word.IsHitTestVisible = false;
+            host.Children.Add(_word);
+            Centre(_word, 0, -6 * _k);
+
+            Snow(host, _snowTop, TopGrains, TopLight, TopDark);
+        }
+
+        private void Snow(Panel host, List<Rectangle> into, int count, Brush light, Brush dark)
+        {
+            double tall = Math.Max(0.5, _k);
+            for (int i = 0; i < count; i++)
+            {
+                // Width is drawn once per grain and never again. The campus re-rolls it every frame,
+                // but a pool of mixed-width runs that MOVE every frame is the same picture and does
+                // not put a layout pass on the glass thirty times a second.
+                double wide = Math.Max(0.5, (1 + _rng.Next(4)) * _k);
+                var r = Box(0, 0, wide, tall, i % 2 == 0 ? light : dark, 1.0);
+                into.Add(r);
+                host.Children.Add(r);
+            }
+        }
+
+        public override void Tick(double tMs)
+        {
+            // Past the arc: hold the dead frame. Guarded, so a late teardown costs one comparison a
+            // frame rather than a pile of property writes on a screen nobody is looking at.
+            if (tMs >= DecayEndMs)
+            {
+                if (_ended) return;
+                _ended = true;
+                _dead.Opacity = 1;
+                _tear.Opacity = 0;
+                return;
+            }
+
+            _flash.Opacity = tMs < FlashMs ? 1.0 - tMs / FlashMs : 0.0;
+
+            if (tMs < CoreEndMs)
+            {
+                Core(tMs);
+                return;
+            }
+
+            Decay((tMs - CoreEndMs) / (DecayEndMs - CoreEndMs));
+        }
+
+        private void Core(double tMs)
+        {
+            // A dropout is the black frame doing the same job it does at the end, briefly. One
+            // element, so there is no second way for the screen to go dark and no way for the two
+            // of them to disagree about who owns the top of the stack.
+            _dead.Opacity = InDropout(tMs) ? 1.0 : 0.0;
+
+            Canvas.SetTop(_roll, (tMs % RollMs) / RollMs * (_h + _rollH) - _rollH);
+
+            if (tMs - _lastScramble >= ScrambleMs)
+            {
+                _lastScramble = tMs;
+                Scramble();
+            }
+
+            if (_variant == Wrongness.Word)
+            {
+                // The word fades up, sits, and is gone well before the collapse, so it is never on
+                // screen at the moment the picture dies. Whatever was there had already left.
+                _word.Opacity = 0.35 * Ramp(tMs, 300, 380, 620, 700);
+            }
+        }
+
+        /// <summary>
+        /// The end: the picture collapses to a bright hairline and the line shrinks out, the way a
+        /// tube dies. The black frame rises underneath the whole way, so by the time the line is
+        /// gone the glass is already the safe final frame.
+        /// </summary>
+        private void Decay(double p)
+        {
+            p = Math.Clamp(p, 0, 1);
+            _dead.Opacity = p;
+
+            if (p < 0.6)
+            {
+                double q = p / 0.6;
+                double hair = Math.Max(1, _k);
+                double tall = _h + (hair - _h) * q;
+                _tear.Width = _w;
+                _tear.Height = tall;
+                Canvas.SetLeft(_tear, 0);
+                Canvas.SetTop(_tear, (_h - tall) / 2);
+                _tear.Opacity = 0.9;
+                return;
+            }
+
+            double r = (p - 0.6) / 0.4;
+            double wide = Math.Max(0.5, _w * (1 - r));
+            _tear.Width = wide;
+            Canvas.SetLeft(_tear, (_w - wide) / 2);
+            _tear.Opacity = 0.9 * (1 - r);
+        }
+
+        private bool InDropout(double t) =>
+            (t >= _dropAt0 && t < _dropAt0 + _dropFor0) ||
+            (t >= _dropAt1 && t < _dropAt1 + _dropFor1);
+
+        /// <summary>
+        /// Re-roll the intrusion. The snow moves; the negative twitches. Both variants get their one
+        /// change on the same beat, so the channel has a single heartbeat rather than two.
+        /// </summary>
+        private void Scramble()
+        {
+            if (_variant == Wrongness.Negative)
+            {
+                // A pixel of drift, no more. A face that swims reads as an effect; a face that is
+                // one pixel off where it just was reads as a picture nobody is holding steady.
+                Canvas.SetLeft(_face, _faceX + (_rng.NextDouble() - 0.5) * 2 * _k);
+                Canvas.SetTop(_face, _faceY + (_rng.NextDouble() - 0.5) * 2 * _k);
+                _ghost.Opacity = 0.45 + _rng.NextDouble() * 0.18;
+                return;
+            }
+
+            for (int i = 0; i < _snow.Count; i++) Move(_snow[i], GrainLight, GrainDark);
+            for (int i = 0; i < _snowTop.Count; i++) Move(_snowTop[i], TopLight, TopDark);
+        }
+
+        private void Move(Rectangle r, Brush light, Brush dark)
+        {
+            Canvas.SetLeft(r, Math.Floor(_rng.NextDouble() * _w));
+            Canvas.SetTop(r, Math.Floor(_rng.NextDouble() * _h));
+            r.Fill = _rng.NextDouble() > 0.5 ? light : dark;
+        }
+
+        /// <summary>
+        /// Centre a text block on the glass with an offset, and hand back where it landed. The
+        /// campus draws with textAlign centre and textBaseline middle; WPF has neither on a Canvas,
+        /// so this measures the ink once at attach time and never again.
+        /// </summary>
+        private Point Centre(TextBlock tb, double dx, double dy)
+        {
+            tb.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            var d = tb.DesiredSize;
+            double x = _w / 2 - d.Width / 2 + dx;
+            double y = _h / 2 - d.Height / 2 + dy;
+            Canvas.SetLeft(tb, x);
+            Canvas.SetTop(tb, y);
+            return new Point(x, y);
+        }
+
+        /// <summary>A 0 to 1 trapezoid: up over [a,b], held to c, down by d.</summary>
+        private static double Ramp(double t, double a, double b, double c, double d)
+        {
+            if (t <= a || t >= d) return 0;
+            if (t < b) return (t - a) / (b - a);
+            if (t <= c) return 1;
+            return (d - t) / (d - c);
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.cs
@@ -26,22 +26,31 @@ namespace ConditioningControlPanel.Services.EmiDesk;
 /// underneath the whole time, so killing a channel is hiding one node and never touches the locked
 /// face renderer.
 /// </summary>
-public static class EmiChannels
+public static partial class EmiChannels
 {
     /// <summary>The channel ids, in the order the ambient rotation offers them.</summary>
-    public static readonly IReadOnlyList<string> All = new[] { "pong", "spiral", "video", "burst", "rain" };
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        "pong", "spiral", "video", "burst", "rain",
+        "browsing", "shop", "reruns", "coderain", "offair",
+    };
 
     /// <summary>
     /// The channels that are a SCREEN SAVER rather than an offer: she is watching them and a tap
     /// only puts her face back. Everything else on the glass is a thing she is holding out to you,
     /// and <see cref="Fire"/> is what taking it does.
     ///
-    /// <para>Pong is the first, and it is why this distinction had to exist: the campus has had a
-    /// whole deck of savers (<c>emi/channels.js</c>) since the takeover work and the desk had none,
-    /// so every flip of the desk's glass was an offer of an EFFECT. Now the wheel can also just
-    /// find her playing something.</para>
+    /// <para>Pong was the first, and it is why this distinction had to exist: the campus has had
+    /// a whole deck of savers (<c>emi/channels.js</c>) since the takeover work and the desk had
+    /// none, so every flip of the desk's glass was an offer of an EFFECT. The 2026-08-30 port
+    /// brought the rest of the campus deck across, so most of what the wheel finds now is her
+    /// just watching television. "wrong" is here too even though it never enters the rotation
+    /// (it rides another channel's exit): a tap on it must put her face back, not fire anything.</para>
     /// </summary>
-    private static readonly HashSet<string> Savers = new(StringComparer.Ordinal) { "pong" };
+    private static readonly HashSet<string> Savers = new(StringComparer.Ordinal)
+    {
+        "pong", "browsing", "shop", "reruns", "coderain", "offair", "wrong",
+    };
 
     /// <summary>True when a tap on this channel fires nothing - see <see cref="Savers"/>.</summary>
     public static bool IsSaver(string? id) => id != null && Savers.Contains(id);
@@ -50,12 +59,15 @@ public static class EmiChannels
     public static readonly TimeSpan ChannelLife = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    /// Idle time before the glass flips (BRIEF 6). Ninety seconds is the owner lock; the only thing
-    /// that can move it is the EMI_DESK_IDLE_MS QA override (see <see cref="EmiDebug"/>), which is
-    /// absent in every normal launch.
+    /// Idle time before the glass flips. BRIEF 6 shipped this as a 90 s owner lock; on 2026-08-30
+    /// the owner unlocked it for the campus channel port ("one every 10 sec or so is fine"), so an
+    /// untouched desk now rotates like the campus TV. The glass resets its idle clock every time a
+    /// channel closes, so ten seconds here against <see cref="ChannelLife"/> reads as a natural
+    /// ~10 s on / ~10 s off rotation. The EMI_DESK_IDLE_MS QA override (see <see cref="EmiDebug"/>)
+    /// still wins when present.
     /// </summary>
     public static TimeSpan IdleBeforeFlip =>
-        EmiDebug.IdleMs is int ms ? TimeSpan.FromMilliseconds(ms) : TimeSpan.FromSeconds(90);
+        EmiDebug.IdleMs is int ms ? TimeSpan.FromMilliseconds(ms) : TimeSpan.FromSeconds(10);
 
     /// <summary>The glitch flip's length: three to four torn frames.</summary>
     public const int GlitchMs = 220;
@@ -112,8 +124,27 @@ public static class EmiChannels
         "video" => EmiOffers.HasVideos(),
         "burst" => EmiOffers.HasImages(),
         "rain" => EmiOffers.HasImages(),
+
+        // The campus deck (2026-08-30 port). The wireframe pages, the pedestal and the test card
+        // hold up fine as stills, so reduced motion keeps them; the code rain is refused for the
+        // same reason pong is - the falling glyphs ARE the channel.
+        "browsing" => true,
+        "shop" => true,
+        "reruns" => RerunsPainter.HasMaterial(),
+        "coderain" => MotionOk(),
+        "offair" => true,
+
+        // Never feasible by name on purpose: "wrong" is not in the rotation. It rides another
+        // channel's exit (the glass code rolls for it on close) and only ever lands there.
         _ => false
     };
+
+    /// <summary>
+    /// The exit roll for the WRONG CHANNEL intrusion (campus <c>rollWrong</c>): 1-in-40 on a
+    /// natural channel exit, full motion only - a glitch burst that cannot move is just a broken
+    /// screen. The once-per-session latch lives with the glass, which owns the session.
+    /// </summary>
+    public static bool RollWrong() => MotionOk() && Rng.Next(40) == 0;
 
     /// <summary>The app-wide motion setting, the same one the wave-A fidgets read. Never throws.</summary>
     private static bool MotionOk()
@@ -135,6 +166,12 @@ public static class EmiChannels
                 "video" => VideoPainter.TryBuild(w, h),
                 "burst" => BurstPainter.TryBuild(w, h),
                 "rain" => RainPainter.TryBuild(w, h),
+                "browsing" => new BrowsingPainter(w, h),
+                "shop" => new ShopPainter(w, h),
+                "reruns" => new RerunsPainter(w, h),
+                "coderain" => new CodeRainPainter(w, h),
+                "offair" => new OffAirPainter(w, h),
+                "wrong" => new WrongPainter(w, h),
                 _ => null
             };
         }

--- a/ConditioningControlPanel/Services/EmiDesk/EmiDebug.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiDebug.cs
@@ -7,8 +7,8 @@ namespace ConditioningControlPanel.Services.EmiDesk;
 /// <summary>
 /// The QA switches for EMI Desk, read ONCE from the environment at first touch.
 ///
-/// <para>EMI's cadence is deliberately slow: the glass waits 90 s of stillness before it flips to a
-/// channel, a line is gated behind a 45 s global floor and a per-moment cooldown that runs to
+/// <para>EMI's cadence is deliberately slow: the glass waits a stillness beat before it flips to a
+/// channel (10 s since the owner unlocked the rotation for the 2026-08-30 campus port), a line is gated behind a 45 s global floor and a per-moment cooldown that runs to
 /// minutes, and an offer needs a third summon plus 10 minutes since the last one. Those numbers are
 /// owner locks (BRIEF 6 / 7 / 8) and none of them are tunable from the UI, which makes the glass,
 /// the asks and most of the moments unreachable in a play-test that lasts minutes rather than

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Glass.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiDeskWindow.Glass.cs
@@ -14,8 +14,9 @@ namespace ConditioningControlPanel;
 /// THE GLASS: what she puts on her own little screen when nobody has touched her for a while, and
 /// what a tap on it does.
 ///
-/// The whole feature is one offer with no words in it. After 90 s of real idle her glass glitches
-/// over to a channel for 10 s and then glitches back. Tap it and the thing on the screen happens.
+/// The whole feature is one offer with no words in it. After 10 s of real idle (the owner
+/// unlocked BRIEF 6's 90 s on 2026-08-30) her glass glitches over to a channel for 10 s and then
+/// glitches back: an untouched desk rolls like a little television. Tap it and the thing on the screen happens.
 /// Do not, and she never mentions it: the decline line is wordless by design (BRIEF 6), because the
 /// failure mode here is an ad break, and an ad break that also nags is unforgivable.
 ///
@@ -58,6 +59,13 @@ public partial class EmiDeskWindow
     /// on a 30 s floor instead of only on an abandoned desk (found on the desk, 2026-08-30).</para>
     /// </summary>
     private bool _offering;
+
+    /// <summary>The WRONG CHANNEL has aired. Once a session, exactly like the campus latch.</summary>
+    private bool _wrongAired;
+
+    /// <summary>How long the wrong channel holds the glass. The painter's whole arc is authored
+    /// to finish inside this - flash in, wrongness, cut - plus a dead beat for a late teardown.</summary>
+    private const int WrongLifeMs = 1400;
     private bool _channelTapped;
     private bool _emiOwnsTheVideo;
     private bool _glassHooked;
@@ -218,7 +226,7 @@ public partial class EmiDeskWindow
     /// <summary>
     /// Put a channel on the glass RIGHT NOW if every gate allows it, and say whether one went up.
     /// The fidget wheel's door to the flip: same gate, same painter, same ten second life as the
-    /// idle watch's, only reached from the rotation instead of from the 90 second clock.
+    /// idle watch's, only reached from the rotation instead of from the idle clock.
     /// </summary>
     internal bool TryFlipGlassNow()
     {
@@ -460,6 +468,65 @@ public partial class EmiDeskWindow
             // Wordless on purpose. effectDeclined is a HOLD row in the moments table, so the engine
             // hands back a face and no bubble, and she never mentions the thing you ignored.
             App.EmiDesk?.Fire("effectDeclined", new { channel = id });
+        }
+
+        // THE WRONG CHANNEL (campus CH6, ported 2026-08-30). Once a session, 1-in-40, a channel
+        // exit is not a clean cut: something that should not be on any feed flashes up for a
+        // second and a half and dies. It rides exits only - never offered, never in the rotation -
+        // and its own close (id == "wrong") may not roll again.
+        if (!_wrongAired && id != "wrong" && !_closingForGood
+            && Visibility == Visibility.Visible && !ChainLive && !AskLive
+            && EmiChannels.RollWrong())
+        {
+            _wrongAired = true;
+            LandWrong();
+        }
+    }
+
+    /// <summary>
+    /// Land the wrong-channel intrusion directly: no glitch lead-in (it IS the glitch), no
+    /// glassOffer, no life beyond <see cref="WrongLifeMs"/>. Any failure just leaves the glass
+    /// dark, which is exactly what a wrong channel cutting out looks like.
+    /// </summary>
+    private void LandWrong()
+    {
+        try
+        {
+            var rect = GlassRect;
+            var painter = EmiChannels.Build("wrong", rect.Width, rect.Height);
+            if (painter == null) return;
+
+            EnsureGlassLayers();
+            if (_glassLayer == null) return;
+
+            _channel = "wrong";
+            _painter = painter;
+            _channelTapped = false;
+            _glassLive = true;
+            StopIdleBeats();
+
+            _glassLayer.Children.Clear();
+            painter.Attach(_glassLayer);
+            _glassLayer.Visibility = Visibility.Visible;
+
+            _channelUpUtc = DateTime.UtcNow;
+            painter.Tick(0);
+
+            _frames = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
+            {
+                Interval = TimeSpan.FromMilliseconds(FrameMs)
+            };
+            _frames.Tick += OnChannelFrame;
+            _frames.Start();
+
+            _channelLife = NewTimer(WrongLifeMs, () => CloseChannel(declined: false));
+
+            Log.Information("[EmiDesk] wrong channel rode the exit");
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "[EmiDesk] wrong channel failed to land");
+            CloseChannel(false, silent: true);
         }
     }
 

--- a/ConditioningControlPanel/docs/emi-desk/BRIEF.md
+++ b/ConditioningControlPanel/docs/emi-desk/BRIEF.md
@@ -72,7 +72,8 @@ Commit on `feat/emi-desk` when your chunk builds; never push, never open a PR, n
    **The tutorial that stops** (wave 3): three nudge tracks teach the pat, the ring and pinning, and
    go permanently silent at 3 pats / 2 ring opens / 1 pin, with a hard cap of 6 lines each, never two
    within 90 s. Never call the glyph a "door" in anything a user can read.
-6. **The glass.** Idle for 90s (no input on her, ring closed, no ask open, no line on screen): the glass
+6. **The glass.** Idle for 10s (shipped at 90s; the owner unlocked the rotation for the 2026-08-30
+   campus channel port; no input on her, ring closed, no ask open, no line on screen): the glass
    glitch-flips to a channel for 10s: `spiral` (animated spiral; tap = `App.Overlay.ShowOverlayTimed("spiral", 6000, ...)`),
    `video` (a thumbnail of a random local video; tap = `App.Video.PlaySpecificVideo(path)`, EMI goes
    Topmost over the video and says a `videoRunning` line), `burst` (3-4 random local gifs/images on her

--- a/Tests/ConditioningControlPanel.Tests/EmiChannelCatalogueTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiChannelCatalogueTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using ConditioningControlPanel.Services.EmiDesk;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The glass channel catalogue, pinned. The 2026-08-30 campus port turned five channels into ten
+/// plus an intrusion, and the ids live as bare strings in three switches (Feasible, Build, the
+/// Savers set) that a typo desyncs without a compile error - a misspelled id is a channel that
+/// simply never airs. These pins are the compile error.
+/// </summary>
+public class EmiChannelCatalogueTests
+{
+    [Fact]
+    public void The_rotation_offers_the_campus_deck_in_order()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "pong", "spiral", "video", "burst", "rain",
+                "browsing", "shop", "reruns", "coderain", "offair",
+            },
+            EmiChannels.All);
+    }
+
+    [Fact]
+    public void Savers_watch_and_offers_fire()
+    {
+        // She is watching these; a tap only puts her face back.
+        foreach (var id in new[] { "pong", "browsing", "shop", "reruns", "coderain", "offair", "wrong" })
+            Assert.True(EmiChannels.IsSaver(id), id);
+
+        // These are held out to you; a tap takes the offer.
+        foreach (var id in new[] { "spiral", "video", "burst", "rain" })
+            Assert.False(EmiChannels.IsSaver(id), id);
+    }
+
+    [Fact]
+    public void Wrong_never_enters_the_rotation()
+    {
+        // It rides another channel's exit (the glass rolls for it on close) and lands there only.
+        Assert.DoesNotContain("wrong", EmiChannels.All);
+        Assert.False(EmiChannels.Feasible("wrong"));
+    }
+
+    [Fact]
+    public void The_owner_unlocked_the_ten_second_rotation()
+    {
+        // "one every 10 sec or so is fine" (owner, 2026-08-30). The close resets the idle clock,
+        // so these constants together are the ~10 s on / ~10 s off television rhythm, and the
+        // fidget wheel's screen-beat floor agrees with the glass's own clock.
+        Assert.Equal(TimeSpan.FromSeconds(10), EmiChannels.IdleBeforeFlip);
+        Assert.Equal(TimeSpan.FromSeconds(10), EmiChannels.ChannelLife);
+        Assert.Equal(10_000, EmiAlive.ScreenBeatRestMs);
+    }
+}


### PR DESCRIPTION
The desk glass had five channels (one saver); the campus TV (emi/channels.js) has had a whole deck since the takeover work. This brings the rest across and unlocks the rotation.

## New channels (all SAVERS - she is watching them, a tap only puts her face back)
- **browsing** (CH2): six wireframe pages incl the BANK beat, page flip on dwell
- **shop** (CH5): pedestal item (CARD 480 / WATCH 1290 / DISC 760), falling price with a per-item slope so it lands inside the 10s airing, CALL NOW blink payoff
- **reruns** (CH4): best graded class off the days blob in arcademy_meta.json (stamp-cached, refuses when there is no graded S/A row)
- **coderain** (CH7): the katakana rain, one TextBlock per column; full motion only
- **offair** (CH8): test card + NO SIGNAL, authored to read finished as a still (reduced motion keeps it)
- **wrong** (CH6): rides a channel exit once a session, 1-in-40, 1.4s burst that dies to black; never in the rotation, never offered

## Cadence
Owner unlock 2026-08-30 ("one every 10 sec or so is fine"): IdleBeforeFlip 90s -> 10s, ScreenBeatRestMs 30s -> 10s. The close resets the idle clock, so an untouched desk rolls ~10s on / ~10s off like the campus TV. ChannelLife stays 10s and the glassOffer/ask odds are untouched, so offers stay rare at the new rate. Every stale 90s comment/doc passage retuned (EmiChannels, EmiAlive, EmiDebug, Glass header, BRIEF rule 6).

## Tests
New EmiChannelCatalogueTests pins the deck order, the saver split, wrong's exclusion and the 10s constants. Full suite 4847/4847 green, 0 build errors, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nMSMQZ2ieD7Hp9enNq63J