### PR TITLE
fix(emi-desk): first ring open was invisible (XAML Visibility=Hidden trap)

### DIFF
--- a/ConditioningControlPanel/Windows/EmiDesk/EmiRingWindow.xaml
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiRingWindow.xaml
@@ -15,11 +15,18 @@
         SnapsToDevicePixels="True"
         Topmost="True"
         Focusable="False"
-        Visibility="Hidden"
         Width="600" Height="400">
 
     <!--
         THE RING.
+
+        NO Visibility="Hidden" HERE (the book's lesson - see EmiBookWindow.xaml). This window is
+        built by EnsureRing and shown by OpenRing in the SAME dispatcher turn, so a XAML hide is
+        queued against an HWND that does not exist yet and lands ~50 ms AFTER Show: WS_VISIBLE
+        goes off the HWND while IsOpen and IsVisible keep reading true. That was the whole of
+        "I gotta click 2 or 3 times for the wheel to pop up" - the first open was real but
+        invisible, and the next click went to the global close hook and folded it. A Window is
+        not visible until Show() runs anyway, so the property simply goes.
 
         A SIBLING window, not a layer inside EmiDeskWindow: the widget carries only 120 DIPs of pad
         around her silhouette, and a full fan at a 420 DIP body needs far more than that. This window

--- a/ConditioningControlPanel/Windows/EmiDesk/EmiRingWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/EmiDesk/EmiRingWindow.xaml.cs
@@ -275,11 +275,30 @@ public partial class EmiRingWindow : Window
     }
 
     private const int GWL_EXSTYLE = -20;
+    private const int GWL_STYLE = -16;
+    private const int WS_VISIBLE = 0x10000000;
     private const int WS_EX_TOOLWINDOW = 0x00000080;
     private const int WS_EX_NOACTIVATE = 0x08000000;
 
     [System.Runtime.InteropServices.DllImport("user32.dll")]
     private static extern int GetWindowLong(IntPtr hwnd, int index);
+
+    /// <summary>
+    /// The NATIVE visibility word for the "ring open" log line. WPF's own properties lied for the
+    /// whole of the invisible-first-open bug (see the note at the top of the XAML); only the HWND
+    /// told the truth, so this is what a repeat would be caught by.
+    /// </summary>
+    private string NativeStyle()
+    {
+        try
+        {
+            var h = new WindowInteropHelper(this).Handle;
+            if (h == IntPtr.Zero) return "wsvisible=nohwnd";
+            int st = GetWindowLong(h, GWL_STYLE);
+            return "wsvisible=" + ((st & WS_VISIBLE) != 0);
+        }
+        catch { return "wsvisible=?"; }
+    }
 
     [System.Runtime.InteropServices.DllImport("user32.dll")]
     private static extern int SetWindowLong(IntPtr hwnd, int index, int newStyle);
@@ -374,7 +393,7 @@ public partial class EmiRingWindow : Window
             _closeAnnounced = false;
 
             EmiSfx.RingOpen();
-            Log.Information("[EmiDesk] ring open with {Count} cards", _slots.Count);
+            Log.Information("[EmiDesk] ring open with {Count} cards, {Native}", _slots.Count, NativeStyle());
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Owner report: right-click on EMI needs 2-3 clicks before the wheel pops, first time only.

The log told the story: the first right-click DID open the ring (`ring open with 6 cards`) and the next click closed it unpicked ~1s later - the open was real but invisible. It is the book's bug (see the write-up in EmiBookWindow.xaml): the ring window is built and shown in the SAME dispatcher turn, so the XAML `Visibility="Hidden"` is queued against an HWND that does not exist yet and lands ~50ms after Show - WS_VISIBLE off, IsOpen/IsVisible still true. The next click goes to the global close hook and folds the invisible ring; the third opens it visibly, since the queued hide has spent itself. Hence "just the first time".

Fix mirrors the book's cure:
- `Visibility="Hidden"` removed from EmiRingWindow.xaml (a Window is not visible until Show() anyway), with the trap documented at the top of the XAML
- the `ring open` log line now reads WS_VISIBLE off the HWND (`wsvisible=...`), so a repeat is caught by the log rather than by the owner

4847/4847 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nMSMQZ2ieD7Hp9enNq63J