### PR TITLE
fix(arcademy): Impulse Control spiral pop echo + the EMI card melt is gone

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/cameo.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/cameo.js
@@ -17,7 +17,7 @@
  *                  no slide at all. Pat her and a manila FOLDER slaps down
  *                  over the basin with a polaroid clipped to it: a live loop,
  *                  a live spiral, a burst, or a stapled note. It holds, then
- *                  a wax sheet melts the whole thing away.
+ *                  it fades away.
  *
  * WHAT A CAMEO IS NOT: A PLAN SLOT.  It is dealt BETWEEN plan bubbles, from
  * `nextBubble()`, and the cursor does not move while it runs. It never writes
@@ -40,7 +40,7 @@
  *       pointer-events:auto rules on that layer, and this feature adds none).
  *       The class's own bubble is never moved, resized, hidden or delayed.
  *   III never still   - the ring breathes, the halo cracks, the photo develops,
- *       the wax runs. All of it CSS, so `.suspended` freezes the lot.
+ *       the card fades out. All of it CSS, so `.suspended` freezes the lot.
  *   IV  images over text - one folder tab, one stamp, and the note card's two
  *       lines. Everything else is drawn.
  *   V   seeded        - three append-only streams off `seed|ic-cameo|`:
@@ -68,7 +68,7 @@
  *
  * THE STYLESHEET is style.js's (the class sheet, one document-level
  * singleton). No new image asset ships with this deck: the folder, the
- * polaroid, the halo, the ring and the wax are all gradients and masks.
+ * polaroid, the halo and the ring are all gradients and masks.
  * ==========================================================================*/
 
 import { makeRng } from '../../core/rng.js';
@@ -95,13 +95,13 @@ export const IC_CAMEO = Object.freeze({
   /** Both cards: no pat by then and she squints and goes home. */
   STOWAWAY_WAIT_MS: 4500,
   DOSSIER_WAIT_MS: 4500,
-  /** The photo holds this long before the wax (owner: about 3 s). */
+  /** The photo holds this long before it leaves (owner: about 3 s). */
   DOSSIER_HOLD_MS: 3000,
   /** How long she stays after the shock chain, so she is still there while
-   *  the folder is open. handle.end() cuts it short at the melt. */
+   *  the folder is open. handle.end() cuts it short at the exit. */
   DOSSIER_STAY_MS: 6000,
-  /** Anomaly's number, and the folder's exit rides it. */
-  MELT_MS: 1400,
+  /** The folder's exit: a plain fade, nothing to sit through. */
+  EXIT_MS: 240,
   /** The basin settle after she is home - the plan's own between-bubble beat
    *  (schedule.js GAP_MS), so a cameo hands the tube back on the same rhythm. */
   GAP_MS: 350,
@@ -255,7 +255,7 @@ export function createIcCameo(o) {
   let ring = null;
   let halo = null;
   let folder = null;
-  let melting = null;           // the folder mid-melt: still ours to remove
+  let leaving = null;           // the folder mid-fade: still ours to remove
   let handle = null;            // the live visit handle, or null
   let visiting = null;          // 'stowaway' | 'dossier' | null
   let rafId = 0;
@@ -658,7 +658,7 @@ export function createIcCameo(o) {
     if (kind === 'burst') burstAround();
 
     const holdMs = IC_CAMEO.DOSSIER_HOLD_MS * (jackpot ? 2 : 1);
-    after(holdMs, melt);
+    after(holdMs, dismiss);
   }
 
   /** One polaroid (or the stapled note), clipped to the folder. */
@@ -796,25 +796,23 @@ export function createIcCameo(o) {
     });
   }
 
-  /* --------------------------------------------------------------- THE MELT */
-  function melt() {
+  /* --------------------------------------------------------------- THE EXIT */
+  /** The card goes. It used to MELT - a wax sheet ran down it for 1.4s and
+   *  dripped - and the owner's verdict on 2026-08-31 was "it shows, it's bad,
+   *  remove it". It fades now, and that is the whole ceremony. */
+  function dismiss() {
     if (destroyed || !folder) return;
-    /* the photo stops being alive the moment the wax starts: one cancelled
-       frame loop, and she is sent home in the same breath. */
+    /* the photo stops being alive the moment the card starts leaving: one
+       cancelled frame loop, and she is sent home in the same breath. */
     stopFrames();
     const host = folder;
-    const wax = el('i', 'g-ic-cameo-wax', host);
-    if (wax) {
-      try { if (typeof wax.offsetWidth === 'number') void wax.offsetWidth; } catch (e) { /* noop */ }
-      setCls(wax, 'on', true);
-    }
-    setCls(host, 'melting', true);
-    melting = host;
+    setCls(host, 'leaving', true);
+    leaving = host;
     cue('whoosh', 0.4);
     try { if (handle && typeof handle.end === 'function') handle.end(); }
     catch (e) { /* noop */ }
     folder = null;
-    after(IC_CAMEO.MELT_MS + 120, () => { if (melting === host) melting = null; drop(host); });
+    after(IC_CAMEO.EXIT_MS + 120, () => { if (leaving === host) leaving = null; drop(host); });
   }
 
   /* ------------------------------------------------------------- TEARDOWN */
@@ -830,7 +828,7 @@ export function createIcCameo(o) {
     drop(ring); ring = null;
     drop(halo); halo = null;
     drop(folder); folder = null;
-    drop(melting); melting = null;
+    drop(leaving); leaving = null;
     sweepParting();
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
@@ -215,11 +215,28 @@ html.arc-reduced .g-ic-dusk{transition:none}
   @keyframes g-ic-holdfade{from{opacity:1}to{opacity:.15}}}
 
 /* ------------------------------------------------------------ the flourish */
-.g-ic-flourish{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);width:0;height:0;pointer-events:none;z-index:4;display:grid;place-items:center;overflow:visible}
-.g-ic-flourish-img{width:34vmin;height:34vmin;object-fit:contain;opacity:0;
-  animation:g-ic-spiralout 1s ease-out forwards}
-@keyframes g-ic-spiralout{0%{opacity:.9;transform:scale(.3) rotate(0)}
-  100%{opacity:0;transform:scale(2.4) rotate(300deg)}}
+/* THE ONE POP - and it is ONE. The flourish wears the bubble's own spiral.png,
+   so anything that makes it read as a SEPARATE object reads as the bubble
+   popping twice (owner 2026-08-31: "an echo of the bubble pop").
+   Two things did:
+     1. THE OFFSET. place-items:center does NOT centre an over-sized item on a
+        0x0 box - Chromium start-aligns it, so a 34vmin flourish bloomed with
+        its TOP-LEFT on the basin, i.e. 17vmin down-and-right of the bubble it
+        was supposed to be replacing. Measured: bubble centre (632,353),
+        flourish centre (752,472). Centre it the way .g-ic-basin centres the
+        bubble - left/top 0 inside the 0x0 anchor plus translate(-50%,-50%) -
+        and drop the grid.
+     2. THE RESTART. It began at scale .3 of 34vmin = ~10vmin, SMALLER than the
+        17.5vmin bubble that had just gone, so the art shrank and then grew
+        again: a second expand-and-pop. It now starts at exactly the bubble's
+        size and full opacity and only ever grows, so it CONTINUES the pop the
+        bubble started (render.js snaps the bubble out on the same tick).
+   End reach is unchanged: 17.5vmin * 4.6 ~= the old 34vmin * 2.4. */
+.g-ic-flourish{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);width:0;height:0;pointer-events:none;z-index:4;overflow:visible}
+.g-ic-flourish-img{position:absolute;left:0;top:0;width:var(--ic-basin-d);height:var(--ic-basin-d);
+  object-fit:contain;opacity:0;animation:g-ic-spiralout 1s ease-out both}
+@keyframes g-ic-spiralout{0%{opacity:1;transform:translate(-50%,-50%) scale(1) rotate(0)}
+  100%{opacity:0;transform:translate(-50%,-50%) scale(4.6) rotate(300deg)}}
 
 /* --------------------------------------------------------------- the stamp */
 /* tracks the bubble: just clear of its crown, still inside the crater's mouth */
@@ -734,47 +751,31 @@ html.arc-reduced.ae-touch .g-ic-hw-go,html.arc-reduced.ae-touch .g-ic-bubble.hit
   font-size:11px;letter-spacing:.18em;text-transform:uppercase}
 .g-ic-file-note-line{display:block;font-size:14px;line-height:1.4}
 
-/* ---- THE MELT (Anomaly's wax, on phase only - nothing reforms here) ---- */
-.g-ic-cameo-wax{position:absolute;left:-2px;right:-2px;top:0;bottom:-2px;border-radius:4px;
-  opacity:0;overflow:visible;transform-origin:50% 0;
-  background:linear-gradient(180deg, rgba(90,20,60,0) 0%, rgba(120,26,74,.55) 30%,
-    rgba(150,32,92,.8) 100%)}
-.g-ic-cameo-wax.on{animation:g-ic-cam-wax 1.4s cubic-bezier(.5,.05,.7,1) forwards}
-@keyframes g-ic-cam-wax{0%{opacity:0;transform:scaleY(.2)}
-  25%{opacity:.85;transform:scaleY(.6)}100%{opacity:.95;transform:scaleY(1.08)}}
-.g-ic-cameo-wax::before,.g-ic-cameo-wax::after{content:"";position:absolute;top:100%;
-  width:14%;height:0;border-radius:0 0 50% 50%;background:rgba(150,32,92,.85);
-  box-shadow:0 2px 8px rgba(120,26,74,.6)}
-.g-ic-cameo-wax::before{left:22%}
-.g-ic-cameo-wax::after{left:61%;width:10%}
-.g-ic-cameo-wax.on::before{animation:g-ic-cam-drip 1.4s .3s ease-in forwards}
-.g-ic-cameo-wax.on::after{animation:g-ic-cam-drip 1.4s .55s ease-in forwards}
-@keyframes g-ic-cam-drip{from{height:0}to{height:46%}}
+/* ---- THE EXIT ----
+   There used to be a MELT here: a magenta wax sheet (.g-ic-cameo-wax) that ran
+   down over the card for 1.4s and grew two drips out of its bottom edge, while
+   the card underneath never moved and then hard-cut away. Owner 2026-08-31:
+   "it shows, it's bad - remove it." The card leaves the way everything else in
+   this room leaves: it fades. No wax, no drips, no overlay node. */
+.g-ic-file.leaving{animation:g-ic-file-out .24s ease-in forwards}
+@keyframes g-ic-file-out{from{opacity:1}to{opacity:0}}
 
 /* ---- REDUCED MOTION (trap 92: the exit is an animation on the ROOT) ---- */
 .g-ic-file.is-reduced{animation:g-ic-file-in-r .2s ease-out both}
-.g-ic-file.is-reduced.melting{animation:g-ic-file-out-r .3s ease-out forwards}
+.g-ic-file.is-reduced.leaving{animation:g-ic-file-out-r .2s ease-out forwards}
 .g-ic-file.is-reduced *{animation:none !important}
 @keyframes g-ic-file-in-r{from{opacity:0}to{opacity:1}}
 @keyframes g-ic-file-out-r{from{opacity:1}to{opacity:0}}
-.g-ic-file.is-reduced .g-ic-cameo-wax{opacity:.7;transform:none}
-.g-ic-file.is-reduced .g-ic-cameo-wax::before,
-.g-ic-file.is-reduced .g-ic-cameo-wax::after{display:none}
 @media (prefers-reduced-motion: reduce){
   .g-ic-cameo-ring::after,.g-ic-cameo-halo::after,.g-ic-polaroid-well.conic::before{animation:none}
   .g-ic-cameo-ring.on{animation:none;transform:translate(-50%,-50%) scale(1)}
   .g-ic-cameo-halo.on{animation:none;transform:translate(-50%,-50%) scale(1)}
-  .g-ic-cameo-wax.on{animation:none;opacity:.7;transform:none}
-  .g-ic-cameo-wax::before,.g-ic-cameo-wax::after{display:none}
 }
 html.arc-reduced .g-ic-cameo-ring::after,
 html.arc-reduced .g-ic-cameo-halo::after,
 html.arc-reduced .g-ic-polaroid-well.conic::before{animation:none}
 html.arc-reduced .g-ic-cameo-ring.on{animation:none;transform:translate(-50%,-50%) scale(1)}
 html.arc-reduced .g-ic-cameo-halo.on{animation:none;transform:translate(-50%,-50%) scale(1)}
-html.arc-reduced .g-ic-cameo-wax.on{animation:none;opacity:.7;transform:none}
-html.arc-reduced .g-ic-cameo-wax::before,
-html.arc-reduced .g-ic-cameo-wax::after{display:none}
 
 /* ---- THE PHONE CEILING (html.ae-touch / html.arc-mobile, trap 42) ----
    The well shrinks to the narrow rule the plan sets (min(280px,70vw)) and the


### PR DESCRIPTION
Two owner reports from the same room, both in `games/impulse-control/`.

## 1. The spiral pop echo

> "when we pop a spiral bubble we see an echo of the bubble pop, double animation of the bubble expanding and popping"

The spiral flourish wears the bubble's **own** `spiral.png`, so anything that makes it read as a separate object reads as a second bubble popping. `81e1382a0` stopped the bubble's own `.pop` from running underneath it, but two things in the flourish's own CSS were still doing it:

**1. The offset — this is the real one.** `.g-ic-flourish` is a `0x0` anchor at the basin point and centred its art with `display:grid;place-items:center`. That does **not** centre an item bigger than its `0x0` area — Chromium start-aligns it — so the `34vmin` flourish bloomed with its **top-left** on the basin, i.e. `17vmin` down-and-right of the bubble it was replacing. Measured in a browser rig at 1264x705:

| node | centre |
|---|---|
| basin anchor | (632, 353) |
| bubble | (632, 353) |
| flourish (before) | **(752, 472)** |
| flourish (after) | (632, 353) |

The player watched the bubble vanish and a second spiral swell out of a *different spot*. That is the echo. It is now centred the way `.g-ic-basin` centres the bubble — `left/top:0` inside the `0x0` anchor plus `translate(-50%,-50%)` — and the grid is gone.

**2. The restart.** It began at `scale(.3)` of `34vmin` (~10vmin), *smaller* than the `17.5vmin` bubble that had just gone, so the same art shrank and then grew again: a second expand-and-pop. It now starts at exactly the bubble's size (`--ic-basin-d`) at full opacity and only ever grows, so it continues the pop the bubble started. End reach is unchanged (`17.5vmin * 4.6` is the old `34vmin * 2.4`).

## 2. The EMI clipboard card melt

> "the EMI melting animation for the clipboard cards, it shows, it's bad — remove it"

The cameo folder exited under `.g-ic-cameo-wax`: a magenta wax sheet that ran down the card for 1.4s and grew two drips out of its bottom edge, while the card underneath never moved and then hard-cut away.

Removed: the wax node, `g-ic-cam-wax`, `g-ic-cam-drip`, and all six of its reduced-motion overrides. The card now fades — `.g-ic-file.leaving`, 240ms — which is the exit the reduced-motion path already used. `melt()` is `dismiss()`, `MELT_MS: 1400` is `EXIT_MS: 240`, and no overlay node is minted at all.

## Verification

- Rebuilt a no-store static rig over `Resources/web/arcademy` and probed the real `style.js`: geometry table above, plus a paused-keyframe filmstrip showing the flourish now leaving the bubble's exact size and centre and blooming once.
- Confirmed the bubble ends the pop tick as `.gone / animation:none / opacity:0`, so exactly one animation runs.
- `.g-ic-file.leaving` and `.g-ic-file.is-reduced.leaving` both resolve; modules parse.
- `dotnet build` green (0 errors).

Not merged — owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jv6WC2ve6iEhh3MjqGUDwz
