### PR TITLE
fix(update): upgrade the copy that is running, not the one the registry remembers

### DIFF
--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -235,6 +235,28 @@ Something new is coming on September 1. Stay tuned... :3";
         }
 
         /// <summary>
+        /// The folder the running exe actually lives in, but only when that folder is a real
+        /// Inno install (its uninstaller sits next to the exe). This is the ground truth for an
+        /// in-place upgrade: unlike the HKCU InstallPath echo it cannot go stale, and it moves
+        /// with the folder when a user relocates the install by hand. Returns null for a
+        /// portable/dev run, or when the exe path can't be resolved.
+        /// </summary>
+        private static string? GetRunningInstallDir()
+        {
+            try
+            {
+                var exeDir = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule?.FileName);
+                if (string.IsNullOrEmpty(exeDir)) return null;
+
+                return File.Exists(Path.Combine(exeDir, "unins000.exe")) ? exeDir : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets the installed version from registry (set by the installer).
         /// Returns null if not installed via installer or registry key not found.
         /// </summary>
@@ -787,12 +809,35 @@ Something new is coming on September 1. Stay tuned... :3";
                 throw new FileNotFoundException("Installer not found", installerPath);
             }
 
-            // Get the current install path from registry (set by Inno Setup)
-            var installPath = GetInstalledPath();
+            // Where to upgrade. The folder the running exe lives in wins over the registry:
+            // HKCU InstallPath is only an echo written at install time, so it goes stale the
+            // moment the user moves the folder by hand or an earlier update relocated the app.
+            // Feeding a stale value to /DIR is what pins the relocation in place - every future
+            // update installs into a folder the user never launches from (ccp-bugs#1090,
+            // ccp-bugs#1004), so they keep starting the old exe and keep being told an update is
+            // available (ccp-bugs#973, #849, #567, #554). Upgrading whatever copy is running
+            // also self-heals an install that already drifted.
+            var registryPath = GetInstalledPath();
+            var installPath = GetRunningInstallDir();
+
             if (string.IsNullOrEmpty(installPath))
             {
-                // Fallback: use the directory where the exe is running from
-                installPath = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule?.FileName);
+                // The running copy is not a recognisable Inno install (portable or dev run, or
+                // the uninstaller was deleted). Use the registry echo, then the exe's own
+                // folder. If neither resolves we pass no /DIR at all and let Inno's
+                // UsePreviousAppDir pick the previous location - no /DIR beats a wrong one.
+                installPath = !string.IsNullOrEmpty(registryPath)
+                    ? registryPath
+                    : Path.GetDirectoryName(Process.GetCurrentProcess().MainModule?.FileName);
+            }
+            else if (!string.IsNullOrEmpty(registryPath) &&
+                     !string.Equals(Path.TrimEndingDirectorySeparator(installPath),
+                                    Path.TrimEndingDirectorySeparator(registryPath),
+                                    StringComparison.OrdinalIgnoreCase))
+            {
+                App.Logger?.Warning(
+                    "Install path mismatch - running from {Running} but registry says {Registry}. " +
+                    "Upgrading the running copy; the registry value is stale.", installPath, registryPath);
             }
 
             App.Logger?.Information("Launching installer for silent update: {Path}, InstallDir: {Dir}", installerPath, installPath);

--- a/installer.iss
+++ b/installer.iss
@@ -30,6 +30,11 @@
 
 [Setup]
 ; Application identity
+; AppId is the key every upgrade hangs off: Setup finds the previous install (and therefore its
+; directory, its privileges mode and its uninstall entry) by this GUID alone. It has been this
+; value since the installer was introduced and must NEVER change - a new GUID would make every
+; existing install invisible to Setup, so upgrades would install fresh into DefaultDirName and
+; leave the old copy behind.
 AppId={{A7B9C3D1-E5F2-4A8B-9C1D-2E3F4A5B6C7D}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
@@ -46,6 +51,17 @@ DefaultGroupName={#MyAppName}
 ; Allow user to change install directory
 DisableDirPage=no
 DirExistsWarning=auto
+
+; An upgrade must never move an existing install. Both of these are already Inno's defaults,
+; but they are now load-bearing and are pinned so they cannot be turned off by accident: when
+; the in-app updater cannot determine which folder the running app lives in it deliberately
+; passes NO /DIR and relies on Setup recovering the previous location by AppId (ccp-bugs#1090,
+; ccp-bugs#1004). UsePreviousPrivileges matters for the same reason - PrivilegesRequired below
+; is "lowest", so without it a per-machine ("all users") install would be looked for in the
+; per-user hive only, no previous directory would be found, and the upgrade would land in
+; DefaultDirName instead of on top of the existing install.
+UsePreviousAppDir=yes
+UsePreviousPrivileges=yes
 
 ; Output settings
 OutputDir=.\installer-output


### PR DESCRIPTION
Fixes the install-path relocation family: the update installs somewhere other than where the app lives, and the app then relaunches on the old version.

Reported in CC-Labs-llc/ccp-bugs#1090 (v6.8.6, "install path is messed up... the install is located elsewhere when updating", corroborated in a support ticket: "the installation path is still fucked on my install") and CC-Labs-llc/ccp-bugs#1004 (v6.8.1, "downloading updates causes a subfolder and doesnt retain original download location, has to manually move from one subfolder to the main folder"). Same root cause as the older "updates but relaunches on the old version" reports: CC-Labs-llc/ccp-bugs#973, CC-Labs-llc/ccp-bugs#849, CC-Labs-llc/ccp-bugs#567, CC-Labs-llc/ccp-bugs#554.

## Root cause

`RunInstallerSilentlyAndExit` decided where to install by reading `HKCU\Software\CodeBambi\Conditioning Control Panel\InstallPath` and passing it to Inno as `/DIR=`:

```csharp
// Get the current install path from registry (set by Inno Setup)
var installPath = GetInstalledPath();
if (string.IsNullOrEmpty(installPath))
{
    // Fallback: use the directory where the exe is running from
    installPath = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule?.FileName);
}
```

That registry value is not a live location. It is an echo written once, at install time, by `[Registry] ... ValueName: "InstallPath"; ValueData: "{app}"`. Nothing keeps it in sync afterwards. The moment it diverges from where the app actually sits - the user moves the folder by hand, or an earlier update already relocated the app - `/DIR=` **forces** the new files into the stale path.

Two things follow, and they are the two reported symptoms:

1. The upgrade lands in a folder the user does not launch from (#1090, #1004). The running install is left untouched at the old version.
2. Because the shortcut, the pinned taskbar entry and the user's habit still point at the untouched copy, the next launch is the **old** exe, which checks for updates and offers the same update again - forever (#973, #849, #567, #554).

It is also self-reinforcing: once the two paths diverge, `/DIR=` re-pins the divergence on every single update. That matches the reports being spread across v6.3.0 -> v6.8.6 rather than clustering on one release.

Supporting evidence that this is the custom-directory case rather than a default-install case: both "relaunches the old version" reporters run from non-default directories, visible in their attached logs.

- #567: `E:\Conditioning Control Panel\Resources\...`
- #554: `A:\VODs\Miscellaneous\CC\Conditioning Control Panel\Resources\...`

### Ruled out

The obvious installer-side suspects were checked and are **not** the cause, so nothing behavioural was changed in `installer.iss`:

- **AppId is stable.** `{{A7B9C3D1-E5F2-4A8B-9C1D-2E3F4A5B6C7D}` has never been edited - `git log -S"AppId=" -- installer.iss` returns exactly one commit, the one that introduced the installer. A drifting AppId would have produced these symptoms, but it did not drift.
- **`DefaultDirName` is not versioned.** `{autopf}\{#MyAppName}`, also untouched since introduction (same single commit under `git log -S"DefaultDirName"`).
- **`/DIR=` was not missing.** It has been passed since v6.3.0 (`e48dadba1`, the #499 helper work). The bug is not the absent flag, it is the *wrong value* in the flag - which is why the #499 fix did not close this family.
- **The download is not the problem.** `DownloadInstallerAsync` stages into `%TEMP%\ConditioningControlPanel_Update`, never into the install directory.

## The fix

**`UpdateService.cs`** - make the running executable's own folder the ground truth for an in-place upgrade.

New `GetRunningInstallDir()` returns the directory the running exe lives in, but only when that directory is a genuine Inno install (`unins000.exe` sits beside the exe). This value cannot go stale, and critically it *travels with the folder* when a user relocates the install by hand - which is exactly the case the registry echo gets wrong.

The resolution order in `RunInstallerSilentlyAndExit` becomes:

1. Running install directory (new, preferred).
2. Registry `InstallPath` (the previous primary, now a fallback for a portable/dev run or an install whose uninstaller was deleted).
3. The exe's own directory (unchanged last resort).
4. **Nothing** - and in that case no `/DIR=` is passed at all, letting Inno recover the previous location itself via `UsePreviousAppDir`. A wrong `/DIR=` is worse than no `/DIR=`; the existing `WriteUpdateHelperScript` already omits the flag on an empty path, so this needed no change there.

When the running folder and the registry disagree, that is logged as a warning naming both paths, so the next report of this shape is diagnosable from the log alone instead of requiring the user to describe their folder layout.

This also **self-heals** installs that already drifted: whichever copy the user actually launches is the copy that gets upgraded, and the relaunch target (`appExe`) is derived from the same path, so the helper restarts the copy it just updated.

**`installer.iss`** - deliberately conservative, no behavioural change:

- Comment on `AppId` recording that it is the key every upgrade hangs off and must never change (documenting the invariant that was verified above).
- `UsePreviousAppDir=yes` and `UsePreviousPrivileges=yes` pinned explicitly. **Both are already Inno's defaults, so compiled output is unchanged** - but they are now load-bearing for fallback 4 above, and `UsePreviousPrivileges` additionally protects the per-machine ("all users") install case: `PrivilegesRequired=lowest` means that without it Setup would look for the previous install in the per-user hive only, find no previous directory, and fall back to `DefaultDirName`. Pinning them stops a future edit from silently reintroducing the relocation.

### Why this is safe

- The default-directory install is unaffected: the running folder and the registry agree there, so the same `/DIR=` is passed as before.
- No version, release plumbing, or localization file was touched.
- The elevation probe, the update helper script, the wait-for-exit handshake and the relaunch are all unchanged.
- Only two call sites read `GetInstalledPath()` in the whole codebase (`IsInstalledViaInstaller` and this method); `IsInstalledViaInstaller` is intentionally left alone since it already has its own account-independent `unins000.exe` fallback.

## Validation

`dotnet build` from `ConditioningControlPanel`: **0 errors**, 346 warnings (at/below the ~350 baseline).

**`installer.iss` could not be compiled in this environment** (no ISCC available), so the two directives added there were validated by reading only. They are documented Inno Setup 6 `[Setup]` directives, set to their own default values, in a script that already relies on 6.x-only directives (`PrivilegesRequiredOverridesAllowed`, `WizardSizePercent`). A compile check before shipping is still worth doing.

## MUST be manually tested before shipping

This is the auto-updater; a regression here strands users on a dead build. The matrix below needs a real Setup.exe pair (a build of the current release and a build of this branch) on a real machine.

**1. Default-directory install (the regression guard).** Install to the default `{autopf}\Conditioning Control Panel`, then auto-update. Verify the files land in that same folder, no second copy appears anywhere, and the app relaunches on the new version. This is the path most users take and it must be byte-for-byte the old behaviour.

**2. Custom-directory install (the actual bug).** Install to a custom path such as `E:\CCP` or `D:\Games\Conditioning Control Panel`, then auto-update. Verify the upgrade lands in that custom folder, that no copy appears under `%LOCALAPPDATA%\Programs\Conditioning Control Panel`, and that the relaunched app reports the new version.

**3. Moved-folder install (the self-heal, i.e. #1004's reporter).** Install anywhere, close the app, move the whole install folder to a new location, launch the app from the moved folder, then auto-update. Before this change the update would go back to the pre-move path; it must now land in the moved folder. The new "Install path mismatch" warning should appear in the log naming both paths.

**4. Per-machine / elevated install.** Install to `C:\Program Files\...` choosing "install for all users" in the privileges dialog, then auto-update. Verify the UAC prompt appears while the app is still on screen, the upgrade lands in Program Files, and declining the prompt leaves the app alive on the old version (the existing decline path).

**5. Old-version relaunch check.** For each of the above, confirm after relaunch that the title/about reports the NEW version and that the update button does not immediately re-offer the same update - that is the exact signature of #973 / #849 / #567 / #554.

Worth checking `%LOCALAPPDATA%\ConditioningControlPanel\logs\update-helper.log` after each run; it records the installer command line and exit code.

## Follow-ups, deliberately not in this PR

- `PrivilegesRequiredOverridesAllowed=dialog` does not include `commandline`, so a silent upgrade of an all-users install cannot be told `/ALLUSERS` and runs in per-user install mode. That leaves registry cruft (a duplicate per-user uninstall entry) rather than relocating anything, and passing the flag risks a new elevation failure mode, so it was left alone.
- Nothing re-syncs the stale HKCU `InstallPath` after a hand-move. This PR stops that value from doing harm rather than repairing it; a startup re-sync would be a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
