### PR TITLE
fix(bubblecount): bubble-count games no longer vanish into the For You feed

### DIFF
--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -77,6 +77,11 @@ public class BubbleCountService : IDisposable
         _retryCount = 0;
         _schedulerTimer?.Stop();
         _schedulerTimer = null;
+
+        // A defer that outlived the service must not coalesce (and so swallow) every future
+        // trigger - same latch reset VideoService.Stop does for its #1073 defer.
+        _feedDeferPending = false;
+        _feedDeferDeadlineUtc = DateTime.MinValue;
         CloseMessageWindows();
         CleanupTempPackFiles();
 
@@ -118,6 +123,146 @@ public class BubbleCountService : IDisposable
         App.Logger?.Debug("Next bubble count game in {Interval:F1} seconds", interval);
     }
 
+    /// <summary>True while the For You feed is actually on the user's screen. A GHOSTED feed is
+    /// deliberately NOT included (sister of #1073): ghost mode parks the real window off-screen and
+    /// leaves a see-through, click-through DWM mirror, so nothing is competing for the screen and
+    /// there is no reason to stand a bubble-count game down.</summary>
+    private static bool FeedOwnsTheScreen =>
+        Fyp.FypHostService.IsActive && !Fyp.FypHostService.IsGhosted;
+
+    /// <summary>True while a game is parked waiting for the For You feed to leave the screen.
+    /// One pending replay at a time — a feed session that swallows several triggers replays one
+    /// game, not a backlog. Cleared by <see cref="Stop"/> so a defer that outlived the service
+    /// cannot coalesce (and so swallow) every future trigger.</summary>
+    private bool _feedDeferPending;
+
+    /// <summary>Longest a trigger will wait out an on-screen feed. Deliberately short, and the same
+    /// ceiling VideoService uses: the feed can stay open for hours (which is why the original guard
+    /// refused to queue behind it at all), and a counting game that fires many minutes after the
+    /// trigger that earned it is a surprise, not a reward. Past this, the trigger is given up on —
+    /// never accumulated.</summary>
+    private static readonly TimeSpan FeedDeferMaxWait = TimeSpan.FromSeconds(90);
+
+    /// <summary>Absolute expiry of the CURRENT feed-defer chain, set on its first defer.
+    /// <see cref="DateTime.MinValue"/> = no chain in flight.</summary>
+    private DateTime _feedDeferDeadlineUtc = DateTime.MinValue;
+
+    /// <summary>Hold a trigger the For You guard refused and replay it once the feed leaves the
+    /// screen (closed, or ghosted away).</summary>
+    private void DeferGamePastFeed(bool forceTest)
+    {
+        if (_feedDeferPending)
+        {
+            App.Logger?.Information("BubbleCountService: For You replay already pending - trigger coalesced");
+            return;
+        }
+
+        // Ceiling measured from the FIRST defer of the chain, not per-hop: a replay that lands back
+        // in front of the feed must not restart the clock.
+        var now = DateTime.UtcNow;
+        if (_feedDeferDeadlineUtc == DateTime.MinValue)
+            _feedDeferDeadlineUtc = now + FeedDeferMaxWait;
+
+        var remaining = _feedDeferDeadlineUtc - now;
+        if (remaining <= TimeSpan.Zero)
+        {
+            App.Logger?.Information("BubbleCountService: For You replay dropped - past the {Sec:F0}s defer ceiling",
+                FeedDeferMaxWait.TotalSeconds);
+            _feedDeferDeadlineUtc = DateTime.MinValue;
+            return;
+        }
+
+        _feedDeferPending = true;
+        RunWhenFeedClear(
+            () =>
+            {
+                _feedDeferPending = false;
+
+                // Re-assert the preconditions at FIRE time. The defer can easily outlive the thing
+                // that justified it - the engine stopped, the user turned bubble count off (#872) -
+                // and replaying then opens a fullscreen game out of a feature that is switched off.
+                // forceTest is the dashboard's own "play it now" and stays exempt, as it is above.
+                if (!forceTest && (!_isRunning || App.Settings?.Current?.BubbleCountEnabled != true))
+                {
+                    App.Logger?.Information("BubbleCountService: For You replay abandoned - bubble count no longer running");
+                    _feedDeferDeadlineUtc = DateTime.MinValue;
+                    return;
+                }
+
+                TriggerGame(forceTest);
+
+                // TriggerGame may have parked itself again (the feed came back). Only release the
+                // ceiling when the chain really ended, so a re-defer inherits it instead of buying
+                // itself another full window.
+                if (!_feedDeferPending) _feedDeferDeadlineUtc = DateTime.MinValue;
+            },
+            remaining,
+            onExpired: () =>
+            {
+                _feedDeferPending = false;
+                _feedDeferDeadlineUtc = DateTime.MinValue;
+            });
+    }
+
+    /// <summary>
+    /// Run <paramref name="action"/> as soon as the For You feed is off the screen, and give up
+    /// after <paramref name="maxWait"/> so nothing can be held forever. Same shape as
+    /// VideoService.RunWhenFeedClear and for the same reason: there is no "feed closed" event to
+    /// hang off, and ghost mode enters and leaves without one either, so the UI dispatcher is
+    /// polled twice a second. Callers only reach here while the feed IS on screen, so there is no
+    /// fire-immediately branch - the first tick handles the case where it has already gone.
+    ///
+    /// <para><paramref name="onExpired"/> is the UNCONDITIONAL give-up callback: it runs on every
+    /// path where <paramref name="action"/> will not, including the "there is no dispatcher to poll
+    /// on" early return. The caller latches a "defer pending" flag before calling in, and a silent
+    /// early return here would latch it forever.</para>
+    /// </summary>
+    private static void RunWhenFeedClear(Action action, TimeSpan maxWait, Action? onExpired = null)
+    {
+        if (action == null) return;
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.HasShutdownStarted)
+        {
+            // No dispatcher to poll on, so the action can never run - release the caller's latch.
+            try { onExpired?.Invoke(); } catch { }
+            return;
+        }
+
+        var deadline = DateTime.UtcNow + maxWait;
+        // Normal, not Background: this project has a documented starvation issue where Background /
+        // Loaded priority work is starved out under load, which would stall the poll that releases
+        // the parked trigger.
+        var timer = new DispatcherTimer(DispatcherPriority.Normal, dispatcher)
+        {
+            Interval = TimeSpan.FromMilliseconds(500)
+        };
+        timer.Tick += (_, _) =>
+        {
+            try
+            {
+                if (FeedOwnsTheScreen && DateTime.UtcNow < deadline) return;   // still on screen, still within the window
+                timer.Stop();
+                if (FeedOwnsTheScreen)
+                {
+                    App.Logger?.Information("BubbleCountService: deferred game expired - For You feed still on screen after {Sec:F0}s",
+                        maxWait.TotalSeconds);
+                    onExpired?.Invoke();
+                    return;
+                }
+                App.Logger?.Information("BubbleCountService: For You feed left the screen - firing deferred game");
+                action();
+            }
+            catch (Exception ex)
+            {
+                try { timer.Stop(); } catch { }
+                try { onExpired?.Invoke(); } catch { }
+                App.Logger?.Debug("BubbleCountService.RunWhenFeedClear: {E}", ex.Message);
+            }
+        };
+        timer.Start();
+        App.Logger?.Information("BubbleCountService: deferring bubble count game until the For You feed leaves the screen");
+    }
+
     public void TriggerGame(bool forceTest = false)
     {
         // Allow forced test even when engine not running
@@ -151,14 +296,29 @@ public class BubbleCountService : IDisposable
         // on, whether this game touches the shared LibVLC instance at all depends on the FILE, and
         // no file has been chosen yet.
 
-        // For You feed open: bubble count is a video-class interaction and stands down like
-        // the mandatory video does. Drop, never queue (the feed outlives the stuck window),
-        // handing a dequeued slot straight back.
-        if (Fyp.FypHostService.IsActive)
+        // For You feed ON SCREEN: bubble count is a video-class interaction and stands down like
+        // the mandatory video does. This guard was copied from the video one and inherited both of
+        // its bugs, fixed there as #1073:
+        //
+        //  1. It gated on IsActive alone, which is just `_host != null`, and a GHOSTED feed is still
+        //     "active". Ghost mode parks the real window off-screen and leaves a see-through,
+        //     click-through DWM mirror - nothing is competing for the screen, so a game is exactly
+        //     as appropriate as it would be with the feed closed. A user browsing ghosted had every
+        //     bubble-count game silently eaten while seeing no feed at all. Hence FeedOwnsTheScreen.
+        //  2. It DROPPED, so a game the scheduler (or a bubble payload) earned simply evaporated.
+        //     The trigger is now held and replayed once the feed leaves the screen - closed, or
+        //     ghosted away.
+        //
+        // The old comment's concern ("never queue: the feed outlives the stuck window") is still
+        // honoured, twice over: the queue slot is RELEASED here rather than held across the wait,
+        // and the wait itself is capped at FeedDeferMaxWait, so nothing parks behind an all-evening
+        // feed session.
+        if (FeedOwnsTheScreen)
         {
-            App.Logger?.Information("BubbleCountService: game dropped - For You feed active");
+            App.Logger?.Information("BubbleCountService: game deferred - For You feed on screen");
             if (App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.BubbleCount)
                 App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+            DeferGamePastFeed(forceTest);
             return;
         }
 


### PR DESCRIPTION
## The sister bug of CC-Labs-llc/ccp-bugs#1073

No ccp-bugs issue exists for this one. It was found while fixing #1073 ("video bubbles vanish into For You", PR #401 / `0d26e13cf`): `BubbleCountService`'s For You guard had been copied from `VideoService`'s, comment and all, so it carried both of the same faults into the Level 50+ counting minigame.

`ConditioningControlPanel/Services/BubbleCountService.cs:157` (before this change):

```csharp
// For You feed open: bubble count is a video-class interaction and stands down like
// the mandatory video does. Drop, never queue (the feed outlives the stuck window),
// handing a dequeued slot straight back.
if (Fyp.FypHostService.IsActive)
{
    App.Logger?.Information("BubbleCountService: game dropped - For You feed active");
    ...
    return;
}
```

### What was wrong

**1. A ghosted feed still counted as "active".** `FypHostService.IsActive` is just `_host != null`. Ghost mode does not close the feed; it parks the real window off-screen and leaves a see-through, click-through DWM mirror. Nothing is competing for the screen, so there is no reason to stand a game down — but a user browsing ghosted had every bubble-count game silently eaten while seeing no feed at all.

**2. It dropped rather than deferred.** A scheduled game that evaporates is simply lost, which is the mistake #1073 corrected in the video path (and #871 two guards higher in that same method).

### The fix — same pattern as #401

- `FeedOwnsTheScreen => IsActive && !IsGhosted`, so a ghosted feed suppresses nothing.
- A visible feed **defers and replays** instead of dropping, via `DeferGamePastFeed` + `RunWhenFeedClear` — the direct analogues of `VideoService`'s `DeferTriggerPastFeed` / `RunWhenFeedClear`.

The old comment's concern ("never queue: the feed outlives the stuck window") is still honoured, twice over. This does **not** queue:

- the `InteractionQueue` slot is **released first** — the same lines the drop already ran — so the wait happens outside the queue and cannot block every interaction for the 5-minute stuck window;
- the wait itself is capped at `FeedDeferMaxWait` (90s, the same ceiling `VideoService` uses), anchored at the **first** defer of a chain so a replay that lands back in front of the feed cannot restart the clock;
- one latch, coalesce-not-append: a feed session that swallows several triggers replays one game, not a backlog;
- preconditions are re-asserted at fire time (engine still running, `BubbleCountEnabled` still true — the #872 failure mode; `forceTest` stays exempt exactly as it is in the guard above);
- `Stop()` clears the latch and the deadline, so a defer that outlived the service cannot coalesce (and so swallow) every future trigger.

There is no fire-immediately branch in `RunWhenFeedClear`: callers only reach it while the feed *is* on screen, and the first tick covers the case where it has already gone. `onExpired` is unconditional, including on the "no dispatcher to poll on" early return, so the caller's latch can never be stuck on. The poll runs at `DispatcherPriority.Normal`, not `Background`, because of this project's documented Background/Loaded starvation issue.

### Deliberately not touched

`AutonomyService.cs:1083`'s `IsActive` check. That one is a candidate filter, not a drop — nothing is lost when it excludes an option.

### Verification

- `dotnet build`: **0 errors**, 346 warnings (baseline ~350).
- `dotnet test`: **4844 passed, 5 failed** — all 5 pre-existing and unrelated (`Phase8RedirectContractTests` and friends); confirmed by re-running the suite on a clean `origin/main` tree, which fails the identical 5.
- Not play-tested against a live For You feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
