### PR TITLE
fix(flash): the Fade slider actually drives the flash fade (ccp-bugs#1095)

### DIFF
--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -2222,8 +2222,9 @@ namespace ConditioningControlPanel.Services
 
         #region Heartbeat & Animation
 
-        // Old 33ms-tick fade step was 0.08/tick — same speed, expressed per second.
-        private const double FADE_PER_SEC = 2.4;
+        // The Fade slider (Visuals tab) is a percentage where 100% = a one second ramp, so the
+        // default 40% lands on 0.4 s — the same envelope the old fixed FADE_PER_SEC = 2.4 gave.
+        private const double FADE_SECONDS_PER_PERCENT = 0.01;
 
         /// <summary>Subscribe the heartbeat to the composition clock (idempotent, any thread).</summary>
         private void StartHeartbeat()
@@ -2278,7 +2279,10 @@ namespace ConditioningControlPanel.Services
 
             var settings = App.Settings.Current;
             var maxAlpha = Math.Min(1.0, Math.Max(0.0, settings.FlashOpacity / 100.0));
-            var fadeStep = FADE_PER_SEC * dt;
+            // Read the Fade slider live so a mid-session change lands on the next frame.
+            // 0% = instant: a full-alpha step arrives (and leaves) in a single frame.
+            var fadeSeconds = settings.FadeDuration * FADE_SECONDS_PER_PERCENT;
+            var fadeStep = fadeSeconds > 0 ? dt / fadeSeconds : 1.0;
 
             FlashWindow[] windowsCopy;
             lock (_lockObj)


### PR DESCRIPTION
Fixes CC-Labs-llc/ccp-bugs#1095 (v6.8.6).

## The defect

The Fade slider on **Flashes > Visuals** did nothing. Dragging it wrote `AppSettings.FadeDuration` and updated the percentage label beside it, but nothing downstream ever read the value. The flash render heartbeat stepped opacity by a hardcoded constant:

```csharp
private const double FADE_PER_SEC = 2.4;
...
var fadeStep = FADE_PER_SEC * dt;
```

So the reporter's repro holds exactly: fade at 0% still faded over roughly four tenths of a second, and fade at 100% looked identical. `FadeDuration` was written by the slider handler and read back by the same control to restore its own position, and by `Preset` to round-trip presets. The flash path never touched it.

## The fix

`Services/Flash/FlashService.cs` — 7 lines added, 3 removed, no other file changed.

The setting is documented in `Models/AppSettings.cs` as a percentage where 100 = one second, its slider runs 0-100, and its tooltip already promised "0% = instant appear/disappear, 100% = slow smooth fade". Read that way, `fadeSeconds = FadeDuration / 100` and the per-frame step is `dt / fadeSeconds`.

Zero is the only value with no rate to derive from it, so it short-circuits to a step of `1.0` — a full-alpha arrival (and departure) in a single frame, which is what "instant" means here, and which keeps a divide-by-zero out of the render path.

## What is deliberately unchanged

e9cb966a4 ("port upstream's fade, so a monitor-sized flash ARRIVES over 0.42 s instead of one frame") exists to stop a full-screen white rectangle appearing in one composited frame. This scales that envelope rather than replacing it. The shipped default of 40% lands on a 0.4 s ramp, within a rounding hair of the 0.42 s the fixed constant gave, so a user who never touches the slider sees no change at all.

Peak brightness, the fade-out sweep that removes a window once it reaches zero alpha, and the 0.1 s stall clamp on `dt` are all untouched.

## Live read

The value comes off `App.Settings.Current` inside `Heartbeat_Tick`, right beside the `FlashOpacity` read that was already live there — not cached at service construction. A slider moved mid-session lands on the very next rendered frame.

## Verification

- `dotnet build` — **0 errors**, 346 warnings (the known baseline).
- `dotnet test` — 4844 passed, 5 failed. All 5 failures (`YouLibraryDoorTests.EachLibraryLauncherIsOneRowBoundToOneExistingHandler` x4, `Phase8RedirectContractTests.PatreonStillRedirectsIntoTheSettingsDoorsAccountSection`) are XAML nav-door contract tests, unrelated to the flash path. Confirmed pre-existing: the same 5 fail identically on a clean tree with this change stashed.

Not play-tested on a live flash run — worth a quick pass at 0%, 40% and 100% before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
