### PR TITLE
fix(attention): never score a missing camera as a failed check

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2302,6 +2302,14 @@ namespace ConditioningControlPanel
 
             // Initialize webcam tracking + focus game services (Lab — gated by consent dialog).
             // Constructors are no-ops; the camera handle only opens after explicit user consent.
+            //
+            // NOT A BUG: the camera deliberately does not come back up on launch, however the
+            // user left it. Camera lifetime is runtime state and is never persisted, so there is
+            // nothing here to restore — see the rule at GazeFocusService.EvaluateDesiredState
+            // ("this NEVER powers the camera on ... would silently light the camera at startup
+            // for any calibrated user") and the privacy contract atop WebcamTrackingService.
+            // Reported as ccp-bugs#1083; answered by making a missing camera cost the user
+            // nothing (AttentionCheckService dismisses neutral) rather than by auto-starting it.
             Webcam = new WebcamTrackingService();
             FocusGame = new FocusGameService();
             // #912: a debug cursor must never be able to kill the launch. Its Skia resources are

--- a/ConditioningControlPanel/Services/AttentionCheckService.cs
+++ b/ConditioningControlPanel/Services/AttentionCheckService.cs
@@ -35,6 +35,12 @@ namespace ConditioningControlPanel.Services
         private const int DwellTargetMs = 1000; // time on target to pass
         private const double BoundsSlackDips = 30; // extra hit area around the ring
 
+        // A gaze sample older than this is treated as "the camera is not telling us
+        // anything right now" rather than "the user is still where we last saw them".
+        // OnGazeMove arrives per processed frame (tens of ms), so 400ms is many frames
+        // of silence — a stopped camera, a lost face, or a wedged capture thread.
+        private const int GazeStaleMs = 400;
+
         // Reward / penalty amounts are fixed by design — these are intentionally
         // not user-tunable. A reachable XP knob would invite gaming; a fixed
         // value preserves the mechanic's role as a check, not a grind lever.
@@ -67,6 +73,7 @@ namespace ConditioningControlPanel.Services
         private DateTime _fireStartedAt;
         private double _dwellMs;
         private System.Windows.Point? _lastGazePoint;
+        private DateTime _lastGazeAt;
         private bool _gazeSubscribed;
 
         // Belt-and-braces shutdown cleanup. Setting Owner on the popup window
@@ -295,6 +302,7 @@ namespace ConditioningControlPanel.Services
                 _fireStartedAt = DateTime.UtcNow;
                 _dwellMs = 0;
                 _lastGazePoint = null;
+                _lastGazeAt = default; // stale until this check's first live sample
 
                 if (App.Webcam != null && !_gazeSubscribed)
                 {
@@ -365,6 +373,7 @@ namespace ConditioningControlPanel.Services
         private void HandleGazeMove(System.Windows.Point p)
         {
             _lastGazePoint = p;
+            _lastGazeAt = DateTime.UtcNow;
         }
 
         private void OnTick(object? sender, EventArgs e)
@@ -374,10 +383,30 @@ namespace ConditioningControlPanel.Services
                 var settings = App.Settings?.Current;
                 if (settings == null || !_checkActive) { ResolveActive(passed: false); return; }
 
-                var elapsed = (DateTime.UtcNow - _fireStartedAt).TotalMilliseconds;
+                // The camera can go away mid-check (stopped from the Lab pill, panic key,
+                // unplugged, grabbed by another app). Fire() checks IsRunning once up front,
+                // but nothing re-checked it after that, so a check that outlived its camera
+                // drained to a FAIL the user had no way to answer. Dismiss it as neutral
+                // instead — no pass, no fail, no bark — and let the scheduler try later.
+                if (App.Webcam?.IsRunning != true)
+                {
+                    App.Logger?.Debug("AttentionCheck: dismissed — webcam tracking stopped mid-check");
+                    ResolveActive(passed: false, fireEvent: false);
+                    return;
+                }
+
+                var now = DateTime.UtcNow;
+                var elapsed = (now - _fireStartedAt).TotalMilliseconds;
                 var graceMs = settings.AttentionCheckGraceMs;
 
-                if (_lastGazePoint.HasValue && _activeBounds.Contains(_lastGazePoint.Value))
+                // A gaze point only counts while it is FRESH. Without this the last point
+                // the camera ever emitted stayed authoritative forever: parked inside the
+                // ring it passed the check for a user who had walked away, and parked
+                // outside it failed one whose tracker had simply stopped feeding.
+                var gazeFresh = _lastGazePoint.HasValue
+                    && (now - _lastGazeAt).TotalMilliseconds <= GazeStaleMs;
+
+                if (gazeFresh && _activeBounds.Contains(_lastGazePoint!.Value))
                 {
                     _dwellMs += TickMs;
                     _control?.SetProgress(_dwellMs / DwellTargetMs);
@@ -398,6 +427,18 @@ namespace ConditioningControlPanel.Services
 
                 if (elapsed >= graceMs)
                 {
+                    // Grace is up. Only call it a FAIL when the tracker was demonstrably
+                    // feeding us at the deadline — that is the one reading that means
+                    // "they were looking somewhere else". Silence means we never had an
+                    // answer to grade, so it resolves neutral rather than penalising an
+                    // absence the user may not even know about.
+                    if (!gazeFresh)
+                    {
+                        App.Logger?.Debug("AttentionCheck: dismissed — no live gaze at grace expiry");
+                        ResolveActive(passed: false, fireEvent: false);
+                        return;
+                    }
+
                     ResolveActive(passed: false);
                 }
             }

--- a/ConditioningControlPanel/Services/GoonGame/Rounds/StaringContestRound.cs
+++ b/ConditioningControlPanel/Services/GoonGame/Rounds/StaringContestRound.cs
@@ -109,9 +109,16 @@ namespace ConditioningControlPanel.Services.GoonGame
                 int attentionPct;
                 lock (sampleLock)
                 {
+                    // No samples means the attention feed never reported — no camera, no
+                    // consent, or the null feed. That is an ABSENT reading, not a bad one,
+                    // and scoring it 0 handed the both-survived tiebreak
+                    // (GoonSuddenDeath.Higher on Progress) to whoever happened to have a
+                    // camera. Fail open at 100, matching GoonScoring, whose AttentionPct
+                    // starts at 100.0 and whose RollingAttention holds its last value
+                    // rather than collapsing when the sample window empties.
                     attentionPct = attentionSamples > 0
                         ? (int)Math.Round(attentionSum / attentionSamples * 100.0)
-                        : 0;
+                        : 100;
                 }
 
                 var elapsed = survived


### PR DESCRIPTION
Closes CC-Labs-llc/ccp-bugs#1083

The report (filed as a suggestion, plus a Discord report from Sarah) reads as
"the webcam does not auto-start on launch, so the mandatory-video attention
check marks me absent". Those are two separate claims, and they resolve
differently: one is working as designed, the other was a real latent bug.

## Half 1 - auto-start: deliberately NOT implemented

The camera not coming back up on launch is a documented design decision, not a
regression or a persistence failure.

There is **no setting that failed to persist**, because camera lifetime was
never persisted in the first place. `WebcamTriggersEnabled` and
`FocusGameEnabled` are legacy: the only remaining reads are the resets inside
`WebcamTrackingService.RevokeConsent`. Nothing in settings can bring a camera
up on launch, by construction.

The rule is stated outright in `GazeFocusService.EvaluateDesiredState`:

> Crucially, this NEVER powers the camera on: the per-feature gaze flags
> default to ON, so warming the webcam whenever they're set would silently
> light the camera at startup for any calibrated user.

It is reinforced in three more places: the `PRIVACY CONTRACT - read before
editing this file` header atop `WebcamTrackingService`; the consent dialog,
which documents that it `Does NOT start the camera`; and the fact that all
sixteen call sites which open the capture handle are direct, in-the-moment
user actions (no timer, session, program, or startup path calls `Start()`).
The Quick Recal hotkey is even deliberately silent without consent because
"a global chord has no such mandate".

Auto-starting would break that contract, so this PR does not. Instead it makes
the camera's absence cost the user nothing, and adds a short note at the
construction site in `App.xaml.cs` so the next triager does not re-open this.

## Half 2 - absent-penalty without a camera: fixed

The live click-based video minigame was already camera-independent and needed
no change: gaze is an optional assist, `VideoService.GetGazeTargets()` returns
empty without it, and mouse clicks still score. `_hits >= _spawned` never
consults the camera.

Two other paths did punish an absent camera:

**`AttentionCheckService`** checked `App.Webcam.IsRunning` once at fire time
and never again, and treated its last gaze point as authoritative forever.
So a camera stopped mid-check (Lab pill, panic key, unplugged, grabbed by
another app) drained to a FAIL the user had no way to answer; and a stale
point parked inside the ring passed a check for someone who had walked away.

Now: tracking must be live at tick time; gaze points expire after
`GazeStaleMs` (400ms, many frames of silence); and grace expiry only counts as
a fail when the tracker was demonstrably feeding at the deadline. That is the
one reading which actually means "they were looking somewhere else". Silence
resolves **neutral** - no pass, no fail, no bark - and reschedules, reusing the
existing `ResolveActive(fireEvent: false)` path.

**`StaringContestRound`** scored "no attention samples at all" as `0`, which is
the both-survived tiebreak (`GoonSuddenDeath.Higher` on `Progress`) - handing
the round to whoever happened to have a camera. It now fails open at `100`,
matching `GoonScoring`, whose `AttentionPct` starts at `100.0` and whose
`RollingAttention()` holds its last value rather than collapsing when the
sample window empties.

## Scope / risk

Both fixed paths are dormant today - `AttentionCheckService` is constructed but
never `Start()`ed (`AttentionCheckEnabled` defaults false), and no live
`IGoonAttentionFeed` implementation exists. So this lands the fix before either
is wired rather than changing behaviour users see this release.

Per the caution on the recent `feat(gaze)` precision wave (b1a39c176): no
tracking math was touched. Changes are confined to startup documentation and
scoring guards; no coordinate-space, calibration, or filter code is involved.
No localization files touched - no new user-facing strings.

## Verification

- `dotnet build`: **0 errors**, 346 warnings (baseline ~350).
- `dotnet test`: **4844 passed, 5 failed** - the identical 5
  (`YouLibraryDoorTests` x4, `Phase8RedirectContractTests` x1) fail on an
  unmodified `origin/main`, confirmed by re-running the suite on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
