### PR TITLE
fix(ui): a broken font install can no longer blank the whole app

### DIFF
--- a/ConditioningControlPanel/App.xaml
+++ b/ConditioningControlPanel/App.xaml
@@ -24,6 +24,13 @@
         <!-- Keep any existing app-level dictionaries below -->
       </ResourceDictionary.MergedDictionaries>
 
+      <!-- The app's monospace face, in ONE place so a broken font install can be corrected in one
+           place. Bind it with DynamicResource, never StaticResource: Services/UI/FontGuard probes
+           these families at startup and REPLACES this value when one of them is present but
+           unreadable, which is the only thing that helps a corrupt face (a comma chain does not -
+           see the FontGuard docs). Keep this in sync with FontGuard.MonoChain. -->
+      <FontFamily x:Key="Font.Mono">Cascadia Mono, Consolas, Courier New</FontFamily>
+
       <!-- Tooltips must NOT be layered (per-pixel transparent) windows. A WPF ToolTip with
            HasDropShadow=True is hosted in an AllowsTransparency popup; when that popup shows/hides
            it does a synchronous HwndTarget.OnResize → MediaContext.CompleteRender() that blocks on

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1541,6 +1541,13 @@ namespace ConditioningControlPanel
             // ships them all (the last 120KB), burying the real failure and polluting triage.
             RotateCrashLogForVersion(logPath);
 
+            // Prove the font families we hardcode can actually be opened, BEFORE any window is
+            // built. A face that is present but corrupt throws from inside the layout pass, so it
+            // re-throws on every measure: the UI renders blank forever and crash.log grows without
+            // bound (a broken Cascadia install did exactly this in v6.8.6). The probe strikes any
+            // unreadable family out of the app's font chains and logs one line. See FontGuard.
+            Services.UI.FontGuard.Verify();
+
             // Before a single service starts: prove the bundled natives actually unpacked. A
             // truncated single-file extraction cache is never repaired by the .NET host on its
             // own, so it bricks every subsequent launch - and it surfaces as a XamlParseException
@@ -4292,8 +4299,48 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// Per-signature write budget for <see cref="LogCrashDetails"/>. Counts THIS session only;
+        /// <see cref="RotateCrashLogForVersion"/> handles growth across sessions.
+        /// </summary>
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, int> _crashSignatureCounts = new();
+        private const int MaxReportsPerCrashSignature = 5;
+
+        /// <summary>
+        /// Collapse an exception to a stable identity: source + type + message + the top stack
+        /// frame. A layout-loop failure re-throws with the identical quadruple every pass, which is
+        /// exactly the storm we want to fold; two genuinely different bugs practically never share
+        /// all four.
+        /// </summary>
+        private static string CrashSignature(string source, Exception ex)
+        {
+            var topFrame = "";
+            try
+            {
+                var trace = ex.StackTrace;
+                if (!string.IsNullOrEmpty(trace))
+                {
+                    var newline = trace.IndexOf('\n');
+                    topFrame = (newline >= 0 ? trace.Substring(0, newline) : trace).Trim();
+                }
+            }
+            catch { }
+            return source + "|" + ex.GetType().FullName + "|" + ex.Message + "|" + topFrame;
+        }
+
+        /// <summary>
         /// Log detailed crash information to both main log and a dedicated crash log file.
         /// This helps debug random crashes by capturing full context.
+        ///
+        /// <para><b>Rate limited per signature.</b> Some exceptions fire from the layout loop, which
+        /// runs on every measure pass — so one broken thing throws thousands of times a minute and
+        /// each throw used to append a ~1KB report. A user with a corrupt Cascadia install
+        /// (<c>UnauthorizedAccessException</c> out of <c>FontFamily.GetFirstMatchingFont</c> during
+        /// <c>TextBlock.MeasureOverride</c>, v6.8.6) grew crash.log to roughly half a gigabyte in a
+        /// single session, which no bug report can carry and no triage can read. The startup
+        /// rotation above cannot help: it only runs at launch, and the storm is intra-session. So we
+        /// write the first <see cref="MaxReportsPerCrashSignature"/> occurrences of any one
+        /// signature in full, then one "suppressed" line, then nothing. The Serilog line is capped
+        /// the same way — the storm floods app-.log too.</para>
         /// </summary>
         private static void LogCrashDetails(string source, Exception? ex)
         {
@@ -4301,6 +4348,29 @@ namespace ConditioningControlPanel
 
             try
             {
+                var signature = CrashSignature(source, ex);
+                var seen = _crashSignatureCounts.AddOrUpdate(signature, 1, (_, n) => n + 1);
+                if (seen > MaxReportsPerCrashSignature)
+                {
+                    // Exactly one notice per signature, then silence for the rest of the session.
+                    if (seen == MaxReportsPerCrashSignature + 1)
+                    {
+                        try
+                        {
+                            Logger?.Error("UNHANDLED {Source} EXCEPTION repeated more than {Max} times and is now SUPPRESSED for this session (likely a layout/render loop): {Type}: {Message}",
+                                source, MaxReportsPerCrashSignature, ex.GetType().FullName, ex.Message);
+                        }
+                        catch { }
+                        try
+                        {
+                            File.AppendAllText(Path.Combine(UserDataPath, "logs", "crash.log"),
+                                $"\n[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] The crash above repeated more than {MaxReportsPerCrashSignature} times — further identical reports are suppressed for this session.\n");
+                        }
+                        catch { }
+                    }
+                    return;
+                }
+
                 // Log to main logger
                 Logger?.Error(ex, "UNHANDLED {Source} EXCEPTION: {Message}", source, ex.Message);
 
@@ -4312,6 +4382,7 @@ CRASH REPORT - {DateTime.Now:yyyy-MM-dd HH:mm:ss}
 ================================================================================
 App Version: {Services.UpdateService.AppVersion}
 Source: {source}
+Occurrence: {seen} of at most {MaxReportsPerCrashSignature} logged this session for this signature
 Exception Type: {ex.GetType().FullName}
 Message: {ex.Message}
 

--- a/ConditioningControlPanel/CLAUDE.md
+++ b/ConditioningControlPanel/CLAUDE.md
@@ -123,23 +123,35 @@ of truth.)
 3. **Duplicate windows**: Only one StartupUri OR manual window creation in App.xaml.cs, not both
 4. **Resource not found in DataTemplate**: Move converters/resources to Window.Resources, not local Grid.Resources
 5. **Screen enumeration crash**: Always check `Screen.AllScreens.Length > 0` before accessing - can return empty during certain system states
+6. **Never hardcode a risky font family; a comma fallback is NOT a guard.** A user's corrupt
+   Cascadia install made every panel render blank in v6.8.6: WPF threw
+   `UnauthorizedAccessException` from `FontFamily.GetFirstMatchingFont` inside
+   `TextBlock.MeasureOverride`, i.e. from the LAYOUT pass, so it re-threw on every measure and
+   crash.log reached ~0.5GB in one session. Every Cascadia site already named
+   `"Cascadia Mono, Consolas, Courier New"` at the time - a chain only rescues an ABSENT family,
+   because deciding whether the first link matches means opening the font file, and that open is
+   what throws. The monospace face now lives in ONE place, App.xaml's `Font.Mono`, bound with
+   **DynamicResource** (never StaticResource - that snapshots at parse time);
+   `Services/UI/FontGuard` probes the risky families at startup and strikes any unreadable one out
+   of every chain. `FontFallbackTests` fails the build if markup names Cascadia directly or names
+   Consolas/Impact/Segoe MDL2/Segoe UI Emoji with nothing behind it.
 
 ### Async/Threading Issues
-6. **Fire-and-forget Task crashes**: Always wrap `Task.Delay().ContinueWith()` callbacks with `if (Application.Current?.Dispatcher == null) return;` and try-catch
-7. **MainWindow null during session**: SessionEngine holds reference to MainWindow - use `IsMainWindowValid` check before calling window methods
-8. **Event handlers on closed windows**: Check `Application.Current.Dispatcher.HasShutdownStarted` before triggering UI operations in event handlers
+7. **Fire-and-forget Task crashes**: Always wrap `Task.Delay().ContinueWith()` callbacks with `if (Application.Current?.Dispatcher == null) return;` and try-catch
+8. **MainWindow null during session**: SessionEngine holds reference to MainWindow - use `IsMainWindowValid` check before calling window methods
+9. **Event handlers on closed windows**: Check `Application.Current.Dispatcher.HasShutdownStarted` before triggering UI operations in event handlers
 
 ### Build Issues
-9. **Velopack "Access denied"**: Delete `%LOCALAPPDATA%\Temp\Velopack` folder and retry
-10. **Build warnings about Screen**: These are CA1416 platform warnings - safe to ignore for Windows-only app
+10. **Velopack "Access denied"**: Delete `%LOCALAPPDATA%\Temp\Velopack` folder and retry
+11. **Build warnings about Screen**: These are CA1416 platform warnings - safe to ignore for Windows-only app
 
 ### Localization
-11. **Never put a literal line break inside a language-file string.** Until 2026-07-29, 8 of the 9 `Localization/Languages/*.json` files carried raw newlines inside 38 tooltip values, so only Newtonsoft's leniency parsed them - `System.Text.Json`, `jq`, Python and most format-on-save tools rejected all 8. They are now escaped as `\n`/`\r\n` and every file parses strictly. Keep it that way: write `\n`, not an actual newline.
-12. **A dead language file no longer empties the UI.** `LocalizationManager.LoadLanguageFile` returns an empty dictionary on failure; `SetLanguage` treats that as "fall back to English", and `EnsureFallbackLoaded` logs **Fatal** if `en.json` itself fails (the one case with nothing to fall back to - the UI then renders raw keys like `btn_start_flashes`). If you see that Fatal line, the language file is broken, not the UI.
-13. **Don't hand-flip language-file line endings.** All 9 `Localization/Languages/*.json` are LF in git; the worktree shows CRLF only because `core.autocrlf=true` converts on checkout. Let autocrlf do its job and never commit a whole-file line-ending diff.
+12. **Never put a literal line break inside a language-file string.** Until 2026-07-29, 8 of the 9 `Localization/Languages/*.json` files carried raw newlines inside 38 tooltip values, so only Newtonsoft's leniency parsed them - `System.Text.Json`, `jq`, Python and most format-on-save tools rejected all 8. They are now escaped as `\n`/`\r\n` and every file parses strictly. Keep it that way: write `\n`, not an actual newline.
+13. **A dead language file no longer empties the UI.** `LocalizationManager.LoadLanguageFile` returns an empty dictionary on failure; `SetLanguage` treats that as "fall back to English", and `EnsureFallbackLoaded` logs **Fatal** if `en.json` itself fails (the one case with nothing to fall back to - the UI then renders raw keys like `btn_start_flashes`). If you see that Fatal line, the language file is broken, not the UI.
+14. **Don't hand-flip language-file line endings.** All 9 `Localization/Languages/*.json` are LF in git; the worktree shows CRLF only because `core.autocrlf=true` converts on checkout. Let autocrlf do its job and never commit a whole-file line-ending diff.
 
 ### EMI Desk
-14. **The outfit / skin layer is the TOPMOST thing in EMI's composition.** It is drawn above the
+15. **The outfit / skin layer is the TOPMOST thing in EMI's composition.** It is drawn above the
     face and above the takeover glass; face art may never paint over a garment. Her face is not
     part of the body PNG - it is a canvas laid over the glass rect, with the glass a second canvas
     on the same rect - so anything a coat, a collar or a pair of goggles draws across that rect is

--- a/ConditioningControlPanel/Chaos/ChaosHubWindow.Debug.cs
+++ b/ConditioningControlPanel/Chaos/ChaosHubWindow.Debug.cs
@@ -124,7 +124,7 @@ public partial class ChaosHubWindow
     {
         Text = text,
         Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0xB4, 0x43)),
-        FontFamily = new FontFamily("Consolas"), FontWeight = FontWeights.Bold, FontSize = 10,
+        FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeights.Bold, FontSize = 10,
         VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 8, 0),
     };
 

--- a/ConditioningControlPanel/Chaos/ChaosHubWindow.xaml
+++ b/ConditioningControlPanel/Chaos/ChaosHubWindow.xaml
@@ -29,7 +29,7 @@
 
         <Style x:Key="SectionHdr" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource Pink}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Margin" Value="0,0,0,10"/>
@@ -204,13 +204,13 @@
                         <TextBlock Text="🐇 DOWN THE RABBIT HOLE" Foreground="White" FontSize="22" FontWeight="Bold">
                             <TextBlock.Effect><DropShadowEffect Color="#FFE84393" BlurRadius="20" ShadowDepth="0" Opacity="0.7"/></TextBlock.Effect>
                         </TextBlock>
-                        <TextBlock Text="the dollhouse" Foreground="{StaticResource Pink}" FontFamily="Consolas" FontWeight="Bold" FontSize="12" VerticalAlignment="Bottom" Margin="10,0,0,4"/>
+                        <TextBlock Text="the dollhouse" Foreground="{StaticResource Pink}" FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="12" VerticalAlignment="Bottom" Margin="10,0,0,4"/>
                     </StackPanel>
                     <!-- rank / drops / gold under the title, left side — the banner art owns the right -->
                     <StackPanel Orientation="Horizontal" Margin="2,10,0,0">
                         <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="12,5" Margin="0,0,8,0">
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="RANK" Foreground="{StaticResource TextMut}" FontFamily="Consolas" FontSize="10" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock Text="RANK" Foreground="{StaticResource TextMut}" FontFamily="Consolas, Courier New" FontSize="10" VerticalAlignment="Center" Margin="0,0,6,0"/>
                                 <TextBlock x:Name="TxtRank" Text="Curious" Foreground="White" FontWeight="Bold" FontSize="13" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Border>
@@ -553,7 +553,7 @@
                         <StackPanel>
                             <TextBlock x:Name="HdrDiary" Text="DIARY · what you've met down there · click to pop out ⤢"
                                        Cursor="Hand" MouseLeftButtonDown="Diary_PopOut" Foreground="{StaticResource Pink}"
-                                       FontFamily="Consolas" FontWeight="Bold" FontSize="12" Margin="0,0,0,10"/>
+                                       FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="12" Margin="0,0,0,10"/>
                             <StackPanel x:Name="DiaryHost"/>
                         </StackPanel>
                     </Border>
@@ -655,7 +655,7 @@
                     <skia:SKElement x:Name="MenuLogoFx" IsHitTestVisible="False"
                                     Width="314" Height="224" HorizontalAlignment="Center"
                                     Margin="0,48,0,0" PaintSurface="MenuLogoFx_PaintSurface"/>
-                    <TextBlock Text="· the dollhouse ·" Foreground="{StaticResource Pink}" FontFamily="Consolas"
+                    <TextBlock Text="· the dollhouse ·" Foreground="{StaticResource Pink}" FontFamily="Consolas, Courier New"
                                FontWeight="Bold" FontSize="12" HorizontalAlignment="Center" Margin="0,2,0,0"/>
                 </StackPanel>
 
@@ -684,7 +684,7 @@
                 <StackPanel Grid.Row="2" Orientation="Horizontal">
                     <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="10,5" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="RANK" Foreground="{StaticResource TextMut}" FontFamily="Consolas" FontSize="10" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock Text="RANK" Foreground="{StaticResource TextMut}" FontFamily="Consolas, Courier New" FontSize="10" VerticalAlignment="Center" Margin="0,0,6,0"/>
                             <TextBlock x:Name="MenuRank" Text="Curious" Foreground="White" FontWeight="Bold" FontSize="13" VerticalAlignment="Center"/>
                         </StackPanel>
                     </Border>
@@ -724,7 +724,7 @@
                     </Grid.RowDefinitions>
 
                     <StackPanel Grid.Row="0">
-                        <TextBlock Text="⚙  OPTIONS" Foreground="{StaticResource Pink}" FontFamily="Consolas" FontWeight="Bold" FontSize="28"/>
+                        <TextBlock Text="⚙  OPTIONS" Foreground="{StaticResource Pink}" FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="28"/>
                         <TextBlock Text="display &amp; comfort — these stick between descents." Foreground="{StaticResource TextMut}" FontSize="13" Margin="2,6,0,0"/>
                     </StackPanel>
 
@@ -748,7 +748,7 @@
 
                         <!-- right: intensity slider -->
                         <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="0,0,6,0">
-                            <TextBlock Text="EFFECT INTENSITY" Foreground="{StaticResource TextMut}" FontFamily="Consolas" FontSize="13" FontWeight="Bold" Margin="0,0,0,10"/>
+                            <TextBlock Text="EFFECT INTENSITY" Foreground="{StaticResource TextMut}" FontFamily="Consolas, Courier New" FontSize="13" FontWeight="Bold" Margin="0,0,0,10"/>
                             <Slider Minimum="0.2" Maximum="1.5" Value="{Binding Value, ElementName=SldEffect, Mode=TwoWay}" Height="30"/>
                             <TextBlock Text="lower = gentler bloom &amp; shake." Foreground="{StaticResource TextMut}" FontSize="12" Margin="0,10,0,0"/>
                         </StackPanel>
@@ -795,7 +795,7 @@
                         <!-- title -->
                         <StackPanel Grid.Row="1" Margin="32,18,32,0">
                             <TextBlock x:Name="HowToStep" Text="STEP 1 / 5" Foreground="{StaticResource Pink}"
-                                       FontFamily="Consolas" FontWeight="Bold" FontSize="11" Margin="0,0,0,4"/>
+                                       FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="11" Margin="0,0,0,4"/>
                             <TextBlock x:Name="HowToTitle" Text="" Foreground="White" FontSize="22" FontWeight="Bold" TextWrapping="Wrap"/>
                         </StackPanel>
 

--- a/ConditioningControlPanel/Chaos/ChaosHubWindow.xaml.cs
+++ b/ConditioningControlPanel/Chaos/ChaosHubWindow.xaml.cs
@@ -1059,7 +1059,7 @@ public partial class ChaosHubWindow : Window
         col.Children.Add(new TextBlock
         {
             Text = label, Foreground = new SolidColorBrush(Color.FromRgb(0x8A, 0x86, 0xB8)),
-            FontFamily = new FontFamily("Consolas"), FontWeight = FontWeights.Bold, FontSize = 11,
+            FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeights.Bold, FontSize = 11,
             Margin = new Thickness(0, 0, 0, 6)
         });
         var row = new StackPanel { Orientation = Orientation.Horizontal };
@@ -1410,7 +1410,7 @@ public partial class ChaosHubWindow : Window
         {
             Text = "DIARY · what you've met down there",
             Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0x43, 0x93)),
-            FontFamily = new FontFamily("Consolas"), FontWeight = FontWeights.Bold, FontSize = 13,
+            FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeights.Bold, FontSize = 13,
             Margin = new Thickness(0, 0, 0, 12)
         });
         FillDiaryRows(host, 440);
@@ -1457,7 +1457,7 @@ public partial class ChaosHubWindow : Window
     private TextBlock SubHeader(string text) => new()
     {
         Text = text, Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0x43, 0x93)),
-        FontFamily = new FontFamily("Consolas"), FontWeight = FontWeights.Bold, FontSize = 11,
+        FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeights.Bold, FontSize = 11,
         Margin = new Thickness(0, 12, 0, 6)
     };
 

--- a/ConditioningControlPanel/Chaos/ChaosHudWindow.xaml
+++ b/ConditioningControlPanel/Chaos/ChaosHudWindow.xaml
@@ -13,7 +13,7 @@
         <SolidColorBrush x:Key="TextDim" Color="#AAB8B8D0"/>
         <Style x:Key="Hdr" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{StaticResource Pink}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="FontSize" Value="13"/>
             <Setter Property="Margin" Value="0,12,0,6"/>
@@ -150,7 +150,7 @@
                 MouseLeftButtonDown="Strip_Click">
             <StackPanel VerticalAlignment="Top" Margin="0,20,0,0" HorizontalAlignment="Center">
                 <TextBlock Text="🐇" Foreground="{StaticResource Pink}" FontSize="30" HorizontalAlignment="Center"/>
-                <TextBlock x:Name="TxtStripClock" Text="{Binding ClockText}" Foreground="White" FontFamily="Consolas" FontSize="17"
+                <TextBlock x:Name="TxtStripClock" Text="{Binding ClockText}" Foreground="White" FontFamily="Consolas, Courier New" FontSize="17"
                            HorizontalAlignment="Center" Margin="0,12,0,0"/>
 
                 <!-- left/right side switch — parks the whole sidebar on the other screen edge so it's
@@ -186,11 +186,11 @@
                     <TextBlock x:Name="TxtStreakLbl" Text="STREAK" Foreground="{StaticResource TextDim}"
                                FontSize="12" FontWeight="Bold" HorizontalAlignment="Center"/>
                     <TextBlock x:Name="TxtStreakNum" Text="x0" Foreground="White" FontWeight="Bold"
-                               FontFamily="Consolas" FontSize="29" HorizontalAlignment="Center"/>
+                               FontFamily="Consolas, Courier New" FontSize="29" HorizontalAlignment="Center"/>
                 </StackPanel>
 
                 <TextBlock x:Name="TxtStripMult" Text="{Binding TotalMultText}" Foreground="#FFD24DFF" FontWeight="Bold" FontSize="15"
-                           FontFamily="/Fonts/#Fredoka" RenderTransformOrigin="0.5,0.5"
+                           FontFamily="/Fonts/#Fredoka, Segoe UI" RenderTransformOrigin="0.5,0.5"
                            HorizontalAlignment="Center" Margin="0,12,0,0"/>
 
                 <!-- FOCUS: the defuse fuel — a core resource like streak, so it lives on the
@@ -218,7 +218,7 @@
                      READY breathes a soft cyan glow (code-behind, same pulse as the toy hero button). -->
                 <StackPanel x:Name="RippleStripBlock" Margin="0,12,0,0" HorizontalAlignment="Center">
                     <TextBlock Text="RIPPLE" Foreground="#FF7AE0FF" FontSize="10" FontWeight="Bold" HorizontalAlignment="Center"/>
-                    <TextBlock x:Name="RippleStripText" Text="{Binding RippleText}" FontWeight="Bold" FontFamily="Consolas" FontSize="13"
+                    <TextBlock x:Name="RippleStripText" Text="{Binding RippleText}" FontWeight="Bold" FontFamily="Consolas, Courier New" FontSize="13"
                                HorizontalAlignment="Center" Margin="0,2,0,0">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
@@ -315,7 +315,7 @@
                     <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
                         <TextBlock x:Name="TxtPanelScore" Text="{Binding ScoreText}" Foreground="White" FontWeight="Bold" FontSize="22" Margin="0,0,16,0"/>
                         <TextBlock x:Name="TxtPanelMult" Text="{Binding TotalMultText}" Foreground="#FFD24DFF" FontWeight="Bold" FontSize="18"
-                                   FontFamily="/Fonts/#Fredoka" RenderTransformOrigin="0.5,0.5" VerticalAlignment="Center"/>
+                                   FontFamily="/Fonts/#Fredoka, Segoe UI" RenderTransformOrigin="0.5,0.5" VerticalAlignment="Center"/>
                     </StackPanel>
                 </StackPanel>
 

--- a/ConditioningControlPanel/Chaos/ChaosIntroWindow.cs
+++ b/ConditioningControlPanel/Chaos/ChaosIntroWindow.cs
@@ -113,7 +113,7 @@ public sealed class ChaosIntroWindow : Window
                         Foreground = new SolidColorBrush(color),
                         FontWeight = FontWeights.Bold,
                         FontSize = 11,
-                        FontFamily = new FontFamily("Consolas"),
+                        FontFamily = new FontFamily("Consolas, Courier New"),
                     },
                 });
             }

--- a/ConditioningControlPanel/Chaos/ChaosUnlockCardOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosUnlockCardOverlay.cs
@@ -162,7 +162,7 @@ public static class ChaosUnlockCards
         {
             Text = d.Ribbon,
             Foreground = accent,
-            FontFamily = new FontFamily("Consolas"),
+            FontFamily = new FontFamily("Consolas, Courier New"),
             FontWeight = FontWeights.Bold,
             FontSize = 11.5,
             Margin = new Thickness(0, 0, 0, 10),

--- a/ConditioningControlPanel/Controls/DescentFuseRailChip.cs
+++ b/ConditioningControlPanel/Controls/DescentFuseRailChip.cs
@@ -222,7 +222,7 @@ namespace ConditioningControlPanel.Controls
             {
                 // Cascadia first, Consolas behind it: the digits must not reflow as they count down,
                 // and a proportional fallback would jitter the readout every second.
-                FontFamily = new FontFamily("Cascadia Mono, Consolas, Courier New"),
+                FontFamily = Services.UI.FontGuard.Mono,
                 FontSize = 12,
                 Foreground = GoldBrush,
                 VerticalAlignment = VerticalAlignment.Center,
@@ -424,7 +424,7 @@ namespace ConditioningControlPanel.Controls
 
             _tipDigits = new TextBlock
             {
-                FontFamily = new FontFamily("Cascadia Mono, Consolas, Courier New"),
+                FontFamily = Services.UI.FontGuard.Mono,
                 FontSize = 15,
                 Foreground = NeutralDigits,
                 HorizontalAlignment = HorizontalAlignment.Center,

--- a/ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml
+++ b/ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml
@@ -99,7 +99,7 @@
         <Border Grid.Row="2" x:Name="PreviewBorder" Background="Black" CornerRadius="8" 
                 Height="80" Margin="0,0,0,20">
             <TextBlock x:Name="PreviewText" Text="{loc:Str label_good_girl}"
-                       FontSize="28" FontWeight="Bold" FontFamily="Arial"
+                       FontSize="28" FontWeight="Bold" FontFamily="Arial, Segoe UI"
                        HorizontalAlignment="Center" VerticalAlignment="Center"/>
         </Border>
 

--- a/ConditioningControlPanel/Dialogs/CompanionPromptEditorDialog.xaml
+++ b/ConditioningControlPanel/Dialogs/CompanionPromptEditorDialog.xaml
@@ -33,7 +33,7 @@
             <Setter Property="BorderBrush" Value="{DynamicResource PanelAccentBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Padding" Value="8"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="AcceptsReturn" Value="True"/>
             <Setter Property="TextWrapping" Value="Wrap"/>

--- a/ConditioningControlPanel/Dialogs/LocalAiSetupWizard.xaml
+++ b/ConditioningControlPanel/Dialogs/LocalAiSetupWizard.xaml
@@ -226,7 +226,7 @@
                 <TextBox x:Name="TxtErrorDetail" Margin="0,12,0,0" MaxHeight="180"
                          Background="{DynamicResource PanelBgBrush}" Foreground="#E0E0E0"
                          BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
-                         Padding="8" FontFamily="Consolas" FontSize="11"
+                         Padding="8" FontFamily="Consolas, Courier New" FontSize="11"
                          IsReadOnly="True" TextWrapping="Wrap"
                          VerticalScrollBarVisibility="Auto"/>
                 <TextBlock Margin="0,12,0,0">

--- a/ConditioningControlPanel/Dialogs/ProfileCustomizeDialog.xaml
+++ b/ConditioningControlPanel/Dialogs/ProfileCustomizeDialog.xaml
@@ -34,7 +34,7 @@
 
         <StackPanel Grid.Row="0" Margin="0,0,0,14">
             <TextBlock Text="{loc:Str profile_customize_title}"
-                       FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                       FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                        FontSize="22" Foreground="White">
                 <TextBlock.Effect>
                     <DropShadowEffect Color="#FF69B4" BlurRadius="16" ShadowDepth="0" Opacity="0.6"/>

--- a/ConditioningControlPanel/Dialogs/ProfilePrivacyDialog.xaml
+++ b/ConditioningControlPanel/Dialogs/ProfilePrivacyDialog.xaml
@@ -21,7 +21,7 @@
 
         <StackPanel Grid.Row="0" Margin="0,0,0,14">
             <TextBlock Text="{loc:Str profile_privacy_title}"
-                       FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                       FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                        FontSize="22" Foreground="White">
                 <TextBlock.Effect>
                     <DropShadowEffect Color="#FF69B4" BlurRadius="16" ShadowDepth="0" Opacity="0.6"/>

--- a/ConditioningControlPanel/Dialogs/WardrobeEditorDialog.xaml
+++ b/ConditioningControlPanel/Dialogs/WardrobeEditorDialog.xaml
@@ -42,7 +42,7 @@
 
         <StackPanel Grid.Row="0" Margin="0,0,0,12">
             <TextBlock Text="{loc:Str wardrobe_editor_title}"
-                       FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                       FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                        FontSize="22" Foreground="White">
                 <TextBlock.Effect>
                     <DropShadowEffect Color="#5EC8F2" BlurRadius="16" ShadowDepth="0" Opacity="0.6"/>

--- a/ConditioningControlPanel/GoonTestWindow.xaml
+++ b/ConditioningControlPanel/GoonTestWindow.xaml
@@ -95,7 +95,7 @@
             <Setter Property="Foreground" Value="{StaticResource GgText}" />
             <Setter Property="Background" Value="{StaticResource GgPanelDeep}" />
             <Setter Property="BorderBrush" Value="#FF3A3A68" />
-            <Setter Property="FontFamily" Value="Consolas" />
+            <Setter Property="FontFamily" Value="Consolas, Courier New" />
             <Setter Property="FontSize" Value="11" />
         </Style>
 

--- a/ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameWindow.xaml
+++ b/ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameWindow.xaml
@@ -202,7 +202,7 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="Image count" Foreground="#CCCCCC" FontSize="12"/>
                                         <TextBlock Grid.Column="1" x:Name="TxtImageCountVal" Text="8"
-                                                   Foreground="#FF69B4" FontFamily="Consolas" FontSize="12"/>
+                                                   Foreground="#FF69B4" FontFamily="Consolas, Courier New" FontSize="12"/>
                                     </Grid>
                                     <Slider x:Name="SliderImageCount" Minimum="0" Maximum="20" Value="8"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
@@ -215,7 +215,7 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="Video count" Foreground="#CCCCCC" FontSize="12"/>
                                         <TextBlock Grid.Column="1" x:Name="TxtVideoCountVal" Text="2"
-                                                   Foreground="#FF69B4" FontFamily="Consolas" FontSize="12"/>
+                                                   Foreground="#FF69B4" FontFamily="Consolas, Courier New" FontSize="12"/>
                                     </Grid>
                                     <Slider x:Name="SliderVideoCount" Minimum="0" Maximum="10" Value="2"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
@@ -228,7 +228,7 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="Image duration (sec)" Foreground="#CCCCCC" FontSize="12"/>
                                         <TextBlock Grid.Column="1" x:Name="TxtImageDurVal" Text="5"
-                                                   Foreground="#FF69B4" FontFamily="Consolas" FontSize="12"/>
+                                                   Foreground="#FF69B4" FontFamily="Consolas, Courier New" FontSize="12"/>
                                     </Grid>
                                     <Slider x:Name="SliderImageDur" Minimum="2" Maximum="10" Value="5"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
@@ -241,7 +241,7 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="Video max duration (sec)" Foreground="#CCCCCC" FontSize="12"/>
                                         <TextBlock Grid.Column="1" x:Name="TxtVideoDurVal" Text="30"
-                                                   Foreground="#FF69B4" FontFamily="Consolas" FontSize="12"/>
+                                                   Foreground="#FF69B4" FontFamily="Consolas, Courier New" FontSize="12"/>
                                     </Grid>
                                     <Slider x:Name="SliderVideoDur" Minimum="10" Maximum="120" Value="30"
                                             TickFrequency="5" IsSnapToTickEnabled="True"
@@ -254,7 +254,7 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="Pass time (sec)" Foreground="#CCCCCC" FontSize="12"/>
                                         <TextBlock Grid.Column="1" x:Name="TxtPassTimeVal" Text="3"
-                                                   Foreground="#FF69B4" FontFamily="Consolas" FontSize="12"/>
+                                                   Foreground="#FF69B4" FontFamily="Consolas, Courier New" FontSize="12"/>
                                     </Grid>
                                     <Slider x:Name="SliderPassTime" Minimum="3" Maximum="30" Value="3"
                                             TickFrequency="1" IsSnapToTickEnabled="True"
@@ -379,7 +379,7 @@
             <Border Background="#88000000" CornerRadius="4" Padding="10,4"
                     HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,12,0,0">
                 <TextBlock x:Name="TxtRoundInfo" Text="Round 1 / 10"
-                           Foreground="White" FontFamily="Consolas" FontSize="13"/>
+                           Foreground="White" FontFamily="Consolas, Courier New" FontSize="13"/>
             </Border>
 
             <!-- Inter-round feedback card. Shown ONLY after panes are cleared

--- a/ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameWindow.xaml.cs
+++ b/ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameWindow.xaml.cs
@@ -278,7 +278,7 @@ namespace ConditioningControlPanel.Lab.GazeMinigame
             {
                 Text = $"{pack.ImageCount} img · {pack.VideoCount} vid",
                 Foreground = new SolidColorBrush(Color.FromRgb(0xAA, 0xAA, 0xAA)),
-                FontFamily = new FontFamily("Consolas"),
+                FontFamily = new FontFamily("Consolas, Courier New"),
                 FontSize = 10,
                 Margin = new Thickness(0, 2, 0, 0),
             });
@@ -1570,14 +1570,14 @@ namespace ConditioningControlPanel.Lab.GazeMinigame
                 {
                     Text = $"#{i + 1,2}",
                     Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88)),
-                    FontFamily = new FontFamily("Consolas"),
+                    FontFamily = new FontFamily("Consolas, Courier New"),
                     Width = 40,
                 });
                 row.Children.Add(new TextBlock
                 {
                     Text = r.Type.ToString(),
                     Foreground = new SolidColorBrush(Color.FromRgb(0xCC, 0xCC, 0xCC)),
-                    FontFamily = new FontFamily("Consolas"),
+                    FontFamily = new FontFamily("Consolas, Courier New"),
                     Width = 60,
                 });
                 row.Children.Add(new TextBlock
@@ -1591,7 +1591,7 @@ namespace ConditioningControlPanel.Lab.GazeMinigame
                 {
                     Text = $"correct {r.CorrectMs:F0}ms · wrong {r.WrongMs:F0}ms",
                     Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88)),
-                    FontFamily = new FontFamily("Consolas"),
+                    FontFamily = new FontFamily("Consolas, Courier New"),
                     FontSize = 11,
                 });
                 ResultsList.Children.Add(row);

--- a/ConditioningControlPanel/MainWindow/MainWindow.DescentFuse.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DescentFuse.cs
@@ -255,7 +255,7 @@ namespace ConditioningControlPanel
                 Text = DescentFuseCopy.TMinus(App.DescentCountdown?.Remaining ?? TimeSpan.Zero),
                 // Cascadia first, Consolas behind it: the digits must not reflow as they count
                 // down, and a proportional fallback would jitter the whole readout every second.
-                FontFamily = new FontFamily("Cascadia Mono, Consolas, Courier New"),
+                FontFamily = Services.UI.FontGuard.Mono,
                 FontSize = 14,
                 Foreground = FuseNeutralDigits,
             };

--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs
@@ -484,7 +484,7 @@ namespace ConditioningControlPanel
                     FontSize = size >= QuestStampWeeklySize ? 12 : 10.5,
                     FontWeight = done ? FontWeights.Bold : FontWeights.Normal,
                     Foreground = done ? QuestStampGoldInk : stroke,
-                    FontFamily = new FontFamily("Segoe UI Emoji"),
+                    FontFamily = new FontFamily("Segoe UI Emoji, Segoe UI Symbol, Segoe UI"),
                     HorizontalAlignment = HorizontalAlignment.Center,
                     VerticalAlignment = VerticalAlignment.Center,
                     TextAlignment = TextAlignment.Center,
@@ -664,7 +664,7 @@ namespace ConditioningControlPanel
                 Foreground = QuestStampPinkStroke,
                 FontSize = 10.5,
                 FontWeight = FontWeights.Bold,
-                FontFamily = new FontFamily("Segoe UI Emoji"),
+                FontFamily = new FontFamily("Segoe UI Emoji, Segoe UI Symbol, Segoe UI"),
             };
 
             _stampPopDone = new Border
@@ -706,7 +706,7 @@ namespace ConditioningControlPanel
             {
                 FontSize = 15,
                 Foreground = QuestStampWhiteInk,
-                FontFamily = new FontFamily("Segoe UI Emoji"),
+                FontFamily = new FontFamily("Segoe UI Emoji, Segoe UI Symbol, Segoe UI"),
                 VerticalAlignment = VerticalAlignment.Center,
                 Margin = new Thickness(0, 0, 6, 0),
             };

--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
@@ -680,7 +680,7 @@ namespace ConditioningControlPanel
                     var shieldLabel = new TextBlock
                     {
                         Text = "🛡️",
-                        FontFamily = new FontFamily("Segoe UI Emoji"),
+                        FontFamily = new FontFamily("Segoe UI Emoji, Segoe UI Symbol, Segoe UI"),
                         FontSize = 10,
                         TextAlignment = TextAlignment.Center
                     };

--- a/ConditioningControlPanel/MainWindow/MainWindow.SessionIO.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.SessionIO.cs
@@ -565,7 +565,7 @@ namespace ConditioningControlPanel
             else
             {
                 block.Foreground = Application.Current.Resources["TextSecondaryBrush"] as Brush;
-                block.FontFamily = new FontFamily("Consolas");
+                block.FontFamily = new FontFamily("Consolas, Courier New");
                 block.FontSize = 11;
                 block.VerticalAlignment = VerticalAlignment.Center;
                 block.TextAlignment = TextAlignment.Right;

--- a/ConditioningControlPanel/MainWindow/MainWindow.Takeaway.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Takeaway.cs
@@ -279,7 +279,7 @@ namespace ConditioningControlPanel
             else
             {
                 meta.Foreground = Application.Current.Resources["TextDimBrush"] as Brush;
-                meta.FontFamily = new FontFamily("Consolas");
+                meta.FontFamily = new FontFamily("Consolas, Courier New");
                 meta.FontSize = 9.5;
                 meta.VerticalAlignment = VerticalAlignment.Center;
                 meta.Margin = new Thickness(8, 0, 0, 0);
@@ -428,7 +428,7 @@ namespace ConditioningControlPanel
             else
             {
                 block.Foreground = Application.Current.Resources["TextSecondaryBrush"] as Brush;
-                block.FontFamily = new FontFamily("Consolas");
+                block.FontFamily = new FontFamily("Consolas, Courier New");
                 block.FontSize = 10.5;
                 block.VerticalAlignment = VerticalAlignment.Center;
                 block.TextAlignment = TextAlignment.Right;

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -785,7 +785,7 @@
                                         <Border Margin="4,0,0,0" VerticalAlignment="Center" CornerRadius="6"
                                                 Padding="3,0" Background="#33FF69B4"
                                                 BorderBrush="#FF69B4" BorderThickness="1">
-                                            <TextBlock Text="NEW" FontFamily="Consolas" FontSize="8"
+                                            <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
                                                        FontWeight="Bold" Foreground="#FF8FC7"/>
                                         </Border>
                                     </StackPanel>
@@ -1212,7 +1212,7 @@
                                             Margin="0,2,2,0" CornerRadius="6"
                                             Padding="3,0" Background="#33FF69B4"
                                             BorderBrush="#FF69B4" BorderThickness="1">
-                                        <TextBlock Text="NEW" FontFamily="Consolas" FontSize="8"
+                                        <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
                                                    FontWeight="Bold" Foreground="#FF8FC7"/>
                                     </Border>
                                 </Grid>
@@ -1272,7 +1272,7 @@
                                         <Border Margin="4,0,0,0" VerticalAlignment="Center" CornerRadius="6"
                                                 Padding="3,0" Background="#33FF69B4"
                                                 BorderBrush="#FF69B4" BorderThickness="1">
-                                            <TextBlock Text="NEW" FontFamily="Consolas" FontSize="8"
+                                            <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
                                                        FontWeight="Bold" Foreground="#FF8FC7"/>
                                         </Border>
                                     </StackPanel>
@@ -1295,7 +1295,7 @@
                                         <Border Margin="4,0,0,0" VerticalAlignment="Center" CornerRadius="6"
                                                 Padding="3,0" Background="#33FF69B4"
                                                 BorderBrush="#FF69B4" BorderThickness="1">
-                                            <TextBlock Text="NEW" FontFamily="Consolas" FontSize="8"
+                                            <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
                                                        FontWeight="Bold" Foreground="#FF8FC7"/>
                                         </Border>
                                     </StackPanel>
@@ -1616,7 +1616,7 @@
                                                    HorizontalAlignment="Center"
                                                    VerticalAlignment="Center"><Run Text="M"/><InlineUIContainer
                                                        BaselineAlignment="Baseline"><TextBlock
-                                                           Text="&#xE713;" FontFamily="Segoe MDL2 Assets"
+                                                           Text="&#xE713;" FontFamily="Segoe MDL2 Assets, Segoe UI Symbol, Segoe UI"
                                                            FontSize="10" FontWeight="Normal"
                                                            Foreground="{DynamicResource PinkBrush}"
                                                            Margin="0.7,0,0.7,-1"/></InlineUIContainer><Run
@@ -2870,7 +2870,7 @@
                     <TextBlock Text="{loc:Str label_remote_controlled}" Foreground="#00FF88" FontSize="28" FontWeight="Bold"
                                HorizontalAlignment="Center" Margin="0,0,0,8"/>
                     <TextBlock x:Name="TxtOverlaySessionCode" Text="" Foreground="{DynamicResource TextMutedBrush}" FontSize="18"
-                               FontFamily="Consolas" HorizontalAlignment="Center" Margin="0,0,0,16"/>
+                               FontFamily="Consolas, Courier New" HorizontalAlignment="Center" Margin="0,0,0,16"/>
 
                     <TextBlock x:Name="TxtRemoteOverlaySubtitle" Text="{loc:Str label_someone_else_is_controlling_your_app}" Foreground="#A0A0A0" FontSize="14"
                                HorizontalAlignment="Center" Margin="0,0,0,24"/>
@@ -2891,7 +2891,7 @@
                                 <helpers:EmojiTextBlock x:Name="TxtRemoteSessionName" Text="" Foreground="{DynamicResource PinkBrush}" FontSize="20" FontWeight="Bold"
                                                         HorizontalAlignment="Center" Margin="0,0,0,8"/>
                                 <TextBlock x:Name="TxtRemoteSessionTime" Text="" Foreground="#FFFFFF" FontSize="28"
-                                           FontFamily="Consolas" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                                           FontFamily="Consolas, Courier New" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,6"/>
                                 <TextBlock x:Name="TxtRemoteSessionPhase" Text="" Foreground="#A0A0B0" FontSize="13"
                                            HorizontalAlignment="Center"/>
                             </StackPanel>
@@ -3440,7 +3440,7 @@
             Background="#B00A0514" BorderBrush="#40E0B052" BorderThickness="1">
         <StackPanel>
             <TextBlock x:Name="FuseCornerDigits" Text=""
-                       FontFamily="Cascadia Mono, Consolas, Courier New" FontSize="15"
+                       FontFamily="{DynamicResource Font.Mono}" FontSize="15"
                        Foreground="#FFC9C4D6" HorizontalAlignment="Center"/>
             <TextBlock x:Name="FuseCornerPresence" Text="" Visibility="Collapsed"
                        FontSize="10" Margin="0,3,0,0" Foreground="#8AC9C4D6"

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -3051,7 +3051,7 @@ namespace ConditioningControlPanel
             var openBtn = new Button
             {
                 Content = "", // Segoe MDL2 'OpenInNewWindow'
-                FontFamily = new FontFamily("Segoe MDL2 Assets"),
+                FontFamily = new FontFamily("Segoe MDL2 Assets, Segoe UI Symbol, Segoe UI"),
                 FontSize = 12,
                 Width = 28,
                 Height = 28,
@@ -3079,7 +3079,7 @@ namespace ConditioningControlPanel
             var removeBtn = new Button
             {
                 Content = "", // Segoe MDL2 'Delete' (trash can)
-                FontFamily = new FontFamily("Segoe MDL2 Assets"),
+                FontFamily = new FontFamily("Segoe MDL2 Assets, Segoe UI Symbol, Segoe UI"),
                 FontSize = 13,
                 Width = 28,
                 Height = 28,
@@ -3117,7 +3117,7 @@ namespace ConditioningControlPanel
                 urlBox.BorderBrush = invalid
                     ? new SolidColorBrush(Color.FromRgb(0xFF, 0x8B, 0x5A))            // warning orange
                     : new SolidColorBrush(Color.FromArgb(0x55, 0x80, 0x80, 0x80));    // default
-                openBtn.FontFamily = invalid ? new FontFamily("Segoe UI Symbol") : new FontFamily("Segoe MDL2 Assets");
+                openBtn.FontFamily = invalid ? new FontFamily("Segoe UI Symbol") : new FontFamily("Segoe MDL2 Assets, Segoe UI Symbol, Segoe UI");
                 openBtn.Content = invalid ? "⚠" : "";    // Warning sign U+26A0 : OpenInNewWindow U+E8A7
                 openBtn.Foreground = invalid
                     ? new SolidColorBrush(Color.FromRgb(0xFF, 0x8B, 0x5A))

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -471,7 +471,7 @@ public class BubbleCountService : IDisposable
                         Foreground = Brushes.Magenta,
                         FontSize = 64,
                         FontWeight = FontWeights.Bold,
-                        FontFamily = new FontFamily("Impact"),
+                        FontFamily = new FontFamily("Impact, Arial Black, Segoe UI"),
                         TextAlignment = TextAlignment.Center,
                         HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
                         VerticalAlignment = VerticalAlignment.Center

--- a/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Screensavers.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiChannels.Screensavers.cs
@@ -123,7 +123,7 @@ public static partial class EmiChannels
         /// exotic kaomoji). The katakana come back full width, a touch wider than their column,
         /// which is what they do on the campus too.
         /// </summary>
-        private static readonly FontFamily RainFont = new(
+        private static readonly FontFamily RainFont = Services.UI.FontGuard.Family(
             "Cascadia Mono, Consolas, Noto Sans Mono, MS Gothic, Yu Gothic UI, Meiryo, " +
             "Courier New, Global Monospace");
 

--- a/ConditioningControlPanel/Services/EmiDesk/EmiFace.cs
+++ b/ConditioningControlPanel/Services/EmiDesk/EmiFace.cs
@@ -169,7 +169,7 @@ public sealed class EmiFace : FrameworkElement
             var hit = FindFontDir("NotoSansMono");
             if (hit != null)
             {
-                var ff = new FontFamily(hit.Value.BaseUri, "./#Noto Sans Mono, " + FallbackChain);
+                var ff = new FontFamily(hit.Value.BaseUri, "./#Noto Sans Mono, " + Services.UI.FontGuard.Sanitize(FallbackChain));
                 if (!_fontLogged)
                 {
                     _fontLogged = true;
@@ -188,7 +188,7 @@ public sealed class EmiFace : FrameworkElement
             _fontLogged = true;
             Log.Information("[EmiDesk] face font: system chain (no ttf/otf in the font folders)");
         }
-        return new FontFamily(FallbackChain);
+        return Services.UI.FontGuard.Family(FallbackChain);
     }
 
     // ---------------------------------------------------------------- the pixel font
@@ -229,7 +229,7 @@ public sealed class EmiFace : FrameworkElement
             var hit = FindFontDir("PressStart2P");
             if (hit != null)
             {
-                var ff = new FontFamily(hit.Value.BaseUri, "./#Press Start 2P, " + PixelFallbackChain);
+                var ff = new FontFamily(hit.Value.BaseUri, "./#Press Start 2P, " + Services.UI.FontGuard.Sanitize(PixelFallbackChain));
                 if (!_pixelLogged)
                 {
                     _pixelLogged = true;
@@ -248,7 +248,7 @@ public sealed class EmiFace : FrameworkElement
             _pixelLogged = true;
             Log.Information("[EmiDesk] pixel font: system chain (no PressStart2P ttf shipped)");
         }
-        return new FontFamily(PixelFallbackChain);
+        return Services.UI.FontGuard.Family(PixelFallbackChain);
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Services/UI/FontGuard.cs
+++ b/ConditioningControlPanel/Services/UI/FontGuard.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+
+namespace ConditioningControlPanel.Services.UI
+{
+    /// <summary>
+    /// Startup probe that keeps a BROKEN font install from turning every navigation into a blank
+    /// screen.
+    ///
+    /// <para><b>The incident (v6.8.6).</b> A user's Cascadia install was missing/corrupt. Every
+    /// panel he opened rendered blank, and the dispatcher took an
+    /// <c>UnauthorizedAccessException</c> at
+    /// <c>MS.Internal.Text.TextInterface.FontFamily.GetFirstMatchingFont</c> ->
+    /// <c>Typeface.ConstructCachedTypeface</c> -> <c>TextBlock.MeasureOverride</c>, inside
+    /// <c>ContextLayoutManager.UpdateLayout</c> off <c>HwndTarget.OnResize</c>. Because it throws
+    /// from the LAYOUT pass it re-throws on every measure, so the UI never finishes a frame and
+    /// crash.log grew to roughly half a gigabyte in one session. Reinstalling the fonts fixed it;
+    /// the app had no guard.</para>
+    ///
+    /// <para><b>Why a comma fallback chain is not enough.</b> Every Cascadia site in this app
+    /// ALREADY named a chain (<c>"Cascadia Mono, Consolas, Courier New"</c>) when that crash
+    /// happened. A chain only covers a family that is ABSENT: WPF walks to the next link when a
+    /// name does not resolve. It does not cover a family that is PRESENT but unreadable - to decide
+    /// whether the first link matches, WPF has to open the font file, and that open is what throws.
+    /// The throw happens before the chain is ever walked. So the chain is worth having (it is the
+    /// cheap half of the fix, and it does handle the uninstalled-font case) but the only thing that
+    /// helps a corrupt face is to STOP NAMING IT.</para>
+    ///
+    /// <para><b>What this does.</b> Once, at startup, on the UI thread: resolve each risky family
+    /// exactly the way the layout pass would (build a <see cref="Typeface"/> and ask for its glyph
+    /// typeface, which is what calls <c>GetFirstMatchingFont</c>). Any family whose probe throws is
+    /// recorded as broken, logged ONE time, and struck out of every chain we hand to WPF from then
+    /// on - including the app-level <c>Font.Mono</c> resource the markup binds with
+    /// <c>DynamicResource</c>. A corrupt Cascadia now costs one warning line and a slightly
+    /// different monospace face instead of an unusable app.</para>
+    ///
+    /// <para>Probing is cheap (a handful of families, each a single typeface construction) and
+    /// deliberately covers only the faces we NAME OURSELVES that a stock Windows install may not
+    /// have in good order. User-picked fonts go through
+    /// <see cref="Helpers.FontPickerHelper.Resolve"/>, which has its own guard.</para>
+    /// </summary>
+    public static class FontGuard
+    {
+        /// <summary>The monospace chain the app uses for code/telemetry readouts.</summary>
+        public const string MonoChain = "Cascadia Mono, Consolas, Courier New";
+
+        /// <summary>Resource key the markup binds so a broken face can be swapped out at runtime.</summary>
+        public const string MonoResourceKey = "Font.Mono";
+
+        /// <summary>
+        /// Families worth probing: ones we hardcode that are NOT guaranteed present and healthy.
+        /// "Segoe UI" is deliberately absent - it is the floor everything else falls back to, and
+        /// a machine whose Segoe UI is corrupt cannot render a WPF window at all.
+        /// </summary>
+        private static readonly string[] ProbedFamilies =
+        {
+            "Cascadia Mono",
+            "Consolas",
+            "Courier New",
+            "Segoe MDL2 Assets",
+            "Segoe UI Emoji",
+        };
+
+        private static readonly HashSet<string> _broken = new(StringComparer.OrdinalIgnoreCase);
+        private static bool _verified;
+
+        /// <summary>Families whose probe threw this session. Empty on a healthy machine.</summary>
+        public static IReadOnlyCollection<string> BrokenFamilies => _broken;
+
+        /// <summary>True when <paramref name="family"/> failed its startup probe.</summary>
+        public static bool IsBroken(string? family) =>
+            !string.IsNullOrWhiteSpace(family) && _broken.Contains(family!.Trim());
+
+        /// <summary>
+        /// The guarded monospace family - <see cref="MonoChain"/> with any broken link removed.
+        /// Code-behind that used to write <c>new FontFamily("Cascadia Mono, Consolas, Courier New")</c>
+        /// should use this instead so it follows the same verdict as the markup.
+        /// </summary>
+        public static FontFamily Mono => Family(MonoChain);
+
+        /// <summary>
+        /// A <see cref="FontFamily"/> for <paramref name="chain"/> with broken links struck out.
+        /// Never throws: a failure here would defeat the point, so the hard floor is Segoe UI.
+        /// </summary>
+        public static FontFamily Family(string chain)
+        {
+            try { return new FontFamily(Sanitize(chain)); }
+            catch { return new FontFamily("Segoe UI"); }
+        }
+
+        /// <summary>
+        /// Drops every family that failed its probe from a comma-separated chain. Returns the
+        /// chain unchanged on a healthy machine (the overwhelmingly common case), and never
+        /// returns empty - if every link is broken the caller still gets Segoe UI to name.
+        /// </summary>
+        public static string Sanitize(string? chain)
+        {
+            if (string.IsNullOrWhiteSpace(chain)) return "Segoe UI";
+            if (_broken.Count == 0) return chain!;
+            return FilterChain(chain!, IsBroken);
+        }
+
+        /// <summary>
+        /// The pure string half of <see cref="Sanitize"/>, split out so it is testable without a
+        /// WPF dispatcher or a deliberately corrupted font install.
+        ///
+        /// <para>Links are compared by their trimmed text. A pack-relative link
+        /// (<c>"./#Press Start 2P"</c>) never matches an installed family name, so bundled faces
+        /// pass through untouched - which is right: they ship with the app and cannot be the
+        /// machine's broken system font.</para>
+        /// </summary>
+        public static string FilterChain(string chain, Func<string, bool> isBroken)
+        {
+            if (string.IsNullOrWhiteSpace(chain)) return "Segoe UI";
+            if (isBroken == null) return chain;
+
+            var kept = chain
+                .Split(',')
+                .Select(link => link.Trim())
+                .Where(link => link.Length > 0 && !isBroken(link))
+                .ToList();
+
+            return kept.Count > 0 ? string.Join(", ", kept) : "Segoe UI";
+        }
+
+        /// <summary>
+        /// Probe every risky family once and publish the app-level font resources. Safe to call
+        /// twice (the second call is a no-op) and safe to call before any window exists.
+        /// </summary>
+        public static void Verify()
+        {
+            if (_verified) return;
+            _verified = true;
+
+            foreach (var family in ProbedFamilies)
+            {
+                if (CanResolve(family, out var error)) continue;
+
+                _broken.Add(family);
+                // ONE line per broken family. Deliberately a warning, not an error: the app is
+                // still fully usable, and this is the line that turns "the whole app is blank"
+                // into a two-minute diagnosis (reinstall the font).
+                App.Logger?.Warning(
+                    "[FONTGUARD] Font family {Family} is installed but unreadable ({Error}) - dropping it from every font chain for this session. The app will use its fallback face. Reinstalling that font restores it.",
+                    family, error);
+            }
+
+            PublishResources();
+        }
+
+        /// <summary>
+        /// Puts the guarded chains into <c>Application.Current.Resources</c>. Markup binds these
+        /// with <c>DynamicResource</c>, so swapping the value here re-renders every consumer -
+        /// which is what lets a broken face be corrected without touching a single call site.
+        /// </summary>
+        private static void PublishResources()
+        {
+            try
+            {
+                var app = Application.Current;
+                if (app == null) return;
+
+                var mono = Sanitize(MonoChain);
+                app.Resources[MonoResourceKey] = new FontFamily(mono);
+
+                if (_broken.Count > 0)
+                    App.Logger?.Information("[FONTGUARD] {Key} resolved to \"{Chain}\"", MonoResourceKey, mono);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("[FONTGUARD] could not publish font resources: {Msg}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Resolve <paramref name="family"/> the same way a layout pass would. Building the
+        /// <see cref="Typeface"/> is not enough on its own - it is
+        /// <see cref="Typeface.TryGetGlyphTypeface"/> that reaches
+        /// <c>GetFirstMatchingFont</c> and opens the font file, which is exactly where the v6.8.6
+        /// crash came from. <see cref="FontFamily.LineSpacing"/> is touched too because the
+        /// measure pass reads it.
+        /// </summary>
+        private static bool CanResolve(string family, out string error)
+        {
+            error = "";
+            try
+            {
+                var ff = new FontFamily(family);
+                var typeface = new Typeface(ff, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal);
+                typeface.TryGetGlyphTypeface(out _);
+                _ = ff.LineSpacing;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.GetType().Name + ": " + ex.Message;
+                return false;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -5633,7 +5633,7 @@ namespace ConditioningControlPanel.Services
                         Foreground = Brushes.Magenta,
                         FontSize = 64,
                         FontWeight = FontWeights.Bold,
-                        FontFamily = new FontFamily("Impact"),
+                        FontFamily = new FontFamily("Impact, Arial Black, Segoe UI"),
                         TextAlignment = TextAlignment.Center,
                         HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
                         VerticalAlignment = VerticalAlignment.Center

--- a/ConditioningControlPanel/Views/Controls/AppSettings/DevicesSettingsSection.xaml
+++ b/ConditioningControlPanel/Views/Controls/AppSettings/DevicesSettingsSection.xaml
@@ -112,7 +112,7 @@
                                                     Foreground="{StaticResource SectionHueDevicesBrush}"
                                                     Text="{loc:Str set2_devices_webcam_title}" FontSize="14" Margin="0"/>
                             <TextBlock Text="{loc:Str set2_devices_webcam_sub}"
-                                       Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas" FontSize="11"/>
+                                       Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New" FontSize="11"/>
                         </StackPanel>
                     </StackPanel>
 
@@ -137,7 +137,7 @@
 
                                 <!-- camera -->
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,4,12,4">
-                                    <TextBlock Text="CAM" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas"
+                                    <TextBlock Text="CAM" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New"
                                                FontSize="10.5" VerticalAlignment="Center" Margin="0,0,7,0"/>
                                     <ComboBox x:Name="CmbWebcamDevice" x:FieldModifier="internal" Width="170"
                                               VerticalAlignment="Center"
@@ -156,7 +156,7 @@
 
                                 <!-- monitor -->
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,4,12,4">
-                                    <TextBlock Text="MON" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas"
+                                    <TextBlock Text="MON" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New"
                                                FontSize="10.5" VerticalAlignment="Center" Margin="0,0,7,0"/>
                                     <ComboBox x:Name="CmbWebcamMonitor" x:FieldModifier="internal" Width="150"
                                               VerticalAlignment="Center"
@@ -174,7 +174,7 @@
                                                  Fill="{DynamicResource TextMutedBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
                                         <TextBlock x:Name="TxtWebcamDebugStatus" x:FieldModifier="internal" Text="{loc:Str rf_webcam_stopped}"
                                                    Foreground="{DynamicResource TextLightBrush}"
-                                                   FontFamily="Consolas" FontWeight="SemiBold" FontSize="12" VerticalAlignment="Center"/>
+                                                   FontFamily="Consolas, Courier New" FontWeight="SemiBold" FontSize="12" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Border>
 
@@ -306,11 +306,11 @@
 
                                     <TextBlock x:Name="TxtWebcamDebugCounters" x:FieldModifier="internal"
                                                Text="Face: — | Blinks: 0 | Gaze: —"
-                                               Foreground="{DynamicResource SuccessGreenBrush}" FontFamily="Consolas" FontSize="12"
+                                               Foreground="{DynamicResource SuccessGreenBrush}" FontFamily="Consolas, Courier New" FontSize="12"
                                                FontWeight="SemiBold" Margin="0,2,0,0"/>
                                     <Border Background="{DynamicResource PreviewBgBrush}" CornerRadius="8" Padding="10" Margin="0,8,0,0">
                                         <TextBlock x:Name="TxtWebcamDebugLog" x:FieldModifier="internal" Text="(events will appear here)"
-                                                   Foreground="{DynamicResource SuccessGreenBrush}" FontFamily="Consolas" FontSize="11"
+                                                   Foreground="{DynamicResource SuccessGreenBrush}" FontFamily="Consolas, Courier New" FontSize="11"
                                                    TextWrapping="Wrap" MinHeight="60"/>
                                     </Border>
                                 </StackPanel>
@@ -346,7 +346,7 @@
                                                     Foreground="{StaticResource SectionHueDevicesBrush}"
                                                     Text="{loc:Str set2_devices_mic_title}" FontSize="14" Margin="0"/>
                             <TextBlock Text="{loc:Str set2_devices_mic_sub}"
-                                       Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas" FontSize="11"/>
+                                       Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New" FontSize="11"/>
                         </StackPanel>
                     </StackPanel>
 

--- a/ConditioningControlPanel/Views/Controls/Companion/AwarenessPrivacyView.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/AwarenessPrivacyView.xaml
@@ -271,7 +271,7 @@
                         <ScrollViewer MaxHeight="180" HorizontalScrollBarVisibility="Auto"
                                       VerticalScrollBarVisibility="Auto"
                                       Visibility="{Binding HasWireJson, Converter={StaticResource CmpBoolToVis}}">
-                            <TextBlock Text="{Binding WireJson}" FontFamily="Consolas" FontSize="10.5"
+                            <TextBlock Text="{Binding WireJson}" FontFamily="Consolas, Courier New" FontSize="10.5"
                                        Foreground="{StaticResource CmpDimBrush}"/>
                         </ScrollViewer>
                         <TextBlock Text="{Binding WireJsonEmptyCopy}" Style="{StaticResource CmpFaintTextStyle}"

--- a/ConditioningControlPanel/Views/Controls/Companion/CompanionHeroCard.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/CompanionHeroCard.xaml
@@ -369,7 +369,7 @@
 
                             <!-- name + mod chip + mood token -->
                             <WrapPanel Orientation="Horizontal">
-                                <TextBlock Text="{Binding Name}" FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                                <TextBlock Text="{Binding Name}" FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                                            FontSize="31" Foreground="White" VerticalAlignment="Center"
                                            Margin="0,0,11,0" Effect="{StaticResource CmpNameGlow}"/>
 

--- a/ConditioningControlPanel/Views/Controls/Companion/MakeHerYoursView.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/MakeHerYoursView.xaml
@@ -163,7 +163,7 @@
                         </Border>
 
                         <StackPanel Margin="0,0,58,0">
-                            <TextBlock Text="{Binding InterviewTitle}" FontFamily="/Fonts/#Fredoka"
+                            <TextBlock Text="{Binding InterviewTitle}" FontFamily="/Fonts/#Fredoka, Segoe UI"
                                        FontWeight="SemiBold" FontSize="16" Foreground="White"
                                        TextWrapping="Wrap" Effect="{StaticResource CmpSectionGlow}"/>
 

--- a/ConditioningControlPanel/Views/Controls/Companion/Themes/CompanionTheme.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/Themes/CompanionTheme.xaml
@@ -266,7 +266,7 @@
 
     <!-- ============================ 4. text styles ============================ -->
     <Style x:Key="CmpPageTitleStyle" TargetType="TextBlock">
-        <Setter Property="FontFamily" Value="/Fonts/#Fredoka"/>
+        <Setter Property="FontFamily" Value="/Fonts/#Fredoka, Segoe UI"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="FontSize" Value="27"/>
         <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
@@ -1269,7 +1269,7 @@
         <Setter Property="Padding" Value="13,10,13,10"/>
     </Style>
     <Style x:Key="CmpWireTextStyle" TargetType="TextBlock">
-        <Setter Property="FontFamily" Value="Cascadia Mono, Consolas, Courier New"/>
+        <Setter Property="FontFamily" Value="{DynamicResource Font.Mono}"/>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="Foreground" Value="#FF8FE3B0"/>
         <Setter Property="TextTrimming" Value="CharacterEllipsis"/>

--- a/ConditioningControlPanel/Views/Controls/DailyQuestCard.xaml
+++ b/ConditioningControlPanel/Views/Controls/DailyQuestCard.xaml
@@ -117,7 +117,7 @@
                                                     FontSize="11" FontWeight="Bold" VerticalAlignment="Center"/>
                             <TextBlock x:Name="TxtXpBonus" Text="" Foreground="#FFB347"
                                        FontSize="10" FontWeight="Bold" Margin="4,0,0,0"
-                                       VerticalAlignment="Center" FontFamily="Segoe UI Emoji"
+                                       VerticalAlignment="Center" FontFamily="Segoe UI Emoji, Segoe UI Symbol, Segoe UI"
                                        Visibility="Collapsed"/>
                         </StackPanel>
                     </Border>

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.Ruler.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.Ruler.cs
@@ -148,7 +148,7 @@ namespace ConditioningControlPanel.Views.Deeper
                         Text = FormatRulerTime(t, majorSec),
                         Foreground = labelBrush,
                         FontSize = 9,
-                        FontFamily = new FontFamily("Consolas"),
+                        FontFamily = new FontFamily("Consolas, Courier New"),
                         IsHitTestVisible = false
                     };
                     label.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml
@@ -1121,7 +1121,7 @@
                                                            TextTrimming="CharacterEllipsis"/>
                                                 <TextBlock Grid.Column="3" Text="{Binding TimeText}"
                                                            Foreground="{DynamicResource TextDimBrush}"
-                                                           FontFamily="Consolas" FontSize="10"
+                                                           FontFamily="Consolas, Courier New" FontSize="10"
                                                            VerticalAlignment="Center"
                                                            Margin="8,0,6,0"/>
                                                 <Button Grid.Column="4"
@@ -1184,7 +1184,7 @@
                         <StackPanel x:Name="RegionEditor" Visibility="Collapsed">
                             <TextBlock Text="{loc:Str deeper_editor_region_id}" Style="{StaticResource EditorLabel}"/>
                             <TextBlock x:Name="TxtRegionId" Foreground="{DynamicResource TextDimBrush}"
-                                       FontSize="11" FontFamily="Consolas" Margin="0,0,0,8"/>
+                                       FontSize="11" FontFamily="Consolas, Courier New" Margin="0,0,0,8"/>
 
                             <TextBlock Text="{loc:Str deeper_editor_region_label}" Style="{StaticResource EditorLabel}"/>
                             <TextBox x:Name="TxtRegionLabel" Style="{StaticResource EditorTextBox}"
@@ -1266,7 +1266,7 @@
                         <StackPanel x:Name="HapticEventEditor" Visibility="Collapsed">
                             <TextBlock Text="{loc:Str deeper_editor_haptic_event}" Style="{StaticResource EditorLabel}"/>
                             <TextBlock x:Name="TxtHapticTrackId" Foreground="{DynamicResource TextDimBrush}"
-                                       FontSize="11" FontFamily="Consolas" Margin="0,0,0,8"/>
+                                       FontSize="11" FontFamily="Consolas, Courier New" Margin="0,0,0,8"/>
 
                             <Grid Margin="0,0,0,4">
                                 <Grid.ColumnDefinitions>
@@ -1303,7 +1303,7 @@
                                 <TextBlock x:Name="TxtHapticIntensityValue" Grid.Column="1"
                                            Text="100%" Foreground="{DynamicResource TextLightBrush}"
                                            HorizontalAlignment="Right" VerticalAlignment="Center"
-                                           FontFamily="Consolas" FontSize="11"/>
+                                           FontFamily="Consolas, Courier New" FontSize="11"/>
                             </Grid>
 
                             <TextBlock Text="{loc:Str deeper_editor_haptic_pattern}" Style="{StaticResource EditorLabel}"/>
@@ -1363,7 +1363,7 @@
                             <DockPanel Margin="0,0,0,10" LastChildFill="True">
                                 <TextBlock x:Name="TxtRuleHeader" DockPanel.Dock="Left"
                                            Foreground="{DynamicResource TextDimBrush}"
-                                           FontSize="11" FontFamily="Consolas" VerticalAlignment="Center"/>
+                                           FontSize="11" FontFamily="Consolas, Courier New" VerticalAlignment="Center"/>
                                 <Button DockPanel.Dock="Right" Content="{loc:Str deeper_editor_rule_delete}"
                                         Click="BtnDeleteRule_Click"
                                         ToolTip="{loc:Str deeper_editor_tip_rule_delete}"

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml
@@ -473,7 +473,7 @@
                 <TextBlock DockPanel.Dock="Right" x:Name="TxtMiniTimelineReadout"
                            Text="0:00 / 0:00"
                            Foreground="{DynamicResource TextMutedBrush}"
-                           FontSize="10" FontFamily="Consolas"
+                           FontSize="10" FontFamily="Consolas, Courier New"
                            VerticalAlignment="Center"/>
             </DockPanel>
             <Border x:Name="MiniTimelineHost"
@@ -515,13 +515,13 @@
                     FontSize="13"/>
             <TextBlock x:Name="TxtCurrent" DockPanel.Dock="Left"
                        Text="0:00" Foreground="{DynamicResource TextLightBrush}"
-                       FontSize="12" FontFamily="Consolas"
+                       FontSize="12" FontFamily="Consolas, Courier New"
                        VerticalAlignment="Center" Margin="14,0,4,0"/>
             <TextBlock DockPanel.Dock="Left" Text="/" Foreground="{DynamicResource TextDimBrush}"
                        FontSize="12" VerticalAlignment="Center"/>
             <TextBlock x:Name="TxtTotal" DockPanel.Dock="Left"
                        Text="0:00" Foreground="{DynamicResource TextMutedBrush}"
-                       FontSize="12" FontFamily="Consolas"
+                       FontSize="12" FontFamily="Consolas, Courier New"
                        VerticalAlignment="Center" Margin="4,0,0,0"/>
 
             <!-- Secondary cluster (right side) — PiP, eye-tracking, volume.
@@ -679,14 +679,14 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Grid.Column="0" Text="{Binding TimestampDisplay}"
                                                    Foreground="{DynamicResource TextDimBrush}"
-                                                   FontFamily="Consolas" FontSize="9"
+                                                   FontFamily="Consolas, Courier New" FontSize="9"
                                                    VerticalAlignment="Center"/>
                                         <TextBlock Grid.Column="1" Text="{Binding IconGlyph}"
                                                    Foreground="{Binding IconBrush}"
                                                    FontSize="10" VerticalAlignment="Center"/>
                                         <TextBlock Grid.Column="2" TextWrapping="NoWrap"
                                                    TextTrimming="CharacterEllipsis"
-                                                   FontFamily="Consolas" FontSize="10"
+                                                   FontFamily="Consolas, Courier New" FontSize="10"
                                                    VerticalAlignment="Center" Margin="2,0,0,0">
                                             <Run Text="{Binding RuleLabel, Mode=OneWay}"
                                                  Foreground="{Binding RuleLabelBrush}"

--- a/ConditioningControlPanel/Views/Deeper/GazePickerWindow.xaml
+++ b/ConditioningControlPanel/Views/Deeper/GazePickerWindow.xaml
@@ -85,7 +85,7 @@
                            VerticalAlignment="Center" Margin="0,0,16,0"/>
                 <TextBlock x:Name="TxtCoords" DockPanel.Dock="Left"
                            Foreground="{DynamicResource DeeperAccentSoftBrush}" FontSize="11"
-                           FontFamily="Consolas" VerticalAlignment="Center" Margin="0,0,16,0"/>
+                           FontFamily="Consolas, Courier New" VerticalAlignment="Center" Margin="0,0,16,0"/>
                 <Button DockPanel.Dock="Right" Content="{loc:Str deeper_editor_gaze_pick_done}"
                         Click="BtnDone_Click" Margin="8,0,0,0"
                         Padding="14,6" Cursor="Hand" FontSize="11" FontWeight="SemiBold"

--- a/ConditioningControlPanel/Views/Tabs/BlinkTrainerTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/BlinkTrainerTabView.xaml
@@ -576,7 +576,7 @@
                                                                FontSize="12" FontWeight="Medium"/>
                                                     <TextBlock x:Name="TxtWebcamStatusChipBlinkTrainer" x:FieldModifier="internal"
                                                                Text="{loc:Str rf_webcam_stopped}" Foreground="{DynamicResource TextMutedBrush}"
-                                                               FontFamily="Consolas" FontSize="11"/>
+                                                               FontFamily="Consolas, Courier New" FontSize="11"/>
                                                 </StackPanel>
                                                 <Button Grid.Column="2" Content="{loc:Str set2_configure_in_settings}"
                                                         Padding="10,4" FontSize="10" VerticalAlignment="Center"

--- a/ConditioningControlPanel/Views/Tabs/DeeperTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/DeeperTabView.xaml
@@ -708,7 +708,7 @@
                                                 </StackPanel>
                                                 <TextBlock x:Name="TxtWebcamStatusChipDeeper" x:FieldModifier="internal"
                                                            Text="{loc:Str rf_webcam_stopped}" Foreground="{DynamicResource TextMutedBrush}"
-                                                           FontFamily="Consolas" FontSize="11" Margin="16,2,0,0"/>
+                                                           FontFamily="Consolas, Courier New" FontSize="11" Margin="16,2,0,0"/>
                                                 <Button Content="{loc:Str set2_configure_in_settings}"
                                                         HorizontalAlignment="Left" Margin="16,6,0,0"
                                                         Padding="8,3" FontSize="10"

--- a/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml
@@ -69,7 +69,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="{loc:Str profile_tab_heading}"
-                                   FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                                   FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                                    FontSize="25" Foreground="White" VerticalAlignment="Center">
                             <TextBlock.Effect>
                                 <DropShadowEffect Color="#FF69B4" BlurRadius="18" ShadowDepth="0" Opacity="0.8"/>
@@ -474,7 +474,7 @@
                                         <TextBlock x:Name="ProfileVatReadout" x:FieldModifier="internal" Grid.Row="1"
                                                    Visibility="Collapsed" HorizontalAlignment="Center"
                                                    TextAlignment="Center"
-                                                   Margin="0,3,0,0" FontFamily="Consolas" FontSize="10"
+                                                   Margin="0,3,0,0" FontFamily="Consolas, Courier New" FontSize="10"
                                                    FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
                                                    ToolTipService.InitialShowDelay="200"
                                                    ToolTipService.ShowDuration="20000"/>
@@ -484,7 +484,7 @@
                                     <StackPanel Grid.Column="1" Margin="16,0,14,0" VerticalAlignment="Top">
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock x:Name="TxtProfileViewerName" x:FieldModifier="internal" Text="{loc:Str login_display_name}"
-                                                       FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                                                       FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                                                        Foreground="White" FontSize="23" TextTrimming="CharacterEllipsis"
                                                        VerticalAlignment="Center"/>
                                             <Button x:Name="BtnChangeDisplayName" x:FieldModifier="internal" Visibility="Collapsed"
@@ -785,7 +785,7 @@
                                 <!-- Column headers carry the equipped accent (Phase 2). -->
                                 <TextBlock x:Name="TxtProfileRecordHeader" x:FieldModifier="internal"
                                            Text="{loc:Str profile_record_title}"
-                                           FontFamily="/Fonts/#Fredoka" FontWeight="Medium"
+                                           FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="Medium"
                                            FontSize="15" Foreground="White" Margin="0,0,0,10"/>
 
                                 <!-- XP -->
@@ -802,7 +802,7 @@
                                     <TextBlock Grid.Column="1" Text="{loc:Str label_xp}" Foreground="#B8B1CC" FontSize="11"
                                                VerticalAlignment="Center" Margin="10,0,8,0" TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="2" x:Name="TxtProfileViewerXp" x:FieldModifier="internal" Text="0"
-                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas"
+                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas, Courier New"
                                                VerticalAlignment="Center" TextAlignment="Right"/>
                                 </Grid>
 
@@ -820,7 +820,7 @@
                                     <TextBlock Grid.Column="1" Text="{loc:Str label_bubbles_2}" Foreground="#B8B1CC" FontSize="11"
                                                VerticalAlignment="Center" Margin="10,0,8,0" TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="2" x:Name="TxtProfileViewerBubbles" x:FieldModifier="internal" Text="0"
-                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas"
+                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas, Courier New"
                                                VerticalAlignment="Center" TextAlignment="Right"/>
                                 </Grid>
 
@@ -838,7 +838,7 @@
                                     <TextBlock Grid.Column="1" Text="{loc:Str label_videos}" Foreground="#B8B1CC" FontSize="11"
                                                VerticalAlignment="Center" Margin="10,0,8,0" TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="2" x:Name="TxtProfileViewerVideos" x:FieldModifier="internal" Text="{loc:Str label_0h}"
-                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas"
+                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas, Courier New"
                                                VerticalAlignment="Center" TextAlignment="Right"/>
                                 </Grid>
 
@@ -856,7 +856,7 @@
                                     <TextBlock Grid.Column="1" Text="{loc:Str label_flashes}" Foreground="#B8B1CC" FontSize="11"
                                                VerticalAlignment="Center" Margin="10,0,8,0" TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="2" x:Name="TxtProfileViewerGifs" x:FieldModifier="internal" Text="0"
-                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas"
+                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas, Courier New"
                                                VerticalAlignment="Center" TextAlignment="Right"/>
                                 </Grid>
 
@@ -874,7 +874,7 @@
                                     <TextBlock Grid.Column="1" Text="{loc:Str label_lock_cards_2}" Foreground="#B8B1CC" FontSize="11"
                                                VerticalAlignment="Center" Margin="10,0,8,0" TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="2" x:Name="TxtProfileViewerLockCards" x:FieldModifier="internal" Text="0"
-                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas"
+                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas, Courier New"
                                                VerticalAlignment="Center" TextAlignment="Right"/>
                                 </Grid>
 
@@ -892,7 +892,7 @@
                                     <TextBlock Grid.Column="1" Text="{loc:Str label_achievements}" Foreground="#B8B1CC" FontSize="11"
                                                VerticalAlignment="Center" Margin="10,0,8,0" TextTrimming="CharacterEllipsis"/>
                                     <TextBlock Grid.Column="2" x:Name="TxtProfileViewerAchievements" x:FieldModifier="internal" Text="0"
-                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas"
+                                               Foreground="White" FontSize="15" FontWeight="Bold" FontFamily="Consolas, Courier New"
                                                VerticalAlignment="Center" TextAlignment="Right"/>
                                 </Grid>
                             </StackPanel>
@@ -907,7 +907,7 @@
                                 <Grid Margin="0,0,0,10">
                                     <TextBlock x:Name="TxtProfileShowcaseHeader" x:FieldModifier="internal"
                                                Text="{loc:Str profile_showcase_title}"
-                                               FontFamily="/Fonts/#Fredoka" FontWeight="Medium"
+                                               FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="Medium"
                                                FontSize="15" Foreground="White"/>
                                     <TextBlock Text="{loc:Str profile_showcase_hint}" Foreground="#8079A3" FontSize="11"
                                                HorizontalAlignment="Right" VerticalAlignment="Center"/>
@@ -1040,7 +1040,7 @@
                             <StackPanel>
                                 <TextBlock x:Name="TxtProfileCommunityHeader" x:FieldModifier="internal"
                                            Text="{loc:Str profile_community_title}"
-                                           FontFamily="/Fonts/#Fredoka" FontWeight="Medium"
+                                           FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="Medium"
                                            FontSize="15" Foreground="White" Margin="0,0,0,10"/>
 
                                 <!-- Search. The 1px border is transparent at rest and brightens on

--- a/ConditioningControlPanel/Views/Tabs/ExclusivesTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/ExclusivesTabView.xaml
@@ -102,7 +102,7 @@
                             </Border>
                             <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
                                 <TextBlock Text="{loc:Str exclusives_vault_title}"
-                                           FontFamily="/Fonts/#Fredoka" FontWeight="Bold"
+                                           FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="Bold"
                                            FontSize="17" Foreground="{StaticResource TextLightBrush}"/>
                                 <TextBlock Text="{loc:Str exclusives_vault_sub}"
                                            FontSize="11.5" Foreground="{StaticResource TextMutedBrush}"
@@ -226,7 +226,7 @@
                                     </Border>
                                 </StackPanel>
                                 <TextBlock x:Name="TxtSpotTitle" x:FieldModifier="internal"
-                                           FontFamily="/Fonts/#Fredoka" FontWeight="SemiBold"
+                                           FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="SemiBold"
                                            FontSize="30" Foreground="White">
                                     <TextBlock.Effect>
                                         <DropShadowEffect Color="#FF69B4" BlurRadius="20"
@@ -283,7 +283,7 @@
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="{loc:Str exclusives_collection}"
-                                   FontFamily="/Fonts/#Fredoka" FontWeight="Medium"
+                                   FontFamily="/Fonts/#Fredoka, Segoe UI" FontWeight="Medium"
                                    FontSize="16" Foreground="{StaticResource TextLightBrush}"/>
                         <Rectangle Grid.Column="1" Height="1" Margin="14,0"
                                    VerticalAlignment="Center">

--- a/ConditioningControlPanel/Views/Tabs/GradedIntakeTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/GradedIntakeTabView.xaml
@@ -61,7 +61,7 @@
                                            Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
                                 <Border Background="{DynamicResource TransparentPink20Brush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1"
                                         CornerRadius="6" Padding="6,1" Margin="10,0,0,0" VerticalAlignment="Center">
-                                    <TextBlock Text="{loc:Str label_beta_2}" Foreground="{DynamicResource PinkBrush}" FontFamily="Consolas" FontWeight="Bold" FontSize="9.5"/>
+                                    <TextBlock Text="{loc:Str label_beta_2}" Foreground="{DynamicResource PinkBrush}" FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="9.5"/>
                                 </Border>
                             </StackPanel>
                             <TextBlock Text="A banded descent that reads how you answer - and how long you take - and drafts a personalised session from it."

--- a/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
@@ -154,7 +154,7 @@
             </Style>
             <Style x:Key="PlayZoneTag" TargetType="TextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
-                <Setter Property="FontFamily" Value="Consolas"/>
+                <Setter Property="FontFamily" Value="Consolas, Courier New"/>
                 <Setter Property="FontWeight" Value="Bold"/>
                 <Setter Property="FontSize" Value="12"/>
                 <Setter Property="VerticalAlignment" Value="Center"/>
@@ -192,7 +192,7 @@
             </Style>
             <Style x:Key="PlayBadgePillText" TargetType="TextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
-                <Setter Property="FontFamily" Value="Consolas"/>
+                <Setter Property="FontFamily" Value="Consolas, Courier New"/>
                 <Setter Property="FontWeight" Value="Bold"/>
                 <Setter Property="FontSize" Value="9.5"/>
             </Style>
@@ -610,12 +610,12 @@
                                          enforced from this card. -->
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,0,0,16">
                                         <TextBlock Text="{loc:Str pl6_goon_free_to_join}" Foreground="{DynamicResource TextMutedBrush}"
-                                                   FontFamily="Consolas" FontSize="10.5" VerticalAlignment="Center"/>
+                                                   FontFamily="Consolas, Courier New" FontSize="10.5" VerticalAlignment="Center"/>
                                         <TextBlock x:Name="TxtPlayGoonPerkSend" x:FieldModifier="internal"
-                                                   Text="{loc:Str pl6_goon_perk_send_t1}" FontFamily="Consolas" FontSize="10.5"
+                                                   Text="{loc:Str pl6_goon_perk_send_t1}" FontFamily="Consolas, Courier New" FontSize="10.5"
                                                    Foreground="{StaticResource PlayLockT1Brush}" Margin="8,0,0,0" VerticalAlignment="Center"/>
                                         <TextBlock x:Name="TxtPlayGoonPerkHost" x:FieldModifier="internal"
-                                                   Text="{loc:Str pl6_goon_perk_host_t2}" FontFamily="Consolas" FontSize="10.5"
+                                                   Text="{loc:Str pl6_goon_perk_host_t2}" FontFamily="Consolas, Courier New" FontSize="10.5"
                                                    Foreground="{StaticResource PlayLockT2Brush}" Margin="8,0,0,0" VerticalAlignment="Center"/>
                                     </StackPanel>
 
@@ -745,7 +745,7 @@
                                 <TextBlock Text="{loc:Str set2_webcam_chip_label}" Foreground="{DynamicResource TextLightBrush}"
                                            FontWeight="Bold" FontSize="14"/>
                                 <TextBlock x:Name="TxtWebcamStatusChipPlay" x:FieldModifier="internal" Text="{loc:Str rf_webcam_stopped}"
-                                           Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas" FontSize="11"/>
+                                           Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New" FontSize="11"/>
                             </StackPanel>
                             <Button Grid.Column="2" Content="{loc:Str set2_configure_in_settings}"
                                     Padding="12,6" VerticalAlignment="Center" Cursor="Hand"
@@ -818,7 +818,7 @@
                                                 Style="{StaticResource PlayStatusPill}" Margin="0,12,0,0">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                                 <Ellipse Width="7" Height="7" Fill="{DynamicResource TextMutedBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                                <TextBlock Text="Start tracking to play" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas" FontSize="11" VerticalAlignment="Center"/>
+                                                <TextBlock Text="Start tracking to play" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New" FontSize="11" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Border>
                                     </StackPanel>
@@ -894,7 +894,7 @@
                                                 Style="{StaticResource PlayStatusPill}" Margin="0,12,0,0">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                                 <Ellipse Width="7" Height="7" Fill="{DynamicResource TextMutedBrush}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                                <TextBlock Text="Start tracking to enable" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas" FontSize="11" VerticalAlignment="Center"/>
+                                                <TextBlock Text="Start tracking to enable" Foreground="{DynamicResource TextMutedBrush}" FontFamily="Consolas, Courier New" FontSize="11" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </Border>
                                     </StackPanel>
@@ -1045,7 +1045,7 @@
                                              Premium sees nothing here at all - patrons must never learn
                                              the free weekly pass exists. -->
                                         <TextBlock x:Name="TxtPlayIntakeState" x:FieldModifier="internal" Text=""
-                                                   Foreground="{DynamicResource PinkBrush}" FontFamily="Consolas" FontSize="11"
+                                                   Foreground="{DynamicResource PinkBrush}" FontFamily="Consolas, Courier New" FontSize="11"
                                                    TextWrapping="Wrap" Margin="0,0,0,12" Visibility="Collapsed"/>
                                         <StackPanel Orientation="Horizontal">
                                             <!-- Every state navigates. A Spent user has to be able to

--- a/ConditioningControlPanel/Views/Tabs/PresetsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/PresetsTabView.xaml
@@ -51,7 +51,7 @@
              not draw a box around content that is already in a panel. -->
         <Style x:Key="SdZoneTag" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontWeight" Value="Bold"/>
             <Setter Property="FontSize" Value="11.5"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
@@ -64,7 +64,7 @@
         </Style>
         <Style x:Key="SdZoneHint" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource TextDimBrush}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="10.5"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="Margin" Value="0,0,10,0"/>
@@ -146,7 +146,7 @@
              jittering with the proportional widths of 5 / 45 / 120. -->
         <Style x:Key="SdRackMeta" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="TextAlignment" Value="Right"/>
@@ -182,7 +182,7 @@
         <!-- The provenance chip: BUILT-IN / YOURS / CAT. Consolas and uppercase because on this
              page mono means "structural label", never content. -->
         <Style x:Key="SdRackBadgeText" TargetType="TextBlock" BasedOn="{StaticResource SdPillText}">
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="9"/>
         </Style>
 
@@ -479,7 +479,7 @@
         </Style>
         <Style x:Key="SdTakeawayChipMeta" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource TextDimBrush}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="9.5"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="Margin" Value="8,0,0,0"/>
@@ -539,7 +539,7 @@
              same reason SdRackMeta is mono on a rack row. -->
         <Style x:Key="SdTakeawayRowMeta" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="10.5"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="TextAlignment" Value="Right"/>
@@ -562,7 +562,7 @@
         </Style>
         <Style x:Key="SdMedLabel" TargetType="TextBlock">
             <Setter Property="Foreground" Value="{DynamicResource TextDimBrush}"/>
-            <Setter Property="FontFamily" Value="Consolas"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
             <Setter Property="FontSize" Value="9.5"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
         </Style>
@@ -724,7 +724,7 @@
                                                VerticalAlignment="Center" Margin="0,0,6,0"
                                                Foreground="{DynamicResource PinkBrush}"/>
                                     <TextBlock Text="{loc:Str label_new}" FontSize="10" FontWeight="Bold"
-                                               FontFamily="Consolas" VerticalAlignment="Center"
+                                               FontFamily="Consolas, Courier New" VerticalAlignment="Center"
                                                Foreground="{DynamicResource PinkBrush}"/>
                                 </StackPanel>
                             </Border>
@@ -949,7 +949,7 @@
                                  it is the drag-drop system's only feedback surface, so it moved
                                  here rather than being dropped with the banner. -->
                             <TextBlock DockPanel.Dock="Right" x:Name="DropZoneStatus" x:FieldModifier="internal" Text=""
-                                       FontSize="11" FontFamily="Consolas" VerticalAlignment="Center"
+                                       FontSize="11" FontFamily="Consolas, Courier New" VerticalAlignment="Center"
                                        MaxWidth="240" Margin="10,0,10,0" TextTrimming="CharacterEllipsis"
                                        Foreground="{DynamicResource PinkBrush}" Visibility="Collapsed"/>
 
@@ -1250,7 +1250,7 @@
                                         Background="{DynamicResource SurfaceBgBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource DangerBrush}">
                                     <TextBlock Text="{loc:Str label_spoilers_below}" Foreground="{DynamicResource DangerBrush}"
-                                               FontFamily="Consolas" FontSize="11.5"
+                                               FontFamily="Consolas, Courier New" FontSize="11.5"
                                                FontWeight="Bold" HorizontalAlignment="Center"/>
                                 </Border>
 

--- a/ConditioningControlPanel/Views/Tabs/QuestsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/QuestsTabView.xaml
@@ -287,7 +287,7 @@
                                                                    Foreground="#FFB347" FontSize="10"
                                                                    FontWeight="Bold" Margin="4,0,0,0"
                                                                    VerticalAlignment="Center"
-                                                                   FontFamily="Segoe UI Emoji"
+                                                                   FontFamily="Segoe UI Emoji, Segoe UI Symbol, Segoe UI"
                                                                    Visibility="Collapsed"/>
                                                         <TextBlock x:Name="TxtWeeklyRerollBonus" x:FieldModifier="internal" Text=""
                                                                    Foreground="#7BC8F6" FontSize="10"

--- a/ConditioningControlPanel/Views/Tabs/RemoteControlTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/RemoteControlTabView.xaml
@@ -219,9 +219,9 @@
                                                    FontSize="10" FontWeight="Bold" Margin="0,0,0,6"/>
                                         <TextBlock x:Name="TxtRemoteCode" x:FieldModifier="internal" Text="- - - - - - - -"
                                                    Foreground="{DynamicResource PinkBrush}" FontSize="52"
-                                                   FontWeight="Bold" FontFamily="Consolas"/>
+                                                   FontWeight="Bold" FontFamily="Consolas, Courier New"/>
                                         <TextBlock x:Name="TxtRemotePin" x:FieldModifier="internal" Text="" Foreground="{DynamicResource SecondaryBrush}"
-                                                   FontSize="24" FontWeight="Bold" FontFamily="Consolas" Margin="0,6,0,0"
+                                                   FontSize="24" FontWeight="Bold" FontFamily="Consolas, Courier New" Margin="0,6,0,0"
                                                    Visibility="Collapsed"/>
                                         <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
                                             <Button x:Name="BtnCopyRemoteCode" x:FieldModifier="internal" Content="{loc:Str btn_copy}"

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -2298,7 +2298,7 @@
             <Canvas x:Name="MarqueeCanvas" x:FieldModifier="internal" ClipToBounds="True">
                 <TextBlock x:Name="MarqueeText" x:FieldModifier="internal"
                            Text="{loc:Str label_v5_2_1_is_out_thanks_to_all_the_100_patreons}"
-                           FontFamily="Impact" FontSize="28" FontWeight="Bold"
+                           FontFamily="Impact, Arial Black, Segoe UI" FontSize="28" FontWeight="Bold"
                            Foreground="{DynamicResource PinkBrush}" Canvas.Top="8">
                     <TextBlock.Effect>
                         <DropShadowEffect Color="{DynamicResource DarkPink}" BlurRadius="8" ShadowDepth="0" Opacity="0.8"/>

--- a/ConditioningControlPanel/Views/Tabs/SpiralTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SpiralTabView.xaml
@@ -89,7 +89,7 @@
                 <TextBlock x:Name="FogDigitsGlow" HorizontalAlignment="Center"
                            Text="{Binding Text, ElementName=FogDigits}"
                            FontSize="{Binding FontSize, ElementName=FogDigits}"
-                           FontFamily="Cascadia Mono, Consolas, Courier New"
+                           FontFamily="{DynamicResource Font.Mono}"
                            FontWeight="Bold" Foreground="#E0B052" Opacity="0.42"
                            Typography.NumeralAlignment="Tabular"
                            IsHitTestVisible="False">
@@ -100,7 +100,7 @@
 
                 <TextBlock x:Name="FogDigits" HorizontalAlignment="Center"
                            FontSize="56" FontWeight="Bold"
-                           FontFamily="Cascadia Mono, Consolas, Courier New"
+                           FontFamily="{DynamicResource Font.Mono}"
                            Foreground="#E0B052"
                            Typography.NumeralAlignment="Tabular"/>
             </Grid>

--- a/ConditioningControlPanel/Views/Tabs/StudioTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/StudioTabView.xaml.cs
@@ -792,7 +792,7 @@ namespace ConditioningControlPanel.Views.Tabs
                     Child = new TextBlock
                     {
                         Text = "NEW",
-                        FontFamily = new FontFamily("Consolas"),
+                        FontFamily = new FontFamily("Consolas, Courier New"),
                         FontSize = 9,
                         FontWeight = FontWeights.Bold,
                         Foreground = pillText,

--- a/ConditioningControlPanel/Windows/BugReportWindow.xaml
+++ b/ConditioningControlPanel/Windows/BugReportWindow.xaml
@@ -62,7 +62,7 @@
                 <TextBlock Text="{loc:Str bug_report_metadata_label}" Style="{StaticResource FormLabel}"/>
                 <Border Background="#14142A" BorderBrush="#3D3D60" BorderThickness="1" CornerRadius="4" Padding="10,8">
                     <TextBlock x:Name="TxtMetadataSummary" Foreground="#B0B0C8" FontSize="11"
-                               FontFamily="Consolas" TextWrapping="Wrap"/>
+                               FontFamily="Consolas, Courier New" TextWrapping="Wrap"/>
                 </Border>
 
                 <CheckBox x:Name="ChkIncludeAppLog"
@@ -78,7 +78,7 @@
                 <Border Background="#0A0A18" BorderBrush="#3D3D60" BorderThickness="1" CornerRadius="4">
                     <TextBox x:Name="TxtPreview" IsReadOnly="True" TextWrapping="NoWrap"
                              Background="Transparent" Foreground="#B0B0C8" BorderThickness="0"
-                             FontFamily="Consolas" FontSize="11"
+                             FontFamily="Consolas, Courier New" FontSize="11"
                              Height="260"
                              VerticalScrollBarVisibility="Auto"
                              HorizontalScrollBarVisibility="Auto"/>
@@ -130,7 +130,7 @@
                                  IsReadOnly="True" IsReadOnlyCaretVisible="True"
                                  Background="#0A0A18" Foreground="#FFFFFF"
                                  BorderBrush="#3D3D60" BorderThickness="1"
-                                 FontFamily="Consolas" FontSize="16" FontWeight="Bold"
+                                 FontFamily="Consolas, Courier New" FontSize="16" FontWeight="Bold"
                                  Padding="10,8" VerticalContentAlignment="Center"
                                  TextWrapping="NoWrap" AcceptsReturn="False"/>
                         <Button x:Name="BtnCopyToken" Grid.Column="1"

--- a/ConditioningControlPanel/Windows/EasterEggWindow.xaml
+++ b/ConditioningControlPanel/Windows/EasterEggWindow.xaml
@@ -28,7 +28,7 @@
             <!-- Content -->
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="25,10,25,10">
                 <StackPanel>
-                    <TextBlock TextWrapping="Wrap" FontFamily="Consolas" FontSize="12" LineHeight="20">
+                    <TextBlock TextWrapping="Wrap" FontFamily="Consolas, Courier New" FontSize="12" LineHeight="20">
                         <Run Foreground="{DynamicResource PinkBrush}" FontWeight="Bold">congrats.</Run>
                         <LineBreak/>
                         <Run Foreground="{DynamicResource TextMutedBrush}">Either you were rlly bored, or u r a coder and looked trough the code, either way doesnt rlly matter, had to write a cupple of lines down.</Run>
@@ -64,7 +64,7 @@
                         <Run Foreground="{DynamicResource PinkBrush}" FontWeight="Bold" FontStyle="Italic">CodeBambi</Run>
                     </TextBlock>
                     <TextBlock x:Name="TxtReaderCount"
-                               FontFamily="Consolas" FontSize="11"
+                               FontFamily="Consolas, Courier New" FontSize="11"
                                Foreground="#FF4444"
                                Margin="0,15,0,5"
                                HorizontalAlignment="Center"

--- a/ConditioningControlPanel/Windows/HapticsSetupWindow.xaml
+++ b/ConditioningControlPanel/Windows/HapticsSetupWindow.xaml
@@ -111,7 +111,7 @@
                             <TextBox x:Name="TxtWizardLovenseIp" Background="{DynamicResource DarkerBgBrush}"
                                      Foreground="White" CaretBrush="{DynamicResource PinkBrush}"
                                      BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
-                                     Padding="8,6" FontSize="14" FontFamily="Consolas"/>
+                                     Padding="8,6" FontSize="14" FontFamily="Consolas, Courier New"/>
                             <TextBlock Text="{loc:Str wizard_lovense_ip_hint}" TextWrapping="Wrap"
                                        Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,6,0,0"/>
                             <TextBlock Text="{loc:Str wizard_lovense_wifi_tip}" TextWrapping="Wrap"

--- a/ConditioningControlPanel/Windows/MiniPlayerWindow.xaml
+++ b/ConditioningControlPanel/Windows/MiniPlayerWindow.xaml
@@ -107,7 +107,7 @@
                 <TextBlock x:Name="TxtTime" Grid.Column="2"
                            Text="00:00 / 00:00" Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
                            VerticalAlignment="Center" Margin="0,0,12,0"
-                           FontFamily="Consolas"/>
+                           FontFamily="Consolas, Courier New"/>
             </Grid>
         </Grid>
     </Border>

--- a/ConditioningControlPanel/Windows/ModCreatorWindow.Barks.cs
+++ b/ConditioningControlPanel/Windows/ModCreatorWindow.Barks.cs
@@ -242,7 +242,7 @@ namespace ConditioningControlPanel
             card.NewFieldsPanel.Children.Add(CreateFieldLabel("Conditions (advanced, raw JSON object - leave empty for none)"));
             card.ConditionsBox = CreateDarkTextBox("{ \"level_gte\": 10 }", multiline: true, height: 56);
             card.ConditionsBox.Width = 400;
-            card.ConditionsBox.FontFamily = new FontFamily("Consolas");
+            card.ConditionsBox.FontFamily = new FontFamily("Consolas, Courier New");
             card.NewFieldsPanel.Children.Add(card.ConditionsBox);
 
             // ── Override fields ──

--- a/ConditioningControlPanel/Windows/MyReportsWindow.xaml
+++ b/ConditioningControlPanel/Windows/MyReportsWindow.xaml
@@ -49,7 +49,7 @@
                                         </Grid.ColumnDefinitions>
                                         <StackPanel Grid.Column="0" VerticalAlignment="Center">
                                             <TextBlock Text="{Binding Token, Mode=OneTime}"
-                                                       Foreground="White" FontFamily="Consolas"
+                                                       Foreground="White" FontFamily="Consolas, Courier New"
                                                        FontSize="14" FontWeight="Bold"
                                                        TextTrimming="CharacterEllipsis"/>
                                             <TextBlock Text="{Binding SubtitleText, Mode=OneTime}"

--- a/ConditioningControlPanel/Windows/QuizCategoryEditorWindow.xaml
+++ b/ConditioningControlPanel/Windows/QuizCategoryEditorWindow.xaml
@@ -191,7 +191,7 @@
                              Background="#10FFFFFF" BorderBrush="#20FFFFFF" BorderThickness="1"
                              Padding="10,8" CaretBrush="White" TextWrapping="Wrap"
                              AcceptsReturn="True" VerticalScrollBarVisibility="Auto"
-                             Height="160" FontFamily="Consolas">
+                             Height="160" FontFamily="Consolas, Courier New">
                         <TextBox.Resources>
                             <Style TargetType="Border"><Setter Property="CornerRadius" Value="8"/></Style>
                         </TextBox.Resources>
@@ -244,7 +244,7 @@
                             Margin="0,8,0,0" Padding="12,10"
                             Background="#10FFFFFF" BorderBrush="#209B59B6" BorderThickness="1">
                         <TextBlock x:Name="TxtPreviewResult" FontSize="12" Foreground="#A0A0B0"
-                                   TextWrapping="Wrap" FontFamily="Consolas"/>
+                                   TextWrapping="Wrap" FontFamily="Consolas, Courier New"/>
                     </Border>
                 </StackPanel>
             </ScrollViewer>

--- a/ConditioningControlPanel/Windows/SessionCompleteWindow.xaml
+++ b/ConditioningControlPanel/Windows/SessionCompleteWindow.xaml
@@ -146,7 +146,7 @@
                                                 <TextBlock Grid.Column="0"
                                                            Text="{Binding TimeOffsetText}"
                                                            Foreground="#A0A0B0" FontSize="12"
-                                                           FontFamily="Consolas"
+                                                           FontFamily="Consolas, Courier New"
                                                            VerticalAlignment="Center"/>
                                                 <TextBlock Grid.Column="1"
                                                            Text="{Binding TypeLabel}"

--- a/ConditioningControlPanel/Windows/WebcamCalibrationWindow.xaml
+++ b/ConditioningControlPanel/Windows/WebcamCalibrationWindow.xaml
@@ -93,7 +93,7 @@
             <TextBlock x:Name="TxtStatus" Text="Look at the pink dot. Press ESC to cancel."
                        Foreground="{DynamicResource TextMutedBrush}" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Center"/>
             <TextBlock x:Name="TxtProgress" Text="" Foreground="#FF69B4" FontSize="13"
-                       Margin="0,4,0,0" HorizontalAlignment="Center" FontFamily="Consolas"/>
+                       Margin="0,4,0,0" HorizontalAlignment="Center" FontFamily="Consolas, Courier New"/>
         </StackPanel>
 
         <Border x:Name="IntroPanel" Visibility="Collapsed"
@@ -172,7 +172,7 @@
                 <TextBlock x:Name="TxtValidationDetail" Text="" Foreground="{DynamicResource TextMutedBrush}"
                            FontSize="16" HorizontalAlignment="Center" Margin="0,12,0,0"/>
                 <TextBlock x:Name="TxtValidationAttempt" Text="" Foreground="#FF69B4"
-                           FontSize="13" FontFamily="Consolas" HorizontalAlignment="Center"
+                           FontSize="13" FontFamily="Consolas, Courier New" HorizontalAlignment="Center"
                            Margin="0,16,0,0"/>
             </StackPanel>
         </Grid>

--- a/ConditioningControlPanel/Windows/WebcamGazeTrackerWindow.xaml
+++ b/ConditioningControlPanel/Windows/WebcamGazeTrackerWindow.xaml
@@ -34,7 +34,7 @@
             <TextBlock Text="Look around the screen. The cyan dot should follow your gaze."
                        Foreground="{DynamicResource TextMutedBrush}" FontSize="13" Margin="0,8,0,0" HorizontalAlignment="Center"/>
             <TextBlock x:Name="TxtCoords" Text="" Foreground="#00B0FF" FontSize="12"
-                       Margin="0,4,0,0" HorizontalAlignment="Center" FontFamily="Consolas"/>
+                       Margin="0,4,0,0" HorizontalAlignment="Center" FontFamily="Consolas, Courier New"/>
             <!-- Always-visible, mouse-clickable close. Lockdown's global keyboard hook swallows
                  Escape/Alt+F4 (#528), so a key-based exit can strand the user inside this test
                  window; a button click bypasses the keyboard hook entirely. -->

--- a/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services.UI;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BROKEN-FONT GUARD, pinned.
+///
+/// <para><b>The incident.</b> A v6.8.6 user's Cascadia install was corrupt, and every panel he
+/// opened rendered blank: WPF threw <c>UnauthorizedAccessException</c> out of
+/// <c>FontFamily.GetFirstMatchingFont</c> during <c>TextBlock.MeasureOverride</c>. Because that is
+/// the LAYOUT pass it re-threw on every measure, so the UI never completed a frame and crash.log
+/// reached roughly half a gigabyte in one session.</para>
+///
+/// <para><b>The trap this suite exists to catch.</b> Every Cascadia site in the app ALREADY named
+/// a comma fallback chain when that happened. A chain only rescues a family that is ABSENT - WPF
+/// walks to the next link when a name does not resolve. It does nothing for a family that is
+/// PRESENT but unreadable, because deciding whether the first link matches means opening the font
+/// file, and that open is what throws. So "it has a fallback" is NOT the guarantee, and the next
+/// person to add a hardcoded Cascadia with a comma after it would reintroduce the bug while
+/// looking like they fixed it. The real guarantee is that risky faces are named in ONE swappable
+/// place that <see cref="FontGuard"/> can strike out at startup.</para>
+/// </summary>
+public class FontFallbackTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string AppDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
+
+    /// <summary>
+    /// Every shipped source file of the given extension.
+    ///
+    /// <para>The exclusions are matched on the path RELATIVE to the app folder, not the absolute
+    /// path. That distinction matters: agent worktrees live at
+    /// <c>ConditioningControlPanel/.claude/worktrees/&lt;id&gt;/</c>, so a suite running inside one
+    /// has ".claude" in every absolute path it sees. Filtering absolute paths would therefore
+    /// exclude the entire tree and pass vacuously in a worktree, while still needing to skip other
+    /// branches' worktrees in a normal checkout. Relative matching gets both right.</para>
+    /// </summary>
+    private static IEnumerable<string> SourceFiles(string extension)
+    {
+        var skip = new[] { "bin", "obj", ".claude" };
+        return Directory.EnumerateFiles(AppDir, "*" + extension, SearchOption.AllDirectories)
+            .Where(p =>
+            {
+                var segments = Path.GetRelativePath(AppDir, p)
+                    .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return !segments.Any(s => skip.Contains(s, StringComparer.OrdinalIgnoreCase));
+            });
+    }
+
+    // ------------------------------------------------------------------ the chain filter
+
+    [Fact]
+    public void A_healthy_machine_gets_its_chain_back_untouched()
+    {
+        Assert.Equal(FontGuard.MonoChain, FontGuard.FilterChain(FontGuard.MonoChain, _ => false));
+    }
+
+    [Fact]
+    public void A_broken_first_link_is_struck_out_and_the_rest_survive_in_order()
+    {
+        var filtered = FontGuard.FilterChain(FontGuard.MonoChain,
+            f => f.Equals("Cascadia Mono", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal("Consolas, Courier New", filtered);
+    }
+
+    [Fact]
+    public void A_broken_middle_link_is_struck_out_without_disturbing_its_neighbours()
+    {
+        var filtered = FontGuard.FilterChain("Cascadia Mono, Consolas, Courier New",
+            f => f.Equals("Consolas", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal("Cascadia Mono, Courier New", filtered);
+    }
+
+    /// <summary>
+    /// The filter must never hand WPF an empty family name - that throws, which would turn the
+    /// guard itself into the crash it exists to prevent.
+    /// </summary>
+    [Fact]
+    public void Striking_out_every_link_still_leaves_something_nameable()
+    {
+        Assert.Equal("Segoe UI", FontGuard.FilterChain(FontGuard.MonoChain, _ => true));
+        Assert.Equal("Segoe UI", FontGuard.FilterChain("", _ => true));
+        Assert.Equal("Segoe UI", FontGuard.Sanitize(null));
+    }
+
+    /// <summary>
+    /// Bundled faces are pack-relative (<c>./#Press Start 2P</c>) and ship inside the app, so they
+    /// can never be the machine's broken system font and must pass through even when a family of
+    /// the same bare name is struck out.
+    /// </summary>
+    [Fact]
+    public void A_bundled_pack_relative_face_is_never_struck_out()
+    {
+        var filtered = FontGuard.FilterChain("./#Press Start 2P, Consolas, Courier New",
+            f => f.Equals("Press Start 2P", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Equal("./#Press Start 2P, Consolas, Courier New", filtered);
+    }
+
+    // ------------------------------------------------------------------ the markup pin
+
+    /// <summary>
+    /// The scans below are all "find me the offenders, expect none", which is exactly the shape
+    /// that passes for free when the file walk returns nothing. YouLibraryDoorTests silently does
+    /// this today inside an agent worktree. So: prove the walk actually sees the app first.
+    /// </summary>
+    [Fact]
+    public void The_markup_scan_actually_finds_the_app()
+    {
+        var xaml = SourceFiles(".xaml").ToList();
+
+        Assert.True(xaml.Count > 50,
+            "the XAML walk found only " + xaml.Count + " files under " + AppDir +
+            " - the scans in this suite would be passing vacuously");
+        Assert.Contains(xaml, p => Path.GetFileName(p) == "MainWindow.xaml");
+    }
+
+    /// <summary>
+    /// Cascadia is the face that took the app down, so no markup may name it directly any more:
+    /// it lives in App.xaml's <c>Font.Mono</c> resource, which the guard can replace. This is the
+    /// assertion that fails when someone pastes a hardcoded chain back in.
+    /// </summary>
+    [Fact]
+    public void No_markup_names_Cascadia_directly()
+    {
+        var offenders = SourceFiles(".xaml")
+            .Where(p => !p.EndsWith(Path.Combine("ConditioningControlPanel", "App.xaml"), StringComparison.OrdinalIgnoreCase))
+            .Where(p => File.ReadAllText(p).Contains("Cascadia", StringComparison.OrdinalIgnoreCase))
+            .Select(p => Path.GetRelativePath(AppDir, p))
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "these XAML files name Cascadia directly instead of binding {DynamicResource Font.Mono}, " +
+            "so FontGuard cannot swap the face out when the user's install is corrupt: " +
+            string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// The one place Cascadia IS named must be the app-level resource, and the markup has to bind
+    /// it DYNAMICALLY - a StaticResource is snapshotted at parse time and would ignore the swap.
+    /// </summary>
+    [Fact]
+    public void App_xaml_declares_the_mono_resource_and_agrees_with_the_guard()
+    {
+        var appXaml = File.ReadAllText(Path.Combine(AppDir, "App.xaml"));
+
+        Assert.Contains("x:Key=\"" + FontGuard.MonoResourceKey + "\"", appXaml);
+        Assert.Contains(FontGuard.MonoChain, appXaml);
+    }
+
+    [Fact]
+    public void Every_consumer_of_the_mono_resource_binds_it_dynamically()
+    {
+        var staticUses = SourceFiles(".xaml")
+            .Where(p => File.ReadAllText(p).Contains("StaticResource " + FontGuard.MonoResourceKey))
+            .Select(p => Path.GetRelativePath(AppDir, p))
+            .ToList();
+
+        Assert.True(staticUses.Count == 0,
+            "StaticResource snapshots the value at parse time, so FontGuard's swap would never " +
+            "reach these files - use DynamicResource: " + string.Join(", ", staticUses));
+    }
+
+    /// <summary>
+    /// The whole point of the mechanical pass: a hardcoded face with NO fallback at all degrades
+    /// to whatever WPF picks. Consolas was the big offender (108 bare sites). This keeps new ones
+    /// from creeping back in.
+    /// </summary>
+    [Fact]
+    public void No_markup_names_a_risky_face_without_a_fallback_behind_it()
+    {
+        var risky = new[] { "Consolas", "Impact", "Segoe MDL2 Assets", "Segoe UI Emoji" };
+        var offenders = new List<string>();
+
+        foreach (var path in SourceFiles(".xaml"))
+        {
+            var text = File.ReadAllText(path);
+            foreach (var face in risky)
+            {
+                // A bare value is the closing quote right after the family name - a chain has a
+                // comma there instead.
+                if (Regex.IsMatch(text, "FontFamily=\"" + Regex.Escape(face) + "\"") ||
+                    Regex.IsMatch(text, "Property=\"FontFamily\"\\s+Value=\"" + Regex.Escape(face) + "\""))
+                {
+                    offenders.Add(Path.GetRelativePath(AppDir, path) + " -> " + face);
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these sites name a font with no fallback behind it: " + string.Join(", ", offenders));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/SpiralRoomTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SpiralRoomTests.cs
@@ -717,7 +717,15 @@ public class SpiralRoomTests
     /// <para>The tab's ONE legal accent read is in code, not markup: the spiral canvas takes the
     /// mod's colour because it colours the SPIRAL. So the rule this pins is that the fog era's
     /// MARKUP — every element the countdown is made of — carries literal gold and reaches for no
-    /// resource at all.</para>
+    /// COLOUR resource at all.</para>
+    ///
+    /// <para>This used to ban the string "DynamicResource" outright, which was a cheap stand-in
+    /// for "no colour lookups". It cannot stay that broad: the countdown digits are monospace, and
+    /// the app's monospace face now has to come from the swappable <c>Font.Mono</c> resource so
+    /// FontGuard can strike out a corrupt Cascadia install (v6.8.6 rendered every panel blank
+    /// because a hardcoded face threw from the layout pass). A font lookup is not an accent, so
+    /// the rule is now stated the way it was always meant: every resource this markup reaches for
+    /// must be a FONT, never a brush or a colour.</para>
     /// </summary>
     [Fact]
     public void TheFogEraWearsTheFusesOwnGoldAndNeverTheModAccent()
@@ -725,9 +733,18 @@ public class SpiralRoomTests
         var xaml = AppFile("Views", "Tabs", "SpiralTabView.xaml");
 
         Assert.Contains("#E0B052", xaml, StringComparison.Ordinal);
-        Assert.DoesNotContain("DynamicResource", xaml, StringComparison.Ordinal);
         Assert.DoesNotContain("PinkBrush", xaml, StringComparison.Ordinal);
         Assert.DoesNotContain("AccentBrush", xaml, StringComparison.Ordinal);
+
+        var colourLookups = System.Text.RegularExpressions.Regex
+            .Matches(xaml, @"\{(?:Dynamic|Static)Resource\s+([^}]+)\}")
+            .Select(m => m.Groups[1].Value.Trim())
+            .Where(key => !key.StartsWith("Font.", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(colourLookups.Count == 0,
+            "the fog era must carry literal gold and look up nothing but fonts, but this markup " +
+            "reaches for: " + string.Join(", ", colourLookups));
     }
 
     /// <summary>


### PR DESCRIPTION
## The incident

v6.8.6, user **SpadeLink**: a missing/corrupt Cascadia install made **every panel navigation render a blank screen**. WPF threw `System.UnauthorizedAccessException` on the dispatcher at:

```
MS.Internal.Text.TextInterface.FontFamily.GetFirstMatchingFont
  -> Typeface.ConstructCachedTypeface
  -> TextBlock.MeasureOverride
     inside ContextLayoutManager.UpdateLayout, off HwndTarget.OnResize
```

Because it throws from the **layout pass**, it re-threw on every measure: the UI never completed a frame, and `crash.log` grew to roughly **0.5 GB** in a single session. He fixed it by reinstalling the Cascadia fonts. The app had no guard.

## The finding that shaped the fix

**All 9 Cascadia sites already had a comma fallback chain** (`"Cascadia Mono, Consolas, Courier New"`) when this happened.

A comma chain only rescues a family that is **absent** — WPF walks to the next link when a name doesn't resolve. It does nothing for a family that is **present but unreadable**, because deciding whether the first link matches means *opening the font file*, and that open is what throws. The throw happens before the chain is ever walked.

So "it has a fallback" was never the guarantee, and the obvious fix (add more fallbacks) would not have prevented this. The only thing that helps a corrupt face is to **stop naming it**.

## What changed

**1. `Services/UI/FontGuard` — the actual fix.** Once at startup, on the UI thread, resolve each risky family exactly the way the layout pass does: build a `Typeface` and ask for its glyph typeface, which is what reaches `GetFirstMatchingFont` and opens the file. Any family whose probe throws is recorded, logged as **one** Serilog warning naming the font, and struck out of every chain the app hands WPF for the rest of the session.

For the swap to reach anything, the face needs one home: `App.xaml` now declares `Font.Mono`, bound with **`DynamicResource`** (a `StaticResource` is snapshotted at parse time and would ignore the swap). The 4 Cascadia markup sites bind it; the 3 code-behind sites use `FontGuard.Mono`; the EMI Desk chains pass through `FontGuard.Sanitize`.

**2. Fallback stacks where there were none.** A chain is still worth having — it covers the uninstalled-font case — so 138 sites across 54 files gained one:

| Face | Now | Sites |
|---|---|---|
| `Consolas` | `Consolas, Courier New` | 108 (92 XAML, 16 C#) |
| `/Fonts/#Fredoka` | `/Fonts/#Fredoka, Segoe UI` | 18 |
| `Segoe UI Emoji` | `Segoe UI Emoji, Segoe UI Symbol, Segoe UI` | 8 |
| `Segoe MDL2 Assets` | `Segoe MDL2 Assets, Segoe UI Symbol, Segoe UI` | 4 |
| `Impact` | `Impact, Arial Black, Segoe UI` | 3 |
| `Arial` | `Arial, Segoe UI` | 1 |

Consolas was the real gap: 108 of its ~113 sites named it bare. `Segoe UI` is deliberately left alone — it is the floor everything falls back to.

Untouched on purpose: user-picked fonts (`FontPickerHelper.Resolve` already builds a guarded chain) and the stored setting values the picker splits on commas — adding a comma there would corrupt the picker.

**3. `crash.log` growth.** `LogCrashDetails` now rate-limits per exception signature (source + type + message + top stack frame): the first 5 occurrences are written in full, then one "suppressed" line, then silence for the session. The Serilog line is capped the same way, since the storm floods `app-.log` too. The existing `RotateCrashLogForVersion` could not help — it only runs at launch, and this storm is intra-session.

## Tests

New `FontFallbackTests` (10) pins the chain filter and the markup rules: no XAML may name Cascadia directly, `Font.Mono` consumers must bind dynamically, and no markup may name a risky face bare. One test asserts the file walk actually finds the app, so the scans can't pass vacuously.

`SpiralRoomTests.TheFogEraWearsTheFusesOwnGoldAndNeverTheModAccent` banned the string `DynamicResource` outright as a cheap stand-in for "no colour lookups". The countdown digits are monospace and now need the swappable font resource, so the assertion is restated the way its own docs describe the rule: every resource that markup reaches for must be a **font**, never a brush or colour. The accent ban itself is unchanged.

## Verification

- `dotnet build` — **0 errors**, 346 warnings (baseline).
- `dotnet test` — **4854 pass**, 5 fail.

The 5 failures are **pre-existing and unrelated**: `YouLibraryDoorTests` and `Phase8RedirectContractTests` filter out any path containing `.claude`, so their recursive file walk matches nothing when the suite runs inside an agent worktree (`ConditioningControlPanel/.claude/worktrees/<id>/`). The handlers they look for are present and byte-identical to `origin/main`. They pass in a normal checkout. Left alone as out of scope — worth a separate fix, and `FontFallbackTests` avoids the same trap by matching on the path relative to the app folder.

Not runtime-verified against an actually corrupt font install — that needs a deliberately broken Cascadia on a real machine. The probe's failure path is unit-tested, but the real-world trigger is unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
