### PR TITLE
fix(session): the corner SPIRAL answers the spiral switch, and never doubles up

### DIFF
--- a/ConditioningControlPanel/Services/Media/CornerGifMedia.cs
+++ b/ConditioningControlPanel/Services/Media/CornerGifMedia.cs
@@ -170,6 +170,23 @@ namespace ConditioningControlPanel.Services
         // Pure and static so both call sites - and the tests - reach the same answer.
 
         /// <summary>
+        /// Does a session's corner overlay draw a SPIRAL? True when the template names no usable art
+        /// of its own, because <c>SessionEngine.ShowCornerGif</c> then falls back to
+        /// <see cref="ResolveDefaultUriString"/> - the active mod's spiral, or the built-in
+        /// <c>spiral_corner.gif</c>. That is every 28-day program day: no program template sets
+        /// <c>CornerGifPath</c>.
+        ///
+        /// <para>Deliberately the SAME "set and on disk" test the overlay itself runs, so the
+        /// admission rule and the thing about to be drawn can never disagree.</para>
+        /// </summary>
+        internal static bool SessionCornerArtIsSpiral(string? cornerGifPath)
+        {
+            if (string.IsNullOrWhiteSpace(cornerGifPath)) return true;
+            try { return !File.Exists(cornerGifPath); }
+            catch { return true; }
+        }
+
+        /// <summary>
         /// May a SESSION (or a 28-day program day) raise its corner GIF right now?
         ///
         /// <para><paramref name="templateEnabled"/> is the session/program template's own
@@ -179,9 +196,28 @@ namespace ConditioningControlPanel.Services
         /// <paramref name="standaloneOverlayActive"/> is "a standalone corner overlay is already on
         /// screen (or queued)": the user's own app-wide choice wins, and the session does not stack
         /// a second spiral behind it.</para>
+        ///
+        /// <para>The last three answer the follow-up report on the same ticket. A session that draws
+        /// no art of its own draws a SPIRAL (<paramref name="artIsSpiral"/>), and a spiral is not
+        /// just any corner overlay: it is the thing the Spiral card's own master
+        /// (<c>AppSettings.SpiralEnabled</c>, <paramref name="userSpiralAllowed"/>) turns off, and
+        /// the thing already filling the screen when the fullscreen overlay is up
+        /// (<paramref name="spiralOverlayActive"/>). So a user-level spiral OFF vetoes it, and a
+        /// spiral already on screen makes it a second one. Both clauses are scoped to the spiral
+        /// case: a template carrying its own corner art is neither what the user switched off nor a
+        /// duplicate of anything.</para>
         /// </summary>
-        internal static bool AllowSessionCornerGif(bool templateEnabled, bool userAllowed, bool standaloneOverlayActive)
-            => templateEnabled && userAllowed && !standaloneOverlayActive;
+        internal static bool AllowSessionCornerGif(
+            bool templateEnabled,
+            bool userAllowed,
+            bool standaloneOverlayActive,
+            bool artIsSpiral,
+            bool userSpiralAllowed,
+            bool spiralOverlayActive)
+            => templateEnabled
+               && userAllowed
+               && !standaloneOverlayActive
+               && (!artIsSpiral || (userSpiralAllowed && !spiralOverlayActive));
 
         /// <summary>
         /// May a STANDALONE corner-GIF slot realize right now? The mirror of

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -2066,6 +2066,18 @@ public class OverlayService : IDisposable
         _sustainedSpiralHeld = false; // overlay is gone (incl. force-stop / panic) — drop any stale sustained hold
         _spiralWindows.Clear();
         App.Logger?.Debug("Spiral stopped");
+
+        // A running session's corner spiral stands down while this overlay is up (one spiral, not
+        // two - ticket 1539282547484139682). Nothing else would put it back: the per-second tick
+        // only re-raises corner GIFs with CornerGifStartMinute above zero, and every stock program
+        // day is a minute-0 one. Same shape as CornerGifService's own admission nudge; the policy
+        // guards its re-entrancy and refuses to raise anything on a paused session. Session end
+        // clears Active before it tears any overlay down, so this cannot resurrect a corner GIF.
+        try { SessionEngine.Active?.RefreshCornerGifPolicy(); }
+        catch (Exception ex)
+        {
+            try { App.Logger?.Warning(ex, "[Overlay] session corner-GIF policy refresh failed"); } catch { }
+        }
     }
 
     private void UpdateSpiralOpacity()

--- a/ConditioningControlPanel/Services/Session/SessionEngine.cs
+++ b/ConditioningControlPanel/Services/Session/SessionEngine.cs
@@ -876,15 +876,16 @@ namespace ConditioningControlPanel.Services
                 }
             }
 
-            // Corner GIF: the user master is honoured LIVE, so unticking "Allow session corner
+            // Corner GIF: the admission rule is honoured LIVE, so unticking "Allow session corner
             // GIFs" mid-session takes the overlay off the screen instead of waiting for the next
-            // session. Same for a standalone corner overlay the user switches on mid-session: the
-            // session yields rather than stacking a second spiral behind it.
-            if (_cornerGifWindow != null && !CornerGifMedia.AllowSessionCornerGif(
-                    settings.CornerGifEnabled, SessionCornerGifAllowedByUser, StandaloneCornerGifActive))
+            // session. Same for a standalone corner overlay the user switches on mid-session, and
+            // for the FULLSCREEN spiral this same tick may have just raised a few lines above: the
+            // session yields rather than stacking a second spiral behind either of them. Asked
+            // through CanRaiseCornerGif so this cannot drift from the show paths' gate.
+            if (_cornerGifWindow != null && !CanRaiseCornerGif(settings))
             {
                 CloseCornerGif();
-                App.Logger?.Information("Corner GIF hidden mid-session (user master or a standalone corner overlay now owns the corner)");
+                App.Logger?.Information("Corner GIF hidden mid-session (user master, a standalone corner overlay, or the fullscreen spiral now owns the corner)");
             }
 
             // Corner GIF delayed start
@@ -1731,15 +1732,45 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// The user's own spiral-overlay master (<c>AppSettings.SpiralEnabled</c>) as it stood
+        /// BEFORE this session overrode it. ApplySessionSettings writes that same flag for the
+        /// session's fullscreen spiral, so the live value stops being the user's answer the moment
+        /// a session starts - the pre-session snapshot is the only place their choice survives.
+        /// TRUE off-session and when the snapshot is missing, so nothing silently disappears.
+        /// </summary>
+        private bool UserSpiralAllowed
+            => _savedSettings?.SpiralEnabled ?? App.Settings?.Current?.SpiralEnabled != false;
+
+        /// <summary>A fullscreen spiral overlay is on screen RIGHT NOW, whoever raised it - this
+        /// session, the user's own switch, or a voice command (OverlayService.IsSpiralVisible reads
+        /// the windows, not the setting).</summary>
+        private static bool SpiralOverlayActive
+        {
+            get
+            {
+                try { return App.Overlay?.IsSpiralVisible == true; }
+                catch { return false; }
+            }
+        }
+
+        /// <summary>
         /// Full admission check for the session-scoped corner GIF: the template asked for it, the
         /// USER still allows it, and the corner is not already occupied by a standalone overlay.
         /// The template flag alone used to be the whole gate - ticket 1539282547484139682, where
         /// the documented "turn the Corner GIF off" workaround did nothing for program days and
         /// two spirals could end up on screen at once.
+        ///
+        /// <para>The follow-up report on that ticket: a program day whose corner art is the SPIRAL
+        /// (i.e. every stock one - no program template sets CornerGifPath) still ignored the Spiral
+        /// card's own master, and still stacked on top of the FULLSCREEN spiral, which the
+        /// standalone dedupe knows nothing about. Both of those live in the shared rule, so the
+        /// standalone side reads the same answer.</para>
         /// </summary>
-        private static bool CanRaiseCornerGif(SessionSettings settings)
+        private bool CanRaiseCornerGif(SessionSettings settings)
             => settings != null && CornerGifMedia.AllowSessionCornerGif(
-                   settings.CornerGifEnabled, SessionCornerGifAllowedByUser, StandaloneCornerGifActive);
+                   settings.CornerGifEnabled, SessionCornerGifAllowedByUser, StandaloneCornerGifActive,
+                   CornerGifMedia.SessionCornerArtIsSpiral(settings.CornerGifPath),
+                   UserSpiralAllowed, SpiralOverlayActive);
 
         /// <summary>
         /// TRUE while a session-scoped corner GIF is on screen. Read by CornerGifService so a

--- a/Tests/ConditioningControlPanel.Tests/CornerGifAdmissionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CornerGifAdmissionTests.cs
@@ -26,25 +26,103 @@ public class CornerGifAdmissionTests
 
     // ---- the session side ----
 
+    /// <summary>
+    /// The admission rule with the spiral clauses parked in their "nothing to see here" state:
+    /// the corner art is the spiral (the stock program-day case), the user allows spirals, and no
+    /// fullscreen spiral is on screen. Keeps the older cases about the switch they are actually
+    /// testing instead of restating six arguments each time.
+    /// </summary>
+    private static bool Allow(
+        bool templateEnabled,
+        bool userAllowed,
+        bool standaloneOverlayActive,
+        bool artIsSpiral = true,
+        bool userSpiralAllowed = true,
+        bool spiralOverlayActive = false)
+        => CornerGifMedia.AllowSessionCornerGif(
+            templateEnabled, userAllowed, standaloneOverlayActive,
+            artIsSpiral, userSpiralAllowed, spiralOverlayActive);
+
     [Fact]
     public void SessionCornerGif_ShowsWhenTemplateAndUserBothAgree()
-        => Assert.True(CornerGifMedia.AllowSessionCornerGif(
-            templateEnabled: true, userAllowed: true, standaloneOverlayActive: false));
+        => Assert.True(Allow(templateEnabled: true, userAllowed: true, standaloneOverlayActive: false));
 
     [Fact]
     public void SessionCornerGif_UserMasterOffBeatsTheTemplate()
-        => Assert.False(CornerGifMedia.AllowSessionCornerGif(
-            templateEnabled: true, userAllowed: false, standaloneOverlayActive: false));
+        => Assert.False(Allow(templateEnabled: true, userAllowed: false, standaloneOverlayActive: false));
 
     [Fact]
     public void SessionCornerGif_TemplateOffStaysOffEvenWhenAllowed()
-        => Assert.False(CornerGifMedia.AllowSessionCornerGif(
-            templateEnabled: false, userAllowed: true, standaloneOverlayActive: false));
+        => Assert.False(Allow(templateEnabled: false, userAllowed: true, standaloneOverlayActive: false));
 
     [Fact]
     public void SessionCornerGif_YieldsToAStandaloneOverlayAlreadyOnScreen()
-        => Assert.False(CornerGifMedia.AllowSessionCornerGif(
-            templateEnabled: true, userAllowed: true, standaloneOverlayActive: true));
+        => Assert.False(Allow(templateEnabled: true, userAllowed: true, standaloneOverlayActive: true));
+
+    // ---- the follow-up report: the SPIRAL clauses ----
+
+    /// <summary>
+    /// The reported bug: spiral overlay switched off on the Spiral card, start a session, and a
+    /// spiral appears in the corner anyway with nothing to turn it off. A user-level spiral OFF is
+    /// a veto on session corner art that IS a spiral.
+    /// </summary>
+    [Fact]
+    public void SessionCornerSpiral_IsVetoedByTheUsersOwnSpiralMaster()
+        => Assert.False(Allow(templateEnabled: true, userAllowed: true, standaloneOverlayActive: false,
+            artIsSpiral: true, userSpiralAllowed: false));
+
+    /// <summary>
+    /// ...but only over the SPIRAL. A template carrying its own corner art is not the thing the
+    /// Spiral card's master switches off, so "no spirals please" must not silently delete a
+    /// session's own artwork.
+    /// </summary>
+    [Fact]
+    public void SpiralOff_DoesNotVetoATemplatesOwnCornerArt()
+        => Assert.True(Allow(templateEnabled: true, userAllowed: true, standaloneOverlayActive: false,
+            artIsSpiral: false, userSpiralAllowed: false));
+
+    /// <summary>
+    /// The second half of the report: the corner spiral rendered WHILE the fullscreen spiral
+    /// overlay ran, so the user watched two spirals at once. The one already on screen wins and
+    /// the session does not spawn a second window.
+    /// </summary>
+    [Fact]
+    public void SessionCornerSpiral_YieldsToTheFullscreenSpiralAlreadyOnScreen()
+        => Assert.False(Allow(templateEnabled: true, userAllowed: true, standaloneOverlayActive: false,
+            artIsSpiral: true, spiralOverlayActive: true));
+
+    /// <summary>Non-spiral corner art alongside a fullscreen spiral is not a double spiral.</summary>
+    [Fact]
+    public void ATemplatesOwnCornerArt_StillShowsUnderAFullscreenSpiral()
+        => Assert.True(Allow(templateEnabled: true, userAllowed: true, standaloneOverlayActive: false,
+            artIsSpiral: false, spiralOverlayActive: true));
+
+    /// <summary>
+    /// What decides "this is a spiral": the template naming no usable art of its own, which is the
+    /// same test ShowCornerGif runs before it falls back to the built-in corner spiral. No program
+    /// template sets CornerGifPath, so every stock program day is a spiral by this rule - and a
+    /// path pointing at a file that is no longer there falls back to the spiral too.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoTemplateArt_MeansTheCornerDrawsTheSpiral(string? path)
+        => Assert.True(CornerGifMedia.SessionCornerArtIsSpiral(path));
+
+    [Fact]
+    public void AMissingFile_FallsBackToTheSpiralAndIsJudgedAsOne()
+        => Assert.True(CornerGifMedia.SessionCornerArtIsSpiral(
+            Path.Combine(Path.GetTempPath(), "ccp-no-such-corner-" + Guid.NewGuid().ToString("N") + ".gif")));
+
+    [Fact]
+    public void ARealTemplateFile_IsTheTemplatesOwnArt()
+    {
+        var file = Path.Combine(Path.GetTempPath(), "ccp-corner-" + Guid.NewGuid().ToString("N") + ".gif");
+        File.WriteAllBytes(file, new byte[] { 0x47, 0x49, 0x46 });
+        try { Assert.False(CornerGifMedia.SessionCornerArtIsSpiral(file)); }
+        finally { try { File.Delete(file); } catch { } }
+    }
 
     // ---- the standalone side ----
 
@@ -74,12 +152,39 @@ public class CornerGifAdmissionTests
     {
         // Whichever one is already up, the other is refused - so the reported "two spirals" state
         // cannot be reached from either direction.
-        var sessionUp = CornerGifMedia.AllowSessionCornerGif(templateEnabled, userAllowed, standaloneOverlayActive: false);
+        var sessionUp = Allow(templateEnabled, userAllowed, standaloneOverlayActive: false);
         Assert.False(sessionUp && CornerGifMedia.AllowStandaloneCornerGif(slotEnabled: true, sessionCornerGifActive: sessionUp));
 
         var standaloneUp = CornerGifMedia.AllowStandaloneCornerGif(slotEnabled: true, sessionCornerGifActive: false);
-        Assert.False(standaloneUp && CornerGifMedia.AllowSessionCornerGif(templateEnabled, userAllowed, standaloneOverlayActive: standaloneUp));
+        Assert.False(standaloneUp && Allow(templateEnabled, userAllowed, standaloneOverlayActive: standaloneUp));
     }
+
+    /// <summary>
+    /// The wider invariant the follow-up report adds: whenever the corner would draw a spiral, the
+    /// session overlay is admitted only when NO other spiral is claiming the screen and the user
+    /// has not switched spirals off. Exhaustive over the six inputs, so no combination can slip
+    /// back into the two-spiral state the ticket describes.
+    /// </summary>
+    [Fact]
+    public void ACornerSpiral_IsNeverAdmittedAlongsideAnotherSpiralOrAgainstTheUsersWishes()
+    {
+        foreach (var template in Bools)
+        foreach (var user in Bools)
+        foreach (var standalone in Bools)
+        foreach (var spiralAllowed in Bools)
+        foreach (var spiralUp in Bools)
+        {
+            var admitted = Allow(template, user, standalone,
+                artIsSpiral: true, userSpiralAllowed: spiralAllowed, spiralOverlayActive: spiralUp);
+            if (!admitted) continue;
+            Assert.True(spiralAllowed, "a corner spiral was admitted with the user's spiral master off");
+            Assert.False(spiralUp, "a corner spiral was admitted while a fullscreen spiral was on screen");
+            Assert.False(standalone, "a corner spiral was admitted behind a standalone corner overlay");
+            Assert.True(template && user);
+        }
+    }
+
+    private static readonly bool[] Bools = { true, false };
 
     // ---- the setting itself ----
 
@@ -357,4 +462,48 @@ public class CornerGifAdmissionTests
         var body = end > start ? source[start..end] : source[start..];
         Assert.Contains("CornerGifMedia.AllowStandaloneCornerGif", body);
     }
+
+    /// <summary>
+    /// The spiral side has to resolve in both directions too. A minute-0 corner GIF refused because
+    /// the fullscreen spiral was up would otherwise stay refused for the rest of the run once that
+    /// spiral stops: the per-second tick only re-raises corner GIFs with CornerGifStartMinute above
+    /// zero, and every stock program day is a minute-0 one. StopSpiral nudges the policy, exactly
+    /// as CornerGifService does from the standalone side.
+    /// </summary>
+    [Fact]
+    public void TheFullscreenSpiralGoingDown_ReAsksTheSessionAdmission()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            RepoRoot(), "ConditioningControlPanel", "Services", "Notifications", "OverlayService.cs"));
+        var start = source.IndexOf("internal void StopSpiral()", StringComparison.Ordinal);
+        Assert.True(start >= 0, "StopSpiral was renamed - update this test with it");
+        var body = source[start..source.IndexOf("\n    private void UpdateSpiralOpacity()", start, StringComparison.Ordinal)];
+        Assert.Contains("RefreshCornerGifPolicy()", body);
+    }
+
+    /// <summary>
+    /// Every gate on the session overlay asks the SAME question. The mid-session re-check used to
+    /// call CornerGifMedia.AllowSessionCornerGif with its own argument list, so the two spiral
+    /// clauses would have had to be remembered in two places - which is how the standalone dedupe
+    /// drifted the first time.
+    /// </summary>
+    [Fact]
+    public void EverySessionSideGate_GoesThroughCanRaiseCornerGif()
+    {
+        var source = SessionEngineSource();
+        // Exactly one call site for the shared rule: the one inside CanRaiseCornerGif itself.
+        Assert.Equal(1, Regex.Matches(source, @"CornerGifMedia\.AllowSessionCornerGif").Count);
+        Assert.Contains("CornerGifMedia.AllowSessionCornerGif",
+            MemberBody(source, "private bool CanRaiseCornerGif(SessionSettings settings)"));
+    }
+
+    /// <summary>
+    /// The user's spiral master must be read from the PRE-SESSION snapshot. ApplySessionSettings
+    /// writes App.Settings.Current.SpiralEnabled for the session's own fullscreen spiral, so a veto
+    /// read from the live value would evaporate the moment the session it is meant to veto starts.
+    /// </summary>
+    [Fact]
+    public void TheSpiralVetoReadsTheUsersPreSessionChoice()
+        => Assert.Contains("_savedSettings?.SpiralEnabled",
+            MemberBody(SessionEngineSource(), "private bool UserSpiralAllowed"));
 }


### PR DESCRIPTION
Two sub-bugs from ticket 1539282547484139682 (reporter randumbrandumb, v6.8.6). The parent report — the program-day corner-GIF freeze — is fixed and closed. These two were not.

## The bugs

**1. The session corner spiral bypassed the user's spiral settings.** Spiral overlay switched OFF on the Spiral card, start a session (or a 28-day program day), and a spiral still appears in the corner. `44c734f46` gave that corner a master of its own (`SessionCornerGifAllowed`), but the switch the user had **already set** — the spiral master itself — was still never consulted. Their answer to "no spirals" only ever counted for the fullscreen one.

**2. Double spiral.** The session's corner spiral could run *while* the fullscreen spiral overlay ran. The dedupe added in `44c734f46` only knew about the **standalone** corner slots (`CornerGifService`); the fullscreen overlay belongs to `OverlayService` and nothing compared the two. Two spirals on screen at once.

## Which conflict-resolution pattern this matches

Sessions **override** user settings for ordinary features. `ApplySessionSettings` writes `PinkFilterEnabled`, `SpiralEnabled`, `BouncingTextEnabled`, `BubblesEnabled`, `MandatoryVideosEnabled`, `LockCardEnabled` and the rest straight over the user's values, and `RestoreSettings` hands them back at session end. Subliminals and the pink filter resolve it exactly that way; there is no user-off veto anywhere in that list.

The one exception already in the file is the corner GIF, added by `44c734f46` for this very ticket: a dedicated user-level master acting as a **veto**, evaluated through a pure static admission helper in `CornerGifMedia` (so both owners of a corner overlay read the same answer), honoured live.

**This change extends that established veto rather than inventing a second shape.** No new setting, no new UI, no change to how any other feature resolves the conflict — the fullscreen spiral keeps overriding exactly as before. The spiral master simply joins `SessionCornerGifAllowed` as an input to the same helper.

## The rule

```csharp
templateEnabled && userAllowed && !standaloneOverlayActive
  && (!artIsSpiral || (userSpiralAllowed && !spiralOverlayActive))
```

Both new clauses are scoped to `artIsSpiral`, so a template carrying its own corner art is untouched: it is neither what the Spiral card switches off nor a duplicate of anything.

- **`artIsSpiral`** — `CornerGifMedia.SessionCornerArtIsSpiral`, deliberately the same "set and on disk" test `ShowCornerGif` runs before it falls back to the built-in corner spiral. No program template sets `CornerGifPath`, so every stock program day is a spiral by this rule — precisely the reported case.
- **`userSpiralAllowed`** — reads the **pre-session snapshot** (`_savedSettings.SpiralEnabled`), not the live value. `ApplySessionSettings` overwrites `App.Settings.Current.SpiralEnabled` for the session's own fullscreen spiral, so a veto read live would evaporate the moment the session it is meant to veto starts.
- **`spiralOverlayActive`** — `OverlayService.IsSpiralVisible`: the windows, not the setting, so a spiral raised by voice or by Deeper counts too.

## Live resolution, both directions

The per-second tick re-asks admission and takes the corner down when the fullscreen spiral arrives. `StopSpiral` now nudges `RefreshCornerGifPolicy` so it comes **back** when the spiral goes — nothing else would do that, since the tick only re-raises corner GIFs with `CornerGifStartMinute > 0` and every stock program day is a minute-0 one. Same shape as `CornerGifService`'s own admission nudge; the policy guards its own re-entrancy and refuses to raise anything on a paused session. Session end clears `Active` before it tears any overlay down, so the nudge cannot resurrect a corner GIF on the way out.

The mid-session re-check now goes through `CanRaiseCornerGif` instead of its own argument list, so there is exactly **one** call site for the shared rule — the two new clauses cannot be forgotten in one place the way the standalone dedupe drifted the first time.

## Changes

| File | What |
|------|------|
| `Services/Media/CornerGifMedia.cs` | `SessionCornerArtIsSpiral`; two new inputs on `AllowSessionCornerGif` |
| `Services/Session/SessionEngine.cs` | `UserSpiralAllowed`, `SpiralOverlayActive`; `CanRaiseCornerGif` now instance-scoped and the single gate |
| `Services/Notifications/OverlayService.cs` | `StopSpiral` nudges the session corner-GIF policy |
| `Tests/.../CornerGifAdmissionTests.cs` | +12 tests |

Localization files untouched.

## Verification

- `dotnet build` — **0 errors**, 346 warnings (baseline).
- `dotnet test` — **4857 passed / 4862**, 52/52 corner-GIF tests green. The 5 failures (`YouLibraryDoorTests` x4, `Phase8RedirectContractTests` x1) are pre-existing and unrelated: verified failing identically on a clean `origin/main` tree in this same worktree. They walk source files while skipping any path containing `.claude`, so their scan matches nothing when the suite runs inside an agent worktree.
- New tests include an exhaustive sweep over the six admission inputs asserting a corner spiral is never admitted alongside another spiral or against the user's wishes, plus source-level pins on the `StopSpiral` nudge, the single shared call site, and the pre-session read.

Not play-tested in the running app — the admission logic is covered by unit tests, but an owner pass on a program day with the spiral overlay switched off would confirm the end-to-end behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
