### PR TITLE
fix(flash): flash voicelines obey the companion's mute switches (ccp-bugs#1099)

### DIFF
--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -1550,6 +1550,15 @@ namespace ConditioningControlPanel.Services
             if (!isSafety && App.EmiDesk?.AvatarMuted == true)
                 return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "emi-desk-mute" };
 
+            // Companion dismissed: the reactive layer goes with her (#1099). This gate never asked.
+            // The only thing that stopped a bark with the companion off was AvatarTubeWindow's
+            // render-side IsAvatarVisibleOnScreen check - which drops the line AFTER CommitFire has
+            // already spent the rule's variant rotation and, for a lifetime one-shot, written the
+            // persisted latch. A milestone bark could be burned forever without ever being heard.
+            // Safety (Panic) stays exempt for the same reason it bypasses every other floor.
+            if (!isSafety && App.Settings?.Current?.AvatarEnabled != true)
+                return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "companion-off" };
+
             // One-shot (repeatable=false): fire once per scope. Session is in-memory; tier/lifetime
             // consult the persisted latch (AppSettings.BarkLifetimeFired). This dedup is NOT bypassed
             // by `guaranteed` — guaranteed means "ignore timing/floor", not "fire again". Otherwise a

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -1217,7 +1217,8 @@ namespace ConditioningControlPanel.Services
                 : settings.FlashDuration;
 
             // Play sound ONLY ONCE per flash event (not for hydra spawns) - only if audio enabled
-            if (settings.FlashAudioEnabled && !_soundPlayingForCurrentFlash && !isMultiplication && !string.IsNullOrEmpty(soundPath) && File.Exists(soundPath))
+            // AND the companion still has a voice (#1099 - see IsCompanionVoiceSilenced).
+            if (settings.FlashAudioEnabled && !IsCompanionVoiceSilenced(settings) && !_soundPlayingForCurrentFlash && !isMultiplication && !string.IsNullOrEmpty(soundPath) && File.Exists(soundPath))
             {
                 try
                 {
@@ -3795,6 +3796,29 @@ namespace ConditioningControlPanel.Services
 
         #region Audio
 
+        /// <summary>
+        /// True when the user has taken the companion's voice away, so a flash voiceline must not
+        /// speak either (#1099).
+        ///
+        /// <para>Flash "sounds" are not SFX: <see cref="SoundsPath"/> IS
+        /// <see cref="CompanionPhraseService.VoiceLineFolder"/>, the active mod's
+        /// <c>flashes_audio</c> folder, and <c>AvatarTubeWindow.OnFlashAudioPlaying</c> renders the
+        /// clip's text in HER speech bubble. They are her voice by content and by presentation, but
+        /// they used to obey none of her switches - two reporters had the companion dismissed and
+        /// every companion audio control off and still heard a clip on every single flash.</para>
+        ///
+        /// <para>The three checked here are exactly the ones the rest of her VO honours
+        /// (<c>PlayBarkVoice</c> / <c>ShowGiggle</c>): master mute, "mute avatar", and #846's
+        /// voiceline-only mute. <see cref="Models.AppSettings.AvatarEnabled"/> is deliberately NOT
+        /// among them - hiding the tube is a window decision (minimize takes the same path), not a
+        /// vow of silence, and killing flash audio on it would surprise anyone running voiced
+        /// flashes without the tube on screen. Silencing the voice leaves the flashes themselves
+        /// untouched; they simply fall back to the settings-driven duration, exactly as they do
+        /// with the "link to audio" toggle off.</para>
+        /// </summary>
+        private static bool IsCompanionVoiceSilenced(Models.AppSettings settings) =>
+            settings.MasterVolume <= 0 || settings.AvatarMuted || settings.CompanionVoiceLinesMuted;
+
         private double PlaySound(string path, int volumePercent)
         {
             StopCurrentSound();
@@ -3807,9 +3831,14 @@ namespace ConditioningControlPanel.Services
                 sound = new WaveOutEvent();
                 App.Audio?.ApplyPreferredDevice(sound);
 
-                // Apply volume curve (gentler, minimum 5%)
+                // Apply volume curve (gentler, minimum 5%). #1099: the 5% is a floor on the CURVE,
+                // never on the mute - it used to keep the clip plainly audible at MasterVolume 0,
+                // while every other voice path in the app (PlayBarkVoice, PlayPhraseAudio,
+                // PlayGiggleSound) returns early at <= 0. The 0.85 matches PlayBarkVoice: these are
+                // companion voicelines (see SoundsPath), and at raw master they were the loudest
+                // thing in the app while the duck sweep pushed everything else down under them.
                 var volume = volumePercent / 100.0f;
-                var curvedVolume = Math.Max(0.05f, (float)Math.Pow(volume, 1.5));
+                var curvedVolume = volume <= 0f ? 0f : Math.Max(0.05f, (float)Math.Pow(volume, 1.5)) * 0.85f;
                 audioFile.Volume = curvedVolume;
 
                 sound.Init(audioFile);


### PR DESCRIPTION
Fixes CC-Labs-llc/ccp-bugs#1099 (v6.8.6, 2 reporters).

## It was never a bark

The reported line — "trigger my brain and make me a bimbo" — is a **file**:

```
Resources/sounds/flashes_audio/trigger my brain and make me a bimbo.mp3
```

That is why it appears nowhere in the source. It is a **flash voiceline**, played by `FlashService`, not by the companion's bark engine.

The reason it reads as the companion talking is that it genuinely is her voice, twice over:

- `FlashService.SoundsPath` **is** `CompanionPhraseService.VoiceLineFolder` (`FlashService.cs:157`) — the pool is the active mod's spoken VO folder, mod-scoped like every other companion line.
- `AvatarTubeWindow.OnFlashAudioPlaying` (`Reactions.cs:442`) prints the clip's text **in her speech bubble**.

So the app shows her saying it, in her voice, from her voice folder — while the audio obeys none of her switches.

## Root cause: which guard was missing

The playback path is `FlashService.cs:1220` → `PlaySound` (`:3798`), which opens its **own private `WaveOutEvent`**, entirely outside `AudioService`. Its only gate was `FlashAudioEnabled` (default `true`). Three concrete holes:

| # | Hole | Detail |
|---|------|--------|
| 1 | **No mute check whatsoever** | `MasterVolume == 0`, `AvatarMuted` and #846's `CompanionVoiceLinesMuted` were never consulted on this path. |
| 2 | **Master mute leaked at 5%** | `Math.Max(0.05f, pow(v,1.5))` floored the *curve* and therefore also the *mute* — the clip stayed plainly audible at MasterVolume 0. Every other voice path (`PlayBarkVoice`, `PlayPhraseAudio`, `PlayGiggleSound`) returns early at `<= 0`. |
| 3 | **It stomped everything** | Played at **raw master with no attenuation** (companion voice ×0.85, event phrases ×0.56, giggle ×0.7, chime ×0.35) *while* triggering `App.Audio.Duck(DuckingLevel)`, which pushes everything else down to 20% — loud clip up, everything else down. |

On "EVERY flash": correct, and by design of the old code — `_soundPlayingForCurrentFlash` only dedupes hydra spawns *within* one flash event, so there was no cooldown at all.

## The fix

**`FlashService`**
- New `IsCompanionVoiceSilenced(settings)` gates the call site on exactly the three switches the rest of her VO honours: master mute, "mute avatar", voiceline-only mute. Because it gates the whole block, the whisper-mark, the bubble event and the duck sweep are all skipped coherently too.
- `AvatarEnabled` is **deliberately excluded**: hiding the tube is a window decision (minimize takes the same path), not a vow of silence, and killing flash audio on it would surprise anyone running voiced flashes without the tube on screen.
- Dropped the mute leak (`volume <= 0f ? 0f : …`) and brought the level to **×0.85**, matching `PlayBarkVoice`. This also covers `PlayRandomSound()` (quest completion), which drew from the same folder at the same raw level.
- Silencing the voice leaves the flashes themselves untouched — they fall back to the settings-driven duration, exactly as with "link to audio" off.

**`BarkService`** — closes a real hole next door while we're here. `EvaluateGate` never asked whether the companion was on; the only thing stopping a bark with her dismissed was `AvatarTubeWindow`'s render-side `IsAvatarVisibleOnScreen` check, which drops the line **after** `CommitFire` has already spent the rule's variant rotation and, for a lifetime one-shot, written the persisted latch. A milestone bark could be burned forever without ever being heard. Safety (Panic) stays exempt, as it is from every other floor.

Bark cooldowns were already sound and are untouched — the shipped flash rule carries `cooldown_ms: 20000` and `chance: 0.5` under a 60s global min-gap.

## Verification

- `dotnet build` — **0 errors**, 346 warnings (baseline ~350).
- `dotnet test` — **4844 passed, 5 failed**. The 5 failures (`YouLibraryDoorTests`, `Phase8RedirectContractTests`) reproduce identically on the untouched baseline and are unrelated to these files (XAML handler binding + Patreon redirect contract).
- Not play-tested on a live rig; the audible verification (mute each switch, confirm silence; confirm flashes still run on the settings duration) is owner-owed.

## One thing left as an owner call

The duck-vs-level relationship is now sane, but flash VO still ducks other audio to `DuckingLevel` (default 80 → others at 20%) *by design*. If it still feels overbearing after this, that dial is a product decision, not a bug — flagging rather than changing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
