### PR TITLE
fix(fyp): ghost mode blank screen + dead swap arrows

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -873,6 +873,50 @@ internal sealed class ChaosWebViewHost : IDisposable
             ? "--force-prefers-reduced-motion"
             : "--force-prefers-no-reduced-motion";
 
+    /// <summary>
+    /// Join the host's own switches to a caller's <see cref="Options.ExtraBrowserArguments"/> so the
+    /// command line carries each Chromium FEATURE switch exactly once.
+    ///
+    /// <para>Chromium keys switches by NAME (base::CommandLine holds a map), so a command line that
+    /// names --disable-features twice keeps only the LAST occurrence and silently drops every value
+    /// in the others. The host and its callers both have a stake in that switch - the For You ghost
+    /// mirror lives or dies on CalculateNativeWinOcclusion being off, and a parked window Chromium
+    /// calls hidden takes the whole feed down with it - and appending a second copy costs nothing
+    /// today only because both copies happen to carry the same value. Merge instead: one
+    /// comma-joined switch per feature list, first-seen order, duplicates dropped.</para>
+    ///
+    /// <para>Everything else is passed through untouched (only exact repeats collapse), so a switch
+    /// Chromium already resolves last-wins keeps resolving exactly as it does today.</para>
+    /// </summary>
+    internal static string ComposeBrowserArguments(string? hostArgs, string? extra)
+    {
+        var featureNames = new List<string>();
+        var featureValues = new List<List<string>>();
+        var plain = new List<string>();
+        var tokens = $"{hostArgs} {extra}".Split(' ',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var token in tokens)
+        {
+            int eq = token.IndexOf('=');
+            var name = eq > 0 ? token[..eq] : token;
+            if (eq > 0 && (name == "--disable-features" || name == "--enable-features"))
+            {
+                int slot = featureNames.IndexOf(name);
+                if (slot < 0) { featureNames.Add(name); featureValues.Add(new List<string>()); slot = featureNames.Count - 1; }
+                foreach (var feature in token[(eq + 1)..].Split(',',
+                             StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    if (!featureValues[slot].Contains(feature, StringComparer.Ordinal))
+                        featureValues[slot].Add(feature);
+                continue;
+            }
+            if (!plain.Contains(token, StringComparer.Ordinal)) plain.Add(token);
+        }
+        for (int i = 0; i < featureNames.Count; i++)
+            if (featureValues[i].Count > 0)
+                plain.Add($"{featureNames[i]}={string.Join(',', featureValues[i])}");
+        return string.Join(' ', plain);
+    }
+
     private async Task InitWebAsync()
     {
         if (_initStarted || _web == null) return;
@@ -886,10 +930,10 @@ internal sealed class ChaosWebViewHost : IDisposable
             // through DWM (the app's established anti-MPO flag). CalculateNativeWinOcclusion:
             // native payload windows stack over the page; Chromium's occlusion tracker would
             // decide the page is covered and throttle rAF — turn it off.
-            var args = "--disable-direct-composition-video-overlays --disable-features=CalculateNativeWinOcclusion";
-            args += " " + PrefersReducedMotionArgument();
-            if (!string.IsNullOrWhiteSpace(_opts.ExtraBrowserArguments))
-                args += " " + _opts.ExtraBrowserArguments;
+            var args = ComposeBrowserArguments(
+                "--disable-direct-composition-video-overlays --disable-features=CalculateNativeWinOcclusion "
+                + PrefersReducedMotionArgument(),
+                _opts.ExtraBrowserArguments);
             var options = new CoreWebView2EnvironmentOptions { AdditionalBrowserArguments = args };
             var env = await CoreWebView2Environment
                 .CreateAsync(browserExecutableFolder: null, userDataFolder: userDataFolder, options: options)

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -462,6 +462,12 @@ body.clickthrough #top-left,
 body.clickthrough #top-right,
 body.clickthrough #attention { display: none !important; }
 
+/* The swap chevrons go with them (#1096: "persistent but noninteractive"). They are a
+   :hover affordance, and ghosting moves the window out from under the cursor without ever
+   sending a mouseleave — so the hover state STICKS and the arrows sit there for the rest of
+   the session on a surface no mouse can reach. Dead chrome; take it off the mirror. */
+body.clickthrough .chev { display: none !important; }
+
 /* Notice shown when ghost mode engages, so the vanished chrome reads as a
    mode, not a breakage. Never interactive; fades out on its own. */
 #ct-note {

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -307,9 +307,17 @@ function applyTrack(animated) {
  * half-swipe reveals, and the warm media a commit resumes with no black gap),
  * everything else OFF. Hidden window: everything off — decoders freed, dwell
  * reported — exactly what the old binary active flag did on minimize.
+ *
+ * ...unless GHOST MODE is on. Ghost parks the real window off every monitor on purpose and
+ * shows a live DWM mirror of it, so "hidden" there means the opposite of what it means on a
+ * minimize: the user is watching this page right now. Tearing every page down on that event
+ * is what made ghost mode a blank screen — the mirror faithfully showed an emptied feed
+ * (ccp-bugs #1091, and #864 before it). Whether Chromium calls a parked window hidden at all
+ * depends on its occlusion tracker, which is why it broke for some machines and not others;
+ * this guard makes ghost mode independent of that verdict.
  */
 function applyWindow() {
-  if (document.hidden) {
+  if (document.hidden && !clickThrough) {
     for (const p of pages.values()) p.setMode('off');
     return;
   }
@@ -904,6 +912,10 @@ function setClickThrough(on, fromHost) {
   clickThrough = !!on;
   document.body.classList.toggle('clickthrough', clickThrough);
   $('toggle-clickthrough').classList.toggle('on', clickThrough);
+  // Re-mount whatever a hidden event tore down before the mode flipped — a minimize of the
+  // main window (which owns this one) empties the feed, and going ghost from there would
+  // otherwise mirror that emptiness with no visibility event left to undo it.
+  if (feed) applyWindow();
   clearTimeout(ctNoteTimer);
   if (clickThrough) {
     $('options-scrim').classList.add('hidden'); // nothing is clickable from here on
@@ -955,7 +967,9 @@ function eyeStatusText() {
 /** True when a gesture must be ignored (a dialog is up, nothing to act on, or
  *  something is already animating). */
 function eyeBusy() {
-  if (!feed || feed.comps.length === 0 || document.hidden) return true;
+  // `hidden` is not idle in ghost mode — the parked window is exactly where eye control is the
+  // only input the user has left, so it may not be what disables it (see applyWindow).
+  if (!feed || feed.comps.length === 0 || (document.hidden && !clickThrough)) return true;
   if (!$('options-scrim').classList.contains('hidden')) return true;  // options open
   if (!$('crash').classList.contains('hidden')) return true;
   if (!$('empty').classList.contains('hidden')) return true;

--- a/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
@@ -314,10 +314,17 @@ internal sealed class FypGhostOverlay
             Region = new SD.Region(EllipsePath(bounds.Width, bounds.Height));
             new WF.ToolTip().SetToolTip(this, tooltip);
             Show();
-            // A see-through feed can sit at 1% — keep the buttons discoverable but quiet.
-            // Plain SLWA alpha is safe here: no DWM thumbnail rides this window.
-            Opacity = 0.82;
+            // Quiet until you reach for it (#1096: "sometimes they just get in the way"). The
+            // ghost-mode notice on the page already says the corner buttons stay clickable, so a
+            // faint disc is a reminder rather than the only clue. Plain SLWA alpha is safe here:
+            // no DWM thumbnail rides this window.
+            Opacity = IdleOpacity;
         }
+
+        /// <summary>Faint enough to stop being furniture over a see-through feed, solid enough
+        /// that the hand landing on it still finds a target.</summary>
+        private const double IdleOpacity = 0.14;
+        private const double HoverOpacity = 0.92;
 
         public void SetGlyph(string glyph)
         {
@@ -337,8 +344,8 @@ internal sealed class FypGhostOverlay
             }
         }
 
-        protected override void OnMouseEnter(EventArgs e) { _hover = true; Invalidate(); base.OnMouseEnter(e); }
-        protected override void OnMouseLeave(EventArgs e) { _hover = false; Invalidate(); base.OnMouseLeave(e); }
+        protected override void OnMouseEnter(EventArgs e) { _hover = true; Opacity = HoverOpacity; Invalidate(); base.OnMouseEnter(e); }
+        protected override void OnMouseLeave(EventArgs e) { _hover = false; Opacity = IdleOpacity; Invalidate(); base.OnMouseLeave(e); }
         protected override void OnMouseUp(WF.MouseEventArgs e)
         {
             base.OnMouseUp(e);

--- a/Tests/ConditioningControlPanel.Tests/BrowserArgumentMergeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BrowserArgumentMergeTests.cs
@@ -1,0 +1,102 @@
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1091: For You ghost mode showed a blank screen. The page-side cause is fixed in
+/// fyp/main.js, but the host's own mitigation for the same class of failure was one edit away
+/// from silently evaporating.
+///
+/// Chromium's command line keys switches by NAME (base::CommandLine holds a map), so naming
+/// --disable-features twice does NOT union the values - the last occurrence wins and every
+/// feature listed in the earlier one is dropped without a warning. ChaosWebViewHost emits
+/// --disable-features=CalculateNativeWinOcclusion for every page it hosts, and FypHostService
+/// appends its own --disable-features for autoplay-adjacent switches; whichever one lost would
+/// take the occlusion opt-out with it. ComposeBrowserArguments unions them into a single switch
+/// so the ghost mirror never depends on argument ordering.
+/// </summary>
+public class BrowserArgumentMergeTests
+{
+    [Fact]
+    public void TwoDisableFeatureSwitches_UnionIntoOne()
+    {
+        var args = ChaosWebViewHost.ComposeBrowserArguments(
+            "--disable-features=CalculateNativeWinOcclusion",
+            "--disable-features=AutoplayIgnoreWebAudio");
+
+        Assert.Equal("--disable-features=CalculateNativeWinOcclusion,AutoplayIgnoreWebAudio", args);
+    }
+
+    [Fact]
+    public void TheOcclusionOptOutSurvivesACallersOwnFeatureList()
+    {
+        // The exact pairing that ships: host switches + FypHostService's ghost arguments.
+        var args = ChaosWebViewHost.ComposeBrowserArguments(
+            "--disable-direct-composition-video-overlays --disable-features=CalculateNativeWinOcclusion",
+            "--autoplay-policy=no-user-gesture-required --disable-features=CalculateNativeWinOcclusion "
+            + "--disable-backgrounding-occluded-windows");
+
+        Assert.Contains("CalculateNativeWinOcclusion", args);
+        // Once, not twice: a repeated switch name is the whole failure mode.
+        Assert.Equal(1, CountOccurrences(args, "--disable-features="));
+        Assert.Contains("--autoplay-policy=no-user-gesture-required", args);
+        Assert.Contains("--disable-backgrounding-occluded-windows", args);
+        Assert.Contains("--disable-direct-composition-video-overlays", args);
+    }
+
+    [Fact]
+    public void ARepeatedFeatureIsNotListedTwice()
+    {
+        var args = ChaosWebViewHost.ComposeBrowserArguments(
+            "--disable-features=A,B", "--disable-features=B,C");
+
+        Assert.Equal("--disable-features=A,B,C", args);
+    }
+
+    [Fact]
+    public void EnableAndDisableStayApart()
+    {
+        var args = ChaosWebViewHost.ComposeBrowserArguments(
+            "--disable-features=A", "--enable-features=B");
+
+        Assert.Contains("--disable-features=A", args);
+        Assert.Contains("--enable-features=B", args);
+    }
+
+    [Fact]
+    public void PlainSwitchesKeepTheirOrderAndDeduplicate()
+    {
+        var args = ChaosWebViewHost.ComposeBrowserArguments(
+            "--first --second", "--second --third");
+
+        Assert.Equal("--first --second --third", args);
+    }
+
+    [Theory]
+    [InlineData(null, null, "")]
+    [InlineData("--only", null, "--only")]
+    [InlineData(null, "--only", "--only")]
+    [InlineData("", "   ", "")]
+    public void MissingSidesAreHarmless(string? hostArgs, string? extra, string expected)
+    {
+        Assert.Equal(expected, ChaosWebViewHost.ComposeBrowserArguments(hostArgs, extra));
+    }
+
+    [Fact]
+    public void AnEmptyFeatureListIsDropped()
+    {
+        // A switch with nothing after the '=' would disable nothing and only add noise.
+        Assert.Equal("--keep", ChaosWebViewHost.ComposeBrowserArguments("--disable-features=", "--keep"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, at = 0;
+        while ((at = haystack.IndexOf(needle, at, System.StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += needle.Length;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
Fixes CC-Labs-llc/ccp-bugs#1091 and the bug half of CC-Labs-llc/ccp-bugs#1096.
Also covers the older duplicates CC-Labs-llc/ccp-bugs#864 and CC-Labs-llc/ccp-bugs#911.

## Root cause of the blank screen (#1091 / #864)

**The native ghost machinery was never the problem. The page emptied itself.**

Ghost mode parks the real For You window off every monitor (`_parkX = vs.Right + 200`) and
paints a live DWM thumbnail of it onto a colour-keyed layered window. The page had no idea
that had happened. `applyWindow()` in `Resources/web/fyp/main.js` treated `document.hidden`
as "nobody is looking":

```js
if (document.hidden) { for (const p of pages.values()) p.setMode('off'); return; }
```

`setMode('off')` runs `unmountTiles()`, which removes every media element. So the moment
Chromium decided the parked window was hidden, the feed deleted its own content and the DWM
mirror faithfully showed the result: a blank screen. Everything host-side kept reporting
healthy the whole time, which is why the #1091 activity log reads `visible=true iconic=false
cloaked=0` with no registration warning while the user sees nothing.

`eyeBusy()` had the same `document.hidden` bail, so eye control — the only input ghost mode
leaves you — died along with the feed.

Why it broke for some people and not others: whether Chromium calls an off-screen parked
window "hidden" is a verdict of its native occlusion tracker, which varies by machine, GPU
path and WebView2 runtime. The guard now makes ghost mode independent of that verdict
instead of hoping for a particular answer.

I verified the native path rather than assuming it. Two throwaway probes (a GDI mirror and a
real WPF + WebView2 mirror, both since deleted) confirmed on this machine that
`LWA_COLORKEY` genuinely drops the RGB(1,1,1) surface, that `DwmRegisterThumbnail` and every
`DwmUpdateThumbnailProperties` call — cover-crop `rcSource` included — return `S_OK`, and
that a WebView2 window parked past the virtual desktop still composes live and animating
into the thumbnail. Two of my own earlier hypotheses (unsupported `DWM_TNP_RECTSOURCE`, and
an unpainted surface after the simultaneous move+resize park) were falsified by those probes
and dropped. **No repaint timer, no band-aid** — the tear-down is the bug.

### The latent second failure, fixed at the same time

`ChaosWebViewHost` emits `--disable-features=CalculateNativeWinOcclusion` for every page it
hosts; `FypHostService.Launch()` appends its own `--disable-features=...`. Chromium's
`base::CommandLine` keys switches by **name**, so a command line naming `--disable-features`
twice keeps only the last occurrence and drops the earlier list without a word. The occlusion
opt-out was therefore one added feature name away from silently evaporating — and it is the
exact switch this bug class depends on. `ComposeBrowserArguments` now unions the feature
lists into a single switch (and de-dupes plain switches), with `BrowserArgumentMergeTests`
pinning the behaviour.

## The dead arrows (#1096)

The prev/next chevrons are `opacity: 0` until `.tile:hover`. Entering ghost mode moves the
window out from under the cursor **without ever delivering a `mouseleave`**, so the hover
state sticks and the arrows sit there for the rest of the session, painted onto a surface no
mouse can reach — "persistent but noninteractive", exactly as reported. They are now hidden
whenever `body.clickthrough` is set.

The same report's second ask (cog + mute auto-hide) was a few lines on the same surface, so
it is included: the gear and mute islands idle at 14% opacity and come up to 92% under the
pointer. They are real Win32 buttons that stay clickable in ghost mode, and the page's own
ghost-mode notice already tells the user so, which is what makes fading them safe for
discoverability.

## Changes

| File | What |
|------|------|
| `Resources/web/fyp/main.js` | `applyWindow()` and `eyeBusy()` exempt ghost mode from the `document.hidden` tear-down; `setClickThrough()` re-runs `applyWindow()` so a feed already emptied by a minimize comes back when the mode flips (the #1091 log shows `rule=win_minimize` firing immediately before the first ghost toggle, with no visibility event left to undo it) |
| `Resources/web/fyp/fyp.css` | `body.clickthrough .chev { display: none }` |
| `Chaos/ChaosWebViewHost.cs` | new pure `ComposeBrowserArguments` helper + call site |
| `Services/Fyp/FypGhostOverlay.cs` | ghost gear/mute buttons idle faint, solid on hover |
| `Tests/…/BrowserArgumentMergeTests.cs` | 10 new tests over the argument union |

## Web sync

**This touches `Resources/web/fyp/**`, so a web sync dispatch is needed after merge.**

## Build and tests

- `dotnet build` — **0 errors**, 346 warnings (baseline ~350).
- `dotnet test` — **4854 passed, 5 failed**. The 5 failures are `YouLibraryDoorTests
  .EachLibraryLauncherIsOneRowBoundToOneExistingHandler` and are an artifact of running in an
  isolated worktree, not a regression: that test skips any source file whose path contains
  `\.claude\`, and the whole worktree lives under `…\ConditioningControlPanel\.claude\worktrees\…`,
  so every handler in the product is filtered out and reported as "defined nowhere". Nothing in
  this branch touches `MainWindow.xaml` or any handler. The 10 new tests pass.

Not play-tested against a real ghost session — the fix wants an owner pass with the
sissyhypno mod active, which is the configuration #1091 was filed from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
