### PR TITLE
fix(video): ESC always escapes a non-strict mandatory video + tell the user when it cannot

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -883,6 +883,39 @@ namespace ConditioningControlPanel
 
         private void OnGlobalKeyPressed(Key key)
         {
+            // Plain ESC on a NON-strict mandatory video, before the lockdown early-out below.
+            //
+            // ESC is the hardcoded "dismiss this video" key, but both engines only handle it at the
+            // WINDOW level (the LibVLC window's PreviewKeyDown / the browser page's key report), so a
+            // fullscreen video that lost keyboard focus swallows it and the user is stuck until a
+            // safety timer fires — the "i pressed the esc key and nothing happens" reports. The panic
+            // key has always had this focus-independent route; ESC gets the same one here.
+            //
+            // Placed ABOVE the lockdown early-out deliberately, and it is not a lockdown bypass:
+            // WantsGlobalEscape is false whenever the video is strict-locked, which is exactly what a
+            // lockdown with the default LockdownForceStrictLock safety produces. A lockdown that does
+            // NOT force strict lock leaves a video the window handler already dismisses on ESC (that
+            // handler carries no lockdown check), so honouring it when unfocused only restores parity.
+            //
+            // A lock card or the settings palette outranks the video dismiss in the panic ladder
+            // (PanicPolicy.Decide) and both own ESC themselves, so leave the press to them. Both checks
+            // are side-effect free — deliberately NOT SettingsPaletteWindow.TryConsumeEscape(), which
+            // CLOSES the palette just by asking and would burn the grace window HandlePanicKeyPress
+            // depends on.
+            if (key == Key.Escape && App.Video?.WantsGlobalEscape == true
+                && !LockCardWindow.IsAnyOpen() && !SettingsPaletteWindow.IsOpen)
+            {
+                // Never run teardown inside the WH_KEYBOARD_LL callback — it is delivered on this
+                // thread's message pump and must return well inside LowLevelHooksTimeout. Same
+                // queue-and-return shape as the panic key below.
+                Dispatcher.BeginInvoke(() =>
+                {
+                    try { App.Video?.TryEscapeFromGlobalKey(); }
+                    catch (Exception ex) { App.Logger?.Warning("Global ESC: video dismiss failed: {Error}", ex.Message); }
+                });
+                return;
+            }
+
             // Lockdown mode: block all key handling (panic key, etc.)
             if (App.Lockdown?.IsActive == true)
                 return;

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -653,7 +653,20 @@ namespace ConditioningControlPanel.Services
                         // only exists when Escape is NOT the panic key, so PanicOverridesAll must
                         // not close it (see PanicPolicy.AllowGracePause).
                         if (TryGracePauseFromPanic(fromPanicKey: false))
+                        {
                             VideoDiag.Log("PANIC", "strict browser window: ESC consumed as video grace pause");
+                            return;
+                        }
+                    }
+
+                    // Parity with the strict LibVLC window: an ESC that was swallowed rather than
+                    // consumed leaves the screen completely still, which reads as a hung app. Fire the
+                    // existing Possession tripwire (no-ops outside a lockdown, throttled per kind) so
+                    // the user learns the lock is deliberate. See the twin comment in SetupStrictHandlers.
+                    if (isEscape)
+                    {
+                        try { App.Lockdown?.NotifyEscapeAttempt(Services.Possession.EscapeKinds.SystemKey); }
+                        catch { /* never let the haunt break key suppression */ }
                     }
                     return;
                 }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -4963,6 +4963,20 @@ namespace ConditioningControlPanel.Services
                         }
                     }
 
+                    // An ESC that reaches this line is swallowed — the grace pause was unavailable,
+                    // already spent, or (the reported case) suppressed because a lockdown is running.
+                    // Nothing on screen moves, which reads as a hung app rather than as a lock working
+                    // as intended: "i pressed the esc key and nothing happens". Fire the EXISTING
+                    // Possession tripwire the suppressed system keys already use — it self-no-ops when
+                    // no lockdown is active, is throttled to one per 2s for this kind (so key-repeat
+                    // cannot spam it), and drives the Warden's "that key does nothing. i do~" line. No
+                    // new UI, and the lock itself is unchanged.
+                    if (e.Key == Key.Escape)
+                    {
+                        try { App.Lockdown?.NotifyEscapeAttempt(Services.Possession.EscapeKinds.SystemKey); }
+                        catch { /* never let the haunt break key suppression */ }
+                    }
+
                     // In strict mode, block panic key, Alt+F4, and system keys
                     if (e.Key.ToString() == App.Settings.Current.PanicKey || e.Key == Key.System ||
                         (e.Key == Key.F4 && Keyboard.Modifiers.HasFlag(ModifierKeys.Alt)))
@@ -5816,6 +5830,75 @@ namespace ConditioningControlPanel.Services
                 // A bug in here must never eat a panic press. Fall through to the normal ladder.
                 App.Logger?.Warning("VideoService.TryGracePauseFromPanic threw: {Error}", ex.Message);
                 VideoDiag.Log("PANIC", "grace pause THREW - falling through to the normal panic ladder: " + ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Cheap, allocation-free pre-check for the global keyboard hook: is there a mandatory video
+        /// on screen that plain ESC is ALLOWED to dismiss? Read inside the WH_KEYBOARD_LL callback,
+        /// which must return well inside LowLevelHooksTimeout, so it is a handful of field reads and
+        /// nothing else. False here means the hook leaves the press alone entirely.
+        /// </summary>
+        public bool WantsGlobalEscape => _videoPlaying && _playbackStarted && !_isCleaningUp && !IsStrictActive;
+
+        /// <summary>
+        /// Focus-independent ESC door for a NON-strict mandatory video — the other half of the
+        /// "I pressed the esc key and nothing happens" reports.
+        ///
+        /// Both engines' ESC handlers are WINDOW-scoped: the LibVLC path needs WPF keyboard focus on
+        /// the video window (<c>SetupStrictHandlers</c>' PreviewKeyDown) and the browser path needs
+        /// the WebView2 page to see the keydown and report it back (<c>HandleBrowserKey</c>). A
+        /// fullscreen video that lost activation — a click on a second monitor, another topmost
+        /// window, a focus steal during the show delay, or the strict retry gap — therefore swallows
+        /// every ESC, and the only remaining way out is the panic key. The global hook has always
+        /// given the PANIC key that independence; this gives plain ESC the same, because ESC is
+        /// documented as the non-rebindable "dismiss this video" key and a user who cannot reach it
+        /// is stuck until a safety timer fires.
+        ///
+        /// Deliberately narrow, and that narrowness is the safety argument: <see cref="WantsGlobalEscape"/>
+        /// is false unless a mandatory video is genuinely on screen AND not strict-locked, so this can
+        /// never eat an ESC that belonged to another application and can never become a strict-lock or
+        /// lockdown bypass (a lockdown that forces strict lock on makes <c>IsStrictActive</c> true, and
+        /// one that does NOT force it leaves a video the window handler already dismisses on ESC).
+        ///
+        /// Must be called on the UI thread — the caller queues it on the dispatcher rather than running
+        /// teardown inside the hook callback. Returns true when the press was consumed.
+        /// </summary>
+        public bool TryEscapeFromGlobalKey()
+        {
+            try
+            {
+                // Re-checked HERE, not just at the hook: on a focused video window the window-level
+                // PreviewKeyDown runs during message dispatch, i.e. BEFORE this queued continuation
+                // drains, so by now the very same keystroke may already have dismissed the video.
+                if (!WantsGlobalEscape) return false;
+
+                // Same order as the window handler, so a press behaves identically whether or not the
+                // video happened to hold focus. If the window handler already turned this keystroke
+                // into a grace pause, EvaluateGraceRequest returns ConsumedDedup (true) and we stop —
+                // exactly the mechanism that keeps the queued panic handler from stopping the engine a
+                // few ms after a pause.
+                if (TryGracePauseFromPanic(fromPanicKey: Services.Safety.PanicPolicy.EscapeIsThePanicKey(
+                        App.Settings?.Current?.PanicKeyEnabled ?? false,
+                        App.Settings?.Current?.PanicKey)))
+                {
+                    VideoDiag.Log("PANIC", "ESC consumed as video grace pause (global hook, unfocused video)");
+                    return true;
+                }
+
+                // Guard the teardown itself the way the browser page's ESC door does: a second ESC
+                // that raced in behind this one must not run Cleanup twice and re-fire VideoEnded.
+                if (!_videoPlaying || _isCleaningUp) return false;
+
+                VideoDiag.Log("PANIC", "ESC received by the global hook - dismissing the unfocused video via Cleanup");
+                Cleanup();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // A bug in here must never be the reason a user cannot leave a video.
+                App.Logger?.Warning("VideoService.TryEscapeFromGlobalKey threw: {Error}", ex.Message);
                 return false;
             }
         }
@@ -7736,6 +7819,17 @@ namespace ConditioningControlPanel.Services
             // CDN URL through MetadataCache would mean a network parse per candidate per refill.
             // The user's MAXIMUM still holds on screen (StartMaxLengthCapTimer is wall-clock, not
             // metadata), but their minimum does not apply to remote clips. See the Phase 4 region.
+            //
+            // CONTENT-PACK videos are in the same boat, and for the same reason (#584/#581/#484 keep
+            // coming back as "max video length ignored" on a pack clip). They are appended to their
+            // own queue BELOW this filter, and they cannot join it: PackFileEntry carries no duration,
+            // pack media is encrypted, and each play decrypts to a fresh ccp_temp_<GUID> path that
+            // MetadataCache — keyed on path+size+mtime — could never hit. Filtering them at selection
+            // would mean decrypting and parsing every pack candidate on every refill. The wall-clock
+            // StartMaxLengthCapTimer is therefore what enforces the maximum for pack videos, and it is
+            // armed for BOTH engines before the first frame (StartVideoPlayback / StartBrowserVideoPlayback),
+            // so a long pack clip is truncated on screen rather than never picked. Do not "fix" this by
+            // making the queue refill parse packs.
             var minSec = App.Settings?.Current?.VideoMinDurationSeconds ?? 0;
             var maxSec = App.Settings?.Current?.VideoMaxDurationSeconds ?? 0;
             if ((minSec > 0 || maxSec > 0) && MetadataCache != null)


### PR DESCRIPTION
A user was locked to a single mandatory video for **an hour** during lockdown: *"theres no escape key for mandatory vids"*, *"i pressed the esc key and nothing happens"*. The video came from an official content pack, so this is reachable out of the box. The community guessed Force Strict Lock was on; she checked and it was **OFF**, which sent everyone looking in the wrong place.

## 1. Why ESC was dead with strict lock "off"

**It wasn't off while the video played.** `LockdownService.Activate` (`Services/Haptics/LockdownService.cs:155`) force-sets `StrictLockEnabled = true` at runtime whenever `LockdownForceStrictLock` is on — and that **defaults to `true`** (`AppSettings.cs:3119`), as one of the default-on "Safeties" on the Lockdown card. `Deactivate` (`:200`) restores the user's real value.

So the video genuinely *was* strict-locked, and by the time she looked at the checkbox lockdown had ended and put it back to OFF. **The Force Strict Lock checkbox only tells the truth outside a lockdown**, which is why both she and everyone helping her read it as innocent.

From there the silence is by design and undiscoverable:
- `SetupStrictHandlers` (`VideoService.cs:4949`) offers ESC as a grace pause **only when `App.Lockdown?.IsActive != true`** — during lockdown that door is closed on purpose, then the press is swallowed.
- `OnGlobalKeyPressed` (`MainWindow.xaml.cs:887`) returns immediately during lockdown, and `LockdownDisablePanicKey` (also default `true`) stops the hook anyway.

Net effect: ESC did *literally nothing*, with no feedback — indistinguishable from a hung app.

**A second, independent gap** that bites even with strict genuinely off: plain ESC is handled **only at the window level** in both engines — the LibVLC window's `PreviewKeyDown`, and the browser page's reported keydown (a focused WebView2 eats keys before WPF sees them). `OnGlobalKeyPressed` never had an Escape branch at all; it only ever matched the panic key and the pause key. So a fullscreen video that lost keyboard focus swallowed every ESC with **no fallback**, and the only way out was the panic key.

For the record, #680 is *not* implicated: bare Esc is deliberately no longer suppressed by the hook (`GlobalKeyboardHook.cs:126-133`), so it does reach the app.

## 2. Duration cap — verified, no path skips it

`StartMaxLengthCapTimer` (`VideoService.cs`) is armed before the first frame on **both** engines (`StartVideoPlayback` and `StartBrowserVideoPlayback`, `VideoService.Browser.cs:176`) and re-armed on attention-retry and vout-heal replays. Content-pack and lockdown-triggered videos both go through that funnel, so the wall-clock cap does hold for them.

What pack videos *do* skip is the duration **selection** filter (they are appended to their own queue below it). They can't join it: `PackFileEntry` carries no duration, pack media is encrypted, and each play decrypts to a fresh `ccp_temp_<GUID>` path that `MetadataCache` — keyed on path+size+mtime — could never hit. Filtering them at selection would mean decrypting and parsing every pack candidate on every refill. **Documented in place** rather than built, since #584/#581/#484 keep coming back here.

So the honest answer to the hour-long video: the cap works, but **defaults to `0` (off)**, so an hour-long pack clip runs to completion unless the user sets a maximum.

## 3. Strict-lock hint — piggybacked on an existing mechanism

A swallowed ESC in strict mode now fires the **existing** Possession tripwire, `NotifyEscapeAttempt(EscapeKinds.SystemKey)` — the same one the suppressed system keys already use — in both engines. The Warden answers *"that key does nothing. i do~"*.

No new UI system: it self-no-ops when no lockdown is running, and is already throttled to one per 2s for this kind, so key-repeat can't spam it. **The lock itself is unchanged.**

Outside a lockdown the tripwire no-ops, and there the strict-mode ESC grace pause already shows a real overlay — so that case has feedback today. I did not build anything for the residual silent corners (strict with the panic key disabled, or a grace pause already spent); `ShowMessage` is the only other text-over-video mechanism and it tears the video down first, so it isn't usable as a transient hint.

## Changes

- **`VideoService.WantsGlobalEscape`** — cheap pre-check safe to read inside the `WH_KEYBOARD_LL` callback.
- **`VideoService.TryEscapeFromGlobalKey()`** — focus-independent ESC door mirroring the window handler exactly (grace pause first, else `Cleanup`). `MainWindow.OnGlobalKeyPressed` routes plain ESC into it, **queued on the dispatcher** so teardown never runs inside the hook callback.
- **Strict-mode ESC tripwire** in `SetupStrictHandlers` and `HandleBrowserKey`.
- **Comment** documenting the pack-video/duration-filter reality.

### Why the new ESC door is not a lock or lockdown bypass

`WantsGlobalEscape` is false unless a mandatory video is genuinely on screen **and not strict-locked** — so it can never eat an ESC belonging to another application, and a lockdown with the default `LockdownForceStrictLock` makes `IsStrictActive` true. It sits above the lockdown early-out deliberately: a lockdown that does *not* force strict lock leaves a video the window handler **already** dismisses on ESC (that handler carries no lockdown check), so honouring it when unfocused only restores parity rather than opening a hole.

It also stands down for an open lock card or settings palette, which outrank it in the panic ladder — checked via the side-effect-free `LockCardWindow.IsAnyOpen()` / `SettingsPaletteWindow.IsOpen`, deliberately **not** `TryConsumeEscape()`, which closes the palette just by asking and would burn the grace window `HandlePanicKeyPress` depends on.

Double-fire is handled: on a focused window the window handler runs first during message dispatch, so the queued continuation re-checks `WantsGlobalEscape` and finds the video gone; if the window handler turned the press into a grace pause, `EvaluateGraceRequest` returns `ConsumedDedup` and the queued call stops there.

## Testing

- `dotnet build`: **0 errors**, 346 warnings (baseline).
- `dotnet test`: **4844 passed**, 5 failed — byte-identical to the failure set on `origin/main` (`YouLibraryDoorTests` x4 + `Phase8RedirectContractTests`). **No regressions.**
- No localization keys were added, so `Localization/Languages/*.json` are untouched.

Not play-tested in a live lockdown — the ESC-during-lockdown hint and the unfocused-video dismiss both want an owner pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
