### PR TITLE
fix(ui): side-menu cluster - submenu leak, hover dead zone, rail scrollbar, bubble hit-test

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Avatar.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Avatar.cs
@@ -765,7 +765,6 @@ namespace ConditioningControlPanel
                 AvatarBorder.Margin = new Thickness(5, 100, 126 - dx, 210 + dy);
                 TitleBox.Margin = new Thickness(0, 0, 121 - dx, 180);
                 InputPanel.Margin = new Thickness(0, 0, 126 - dx, 520);
-                SpeechBubble.Margin = new Thickness(0, 0, 125 - dx, 550);
                 TakeoverCountdownBar.Margin = new Thickness(0, 0, 116 - dx, 246);
             }
             else
@@ -777,12 +776,16 @@ namespace ConditioningControlPanel
                 AvatarBorder.Margin = new Thickness(5, 100, 436 - dx, 228 + dy);
                 TitleBox.Margin = new Thickness(0, 0, 416 - dx, 193);
                 InputPanel.Margin = new Thickness(0, 0, 426 - dx, 520);
-                SpeechBubble.Margin = new Thickness(0, 0, 425 - dx, 550);
                 // Keep the Takeover countdown bar glued to the pod; it isn't in the XAML's
                 // attached-only default, so without this it floats at the attached spot
                 // whenever the tube detaches (e.g. the bubble-pop easter egg, #464).
                 TakeoverCountdownBar.Margin = new Thickness(0, 0, 416 - dx, 264);
             }
+
+            // The bubble is placed from one method for both modes now: attached it is anchored on
+            // the hit-test seam rather than centred, so its margin is not simply "the attached
+            // constant minus dx" any more. See ApplySpeechBubblePlacement.
+            ApplySpeechBubblePlacement();
         }
 
         /// <summary>

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
@@ -488,8 +488,12 @@ namespace ConditioningControlPanel
             // Hide the per-message AI badge when showing the chat history list (mixed AI + user lines).
             if (AiBadge != null) AiBadge.Visibility = Visibility.Collapsed;
 
-            // Enlarge bubble for the chat history layout.
+            // Enlarge bubble for the chat history layout. Re-place it afterwards: the attached
+            // placement is derived from MaxWidth (a 600px bubble does not fit left of the seam and
+            // is allowed to give the seam up rather than hang off the canvas), so the margin has
+            // to be recomputed before the layout pass below or the panel lands clipped.
             SpeechBubble.MaxWidth = 600;
+            ApplySpeechBubblePlacement();
 
             SpeechBubble.UpdateLayout();
             SpeechBubble.Visibility = Visibility.Visible;

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
@@ -868,12 +868,53 @@ namespace ConditioningControlPanel
             SpeechScroller?.ScrollToTop();
 
             // Position bubble next to avatar — align with tube position based on attach state.
-            var bubbleUseAttached = _isAttached || ModOverridesAttachedTubeOnly();
-            var bubbleDx = bubbleUseAttached
-                ? EffAvatarOffsetX()
-                : EffAvatarDetachedOffsetX();
-            var bubbleRight = bubbleUseAttached ? 125 - bubbleDx : 425 - bubbleDx;
-            SpeechBubble.Margin = new Thickness(0, 0, bubbleRight, 550);
+            ApplySpeechBubblePlacement();
+        }
+
+        /// <summary>
+        /// Where the speech bubble sits. One method for all three callers (this file's
+        /// <see cref="AdjustBubbleSize"/>, ApplyTubeLayoutOffsets, and the deferred placement reset
+        /// on the Loaded hop), which each carried their own copy of this arithmetic.
+        ///
+        /// <para><b>Attached, the bubble is right-anchored on the seam</b> - see
+        /// <c>AttachedBubbleRightMargin</c> in AvatarTubeWindow.Windowing.cs for why an opaque
+        /// pixel past that line goes on to eat every click aimed at main's nav rail underneath.
+        /// Right-anchored rather than re-centred: the bubble's right edge is the edge that has to
+        /// hold, so a short line barely moves from where it has always sat beside her and only a
+        /// long one grows further left, instead of every bubble sliding 90px off her mouth.</para>
+        ///
+        /// <para>A mod's avatar offset may pull the bubble LEFT with the art it belongs to, never
+        /// right - the seam is main's, not the mod's. And a bubble too wide to fit left of the
+        /// seam (chat-history mode widens MaxWidth to 600) gives the seam up rather than hang off
+        /// the canvas and get clipped by the window: an unreadable bubble is the worse bug, and
+        /// chat history is a panel the user opened and can close.</para>
+        ///
+        /// <para>Detached there is nothing underneath to protect, so that mode keeps the centred
+        /// placement it has always had, untouched.</para>
+        /// </summary>
+        private void ApplySpeechBubblePlacement()
+        {
+            var useAttached = _isAttached || ModOverridesAttachedTubeOnly();
+            var dx = useAttached ? EffAvatarOffsetX() : EffAvatarDetachedOffsetX();
+
+            double right;
+            if (useAttached)
+            {
+                right = Math.Max(AttachedBubbleRightMargin, AttachedBubbleRightMargin - dx);
+
+                var maxWidth = SpeechBubble.MaxWidth;
+                if (double.IsFinite(maxWidth) && maxWidth > 0)
+                    right = Math.Min(right, Math.Max(0, DesignWidth - maxWidth));
+            }
+            else
+            {
+                right = 425 - dx;
+            }
+
+            SpeechBubble.HorizontalAlignment = useAttached
+                ? HorizontalAlignment.Right
+                : HorizontalAlignment.Center;
+            SpeechBubble.Margin = new Thickness(0, 0, right, 550);
         }
 
         /// <summary>

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
@@ -65,6 +65,24 @@ namespace ConditioningControlPanel
         private const double SeamOverlapOverMain = 0;     // <= 60 (owner decision #1)
         private const double BaseOffsetFromParent = -(TubeArtRightPadding - SeamOverlapOverMain);
 
+        // THE SEAM IS A HIT-TEST BUDGET, NOT JUST A LOOK. Everything right of the art in the
+        // attached tube is alpha-0, and a fully transparent pixel on a layered window is
+        // click-through - that is the whole reason main's left edge (the door rail since UX
+        // restructure Phase 1) works at all under a window whose RECT covers it by 353 canvas px.
+        // An OPAQUE pixel there is NOT click-through: it swallows the click, WPF hit-tests it
+        // against the tube's own tree, and main never hears about it.
+        //
+        // The speech bubble is the one part of her that can paint opaque pixels out there. Centred
+        // in the 780px canvas behind a 125px right margin, a full 380px bubble ran to canvas
+        // x = (780-125)/2 + 190 = 517 - ninety px past the art's edge at 427, i.e. squarely over
+        // main's 56px collapsed rail, which went dead for as long as she was talking (Discord,
+        // v6.8.6: the bubbles "block the You section"). So the attached bubble is anchored by its
+        // RIGHT edge on this margin and grows leftward, and this is where that budget lives.
+        // 12px of daylight so a short bubble does not read as glued to main's frame.
+        private const double AttachedBubbleSeamGap = 12;
+        private const double AttachedBubbleRightMargin =
+            TubeArtRightPadding - SeamOverlapOverMain + AttachedBubbleSeamGap;
+
         // Transparent LEFT margin of the tube frame, measured the same way as TubeArtRightPadding:
         // the opaque pixels start at 664/2048 of tube.png -> canvas x 252.9 -> 21.7 + 252.9*0.9444
         // = 260.5 px from the tube WINDOW's left edge. The drop-shadowed avatar layer and the pink

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.xaml.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.xaml.cs
@@ -597,14 +597,10 @@ namespace ConditioningControlPanel
                     // Z-order: native ownership (seeded above) keeps the tube above main.
                 }
 
-                            // Reset bubble position to ensure correct placement after layout
-                            // Anchored at bottom, grows upward. Margin = left, top, right, bottom
-                            var initUseAttached = _isAttached || ModOverridesAttachedTubeOnly();
-                            var initDx = initUseAttached
-                                ? EffAvatarOffsetX()
-                                : EffAvatarDetachedOffsetX();
-                            var initRight = initUseAttached ? 125 - initDx : 425 - initDx;
-                            SpeechBubble.Margin = new Thickness(0, 0, initRight, 550);
+                            // Reset bubble position to ensure correct placement after layout.
+                            // Anchored at bottom, grows upward; attached it is also anchored by its
+                            // RIGHT edge on the hit-test seam - see ApplySpeechBubblePlacement.
+                            ApplySpeechBubblePlacement();
 
                             // Restore a saved detached placement (#669) after the initial attached layout
                             // and native-owner seeding have settled, so Detach/position land cleanly.

--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -881,6 +881,14 @@ namespace ConditioningControlPanel
             foreach (var b in _navRailButtons)
                 b.HorizontalContentAlignment = expand ? HorizontalAlignment.Left : HorizontalAlignment.Center;
 
+            // The scrollbar is only allowed out while the rail is. Shut, it is ~17px of chrome
+            // laid over the right third of a 44px medallion (MainWindow.xaml authors Hidden and
+            // carries the arithmetic); open, 236px has room for it and an overflowing rail should
+            // say so. Flipped on both paths, animated or not - it is a Visibility, not a tween.
+            if (NavRailScroll != null)
+                NavRailScroll.VerticalScrollBarVisibility =
+                    expand ? ScrollBarVisibility.Auto : ScrollBarVisibility.Hidden;
+
             ApplyNavDoorRows(expand, animate);
             ApplyNavRailDoorState(animate);
             ApplyNavRailAirspace(expand);

--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -1001,9 +1001,8 @@ namespace ConditioningControlPanel
                 var parts = NavDoorParts(d.Door);
                 if (parts.Panel == null) continue;   // pinned Settings door has no panel
 
-                bool open = _navRailExpanded &&
-                            string.Equals(d.Door, _expandedDoor, StringComparison.Ordinal);
-                SetDoorPanelExpanded(d.Door, parts.Panel, parts.Entries, open, animate);
+                SetDoorPanelExpanded(d.Door, parts.Panel, parts.Entries,
+                                     IsDoorPanelOpenFor(d.Door), animate);
             }
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -283,6 +283,14 @@ namespace ConditioningControlPanel
 
                 NavSidebar.MouseEnter += (_, __) => SetNavRailExpanded(true);
 
+                // The same intent, LEVEL-triggered - see the dead-zone note on
+                // SyncNavRailToPointer. MouseEnter is an edge, and an edge can be missed;
+                // MouseMove is re-hit-tested from scratch on every WM_MOUSEMOVE, so the pointer
+                // being on the rail is enough to open it however the enter got lost.
+                // SetNavRailExpanded early-outs on the state it is already in, so this is one
+                // bool compare per move for as long as the rail is out.
+                NavSidebar.MouseMove += (_, __) => SetNavRailExpanded(true);
+
                 // No timer, by owner call (NavRailCollapseAnimMs): leaving the rail IS the
                 // collapse trigger. NavSidebar is the whole rail, so this does not fire while the
                 // pointer is travelling between doors or down into an open accordion.
@@ -299,6 +307,17 @@ namespace ConditioningControlPanel
                 {
                     if (NavSidebar.IsMouseOver) return;
                     if (_navRailHoldCount > 0) return;
+                    SetNavRailExpanded(false);
+                };
+
+                // The other half of the level trigger: a rail that is out while the pointer is
+                // demonstrably somewhere else shuts, whatever happened to its MouseLeave. Guarded
+                // on _navRailExpanded first so the normal case is one field read per move.
+                PreviewMouseMove += (_, __) =>
+                {
+                    if (!_navRailExpanded) return;
+                    if (_navRailHoldCount > 0) return;
+                    if (NavSidebar.IsMouseOver) return;
                     SetNavRailExpanded(false);
                 };
 
@@ -1004,6 +1023,38 @@ namespace ConditioningControlPanel
                 SetDoorPanelExpanded(d.Door, parts.Panel, parts.Entries,
                                      IsDoorPanelOpenFor(d.Door), animate);
             }
+        }
+
+        /// <summary>
+        /// Re-seats the flyout on the pointer, ignoring every edge that may have been missed.
+        ///
+        /// <para><b>The dead zone (Discord, v6.8.6).</b> "After clicking in the side panel and
+        /// minimising the app, hover does not re-open the menu until the mouse crosses a line and
+        /// comes back." Until now the rail's ONLY way in was <c>NavSidebar.MouseEnter</c> and its
+        /// only ways out were <c>MouseLeave</c> and the click-elsewhere - three edges, and nothing
+        /// anywhere that re-reads the truth. A minimise taken with the pointer over the rail
+        /// delivers neither a leave nor a click to this window, so the rail comes back from the
+        /// taskbar still believing the pointer is on it: the next real MouseEnter is not raised
+        /// (WPF thinks it never left), and the rail sits inert until the pointer crosses out of
+        /// its subtree far enough to force a leave and then comes back in - which is precisely the
+        /// line the reporter drew on their screenshot.</para>
+        ///
+        /// <para>So the window's state changes now ask this instead, and it answers from
+        /// <c>IsMouseOver</c> rather than from anything remembered. Snapped, not tweened: nobody
+        /// is watching a rail animate while the window is coming back from the taskbar. A hold is
+        /// still a hold - a tutorial spotlight survives a minimise.</para>
+        /// </summary>
+        internal void SyncNavRailToPointer()
+        {
+            try
+            {
+                if (!_navRailReady || NavSidebar == null) return;
+                if (_navRailHoldCount > 0) return;
+
+                bool over = WindowState != WindowState.Minimized && NavSidebar.IsMouseOver;
+                SetNavRailExpanded(over, animate: false);
+            }
+            catch (Exception ex) { App.Logger?.Debug("SyncNavRailToPointer: {E}", ex.Message); }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
@@ -798,6 +798,26 @@ namespace ConditioningControlPanel
             catch (Exception ex) { App.Logger?.Debug("ExpandDoorForTab({Tab}): {E}", tabKey, ex.Message); }
         }
 
+        /// <summary>
+        /// Moves the accordion to <paramref name="door"/>.
+        ///
+        /// <para><b>A SHUT rail opens nothing.</b> Every panel this touches is gated on
+        /// <c>_navRailExpanded</c> as well as on the door key, exactly the way
+        /// <see cref="ApplyNavRailDoorState"/> gates it. ShowTab calls
+        /// <see cref="ExpandDoorForTab"/> on every navigation, and the rail is shut for most of
+        /// them - a door press whose Click lands after the pointer has already whipped off the
+        /// rail (MouseLeave collapses on the spot since 2026-08-13, so with a quick enough hand
+        /// the collapse beats the Click), a notification, the Ctrl+K palette, a tutorial step.
+        /// Without the gate each of those re-opened a panel underneath a 56px rail and left it
+        /// there: the entries paint as a run of unlabelled child icons wedged between the
+        /// medallions, which is the exact noise collapsing the rail exists to remove (see the
+        /// class remarks on MainWindow.NavRail.cs). Reported on Discord against v6.8.6 as the
+        /// submenu staying open after the menu collapsed, "mainly with rapid mouse movement".</para>
+        ///
+        /// <para><c>_expandedDoor</c> is still written whatever the rail is doing - it is the
+        /// user's choice of door, not a piece of the flyout's state, and the next hover restores
+        /// it through ApplyNavRailDoorState.</para>
+        /// </summary>
         private void SetExpandedDoor(string door)
         {
             if (string.Equals(_expandedDoor, door, StringComparison.Ordinal)) return;
@@ -815,9 +835,18 @@ namespace ConditioningControlPanel
                 var parts = NavDoorParts(d.Door);
                 if (parts.Panel == null) continue;
                 SetDoorPanelExpanded(d.Door, parts.Panel, parts.Entries,
-                                     string.Equals(d.Door, door, StringComparison.Ordinal), animate);
+                                     IsDoorPanelOpenFor(d.Door), animate);
             }
         }
+
+        /// <summary>
+        /// The one answer to "should this door's panel be open right now": the rail has to be out
+        /// AND the door has to be the chosen one. Both callers - <see cref="SetExpandedDoor"/> and
+        /// the tween completion in <see cref="SetDoorPanelExpanded"/> - ask this rather than
+        /// carrying their own half of it, because the two halves disagreeing is the bug.
+        /// </summary>
+        private bool IsDoorPanelOpenFor(string door)
+            => _navRailExpanded && string.Equals(_expandedDoor, door, StringComparison.Ordinal);
 
         /// <summary>
         /// The accordion itself: a 160ms Height tween on the door's panel, nothing else. No
@@ -858,9 +887,12 @@ namespace ConditioningControlPanel
             {
                 try
                 {
-                    // A faster click already moved on: whoever owns the panel now finishes it.
-                    bool stillOpen = string.Equals(_expandedDoor, door, StringComparison.Ordinal);
-                    if (stillOpen != expand) return;
+                    // A faster click - or a faster POINTER - already moved on: whoever owns the
+                    // panel now finishes it. This asks the same question SetExpandedDoor asks, rail
+                    // state included: a 160ms open tween that started on a rail the pointer has
+                    // since left would otherwise land here and write Height=NaN, handing an open
+                    // panel back to layout underneath a rail that is already 56px wide.
+                    if (IsDoorPanelOpenFor(door) != expand) return;
                     panel.BeginAnimation(FrameworkElement.HeightProperty, null);
                     // Hand an open panel back to layout so a later Visibility change on one of
                     // its entries (BtnDeeper follows EnableDeeper) still resizes the door.

--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -391,6 +391,13 @@ namespace ConditioningControlPanel
         {
             base.OnStateChanged(e);
 
+            // The nav rail's flyout is driven purely by pointer EDGES (enter / leave / click
+            // elsewhere), and a minimise delivers none of them to this window - so the rail can
+            // come back from the taskbar holding a hover state that is no longer true, and then
+            // refuse to open until the pointer crosses out of it and back in. Re-read the truth on
+            // every state change instead. See MainWindow.NavRail.cs, SyncNavRailToPointer.
+            SyncNavRailToPointer();
+
             // Handle restoring from tray or maximizing
             if (WindowState == WindowState.Normal)
             {

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -598,7 +598,19 @@
                     </Grid>
                 </Button>
 
-                <ScrollViewer x:Name="NavRailScroll" Grid.Row="1" VerticalScrollBarVisibility="Auto"
+                <!-- VerticalScrollBarVisibility authors the COLLAPSED state, like every other
+                     rail part: Hidden, because a WPF vertical scrollbar is ~17px and the shut
+                     rail is 56px of which the medallion tile is 44 - the bar does not sit BESIDE
+                     the icons, it lands on top of the right third of every one of them, and once
+                     the extent clears the viewport by even a rounding pixel (the content grid's
+                     MinHeight is bound to the viewport, under a Viewbox at a fractional scale) it
+                     never goes away again. Reported on Discord against v6.8.6 as a permanent
+                     scrollbar drawn over the collapsed rail.
+
+                     Hidden, not Disabled: the wheel still scrolls, so a rail that really does
+                     overflow while shut is still reachable. MainWindow.NavRail.cs hands it back
+                     to Auto while the flyout is out, where 236px has room to show a bar. -->
+                <ScrollViewer x:Name="NavRailScroll" Grid.Row="1" VerticalScrollBarVisibility="Hidden"
                               HorizontalScrollBarVisibility="Disabled">
                     <!-- ============ TOP-PACKED DOORS (Velvet Kit, UI polish 2) ============
                          Six Auto door rows with fixed SPACER rows between them, all pooled at


### PR DESCRIPTION
Four side-menu / interaction polish bugs reported by v6.8.6 users on Discord. None of them were filed on the tracker. One commit each; the rail is not restructured anywhere.

---

### 1. Submenu stays expanded after the menu collapses
*"seems to mainly happen with rapid mouse movement"* — `d850cf9`

`SetExpandedDoor` opened a door's panel on the door key alone, with no regard for whether the rail was out. `ShowTab` runs `ExpandDoorForTab` on **every** navigation and the rail is shut for most of them, so a door press whose `Click` lands after the pointer has already whipped off the rail re-opened the panel underneath a 56px rail and left it there. (`MouseLeave` collapses on the spot since 2026-08-13, so a quick enough hand beats the click — hence "rapid mouse movement".)

Second way in: `SetDoorPanelExpanded`'s `anim.Completed` guarded on `_expandedDoor` only, so a 160ms open tween that started while the rail was out and finished after it shut still wrote `Height = NaN`, handing an open panel back to layout.

Both now ask one predicate, `IsDoorPanelOpenFor(door)` (rail expanded **and** chosen door), and so does `ApplyNavRailDoorState`, which already had the correct test inline. The two halves disagreeing was the bug. `_expandedDoor` is still written whatever the rail is doing — it is the user's choice of door, and the next hover restores it.

---

### 2. Menu dead zone after minimise
*hover won't re-trigger until the mouse crosses a line and comes back* — `b29b6e7`

The flyout's state machine was purely **edge**-triggered: one way in (`NavSidebar.MouseEnter`), two ways out (`MouseLeave`, window `PreviewMouseDown`), and nothing anywhere re-reading the truth. There is no `StateChanged` / minimise / restore resync in the rail at all. A minimise taken with the pointer over the rail delivers none of those three to this window, so the rail comes back from the taskbar still believing the pointer is on it — the next real hover raises no `MouseEnter` (WPF thinks it never left) and the rail sits inert until the pointer travels out of its subtree far enough to force a leave, then returns. That is the line on the reporter's screenshot: the edge of `NavSidebar`'s subtree.

**Honest caveat:** I could not reproduce this live and so could not pin down which exact WPF-internal edge gets eaten across a minimise. Rather than patch one edge on a guess, this hardens the machine at both ends and adds the missing resync:

- `NavSidebar.MouseMove` opens it — a level trigger in. Every `WM_MOUSEMOVE` is hit-tested from scratch, so the pointer being on the rail is enough however the enter got lost.
- window `PreviewMouseMove` collapses a rail that is out while the pointer is demonstrably elsewhere — a level trigger out, guarded on `_navRailExpanded` first so the normal case is one field read per move.
- `OnStateChanged` calls the new `SyncNavRailToPointer()`, which snaps the rail to `IsMouseOver` rather than to anything remembered.

`SetNavRailExpanded` early-outs on the state it is already in, so the move handlers cost one bool compare. Holds still win (a tutorial spotlight survives a minimise). The `MouseLeave` → `PreviewMouseDown` block is untouched and `NavRailFlyoutTests` still scrapes it clean — no timer, no delay.

---

### 3. Persistent scrollbar over the collapsed rail
`5cbda22`

`NavRailScroll` authored `VerticalScrollBarVisibility="Auto"`. A WPF vertical scrollbar is ~17px; the shut rail is 56px wide of which the medallion tile is 44 — so the bar does not sit *beside* the icons, it lands on the right third of every one of them. And it never goes away: the content grid's `MinHeight` is bound to the ScrollViewer's `ViewportHeight`, and under a `Viewbox` at a fractional scale the extent clears the viewport by a rounding pixel, latching `Auto` on for good.

The XAML now authors the collapsed state (`Hidden`, like every other rail part) and `SetNavRailExpanded` hands it back to `Auto` while the flyout is out, where 236px has room for a bar. `Hidden` not `Disabled`: the wheel still scrolls, so an overflowing shut rail stays reachable.

---

### 4. AI speech bubbles block the menu while she talks
`ee3ab3e`

The attached tube's window RECT deliberately overlaps main by 353 canvas px (`BaseOffsetFromParent`). That works because everything right of the tube art is alpha-0, and a fully transparent pixel on a layered window is click-through — it is the only reason main's left edge is usable under her at all. An **opaque** pixel there is not: Win32 hit-tests it to the tube HWND, WPF resolves it against the tube's own tree, and main never hears the click.

The bubble is the one part of her that paints opaque pixels past the art. Centred in the 780px canvas behind a 125px right margin, a full 380px bubble ran to canvas `x = (780-125)/2 + 190 = 517` — ninety px past the art edge at 427, squarely over main's 56px collapsed rail.

**`IsHitTestVisible=false` does not fix this**, so the brief's preferred route is not the one taken. The flag is a WPF concept and the click is already lost at the Win32 layer: it would land on the tube `Window`'s `Transparent` background instead of the bubble and still never reach main. The bubble also genuinely has click affordances — markdown `[text](url)` becomes `Hyperlink` inlines, `SpeechScroller` scrolls, hover keeps it open — so blanket hit-test transparency would be wrong even where it worked.

So: the sanctioned alternative, constrain placement. Attached, the bubble is anchored by its **right** edge on the same seam budget the tube art already honours (`AttachedBubbleRightMargin` = 353 + 12px of daylight) and grows leftward. Right-anchored rather than re-centred, so a short line barely moves from where it has always sat beside her and only a long one reaches further left, instead of every bubble sliding 90px off her mouth. A mod's avatar offset may pull it left with the art it belongs to, never right — the seam is main's, not the mod's.

Chat-history mode widens `MaxWidth` to 600, which cannot fit left of the seam; it clamps to `DesignWidth - MaxWidth` and gives the seam up rather than hang off the canvas and get clipped. An unreadable bubble is the worse bug, and chat history is a panel the user opened and can close.

Detached is untouched — nothing underneath to protect. Placement also stops being copy-pasted: `AdjustBubbleSize`, `ApplyTubeLayoutOffsets` and the deferred `Loaded` reset each carried their own copy of the same arithmetic and now all call `ApplySpeechBubblePlacement`.

---

### Build & tests

- `dotnet build` — **0 errors**, 346 warnings (baseline ~350).
- `dotnet test` — **4844 passed, 5 failed**. All 5 are pre-existing on `origin/main`: verified by stashing this work and re-running the same two classes on the clean tree, same 5 failures. They are `YouLibraryDoorTests.EachLibraryLauncherIsOneRowBoundToOneExistingHandler` (BtnNavCatalogue / BtnNavMediaLog / BtnNavMods / BtnNavPhrases) and `Phase8RedirectContractTests.PatreonStillRedirectsIntoTheSettingsDoorsAccountSection`.

No `Localization/Languages/*.json` file is touched.

**Not play-tested** — bugs 1, 2 and 4 are pointer-timing and window-layering behaviours that want a human at the machine. Bug 2 in particular is a fix by reasoning, not by reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
