### PR TITLE
chore(installer): regenerate content-pack deletions for mod-infection

### DIFF
--- a/installer-content-deletions.iss
+++ b/installer-content-deletions.iss
@@ -7,9 +7,10 @@
 ; into a content pack, deleted from {app} by EXACT name on upgrade. No wildcards: files a
 ; user hand-dropped into these folders are never matched and survive. dirifempty removes
 ; only folders the sweep actually emptied.
-; 8429 files, 28 folder candidates.
+; 8430 files, 29 folder candidates.
 ; ============================================================================================
 Type: files;      Name: "{app}\DroneMod\drone-mode.ccpmod"
+Type: files;      Name: "{app}\InfectionMod\infection-control.ccpmod"
 Type: files;      Name: "{app}\LockedMod\locked-resources.ccpmod"
 Type: files;      Name: "{app}\Resources\sounds\companion_audio\mods\builtin-bambisleep\achievement_1.mp3"
 Type: files;      Name: "{app}\Resources\sounds\companion_audio\mods\builtin-bambisleep\achievement_2.mp3"
@@ -8465,4 +8466,5 @@ Type: dirifempty; Name: "{app}\Resources\web\intake\assets\sfx"
 Type: dirifempty; Name: "{app}\Resources\web\intake\assets\vo"
 Type: dirifempty; Name: "{app}\Resources\sounds\flashes_audio"
 Type: dirifempty; Name: "{app}\DroneMod"
+Type: dirifempty; Name: "{app}\InfectionMod"
 Type: dirifempty; Name: "{app}\LockedMod"


### PR DESCRIPTION
Regenerates installer-content-deletions.iss for the mod-infection pack added in #422 (the fragment is committed by contract; without it upgrades leave a stale InfectionMod/infection-control.ccpmod in {app}). Generated by Scripts/build-content-packs.ps1 during the 6.8.6 pack build; all six existing pack SHAs were byte-identical to the hosted v6.8.0 assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
