### PR TITLE
test: .claude path exclusion no longer blinds the source-walk tests in agent worktrees

### DIFF
--- a/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
@@ -45,18 +45,29 @@ public class Phase8RedirectContractTests
 
     private static string TabNavigation() => ReadSource("MainWindow", "MainWindow.TabNavigation.cs");
 
-    /// <summary>Every .cs/.xaml under the product project, obj/bin and sibling worktrees excluded.</summary>
+    /// <summary>Every .cs/.xaml under the product project, obj/bin and nested worktrees excluded.
+    ///
+    /// <para>The exclusion is matched on each file's path RELATIVE to <see cref="ProductDir"/>,
+    /// because it is about directories INSIDE the tree under test. Matching the absolute path — as
+    /// this did — silently emptied the whole walk inside an agent worktree, where the checkout
+    /// itself lives at <c>&lt;repo&gt;/.claude/worktrees/&lt;name&gt;/</c> and therefore gives every
+    /// file in the product a <c>.claude</c> segment. The demolition tests below then asserted
+    /// "nothing references this type" against zero files.</para></summary>
     private static IEnumerable<string> ProductSources()
     {
-        var skip = new[] { Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar,
-                           Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar,
-                           Path.DirectorySeparatorChar + ".claude" + Path.DirectorySeparatorChar,
-                           Path.DirectorySeparatorChar + "node_modules" + Path.DirectorySeparatorChar };
+        var skip = new[] { "obj", "bin", ".claude", "node_modules" };
 
-        return Directory.EnumerateFiles(ProductDir, "*.*", SearchOption.AllDirectories)
-                        .Where(f => f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
-                                 || f.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
-                        .Where(f => !skip.Any(s => f.Contains(s, StringComparison.OrdinalIgnoreCase)));
+        var files = Directory.EnumerateFiles(ProductDir, "*.*", SearchOption.AllDirectories)
+                             .Where(f => f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                                      || f.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
+                             .Where(f => !Path.GetRelativePath(ProductDir, f)
+                                              .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                                              .Any(segment => skip.Contains(segment, StringComparer.OrdinalIgnoreCase)))
+                             .ToList();
+
+        // A walk that finds nothing would make every assertion below vacuously true.
+        Assert.True(files.Count > 0, "the product source walk found no .cs/.xaml files under " + ProductDir);
+        return files;
     }
 
     /// <summary>Source with // and /* */ comments and XML comments stripped, so a tombstone note

--- a/Tests/ConditioningControlPanel.Tests/YouLibraryDoorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/YouLibraryDoorTests.cs
@@ -49,8 +49,27 @@ public class YouLibraryDoorTests
         return dir!.FullName;
     }
 
+    private static string ProductDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
+
     private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+        File.ReadAllText(Path.Combine(new[] { ProductDir }.Concat(parts).ToArray()));
+
+    /// <summary>Build output and nested agent worktrees, matched on the path RELATIVE to the
+    /// product directory.</summary>
+    ///
+    /// <para>Matching the ABSOLUTE path is the bug this replaces: an agent worktree checks the whole
+    /// repo out under <c>&lt;repo&gt;/.claude/worktrees/&lt;name&gt;/</c>, so every file's absolute
+    /// path carries a <c>.claude</c> segment and the walk excluded all of them — the source scan
+    /// below then "passed" against an empty set in a worktree and only really ran on a normal
+    /// checkout. The exclusion is about directories INSIDE the tree under test, so only the
+    /// relative path may decide it.</para>
+    private static bool IsExcludedSource(string file)
+    {
+        var skip = new[] { "obj", "bin", ".claude" };
+        return Path.GetRelativePath(ProductDir, file)
+                   .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                   .Any(segment => skip.Contains(segment, StringComparer.OrdinalIgnoreCase));
+    }
 
     private static string MainWindowXaml() => ReadSource("MainWindow", "MainWindow.xaml");
 
@@ -119,12 +138,13 @@ public class YouLibraryDoorTests
         // The handler has to exist somewhere in the product. XAML Click= is compile-checked, so
         // this is belt-and-braces — but it is also the assertion that fails loudly if someone
         // "simplifies" a row by pointing it at a new duplicate launcher instead of the real one.
-        var found = Directory
-            .EnumerateFiles(Path.Combine(RepoRoot(), "ConditioningControlPanel"), "*.cs", SearchOption.AllDirectories)
-            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
-                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
-                        && !f.Contains($"{Path.DirectorySeparatorChar}.claude{Path.DirectorySeparatorChar}"))
-            .Any(f => Regex.IsMatch(File.ReadAllText(f), @"\bvoid\s+" + handler + @"\s*\("));
+        var sources = Directory
+            .EnumerateFiles(ProductDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsExcludedSource(f))
+            .ToList();
+        Assert.True(sources.Count > 0, "the product source walk found no .cs files under " + ProductDir);
+
+        var found = sources.Any(f => Regex.IsMatch(File.ReadAllText(f), @"\bvoid\s+" + handler + @"\s*\("));
         Assert.True(found, handler + " is bound in MainWindow.xaml but defined nowhere");
     }
 


### PR DESCRIPTION
## The five "pre-existing failures"

`YouLibraryDoorTests` and `Phase8RedirectContractTests` walk the product tree in source and skip anything whose path contains a `.claude` segment, so an agent worktree checked out under `ConditioningControlPanel/.claude/worktrees/<name>/` is never mistaken for the real product source.

Both matched the **absolute** path. Inside such a worktree the checkout *itself* lives below a `.claude` directory, so every file in the product carries that segment and the exclusion swallowed the whole walk:

| test | symptom in a worktree |
|---|---|
| `EachLibraryLauncherIsOneRowBoundToOneExistingHandler` (x4 theory rows) | "`BtnManageMods_Click` is bound in MainWindow.xaml but defined nowhere" — no `.cs` file survived the filter |
| `PatreonStillRedirectsIntoTheSettingsDoorsAccountSection` | `Assert.Contains` against `Collection: []` |

That is the set of five failures every agent worktree has been reporting this cycle, and it is a false alarm in both directions. The louder half is the noise; the quieter half is that the tests which assert an **absence** — `ADemolishedTypeHasNoFilesAndNoLiveReference`, `ADemolishedContainerIsNoLongerDereferencedAnywhere` — passed *vacuously* over zero files. A live reference to a demolished type would not have been caught in a worktree at all.

## The fix

The exclusion is about directories **inside** the tree under test, so it is now matched on each file's path *relative* to the product directory, segment by segment, in both files:

- `Phase8RedirectContractTests.ProductSources()` — the four skip entries become bare segment names checked against `Path.GetRelativePath(ProductDir, f).Split(...)`.
- `YouLibraryDoorTests` — the inline three-`Contains` filter becomes a shared `IsExcludedSource` helper on the same relative-path rule, alongside a new `ProductDir` property (the path was already being recomputed inline).

A normal checkout behaves exactly as before: there the worktrees genuinely do live at `ConditioningControlPanel/.claude/worktrees`, which *is* relative to the product dir and stays excluded. What changes is only that ancestor directories above the repo root no longer get a vote.

Both walks now also assert they found at least one file, so a future filter bug fails loudly instead of quietly asserting nothing.

## Verification

Run from inside a `.claude/worktrees/*` worktree — the exact repro:

- before: `Failed: 5, Passed: 4895, Total: 4900`
- after: `Passed! - Failed: 0, Passed: 4900, Skipped: 0, Total: 4900` (green on two consecutive full runs)

No production code is touched; the diff is two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
