### PR TITLE
fix(arcademy): desktop Lost & Found handles animated .webp (ccp-bugs#1086)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1195,6 +1195,21 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
   the same `assets {reqId, urls:[{url,kind,mime,tag,src}], done}` mailbox, keyed by reqId
   (`src` = `r/<sub>` | `<folder rel path>` | `preset:<id>`). The host contract is unchanged:
   ask again after every reply, MAX_ASKS **per tag** 8, RETRY_MS 1500, batch cap 24.
+- **AN ANIMATED `.webp` IS A LOOP, AND ONLY THE DESKTOP HOST CAN SAY SO** (ccp-bugs#1086). A webp
+  animates because of a flag in its VP8X container header, never because of its name, so the page
+  cannot tell one from a still and used to class every one of them `still`. That put them outside
+  every motion budget on the page - Lost & Found's live window (`liveCap`, board.js §4), its frame
+  governor's shed, and the same `/\.gif(\?|#|$)/` test in anomaly / deja-vu / instant-recall - and
+  a library of them dealt ONE main-thread decoder per seat instead of ~30. The wall fell to about
+  a frame a second, the row drifted under the pointer, and a click on the right tile scored a miss.
+  `ArcademyHostService` now header-probes a **sampled** local webp (never a whole library walk) and
+  stamps `#.gif` on its `ccp.assets` url (`AnimatedImageHint`), the same fragment-hint lane
+  `provider/index.js hintedPileUrl()` uses to give an extension-less `blob:` row a kind. The URL
+  Standard drops the fragment before the fetch, so the identical bytes load; `inventory.js`
+  `hintExtOf()` lets `kindOf()` read it ahead of the extension, and the rows the host builds carry
+  `kind:"loop"` to match. `.webp` therefore sits in **both** `LocalLoopExts` and `LocalStillExts` -
+  the probe, not the extension, decides which ask it answers. An **unhinted** webp is still a
+  still, which stays the only honest answer on the web port, where no host holds the file.
 - **THE DOOR'S OTHER FOUR VERBS** hang off the same object and are how SORT's setup screen
   draws itself: `catalog()` (the sanitized `init.settings` projection - `remoteCatalog`
   `[{id,label,subs}]`, `subLibrary` `[{name,ok,videoCount,stillOnly,selected}]`, `localFolders`

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/board.js
@@ -80,8 +80,22 @@ const GIF_RE = /\.gif(\?|#|$)/i;
 
 /** Is this url a <video> tile rather than an <img>? */
 export function isVideoUrl(url) { return VIDEO_EXT_RE.test(String(url || '')); }
-/** Is this url an animated <img>? (webp is classed 'still' by the provider's
- *  own kindOf(), so an animated webp is a known blind spot, not an oversight.) */
+/** Is this url an animated <img>?
+ *
+ *  ANIMATED WEBP (ccp-bugs#1086). This used to be a documented blind spot: a webp is classed
+ *  'still' by extension, so an animated one paid a decoder and a clock that NO budget on this
+ *  page could see - the live window did not count it, the frame governor could not shed it, and
+ *  a library of them dealt one main-thread decoder per seat. A dense wall of those is the
+ *  reported symptom: the page drops to ~1.3fps, the row has drifted by the time the click lands,
+ *  and the right tile registers as a miss.
+ *
+ *  Animation lives in the webp's VP8X container flag, so a URL genuinely cannot answer it and
+ *  the page never gets the bytes. The DESKTOP host does: ArcademyHostService header-probes a
+ *  local webp and stamps `#.gif` on its ccp.assets url (AnimatedImageHint - the same fragment-hint
+ *  convention provider/index.js hintedPileUrl() uses for blob: rows, and dropped before the fetch
+ *  by the URL Standard, so the same bytes load). GIF_RE's `#` alternative already reads it, which
+ *  is why every budget below this line needed no change. An unhinted webp stays a still - which
+ *  is still the honest answer on the web port, where no host has the file. */
 export function isGifUrl(url) { return GIF_RE.test(String(url || '')); }
 /** Does this url cost a decoder + a clock? THE budget question. */
 export function isAnimatedUrl(url) { return isVideoUrl(url) || isGifUrl(url); }

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/inventory.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/inventory.js
@@ -78,10 +78,33 @@ export function toAssetUrl(entry) {
   return ASSET_HOST + clean.split('/').map(encodeURIComponent).join('/');
 }
 
+/**
+ * A trailing `#.<ext>` FRAGMENT HINT, if the url carries one.
+ *
+ * The convention is already load-bearing here: `provider/index.js hintedPileUrl()` stamps
+ * `#.mp4` on an extension-less `blob:` pile row so the games' `<video>`-vs-`<img>` regexes can
+ * read its kind. The desktop host uses the same lane for a fact only IT can know - a `.webp`
+ * whose VP8X container flag says it ANIMATES (ccp-bugs#1086, ArcademyHostService
+ * AnimatedImageHint). The URL Standard drops the fragment before the fetch, so a hinted url
+ * loads the identical bytes.
+ *
+ * A hint is a HINT, never an origin claim: it can only say which pool an url belongs in, and
+ * `isLocalUrl` still decides local-vs-remote off the origin alone (see the header, rule 1).
+ */
+export function hintExtOf(url) {
+  const m = /#\.([a-z0-9]{1,5})$/i.exec(String(url || ''));
+  return m ? m[1].toLowerCase() : '';
+}
+
 /** Which pool kind an url belongs to. 'loop' = animated/video, 'still' = image. */
 export function kindOf(entry) {
   if (entry && typeof entry === 'object' && (entry.kind === 'loop' || entry.kind === 'still')) return entry.kind;
-  const ext = extOf(typeof entry === 'string' ? entry : (entry && (entry.url || entry.path)) || '');
+  const raw = typeof entry === 'string' ? entry : (entry && (entry.url || entry.path)) || '';
+  // The hint outranks the extension because it is the more specific fact: `a.webp` is a guess,
+  // `a.webp#.gif` is the host reporting a header it actually read.
+  const ext = hintExtOf(raw) || extOf(raw);
+  // `webp` sits in LOOP_EXTS but is excluded here: the NAME cannot tell an animated webp from a
+  // still one, so an unhinted webp is a still. A hinted one arrives as 'gif' above.
   if (LOOP_EXTS.includes(ext) && ext !== 'webp') return 'loop';
   if (ext === 'gif') return 'loop';
   return IMAGE_EXTS.includes(ext) ? 'still' : 'still';
@@ -131,4 +154,4 @@ export function wantRemote(ratio, rand, haveRemote, canvasSafe) {
   return rand < Math.min(1, r);
 }
 
-export default { buildLocalPools, isLocalUrl, isOwnPageUrl, formatOk, kindOf, toAssetUrl, wantRemote };
+export default { buildLocalPools, isLocalUrl, isOwnPageUrl, formatOk, hintExtOf, kindOf, toAssetUrl, wantRemote };

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1509,12 +1509,59 @@ internal static class ArcademyHostService
             return pool.GetRange(0, Math.Min(take, pool.Count));
         }
 
+        // An ANIMATED webp is a loop wearing a still's extension (ccp-bugs#1086): it is sampled
+        // out of `stills` above and moved over here, so the page's budgets meet it as what it
+        // costs. Only the SAMPLED files are probed - a header read per file across a whole
+        // library is exactly the boot cost this manifest exists to avoid.
+        var gifUrls = Sample(gifs, rng, LocalAssetSample).Select(ToAssetsUrl).ToList();
+        var stillUrls = new List<string>();
+        foreach (var file in Sample(stills, rng, LocalAssetSample))
+        {
+            // The hint travels with the URL, not with the bucket: provider/index.js
+            // resolveManifest() FLATTENS gifs+stills into one list and re-derives every entry's
+            // kind from its url, so a bucket move on its own would be silently undone.
+            if (IsAnimatedLocalImage(file)) gifUrls.Add(ToAssetsUrl(file) + AnimatedImageHint);
+            else stillUrls.Add(ToAssetsUrl(file));
+        }
+
         return new JObject
         {
-            ["gifs"] = new JArray(Sample(gifs, rng, LocalAssetSample).Select(ToAssetsUrl).Cast<object>().ToArray()),
-            ["stills"] = new JArray(Sample(stills, rng, LocalAssetSample).Select(ToAssetsUrl).Cast<object>().ToArray()),
+            ["gifs"] = new JArray(gifUrls.Cast<object>().ToArray()),
+            ["stills"] = new JArray(stillUrls.Cast<object>().ToArray()),
         };
     }
+
+    /// <summary>
+    /// THE ANIMATED-WEBP HINT (ccp-bugs#1086). Appended to a <c>ccp.assets</c> url whose file the
+    /// header probe says ANIMATES, and read by every page-side budget that decides "does this url
+    /// cost a decoder and an animation clock" with <c>/\.gif(\?|#|$)/</c> - Lost &amp; Found's live
+    /// window, its frame governor, and the same test in anomaly / deja-vu / instant-recall.
+    ///
+    /// <para>Why a fragment and not a query: the URL Standard drops the fragment before the fetch,
+    /// so <c>a.webp#.gif</c> loads byte-for-byte the same file out of the virtual-host mapping while
+    /// every one of those regexes reads it. That is not a new convention - it is the one
+    /// <c>provider/index.js hintedPileUrl()</c> already uses to tell an extension-less <c>blob:</c>
+    /// row's kind (<c>#.mp4</c>). The MIME the host puts on the wire stays the true one.</para>
+    ///
+    /// <para>WHY IT IS NEEDED AT ALL: the page cannot answer this question. Animation lives in a
+    /// webp's VP8X container flag, not in its name, so a url alone can only guess - which is why
+    /// the pre-fix code classed every webp as a still and a library of animated ones dealt ~170
+    /// simultaneous main-thread decoders onto one wall (the reported symptom: Lost &amp; Found
+    /// lagging so hard that a click landed on the tile that had drifted into place). Only the
+    /// desktop host has the bytes, so only the desktop host can say.</para>
+    /// </summary>
+    internal const string AnimatedImageHint = "#.gif";
+
+    /// <summary>
+    /// Does this local image ANIMATE despite carrying a still's extension? True only for a
+    /// <c>.webp</c> whose container header sets the animation flag; every other extension already
+    /// tells the truth (a <c>.gif</c> is dealt as a loop by name, a <c>.png</c>/<c>.jpg</c> cannot
+    /// animate). Cheap - <see cref="AnimatedWebp.IsAnimated"/> is a 21-byte header read - but still
+    /// a file open, so call it on a SAMPLED slice, never over a whole library walk.
+    /// </summary>
+    internal static bool IsAnimatedLocalImage(string file)
+        => Path.GetExtension(file).Equals(".webp", StringComparison.OrdinalIgnoreCase)
+           && AnimatedWebp.IsAnimated(file);
 
     private static string ToAssetsUrl(string file)
     {
@@ -4821,7 +4868,11 @@ internal static class ArcademyHostService
     // deselection blacklist the flash pool honours, and the same ccp.assets urls BuildLocalAssets
     // hands out - a row's src is the folder it really came from.
 
-    private static readonly string[] LocalLoopExts = { ".gif", ".mp4", ".webm" };
+    /// <summary>`.webp` is in BOTH lists on purpose (ccp-bugs#1086): the extension does not say
+    /// which one it belongs to, so it is admitted to either ask and the header probe in
+    /// <see cref="SampleLocalAssets"/> settles it - a still one is dropped from a `loop` ask, an
+    /// animated one is stamped with <see cref="AnimatedImageHint"/> and served as the loop it is.</summary>
+    private static readonly string[] LocalLoopExts = { ".gif", ".mp4", ".webm", ".webp" };
     private static readonly string[] LocalStillExts = { ".png", ".jpg", ".jpeg", ".webp" };
 
     private static async void OnLocalSampleRequest(JObject o)
@@ -4931,22 +4982,37 @@ internal static class ArcademyHostService
         if (pool.Count == 0) return rows;
 
         // Seeded off the reqId so a retake of the same ask deals the same slice; partial
-        // Fisher-Yates, the same random-slice trick BuildLocalAssets uses.
+        // Fisher-Yates, the same random-slice trick BuildLocalAssets uses - except the swap runs
+        // as the slice is CONSUMED, because a .webp only says whether it animates once its header
+        // is read (ccp-bugs#1086) and a `loop` ask may have to walk past a few still ones.
         var rng = new Random(StableSeed(reqId));
-        int take = Math.Min(count, pool.Count);
-        for (int i = 0; i < take; i++)
+        int probed = 0;
+        for (int i = 0; i < pool.Count && rows.Count < count; i++)
         {
             int j = rng.Next(i, pool.Count);
             (pool[i], pool[j]) = (pool[j], pool[i]);
-        }
-        for (int i = 0; i < take; i++)
-        {
+
             var file = pool[i];
-            var url = ToAssetsUrl(file);
-            rows.Add(new AssetUrl(url, kind, MimeFor(url, kind), tag, presetSrc ?? RelativeFolder(root, file)));
+            bool isWebp = Path.GetExtension(file).Equals(".webp", StringComparison.OrdinalIgnoreCase);
+            // Bounded: a library of nothing but STILL webps must not turn one `loop` ask into a
+            // header read per file. Past the budget an unprobed webp reads as "still" - the safe
+            // direction, since the failure this fixes is dealing animation nothing has counted.
+            bool animated = isWebp && probed++ < AnimatedProbeBudget && AnimatedWebp.IsAnimated(file);
+            // A still webp has no business in the loop lane - it is the one candidate here that
+            // was admitted on a maybe (see LocalLoopExts).
+            if (kind == "loop" && isWebp && !animated) continue;
+
+            var rowKind = animated ? "loop" : kind;
+            var url = ToAssetsUrl(file) + (animated ? AnimatedImageHint : "");
+            rows.Add(new AssetUrl(url, rowKind, MimeFor(url, rowKind), tag, presetSrc ?? RelativeFolder(root, file)));
         }
         return rows;
     }
+
+    /// <summary>Header probes one local-sample ask may spend (ccp-bugs#1086). Generous next to the
+    /// 24-row batch cap, so an honest ask never runs short, and small enough that a still-webp
+    /// library cannot turn a `loop` ask into a walk of the whole tree with a file open per entry.</summary>
+    private const int AnimatedProbeBudget = 200;
 
     /// <summary>A page-supplied folder resolved under the assets root, or null when it does not
     /// exist or tries to climb out of it. Never trust a path that arrived over the bridge.</summary>

--- a/Tests/ConditioningControlPanel.Tests/ArcademyAnimatedWebpHintTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyAnimatedWebpHintTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Arcademy;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs#1086 — Lost &amp; Found lagged so hard on a library of ANIMATED .webp images that a
+/// click on the right tile registered as a miss.
+///
+/// <para>Not a decode failure: WebView2 plays animated webp perfectly well, which is precisely the
+/// problem. The wall's whole media layer is built on a budget over DISTINCT ANIMATED URLS (one
+/// Chromium decoder + one main-thread animation clock each, board.js §4), and every gate in it —
+/// the live window, the sleeper draw, the frame governor's shed — asks the same question of a bare
+/// url: <c>/\.gif(\?|#|$)/</c>. A webp's animation lives in its VP8X container flag, not its name,
+/// so every animated webp answered "still", none were counted, none could be shed, and a dense
+/// board dealt one decoder per seat instead of ~30.</para>
+///
+/// <para>The page cannot fix that — it never has the bytes. The DESKTOP host does, so it header-
+/// probes a sampled local webp and stamps <see cref="ArcademyHostService.AnimatedImageHint"/> on
+/// the url, riding the fragment-hint convention <c>provider/index.js hintedPileUrl()</c> already
+/// uses for extension-less <c>blob:</c> rows. Two halves have to stay true for that to work, and
+/// both are pinned here: the C# probe must be right, and the hint must be a shape the page-side
+/// regexes actually read.</para>
+/// </summary>
+public class ArcademyAnimatedWebpHintTests
+{
+    // =====================================================================================
+    //  fixtures — hand-built WebP container headers (the probe reads 21 bytes, no more)
+    // =====================================================================================
+
+    /// <summary>A RIFF/WEBP file whose VP8X extended header sets (or clears) the animation flag.
+    /// Only the first 21 bytes carry meaning for the probe; the tail is padding.</summary>
+    private static byte[] Vp8xHeader(bool animated)
+    {
+        var b = new byte[32];
+        void Ascii(int at, string s) { for (int i = 0; i < s.Length; i++) b[at + i] = (byte)s[i]; }
+        Ascii(0, "RIFF");
+        b[4] = 24;                       // file size, little-endian — unread by the probe
+        Ascii(8, "WEBP");
+        Ascii(12, "VP8X");
+        b[16] = 10;                      // chunk payload size
+        b[20] = (byte)(animated ? 0x02 : 0x00);   // libwebp ANIMATION_FLAG
+        return b;
+    }
+
+    /// <summary>A plain (simple-format) still webp: no VP8X chunk at all.</summary>
+    private static byte[] Vp8Still()
+    {
+        var b = new byte[32];
+        void Ascii(int at, string s) { for (int i = 0; i < s.Length; i++) b[at + i] = (byte)s[i]; }
+        Ascii(0, "RIFF");
+        Ascii(8, "WEBP");
+        Ascii(12, "VP8 ");
+        return b;
+    }
+
+    private static string WriteTemp(string extension, byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(),
+            "ccp-1086-" + Guid.NewGuid().ToString("N") + extension);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    // =====================================================================================
+    //  half one — the probe
+    // =====================================================================================
+
+    [Fact]
+    public void AnAnimatedWebpIsRecognisedAsAnimated()
+    {
+        var path = WriteTemp(".webp", Vp8xHeader(animated: true));
+        try
+        {
+            Assert.True(AnimatedWebp.IsAnimated(path), "VP8X with ANIMATION_FLAG set reads as still");
+            Assert.True(ArcademyHostService.IsAnimatedLocalImage(path),
+                "the Arcademy host must class an animated webp as a loop, not a still");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Theory]
+    [InlineData(false)]   // VP8X, animation flag clear
+    [InlineData(true)]    // simple VP8, no extended header
+    public void AStillWebpStaysAStill(bool simpleFormat)
+    {
+        var path = WriteTemp(".webp", simpleFormat ? Vp8Still() : Vp8xHeader(animated: false));
+        try
+        {
+            Assert.False(AnimatedWebp.IsAnimated(path));
+            Assert.False(ArcademyHostService.IsAnimatedLocalImage(path),
+                "a still webp must keep its seat on the sleeping side of the live window");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Theory]
+    [InlineData(".png")]
+    [InlineData(".jpg")]
+    [InlineData(".gif")]
+    public void OnlyWebpIsEverProbed(string extension)
+    {
+        // Every other extension already tells the truth by name — a .gif is dealt as a loop on
+        // sight, a .png cannot animate — so the probe must not spend a file open on them. The
+        // bytes here ARE an animated webp header; the extension gate is what has to refuse it.
+        var path = WriteTemp(extension, Vp8xHeader(animated: true));
+        try
+        {
+            Assert.False(ArcademyHostService.IsAnimatedLocalImage(path),
+                extension + " must be classed by name, never by a header read");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void AMissingOrTruncatedFileIsNotAnimated()
+    {
+        Assert.False(AnimatedWebp.IsAnimated(Path.Combine(Path.GetTempPath(), "ccp-1086-nope.webp")));
+
+        var stub = WriteTemp(".webp", new byte[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F' });
+        try { Assert.False(AnimatedWebp.IsAnimated(stub), "a 4-byte file must not read past its end"); }
+        finally { File.Delete(stub); }
+    }
+
+    // =====================================================================================
+    //  half two — the hint, as the page actually reads it
+    // =====================================================================================
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string ReadWebSource(params string[] parts) =>
+        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel", "Resources", "web", "arcademy" }
+            .Concat(parts).ToArray()));
+
+    /// <summary>Every page-side "does this url cost a decoder and a clock" test, by file. They are
+    /// separate copies of one regex by design (a game may not reach into engine internals), which
+    /// is exactly why a hint shape has to be checked against all of them rather than one.</summary>
+    public static TheoryData<string, string> AnimatedUrlTests() => new()
+    {
+        { "games/lost-and-found/board.js", "GIF_RE" },
+        { "games/instant-recall/montage.js", "GIF_RE" },
+        { "engine/util.js", "GIF_URL_RE" },
+    };
+
+    [Theory]
+    [MemberData(nameof(AnimatedUrlTests))]
+    public void TheHintIsReadByEveryAnimatedUrlTest(string file, string constant)
+    {
+        var src = ReadWebSource(file.Split('/'));
+        var decl = Regex.Match(src, @"\b" + Regex.Escape(constant) + @"\s*=\s*/(?<body>.+?)/[a-z]*\s*;");
+        Assert.True(decl.Success, constant + " is no longer a regex literal in " + file);
+
+        // The JS source is the single source of truth: the pattern is lifted out of it and run
+        // here, so a future edit that tightens it (say, to /\.gif$/) fails this test instead of
+        // silently un-budgeting every animated webp again.
+        var re = new Regex(decl.Groups["body"].Value, RegexOptions.IgnoreCase);
+        var hinted = "https://ccp.assets/images/loop.webp" + ArcademyHostService.AnimatedImageHint;
+
+        Assert.True(re.IsMatch(hinted),
+            file + "'s " + constant + " no longer reads the animated-webp hint (ccp-bugs#1086)");
+        Assert.False(re.IsMatch("https://ccp.assets/images/loop.webp"),
+            "an UNHINTED webp must stay a still — the url alone cannot know");
+        Assert.True(re.IsMatch("https://ccp.assets/images/loop.gif"),
+            "a real gif must still read as animated");
+    }
+
+    [Fact]
+    public void TheHintIsAFragment()
+    {
+        // Load-bearing: the URL Standard drops the fragment before the fetch, so the hinted url
+        // resolves to byte-for-byte the same file under the ccp.assets virtual-host mapping. A
+        // query string would be part of the request and is NOT guaranteed to resolve there.
+        Assert.StartsWith("#", ArcademyHostService.AnimatedImageHint, StringComparison.Ordinal);
+        Assert.DoesNotContain("?", ArcademyHostService.AnimatedImageHint, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheProviderResolvesTheHintAheadOfTheExtension()
+    {
+        // kindOf() buckets a url into the loop or still pool. extOf() strips the fragment, so
+        // without a hint reader a stamped webp would land back in the still pool and the fix
+        // would only half-work.
+        var src = ReadWebSource("provider", "inventory.js");
+        Assert.Contains("export function hintExtOf(", src, StringComparison.Ordinal);
+
+        var kindOf = Regex.Match(src, @"export function kindOf\(entry\)\s*\{(?<body>[\s\S]*?)\n\}");
+        Assert.True(kindOf.Success, "kindOf is no longer a plain function declaration");
+        Assert.Contains("hintExtOf(", kindOf.Groups["body"].Value, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheHostAdmitsWebpToBothLocalLanes()
+    {
+        // The extension cannot say which lane a webp belongs to, so it is a candidate for both
+        // and the probe decides. Dropping it back out of the loop lane would leave an
+        // animated-webp-only library with an empty loop pool and a dead-looking wall.
+        var host = File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel",
+            "Services", "Arcademy", "ArcademyHostService.cs"));
+        var loop = Regex.Match(host, @"LocalLoopExts\s*=\s*\{(?<body>[^}]*)\}");
+        Assert.True(loop.Success, "LocalLoopExts is no longer an array initialiser");
+        Assert.Contains("\".webp\"", loop.Groups["body"].Value, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Fixes CC-Labs-llc/ccp-bugs#1086 (desktop half; the phone touch path shipped separately).

## The symptom

> Lost & Found in Arcademy lags so much that clicking the correct image usually registers as a miss
> — I have a lot of animated webp images in my folder.

## Root cause — not a decode failure

WebView2 plays animated `.webp` perfectly well. That is the problem.

The wall's whole media layer is built on one fact (board.js §4): Chromium keeps **one decoder and one main-thread animation clock per image resource**, so cost scales with **distinct animated urls**, not with tiles. The board therefore deals at most `liveCap` (~30–40) animated urls; every other seat wears a still, and the churn trades animated looks with still looks so the motion roams. A frame governor sheds live seats when the achieved rAF cadence sags.

Every gate in that design asks the same question of a bare url: `/\.gif(\?|#|$)/`.

A webp animates because of a flag in its **VP8X container header**, never because of its name. So every animated webp answered *"still"*:

- it was never counted against `liveCap`,
- the frame governor could not see it to shed it (`shedGifSeat` filters on `t.live`),
- and a dense board dealt **one decoder per seat** — ~170 — instead of ~30.

Blink drops the whole page to about a frame a second. The rows are still drifting, so by the time a click lands the tile under the pointer is not the tile that was there. Hence "the correct image registers as a miss".

This was known and written down, not an oversight — `board.js` called it "a known blind spot", the host listed `.webp` in `LocalStillExts`, and `provider/inventory.js kindOf()` carries an explicit `ext !== 'webp'` guard. What was missing was a way for the page to learn the truth.

## The fix

The page cannot answer this — it never has the bytes. The **desktop host** does.

- **`ArcademyHostService`** header-probes a **sampled** local `.webp` (`AnimatedWebp.IsAnimated`, a 21-byte read — never a whole-library walk) and stamps `#.gif` on its `ccp.assets` url (`AnimatedImageHint`).
  That is not a new convention: `provider/index.js hintedPileUrl()` already uses a trailing `#.<ext>` fragment to give an extension-less `blob:` row a kind. The URL Standard drops the fragment before the fetch, so the hinted url loads byte-for-byte the same file out of the virtual-host mapping while every one of those `\.gif(\?|#|$)` regexes reads it — **which is why no budget logic needed changing at all**. The MIME on the wire stays the true one (`image/webp`).
- **`provider/inventory.js`** gains `hintExtOf()`, and `kindOf()` reads the hint ahead of the extension. Needed because `extOf()` strips fragments — without it a stamped webp would land back in the still pool and the fix would only half-work.
- **`.webp` now sits in both `LocalLoopExts` and `LocalStillExts`.** The extension cannot say which lane it belongs to, so it is admitted to either ask and the probe settles it: a still one is dropped from a `loop` ask, an animated one is served as the loop it is. Probes are budgeted so a still-webp library cannot turn one ask into a file open per entry, and an unprobed webp reads as *"still"* — the safe direction, since the failure being fixed is dealing animation nothing has counted.
- An **unhinted** webp is still a still, which stays the only honest answer on the web port, where no host holds the file.

`BuildLocalFolders`' advisory counts are deliberately left alone — probing a whole tree there is exactly the cost this avoids everywhere else.

No new dependencies: `AnimatedWebp` (SkiaSharp) already ships and already had the header probe, added for `BlinkTrainerService`.

## Blast radius

The hint reaches every Arcademy game that budgets animation off the same regex — anomaly, deja-vu, instant-recall and the engine all carry their own copy of `\.gif(\?|#|$)` — so all of them now count animated webp correctly. Nothing else changes for a library with no animated webp in it.

## Tests

`ArcademyAnimatedWebpHintTests`, 13 cases:

- **the probe** — hand-built container headers: VP8X with the animation flag, VP8X with it clear, simple-format VP8, an animated-webp body under a `.png`/`.jpg`/`.gif` name (must be classed by name, never by a header read), a missing file, a 4-byte truncated file.
- **the hint, as the page actually reads it** — the `\.gif(\?|#|$)` literal is **lifted out of** `games/lost-and-found/board.js`, `games/instant-recall/montage.js` and `engine/util.js` and run here against a hinted url. A future edit that tightens any of the three (say to `/\.gif$/`) fails the suite instead of silently un-budgeting animated webp again. Also pins that the hint is a *fragment* (not a query), that `kindOf` consults `hintExtOf`, and that `.webp` stays in the loop lane.

## Verification

- `dotnet build ConditioningControlPanel` — **0 errors**.
- `dotnet test` — **4908 passing**. The 5 failures are the pre-existing `YouLibraryDoorTests` / `Phase8RedirectContractTests` artifact seen in agent worktrees; no new failures.

Not play-tested against a real animated-webp library — worth an owner pass on the wall's feel before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
