### PR TITLE
fix(mods): a mod that ships no voice lines stays silent instead of speaking in Bambi's voice

### DIFF
--- a/ConditioningControlPanel/Services/Companion/CompanionContentResolver.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionContentResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Services.Companion
 {
@@ -125,6 +126,31 @@ namespace ConditioningControlPanel.Services.Companion
             Path.Combine(CompanionAudioRelativeDir, "mods", modId);
 
         /// <summary>
+        /// Whether the shared baseline voice-line library (<c>Resources\sounds\flashes_audio</c>) is
+        /// THIS mod's own voice.
+        ///
+        /// That folder is not a neutral fallback: it is BambiSleep's recorded VO, named line by line
+        /// ("be a good girl accept your conditioning.mp3"), and <c>FlashService</c> both plays it and
+        /// fires <c>FlashAudioPlaying</c> so the avatar prints that file name in HER speech bubble.
+        /// Handing it to another character therefore makes that character speak Bambi's lines in
+        /// Bambi's voice - which is exactly what a mod that ships bark audio but no
+        /// <c>flashes_audio</c> folder (the Infection Control creator mod) did.
+        ///
+        /// Only the two mods the library belongs to get it: BambiSleep, and CCP Default (the neutral
+        /// baseline persona, which has always spoken with these clips). Every other mod either ships
+        /// its own folder - Sissy per-mod, Drone/Locked inside their .ccpmod - or stays silent on
+        /// this channel, the same way <see cref="CompanionChannel.EventAudio"/> already leaves a mod
+        /// that ships none text-only.
+        ///
+        /// An unknown/absent mod id (ModService not up yet) keeps the baseline, so startup order can
+        /// never take the default companion silent.
+        /// </summary>
+        public static bool OwnsBaselineVoiceLines(string? modId) =>
+            string.IsNullOrWhiteSpace(modId)
+            || string.Equals(modId, BuiltInMods.BambiSleepId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(modId, BuiltInMods.CCPDefaultId, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
         /// The ordered candidate list for one channel. Roots that are empty (no content root on a
         /// full install, no InstalledPath on a built-in mod) simply contribute no candidates, so the
         /// ladder shortens instead of producing bogus paths.
@@ -197,7 +223,10 @@ namespace ConditioningControlPanel.Services.Companion
             //    a mod that simply has no overlay of its own.
             switch (channel)
             {
-                case CompanionChannel.VoiceLines:
+                // Voice lines only fall through to the baseline for the mods whose voice that library
+                // actually is — see OwnsBaselineVoiceLines. Anyone else stays silent rather than
+                // borrowing another character's recordings (and her speech bubble).
+                case CompanionChannel.VoiceLines when OwnsBaselineVoiceLines(modId):
                     if (!string.IsNullOrWhiteSpace(installRoot))
                         list.Add(new CompanionContentCandidate(CompanionContentSource.Baseline,
                             Path.Combine(installRoot, VoiceLinesRelativeDir), true));

--- a/ConditioningControlPanel/Services/Companion/CompanionPhraseService.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionPhraseService.cs
@@ -56,10 +56,11 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private static (string Absolute, string? Relative) ResolveVoiceLineFolder()
         {
+            string? modVoiceDir = null;
             var modPath = App.Mods?.ActiveMod?.InstalledPath;
             if (modPath != null)
             {
-                var modVoiceDir = Path.Combine(modPath, "resources", "sounds", "flashes_audio");
+                modVoiceDir = Path.Combine(modPath, "resources", "sounds", "flashes_audio");
                 if (Directory.Exists(modVoiceDir))
                     return (modVoiceDir, null);
             }
@@ -67,13 +68,23 @@ namespace ConditioningControlPanel.Services
             // mirroring how bark_rules.json / avatar_manifest.json resolve. Lets Sissy play its own
             // idle "giggle" lines (in the bark voice) instead of the shared old ones.
             var modId = App.Mods?.ActiveModId;
+            string? perModRel = null;
             if (!string.IsNullOrEmpty(modId))
             {
-                var rel = Path.Combine(CompanionAudioRelativeDir, "mods", modId, "flashes_audio");
-                if (ContentLocator.DirectoryExists(rel))
-                    return (ContentLocator.ResolveDirectory(rel), rel);
+                perModRel = Path.Combine(CompanionAudioRelativeDir, "mods", modId, "flashes_audio");
+                if (ContentLocator.DirectoryExists(perModRel))
+                    return (ContentLocator.ResolveDirectory(perModRel), perModRel);
             }
-            return (ContentLocator.ResolveDirectory(VoiceLineRelativeDir), VoiceLineRelativeDir);
+
+            // The shared folder is not a neutral fallback — it is BambiSleep's own recorded VO, and
+            // FlashService prints each clip's file name in the companion's speech bubble as it plays.
+            // Only the mods it belongs to may speak with it (see
+            // CompanionContentResolver.OwnsBaselineVoiceLines); anyone else points at their OWN
+            // (possibly empty) folder and simply has no voice lines, instead of borrowing Bambi's.
+            if (Companion.CompanionContentResolver.OwnsBaselineVoiceLines(modId))
+                return (ContentLocator.ResolveDirectory(VoiceLineRelativeDir), VoiceLineRelativeDir);
+            if (modVoiceDir != null) return (modVoiceDir, null);
+            return (ContentLocator.ResolveDirectory(perModRel!), perModRel);
         }
 
         /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/CompanionContentResolverTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionContentResolverTests.cs
@@ -101,6 +101,77 @@ public class CompanionContentResolverTests
         Assert.Equal(Path.Combine(ContentRoot, "Resources", "sounds", "flashes_audio"), candidates[^1].Path);
     }
 
+    // ------------------------------------------------ the baseline VO library belongs to Bambi
+
+    [Theory]
+    [InlineData(BuiltInMods.BambiSleepId)]
+    [InlineData(BuiltInMods.CCPDefaultId)]
+    [InlineData(null)]
+    public void TheBaselineVoiceLibraryIsOfferedToTheModsItActuallyBelongsTo(string? modId)
+    {
+        Assert.True(CompanionContentResolver.OwnsBaselineVoiceLines(modId));
+    }
+
+    [Theory]
+    [InlineData(BuiltInMods.SissyHypnoId)]
+    [InlineData(BuiltInMods.LockedId)]
+    [InlineData(BuiltInMods.DronificationId)]
+    [InlineData(BuiltInMods.InfectionControlId)]
+    [InlineData("some-creator-mod")]
+    public void EveryOtherModIsDeniedTheBaselineVoiceLibrary(string modId)
+    {
+        Assert.False(CompanionContentResolver.OwnsBaselineVoiceLines(modId));
+    }
+
+    /// <summary>
+    /// The reported bug: Infection Control ships its bark clips under
+    /// resources\sounds\companion_audio but no flashes_audio folder, so the voice-line ladder used
+    /// to end on the shared baseline — BambiSleep's recorded VO, which FlashService plays AND whose
+    /// file name the avatar prints in the companion's own speech bubble. A mod that ships none must
+    /// stay silent instead.
+    /// </summary>
+    [Fact]
+    public void AModThatShipsNoVoiceLinesGetsSilenceNotBambisRecordings()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.VoiceLines, BuiltInMods.InfectionControlId,
+            installedPath: PackagedPath, InstallRoot, ContentRoot);
+
+        Assert.DoesNotContain(candidates, c => c.Source == CompanionContentSource.Baseline);
+        Assert.Equal(
+            new[]
+            {
+                CompanionContentSource.PackagedMod,
+                CompanionContentSource.ModInstallDir,
+                CompanionContentSource.ModContentPack
+            },
+            candidates.Select(c => c.Source).ToArray());
+
+        // With nothing on disk anywhere, the pick is None — i.e. no voice lines at all.
+        Assert.False(CompanionContentResolver.Pick(candidates, _ => false).Found);
+    }
+
+    [Fact]
+    public void AModShippingItsOwnVoiceLinesStillWinsAheadOfEverything()
+    {
+        var own = Path.Combine(PackagedPath, "resources", "sounds", "flashes_audio");
+        var pick = CompanionContentResolver.Resolve(
+            CompanionChannel.VoiceLines, BuiltInMods.DronificationId, PackagedPath,
+            InstallRoot, ContentRoot, ProbeFor(own));
+
+        Assert.Equal(CompanionContentSource.PackagedMod, pick.Source);
+        Assert.Equal(own, pick.Path);
+    }
+
+    [Fact]
+    public void EventAudioNeverHadABaselineAndStillDoesNot()
+    {
+        var candidates = CompanionContentResolver.Candidates(
+            CompanionChannel.EventAudio, BambiId, null, InstallRoot, ContentRoot);
+
+        Assert.DoesNotContain(candidates, c => c.Source == CompanionContentSource.Baseline);
+    }
+
     [Fact]
     public void BarkAudioFallsBackToTheSharedCompanionAudioRoot()
     {


### PR DESCRIPTION
## The report

The Infection Control creator (Miss Jenny), testing her standalone `.ccpmod` by drag-and-drop:

> "She does audio barks now, but she's using the Bambi/Sissy ones instead of whatever lines you made for this mod."

## Her barks were never the problem

The packaging is correct. `infection-control-1.0.0.ccpmod` ships `bark_rules.json` + 152 clips at
`resources/sounds/companion_audio/`, which is exactly the packaged-mod rung of the ladder
(`CompanionContentResolver.Candidates`, `BarkRules` / `BarkAudio`). All 61 rules are well formed:
the 14 that omit `trigger` are precisely the 14 whose ids exist in the base manifest and inherit it
through the field-level merge, and all 20 distinct triggers are keys `BarkService` raises.

## What she actually heard

The flash voice-line pool. `FlashService.SoundsPath` **is** `CompanionPhraseService.VoiceLineFolder`,
and the last rung of that ladder is the shared `Resources/sounds/flashes_audio` folder — 123 clips of
**BambiSleep's own recorded VO**, named line by line (`be a good girl accept your conditioning.mp3`).
`FlashService` plays one per flash and fires `FlashAudioPlaying`, so
`AvatarTubeWindow.OnFlashAudioPlaying` prints that file name in **her** speech bubble.

Nurse Amber was speaking Bambi's lines, in Bambi's voice, in Bambi's words, on every flash image.

That folder is not a neutral baseline, it is one character's library:

| mod | flash VO source |
|---|---|
| BambiSleep, CCP Default | the shared folder (it is theirs) |
| SissyHypno | `companion_audio/mods/builtin-sissyhypno/flashes_audio/` |
| Drone, Locked | ~200 clips inside their own `.ccpmod` |
| **any creator mod** | **inherited Bambi's** |

## The fix

The baseline rung is offered only to the two mods it belongs to (`OwnsBaselineVoiceLines`). Everyone
else resolves to their own — possibly empty — folder and simply has no voice lines, the same way
`CompanionChannel.EventAudio` already leaves a mod that ships none text-only. Their own voiced barks,
the flash bark included, are untouched, and a flash with no clip falls back to the settings-driven
duration exactly as with "link to audio" off.

**No behaviour change for existing users:** Sissy, Drone and Locked already never reached the shared
folder, so the only mods whose audio moves are the ones that were borrowing a voice that was not theirs.
An unknown mod id (ModService not up yet) still gets the baseline, so startup order can never take the
default companion silent.

Both call sites are covered: the pure ladder in `CompanionContentResolver` (what `BarkRuleLoader` and
the `CompanionContent[...]` activation log read) and the hand-rolled copy in
`CompanionPhraseService.ResolveVoiceLineFolder` that `FlashService` actually uses.

## Creator-side follow-up (not a code fix)

A mod **can** own this channel by shipping `resources/sounds/flashes_audio/<the spoken line>.mp3`
inside its `.ccpmod`, the way `drone-mode.ccpmod` and `locked-resources.ccpmod` do — the file name is
the bubble text. Infection Control ships none today, so after this it is silent on flashes rather than
wrong, until Miss Jenny voices a set.

## Verification

- `dotnet build` — 0 errors.
- `CompanionContentResolverTests` 37 passed (8 new: baseline ownership per mod id, the
  Infection-Control ladder having no `Baseline` rung and picking `None`, a packaged mod's own folder
  still winning, `EventAudio` unchanged).
- Bark / phrase / voice-line / flash suites: 183 passed, 0 failed.
- In-app: activate a mod with no `flashes_audio`, start flashes — no Bambi VO and no Bambi text in
  the bubble; her own bark voice still fires. On Bambi/CCP Default, flash VO is unchanged. The
  `CompanionContent[<mod>]: ... voiceLines=` log line names the winning source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
