### PR TITLE
feat(video): audio output device routing on the first-party player page (#938 plumbing)

### DIFF
--- a/ConditioningControlPanel/Resources/web/player/player.js
+++ b/ConditioningControlPanel/Resources/web/player/player.js
@@ -130,6 +130,91 @@
     post({ type: 'error', code: code, message: String(message) });
   }
 
+  // ---------- audio output sink (#938 plumbing) ----------
+
+  // The host may name an output device by LABEL on the load message; deviceIds
+  // are per-origin salted hashes so the label string is the only stable key.
+  // FAIL-SAFE CONTRACT: every path out of here either applies the sink and
+  // posts {type:'sink', ok:true} or changes NOTHING (audio stays on the
+  // Windows default) and posts ok:false with a reason. Nothing here may ever
+  // pause, mute or delay the clip itself.
+  let sinkAppliedLabel = null;
+
+  function reportSink(ok, label, detail) {
+    post({ type: 'sink', ok: !!ok, label: String(label || ''), detail: String(detail || '') });
+  }
+
+  function normLabel(s) {
+    return String(s || '').trim().toLowerCase();
+  }
+
+  // Same tolerant match AudioService.ResolvePreferredWaveOutDeviceNumber uses:
+  // exact label first, then the bracketed driver name out of a friendly name
+  // like "Speakers (Realtek High Definition Audio)", matched by bidirectional
+  // prefix/contains because Windows truncates device names at 31 chars in some
+  // APIs and the two sides rarely agree on the full string.
+  function pickSink(devices, wanted) {
+    const w = normLabel(wanted);
+    if (!w) return null;
+    const outs = devices.filter((d) =>
+      d.kind === 'audiooutput' && d.deviceId && d.deviceId !== 'default' && d.deviceId !== 'communications');
+    let hit = outs.find((d) => normLabel(d.label) === w);
+    if (hit) return hit;
+    const open = w.indexOf('(');
+    const close = w.lastIndexOf(')');
+    const driver = open >= 0 && close > open ? w.substring(open + 1, close).trim() : w;
+    hit = outs.find((d) => {
+      const l = normLabel(d.label);
+      return !!l && (l.startsWith(driver) || driver.startsWith(l) || l.indexOf(driver) >= 0 || w.indexOf(l) >= 0);
+    });
+    return hit || null;
+  }
+
+  function applySink(label) {
+    const wanted = typeof label === 'string' ? label.trim() : '';
+    if (!wanted) {
+      // The elements outlive loads: a clip with no routing must not inherit the
+      // previous clip's sink. '' is the spec's name for the default device.
+      if (sinkAppliedLabel && typeof fg.setSinkId === 'function') {
+        try { fg.setSinkId('').catch(() => { /* stay wherever we are */ }); } catch (e) { /* ignore */ }
+        sinkAppliedLabel = null;
+      }
+      return;
+    }
+    if (sinkAppliedLabel === wanted) return; // already routed; re-report nothing
+    if (!navigator.mediaDevices || typeof navigator.mediaDevices.enumerateDevices !== 'function'
+        || typeof fg.setSinkId !== 'function') {
+      reportSink(false, wanted, 'setSinkId unsupported');
+      return;
+    }
+    // Labels are blank until the origin holds mic permission; the host grants
+    // it for this page alone (BrowserVideoSurface.OnPermissionRequested). Only
+    // run the getUserMedia probe when enumerate comes back label-less, and stop
+    // its tracks on the next line - nothing records anything.
+    navigator.mediaDevices.enumerateDevices()
+      .then((devices) => {
+        if (devices.some((d) => d.kind === 'audiooutput' && d.label)) return devices;
+        return navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
+          stream.getTracks().forEach((t) => { try { t.stop(); } catch (e) { /* ignore */ } });
+          return navigator.mediaDevices.enumerateDevices();
+        });
+      })
+      .then((devices) => {
+        const hit = pickSink(devices, wanted);
+        if (!hit) {
+          reportSink(false, wanted, 'no audiooutput label matched');
+          return;
+        }
+        return fg.setSinkId(hit.deviceId).then(() => {
+          sinkAppliedLabel = wanted;
+          reportSink(true, wanted, hit.label);
+        });
+      })
+      .catch((err) => {
+        reportSink(false, wanted, (err && (err.name || err.message)) || 'error');
+      });
+  }
+
   // ---------- load ----------
 
   function startLoad(d) {
@@ -171,6 +256,7 @@
 
     document.body.classList.toggle('has-bg', cur.blur);
     applyVolume();
+    applySink(d.sinkLabel);
 
     // Backdrop first so it is never the thing that delays the real clip.
     if (cur.blur) {

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserSinkLabel.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserSinkLabel.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Video.Browser
+{
+    /// <summary>
+    /// Decides what audio-output device label rides a player-page <c>load</c> message (#938
+    /// plumbing). The page matches the label against <c>enumerateDevices()</c> and applies
+    /// <c>setSinkId</c>; every failure path page-side reports back and leaves audio on the
+    /// Windows default, so a wrong or stale label can never silence a clip.
+    ///
+    /// This is deliberately dormant in the field today: <see cref="BrowserVideoGate"/> still
+    /// routes device-pinned users to LibVLC (#938), so a real user with a chosen device never
+    /// reaches the player page. The label still flows for the surfaces the gate does not govern
+    /// once that demotion is retired — a separate change, made only after this path has proven
+    /// itself. Until then the test-override environment variable is the way to exercise it
+    /// ears-on without touching the gate.
+    /// </summary>
+    internal static class BrowserSinkLabel
+    {
+        /// <summary>Manual-verification override: set to a device's friendly name (or a prefix of
+        /// it) and the player page routes there even with the picker on "System default" — which
+        /// is the one configuration where the browser engine actually runs today (see the gate
+        /// note above). Absent in production use.</summary>
+        public const string TestOverrideVariable = "CCP_BROWSER_SINK_TEST_LABEL";
+
+        /// <summary>Label from live settings + environment; null when no routing is wanted.</summary>
+        public static string? Resolve()
+        {
+            string? env = null;
+            try { env = Environment.GetEnvironmentVariable(TestOverrideVariable); } catch { }
+            var s = App.Settings?.Current;
+            return Resolve(s?.AudioOutputDeviceId, s?.AudioOutputDeviceName, env);
+        }
+
+        /// <summary>
+        /// Pure core, one rule per line so the tests can pin them: a non-blank test override wins
+        /// outright; an empty device id is the "System default" picker choice and asks for no
+        /// routing; a chosen id with no persisted friendly name yields null too, because the page
+        /// can only match by label. Trimmed, never empty-string (null is the "don't" signal).
+        /// </summary>
+        public static string? Resolve(string? deviceId, string? deviceName, string? testOverride)
+        {
+            if (!string.IsNullOrWhiteSpace(testOverride)) return testOverride.Trim();
+            if (string.IsNullOrEmpty(deviceId)) return null;
+            if (string.IsNullOrWhiteSpace(deviceName)) return null;
+            return deviceName.Trim();
+        }
+
+        /// <summary>Only the audio-bearing surface gets a label: secondaries are permanently muted
+        /// (one WASAPI session per clip), and handing them one would spend a mic-probe stream per
+        /// monitor for audio nobody hears.</summary>
+        public static string? ForWindow(bool primary, string? resolved) => primary ? resolved : null;
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -423,10 +423,13 @@ namespace ConditioningControlPanel.Services.Video.Browser
             _failedRaised = false;
             _isHostPaused = req.IsHostPaused;
             _isHostStrict = req.IsHostStrict;
+            // Resolved once per session, not per window: the load posts below run in a loop and the
+            // settings could change between iterations, splitting one clip across two devices.
+            var sinkLabel = BrowserSinkLabel.Resolve();
 
             try
             {
-                _primary = CreateWindow(req, req.PrimaryScreen, primary: true, url);
+                _primary = CreateWindow(req, req.PrimaryScreen, primary: true, url, sinkLabel);
                 if (_primary == null)
                 {
                     App.Logger?.Warning("BrowserVideo: the audio-bearing window on {Screen} could not be created - handing the whole clip to LibVLC",
@@ -437,7 +440,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
 
                 foreach (var scr in req.SecondaryScreens)
                 {
-                    var w = CreateWindow(req, scr, primary: false, url);
+                    var w = CreateWindow(req, scr, primary: false, url, sinkLabel);
                     if (w != null) _windows.Add(w);
                 }
             }
@@ -456,7 +459,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
             return true;
         }
 
-        private BrowserVideoWindow? CreateWindow(BrowserVideoRequest req, Screen screen, bool primary, string url)
+        private BrowserVideoWindow? CreateWindow(BrowserVideoRequest req, Screen screen, bool primary, string url, string? sinkLabel)
         {
             BrowserVideoWindow? win = null;
             try
@@ -495,6 +498,10 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     blurBackground = req.BlurBackground,
                     hideCursor = req.HideCursor,
                     startAtMs = req.StartAtMs,
+                    // Audio-output routing by device label (#938 plumbing). Null = leave the page on
+                    // the Windows default; the page treats every failure the same way and reports it
+                    // back as {type:'sink'}.
+                    sinkLabel = BrowserSinkLabel.ForWindow(primary, sinkLabel),
                 });
 
                 try { req.ConfigureBeforeShow?.Invoke(win, screen, primary); }
@@ -710,6 +717,19 @@ namespace ConditioningControlPanel.Services.Video.Browser
                         var msg = (string?)o["message"] ?? "";
                         App.Logger?.Warning("BrowserVideo: page error {Code}: {Msg}", code, msg);
                         RaiseFailed($"page error {code}: {msg}", blameFile: BlamesFile(code));
+                        break;
+                    }
+                    case "sink":
+                    {
+                        // The page's verdict on the requested audio-output routing (#938 plumbing).
+                        // Exactly one line each way; failure is deliberately only a Warning because
+                        // the fail-safe already happened page-side - audio stayed on the default.
+                        var label = (string?)o["label"] ?? "";
+                        if ((bool?)o["ok"] == true)
+                            App.Logger?.Information("BrowserVideo: audio routed to output device \"{Label}\" via setSinkId", label);
+                        else
+                            App.Logger?.Warning("BrowserVideo: could not route audio to \"{Label}\" ({Detail}) - staying on the Windows default output",
+                                label, (string?)o["detail"] ?? "");
                         break;
                     }
                     case "click":

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
@@ -127,6 +127,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 core.NavigationStarting += OnNavigationStarting;
                 core.WebMessageReceived += OnWebMessageReceived;
                 core.ProcessFailed += OnCoreProcessFailed;
+                core.PermissionRequested += OnPermissionRequested;
                 _navHost = primaryHost;
 
                 core.Navigate(startUrl);
@@ -204,6 +205,34 @@ namespace ConditioningControlPanel.Services.Video.Browser
             }
         }
 
+        /// <summary>
+        /// The player page's audio-output routing (#938 plumbing) needs device LABELS from
+        /// <c>enumerateDevices()</c>, and Chromium blanks audiooutput labels until the origin holds
+        /// microphone permission - so the page's probe (a getUserMedia stream it stops on the next
+        /// line) surfaces here. Grant is scoped to exactly our own page: https scheme AND the host
+        /// this surface navigated to (the ccp.game virtual host; OnNavigationStarting already
+        /// cancels every navigation elsewhere). Everything else - other origins, other permission
+        /// kinds - is denied outright rather than left to a prompt, because these are chromeless
+        /// fullscreen windows where a permission bubble would be unanswerable.
+        /// </summary>
+        private void OnPermissionRequested(object? sender, CoreWebView2PermissionRequestedEventArgs e)
+        {
+            try
+            {
+                bool ourPage = Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri)
+                    && uri.Scheme == Uri.UriSchemeHttps
+                    && string.Equals(uri.Host, _navHost, StringComparison.OrdinalIgnoreCase);
+                e.State = ourPage && e.PermissionKind == CoreWebView2PermissionKind.Microphone
+                    ? CoreWebView2PermissionState.Allow
+                    : CoreWebView2PermissionState.Deny;
+                e.Handled = true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BrowserVideo[{Tag}]: PermissionRequested handler failed: {E}", _tag, ex.Message);
+            }
+        }
+
         private void OnCoreProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
         {
             App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 process failed ({Kind})", _tag, e.ProcessFailedKind);
@@ -264,6 +293,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     _web.CoreWebView2.NavigationStarting -= OnNavigationStarting;
                     _web.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
                     _web.CoreWebView2.ProcessFailed -= OnCoreProcessFailed;
+                    _web.CoreWebView2.PermissionRequested -= OnPermissionRequested;
                 }
             }
             catch { }

--- a/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
@@ -863,6 +863,9 @@ namespace ConditioningControlPanel
                 // unplayable, so the page's cursor hiding stays off here.
                 hideCursor = false,
                 startAtMs = 0,
+                // Audio-output routing by device label (#938 plumbing), primary-only like the
+                // volume above; the page falls back to the Windows default on any failure.
+                sinkLabel = BrowserSinkLabel.ForWindow(_isPrimary, BrowserSinkLabel.Resolve()),
             });
 
             if (_isPrimary)
@@ -961,6 +964,15 @@ namespace ConditioningControlPanel
                         _browserPlayingSeen = true;
                         StopBrowserFirstFrameWatch();
                         VideoDiag.Log("BUBBLE", "browser PLAYING (page reported the first frame)");
+                        break;
+                    case "sink":
+                        // Same one-line-each-way contract as BrowserVideoEngine (#938 plumbing);
+                        // failure page-side already left the audio on the Windows default.
+                        if ((bool?)o["ok"] == true)
+                            App.Logger?.Information("BubbleCountWindow: audio routed to output device \"{Label}\" via setSinkId", (string?)o["label"] ?? "");
+                        else
+                            App.Logger?.Warning("BubbleCountWindow: could not route audio to \"{Label}\" ({Detail}) - staying on the Windows default output",
+                                (string?)o["label"] ?? "", (string?)o["detail"] ?? "");
                         break;
                     case "ended":
                         // Same completion path as EndReached.

--- a/Tests/ConditioningControlPanel.Tests/BrowserSinkLabelTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BrowserSinkLabelTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using ConditioningControlPanel.Services.Video.Browser;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #938 plumbing — audio-output routing on the first-party player page (https://ccp.game).
+///
+/// <para>Two halves must stay true together. The C# half (<see cref="BrowserSinkLabel"/>) decides
+/// WHETHER a device label rides the <c>load</c> message at all — null is the "leave audio on the
+/// Windows default" signal and must come out of every configuration that cannot be routed. The
+/// page half (player.js <c>applySink</c>) matches that label against <c>enumerateDevices()</c> and
+/// applies <c>setSinkId</c>, with the fail-safe contract that every failure path posts
+/// <c>{type:'sink', ok:false}</c> and changes nothing.</para>
+///
+/// <para>The page half cannot run under xunit, so it is pinned the way this suite pins every
+/// player-page contract: static reads of the product sources, asserting the wiring strings that
+/// the C# side depends on byte-for-byte.</para>
+/// </summary>
+public class BrowserSinkLabelTests
+{
+    // =====================================================================================
+    //  pure resolver
+    // =====================================================================================
+
+    [Fact]
+    public void Resolve_SystemDefault_ReturnsNull()
+    {
+        // Empty/null device id is the picker's "System default" — no routing wanted.
+        Assert.Null(BrowserSinkLabel.Resolve(null, "Speakers (Realtek)", null));
+        Assert.Null(BrowserSinkLabel.Resolve("", "Speakers (Realtek)", null));
+    }
+
+    [Fact]
+    public void Resolve_DeviceChosenWithName_ReturnsTrimmedName()
+    {
+        Assert.Equal("Speakers (Realtek High Definition Audio)",
+            BrowserSinkLabel.Resolve("{guid}", "  Speakers (Realtek High Definition Audio)  ", null));
+    }
+
+    [Fact]
+    public void Resolve_DeviceChosenButNoName_ReturnsNull()
+    {
+        // The page can only match by label; an id with no persisted friendly name is unroutable.
+        Assert.Null(BrowserSinkLabel.Resolve("{guid}", null, null));
+        Assert.Null(BrowserSinkLabel.Resolve("{guid}", "", null));
+        Assert.Null(BrowserSinkLabel.Resolve("{guid}", "   ", null));
+    }
+
+    [Fact]
+    public void Resolve_TestOverride_WinsOverEverything()
+    {
+        // The manual-verification path: CCP_BROWSER_SINK_TEST_LABEL routes the page even with the
+        // picker on "System default" (the one configuration BrowserVideoGate's #938 demotion lets
+        // reach the browser engine at all).
+        Assert.Equal("USB Headset", BrowserSinkLabel.Resolve(null, null, "USB Headset"));
+        Assert.Equal("USB Headset", BrowserSinkLabel.Resolve("", "", " USB Headset "));
+        Assert.Equal("USB Headset", BrowserSinkLabel.Resolve("{guid}", "Speakers", "USB Headset"));
+    }
+
+    [Fact]
+    public void Resolve_BlankTestOverride_DoesNotShadowSettings()
+    {
+        Assert.Equal("Speakers", BrowserSinkLabel.Resolve("{guid}", "Speakers", "   "));
+        Assert.Null(BrowserSinkLabel.Resolve(null, null, ""));
+    }
+
+    [Fact]
+    public void ForWindow_OnlyThePrimaryCarriesTheLabel()
+    {
+        // Secondaries are permanently muted (one WASAPI session per clip); a label there would
+        // spend a mic-probe stream per monitor for audio nobody hears.
+        Assert.Equal("Speakers", BrowserSinkLabel.ForWindow(primary: true, "Speakers"));
+        Assert.Null(BrowserSinkLabel.ForWindow(primary: false, "Speakers"));
+        Assert.Null(BrowserSinkLabel.ForWindow(primary: true, null));
+    }
+
+    [Fact]
+    public void TestOverrideVariable_IsTheDocumentedName()
+    {
+        // The PR body / manual verification script names this variable; a rename must be loud.
+        Assert.Equal("CCP_BROWSER_SINK_TEST_LABEL", BrowserSinkLabel.TestOverrideVariable);
+    }
+
+    // =====================================================================================
+    //  wiring — static reads of the product sources
+    // =====================================================================================
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string ReadProduct(params string[] parts)
+    {
+        var path = Path.Combine(RepoRoot(), Path.Combine(parts));
+        Assert.True(File.Exists(path), $"product source missing: {path}");
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void PlayerPage_CarriesTheSinkContract()
+    {
+        var js = ReadProduct("ConditioningControlPanel", "Resources", "web", "player", "player.js");
+
+        // The load message's field, read exactly as C# writes it.
+        Assert.Contains("applySink(d.sinkLabel)", js);
+
+        // The fail-safe report both hosts switch on.
+        Assert.Contains("type: 'sink'", js);
+
+        // Label matching happens against enumerateDevices via setSinkId — the two APIs this whole
+        // feature stands on. Their absence would mean the sink section was gutted.
+        Assert.Contains("enumerateDevices", js);
+        Assert.Contains("setSinkId", js);
+
+        // The permission probe must stop its tracks (nothing may keep a live mic stream).
+        Assert.Contains("getTracks().forEach", js);
+    }
+
+    [Fact]
+    public void Engine_PostsTheLabelAndLogsTheVerdict()
+    {
+        var cs = ReadProduct("ConditioningControlPanel", "Services", "Video", "Browser", "BrowserVideoEngine.cs");
+
+        // load post carries the field player.js reads, primary-gated through ForWindow.
+        Assert.Contains("sinkLabel = BrowserSinkLabel.ForWindow(primary, sinkLabel)", cs);
+
+        // Exactly one log line each way.
+        Assert.Contains("case \"sink\"", cs);
+        Assert.Contains("staying on the Windows default output", cs);
+    }
+
+    [Fact]
+    public void BubbleCount_PostsTheLabelAndLogsTheVerdict()
+    {
+        var cs = ReadProduct("ConditioningControlPanel", "Windows", "BubbleCountWindow.xaml.cs");
+        Assert.Contains("sinkLabel = BrowserSinkLabel.ForWindow(_isPrimary, BrowserSinkLabel.Resolve())", cs);
+        Assert.Contains("case \"sink\"", cs);
+        Assert.Contains("staying on the Windows default output", cs);
+    }
+
+    [Fact]
+    public void Surface_GrantsMicOnlyToOurOwnHttpsHost()
+    {
+        var cs = ReadProduct("ConditioningControlPanel", "Services", "Video", "Browser", "BrowserVideoSurface.cs");
+
+        // The grant predicate: https scheme AND the navigated host, mic only; all else denied.
+        Assert.Contains("PermissionRequested += OnPermissionRequested", cs);
+        Assert.Contains("uri.Scheme == Uri.UriSchemeHttps", cs);
+        Assert.Contains("uri.Host, _navHost, StringComparison.OrdinalIgnoreCase", cs);
+        Assert.Contains("CoreWebView2PermissionKind.Microphone", cs);
+        Assert.Contains("CoreWebView2PermissionState.Deny", cs);
+        Assert.Contains("e.Handled = true", cs);
+
+        // And the unhook alongside the other core events.
+        Assert.Contains("PermissionRequested -= OnPermissionRequested", cs);
+    }
+
+    [Fact]
+    public void Gate_StillDemotesDevicePinnedUsersToLibVlc()
+    {
+        // Scoping decision pinned in code: BrowserVideoGate's #938 force-demotion is deliberately
+        // untouched by this PR, so a user with a chosen output device still gets LibVLC (which can
+        // target the device natively). Relaxing the gate is a separate, later change.
+        var cs = ReadProduct("ConditioningControlPanel", "Services", "Video", "Browser", "BrowserVideoGate.cs");
+        Assert.Contains("AudioOutputDeviceId", cs);
+        Assert.Contains("routing to LibVLC, which can target it (#938)", cs);
+    }
+}


### PR DESCRIPTION
## What

Teaches the **first-party player page** (`https://ccp.game` — mandatory videos via BrowserVideoEngine, and BubbleCount) to route audio to the user's chosen output device with `setSinkId` (#938 plumbing).

- Host side: `BrowserSinkLabel.Resolve()` decides whether a device **label** rides the `load` message (null = leave audio on the Windows default). Primary window only — secondaries are permanently muted.
- Page side: `applySink()` matches the label against `enumerateDevices()` with the same tolerant heuristic `AudioService.ResolvePreferredWaveOutDeviceNumber` uses (exact → bracketed driver name → bidirectional prefix/contains), then `fg.setSinkId(deviceId)`.
- Permission: Chromium blanks `audiooutput` labels until the origin holds mic permission, so `BrowserVideoSurface` handles `PermissionRequested` — **Allow only for Microphone + https + the exact navigated host** (`ccp.game`, whose navigation `OnNavigationStarting` already locks down); everything else is denied outright (`Handled = true`, no unanswerable prompt in a chromeless fullscreen window). The page's `getUserMedia` probe runs only when labels come back blank and stops its tracks immediately.

## Fail-safe contract

Every failure path page-side (unsupported API, no label match, `setSinkId` rejection, permission denied) posts `{type:'sink', ok:false, detail}` and **changes nothing** — audio stays on the Windows default and the clip is never paused, muted, or delayed. Host logs exactly one line each way:

- `Information`: `audio routed to output device "X" via setSinkId`
- `Warning`: `could not route audio to "X" (reason) - staying on the Windows default output`

A later load without a label resets a previously applied sink (`setSinkId('')`), since the media element outlives loads.

## Scoping decisions (deliberate)

1. **BrowserVideoGate's #938 LibVLC force-demotion (BrowserVideoGate.cs:51-60) is kept EXACTLY as is.** A user with a chosen output device still routes to LibVLC, which targets the device natively. Relaxing the gate so device-pinned users get the browser engine + setSinkId is a separate future PR, after this path has proven itself. A static-content test pins the gate so nobody relaxes it by accident here.
2. **The Deeper EnhancementPlayerWindow is OUT of scope.** It is not first-party: it navigates to third-party allowlisted preview hosts and `file://` URIs, so auto-granting mic permission there would hand it to external origins — the exact trade this PR refuses for the browser tab. No changes to that file.

## Manual verification (~2 minutes, needs ears)

1. Leave **Settings → Audio → Output device** on **System default** (this is the one config the gate lets reach the browser engine).
2. Set the env var and launch from the same shell:
   ```powershell
   $env:CCP_BROWSER_SINK_TEST_LABEL = "Headphones"   # any prefix of a real output device's name
   dotnet run
   ```
3. Enable the browser video engine, play a mandatory video (.mp4).
4. **Listen**: audio should come out of the named device while Windows default stays elsewhere. Check the log for `audio routed to output device ... via setSinkId`.
5. Negative path: set the var to `NoSuchDevice`, play again — audio on the default, log shows the `staying on the Windows default output` warning.
6. Unset the var (`Remove-Item Env:CCP_BROWSER_SINK_TEST_LABEL`) — production behavior, no sink message at all.

## Tests

12 new (`BrowserSinkLabelTests`): resolver rules (default/no-name/override precedence/trim), primary-only gating, and static-content pins on the page contract, the load-post wiring in both hosts, the permission grant predicate, and the untouched gate. Suite: **4935 passed, 2 failed — both pre-existing on origin/main** (`EmiRingCardFitTests`: the German label "Fernsteuerung" from the book-translations wave outgrew the EMI ring card strip; files untouched by this branch).

## Not verifiable without hardware

Actual audible routing, the mic-permission grant flow, and setSinkId acceptance need a real machine with ≥2 output devices — owner ears-on test required (script above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
