### PR TITLE
fix(fyp): ghost mirror frozen on stale intro card - re-assert WebView2 render visibility

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -744,6 +744,22 @@ internal sealed class ChaosWebViewHost : IDisposable
         {
             ApplyNativeOwner(false);
             handled = true;   // swallow it: DefWindowProc is what would hide us
+            // The swallow keeps USER32 from hiding the window, but the message may already have
+            // been taken at face value elsewhere in the chain (WPF's own bookkeeping, the
+            // WebView2 wrapper) on its way here. When that happens the WINDOW stays on screen
+            // while CoreWebView2Controller.IsVisible drops underneath it: Chromium stops
+            // producing frames, the page freezes on its last composed frame with document.hidden
+            // stuck true (script and audio run on), and nothing ever flips it back because the
+            // window never gets a real re-show. That stuck state is what the For You ghost
+            // mirrored as a stale intro card (v6.9.0 report; main.js's re-mount in
+            // setClickThrough could only repair the DOM half). Re-sync once the storm passes.
+            try
+            {
+                _window?.Dispatcher.BeginInvoke(
+                    System.Windows.Threading.DispatcherPriority.Background,
+                    new Action(() => KickRenderVisibility("owner-minimize cascade vetoed")));
+            }
+            catch { }
         }
         return IntPtr.Zero;
     }
@@ -761,8 +777,84 @@ internal sealed class ChaosWebViewHost : IDisposable
             var hwnd = new WindowInteropHelper(_window).Handle;
             if (hwnd == IntPtr.Zero || IsWindowVisible(hwnd)) return;
             ShowWindow(hwnd, SW_SHOWNA);
+            // The native re-show does not necessarily reach the WebView2 controller (the hide
+            // may never have reached WPF either) — re-drive the render chain explicitly.
+            try
+            {
+                _window.Dispatcher.BeginInvoke(
+                    System.Windows.Threading.DispatcherPriority.Background,
+                    new Action(() => KickRenderVisibility("cascade hide healed")));
+            }
+            catch { }
         }
         catch (Exception ex) { App.Logger?.Debug("{Tag}.EnsureNativeVisible: {E}", _opts.LogTag, ex.Message); }
+    }
+
+    /// <summary>Re-assert the WebView2 RENDER visibility chain for a window that is supposed to
+    /// be composing — on screen, or parked-but-shown as the For You ghost's source window is.
+    ///
+    /// <para>Why it exists: a vetoed (or healed) owner-minimize cascade can leave the chain out
+    /// of sync. USER32 says the window is visible, WPF says Visible, yet the wrapper has taken
+    /// the WM_SHOWWINDOW hide at face value and dropped <c>CoreWebView2Controller.IsVisible</c>.
+    /// Chromium then stops producing frames: the page freezes on its last composed frame,
+    /// <c>document.hidden</c> sticks true, script and audio keep running — and because the window
+    /// never gets a real re-show, no event ever restores the state. Live signature (v6.9.0 ghost
+    /// report, 2026-08-31 log): the feed window frozen on the intro card from the moment main was
+    /// minimized, remote fetches and XP still ticking behind it, ghost diag healthy
+    /// (visible=true iconic=false cloaked=0).</para>
+    ///
+    /// <para>Two levers, belt and braces. First set the controller's IsVisible directly — the
+    /// WPF control does not expose the controller, so this goes through reflection and is allowed
+    /// to miss on a future SDK. Then bounce the ELEMENT's Visibility through a real
+    /// Hidden→Visible transition so the wrapper itself re-pushes visibility into the controller,
+    /// whichever direction it was stuck in. The bounce is synchronous (no frame is pumped between
+    /// the two sets) and a no-op visually.</para>
+    ///
+    /// <para>Only kicks a window that is meant to be visible: a deliberate <c>Hide()</c> (tray)
+    /// or a genuinely hidden native window is left alone.</para></summary>
+    public void KickRenderVisibility(string reason)
+    {
+        try
+        {
+            if (_disposed || _window == null || _web == null) return;
+            if (!_window.Dispatcher.CheckAccess())
+            {
+                try { _window.Dispatcher.BeginInvoke(new Action(() => KickRenderVisibility(reason))); } catch { }
+                return;
+            }
+            if (_window.Visibility != Visibility.Visible) return;   // hidden on purpose (tray)
+            var hwnd = new WindowInteropHelper(_window).Handle;
+            if (hwnd == IntPtr.Zero || !IsWindowVisible(hwnd)) return; // a real hide is not ours to undo
+
+            bool? controllerWas = null;
+            try
+            {
+                var t = _web.GetType();
+                object? ctrl = t.GetProperty("CoreWebView2Controller",
+                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Public)?.GetValue(_web)
+                    ?? t.GetField("_coreWebView2Controller",
+                        System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)?.GetValue(_web);
+                if (ctrl is Microsoft.Web.WebView2.Core.CoreWebView2Controller c)
+                {
+                    controllerWas = c.IsVisible;
+                    c.IsVisible = true;
+                }
+            }
+            catch { /* SDK internals moved — the element bounce below still re-drives the wrapper */ }
+
+            bool elementWas = _web.IsVisible;
+            _web.Visibility = Visibility.Hidden;
+            _web.Visibility = Visibility.Visible;
+
+            // Information on purpose: Serilog's floor is Information (App.xaml.cs), and this line
+            // in an activity log is what turns the next frozen-feed report into a diagnosis —
+            // controller=False here is the wedge caught red-handed.
+            App.Logger?.Information(
+                "{Tag}: render visibility kicked ({Reason}; controller={Ctrl}, element={El})",
+                _opts.LogTag, reason, controllerWas?.ToString() ?? "n/a", elementWas);
+        }
+        catch (Exception ex) { App.Logger?.Debug("{Tag}.KickRenderVisibility: {E}", _opts.LogTag, ex.Message); }
     }
 
     /// <summary>Unhook the state listener and clear the native owner before the window closes, so

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -163,6 +163,18 @@ internal static class FypHostService
     {
         try
         {
+            // A page (re)init while ghosted means the page rebooted under the mirror (a
+            // navigation or renderer recreation). The fresh page comes up at the intro card with
+            // clickThrough deliberately reset (main.js: "never sticky across a reload") while the
+            // host still holds a parked window and a live mirror — which would mirror an intro
+            // card no mouse can ever reach. Give the window back instead; the user re-dives and
+            // re-ghosts from a surface that works.
+            if (_ghosted)
+            {
+                App.Logger?.Information("FypHostService: page re-init while ghosted - leaving ghost mode");
+                ExitGhost();
+            }
+
             var s = App.Settings?.Current;
             _meta ??= new FypMetaStore();
             _host?.Post(new
@@ -803,6 +815,15 @@ internal static class FypHostService
             // through Show Desktop live (2026-08-04).
             _host?.SuspendMainWindowGlue(true);
 
+            // The park keeps DWM composing the window — but the mirror also needs CHROMIUM to
+            // keep producing frames, and it may already have stopped before ghost was ever
+            // asked for: minimizing MAIN while the feed is glued to it can wedge the WebView2
+            // controller invisible even though the window stays on screen (the v6.9.0 report —
+            // the mirror faithfully showed a frame frozen minutes earlier, the intro card,
+            // while fetches and audio ran on behind it). Re-assert the render chain now, so the
+            // mirror starts from a window that is actually drawing.
+            _host?.KickRenderVisibility("ghost enter");
+
             // Show Desktop / Win+D also minimizes every restorable top-level window — the
             // parked source included. Veto SC_MINIMIZE while ghosted (the window is off-screen,
             // minimizing it means nothing), veto the owner-cascade hide, and if a minimize or a
@@ -910,6 +931,10 @@ internal static class FypHostService
         // Window is back on-screen: give it its owner link (and its z-order slot) back.
         try { _host?.SuspendMainWindowGlue(false); }
         catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost glue resume: {E}", ex.Message); }
+        // If the render chain wedged while parked, the restored window would sit frozen on
+        // screen exactly the way the mirror was — same repair on the way out as on the way in.
+        try { _host?.KickRenderVisibility("ghost exit"); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost kick: {E}", ex.Message); }
         _ghostWasMaximized = false;
         _lastGhostExitUtc = DateTime.UtcNow;
         try { _host?.Post(new { type = "clickThrough", on = false }); }
@@ -964,6 +989,10 @@ internal static class FypHostService
                 ShowWindow(hwnd, SW_SHOWNA);
                 App.Logger?.Information("FypHostService: parked window was natively hidden — re-shown");
             }
+            // Whether the hide landed or was vetoed, the WebView2 controller may have taken it
+            // at face value and stopped producing frames — the one freeze the diag tick cannot
+            // see (visible/iconic/cloaked all stay healthy). Re-drive it.
+            _host?.KickRenderVisibility("ghost visibility heal");
             _ghost?.RefreshThumbnail();
         }
         catch (Exception ex) { App.Logger?.Debug("FypHost: ghost visibility heal failed: {E}", ex.Message); }


### PR DESCRIPTION
## The regression (v6.9.0 install test)

Starting Ghost mode over a running FYP feed showed a semi-opaque rectangle with the **intro card** (logo, DIVE IN) and no media; Esc to exit.

## Root cause - with the log as witness

The page behind the mirror was **alive the entire time**. From `app-20260831.log`, during ghost #3 (18:58:27-18:58:55):

- `[FYP online] +30 entries from r/pokemon (fyp)` at 18:58:34 - remote fetches are `started`-gated (`main.js` `ensureRemoteBuffer`), so the feed was dived-in and cycling
- XP +5 awards ticking
- `FypGhost diag: visible=true iconic=false cloaked=0` healthy at 18:58:52, the screenshot moment

A live page cannot show the intro card (`showIntro()` only runs on a fresh boot; no reload or ProcessFailed appears anywhere in the log). Therefore **the DWM mirror was showing a stale frame** - the last frame Chromium ever composed, from before DIVE IN.

The wedge is born a few seconds earlier, both runs identically: the main window is minimized ~4s after FYP launch, while the intro is still up (BARK `win_minimize` 18:57:41 / 18:58:21). The feed window is owner-glued (`OwnedByMainWindow`), so the owner-minimize cascade sends it `WM_SHOWWINDOW`/`SW_PARENTCLOSING`. `ChaosWebViewHost.VetoCascadeHide` keeps USER32 from hiding the window - but the hide can still be taken at face value down the chain, leaving `CoreWebView2Controller.IsVisible` **false under a window that stays on screen**:

- Chromium stops producing frames -> everything (the on-screen window, and later the ghost mirror) freezes on the last composed frame = the intro card
- `document.hidden` sticks true -> the feed never mounts between DIVE IN and ghost (exactly the state PR #432's `setClickThrough` re-mount comment describes: "no visibility event left to undo it")
- script + audio keep running (the fetches, the XP)
- nothing ever flips it back, because the window never gets a real re-show

## About PR #432 - kept, not reverted

#432's changes are **correct and preserved**: the `document.hidden && !clickThrough` unmount guard and the `setClickThrough` re-mount repaired the DOM half (and are what made media *mount* during ghost here - the fetch at 18:58:34 is #432 working). The args-union (`ComposeBrowserArguments`) is behaviorally a no-op for FYP (both copies carried the same value) - verified, untouched. What #432 could not reach from page-side is **frame production**; that is host territory, and that is what this PR fixes.

## The fix (desktop-only; fyp is not web-synced)

- **`ChaosWebViewHost.KickRenderVisibility(reason)`** - re-asserts the render chain for a window that is meant to be composing: sets the controller's `IsVisible` directly (reflection, allowed to miss on a future SDK) then bounces the element's `Visibility` through a real Hidden->Visible transition so the wrapper re-pushes the state itself. Never wakes a deliberately hidden (tray) or genuinely hidden window. Logs at Information - `controller=False` in a user's activity log is the wedge caught red-handed.
- Kicked where the wedge is born: after a **vetoed owner-minimize cascade** and after a **healed cascade hide** (all glued hosts benefit - "minimize main empties the feed" was a known symptom).
- Kicked on the FYP ghost paths: **ghost enter** (heals a wedge that predates the ghost - the reported repro), **ghost visibility heal**, **ghost exit** (so the restored window is not frozen on screen).
- **`FypHostService.PostInit`**: a page (re)init while ghosted now exits ghost mode - a fresh page boots to the intro with `clickThrough` reset (never sticky across reload), and mirroring an unclickable intro card is a dead end.

## Verification

- Build: 0 errors.
- Tests: 4911/4913 - the 2 `EmiRingCardFitTests` failures reproduce on a pristine `b45c4ab80` worktree in this environment (font measurement, unrelated to this change).
- **NOT verified live**: the app is single-instance and was in use on the only machine that reproduces this (the wedge is per-machine - the 2026-08-04 probe of the same park/mirror/flags sailed through). The Information-level kick lines make the next run diagnostic either way: on the repro machine, ghost enter should log `render visibility kicked (ghost enter; controller=False, ...)` and the mirror should go live.

**DO NOT MERGE** - owner review + live play-test first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nBYprMrjbzo33b5E9mLUL
