### PR TITLE
[1/n] chore: remove five unreferenced NuGet packages

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -91,7 +91,6 @@
          dep carries the native lib. Privacy: identical to Vosk — audio stays on device, never sent. -->
     <PackageReference Include="org.k2fsa.sherpa.onnx" Version="1.13.3" />
     <PackageReference Include="org.k2fsa.sherpa.onnx.runtime.win-x64" Version="1.13.3" />
-    <PackageReference Include="OllamaSharp" Version="5.4.16" />
     
     <!-- Logging -->
     <PackageReference Include="Serilog" Version="3.1.1" />
@@ -111,13 +110,6 @@
     <!-- Embedded Browser -->
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2535.41" />
 
-    <!-- AI Service -->
-    <PackageReference Include="OpenAI-DotNet" Version="8.6.2" />
-    
-    <!-- SharpDX for Desktop Duplication API (DXGI) -->
-    <PackageReference Include="SharpDX" Version="4.2.0" />
-    <PackageReference Include="SharpDX.DXGI" Version="4.2.0" />
-    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.21">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
**8 lines deleted, 0 added.** First in a small numbered series — see "About this series" below.

## What

Removes five packages that nothing references:

| Package | Why it's dead |
|---|---|
| `SharpDX`, `SharpDX.DXGI`, `SharpDX.Direct3D11` | The csproj comment says "for Desktop Duplication API (DXGI)", but the actual screen capture in `Services/Compositor/BrainDrainCapturePump.cs` is plain GDI `GetDC` + `StretchBlt`. DXGI is never used. |
| `OpenAI-DotNet` | Every `OpenAI` hit in the tree is prose describing the OpenAI-**compatible** protocol — settings fields, dialog copy, doc comments. Not the package. |
| `OllamaSharp` | `Services/AIService/LocalAiService.cs:24` says it directly: dropped for hand-rolled HTTP because 5.4.16 returned 404. |

## Verification

Zero `using` statements and zero type references (`OpenAIClient`, `OllamaApiClient`, `SharpDX.*`)
across every `.cs` file. `dotnet build -c Release` succeeds with all five removed.

## About this series

I'm working on making the app cross-platform, and rather than propose that as one large change, I'm
sending it as a numbered series of small, independently reviewable PRs — target ≤600 added lines,
hard cap 1000, unlimited deletions.

The first four carry **no architectural commitment at all**: this cleanup, then three bug fixes to
code that already exists here. They stand on their own merits whatever you decide about the larger
work, so please feel free to take or leave them independently.

The next three are genuine security fixes, including one I'd rate as important:

- **[2/n]** a minor-protection bypass in `ModerationGuard` — ages 1, 3, 4, 5 and 7 are currently
  unmatchable, in English and every localised pattern
- **[3/n]** `UrlSafety` lets `240.0.0.0/4` and `255.255.255.255` through as public addresses
- **[4/n]** `LogScrubber` only redacts Windows-shaped home paths

Happy to reorder, split further, or drop any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHDSvq8cdF5R6z3czxt5M