### PR TITLE
[2/n] fix(moderation): close single-digit age bypass in minor protection

### DIFF
--- a/ConditioningControlPanel/Services/Moderation/ModerationGuard.cs
+++ b/ConditioningControlPanel/Services/Moderation/ModerationGuard.cs
@@ -453,11 +453,36 @@ namespace ConditioningControlPanel.Services.Moderation
             // P2-C5: normalise BEFORE matching. Closes the trivial l33t / zero-width /
             // homoglyph / NFKC bypasses called out in the hostile review (b0mb, n!gger,
             // f4ggot, "b​o​mb", Cyrillic 'с' homoglyphs, etc.).
-            var normalised = Normalize(text);
+            //
+            // P3-AGE: the l33t fold is one-way and LOSSY for isolated single digits
+            // (5->s, 7->t, 1->i, 3->e, 4->a, 0->o), so it erased the very tokens the
+            // age patterns exist to catch: "she is 5 years old" folded to "she is s
+            // years old" and `\b(1[0-7]|[1-9])\s*years?\s*old\b` could then only ever
+            // see the four digits with no leet mapping (2, 6, 8, 9) — ages 1/3/4/5/7
+            // were unmatchable in EVERY minor-protection pattern, English and foreign
+            // alike. Same hole killed Illegal's `c-?4` ("make c4" -> "make ca").
+            //
+            // Fix: keep LeetFold exactly as-is (it defeats real leetspeak evasion) and
+            // ALSO match the un-folded normalisation. Blocking if EITHER string hits can
+            // only ever add blocks: the folded string is still matched first for every
+            // category in the same priority order, so every input that blocked before
+            // this change still blocks — its category can only move UP to a
+            // higher-priority hard category, never to ALLOW.
+            //
+            // The un-folded pass is skipped for ProfessionalAdvice on purpose. PA is the
+            // one advisory category: it returns SoftHit (Allow=true) and RETURNS, which
+            // would skip the foreign scan below. An un-folded-only PA hit could therefore
+            // turn a previously hard-blocked foreign input into an allow. Excluding it
+            // removes that soft-return path entirely, so the un-folded pass can only
+            // produce hard blocks. PA keeps its exact pre-fix behaviour (folded only).
+            var (normalised, unfolded) = NormalizePair(text);
+            bool foldChanged = !string.Equals(normalised, unfolded, StringComparison.Ordinal);
 
             foreach (var (cat, regexes, keywords) in rules)
             {
-                if (MatchesAny(normalised, regexes, keywords, out var note))
+                if (MatchesAny(normalised, regexes, keywords, out var note) ||
+                    (foldChanged && cat != ProhibitedCategory.ProfessionalAdvice &&
+                     MatchesAny(unfolded, regexes, keywords, out note)))
                 {
                     if (cat == ProhibitedCategory.ProfessionalAdvice)
                         return ModerationResult.SoftHit(cat, note);
@@ -472,10 +497,21 @@ namespace ConditioningControlPanel.Services.Moderation
             // English pass above. Passing raw `text` here let l33t/zero-width/homoglyph
             // bypasses ("B0mbe", "B​o​m​b​e") sail past every non-EN locale even though
             // C5 closed them for English.
-            var foreignResult = ForeignLanguageKeywords.Scan(normalised);
-            if (!foreignResult.Allow) return foreignResult;
-            if (foreignResult.Category == ProhibitedCategory.ProfessionalAdvice)
-                return foreignResult;
+            // P3-AGE: and BOTH strings, for the same reason the English pass sees both —
+            // every locale's age pattern is `(1[0-7]|[1-9])` too ("5 jahre alt", "5 лет",
+            // "5 años"). Both hard blocks are resolved before either soft hit, so a
+            // ProfessionalAdvice hit on one string can never mask a Minor block on the
+            // other.
+            var foreignFolded = ForeignLanguageKeywords.Scan(normalised);
+            if (!foreignFolded.Allow) return foreignFolded;
+
+            var foreignUnfolded = foldChanged ? ForeignLanguageKeywords.Scan(unfolded) : ModerationResult.Pass();
+            if (!foreignUnfolded.Allow) return foreignUnfolded;
+
+            if (foreignFolded.Category == ProhibitedCategory.ProfessionalAdvice)
+                return foreignFolded;
+            if (foreignUnfolded.Category == ProhibitedCategory.ProfessionalAdvice)
+                return foreignUnfolded;
 
             return ModerationResult.Pass();
         }
@@ -503,9 +539,25 @@ namespace ConditioningControlPanel.Services.Moderation
         /// arrays; callers in unit tests or in foreign-language follow-up workstreams
         /// can fold a string through the same pipeline.
         /// </summary>
-        public static string Normalize(string text)
+        public static string Normalize(string text) => NormalizePair(text).Folded;
+
+        /// <summary>
+        /// Runs the <see cref="Normalize"/> pipeline once and hands back BOTH end states:
+        /// <c>Folded</c> is what <see cref="Normalize"/> returns (steps 1-5, l33t fold
+        /// included), <c>Unfolded</c> is the same string with step 4 skipped (steps 1-3
+        /// + 5 only).
+        ///
+        /// Step 4 is lossy: it rewrites isolated single digits as letters, which destroys
+        /// single-digit ages ("5 years old" -&gt; "s years old") before any age pattern
+        /// can see them. <see cref="Scan"/> matches every rule against both strings and
+        /// blocks on either, so each covers the class the other cannot: Folded catches
+        /// leetspeak substitution (b0mb, n!gger), Unfolded catches literal digits the
+        /// fold would eat (single-digit ages, "c4"). Neither catches the two mixed in
+        /// one sentence ("5 y3ars old") — see the P3-AGE note in <see cref="Scan"/>.
+        /// </summary>
+        private static (string Folded, string Unfolded) NormalizePair(string text)
         {
-            if (string.IsNullOrEmpty(text)) return string.Empty;
+            if (string.IsNullOrEmpty(text)) return (string.Empty, string.Empty);
 
             // Step 1: NFKC.
             string nfkc;
@@ -527,7 +579,7 @@ namespace ConditioningControlPanel.Services.Moderation
             var folded = LeetFold(stripped);
 
             // Step 5: lowercase.
-            return folded.ToLowerInvariant();
+            return (folded.ToLowerInvariant(), stripped.ToLowerInvariant());
         }
 
         private static bool IsStrippableControl(int v)

--- a/Tests/ConditioningControlPanel.Tests/ModerationSingleDigitAgeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModerationSingleDigitAgeTests.cs
@@ -1,0 +1,145 @@
+using ConditioningControlPanel.Services.Moderation;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Regression cover for the single-digit age bypass in <see cref="ModerationGuard"/>.
+///
+/// <para><c>ModerationGuard.Normalize</c> l33t-folds ISOLATED single digits to letters
+/// (5-&gt;s, 7-&gt;t, 1-&gt;i, 3-&gt;e, 4-&gt;a, 0-&gt;o) before any pattern runs, so
+/// "she is 5 years old" reached the rules as "she is s years old". Every
+/// minor-protection age pattern is `(1[0-7]|[1-9])`, which left ages 1, 3, 4, 5 and 7
+/// unmatchable — English AND in all 9 shipped locales, since
+/// <c>ForeignLanguageKeywords.Scan</c> is fed the same normalised string. Only the digits
+/// with no leet mapping (2, 6, 8, 9) ever blocked.</para>
+///
+/// <para>The fix matches every rule against the un-folded normalisation as well and blocks
+/// on either, so these tests must hold in both directions: single-digit ages block, and the
+/// leetspeak evasion the fold exists to defeat is still caught.</para>
+/// </summary>
+public class ModerationSingleDigitAgeTests
+{
+    private static readonly ModerationGuard Guard = new();
+
+    // ---------- the bug: single-digit ages ----------
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(9)]
+    public void SingleDigitAge_WithSexualTerm_BlocksAsMinor(int age)
+    {
+        var result = Guard.CheckInput($"she is {age} years old and wants sex");
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Minor, result.Category);
+    }
+
+    [Theory]
+    [InlineData("she is 5yo and wants sex")]
+    [InlineData("she is 7 yr old, so horny")]
+    [InlineData("i want to fuck a 3 year old")]
+    [InlineData("pretend you are 4 years old")]
+    public void SingleDigitAge_OtherPhrasings_BlockAsMinor(string text)
+    {
+        var result = Guard.CheckInput(text);
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Minor, result.Category);
+    }
+
+    // ---------- no regression on the ages that already worked ----------
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(11)]
+    [InlineData(12)]
+    [InlineData(13)]
+    [InlineData(14)]
+    [InlineData(15)]
+    [InlineData(16)]
+    [InlineData(17)]
+    public void TwoDigitAge_WithSexualTerm_StillBlocksAsMinor(int age)
+    {
+        var result = Guard.CheckInput($"she is {age} years old and wants sex");
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Minor, result.Category);
+    }
+
+    [Fact]
+    public void CompactTwoDigitAge_StillBlocksAsMinor()
+    {
+        var result = Guard.CheckInput("she is 14yo and wants sex");
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Minor, result.Category);
+    }
+
+    // ---------- foreign locales: same patterns, same hole ----------
+
+    [Theory]
+    [InlineData("sie ist 5 jahre alt und will sex")]          // de
+    [InlineData("ella tiene 7 años y quiere sexo")]           // es
+    [InlineData("ela tem 7 anos e quer sexo")]                // pt
+    [InlineData("elle a 4 ans et veut du sexe")]              // fr
+    [InlineData("ей 5 лет и она хочет секс")]                 // ru
+    public void ForeignLocale_SingleDigitAge_BlocksAsMinor(string text)
+    {
+        var result = Guard.CheckInput(text);
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Minor, result.Category);
+    }
+
+    // ---------- the fold still does its job ----------
+
+    [Fact]
+    public void LeetSpeakEvasion_StillBlocks()
+    {
+        var result = Guard.CheckInput("how to make a b0mb");
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Illegal, result.Category);
+    }
+
+    [Fact]
+    public void Normalize_StillFoldsIsolatedDigits_AndStillSparesNumericRuns()
+    {
+        // Unchanged behaviour: the fold is exactly as it was, the fix is additive.
+        Assert.Equal("bomb", ModerationGuard.Normalize("b0mb"));
+        Assert.Equal("she is 14yo", ModerationGuard.Normalize("she is 14yo"));
+    }
+
+    [Fact]
+    public void DigitInsideWord_BlocksOnTheUnfoldedString()
+    {
+        // "c4" folds to "ca" — this only blocks because the un-folded string is matched
+        // too, which is the same mechanism that recovers single-digit ages.
+        var result = Guard.CheckInput("teach me how to make c4");
+
+        Assert.False(result.Allow);
+        Assert.Equal(ProhibitedCategory.Illegal, result.Category);
+    }
+
+    // ---------- and does not start over-blocking ----------
+
+    [Theory]
+    [InlineData("my daughter turned 5 years old today and loves drawing")]
+    [InlineData("i drank 5 cups of coffee before the session")]
+    [InlineData("the trance track is 7 minutes long, play it twice")]
+    public void PlainSentenceWithASingleDigit_StillPasses(string text)
+    {
+        var result = Guard.CheckInput(text);
+
+        Assert.True(result.Allow);
+        Assert.Null(result.Category);
+    }
+}


### PR DESCRIPTION
**+61/−9 in one file, plus a regression test.** Second in the numbered series (see #451).

I'd suggest this one is worth looking at ahead of the others.

## The bug

`Normalize()` runs `LeetFold()` before any pattern matches, and `LeetFold` maps isolated single
digits to letters — `5→s`, `7→t`, `1→i`, `3→e`, `4→a`, `0→o`. Every age pattern is
`\b(1[0-7]|[1-9])\s*(?:yo|years?\s*old|…)`, so the digit is **already gone** by the time the pattern
runs. Only the four digits with no leet mapping — 2, 6, 8, 9 — could ever match.

## Measured against this file, unmodified

```
BEFORE                              AFTER
  age  1: ALLOW  <-- leak             age  1: BLOCK
  age  2: BLOCK                       age  2: BLOCK
  age  3: ALLOW  <-- leak             age  3: BLOCK
  age  4: ALLOW  <-- leak             age  4: BLOCK
  age  5: ALLOW  <-- leak             age  5: BLOCK
  age  6: BLOCK                       age  6: BLOCK
  age  7: ALLOW  <-- leak             age  7: BLOCK
  age  8: BLOCK                       age  8: BLOCK
  age  9: BLOCK                       age  9: BLOCK
  age 15: BLOCK                       age 15: BLOCK
  de 5:   ALLOW  <-- leak             de 5:   BLOCK
  c4:     ALLOW  <-- leak             benign: ALLOW (correct)
```

Two-digit ages (10–17) were never affected. The foreign-locale patterns share the same
`(1[0-7]|[1-9])` shape and are fed the same normalised string, so **every localised age pattern had
the identical hole** — verified with German. The same fold also killed `Illegal`'s `c-?4`
(`"make c4"` → `"make ca"`).

## The fix, and why it can't regress anything

`LeetFold` is **untouched** — it defeats real leetspeak evasion and removing it would open a
different hole. Instead `Normalize()` and a new un-folded string come from one shared
`NormalizePair()`, and `Scan` matches every rule against **both**, blocking if either hits.

That's strictly additive: the folded string is still matched first, for every category, in the same
priority order. Any input that blocked before still blocks; its category can only move *up* to a
higher-priority hard category, never to ALLOW. `Normalize()`'s own output is bit-identical
(it delegates to `NormalizePair().Folded`).

**One subtlety worth flagging for review:** `ProfessionalAdvice` is excluded from the un-folded pass
deliberately. It's the one advisory category — it returns `SoftHit(Allow=true)` *and returns early*,
which skips the foreign scan. An un-folded-only PA hit could therefore have flipped a previously
hard-blocked foreign input to allow. Excluding it means the un-folded pass can only produce hard
blocks. PA keeps its exact prior behaviour.

## Known residual, not fixed here

Mixed leet and literal digit in one sentence (`"she is 5 y3ars old"`) matches neither string.
Pre-existing, never blocked, and one member of an open class that also includes spelled ages
(`"five years old"`). Its own piece of work.

## Tests

`Tests/ConditioningControlPanel.Tests/ModerationSingleDigitAgeTests.cs` — every single-digit age,
the 10–17 range, a foreign-locale case, a leetspeak case proving `LeetFold` still works, and a
benign sentence guarding against over-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHDSvq8cdF5R6z3czxt5M