### PR TITLE
[3/n] fix(deeper): block reserved and broadcast IPv4 space in UrlSafety

### DIFF
--- a/ConditioningControlPanel/Services/Deeper/UrlSafety.cs
+++ b/ConditioningControlPanel/Services/Deeper/UrlSafety.cs
@@ -114,8 +114,12 @@ namespace ConditioningControlPanel.Services.Deeper
                 if (b[0] == 0) return true;
                 // 100.64.0.0/10 (CGNAT)
                 if (b[0] == 100 && (b[1] & 0xC0) == 64) return true;
-                // 224.0.0.0/4 multicast
-                if (b[0] >= 224 && b[0] <= 239) return true;
+                // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved (RFC 1112 class E), and
+                // 255.255.255.255 limited broadcast. The bound used to be `<= 239`, which
+                // covered multicast only and let 240.0.0.0/4 and the broadcast address
+                // through as "public" - reachable from EnhancementFetcher, which resolves
+                // user-supplied URLs. Everything from 224 up is non-routable here.
+                if (b[0] >= 224) return true;
                 return false;
             }
 

--- a/Tests/ConditioningControlPanel.Tests/UrlSafetyReservedRangeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/UrlSafetyReservedRangeTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using ConditioningControlPanel.Services.Deeper;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Boundary tests for <see cref="UrlSafety.IsPrivateOrReservedIp"/>.
+///
+/// The multicast guard used to read <c>b[0] &gt;= 224 &amp;&amp; b[0] &lt;= 239</c>, so 240.0.0.0/4
+/// (RFC 1112 class E) and 255.255.255.255 fell through as "public". That is reachable:
+/// EnhancementFetcher resolves user-supplied URLs through CreateGuardedHandler and
+/// IsSafePublicHttpsAsync, both of which gate on this method.
+/// </summary>
+public class UrlSafetyReservedRangeTests
+{
+    [Theory]
+    // The regression: reserved and broadcast space above the old 239 bound.
+    [InlineData("240.0.0.1")]
+    [InlineData("250.1.2.3")]
+    [InlineData("255.255.255.254")]
+    [InlineData("255.255.255.255")]
+    public void ReservedAndBroadcastSpace_IsRejected(string address)
+        => Assert.True(UrlSafety.IsPrivateOrReservedIp(IPAddress.Parse(address)));
+
+    [Theory]
+    // Ranges that were already rejected — proving the widened bound did not disturb them.
+    [InlineData("10.0.0.1")]
+    [InlineData("172.16.0.1")]
+    [InlineData("192.168.1.1")]
+    [InlineData("169.254.169.254")] // cloud metadata
+    [InlineData("127.0.0.1")]
+    [InlineData("0.0.0.0")]
+    [InlineData("100.64.0.1")]      // CGNAT
+    [InlineData("224.0.0.1")]       // multicast, low edge
+    [InlineData("239.255.255.255")] // multicast, high edge
+    public void PrivateAndMulticast_StillRejected(string address)
+        => Assert.True(UrlSafety.IsPrivateOrReservedIp(IPAddress.Parse(address)));
+
+    [Theory]
+    // Genuinely routable addresses must still pass, or the fetcher blocks everything.
+    [InlineData("8.8.8.8")]
+    [InlineData("1.1.1.1")]
+    [InlineData("93.184.216.34")]
+    [InlineData("223.255.255.255")] // last address below the multicast boundary
+    public void PublicAddresses_StillAllowed(string address)
+        => Assert.False(UrlSafety.IsPrivateOrReservedIp(IPAddress.Parse(address)));
+
+    [Fact]
+    public void IPv4MappedReservedAddress_IsRejectedThroughTheV6Path()
+        => Assert.True(UrlSafety.IsPrivateOrReservedIp(IPAddress.Parse("240.0.0.1").MapToIPv6()));
+
+    [Fact]
+    public void NullAddress_FailsClosed()
+        => Assert.True(UrlSafety.IsPrivateOrReservedIp(null!));
+}


### PR DESCRIPTION
**One-line range fix plus a boundary test.** Third in the numbered series (see #451).

## The gap

`UrlSafety.IsPrivateOrReservedIp` gated multicast as:

```csharp
if (b[0] >= 224 && b[0] <= 239) return true;
```

So **240.0.0.0/4** (RFC 1112 class E, reserved) and **255.255.255.255** (limited broadcast) returned
`false` — treated as ordinary public addresses.

**Reachable, not theoretical.** `Services/Deeper/EnhancementFetcher` resolves user-supplied
enhancement URLs through `UrlSafety.CreateGuardedHandler()` and `IsSafePublicHttpsAsync()`, both of
which gate on this method. The guarded handler exists precisely to collapse the DNS-rebind window,
so a hole in the range check defeats the reason it was written.

## Verified against the built assembly

| Address | Before | After |
|---|---|---|
| `240.0.0.1`, `250.1.2.3` | allowed | **blocked** |
| `255.255.255.254`, `255.255.255.255` | allowed | **blocked** |
| `10.0.0.1`, `169.254.169.254`, `127.0.0.1`, `100.64.0.1` | blocked | blocked |
| `224.0.0.1`, `239.255.255.255` | blocked | blocked |
| `8.8.8.8`, `1.1.1.1`, `223.255.255.255` | allowed | allowed |
| `::ffff:240.0.0.1` | allowed | **blocked** (inherits via the v4-mapped path) |

Strictly additive — it can only reject more, so it cannot break a URL that worked before unless that
URL pointed at reserved space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHDSvq8cdF5R6z3czxt5M