### PR TITLE
[4/n] fix(privacy): redact POSIX and macOS home paths in LogScrubber

### DIFF
--- a/ConditioningControlPanel/Services/LogScrubber.cs
+++ b/ConditioningControlPanel/Services/LogScrubber.cs
@@ -29,6 +29,19 @@ namespace ConditioningControlPanel.Services
             @"(?i)([A-Z]:[\\/])Users[\\/]([^\\/\r\n""']+)",
             RegexOptions.Compiled);
 
+        // /home/<name>/... and /Users/<name>/... — the POSIX and macOS home shapes.
+        //
+        // This class only knew the Windows shape while Core ran exclusively inside the WPF
+        // process, so on a Linux head the username went into crash.log verbatim. Found by
+        // actually executing Core on Linux (CCP.LinuxSmoke), not by any compile-time gate:
+        // a Windows path redacted correctly while "/home/alice/..." passed straight through.
+        //
+        // "root" is deliberately kept: it identifies no one and dropping it would obscure that
+        // the app ran elevated, which matters when reading a crash report.
+        private static readonly Regex PosixHomePathRegex = new(
+            @"(?i)(^|[\s""'(\[=:])(/home/|/Users/)(?!root(?:[/\s""')\]]|$))([^/\r\n""'\s]+)",
+            RegexOptions.Compiled);
+
         // Email addresses (RFC-ish — good enough for log scrubbing).
         private static readonly Regex EmailRegex = new(
             @"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b",
@@ -78,11 +91,18 @@ namespace ConditioningControlPanel.Services
 
             int paths = 0, emails = 0, tokens = 0, appdata = 0;
 
-            // 1. User paths (home folder → redacted).
+            // 1. User paths (home folder → redacted). Windows shape first, then POSIX/macOS,
+            //    so a report from any head redacts the username the same way.
             var step1 = UserPathRegex.Replace(input, m =>
             {
                 paths++;
                 return $"{m.Groups[1].Value}Users\\<redacted>";
+            });
+
+            step1 = PosixHomePathRegex.Replace(step1, m =>
+            {
+                paths++;
+                return $"{m.Groups[1].Value}{m.Groups[2].Value}<redacted>";
             });
 
             // 2. Email addresses.

--- a/ConditioningControlPanel/Services/LogScrubber.cs
+++ b/ConditioningControlPanel/Services/LogScrubber.cs
@@ -38,8 +38,16 @@ namespace ConditioningControlPanel.Services
         //
         // "root" is deliberately kept: it identifies no one and dropping it would obscure that
         // the app ran elevated, which matters when reading a crash report.
+        //
+        // The leading boundary is a zero-width lookbehind, not a captured group: a consumed
+        // delimiter belongs to one match and is then missing for the next, so the second half
+        // of "/home/alice,/home/bob" would leak. The name class stops short of trailing
+        // punctuation for the same reason, and the "root" guard mirrors that class so that
+        // "root," is still recognised as root. Case-sensitive on purpose — the real shapes are
+        // lowercase "/home/" and capital-U "/Users/"; a lowercase "/users/" is an HTTP route
+        // ("GET /users/alice HTTP/1.1"), not a home directory.
         private static readonly Regex PosixHomePathRegex = new(
-            @"(?i)(^|[\s""'(\[=:])(/home/|/Users/)(?!root(?:[/\s""')\]]|$))([^/\r\n""'\s]+)",
+            @"(?<=^|[\s""'(\[=:,;])(/home/|/Users/)(?!root(?![^/\r\n""'\s,;)\]]))([^/\r\n""'\s,;)\]]+)",
             RegexOptions.Compiled);
 
         // Email addresses (RFC-ish — good enough for log scrubbing).
@@ -102,7 +110,7 @@ namespace ConditioningControlPanel.Services
             step1 = PosixHomePathRegex.Replace(step1, m =>
             {
                 paths++;
-                return $"{m.Groups[1].Value}{m.Groups[2].Value}<redacted>";
+                return $"{m.Groups[1].Value}<redacted>";
             });
 
             // 2. Email addresses.

--- a/Tests/ConditioningControlPanel.Tests/LogScrubberPosixPathTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LogScrubberPosixPathTests.cs
@@ -1,0 +1,97 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The POSIX/macOS home-path rule in <see cref="LogScrubber"/>. A crash report filed from a
+/// non-Windows head used to carry "/home/&lt;name&gt;/..." through verbatim, so the rule was added
+/// alongside the Windows one — but a home-path regex is exactly the kind that over- and
+/// under-matches quietly, and a scrubber that misses one name in a report is a privacy bug that
+/// nobody notices until the report is already attached to an issue.
+///
+/// <para>These pin the three boundary behaviours the rule stands or falls on:</para>
+/// <list type="number">
+/// <item>the delimiter before a path is matched zero-width, so two paths separated by a single
+/// comma both redact instead of the first eating the second's boundary;</item>
+/// <item>trailing punctuation is not part of a username, so "/home/root," is still recognised
+/// as the deliberately preserved <c>root</c>;</item>
+/// <item>the match is case-sensitive, so a lowercase HTTP route ("GET /users/alice") is left
+/// alone rather than redacted and counted as a home directory.</item>
+/// </list>
+/// </summary>
+public class LogScrubberPosixPathTests
+{
+    [Fact]
+    public void PosixAndMacHomePaths_AreRedacted()
+    {
+        var (linux, linuxCounts) = LogScrubber.Scrub("crash while reading /home/alice/app/log.txt");
+        Assert.Equal("crash while reading /home/<redacted>/app/log.txt", linux);
+        Assert.Equal(1, linuxCounts.Paths);
+
+        var (mac, macCounts) = LogScrubber.Scrub("crash while reading /Users/alice/Library/Logs/x.log");
+        Assert.Equal("crash while reading /Users/<redacted>/Library/Logs/x.log", mac);
+        Assert.Equal(1, macCounts.Paths);
+    }
+
+    [Fact]
+    public void Root_IsPreserved_EvenBeforeTrailingPunctuation()
+    {
+        var (slash, slashCounts) = LogScrubber.Scrub("running from /home/root/app");
+        Assert.Equal("running from /home/root/app", slash);
+        Assert.Equal(0, slashCounts.Paths);
+
+        // The comma is not part of the name, so what precedes it is still plain "root".
+        var (comma, commaCounts) = LogScrubber.Scrub("ls /home/root, ok");
+        Assert.Equal("ls /home/root, ok", comma);
+        Assert.Equal(0, commaCounts.Paths);
+
+        // ...but a name that merely starts with "root" is a real user and is redacted.
+        var (rooter, rooterCounts) = LogScrubber.Scrub("home is /home/rooter/app");
+        Assert.Equal("home is /home/<redacted>/app", rooter);
+        Assert.Equal(1, rooterCounts.Paths);
+    }
+
+    [Fact]
+    public void ConsecutiveCommaSeparatedPaths_BothRedact()
+    {
+        var (scrubbed, counts) = LogScrubber.Scrub("scanned /home/alice,/home/bob");
+
+        Assert.Equal("scanned /home/<redacted>,/home/<redacted>", scrubbed);
+        Assert.Equal(2, counts.Paths);
+    }
+
+    [Fact]
+    public void LowercaseUsersRoute_IsNotAHomeDirectory()
+    {
+        var (route, routeCounts) = LogScrubber.Scrub("GET /users/alice HTTP/1.1");
+        Assert.Equal("GET /users/alice HTTP/1.1", route);
+        Assert.Equal(0, routeCounts.Paths);
+
+        var (url, urlCounts) = LogScrubber.Scrub("fetching https://cclabs.app/users/alice/profile");
+        Assert.Equal("fetching https://cclabs.app/users/alice/profile", url);
+        Assert.Equal(0, urlCounts.Paths);
+    }
+
+    [Fact]
+    public void WindowsPaths_AreUnaffectedByThePosixRule()
+    {
+        var (scrubbed, counts) = LogScrubber.Scrub(@"loading C:\Users\bob\AppData\Local\ConditioningControlPanel");
+
+        Assert.Equal(@"loading C:\Users\<redacted>\AppData\Local\ConditioningControlPanel", scrubbed);
+        // Redacted exactly once — the POSIX rule must not double-count the Windows shape.
+        Assert.Equal(1, counts.Paths);
+    }
+
+    [Fact]
+    public void MixedHeads_CountEveryRedactionOnce()
+    {
+        var (scrubbed, counts) = LogScrubber.Scrub(
+            @"C:\Users\bob\logs and /home/alice/logs and /Users/carol/logs and /home/root/logs");
+
+        Assert.Equal(
+            @"C:\Users\<redacted>\logs and /home/<redacted>/logs and /Users/<redacted>/logs and /home/root/logs",
+            scrubbed);
+        Assert.Equal(3, counts.Paths);
+    }
+}


### PR DESCRIPTION
**One regex plus one replace step.** Fourth in the numbered series (see #451), and the last that
carries no architectural commitment.

## The gap

`LogScrubber` strips the user's home folder out of bug reports and `crash.log`, but only knew the
Windows shape:

```csharp
// C:\Users\<name>\...  or  C:/Users/<name>/...
private static readonly Regex UserPathRegex = ...
```

So this happens:

```
windows: failed at C:\Users\<redacted>\AppData\Local\...   ← redacted
unix:    failed at /home/alice/.local/share/...            ← "alice" survives
```

Reachable on Windows today — a shared `.ccpenh.json`, a stack trace, or a log line quoting a POSIX
path from another machine goes into the report verbatim.

## The fix

Adds `/home/<name>/` and `/Users/<name>/` patterns, counted in the same `Paths` bucket so the
bug-report preview still shows the user an accurate redaction count.

**`root` is deliberately preserved.** It identifies nobody, and hiding it would obscure that the app
ran elevated — which is exactly what you want to know when reading a crash report.

## How it was found

By actually executing this class on Linux, where the Windows path redacted correctly and
`/home/alice/…` did not. Not visible in source review, and no compile-time check could have caught
it — the code is perfectly valid, it just knows one platform's path shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHDSvq8cdF5R6z3czxt5M