### PR TITLE
fix(explorer): keep the /select switch outside the quotes so reveal works on spaced paths

### DIFF
--- a/ConditioningControlPanel/Helpers/ExplorerLauncher.cs
+++ b/ConditioningControlPanel/Helpers/ExplorerLauncher.cs
@@ -8,16 +8,25 @@ namespace ConditioningControlPanel.Helpers
     /// Opens Windows Explorer on a file or folder.
     ///
     /// <para>Every "Reveal in Explorer" / "Open folder" button in the app used to hand-roll
-    /// <c>Process.Start("explorer.exe", $"/select,\"{path}\"")</c>. Building the command line as a
-    /// single pre-quoted string is fragile: the embedded quotes are re-parsed by the CRT before
-    /// explorer ever sees them, and on a mismatch explorer silently falls back to opening the
-    /// default folder (the desktop) instead of reporting an error - so the button looked like it
-    /// did nothing useful (ccp-bugs #998, media on D: while the app runs from C:).</para>
+    /// <c>Process.Start("explorer.exe", $"/select,\"{path}\"")</c>, and on a mismatch explorer
+    /// silently falls back to opening a default folder instead of reporting an error - so the
+    /// button looked like it did nothing useful (ccp-bugs #998, media on D: while the app runs
+    /// from C:).</para>
     ///
-    /// <para><see cref="ProcessStartInfo.ArgumentList"/> hands the argument over as a single
-    /// pre-tokenized element and lets the runtime apply the correct Windows quoting rules, so
-    /// spaces and non-ASCII characters survive intact. It requires
-    /// <c>UseShellExecute = false</c>, which is fine - explorer.exe is a plain executable.</para>
+    /// <para>The #998 fix handed <c>/select,&lt;path&gt;</c> to
+    /// <see cref="ProcessStartInfo.ArgumentList"/> as a single token so the runtime would apply the
+    /// correct Windows quoting rules. It does - and that is exactly the bug. ArgumentList wraps a
+    /// token in double quotes when it contains whitespace, and it wraps the WHOLE token, so a path
+    /// with spaces came out as <c>explorer.exe "/select,D:\Conditioning Control Panel\..."</c> with
+    /// the switch trapped inside the quotes. Explorer reads that as one nonsense location and falls
+    /// back to Documents. Paths without spaces are never quoted, which is why the button kept
+    /// working for most people and on the dev's machine, and why #998 looked fixed (ccp-bugs
+    /// #1108).</para>
+    ///
+    /// <para>So the command line is built by hand: the switch stays OUTSIDE the quotes and only the
+    /// path is quoted, which is the syntax explorer actually expects. Windows filenames cannot
+    /// contain a double quote, so a path carrying one is rejected rather than escaped - escaping it
+    /// could only ever build a command line that points somewhere else.</para>
     /// </summary>
     public static class ExplorerLauncher
     {
@@ -34,13 +43,15 @@ namespace ConditioningControlPanel.Helpers
             {
                 if (File.Exists(path))
                 {
-                    // One argument, not two: explorer expects the switch and the path glued by the
-                    // comma. ArgumentList quotes the whole token for us.
-                    return Launch($"/select,{Path.GetFullPath(path)}");
+                    var arguments = BuildRevealArguments(Path.GetFullPath(path));
+                    return arguments != null && Launch(arguments);
                 }
 
                 if (Directory.Exists(path))
-                    return Launch(Path.GetFullPath(path));
+                {
+                    var arguments = BuildFolderArguments(Path.GetFullPath(path));
+                    return arguments != null && Launch(arguments);
+                }
 
                 // File is gone (deleted / drive detached) - settle for its folder.
                 return OpenFolder(Path.GetDirectoryName(path));
@@ -67,7 +78,9 @@ namespace ConditioningControlPanel.Helpers
                     App.Logger?.Debug("ExplorerLauncher: folder no longer exists: {Dir}", directory);
                     return false;
                 }
-                return Launch(Path.GetFullPath(directory));
+
+                var arguments = BuildFolderArguments(Path.GetFullPath(directory));
+                return arguments != null && Launch(arguments);
             }
             catch (Exception ex)
             {
@@ -76,24 +89,63 @@ namespace ConditioningControlPanel.Helpers
             }
         }
 
-        private static bool Launch(string argument)
+        /// <summary>
+        /// Command line that opens Explorer on <paramref name="fullPath"/>'s folder with the file
+        /// selected. Null if the path cannot be expressed safely on a command line.
+        /// </summary>
+        internal static string? BuildRevealArguments(string fullPath)
+        {
+            if (!IsQuotable(fullPath)) return null;
+            // The switch must stay outside the quotes: explorer parses `/select,` off the front and
+            // treats the rest as the target. Quoting the pair together is what broke #1108.
+            return $"/select,\"{fullPath}\"";
+        }
+
+        /// <summary>
+        /// Command line that opens Explorer on the folder <paramref name="fullPath"/>. Null if the
+        /// path cannot be expressed safely on a command line.
+        /// </summary>
+        internal static string? BuildFolderArguments(string fullPath)
+        {
+            if (!IsQuotable(fullPath)) return null;
+            // No switch here, so the quotes are only there for the spaces.
+            return $"\"{fullPath}\"";
+        }
+
+        /// <summary>
+        /// A double quote cannot appear in a Windows path, so one showing up means the string is
+        /// not a path we can hand to explorer without changing where it points.
+        /// </summary>
+        private static bool IsQuotable(string fullPath)
+        {
+            if (string.IsNullOrWhiteSpace(fullPath)) return false;
+            if (fullPath.IndexOf('"') >= 0)
+            {
+                App.Logger?.Warning("ExplorerLauncher: refusing path containing a quote: {Path}", fullPath);
+                return false;
+            }
+            return true;
+        }
+
+        private static bool Launch(string arguments)
         {
             try
             {
                 var psi = new ProcessStartInfo
                 {
                     FileName = "explorer.exe",
-                    // ArgumentList needs UseShellExecute = false; it is the whole point of this helper.
+                    // Pre-built command line, so Arguments rather than ArgumentList - see the class
+                    // remarks. UseShellExecute = false keeps the string we built verbatim.
+                    Arguments = arguments,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };
-                psi.ArgumentList.Add(argument);
                 Process.Start(psi);
                 return true;
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "ExplorerLauncher: explorer.exe failed to start for {Arg}", argument);
+                App.Logger?.Warning(ex, "ExplorerLauncher: explorer.exe failed to start for {Args}", arguments);
                 return false;
             }
         }

--- a/ConditioningControlPanel/Windows/MediaHistoryWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/MediaHistoryWindow.xaml.cs
@@ -178,7 +178,7 @@ namespace ConditioningControlPanel
             StopPreview();
             PreviewHint.Visibility = Visibility.Collapsed;
             PreviewName.Text = row.DisplayName;
-            PreviewPath.Text = row.Entry.FilePath;
+            PreviewPath.Text = DisplayPath(row.Entry.FilePath);
 
             bool exists = row.FileExists;
             BtnPreviewOpenFolder.IsEnabled = exists;
@@ -314,6 +314,17 @@ namespace ConditioningControlPanel
         {
             // Helper handles the missing-file fallback to the containing folder (#998).
             Helpers.ExplorerLauncher.RevealInExplorer(path);
+        }
+
+        /// <summary>
+        /// Paths reach the log from a mix of sources, so a stored path can carry forward slashes
+        /// from whichever one wrote it and read back as "D:/Assets/images\personal\x.gif" (#1108).
+        /// Display only - the stored path is left alone.
+        /// </summary>
+        private static string DisplayPath(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return path;
+            return path.Replace('/', '\\');
         }
 
         // ---- Chrome -------------------------------------------------------

--- a/Tests/ConditioningControlPanel.Tests/ExplorerRevealArgumentTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ExplorerRevealArgumentTests.cs
@@ -1,0 +1,77 @@
+using ConditioningControlPanel.Helpers;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// ccp-bugs #1108: "open in folder" in the media log opened Documents instead of the file's
+/// folder, for everyone keeping assets in a path with spaces (D:\Conditioning Control Panel\...).
+///
+/// The #998 fix passed "/select,&lt;path&gt;" to ProcessStartInfo.ArgumentList as one token so the
+/// runtime would quote it correctly. It did: ArgumentList wraps any token containing whitespace in
+/// double quotes, and it wraps the whole token, so the command line became
+/// explorer.exe "/select,D:\Conditioning Control Panel\..." with the switch INSIDE the quotes.
+/// Explorer cannot parse that and falls back to its default folder (Documents on Windows 11)
+/// without raising an error. A path with no spaces is never quoted, so it kept working for most
+/// people and on the dev's machine, which is why #998 looked fixed.
+///
+/// These lock the shape of the command line: the switch outside the quotes, the path inside.
+/// </summary>
+public class ExplorerRevealArgumentTests
+{
+    [Fact]
+    public void SpacedPath_KeepsTheSwitchOutsideTheQuotes()
+    {
+        var args = ExplorerLauncher.BuildRevealArguments(@"D:\Conditioning Control Panel\images\personal\file.gif");
+
+        Assert.Equal(@"/select,""D:\Conditioning Control Panel\images\personal\file.gif""", args);
+        // The exact regression: the whole token quoted as one unit.
+        Assert.DoesNotContain(@"""/select", args);
+        Assert.StartsWith("/select,\"", args);
+    }
+
+    [Fact]
+    public void UnspacedPath_IsQuotedToo_SoBothCasesTakeOneCodePath()
+    {
+        var args = ExplorerLauncher.BuildRevealArguments(@"D:\CCP\images\file.gif");
+
+        // Quoting a path that does not need it is harmless, and it means the spaced path is not a
+        // special case that only some machines ever exercise.
+        Assert.Equal(@"/select,""D:\CCP\images\file.gif""", args);
+    }
+
+    [Fact]
+    public void UncPath_SurvivesIntact()
+    {
+        var args = ExplorerLauncher.BuildRevealArguments(@"\\media-nas\Shared Assets\images\file.gif");
+
+        Assert.Equal(@"/select,""\\media-nas\Shared Assets\images\file.gif""", args);
+    }
+
+    [Fact]
+    public void FolderArguments_QuoteThePathAndCarryNoSwitch()
+    {
+        Assert.Equal(@"""D:\Conditioning Control Panel\images""",
+            ExplorerLauncher.BuildFolderArguments(@"D:\Conditioning Control Panel\images"));
+        Assert.Equal(@"""\\media-nas\Shared Assets""",
+            ExplorerLauncher.BuildFolderArguments(@"\\media-nas\Shared Assets"));
+    }
+
+    [Theory]
+    [InlineData("D:\\weird\"path\\file.gif")]
+    [InlineData("\"")]
+    public void PathContainingAQuote_IsRefused(string path)
+    {
+        // Windows filenames cannot hold a double quote, so this is not a real path - and escaping
+        // it could only ever produce a command line pointing somewhere other than intended.
+        Assert.Null(ExplorerLauncher.BuildRevealArguments(path));
+        Assert.Null(ExplorerLauncher.BuildFolderArguments(path));
+    }
+
+    [Fact]
+    public void EmptyPath_IsRefused()
+    {
+        Assert.Null(ExplorerLauncher.BuildRevealArguments(""));
+        Assert.Null(ExplorerLauncher.BuildFolderArguments("   "));
+    }
+}


### PR DESCRIPTION
Fixes the media log's "open in folder" / reveal-in-Explorer button opening `C:\Users\<user>\Documents` instead of the file's folder (ccp-bugs #1108, reported by luzy, corroborated by Wobberjockey). Both reporters keep assets on another drive in a folder with spaces.

## Root cause

`ExplorerLauncher` built `/select,<path>` as a single token and handed it to `ProcessStartInfo.ArgumentList`, on the theory that the runtime would apply the correct Windows quoting rules. It does, and that is exactly the bug: `ArgumentList` wraps a token in double quotes when it contains whitespace, and it wraps the **whole** token. So a path with spaces produced

```
explorer.exe "/select,D:\Conditioning Control Panel\images\personal\file.gif"
```

with the switch trapped **inside** the quotes. Explorer reads that as one nonsense location and silently falls back to its default folder (Documents on Windows 11) rather than reporting an error.

A path with no spaces is never quoted, so it came out as `/select,D:\CCP\images\file.gif` and worked. That is why the button kept working for most people and on the dev's machine, and why the earlier fix (#998) looked correct. The old code comment, "ArgumentList quotes the whole token for us", documents the exact mistake.

Confirmed empirically with an echo-args harness that prints `GetCommandLineW()`:

| form | resulting command line |
|---|---|
| `ArgumentList`, spaced | `"/select,D:\Conditioning Control Panel\..."` (broken) |
| `ArgumentList`, unspaced | `/select,D:\CCP\images\file.gif` (works) |
| `Arguments`, spaced | `/select,"D:\Conditioning Control Panel\..."` (works) |

## Fix

- Build the command line by hand so the switch stays **outside** the quotes and only the path is quoted, which is the syntax explorer expects. `Launch` now sets `psi.Arguments` instead of `psi.ArgumentList`.
- Factor the string building into internal `BuildRevealArguments` / `BuildFolderArguments` so it is testable without launching Explorer.
- Refuse a path containing a double quote rather than escaping it. Windows filenames cannot hold one, so escaping could only ever aim the command line somewhere other than intended.
- Rewrite the class remarks to explain *why* the switch must stay outside the quotes, so the next person does not re-introduce `ArgumentList`.
- Cosmetic: normalise separators in the media log's preview path for display, which is where luzy's screenshot's `D:/Conditioning Control Panel/images\personal\...` mix came from. Display only, the stored path is untouched.

Callers are unchanged: the public `RevealInExplorer` / `OpenFolder` signatures and the missing-file fallback behaviour are the same, so all 8 call sites (media log, DtRH, Loom, tutorial, Deeper editor, session complete, assets tab) get the fix for free.

## How tested

- **Reproduced the bug against real Explorer.** Created `C:\wt-691-explorer\scratch\Folder With Spaces\test file.txt` and launched the shipped `ArgumentList` form from a harness. Enumerated open Explorer windows via `Shell.Application`: `file:///C:/Users/PC/Documents  |  Documents`. Exactly the reported symptom.
- **Confirmed the fix against real Explorer.** Same file, hand-built form: `file:///C:/wt-691-explorer/scratch/Folder%20With%20Spaces  |  Folder With Spaces`, with the file selected.
- **Proved the syntax by hand:** `cmd /c 'explorer.exe /select,"C:\...\Folder With Spaces\test file.txt"'` opens the right folder. (`explorer.exe` always returns exit code 1; that is normal and the code does not check it.)
- **7 new unit tests**, all passing: spaced path, unspaced path, UNC path, folder-only arguments, quote-bearing path refused (x2), empty path refused. The spaced-path test asserts `DoesNotContain("\"/select")`, which is the regression itself.
- `dotnet build ConditioningControlPanel.csproj` clean (exit 0, only CA1416 platform noise).

## Not covered

- Not tested on a genuine second physical drive or a real UNC share; the spaced-path reproduction was on `C:`, which exercises the same quoting path since the failure is command-line parsing, not drive handling.
- Three unrelated `Process.Start("explorer.exe", path)` folder-open call sites remain (`MainWindow.Assets.cs:47`, `MainWindow.UiUpdates.cs:2392`, `SessionFileService.cs:305`). Those pass a bare unquoted path, which explorer parses fine because it takes the whole tail as the target, so they are not affected by this bug. Left alone to keep the hotfix diff tight; they could be routed through `ExplorerLauncher.OpenFolder` later for the never-throws guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
