### PR TITLE
fix(descent): "Not tonight" defers the migration ceremony for the session (#1111)

### DIFF
--- a/ConditioningControlPanel/Services/Descent/DescentMigrationService.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentMigrationService.cs
@@ -27,13 +27,15 @@ namespace ConditioningControlPanel.Services.Descent
         private bool _ceremonyOpen;
         private int _offerHold;
         private bool _muteLogged;
+        private bool _deferredThisSession;
+        private bool _deferralLogged;
 
         /// <summary>
         /// THE DEV MUTE. Set <c>CCP_DESCENT_CEREMONY=off</c> to stop the ceremony painting.
         ///
-        /// <para>The ceremony is deliberately NOT dismissible: "Not tonight" defers it, and
-        /// <see cref="OfferReceived"/> is called again on every sync that still carries
-        /// <c>descent_migration.required</c>, so it returns on the next launch and the one after.
+        /// <para>The ceremony is deliberately NOT dismissible: "Not tonight" defers it for the
+        /// session only, and the server keeps sending <c>descent_migration.required</c> until a
+        /// choice lands, so it returns on the next launch and the one after.
         /// That is right for the single account-lifetime event this is, and it makes a tree you
         /// launch twenty times an afternoon unusable - the only ways out are committing a door you
         /// did not mean to commit, or closing the same fullscreen window on every run.</para>
@@ -90,15 +92,51 @@ namespace ConditioningControlPanel.Services.Descent
         internal int OfferHoldDepth { get { lock (_gate) return _offerHold; } }
 
         /// <summary>
+        /// TRUE once the subject has closed the ceremony this process without committing — "Not
+        /// tonight", the window chrome's X, or the panic key. Per-process and never persisted, so
+        /// the next launch is offered the ceremony exactly as designed. Test seam.
+        /// </summary>
+        internal bool DeferredThisSession { get { lock (_gate) return _deferredThisSession; } }
+
+        /// <summary>
         /// Whether an offer could open the ceremony RIGHT NOW: one is in hand, none is on screen,
-        /// and nothing is holding it back. Read by <see cref="ReleaseOffers"/> to decide whether a
-        /// release has anything to replay, and by the tests — the hold's whole behaviour is this
-        /// one predicate, and a state machine that can only be observed through a window opening is
-        /// a state machine nobody can test.
+        /// nothing is holding it back, and it has not already been closed once this session. Read by
+        /// <see cref="ReleaseOffers"/> to decide whether a release has anything to replay, and by
+        /// the tests — the hold's whole behaviour is this one predicate, and a state machine that
+        /// can only be observed through a window opening is a state machine nobody can test.
         /// </summary>
         internal bool CanOpenCeremony()
         {
-            lock (_gate) return !_ceremonyOpen && _offerHold == 0 && _liveOffer != null;
+            lock (_gate)
+                return ShouldOpenCeremonyFor(_liveOffer is not null, _ceremonyOpen, _offerHold, _deferredThisSession);
+        }
+
+        /// <summary>
+        /// The open decision, as arithmetic — every input passed in, the way
+        /// <see cref="SpiralWithheldFor"/> takes its own, so the deferral can be pinned in a test
+        /// without an <c>Application</c>, a dispatcher or a window that cannot be constructed
+        /// headless.
+        ///
+        /// <para><b>The bug this fourth input closes (#1111).</b> The sync heartbeat runs every 120
+        /// seconds and every response still carries <c>descent_migration.required</c> — by design,
+        /// since the server keeps offering until a choice actually lands. Before this,
+        /// <see cref="OfferReceived"/> guarded on nothing but "a window is already up", so "Not
+        /// tonight" bought the subject about two minutes before the fullscreen ceremony came back,
+        /// over and over, and the app was unusable until they rolled back.</para>
+        ///
+        /// <para><b>Why it is not persisted, and must never be.</b> The ceremony is a single
+        /// account-lifetime question and the answer is worth asking for. A per-process flag defers
+        /// it for tonight and nothing further: the next launch takes the same offer off the same
+        /// sync and opens the same window. Persisting it would turn a deferral into a dismissal and
+        /// leave veterans permanently mid-migration, which is the failure mode on the other side of
+        /// this one.</para>
+        /// </summary>
+        internal static bool ShouldOpenCeremonyFor(bool offerInHand, bool ceremonyOpen, int offerHold, bool deferredThisSession)
+        {
+            if (!offerInHand) return false;
+            if (ceremonyOpen) return false;
+            if (offerHold > 0) return false;
+            return !deferredThisSession;
         }
 
         /// <summary>The offer the live ceremony is running against, or null.</summary>
@@ -203,16 +241,41 @@ namespace ConditioningControlPanel.Services.Descent
         /// <summary>
         /// The server has offered the ceremony. Open it — once — on the UI thread.
         /// ProfileSyncService has already ruled out "already migrated" and "a choice is already
-        /// pending"; this method only has to avoid opening a second window over the first.
+        /// pending"; this method has to avoid opening a second window over the first, and (#1111)
+        /// avoid re-opening one the subject already closed tonight.
         /// </summary>
         public void OfferReceived(DescentMigrationOffer offer)
         {
             if (offer is null) return;
 
+            bool deferred;
+            bool logLoudly;
             lock (_gate)
             {
                 if (_ceremonyOpen) return;
+
+                // THE OFFER IS TAKEN EVEN WHEN IT WILL NOT OPEN. _liveOffer is the withhold's input
+                // (see SpiralWithheldFor) and it is never cleared, which is what keeps the spiral
+                // surfaces dark for the rest of a deferred session. Refreshing it here is free and
+                // keeps the deferral path and the open path reading the same object.
                 _liveOffer = offer;
+
+                deferred = _deferredThisSession;
+                logLoudly = deferred && !_deferralLogged;
+                if (logLoudly) _deferralLogged = true;
+            }
+
+            if (deferred)
+            {
+                // Loud once so support can find it in a user's log, quiet after: the sync heartbeat
+                // is 120 seconds, so an Information line every time would be thirty an hour saying
+                // the same thing. Same shape as the dev mute's _muteLogged above.
+                if (logLoudly)
+                    Log.Information("[Descent] The migration offer is still standing, but the ceremony was closed " +
+                                    "this session — it will not re-open until the next launch.");
+                else
+                    Log.Debug("[Descent] Migration offer re-sent; still deferred for this session.");
+                return;
             }
 
             // REMEMBER THAT THE QUESTION WAS ASKED, before anything opens. This is what withholds
@@ -312,6 +375,14 @@ namespace ConditioningControlPanel.Services.Descent
                         Log.Debug("[Descent] Ceremony offer held behind a fullscreen show — it will open when the hold lifts.");
                         return;
                     }
+                    // DEFERRED, re-checked at the last possible moment. OfferReceived already turns
+                    // these away, but this call can also arrive as a dispatcher BeginInvoke queued
+                    // before the close landed — the flag has to win on that path too.
+                    if (_deferredThisSession)
+                    {
+                        Log.Debug("[Descent] Ceremony open skipped — closed once already this session.");
+                        return;
+                    }
                     offer = _liveOffer;
                     if (offer is null) return;
                     _ceremonyOpen = true;
@@ -319,11 +390,7 @@ namespace ConditioningControlPanel.Services.Descent
 
                 // Flat namespace — see the trap note at the top of DescentCeremonyWindow.xaml.cs.
                 var window = new DescentCeremonyWindow(offer);
-                window.Closed += (_, _) =>
-                {
-                    lock (_gate) _ceremonyOpen = false;
-                    RaiseCeremonyClosed();
-                };
+                window.Closed += (_, _) => OnCeremonyWindowClosed();
 
                 var main = Application.Current?.MainWindow;
                 if (main != null && main.IsLoaded) window.Owner = main;
@@ -341,10 +408,15 @@ namespace ConditioningControlPanel.Services.Descent
         }
 
         /// <summary>
-        /// Announce the close, with whether a choice was actually taken. Isolated from the caller
-        /// so a subscriber that throws cannot leave the ceremony's own guard half-reset.
+        /// The ceremony window's Closed handler. Reads "was a choice actually taken" off the
+        /// settings — the window's own <c>_committed</c> is private, and the settings are the thing
+        /// that is really true — then hands the answer to <see cref="NoteCeremonyClosed"/>.
+        ///
+        /// <para>Settings that cannot be read count as NOT committed, which is the safe way round
+        /// on both sides: nothing irreversible is inferred, and the worst case is one deferral for a
+        /// session where the ledger was unreadable anyway.</para>
         /// </summary>
-        private void RaiseCeremonyClosed()
+        private void OnCeremonyWindowClosed()
         {
             bool committed;
             try
@@ -355,6 +427,39 @@ namespace ConditioningControlPanel.Services.Descent
                              DescentMigrationChoices.IsValid(s.PendingDescentMigrationChoice));
             }
             catch { committed = false; }
+
+            NoteCeremonyClosed(committed);
+        }
+
+        /// <summary>
+        /// The close, as a state transition: drop the open guard, arm the session deferral if the
+        /// window left without a commit, and announce it. Isolated from the caller so a subscriber
+        /// that throws cannot leave the ceremony's own guard half-reset — and internal rather than
+        /// private so the deferral can be tested without a window, which is not constructible in a
+        /// headless test.
+        ///
+        /// <para><b>Every uncommitted close counts, the panic key's included.</b>
+        /// <c>DescentCeremonyWindow.ForceCloseAll</c> arrives here through the same Closed handler
+        /// as "Not tonight", and that is deliberate: somebody who hit the panic key wants the
+        /// fullscreen window gone, not back in two minutes. It cannot swallow the ceremony for good
+        /// because the flag is per-process — the next launch is offered it again by the same
+        /// sync.</para>
+        ///
+        /// <para><b>What does NOT count.</b> Only an actual close reaches this. A ceremony suppressed
+        /// by the dev mute or parked behind <see cref="HoldOffers"/> never opened and never closed,
+        /// so it never defers — a held offer still replays on release, exactly as before.</para>
+        /// </summary>
+        internal void NoteCeremonyClosed(bool committed)
+        {
+            lock (_gate)
+            {
+                _ceremonyOpen = false;
+                if (!committed) _deferredThisSession = true;
+            }
+
+            if (!committed)
+                Log.Information("[Descent] Ceremony closed without a choice — deferred for the rest of this session. " +
+                                "The server will offer it again on the next launch.");
 
             try { CeremonyClosed?.Invoke(this, committed); }
             catch (Exception ex) { Log.Debug("[Descent] A CeremonyClosed handler threw: {Error}", ex.Message); }

--- a/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs
@@ -239,7 +239,10 @@ namespace ConditioningControlPanel
 
         private void OnLater(object sender, RoutedEventArgs e)
         {
-            Log.Information("[Descent] Ceremony deferred by the user — nothing written, the server will re-offer.");
+            // Nothing is written here on purpose. The service's Closed handler is what arms the
+            // session deferral (#1111) — it has to, because the chrome's X and the panic key close
+            // this window without ever reaching "Not tonight".
+            Log.Information("[Descent] Ceremony deferred by the user — nothing written, the server will re-offer on the next launch.");
             Close();
         }
 

--- a/Tests/ConditioningControlPanel.Tests/DescentSpiralWithholdTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentSpiralWithholdTests.cs
@@ -192,4 +192,36 @@ public class DescentSpiralWithholdTests
         Assert.NotNull(service.LiveOffer);
         Assert.True(DescentMigrationService.SpiralWithheldFor(Fresh(), offerInHand: service.LiveOffer is not null, ceremonyOpen: false));
     }
+
+    /// <summary>
+    /// THE #1111 LATCH IS NOT A WITHHOLD INPUT, and must never become one. The per-session deferral
+    /// added in v6.9.1 stops the ceremony RE-OPENING every 120-second heartbeat after "Not tonight";
+    /// it says nothing about whether the question has been answered, and the spiral is still owed
+    /// nobody until it has. So the offer stays in <c>LiveOffer</c> across the close, the withhold
+    /// still reads true off it, and the arithmetic below is byte-identical to the case above.
+    ///
+    /// <para>The failure this pins is the tempting one: "they closed it, so let them have the
+    /// spiral". That would pay out the reveal for dismissing the question instead of answering it,
+    /// and it would do so on a flag that exists purely to stop a window re-painting.</para>
+    /// </summary>
+    [Fact]
+    public void ADeferredCeremony_StillWithholdsTheSpiral()
+    {
+        var service = new DescentMigrationService();
+        service.HoldOffers();
+        service.OfferReceived(new DescentMigrationOffer { TotalXpEarned = 120_000, DevotionDays = 240 });
+
+        service.NoteCeremonyClosed(committed: false);
+
+        Assert.True(service.DeferredThisSession);
+        Assert.NotNull(service.LiveOffer);      // the withhold's input survives the close
+
+        var s = Fresh();
+        s.DescentMigrationOffered = true;
+        Assert.True(DescentMigrationService.SpiralWithheldFor(s, offerInHand: service.LiveOffer is not null, ceremonyOpen: false));
+
+        // ...and committing is still the only thing that opens it, deferral latched or not.
+        s.PendingDescentMigrationChoice = DescentMigrationChoices.Restore;
+        Assert.False(DescentMigrationService.SpiralWithheldFor(s, offerInHand: true, ceremonyOpen: false));
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
@@ -109,6 +109,172 @@ public class DescentZeroShowOrderingTests
         Assert.False(service.CanOpenCeremony());
     }
 
+    // ------------------------------------------------- the same-session deferral (#1111)
+
+    /// <summary>
+    /// THE BUG v6.9.0 SHIPPED. The sync heartbeat is 120 seconds and every response still carries
+    /// <c>descent_migration.required</c> — by design, because the server keeps offering until a
+    /// choice actually lands. With nothing but the "a window is already up" guard in front of it,
+    /// "Not tonight" bought about two minutes before the fullscreen ceremony came back, and back,
+    /// and back; #1111 (RopePunny, Michaela) both rolled back to 6.8.6 over it.
+    ///
+    /// <para>The whole fix is the fourth input to the open predicate, so that is what this pins:
+    /// an uncommitted close latches, and every re-offer after it is a no-op.</para>
+    /// </summary>
+    [Fact]
+    public void AnUncommittedClose_StopsTheHeartbeatReopeningTheCeremony()
+    {
+        var service = new DescentMigrationService();
+        service.HoldOffers();               // keeps the open path off a dispatcher that is not there
+
+        service.OfferReceived(AnOffer());
+        Assert.False(service.DeferredThisSession);
+
+        // "Not tonight" — the window leaves with nothing written.
+        service.NoteCeremonyClosed(committed: false);
+
+        Assert.True(service.DeferredThisSession);
+        Assert.False(service.IsCeremonyOpen);
+
+        // The next four heartbeats. Each one re-sends the same standing offer and each one is
+        // turned away — this is the loop, and this is it not happening.
+        for (var i = 0; i < 4; i++) service.OfferReceived(AnOffer());
+
+        Assert.False(service.IsCeremonyOpen);
+        Assert.False(service.CanOpenCeremony());
+    }
+
+    /// <summary>
+    /// THE DEFERRAL DOES NOT COST THE WITHHOLD. <c>_liveOffer</c> is never cleared, so the spiral
+    /// surfaces stay dark for the rest of a deferred session exactly as they did before — the
+    /// documented intent, and the thing a fix that "cancelled" the offer instead would have broken.
+    /// </summary>
+    [Fact]
+    public void ADeferredSession_StillHoldsTheOfferAndTheWithhold()
+    {
+        var service = new DescentMigrationService();
+        service.HoldOffers();
+
+        service.OfferReceived(AnOffer());
+        service.NoteCeremonyClosed(committed: false);
+        service.OfferReceived(AnOffer());
+
+        Assert.NotNull(service.LiveOffer);
+        Assert.Equal(240, service.LiveOffer!.DevotionDays);
+        Assert.True(DescentMigrationService.SpiralWithheldFor(
+            new ConditioningControlPanel.Models.AppSettings { DescentMigrationOffered = true },
+            offerInHand: service.LiveOffer is not null, ceremonyOpen: false));
+    }
+
+    /// <summary>
+    /// THE SECOND DOOR INTO THE SAME LOOP. <see cref="DescentMigrationService.ReleaseOffers"/>
+    /// re-opens the moment <c>CanOpenCeremony</c> passes, so a deferral enforced only inside
+    /// <c>OfferReceived</c> would still be walked straight through by a catch-up show that ends
+    /// after the subject closed the ceremony. The latch lives in the predicate for exactly this.
+    /// </summary>
+    [Fact]
+    public void AHoldReleaseCycleAfterADeferral_DoesNotReopen()
+    {
+        var service = new DescentMigrationService();
+        service.HoldOffers();
+        service.OfferReceived(AnOffer());
+        service.NoteCeremonyClosed(committed: false);
+
+        // A fullscreen show comes and goes on top of the deferred session.
+        service.HoldOffers();
+        Assert.False(service.CanOpenCeremony());
+        service.ReleaseOffers();
+
+        Assert.False(service.CanOpenCeremony());
+        Assert.False(service.IsCeremonyOpen);
+
+        // ...and the original hold lifting is not a way back in either.
+        service.ReleaseOffers();
+        Assert.Equal(0, service.OfferHoldDepth);
+        Assert.False(service.CanOpenCeremony());
+    }
+
+    /// <summary>
+    /// A COMMITTED CLOSE IS NOT A DEFERRAL. It does not need to be — the server stops sending
+    /// <c>required</c> once the choice lands, and ProfileSyncService turns the re-send away on the
+    /// pending choice long before this — but latching on a commit would be a lie in the state, and
+    /// the flag is read by the predicate that decides whether anything can ever open again.
+    /// </summary>
+    [Fact]
+    public void ACommittedClose_DoesNotDefer()
+    {
+        var service = new DescentMigrationService();
+        service.HoldOffers();
+        service.OfferReceived(AnOffer());
+
+        service.NoteCeremonyClosed(committed: true);
+
+        Assert.False(service.DeferredThisSession);
+        Assert.False(service.IsCeremonyOpen);
+
+        service.ReleaseOffers();
+        Assert.True(service.CanOpenCeremony());
+    }
+
+    /// <summary>
+    /// A CEREMONY THAT NEVER PAINTED NEVER DEFERRED. A held offer — the catch-up crack's ordering
+    /// guarantee, and the same shape as a run muted with <c>CCP_DESCENT_CEREMONY=off</c> — opens no
+    /// window and closes none, so nothing latches and the release replays it exactly as it always
+    /// did. The latch is armed by a user closing something, never by a sync.
+    /// </summary>
+    [Fact]
+    public void AHeldOfferThatNeverOpened_IsNotADeferral()
+    {
+        var service = new DescentMigrationService();
+        service.HoldOffers();
+
+        service.OfferReceived(AnOffer());
+        service.OfferReceived(AnOffer());   // and again, the way the heartbeat does
+
+        Assert.False(service.DeferredThisSession);
+
+        service.ReleaseOffers();
+        Assert.True(service.CanOpenCeremony());
+    }
+
+    /// <summary>
+    /// THE CLOSE EVENT IS UNCHANGED. <c>CeremonyClosed</c> still carries "was it committed" to the
+    /// Year One ignition on every exit path — the deferral latch is set beside the raise, not
+    /// instead of it, so a subscriber added for the fuse still hears both halves.
+    /// </summary>
+    [Fact]
+    public void TheCloseEvent_StillFiresWithTheCommittedFlag()
+    {
+        var service = new DescentMigrationService();
+        var heard = new System.Collections.Generic.List<bool>();
+        service.CeremonyClosed += (_, committed) => heard.Add(committed);
+
+        service.NoteCeremonyClosed(committed: false);
+        service.NoteCeremonyClosed(committed: true);
+
+        Assert.Equal(new[] { false, true }, heard);
+    }
+
+    /// <summary>
+    /// THE OPEN PREDICATE, as arithmetic. Four inputs, and every one of them is a veto — the same
+    /// shape as <c>SpiralWithheldFor</c>, and testable without a dispatcher for the same reason.
+    /// </summary>
+    [Fact]
+    public void TheOpenPredicate_VetoesOnEveryInput()
+    {
+        Assert.True(DescentMigrationService.ShouldOpenCeremonyFor(
+            offerInHand: true, ceremonyOpen: false, offerHold: 0, deferredThisSession: false));
+
+        Assert.False(DescentMigrationService.ShouldOpenCeremonyFor(
+            offerInHand: false, ceremonyOpen: false, offerHold: 0, deferredThisSession: false));
+        Assert.False(DescentMigrationService.ShouldOpenCeremonyFor(
+            offerInHand: true, ceremonyOpen: true, offerHold: 0, deferredThisSession: false));
+        Assert.False(DescentMigrationService.ShouldOpenCeremonyFor(
+            offerInHand: true, ceremonyOpen: false, offerHold: 1, deferredThisSession: false));
+        Assert.False(DescentMigrationService.ShouldOpenCeremonyFor(
+            offerInHand: true, ceremonyOpen: false, offerHold: 0, deferredThisSession: true));
+    }
+
     // ------------------------------------------------------------ the heartbeat
 
     /// <summary>


### PR DESCRIPTION
Hotfix for ccp-bugs #1111 (RopePunny, also Michaela; both rolled back to 6.8.6).

## Root cause

`ProfileSyncService` heartbeats every 120s, and every sync response still carries
`descent_migration.required == true` - by design, because the server keeps offering
until a choice actually lands. `HandleDescentMigrationOffer` has three reasons not to
open (block not required, `DescentMigrationCompleted`, a valid `PendingDescentMigrationChoice`);
a deferral is none of those, so it called `DescentMigrationService.OfferReceived` on every
sync. `OfferReceived` guarded only on `if (_ceremonyOpen) return;` and re-opened the window.

So "Not tonight" bought about two minutes before the fullscreen ceremony came back, over
and over. Combined with the high-DPI door clipping (fixed separately, not touched here),
the app was unusable.

**The distinction that matters:** the ceremony is *intentionally* non-dismissible across
LAUNCHES, and this PR preserves that exactly. What it stops is the same-session reopen on
the 120-second heartbeat. The file's own comment already stated that intent - `_liveOffer`
is never cleared "so this stays true across a 'Not tonight' deferral for the rest of the
session" - the guard to match it was simply missing.

## Fix

- New `_deferredThisSession` / `_deferralLogged` fields, read and written under the existing
  `_gate` alongside `_ceremonyOpen` / `_offerHold` (the latch is a mutable instance bool set
  from the window's Closed handler on the UI thread and read from a background sync
  continuation, so unlike the static env-read dev mute it cannot sit outside the lock).
- `ShouldOpenCeremonyFor(offerInHand, ceremonyOpen, offerHold, deferredThisSession)` - a pure
  static in the same shape as `SpiralWithheldFor`, so the decision is testable without an
  `Application`, a dispatcher or a window. `CanOpenCeremony()` is now a lock around it, which
  means **`ReleaseOffers` respects the latch too**: enforcing the deferral only inside
  `OfferReceived` would have left a hold/release cycle as a second door into the same loop.
- The window's `Closed` handler now calls `OnCeremonyWindowClosed()` -> `NoteCeremonyClosed(committed)`.
  `committed` is the same value `RaiseCeremonyClosed` already computed off the settings; the
  latch is armed only on the `committed == false` path, beside the unchanged `CeremonyClosed`
  raise. `NoteCeremonyClosed` is `internal` so tests can drive a close without constructing a
  window (not possible headless).
- A last-moment re-check inside `OpenCeremonyWindow`'s lock, for a dispatcher `BeginInvoke`
  queued before the close landed.

### Decisions worth calling out

- **The panic key counts as a deferral.** `DescentCeremonyWindow.ForceCloseAll` reaches the
  same Closed handler as "Not tonight". Somebody who hit panic wants the fullscreen window
  gone, not back in two minutes. It cannot swallow the ceremony for good because the latch is
  per-process. Documented in a comment on `NoteCeremonyClosed`.
- **Never persisted.** Persisting would turn a deferral into a dismissal and leave veterans
  permanently mid-migration - the failure mode on the other side of this one.
- **`_liveOffer` is deliberately not cleared**, and the deferral is *not* implemented by leaving
  `_offerHold` raised (that is depth-counted and paired with the show director's handler). The
  spiral stays withheld for the rest of a deferred session exactly as before.
- **A ceremony that never painted never defers.** A held offer or a run muted with
  `CCP_DESCENT_CEREMONY=off` opens no window and closes none, so the release still replays it.
- **Logging:** Information once per session, Debug thereafter (same `_muteLogged` shape as the
  dev mute), so support can find it in a user log without thirty identical lines an hour. The
  close itself also logs at Information.

## How tested

`dotnet build` clean (0 errors) and the **full suite green: 4952 passed, 0 failed**.

Extended the two existing files rather than adding new ones:

`DescentZeroShowOrderingTests.cs` (7 new)
- `AnUncommittedClose_StopsTheHeartbeatReopeningTheCeremony` - the bug itself: offer, close
  uncommitted, four more heartbeats, nothing reopens.
- `AHoldReleaseCycleAfterADeferral_DoesNotReopen` - the `ReleaseOffers` door.
- `ACommittedClose_DoesNotDefer` / `AHeldOfferThatNeverOpened_IsNotADeferral`.
- `ADeferredSession_StillHoldsTheOfferAndTheWithhold`.
- `TheCloseEvent_StillFiresWithTheCommittedFlag` - the `CeremonyClosed` contract is unchanged.
- `TheOpenPredicate_VetoesOnEveryInput` - the pure static.

`DescentSpiralWithholdTests.cs` (1 new)
- `ADeferredCeremony_StillWithholdsTheSpiral` - the latch is not a withhold input, and
  committing is still the only thing that opens the gate. The existing
  `AnOfferReceived_LeavesTheWithholdsInputSet` still passes.

**Not verified:** no live run against a server actually sending `descent_migration.required`
(DESCENT_MIGRATION is armed in prod but this account is not a migration candidate), so the
end-to-end "close it, wait four minutes, it stays gone" is reasoned from the sync path rather
than observed. The window itself cannot be constructed headless, so the Closed-handler wiring
(`window.Closed += OnCeremonyWindowClosed`) is the one line covered by inspection only - the
state transition behind it is fully tested.

No XAML touched. `Windows/DescentCeremonyWindow.xaml.cs` has a two-line comment and one
corrected log string only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
