### PR TITLE
fix(video): Strict Lock survives OS media keys (Bluetooth play/pause)

### DIFF
--- a/ConditioningControlPanel/Resources/web/player/player.js
+++ b/ConditioningControlPanel/Resources/web/player/player.js
@@ -24,6 +24,12 @@
   const BG_RESYNC_GAP_MS = 4000;
   const BG_PLAY_RETRIES = 3;    // then give up on the backdrop (never on the clip)
 
+  // Unrequested-pause rule. One stray pause is an OS media key or a browser
+  // hiccup and is simply resumed; only a BURST of them means we are fighting the
+  // browser and will never win. See pauseLoopDetected.
+  const PAUSE_WINDOW_MS = 5000;
+  const PAUSE_WINDOW_MAX = 6;
+
   // Error codes 1-4 are MediaError.code verbatim (a real decode/network failure
   // => the file belongs in BrowserUnsafeVideoCache). 100+ are ours; only 100/101
   // mean "this file misbehaved", 102/103 are session-level.
@@ -101,11 +107,55 @@
     }
   }
 
+  // ---------- media-key guard (strict lock) ----------
+
+  // The focused WebView2 owns the OS media session, so a Bluetooth headset's
+  // play/pause tap (Sony WH-1000XM6 and friends) or a keyboard media key reaches
+  // the element through Chromium itself - it is already paused by the time our
+  // 'pause' listener runs, and under a strict lock nothing may interrupt the clip
+  // at all. Claiming every Media Session action with a no-op handler is the
+  // documented way to stop that: Chromium hands the action to the HANDLER instead
+  // of acting on the element, so the key becomes a no-op rather than a pause.
+  //
+  // Strict only. Outside the lock a pause is the user's business again, and the
+  // rolling pause rule below is enough on its own.
+  const MEDIA_KEY_ACTIONS = [
+    'play', 'pause', 'stop', 'seekbackward', 'seekforward', 'seekto',
+    'previoustrack', 'nexttrack',
+  ];
+
+  let mediaKeyGuardArmed = false;
+
+  function setMediaKeyGuard(on) {
+    const want = !!on;
+    if (mediaKeyGuardArmed === want) return;
+    if (!('mediaSession' in navigator) || !navigator.mediaSession
+        || typeof navigator.mediaSession.setActionHandler !== 'function') {
+      return; // older WebView2 runtime: the pause rule is the only lock we have
+    }
+    let claimed = 0;
+    MEDIA_KEY_ACTIONS.forEach((action) => {
+      try {
+        // A no-op function, never null: null hands the action straight back to
+        // Chromium, which is exactly the default we are here to suppress.
+        navigator.mediaSession.setActionHandler(action, want ? function () { } : null);
+        claimed++;
+      } catch (e) {
+        // This runtime does not know the action. The others still land, and every
+        // one of them is a separate key the headset can no longer press.
+      }
+    });
+    mediaKeyGuardArmed = want;
+    log('media-key guard ' + (want ? 'armed' : 'released')
+      + ' (' + claimed + '/' + MEDIA_KEY_ACTIONS.length + ' actions)');
+  }
+
   // ---------- teardown ----------
 
   /** Free both decoders NOW. Safe to call at any time, including with no session. */
   function teardown() {
     cur = null; // first, so the pause/error churn below reaches no handler
+    setMediaKeyGuard(false); // the lock belongs to the clip, not to the page
     clearAttention(); // targets belong to the clip that is going away
     stopTicker();
     lastTimeMs = -1;
@@ -239,6 +289,9 @@
     cur = {
       url: url,
       blur: !!d.blurBackground,
+      // Strict lock (Lock Card / Lockdown / Possession). The host stamps it on the
+      // load; absent means never strict, same default the C# side uses.
+      strict: !!d.strict,
       startAtMs: Number.isFinite(d.startAtMs) && d.startAtMs > 0 ? d.startAtMs : 0,
       startedAt: now,
       lastProgressAt: now,
@@ -248,6 +301,7 @@
       errored: false,
       hostPaused: false,
       unrequestedPauses: 0,
+      pauseStamps: [],
       startApplied: false,
       bgPlayFails: 0,
       bgResyncAt: 0,
@@ -255,6 +309,7 @@
     };
 
     document.body.classList.toggle('has-bg', cur.blur);
+    setMediaKeyGuard(cur.strict);
     applyVolume();
     applySink(d.sinkLabel);
 
@@ -433,9 +488,31 @@
     fail(code || ERR_BAD_LOAD, 'media error (' + name + ')' + detail);
   });
 
+  /**
+   * The rolling-window half of the anti-pause rule, kept pure so it can be
+   * reasoned about (and exercised) on its own.
+   *
+   * `stamps` is this load's list of unrequested-pause times and is TRIMMED IN
+   * PLACE: everything older than PAUSE_WINDOW_MS is dropped before the count is
+   * taken, so the list can never grow without bound over a long clip. Returns
+   * true only when the page should stop resuming and report ERR_PAUSE_LOOP.
+   *
+   * It used to be a per-load counter with no decay, and the SECOND unrequested
+   * pause anywhere in a clip was fatal - so two taps on a Bluetooth headset's
+   * play/pause, minutes apart, ended a Strict Lock video in v6.9.0. What the rule
+   * is actually guarding against is a browser that re-pauses us as fast as we
+   * resume, which is a burst, not a total.
+   */
+  function pauseLoopDetected(stamps, now) {
+    stamps.push(now);
+    const cutoff = now - PAUSE_WINDOW_MS;
+    while (stamps.length && stamps[0] < cutoff) stamps.shift();
+    return stamps.length > PAUSE_WINDOW_MAX;
+  }
+
   // Anti-pause. There is no user-facing pause on a mandatory video, so a pause we
-  // did not ask for is an interruption: resume it once, and if it happens again
-  // in the same load report an error rather than fighting the browser forever.
+  // did not ask for is an interruption: resume it, and only give up once they are
+  // arriving faster than we can answer rather than fighting the browser forever.
   fg.addEventListener('pause', () => {
     if (!cur || cur.errored || cur.ended || cur.hostPaused) return;
     if (fg.ended || fg.error) return; // 'ended'/'error' own those transitions
@@ -444,13 +521,14 @@
     const dur = fg.duration;
     if (Number.isFinite(dur) && dur > 0 && (fg.currentTime || 0) >= dur - 0.5) return;
     cur.unrequestedPauses++;
-    if (cur.unrequestedPauses === 1) {
-      log('unrequested pause - resuming');
+    if (!pauseLoopDetected(cur.pauseStamps, performance.now())) {
+      log('unrequested pause #' + cur.unrequestedPauses + ' - resuming');
       playEl(fg, 'fg');
       if (cur.blur) playEl(bg, 'bg');
       return;
     }
-    fail(ERR_PAUSE_LOOP, 'playback paused ' + cur.unrequestedPauses + ' times without a request');
+    fail(ERR_PAUSE_LOOP, 'playback paused ' + cur.pauseStamps.length + ' times in '
+      + PAUSE_WINDOW_MS + 'ms without a request');
   });
 
   // ---------- backdrop media events (never fatal) ----------
@@ -821,6 +899,9 @@
       get durationMs() { return Number.isFinite(fg.duration) ? Math.round(fg.duration * 1000) : 0; },
       get blur() { return !!(cur && cur.blur); },
       get unrequestedPauses() { return cur ? cur.unrequestedPauses : 0; },
+      get strict() { return !!(cur && cur.strict); },
+      get mediaKeyGuard() { return mediaKeyGuardArmed; },
+      pauseLoopDetected: pauseLoopDetected,
       get attentionCount() { return attn.size; },
       get errored() { return !!(cur && cur.errored); },
     },

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -40,6 +40,14 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>Start position for the chaos random-segment mode. 0 = from the top.</summary>
         public long StartAtMs { get; init; }
 
+        /// <summary>
+        /// This clip runs under a strict lock, as a FIXED fact of the session rather than the live
+        /// probe <see cref="IsHostStrict"/> answers. It rides the page's <c>load</c> message, where
+        /// it arms the Media Session guard: a focused WebView2 owns the OS media session, so without
+        /// it a Bluetooth headset's play/pause tap pauses the element behind our backs.
+        /// </summary>
+        public bool Strict { get; init; }
+
         /// <summary>Runs on each window after construction and BEFORE Show() - the host's hook for
         /// strict handlers and anything that must be wired before the HWND is realized.</summary>
         public Action<Window, Screen, bool>? ConfigureBeforeShow { get; init; }
@@ -498,6 +506,10 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     blurBackground = req.BlurBackground,
                     hideCursor = req.HideCursor,
                     startAtMs = req.StartAtMs,
+                    // Arms the page's Media Session guard (player.js setMediaKeyGuard), which is what
+                    // stops an OS/Bluetooth media key from pausing a video the user must not be able
+                    // to stop. Every window carries it: a mirror is just as pausable as the primary.
+                    strict = req.Strict,
                     // Audio-output routing by device label (#938 plumbing). Null = leave the page on
                     // the Windows default; the page treats every failure the same way and reports it
                     // back as {type:'sink'}.

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -133,6 +133,10 @@ namespace ConditioningControlPanel.Services
                     // that swallows the cursor while the rest of the app still shows one reads as a
                     // frozen machine, and attention targets are clicked over this surface.
                     HideCursor = false,
+                    // The SAME flag SetupStrictHandlers is given below, not the live IsStrictActive
+                    // probe: the page wants one fixed answer at load time, and this is the value the
+                    // whole run is locked to.
+                    Strict = strict,
                     IsHostPaused = () => _gracePaused,
                     // Lock Card / Lockdown / Possession: every screen is covered on purpose, so a
                     // dead mirror is left black rather than uncovered mid-clip (the engine asks
@@ -328,23 +332,26 @@ namespace ConditioningControlPanel.Services
         /// video run, and the duck ref taken in PlayVideo is deliberately kept so CloseAll still
         /// balances it exactly once.
         ///
-        /// A failure AFTER playback genuinely started is NOT replayed: see the branch below.
+        /// A failure AFTER playback genuinely started is NOT replayed: see the branch below - unless
+        /// the clip is under a STRICT lock, where ending it would hand the user an exit and the same
+        /// clip is replayed through LibVLC instead.
         /// </summary>
-        private void FallbackToLibVlc(string reason)
+        private void FallbackToLibVlc(string reason, bool blameFile = false)
         {
-            // The two branches below are the pure policy in VideoSurfaceHealth.DecideBrowserFailure;
-            // this call site is the ONLY one that acts on it for the primary surface. (Secondary
-            // failures never reach here at all - the engine drops the mirror and keeps the session,
-            // which is DecideBrowserFailure's DropSecondary arm.)
+            // The branches below are the pure policy in VideoSurfaceHealth.DecideBrowserFailure; this
+            // call site is the ONLY one that acts on it for the primary surface. (Secondary failures
+            // never reach here at all - the engine drops the mirror and keeps the session, which is
+            // DecideBrowserFailure's DropSecondary arm.)
             var action = VideoSurfaceHealth.DecideBrowserFailure(
-                isPrimarySurface: true, alreadyFellBack: _browserFallbackDone, playbackStartedFired: _browserStartedFired);
+                isPrimarySurface: true, alreadyFellBack: _browserFallbackDone, playbackStartedFired: _browserStartedFired,
+                strictLock: _browserStrict, blamesFile: blameFile);
             if (action == VideoSurfaceHealth.BrowserFailureAction.Ignore) return;
             _browserFallbackDone = true;
 
             var path = _browserPath;
             var strict = _browserStrict;
 
-            // ---- mid-clip failure: end the run, never replay it ----
+            // ---- mid-clip failure, no strict lock: end the run, never replay it ----
             // VideoStarted has already gone out to seven subscribers; a replay would fire it a
             // second time and make the user rewatch the whole clip from 0 for a stall at the end.
             // The engine has already marked the file browser-unsafe when it blamed the file, so the
@@ -360,9 +367,20 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
-            App.Logger?.Warning("VideoService: browser playback failed for {File} ({Reason}) - replaying via LibVLC",
-                Path.GetFileName(path ?? "(none)"), reason);
-            VideoDiag.Log("VIDEO", $"browser FALLBACK ({reason}) - replaying {Path.GetFileName(path ?? "?")} via LibVLC");
+            if (_browserStartedFired)
+            {
+                // Only the strict arm reaches here mid-clip. Worth its own line: the user WILL see
+                // the clip restart, and this is the line that explains why the lock did not lift.
+                App.Logger?.Warning("VideoService: browser playback failed MID-CLIP for {File} ({Reason}) under a STRICT lock - replaying via LibVLC rather than releasing the lock",
+                    Path.GetFileName(path ?? "(none)"), reason);
+                VideoDiag.Log("VIDEO", $"browser MID-CLIP FAILURE ({reason}) under STRICT - replaying {Path.GetFileName(path ?? "?")} via LibVLC, the lock holds");
+            }
+            else
+            {
+                App.Logger?.Warning("VideoService: browser playback failed for {File} ({Reason}) - replaying via LibVLC",
+                    Path.GetFileName(path ?? "(none)"), reason);
+                VideoDiag.Log("VIDEO", $"browser FALLBACK ({reason}) - replaying {Path.GetFileName(path ?? "?")} via LibVLC");
+            }
 
             // Handing the clip back to LibVLC means the wedge ladder matters again. Re-arm it in
             // the pre-roll observation state BEFORE the handoff below - closing WebView2 HWNDs is
@@ -550,7 +568,10 @@ namespace ConditioningControlPanel.Services
             // Marked immediately (cheap, and the routing decision must not depend on the hop landing).
             if (blameFile && !string.IsNullOrEmpty(_browserPath))
                 BrowserUnsafeVideoCache.Add(_browserPath, reason);
-            PostAfterPageMessage(() => { if (_browserActive) FallbackToLibVlc(reason); });
+            // blameFile travels with the reason: mid-clip under a strict lock it is what tells a
+            // genuinely undecodable file (end the run) apart from a session-level fault such as the
+            // pause rule (102), which must never be a way out of the lock.
+            PostAfterPageMessage(() => { if (_browserActive) FallbackToLibVlc(reason, blameFile); });
         }
 
         private void OnBrowserClicked()

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -120,12 +120,25 @@ namespace ConditioningControlPanel.Services
         /// Policy for a browser-engine surface failure. A secondary is a mirror and is never allowed
         /// to end the run; the primary carries the audio and the session, so its pre-first-frame
         /// failure replays through LibVLC and its mid-clip failure ends the run.
+        ///
+        /// <para>The one exception is the STRICT lock, and it is a content-lock integrity rule rather
+        /// than a playback nicety. Ending a clip mid-run releases the lock, so under strict a page
+        /// failure that does NOT blame the file is a way OUT of a video the user is not allowed to
+        /// stop - which is exactly how two taps on a Bluetooth headset's play/pause ended a Strict
+        /// Lock video in v6.9.0: the page's pause rule reported 102, nothing blamed the file, and
+        /// EndClip let the user go. A non-file failure under the lock hands the SAME clip to LibVLC
+        /// instead, so the cover stays on screen and the session runs on. A failure that DOES blame
+        /// the file still ends the run: replaying a file that cannot decode would only trap the user
+        /// against a clip that can never finish.</para>
         /// </summary>
-        internal static BrowserFailureAction DecideBrowserFailure(bool isPrimarySurface, bool alreadyFellBack, bool playbackStartedFired)
+        internal static BrowserFailureAction DecideBrowserFailure(bool isPrimarySurface, bool alreadyFellBack, bool playbackStartedFired,
+            bool strictLock = false, bool blamesFile = false)
         {
             if (!isPrimarySurface) return BrowserFailureAction.DropSecondary;
             if (alreadyFellBack) return BrowserFailureAction.Ignore;
-            return playbackStartedFired ? BrowserFailureAction.EndClip : BrowserFailureAction.FallbackWholeClip;
+            if (!playbackStartedFired) return BrowserFailureAction.FallbackWholeClip;
+            if (strictLock && !blamesFile) return BrowserFailureAction.FallbackWholeClip;
+            return BrowserFailureAction.EndClip;
         }
 
         /// <summary>What one tick of the browser engine's per-surface first-frame sweep should do

--- a/Tests/ConditioningControlPanel.Tests/StrictMediaKeyLockTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/StrictMediaKeyLockTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using Xunit;
+using static ConditioningControlPanel.Services.VideoSurfaceHealth;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Strict Lock vs the OS media keys (v6.9.1).
+///
+/// <para>Reported against v6.9.0: a mandatory video under Strict Lock ended early when the user
+/// double-tapped the touchpad on a pair of Sony WH-1000XM6 headphones twice. Two OS media-key
+/// pauses anywhere in the clip were enough, on every video, and changing the Panic Key made no
+/// difference - because none of it went anywhere near the panic path.</para>
+///
+/// <para>The chain was: the focused WebView2 owns the OS media session, so Chromium pauses the
+/// element itself; player.js counted unrequested pauses per LOAD with no decay and the SECOND one
+/// reported ERR_PAUSE_LOOP (102); 102 correctly does not blame the file, so the engine raised a
+/// plain failure; and VideoService's mid-clip policy ENDS a run rather than replaying it - which
+/// released the lock. Three locks now sit in that chain, and all three are asserted here.</para>
+///
+/// <para>Only the WebView2 engine was ever affected. LibVLC is built with
+/// <c>--no-keyboard-events</c>/<c>--no-mouse-events</c> and registers no OS media session at all,
+/// so a media key has nothing to act on there.</para>
+/// </summary>
+public class StrictMediaKeyLockTests
+{
+    // ---- lock 3: a page failure under the lock must never end the run ----
+
+    [Fact]
+    public void StrictMidClipFailure_ThatDoesNotBlameTheFile_ReplaysInsteadOfEndingTheRun()
+    {
+        // This is error 102 exactly: mid-clip, session-level, file blameless. Ending here is what
+        // handed the user a way out of a video they must not be able to stop.
+        Assert.Equal(BrowserFailureAction.FallbackWholeClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: true,
+                strictLock: true, blamesFile: false));
+    }
+
+    [Fact]
+    public void StrictMidClipFailure_ThatBlamesTheFile_StillEndsTheRun()
+    {
+        // A file that genuinely cannot decode any further must not trap the user against a clip
+        // that can never finish, so the lock does not buy it a replay.
+        Assert.Equal(BrowserFailureAction.EndClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: true,
+                strictLock: true, blamesFile: true));
+    }
+
+    [Fact]
+    public void WithoutTheLock_MidClipFailure_KeepsTheOldEndBehaviour()
+    {
+        // Unchanged for every ordinary video: a replay would re-fire VideoStarted and make the user
+        // rewatch the whole clip from 0 for a stall at the end.
+        Assert.Equal(BrowserFailureAction.EndClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: true,
+                strictLock: false, blamesFile: false));
+        Assert.Equal(BrowserFailureAction.EndClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: true,
+                strictLock: false, blamesFile: true));
+    }
+
+    [Fact]
+    public void TheLockChangesNothingAboutTheOtherArms()
+    {
+        // Pre-first-frame already replayed; a mirror is still never allowed to end the run; and the
+        // one-replay-per-trigger latch still holds, so the strict arm cannot loop.
+        Assert.Equal(BrowserFailureAction.FallbackWholeClip,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: false, playbackStartedFired: false,
+                strictLock: true, blamesFile: false));
+        Assert.Equal(BrowserFailureAction.DropSecondary,
+            DecideBrowserFailure(isPrimarySurface: false, alreadyFellBack: false, playbackStartedFired: true,
+                strictLock: true, blamesFile: false));
+        Assert.Equal(BrowserFailureAction.Ignore,
+            DecideBrowserFailure(isPrimarySurface: true, alreadyFellBack: true, playbackStartedFired: true,
+                strictLock: true, blamesFile: false));
+    }
+
+    // ---- locks 1 + 2: the page halves ----
+    //
+    // player.js is plain JS with no test home in this repo, so its half of the contract is asserted
+    // against the product source the same way BrowserSinkLabelTests asserts the sink contract.
+
+    [Fact]
+    public void PlayerPage_ArmsTheMediaKeyGuardFromTheLoadMessage()
+    {
+        var js = ReadProduct("ConditioningControlPanel", "Resources", "web", "player", "player.js");
+
+        // The flag, read exactly as C# writes it, and the guard hung off it.
+        Assert.Contains("strict: !!d.strict", js);
+        Assert.Contains("setMediaKeyGuard(cur.strict)", js);
+        // Released on teardown, so a non-strict clip on the same page is not left locked.
+        Assert.Contains("setMediaKeyGuard(false)", js);
+
+        // Feature-detected, never assumed: an older WebView2 runtime must fall through to the pause
+        // rule rather than throw on the load path.
+        Assert.Contains("'mediaSession' in navigator", js);
+        Assert.Contains("setActionHandler", js);
+
+        // Every action a headset or keyboard can send. Each one is a separate key that would
+        // otherwise reach the element; nexttrack/previoustrack matter because a double-tap on an
+        // XM6 sends those rather than play/pause.
+        foreach (var action in new[]
+                 {
+                     "'play'", "'pause'", "'stop'", "'seekbackward'", "'seekforward'", "'seekto'",
+                     "'previoustrack'", "'nexttrack'",
+                 })
+            Assert.Contains(action, js);
+
+        // The handler must be a no-op FUNCTION when armed. Registering null would hand the action
+        // straight back to Chromium, which is the default this exists to suppress.
+        Assert.Contains("want ? function () { } : null", js);
+    }
+
+    [Fact]
+    public void PlayerPage_CountsUnrequestedPausesInARollingWindow()
+    {
+        var js = ReadProduct("ConditioningControlPanel", "Resources", "web", "player", "player.js");
+
+        // The rule and its tunables.
+        Assert.Contains("const PAUSE_WINDOW_MS = 5000;", js);
+        Assert.Contains("const PAUSE_WINDOW_MAX = 6;", js);
+        Assert.Contains("function pauseLoopDetected(stamps, now)", js);
+        // Trimmed in place, so a two-hour clip cannot accumulate stamps.
+        Assert.Contains("while (stamps.length && stamps[0] < cutoff) stamps.shift();", js);
+        Assert.Contains("return stamps.length > PAUSE_WINDOW_MAX;", js);
+
+        // The 1-strike rule is gone. This is the literal line that ended BambiBirdy's video.
+        Assert.DoesNotContain("cur.unrequestedPauses === 1", js);
+
+        // Resuming is still the default answer to an unrequested pause.
+        Assert.Contains("if (!pauseLoopDetected(cur.pauseStamps, performance.now()))", js);
+    }
+
+    [Fact]
+    public void Engine_PutsTheStrictFlagOnEveryLoad()
+    {
+        var cs = ReadProduct("ConditioningControlPanel", "Services", "Video", "Browser", "BrowserVideoEngine.cs");
+
+        // The load post carries the field player.js reads. It is NOT primary-gated: a mirror's
+        // WebView2 owns a media session too and is just as pausable.
+        Assert.Contains("strict = req.Strict,", cs);
+        Assert.Contains("public bool Strict { get; init; }", cs);
+    }
+
+    [Fact]
+    public void VideoService_FeedsTheEngineTheSameFlagStrictHandlersGet()
+    {
+        var cs = ReadProduct("ConditioningControlPanel", "Services", "Video", "VideoService.Browser.cs");
+
+        // The fixed session fact, not the live IsStrictActive probe (which blinks across a handoff).
+        Assert.Contains("Strict = strict,", cs);
+
+        // And blameFile has to reach the policy, or the mid-clip strict arm cannot tell 102 from a
+        // file that will not decode.
+        Assert.Contains("FallbackToLibVlc(reason, blameFile)", cs);
+        Assert.Contains("strictLock: _browserStrict, blamesFile: blameFile", cs);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string ReadProduct(params string[] parts)
+    {
+        var path = Path.Combine(RepoRoot(), Path.Combine(parts));
+        Assert.True(File.Exists(path), $"product source missing: {path}");
+        return File.ReadAllText(path);
+    }
+}


### PR DESCRIPTION
Hotfix for v6.9.1. Support ticket from BambiBirdy, owner acked: a mandatory video under **Strict Lock** could be ended early by double-tapping the touchpad on Sony WH-1000XM6 Bluetooth headphones twice. Reproducible on every video, and changing the Panic Key did nothing. Strict Lock is a promise, so this is a content-lock integrity hole rather than a playback annoyance.

## Root cause

Three separate things had to line up, and all three did:

1. **The page never saw the key coming.** The focused WebView2 owns the OS media session, so Chromium acts on the `<video>` element itself. By the time `player.js`'s `pause` listener ran, the element was already paused.
2. **The pause rule was a 1-strike counter with no decay.** `player.js` counted `cur.unrequestedPauses` per *load*; the first unrequested pause was resumed, the **second one anywhere in the clip** called `fail(ERR_PAUSE_LOOP /* 102 */)`. Two media-key taps, however far apart, were fatal.
3. **A 102 mid-clip released the lock.** 102 correctly does *not* blame the file (`BrowserVideoEngine.BlamesFile`), so `RaiseFailed(reason, blameFile: false)` -> `VideoService.OnBrowserFailed` -> `FallbackToLibVlc`. There, `VideoSurfaceHealth.DecideBrowserFailure` returns `EndClip` for any mid-clip primary failure (because a replay would re-fire `VideoStarted` and restart the clip from 0), and `EndClip` calls `OnEnded()` - the *normal* end funnel. The video ended and the lock lifted. That is exactly the reported behaviour: the clip just ends.

## Fix (defence in depth, all three links)

**1. Media Session guard, `player.js`.** While the host says the clip is strict, the page claims every action (`play`, `pause`, `stop`, `seekbackward`, `seekforward`, `seekto`, `previoustrack`, `nexttrack`) with a no-op `setActionHandler`, so Chromium hands the key to the handler instead of acting on the element. Feature-detected (`'mediaSession' in navigator`) and per-action try/catch, released to `null` on teardown so a non-strict clip on the same page is not left locked. The page learns the mode from a new `strict` field on the `load` message, fed from `BrowserVideoRequest.Strict` - the same flag `SetupStrictHandlers` gets, not the live `IsStrictActive` probe (which deliberately blinks across a handoff). Every window carries it: a mirror owns a media session too.

**2. Rolling pause rule, `player.js`.** The 1-strike counter is replaced by `pauseLoopDetected(stamps, now)`: keep resuming unrequested pauses, and only report 102 on **more than 6 within a rolling 5s window** - the "browser re-pauses us as fast as we resume" case the original comment was actually guarding. Stamps are trimmed in place, so a two-hour clip cannot accumulate them. Log lines kept (now numbered).

**3. The lock outranks the end funnel, C#.** `DecideBrowserFailure` takes `strictLock` and `blamesFile`. Under a strict lock, a mid-clip failure that does **not** blame the file now returns `FallbackWholeClip` - the same clip is replayed through LibVLC, which keeps the cover on screen and the session running, instead of `EndClip` releasing the user. A failure that **does** blame the file still ends the run, so an undecodable file cannot trap the user against a clip that can never finish. Non-strict behaviour is untouched.

## LibVLC path

**Not affected, and no change needed.** `_libVLC` is constructed with `--no-mouse-events --no-keyboard-events` (`VideoService.cs:811-812`), and libvlc registers no Windows media session, so a hardware media key has nothing to act on there. The WebView2 engine is the only path where the OS routes a media key into the player.

## How tested

- **`dotnet build`** clean (0 errors).
- **Full suite: 4952 passed, 0 failed**, including 8 new tests in `Tests/ConditioningControlPanel.Tests/StrictMediaKeyLockTests.cs` covering every arm of the new policy (strict + non-file mid-clip replays; strict + file-blaming still ends; non-strict unchanged; secondary/pre-first-frame/already-fell-back arms unchanged) plus the `player.js` contract (guard armed from the load flag, released on teardown, feature detection, all 8 actions, no-op function rather than `null`, the rolling-window constants, and that `cur.unrequestedPauses === 1` is gone).
- **`pauseLoopDetected` exercised for real.** There is no JS test home under `Resources/web`, so a throwaway node harness lifted the function out of the product source and ran it: two taps 3s apart survive; a 300ms double-tap survives; the burst trips on the 7th pause inside the window; 120 stray pauses over a simulated 2h never trip and the stamp list stays at length 1; 7 pauses over 6s do not trip, 7 over 4.2s do. All green. Not committed (no JS test home to put it in).

## Not verified

- **No end-to-end play-test with real headphones or a real media key.** Launching the app from the worktree would take over the owner's live app instance and mutate real user data, and a Strict Lock video is by design a fullscreen cover on every monitor that cannot be dismissed - not something to start unattended on release morning.
- **The Media Session guard itself is unproven empirically.** A standalone Chromium harness could not deliver synthetic media keys even in the *control* case (no handlers, no pause), so it proved nothing either way and was abandoned. The behaviour it relies on - a registered action handler suppresses the browser's default action - is documented Chromium behaviour and is what every web player uses to take over media keys, but it wants an owner play-test with the XM6s. It is the *outer* lock: even if it did nothing, fixes 2 and 3 independently stop the reported bug.

**Suggested owner play-test:** start a Strict Lock mandatory video, double-tap the XM6 touchpad several times, confirm the video does not end. `video-diag.log` should show `unrequested pause #N - resuming` lines and a `media-key guard armed (8/8 actions)` line, and no `MID-CLIP FAILURE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
