### PR TITLE
fix(profile): hide Customize and Privacy on other people's cards (#1113)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.ProfileCard.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.ProfileCard.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -83,7 +83,8 @@ namespace ConditioningControlPanel
 
         /// <summary>
         /// Shows or hides the header's "back to me" chip. Someone else's card is on screen ⇒ the
-        /// chip is the way home.
+        /// chip is the way home. Also the single switch every self-only surface on the card reads,
+        /// so a new one is gated here rather than by re-deriving "is this mine" at its own site.
         /// </summary>
         internal void SetProfileViewingSelf(bool isSelf)
         {
@@ -97,6 +98,15 @@ namespace ConditioningControlPanel
                 RefreshProfileSpiralPlate();
                 // So does the migration receipt, and for the same reason.
                 RefreshProfileDescentReceipt();
+                // Bug #1113: Customize and Privacy always edit YOUR loadout and YOUR sharing
+                // toggles whoever's card is up, so over a searched profile they read as an offer
+                // to edit that stranger's. Same switch, same reason, and set before the early
+                // return below so a missing chip cannot strand them either.
+                var selfOnly = isSelf ? Visibility.Visible : Visibility.Collapsed;
+                if (DiscordTab?.BtnProfileCustomize != null)
+                    DiscordTab.BtnProfileCustomize.Visibility = selfOnly;
+                if (DiscordTab?.BtnProfilePrivacy != null)
+                    DiscordTab.BtnProfilePrivacy.Visibility = selfOnly;
                 if (DiscordTab?.BtnProfileBackToMe == null) return;
                 DiscordTab.BtnProfileBackToMe.Visibility = isSelf ? Visibility.Collapsed : Visibility.Visible;
             }

--- a/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml
@@ -685,8 +685,11 @@
                                                 </StackPanel>
                                             </Button>
 
-                                            <!-- Phase 2: opens the customization kit. Always edits YOUR
-                                                 loadout, even while someone else's card is on screen. -->
+                                            <!-- Phase 2: opens the customization kit, which always edits YOUR
+                                                 loadout. Both this and Privacy below are therefore self-only -
+                                                 SetProfileViewingSelf (MainWindow.ProfileCard.cs) collapses the
+                                                 pair while somebody else's card is on screen, so neither can
+                                                 read as an offer to edit a stranger's profile (bug #1113). -->
                                             <Button x:Name="BtnProfileCustomize" x:FieldModifier="internal"
                                                     Content="{loc:Str profile_btn_customize}"
                                                     Background="#33B478FF" Foreground="#E7DEFF" BorderThickness="0"


### PR DESCRIPTION
## What

`Customize` and `Privacy & Sharing` on the Trainer Card are now collapsed while somebody else's profile is on screen, and visible again on your own.

## Why

ccp-bugs **#1113** (v6.9.0): *"the Customize profile button appears on other people's profiles and edits your own."*

This was by design and the old XAML comment said so, but the design is the bug: a button labelled **Customize** sitting on a stranger's card reads as an offer to edit *theirs*. `Privacy & Sharing` right beside it has the same problem - it opens your own ten sharing toggles regardless of whose card is up.

## How

Both buttons ride `SetProfileViewingSelf` (`MainWindow/MainWindow.ProfileCard.cs`), the existing single "whose card is on screen" switch that already gates the `← Back to me` chip and THE SPIRAL plate. No new flag, and no re-deriving "is this mine" at the button's own site.

Every path that paints a card funnels through that switch, so the pair cannot get stuck hidden on your own card:

| Path | Call site |
|---|---|
| me-first open / `My Profile` / `Back to me` -> `DisplayOwnProfile` | `SetProfileViewingSelf(true)` |
| search result / leaderboard click -> `DisplayProfileEntry` | `SetProfileViewingSelf(isOwnProfile)` |
| `Clear` -> `ClearProfileViewer` | `SetProfileViewingSelf(true)` |

`ProfileCardWrapper` is only ever made `Visible` by those first two methods, so there is no fourth render path to miss. The assignment sits *before* the chip's early return, for the same reason `RefreshProfileSpiralPlate()` does - a missing chip must not strand the buttons.

Click behaviour is unchanged: both still edit your own loadout and your own settings.

## How tested

- `dotnet build ConditioningControlPanel.csproj` - 0 errors (warnings all pre-existing).
- Full suite: **4944 passed, 0 failed**.
- Ran the real app offscreen (temporary `RenderTargetBitmap` rig, reverted before commit; not in this diff), opened the Profile tab and flipped the switch the way a searched profile does:

```
own-card-on-open:  customize=Visible   privacy=Visible   backToMe=Collapsed  cardVisible=Visible
stranger-card:     customize=Collapsed privacy=Collapsed backToMe=Visible    cardVisible=Visible
back-to-own-card:  customize=Visible   privacy=Visible   backToMe=Collapsed  cardVisible=Visible
```

Screenshots confirm it: own card shows `Share Profile | Customize | Privacy & Sharing`; the stranger card shows `Share Profile` only, with the `← Back to me` chip and no spiral plate.

## Note, not changed

`Share Profile` also stays on a stranger's card and also targets *your* public page. It was left alone deliberately - its doc comment says it is visible-but-disabled on purpose, as the only place a signed-out user learns a public profile exists, so hiding it is a design call rather than a hotfix. Worth a follow-up decision. The privacy gear in the Community rail's sharing footer (`BtnProfilePrivacyGear`) is correctly ungated: that rail is persistent chrome showing your own sharing summary, not part of the viewed card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
