### PR TITLE
fix(flash): unduck survives Stop(); fade ramp stops flooding layered-window blits (#1107, meadow)

### DIFF
--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -63,6 +63,40 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         internal static int ResolveFlashCap(bool useLayer, bool useHost)
             => (useLayer || useHost) ? MAX_CONCURRENT_FLASH_HOST : MAX_CONCURRENT_FLASH;
+
+        /// <summary>
+        /// The current run's cancellation token, or <see cref="CancellationToken.None"/> when no run
+        /// owns one (Stop retires it - see #1107). Tolerates a source disposed by a racing Stop.
+        /// </summary>
+        private CancellationToken CurrentRunToken()
+        {
+            try { return _cancellationSource?.Token ?? CancellationToken.None; }
+            catch (ObjectDisposedException) { return CancellationToken.None; }
+        }
+
+        /// <summary>
+        /// #1107 - schedule the flash-audio unduck. Deliberately takes NO CancellationToken: the
+        /// unduck RELEASES a ref-counted duck, so skipping it leaves every other app on the machine
+        /// quiet until AudioService's five minute watchdog fires. It used to hang off the run token
+        /// with TaskContinuationOptions.NotOnCanceled, so any Takeover that played a video first
+        /// (VideoService stops flashes in its prologue) silently dropped it. A late unduck is
+        /// harmless: Unduck is generation-guarded and its ref count is clamped at zero.
+        /// Pure enough to unit-test without WPF.
+        /// </summary>
+        internal static Task ScheduleUnduck(int delayMs, Action unduck)
+        {
+            if (unduck == null) return Task.CompletedTask;
+            if (delayMs < 0) delayMs = 0;
+            return Task.Delay(delayMs).ContinueWith(_ =>
+            {
+                try { unduck(); }
+                catch (Exception ex)
+                {
+                    try { App.Logger?.Debug("FlashService unduck failed: {Error}", ex.Message); }
+                    catch { }
+                }
+            });
+        }
         // Per-window shells are sized to a coarse bucket grid so the pool recycles by size instead of
         // realizing a fresh window on nearly every (image-sized, so almost-always-unique) flash. A fresh
         // Window.Show() runs a synchronous MediaContext.CompleteRender on first realization; under a
@@ -427,7 +461,18 @@ namespace ConditioningControlPanel.Services
         public void Stop()
         {
             _isRunning = false;
-            try { _cancellationSource?.Cancel(); }
+            // #1107: cancel AND retire the source. It used to stay in the field, cancelled forever,
+            // so every later one-shot (TriggerFlashOnce creates no source of its own) inherited a
+            // dead token: Task.Delay handed back an already-cancelled task and the NotOnCanceled
+            // continuations were dropped. Delays scheduled BEFORE this point captured the token
+            // already, so Cancel() still stops them - the staggered hydra spawns in ShowImages must
+            // keep being cancelled by Stop. Only NEW schedules fall through to CancellationToken.None,
+            // and those are gated by _isRunning / _oneShotActive / OneShotGate instead.
+            var retiredCts = _cancellationSource;
+            _cancellationSource = null;
+            try { retiredCts?.Cancel(); }
+            catch (ObjectDisposedException) { }
+            try { retiredCts?.Dispose(); }
             catch (ObjectDisposedException) { }
             StopHeartbeat();
             _schedulerTimer?.Stop();
@@ -1236,14 +1281,9 @@ namespace ConditioningControlPanel.Services
                         App.Audio.Duck(settings.DuckingLevel);
                         var duckGen = App.Audio?.DuckGeneration ?? -1;
 
-                        // Schedule unduck
+                        // Schedule unduck (#1107: never cancellable - see ScheduleUnduck)
                         var unduckDelay = (int)(duration * 1000) + 1500;
-                        var token = _cancellationSource?.Token ?? CancellationToken.None;
-                        Task.Delay(unduckDelay, token).ContinueWith(_ =>
-                        {
-                            try { App.Audio?.Unduck(duckGen); }
-                            catch (Exception ex) { App.Logger?.Debug("FlashService unduck failed: {Error}", ex.Message); }
-                        }, TaskContinuationOptions.NotOnCanceled);
+                        ScheduleUnduck(unduckDelay, () => App.Audio?.Unduck(duckGen));
                     }
                 }
                 catch (Exception ex)
@@ -1266,7 +1306,7 @@ namespace ConditioningControlPanel.Services
             if (_oneShotActive && !isMultiplication)
             {
                 var oneShotCleanupDelay = lifetimeMs + 2000; // extra 2s for fade-out
-                var cleanupToken = _cancellationSource?.Token ?? CancellationToken.None;
+                var cleanupToken = CurrentRunToken();
                 Task.Delay(oneShotCleanupDelay, cleanupToken).ContinueWith(_ =>
                 {
                     try
@@ -1307,7 +1347,7 @@ namespace ConditioningControlPanel.Services
                     var capturedGeneration = hydraGeneration;
                     var capturedSuppressHaptic = suppressHaptic;
                     var capturedOneShotGen = oneShotGen;
-                    var spawnToken = _cancellationSource?.Token ?? CancellationToken.None;
+                    var spawnToken = CurrentRunToken();
                     Task.Delay(delayMs, spawnToken).ContinueWith(_ =>
                     {
                         try
@@ -1696,6 +1736,8 @@ namespace ConditioningControlPanel.Services
                     window.Background = System.Windows.Media.Brushes.Transparent;
                     window.Content = content;
                     window.Opacity = 0;
+                    window.FadeAlpha = 0;
+                    window.LastWrittenAlpha = 0;
 
                     // Click handler + Alt+Tab hiding are wired ONCE in AcquireFlashWindow (the
                     // handler reads IsClickable per spawn) so recycled windows never stack handlers.
@@ -2227,6 +2269,41 @@ namespace ConditioningControlPanel.Services
         // default 40% lands on 0.4 s — the same envelope the old fixed FADE_PER_SEC = 2.4 gave.
         private const double FADE_SECONDS_PER_PERCENT = 0.01;
 
+        // meadow (6.9.0): the Fade slider went live in 3d6601a15 and a high percentage tanked the
+        // frame rate. A classic per-flash window is AllowsTransparency=true, so EVERY Window.Opacity
+        // write costs a full re-rasterise plus an UpdateLayeredWindow blit of a monitor-sized bitmap
+        // on the UI thread, inside CompositionTarget.Rendering - and a lucky flash re-blurs its
+        // DropShadowEffect glow on top of that. At 0% the ramp is 2 writes per flash; at 100% it was
+        // ~60 in and ~60 out per window, times MAX_CONCURRENT_FLASH. Two cheap brakes, layered path
+        // only: cap the ramp length, and only write when the alpha has actually moved a visible step.
+        // Compositor/solid-host flashes write LayerItem.Opacity / a hosted element's Opacity, which
+        // costs nothing, so they keep the exact per-frame ramp.
+        private const double LAYERED_MAX_FADE_SECONDS = 0.5;
+        private const double LAYERED_ALPHA_EPSILON = 1.0 / 32.0;
+
+        /// <summary>
+        /// Fade ramp length for one window. The layered (per-window, AllowsTransparency) path is
+        /// clamped to <see cref="LAYERED_MAX_FADE_SECONDS"/>; compositor and solid-host visuals are
+        /// cheap to nudge and keep the slider's full ramp. Pure so it can be unit-tested.
+        /// </summary>
+        internal static double ResolveFadeSeconds(double fadeSeconds, bool cheapAlpha)
+            => cheapAlpha ? fadeSeconds : Math.Min(fadeSeconds, LAYERED_MAX_FADE_SECONDS);
+
+        /// <summary>
+        /// Quantiser for the layered fade path: skip an opacity write the viewer cannot see, but
+        /// ALWAYS write the terminal values - the exact target alpha (so a fade-in settles where the
+        /// Opacity slider says) and an exact 0 (the heartbeat's removal trigger reads
+        /// <c>newAlpha &lt;= 0</c>, so a skipped zero would strand the window on screen).
+        /// Pure so it can be unit-tested without WPF.
+        /// </summary>
+        internal static bool ShouldWriteAlpha(double last, double next, double target, double epsilon)
+        {
+            if (double.IsNaN(next)) return false;
+            if (next <= 0.0) return true;                       // fade-out terminal: 0 must land exactly
+            if (Math.Abs(next - target) <= 1e-9) return true;   // fade-in terminal: settle on target
+            return Math.Abs(next - last) >= epsilon;
+        }
+
         /// <summary>Subscribe the heartbeat to the composition clock (idempotent, any thread).</summary>
         private void StartHeartbeat()
         {
@@ -2283,7 +2360,6 @@ namespace ConditioningControlPanel.Services
             // Read the Fade slider live so a mid-session change lands on the next frame.
             // 0% = instant: a full-alpha step arrives (and leaves) in a single frame.
             var fadeSeconds = settings.FadeDuration * FADE_SECONDS_PER_PERCENT;
-            var fadeStep = fadeSeconds > 0 ? dt / fadeSeconds : 1.0;
 
             FlashWindow[] windowsCopy;
             lock (_lockObj)
@@ -2319,15 +2395,33 @@ namespace ConditioningControlPanel.Services
                     var targetAlpha = showThisWindow ? maxAlpha : 0.0;
 
                     // Fade in/out per-window~ uwu (VisualOpacity routes to the hosted root in solid mode)
-                    var currentAlpha = window.VisualOpacity;
+                    // Layered windows pay a monitor-sized blit per opacity write, so their ramp is
+                    // clamped and their writes quantised; the ramp itself still advances every frame
+                    // (window.FadeAlpha), only the writes are thinned.
+                    var cheapAlpha = window.UsesLayer || window.UsesHost;
+                    var winFadeSeconds = ResolveFadeSeconds(fadeSeconds, cheapAlpha);
+                    var fadeStep = winFadeSeconds > 0 ? dt / winFadeSeconds : 1.0;
+
+                    var currentAlpha = cheapAlpha ? window.VisualOpacity : window.FadeAlpha;
                     if (targetAlpha > currentAlpha)
                     {
-                        window.VisualOpacity = Math.Min(targetAlpha, currentAlpha + fadeStep);
+                        var newAlpha = Math.Min(targetAlpha, currentAlpha + fadeStep);
+                        window.FadeAlpha = newAlpha;
+                        if (cheapAlpha || ShouldWriteAlpha(window.LastWrittenAlpha, newAlpha, targetAlpha, LAYERED_ALPHA_EPSILON))
+                        {
+                            window.VisualOpacity = newAlpha;
+                            window.LastWrittenAlpha = newAlpha;
+                        }
                     }
                     else if (targetAlpha < currentAlpha)
                     {
                         var newAlpha = Math.Max(0.0, currentAlpha - fadeStep);
-                        window.VisualOpacity = newAlpha;
+                        window.FadeAlpha = newAlpha;
+                        if (cheapAlpha || ShouldWriteAlpha(window.LastWrittenAlpha, newAlpha, targetAlpha, LAYERED_ALPHA_EPSILON))
+                        {
+                            window.VisualOpacity = newAlpha;
+                            window.LastWrittenAlpha = newAlpha;
+                        }
 
                         if (newAlpha <= 0)
                         {
@@ -4077,6 +4171,8 @@ namespace ConditioningControlPanel.Services
                 window.Effect = null;   // belt-and-suspenders: ensure no effect render-target lingers on the pooled shell
                 window.IsFadingOut = false;
                 window.Opacity = 0;
+                window.FadeAlpha = 0;
+                window.LastWrittenAlpha = 0;
 
                 // Recycle instead of Close: hide the window and return it to the pool.
                 // Closing a layered window mid-run is the render-thread-deadlock trigger.
@@ -4314,6 +4410,21 @@ namespace ConditioningControlPanel.Services
                 else Opacity = value;
             }
         }
+
+        /// <summary>
+        /// Layered path only: the logical fade ramp, advanced every heartbeat frame. Split from the
+        /// value actually written to <see cref="VisualOpacity"/> because those writes are quantised
+        /// (see FlashService.ShouldWriteAlpha) - reading the window's own Opacity back as "current"
+        /// would stall the ramp on every frame whose step lands under the epsilon.
+        /// </summary>
+        public double FadeAlpha { get; set; }
+
+        /// <summary>
+        /// Layered path only: the last alpha actually pushed to <see cref="VisualOpacity"/>, so the
+        /// quantiser knows when the ramp has moved a visible step. Reset with Opacity at spawn and
+        /// on pool return.
+        /// </summary>
+        public double LastWrittenAlpha { get; set; }
 
         /// <summary>
         /// The lucky/sparkle glow effect applied this spawn, if any. Held so the pool-return path

--- a/Tests/ConditioningControlPanel.Tests/FlashFadeAndUnduckTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FlashFadeAndUnduckTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #1107 (takeover ducking never restores) and the 6.9.0 fade-slider frame-rate report (meadow).
+///
+/// The unduck used to be scheduled as Task.Delay(ms, runToken).ContinueWith(.., NotOnCanceled).
+/// FlashService.Stop() cancelled the run token but never replaced it, and TriggerFlashOnce (the
+/// one-shot entry Takeover uses) never made one of its own, so once anything had stopped the
+/// service the delay came back already-cancelled and the continuation was dropped: the audio duck
+/// ref leaked and every other app stayed quiet until the five minute watchdog.
+///
+/// The fade ramp used to write Window.Opacity every frame. A flash window is AllowsTransparency,
+/// so each write is a re-rasterise plus a monitor-sized UpdateLayeredWindow blit on the UI thread.
+/// </summary>
+public class FlashFadeAndUnduckTests
+{
+    private const double Eps = 1.0 / 32.0;
+
+    // ---- Bug 1: the unduck must not be cancellable ---------------------------------------
+
+    [Fact]
+    public void ScheduleUnduck_TakesNoCancellationToken()
+    {
+        // The regression guard: re-threading a token through here is exactly what broke #1107.
+        var method = typeof(FlashService).GetMethod(
+            "ScheduleUnduck", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.NotNull(method);
+        Assert.DoesNotContain(method!.GetParameters(),
+            p => p.ParameterType == typeof(CancellationToken) || p.ParameterType == typeof(CancellationTokenSource));
+    }
+
+    [Fact]
+    public async Task ScheduleUnduck_RunsTheCallback()
+    {
+        int calls = 0;
+        await FlashService.ScheduleUnduck(1, () => Interlocked.Increment(ref calls));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ScheduleUnduck_RunsEvenWhenAnAmbientSourceIsAlreadyCancelled()
+    {
+        // Stands in for the post-Stop state that used to swallow the unduck.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        int calls = 0;
+        var task = FlashService.ScheduleUnduck(1, () => Interlocked.Increment(ref calls));
+        await task;
+
+        Assert.Equal(TaskStatus.RanToCompletion, task.Status);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ScheduleUnduck_NegativeDelayStillRuns()
+    {
+        int calls = 0;
+        await FlashService.ScheduleUnduck(-5000, () => Interlocked.Increment(ref calls));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ScheduleUnduck_NullCallbackIsANoOp()
+    {
+        await FlashService.ScheduleUnduck(1, null!);
+    }
+
+    // ---- Bug 2a: the layered ramp is clamped ---------------------------------------------
+
+    [Fact]
+    public void ResolveFadeSeconds_ClampsTheLayeredPath()
+    {
+        // 100% on the slider = a 1.0 s ramp; layered windows get at most 0.5 s of blits.
+        Assert.Equal(0.5, FlashService.ResolveFadeSeconds(1.0, cheapAlpha: false));
+    }
+
+    [Fact]
+    public void ResolveFadeSeconds_LeavesShortLayeredRampsAlone()
+    {
+        Assert.Equal(0.4, FlashService.ResolveFadeSeconds(0.4, cheapAlpha: false), 9);
+        Assert.Equal(0.0, FlashService.ResolveFadeSeconds(0.0, cheapAlpha: false), 9);
+    }
+
+    [Fact]
+    public void ResolveFadeSeconds_DoesNotTouchCompositorOrHost()
+    {
+        Assert.Equal(1.0, FlashService.ResolveFadeSeconds(1.0, cheapAlpha: true), 9);
+        Assert.Equal(0.4, FlashService.ResolveFadeSeconds(0.4, cheapAlpha: true), 9);
+    }
+
+    // ---- Bug 2b: opacity writes are quantised, terminals always land ----------------------
+
+    [Fact]
+    public void SubEpsilonStepIsSkipped()
+        => Assert.False(FlashService.ShouldWriteAlpha(last: 0.50, next: 0.51, target: 1.0, epsilon: Eps));
+
+    [Fact]
+    public void EpsilonSizedStepIsWritten()
+        => Assert.True(FlashService.ShouldWriteAlpha(last: 0.50, next: 0.50 + Eps, target: 1.0, epsilon: Eps));
+
+    [Fact]
+    public void ReachingTheTargetIsAlwaysWritten()
+    {
+        // The fade-in must settle exactly on the Opacity slider's value, however small the last step.
+        Assert.True(FlashService.ShouldWriteAlpha(last: 0.999, next: 1.0, target: 1.0, epsilon: Eps));
+        Assert.True(FlashService.ShouldWriteAlpha(last: 0.699, next: 0.7, target: 0.7, epsilon: Eps));
+    }
+
+    [Fact]
+    public void ReachingZeroIsAlwaysWritten()
+    {
+        // The heartbeat removes the window on "newAlpha <= 0"; a skipped zero strands it on screen.
+        Assert.True(FlashService.ShouldWriteAlpha(last: 0.01, next: 0.0, target: 0.0, epsilon: Eps));
+        Assert.True(FlashService.ShouldWriteAlpha(last: 0.001, next: 0.0, target: 0.0, epsilon: Eps));
+    }
+
+    [Fact]
+    public void FadingDownIsQuantisedToo()
+    {
+        Assert.False(FlashService.ShouldWriteAlpha(last: 0.50, next: 0.49, target: 0.0, epsilon: Eps));
+        Assert.True(FlashService.ShouldWriteAlpha(last: 0.50, next: 0.40, target: 0.0, epsilon: Eps));
+    }
+
+    [Fact]
+    public void NaNIsNeverWritten()
+        => Assert.False(FlashService.ShouldWriteAlpha(last: 0.5, next: double.NaN, target: 1.0, epsilon: Eps));
+
+    [Fact]
+    public void FullRamp_CostsAtMostThirtyThreeWrites()
+    {
+        // The point of the change: a 0.5 s layered fade-in at 60 fps used to be one blit per frame.
+        int writes = 0;
+        double last = 0.0, alpha = 0.0;
+        const double target = 1.0;
+        const double step = 1.0 / 240.0;   // deliberately finer than any real frame step
+
+        while (alpha < target)
+        {
+            alpha = Math.Min(target, alpha + step);
+            if (FlashService.ShouldWriteAlpha(last, alpha, target, Eps))
+            {
+                writes++;
+                last = alpha;
+            }
+        }
+
+        Assert.Equal(target, last, 9);       // the ramp ends exactly on target
+        Assert.InRange(writes, 1, 33);       // 32 quantised steps plus the terminal
+    }
+
+    [Fact]
+    public void RampNeverStalls_EveryStepEitherWritesOrKeepsClimbing()
+    {
+        // Guards the FadeAlpha/LastWrittenAlpha split: the logical ramp advances every frame even
+        // when the write is skipped, so a skipped write can never freeze the fade.
+        double alpha = 0.0, last = 0.0;
+        const double target = 0.75;
+        const double step = 0.004;
+        int frames = 0;
+
+        while (alpha < target && frames < 10_000)
+        {
+            frames++;
+            alpha = Math.Min(target, alpha + step);
+            if (FlashService.ShouldWriteAlpha(last, alpha, target, Eps)) last = alpha;
+        }
+
+        Assert.True(alpha >= target, "the ramp must reach the target");
+        Assert.Equal(target, last, 9);
+    }
+}


### PR DESCRIPTION
Two confirmed 6.9.0 bugs, both in `Services/Flash/FlashService.cs`.

## Bug 1 - Takeover ducking never restores (ccp-bugs #1107)

**Root cause.** The flash-audio unduck was scheduled as
`Task.Delay(unduckDelay, token).ContinueWith(.., TaskContinuationOptions.NotOnCanceled)`, where
`token = _cancellationSource?.Token`. `_cancellationSource` is created only in `Start()`; `Stop()`
cancelled it but never nulled or replaced it, and `Dispose()` was the only place it was ever
disposed. `TriggerFlashOnce()` - the one-shot entry Takeover reaches through
`AutonomyService` - creates no source of its own.

So once anything had ever stopped the service, the field held a permanently-cancelled source.
`VideoService` calls `App.Flash?.Stop()` in its video prologue, so **any Takeover that plays a
video does it**. From then on `Task.Delay` handed back an already-cancelled task, `NotOnCanceled`
dropped the continuation, and the duck ref leaked with `_isDucked` pinned true until
`AudioService`'s 5 minute `DuckWatchdogMs`. Every other app on the machine stayed quiet for those
five minutes.

**Change.**
- The unduck is no longer cancellable. It moved into `internal static Task ScheduleUnduck(int
  delayMs, Action unduck)` which takes **no** `CancellationToken`. Skipping an unduck is far worse
  than running a late one, because it is a *release* of a ref-counted duck.
- `Stop()` now retires `_cancellationSource` (cancel, null the field, dispose) instead of leaving a
  dead one behind.
- The two remaining token consumers go through an `ObjectDisposedException`-safe
  `CurrentRunToken()` so the new dispose cannot bite a racing scheduler thread.

**Should the other consumers still be cancelled by Stop? Yes, and they still are.** Both the
one-shot cleanup and the staggered hydra spawns capture their token into a local *before*
`Task.Delay`, so `Stop()`'s `Cancel()` still kills everything already in flight - which is the case
that matters for stray spawns. Only *new* schedules made after a Stop fall through to
`CancellationToken.None`, and those are already gated by `_isRunning` / `_oneShotActive` /
`OneShotGate.IsRetired` inside the continuation bodies (a point-fired flash is cancelled by
`StopOneShotFlashes` retiring the generation, not by this token). The one-shot cleanup running
unconditionally is a small improvement on top: it is what clears `_oneShotActive` and stops the
heartbeat, and it used to be droppable.

## Bug 2 - Fade slider costs frame rate in proportion to the percent (Discord reporter: meadow)

**Root cause.** `3d6601a15` made `AppSettings.FadeDuration` live, so the heartbeat ramp length now
scales with the slider: `fadeSeconds = FadeDuration * 0.01`, `fadeStep = dt / fadeSeconds`. Flash
windows are created with `AllowsTransparency = true`, so on the classic per-window path
`VisualOpacity` resolves to plain `Window.Opacity` and **every write is a full re-rasterise plus an
`UpdateLayeredWindow` blit of a monitor-sized bitmap**, on the UI thread, inside
`CompositionTarget.Rendering`. A lucky flash re-blurs its `DropShadowEffect` glow on each one.

At 0% `fadeStep` is 1.0, so a flash costs two writes total. At 100% it was roughly 60 in and 60 out
per window, times `MAX_CONCURRENT_FLASH`. That is the reported lag, and it scales with the slider
exactly as reported.

**Change** (layered path only - compositor `LayerItem.Opacity` and solid-host element opacity are
cheap and keep the exact per-frame ramp, and the fade math for those is untouched):
- `ResolveFadeSeconds(fadeSeconds, cheapAlpha)` clamps the layered ramp to 0.5 s.
- `ShouldWriteAlpha(last, next, target, epsilon)` skips a write the viewer cannot see (epsilon
  1/32), but **always** writes the terminal values: the exact target alpha, and an exact 0 so the
  heartbeat's `newAlpha <= 0` removal still lands and no window is stranded on screen.
- `FlashWindow` gains `FadeAlpha` (the logical ramp, advanced every frame) next to
  `LastWrittenAlpha` (the value actually pushed). Splitting them is what stops a skipped write from
  stalling the ramp: reading the window's own `Opacity` back as "current" would have frozen the fade
  on any frame whose step landed under the epsilon. Both reset alongside `Opacity` at spawn and on
  pool return.

The slider UI is untouched.

## Risk notes

- **An extra or late `Unduck` is harmless.** `AudioService.Unduck` is generation-guarded (a stale
  generation returns early) and its ref count is clamped with `Math.Max(0, _duckCount - 1)`, so it
  cannot go negative or un-duck someone else's duck. The failure mode we removed - a *missing*
  unduck - was the damaging one.
- **`Stop()` now disposes the retired CTS**, which it never did before. Both remaining token reads
  are wrapped in `CurrentRunToken()`, which catches `ObjectDisposedException` and degrades to
  `CancellationToken.None`.
- **Quantising coarsens the layered ramp to at most 32 visible steps**, and the clamp caps a 100%
  fade at 0.5 s instead of 1.0 s. On a 32-step ramp the quantisation is at or below the perceptual
  threshold for an alpha blend; the clamp is a real behaviour change for users sitting above 50% on
  the slider, and is the deliberate trade for the frame rate. Compositor and solid-host users see no
  change at all.
- Scope is one service file plus one new test file; no localization, no XAML, no settings.

## Tests

`Tests/ConditioningControlPanel.Tests/FlashFadeAndUnduckTests.cs`, 16 new cases:

- `ShouldWriteAlpha`: terminal target always written, exact 0 always written, sub-epsilon step
  skipped, epsilon-sized step written, fade-down quantised, NaN never written, a full ramp costs at
  most 33 writes and still lands exactly on target, and a ramp-never-stalls loop that guards the
  `FadeAlpha` / `LastWrittenAlpha` split.
- `ResolveFadeSeconds`: layered clamped to 0.5, short layered ramps untouched, compositor/host
  untouched.
- `ScheduleUnduck`: a reflection guard that its signature carries **no** `CancellationToken` (the
  exact regression that caused #1107), plus it runs the callback, runs with an ambient cancelled
  source in scope, tolerates a negative delay, and no-ops on a null callback.

Full suite: **4960 passed, 0 failed, 0 skipped** (4944 before this branch).
App build: 0 errors, 346 warnings, **none in `FlashService.cs`** - no new warnings.

## Manual verification recipes

1. **#1107.** Trigger a Takeover that plays a video (the prologue calls `App.Flash?.Stop()`), then
   let it fire a flash with `FlashAudioEnabled` + `AudioDuckingEnabled` on. Play music in another
   app. Volume must come back within `unduckDelay` (flash duration + 1.5 s), not after 5 minutes.
2. **meadow.** Set the Fade slider to 100% with `SimultaneousImages` high and the compositor OFF
   (classic layered windows). Watch the frame rate / UI responsiveness while several flashes fade in
   and out at once. Then confirm the fade still looks smooth and still fully clears the screen (no
   window left stranded at a low alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
