### PR TITLE
fix(descent): the ceremony's two doors survive high DPI scaling

### DIFF
--- a/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml
+++ b/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml
@@ -72,8 +72,31 @@
                 </TextBlock.RenderTransform>
             </TextBlock>
 
-            <!-- One act visible at a time; the code-behind swaps Visibility. -->
-            <Grid Grid.Row="1" x:Name="ActHost">
+            <!--
+              One act visible at a time; the code-behind swaps Visibility.
+
+              THE ACT SCALES, IT DOES NOT CLIP (ccp-bugs #1109/#1110/#1111/#1115). Every size in
+              this window is a hardcoded DIP, and a maximized window on a 3840x2160 screen at 300%
+              scaling is only 1280x720 DIPs: small enough that the two door cards overflowed their
+              row, and WPF's layout clip cut the choose buttons off the bottom of the cards with no
+              scrollbar, no error and no way to reach them with a mouse. The Viewbox shrinks the
+              whole act to fit before that can happen - DownOnly, so at every size where it already
+              fit nothing moves by a pixel - and the ScrollViewer under it is the floor: below
+              ActMinHeight the act stops shrinking and scrolls instead, because readable and
+              scrollable beats legible to nobody.
+
+              ActHost's MinHeight is what keeps the composition: each act centres itself inside a
+              host as tall as the viewport, exactly as it did when it filled the row directly.
+            -->
+            <ScrollViewer Grid.Row="1" x:Name="ActScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Focusable="False"
+                          SizeChanged="OnActScrollerSizeChanged">
+            <Viewbox x:Name="ActBox"
+                     Stretch="Uniform" StretchDirection="DownOnly"
+                     HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Grid x:Name="ActHost" MinHeight="{Binding ActualHeight, ElementName=ActScroller}">
 
                 <!-- ACT I - the intro -->
                 <StackPanel x:Name="ActIntro"
@@ -95,6 +118,7 @@
                                Foreground="{DynamicResource TextMutedBrush}"
                                TextWrapping="Wrap" TextAlignment="Center"/>
                     <Button x:Name="BtnIntroContinue"
+                            TabIndex="1"
                             Margin="0,40,0,0"
                             HorizontalAlignment="Center"
                             Padding="30,13"
@@ -104,7 +128,10 @@
                 </StackPanel>
 
                 <!-- ACT II - the two doors -->
-                <Grid x:Name="ActChoice" Visibility="Collapsed">
+                <!-- MaxWidth matches the door grid below: inside the Viewbox the act is measured
+                     against an unbounded width, so the block needs a width of its own or a long
+                     headline would size the whole ceremony. -->
+                <Grid x:Name="ActChoice" Visibility="Collapsed" MaxWidth="1080">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
@@ -155,6 +182,7 @@
                                            Foreground="{DynamicResource TextMutedBrush}"
                                            TextWrapping="Wrap"/>
                                 <Button x:Name="BtnChooseRestore"
+                                        TabIndex="1"
                                         Margin="0,24,0,0"
                                         Padding="0,12"
                                         FontSize="14"
@@ -193,6 +221,7 @@
                                            Foreground="{DynamicResource TextMutedBrush}"
                                            TextWrapping="Wrap"/>
                                 <Button x:Name="BtnChooseCycle"
+                                        TabIndex="2"
                                         Margin="0,24,0,0"
                                         Padding="0,12"
                                         FontSize="14"
@@ -227,10 +256,12 @@
                                TextWrapping="Wrap" TextAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,38,0,0">
                         <Button x:Name="BtnConfirmBack"
+                                TabIndex="1"
                                 Padding="26,12" FontSize="14"
                                 Style="{DynamicResource SecondaryButton}"
                                 Click="OnConfirmBack"/>
                         <Button x:Name="BtnConfirmYes"
+                                TabIndex="2"
                                 Margin="16,0,0,0"
                                 Padding="26,12" FontSize="14"
                                 Style="{DynamicResource PinkButton}"
@@ -259,6 +290,7 @@
                                Foreground="{DynamicResource TextMutedBrush}"
                                TextWrapping="Wrap" TextAlignment="Center"/>
                     <Button x:Name="BtnDoneClose"
+                            TabIndex="1"
                             Margin="0,40,0,0"
                             HorizontalAlignment="Center"
                             Padding="34,13" FontSize="15"
@@ -266,10 +298,13 @@
                             Click="OnDoneClose"/>
                 </StackPanel>
             </Grid>
+            </Viewbox>
+            </ScrollViewer>
 
             <!-- The escape hatch. Closing before a choice is made costs nothing. -->
             <StackPanel Grid.Row="2" x:Name="LaterHost" HorizontalAlignment="Center" Margin="0,0,0,14">
                 <Button x:Name="BtnLater"
+                        TabIndex="9"
                         HorizontalAlignment="Center"
                         Background="Transparent" BorderThickness="0"
                         Foreground="{DynamicResource TextDimBrush}"

--- a/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs
@@ -42,6 +42,22 @@ namespace ConditioningControlPanel
         /// </summary>
         private static readonly List<DescentCeremonyWindow> Live = new();
 
+        /// <summary>
+        /// The height, in DIPs, below which the act stops scaling down and starts scrolling
+        /// instead (ccp-bugs #1109). The tallest act is the two doors at roughly 630 DIPs, so the
+        /// floor is a little under half scale - and the machines that reach it are running 250% to
+        /// 300% Windows scaling, where half scale is still larger on the glass than the design is
+        /// at 100%.
+        ///
+        /// <para>The act host is the window less the margins, the eyebrow and the escape hatch,
+        /// which is about 187 DIPs: every scaling Windows actually offers clears this floor and
+        /// scales to fit rather than scrolling. 3840x2160 at 300% (1280x720 DIPs), 2560x1600 at
+        /// 250% (1024x640), 1920x1080 at 200% (960x540) and 2560x1440 at 300% (853x480) all fit
+        /// whole. Past that the scroller takes over, because a button that has to be scrolled to
+        /// is still a button, and one shrunk past reading is not.</para>
+        /// </summary>
+        private const double ActMinHeight = 290;
+
         private readonly DescentMigrationOffer _offer;
         private readonly int _restoreLevel;
         private string? _pendingChoice;
@@ -130,6 +146,31 @@ namespace ConditioningControlPanel
             }
 
             Say(DescentCeremonyCopy.CompanionIntro);
+        }
+
+        /// <summary>
+        /// Hand the act's Viewbox a height budget, which is the one thing XAML cannot state on its
+        /// own: inside a vertical ScrollViewer the Viewbox is measured against infinity, so without
+        /// a MaxHeight it would never scale anything down and would scroll instead every time.
+        ///
+        /// <para>The budget is the viewport, or <see cref="ActMinHeight"/> when the viewport is
+        /// smaller than that - and that floor is what hands the overflow back to the scroller.</para>
+        ///
+        /// <para>It reads the scroller's own height and not its ViewportHeight, which is still 0
+        /// the first time this fires and never changes again on a window that cannot be resized:
+        /// reading it there left the Viewbox at MaxHeight=Infinity for the life of the ceremony,
+        /// which is to say scaled by width alone, which is to say the bug was still there.</para>
+        /// </summary>
+        private void OnActScrollerSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            var viewport = e.NewSize.Height;
+            if (viewport <= 0) return;
+
+            var budget = Math.Max(ActMinHeight, viewport);
+
+            // Only on a real change: assigning MaxHeight re-measures, and a same-value write on
+            // every SizeChanged is a layout pass nobody asked for.
+            if (Math.Abs(ActBox.MaxHeight - budget) > 0.5) ActBox.MaxHeight = budget;
         }
 
         private void OnClosedInternal(object? sender, EventArgs e)


### PR DESCRIPTION
Top issue of the v6.9.0 launch: the Descent migration ceremony shows the two door cards but neither door can be clicked. 5 named reporters plus 3 me-toos, ccp-bugs #1109 #1110 #1111 #1115.

## Root cause

`DescentCeremonyWindow.xaml` is `WindowState="Maximized" ResizeMode="NoResize"`, has no ScrollViewer anywhere, and hardcodes every size in DIPs (FontSize 24/17/14, Padding 30,28, LineHeight 23). A maximized window on Luna's 3840x2160 at 300% is only **1280x720 DIPs**.

The ActChoice act is a 3 row grid (Auto / \* / Auto). The two door cards sit in the star row, and each card is a StackPanel whose last child is the choose button. At 1280x720 the cards need about 630 DIPs and the row has about 530, so the StackPanels overflow and WPF's layout clip silently cuts the bottom off both cards. No scrollbar, no error, no exception. The buttons still exist and still take keyboard focus, which is exactly why RopePunny reached one by mashing Tab and Enter, but no mouse could: the hit test lands on the clip, not the button. `BtnLater` survives because it lives in the outer grid's row 2.

Reproduced before touching anything, hit-testing the centre of each button through the visual tree:

```
1280x720  BtnChooseRestore  inside=True  clickable=False
1280x720  BtnChooseCycle    inside=True  clickable=False
1280x720  BtnLater          inside=True  clickable=True
 853x480  BtnChooseRestore  inside=False clickable=False   (laid out past the window)
```

The intro and confirm acts have the same hardcoded shape and fail the same way further down the scale (`BtnIntroContinue` at 853x480).

## Fix

The act host now sits in a `Viewbox` (Uniform, DownOnly) inside a `ScrollViewer`:

- **Viewbox** shrinks the whole act to fit the space it actually has. DownOnly means at every size where the act already fit, the scale is exactly 1.0 and nothing moves.
- **ScrollViewer** is the floor under it. `ActMinHeight = 290` DIPs: below that the act stops shrinking and scrolls instead, because readable and scrollable beats legible to nobody.
- **`ActHost.MinHeight`** binds to the scroller's height so each act still centres itself in a host as tall as the viewport, exactly as it did when it filled the row directly. This is what keeps the composition identical at full size.
- The Viewbox's `MaxHeight` is the one thing XAML cannot state on its own: inside a vertical ScrollViewer it is measured against infinity, so without it the box would never scale and would always scroll. It is set from `SizeChanged`, reading `e.NewSize.Height` and **not** `ViewportHeight`, which is still 0 the first time that fires and never changes again on a window that cannot be resized. That mistake cost a build: the Viewbox sat at MaxHeight=Infinity and scaled by width alone, so the bug was still there.
- Buttons get an explicit `TabIndex` so keyboard order is reading order. Enter on a focused door already worked and still does; focus into the scroller now also brings the button into view.

The window is still **not** `AllowsTransparency` and the design note about the render thread is untouched.

## How tested

A throwaway WPF harness in the worktree (deliberately not committed) builds the real `DescentCeremonyWindow` with a real `DescentMigrationOffer` at fixed sizes, walks intro -> doors -> confirm through the actual click handlers, and for every button asserts its `TransformToAncestor(window)` bounds are inside the window and that `InputHitTest` at the button's centre resolves to that button. It also writes a RenderTargetBitmap of each act.

| DIP size | before | after |
|---|---|---|
| 1700x1070 (largest this machine allows) | OK | scale 1.00, no scroll, **geometry identical** except the left door card is 2 DIPs narrower |
| 1280x720 (4K @ 300%, Luna) | **both doors unclickable** | scale 0.84, whole act on screen, both doors clickable |
| 1024x640 (2560x1600 @ 250%) | **both doors unclickable** | scale 0.71, clean |
| 853x480 (2560x1440 @ 300%) | **doors laid out past the window** | scale 0.46, clean |
| 800x400 (past the floor, not a real config) | doors past the window | scales to the floor and scrolls, every button reachable after scrolling |

Pixel diff of the 1700x1070 renders, baseline build vs this one: the intro and confirm acts differ only in sub-8/255 text antialiasing, and their button geometry is byte identical (`BtnIntroContinue x=728 y=677 w=231` in both). The choice act's left card measures 460 DIPs wide instead of 462 and sits 1 DIP right. That is device-pixel rounding under the Viewbox's transform at this machine's 150% DPI, not a layout change; an experiment with `UseLayoutRounding="False"` inside the box made it worse (unrounded button heights, 47 -> 45.6, on every act) and was reverted.

**Not verified:** no run at a true 100% DPI, since this machine is 150% and the manifest ignores the DPIUNAWARE compat shim; the largest window Win32 would give a `NoResize` window here was 1700x1070, so 1920x1080 exactly was not measured. Nothing was tested on a real 300% display.

## Noted, not fixed

`Views/Tabs/SpiralTabView.xaml` (hosted in `MainWindow.xaml:2525` as `<views:SpiralTabView Margin="10,5,10,10"/>`) has exactly the same shape: full bleed Grid, centred StackPanels, hardcoded DIPs (FontSize 56 digits, 21 line, 30/20/22 margins), no ScrollViewer and no Viewbox. That matches Luna's report of the Spiral page overlapping the nav at 300%. Left alone here on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
