### PR TITLE
fix(privacy): stop writing OCR screen text into app logs

### DIFF
--- a/ConditioningControlPanel/Services/KeywordTriggerService.cs
+++ b/ConditioningControlPanel/Services/KeywordTriggerService.cs
@@ -875,7 +875,7 @@ namespace ConditioningControlPanel.Services
             NeedsOcrConfirmation = false;
 
             if (!_isActive || _disposed) return;
-            // Live entitlement re-check (see OnKeyPressed). Placed ahead of the token diagnostic
+            // Live entitlement re-check (see OnKeyPressed). Placed ahead of the scan diagnostic
             // below on purpose: once access has lapsed, the user's screen contents are none of our
             // business - not even at log level.
             if (!HasAccess()) return;
@@ -886,37 +886,17 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
-            // App scope, checked FIRST - ahead of the token diagnostic below on purpose. That
-            // diagnostic writes the scanned words to the log at Information level, and the whole
-            // point of excluding an app is that its contents are none of our business: logging them
-            // and then declining to act on them would be the wrong half of the promise. Dropping
-            // the entire scan is right rather than filtering word by word, because a blocked app is
-            // usually the thing filling the screen. The position guards are cleared so no streak
-            // survives the gap and nothing fires the instant focus returns.
+            // App scope, checked FIRST - ahead of the scan diagnostic below on purpose. The whole
+            // point of excluding an app is that its contents are none of our business, so an
+            // excluded app should not reach the matching pass or the counts it logs at all.
+            // Dropping the entire scan is right rather than filtering word by word, because a
+            // blocked app is usually the thing filling the screen. The position guards are cleared
+            // so no streak survives the gap and nothing fires the instant focus returns.
             if (!IsForegroundAppAllowed("OCR"))
             {
                 _ocrSeenCounts.Clear();
                 _highlightedOcrKeys.Clear();
                 return;
-            }
-
-            // Diagnostic: log the raw OCR tokens per scan so we can see exactly what
-            // Windows OCR returned (tokenization + casing). Helps debug issues like
-            // "GOOD BOY doesn't match" where OCR may merge all-caps into one token.
-            // Keep this short — log at most the first 40 tokens and truncate long ones.
-            if (App.Logger != null)
-            {
-                var snippet = new System.Text.StringBuilder();
-                int n = Math.Min(40, allWords.Count);
-                for (int i = 0; i < n; i++)
-                {
-                    if (i > 0) snippet.Append(' ');
-                    var t = allWords[i].Text ?? "";
-                    if (t.Length > 20) t = t.Substring(0, 20) + "…";
-                    snippet.Append('"').Append(t).Append('"');
-                }
-                if (allWords.Count > n) snippet.Append(" …+").Append(allWords.Count - n);
-                App.Logger.Information("OCR tokens ({Total}): {Tokens}", allWords.Count, snippet.ToString());
             }
 
             var settings = App.Settings?.Current;
@@ -965,6 +945,21 @@ namespace ConditioningControlPanel.Services
                     firedTriggers.Add(trigger);
                     matchedWords.AddRange(words);
                 }
+            }
+
+            // Diagnostic for keyword matching. This deliberately logs NO screen content: the
+            // tokens are whatever happened to be on the user's screen, and this file is
+            // logs/app-.log, which ships with every bug report. Counts still answer the question
+            // the old token dump was for ("62 tokens, 0 matches" points straight at tokenisation),
+            // and the keywords named here are the user's OWN configured trigger words - the
+            // matching loop above tests trigger.Keyword against the scan, so these are the
+            // needles, never the haystack. Debug keeps it off disk on a normal install
+            // (App.xaml.cs pins the sink floor to Information).
+            if (App.Logger != null)
+            {
+                App.Logger.Debug("OCR scan: {Total} token(s), {Matched} matched word(s), keyword(s): [{Keywords}]",
+                    allWords.Count, matchedWords.Count,
+                    firedTriggers.Count > 0 ? string.Join(",", firedTriggers.Select(t => t.Keyword)) : "none");
             }
 
             if (matchedWords.Count == 0 || firedTriggers.Count == 0)


### PR DESCRIPTION
## The leak

`KeywordTriggerService.CheckOcrWords` opened every OCR scan with a diagnostic that
dumped the recognised tokens straight into the log:

```csharp
App.Logger.Information("OCR tokens ({Total}): {Tokens}", allWords.Count, snippet.ToString());
```

Up to 40 words of whatever was on the user's screen, every scan (3s default interval),
unconditionally, at **Information**. The Serilog sink floor is Information
(`App.xaml.cs`), so it landed on disk in `logs/app-.log` - and that file is attached to
every bug report. `LogScrubber` redacts paths, emails and tokens; it cannot redact
arbitrary prose scraped off a screen. Anyone running keyword triggers was shipping
fragments of their documents, chats and browser tabs to us in support threads.

## What is logged now

The token dump is gone. In its place, after the matching pass, a **Debug** line with no
screen content:

```
OCR scan: {Total} token(s), {Matched} matched word(s), keyword(s): [{Keywords}]
```

- token **count** only, never the tokens
- number of matched words
- the trigger keywords that matched - the matching loop tests `trigger.Keyword` against
  the scan, so these are the user's own configured trigger words (the needles), never
  screen text (the haystack)

That still answers the question the dump existed for - "62 tokens, 0 matches" points
straight at tokenisation/casing - and at Debug it stays off disk on a normal install.
No new setting was added.

## Scope

Swept the tree for other OCR content logging
(`git grep -n -i "ocr" -- '*.cs' | grep -iE "Logger|Log\."`, plus `ScreenOcrService`,
`AwarenessObserver`). No other site logs screen text: `ScreenOcrService` logs only
lifecycle and error strings, and the two remaining Information lines in
`KeywordTriggerService` ("OCR guard", "OCR keyword confirmed") log counts and configured
keywords only. Diff is limited to the log statement and the two nearby comments that
described the removed line.

Build: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxTh3wV7dZKwyaWNAQYbj7
