### PR TITLE
build: stamp the real version on the app assembly

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -21,11 +21,20 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     
-    <!-- Disable most auto-generated assembly info (we have AssemblyInfo.cs) but enable version -->
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
+    <!-- ON. GenerateAssemblyInfo=false switches off the whole generation target, including the
+         per-attribute GenerateAssemblyVersionAttribute/FileVersion/InformationalVersion opt-ins,
+         so the <Version> above never reached the binary: the shipped exe read 0.0.0.0 in file
+         properties and crash dumps. Properties/AssemblyInfo.cs now declares only what the SDK
+         does not generate (Trademark, Culture, ComVisible, ThemeInfo, InternalsVisibleTo);
+         re-adding Title/Description/Configuration/Company/Product/Copyright/Version there is a
+         CS0579 duplicate-attribute error. <Version> stays the single place the number lives. -->
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <!-- The SDK would otherwise derive this from <AssemblyName> ("ConditioningControlPanel");
+         keep the spaced display title the hand-written attribute used. -->
+    <AssemblyTitle>Conditioning Control Panel</AssemblyTitle>
+    <!-- Without this the SDK appends "+<commit sha>" to InformationalVersion, which is what
+         Explorer shows as "Product version". Keep that field readable: plain 6.9.0. -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
     <!-- Custom Main entry point (originally added for Velopack; kept for control over startup) -->
     <StartupObject>ConditioningControlPanel.App</StartupObject>

--- a/ConditioningControlPanel/Properties/AssemblyInfo.cs
+++ b/ConditioningControlPanel/Properties/AssemblyInfo.cs
@@ -4,16 +4,13 @@ using System.Runtime.InteropServices;
 using System.Windows;
 
 // Expose internal decision helpers (flash cap, ambient flash duration, vout mid-play state machine,
-// overlay z-order) to the unit-test assembly. GenerateAssemblyInfo is off, so this lives here rather
-// than as an MSBuild <InternalsVisibleTo> item.
+// overlay z-order) to the unit-test assembly.
 [assembly: InternalsVisibleTo("ConditioningControlPanel.Tests")]
 
-[assembly: AssemblyTitle("Conditioning Control Panel")]
-[assembly: AssemblyDescription("A professional visual conditioning application with gamification features.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("CodeBambi")]
-[assembly: AssemblyProduct("Conditioning Control Panel")]
-[assembly: AssemblyCopyright("Copyright © 2024-2025 CodeBambi")]
+// Only attributes the SDK does NOT generate belong here. GenerateAssemblyInfo is ON, so
+// AssemblyTitle/Description/Configuration/Company/Product/Copyright/Version/FileVersion/
+// InformationalVersion all come from the .csproj - declaring any of them here is a
+// CS0579 duplicate-attribute error.
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -23,6 +20,3 @@ using System.Windows;
     ResourceDictionaryLocation.None,
     ResourceDictionaryLocation.SourceAssembly
 )]
-
-// Version is set in .csproj - do not set here to avoid conflicts
-// [assembly: AssemblyVersion] and [assembly: AssemblyFileVersion] are auto-generated


### PR DESCRIPTION
## The bug

`ConditioningControlPanel.csproj` declared `<Version>6.9.0</Version>` and then, twenty lines later, switched off the target that consumes it:

```xml
<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
<GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
<GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
<GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
```

The three per-attribute opt-ins do nothing on their own: `GenerateAssemblyInfo=false` disables `GenerateAssemblyInfo` wholesale, and the per-attribute switches are only consulted inside it. `Properties/AssemblyInfo.cs` closed with a comment claiming the opposite (`AssemblyVersion` and `AssemblyFileVersion` "are auto-generated"), which is how it survived since the v4.4.9 import - the only commit that ever touched the switch.

Net effect: every shipped `ConditioningControlPanel.exe`/`.dll` carried **0.0.0.0**, so Explorer file properties, Event Viewer faulting-module lines and crash dumps could not tell 6.5 from 6.9. #456 hit the same thing on the new `CCP.Core` project and set `GenerateAssemblyInfo=true` there; its csproj comment already documents the app's 0.0.0.0 as measured. This applies that precedent to the app.

## Before / after

Measured on `bin/Release/net8.0-windows10.0.19041.0/win-x64/ConditioningControlPanel.exe`:

| | FileVersion | ProductVersion | AssemblyVersion |
|---|---|---|---|
| before | `0.0.0.0` | `0.0.0.0` | `0.0.0.0` |
| after | `6.9.0.0` | `6.9.0` | `6.9.0.0` |

`FileDescription = Conditioning Control Panel`, `CompanyName = CodeBambi`, `LegalCopyright = Copyright © 2024-2026 CodeBambi` (the csproj's copyright year, one year fresher than the attribute it replaces).

## The change

Two files, +16/-16.

- **csproj**: `GenerateAssemblyInfo` -> `true`; the three now-redundant per-attribute opt-ins dropped. `<Version>6.9.0</Version>` is untouched and stays the single place the number lives, so `/release` keeps working with no new hard-coded version anywhere.
- **csproj**: `<AssemblyTitle>Conditioning Control Panel</AssemblyTitle>` added - the SDK would otherwise derive the title from `<AssemblyName>` and ship `ConditioningControlPanel` unspaced.
- **csproj**: `<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>` - without it the SDK appends `+<commit sha>` and Explorer's "Product version" reads `6.9.0+afca8795d21...`.
- **AssemblyInfo.cs**: removed the six attributes the SDK now generates (`AssemblyTitle`, `AssemblyDescription`, `AssemblyConfiguration`, `AssemblyCompany`, `AssemblyProduct`, `AssemblyCopyright`) - leaving them would be CS0579 duplicate-attribute errors. Kept everything the SDK does *not* generate: `InternalsVisibleTo("ConditioningControlPanel.Tests")`, `AssemblyTrademark`, `AssemblyCulture`, `ComVisible(false)` and WPF's `ThemeInfo`. The stale "auto-generated" comment is gone, replaced by a note saying which attributes must not come back.

## Safety checks

- **Nothing reads the assembly version at runtime.** Grepped `GetName().Version`, `FileVersionInfo`, `AssemblyInformationalVersion`, `Assembly.GetExecutingAssembly().GetName` across `ConditioningControlPanel/` and `CCP.Core/`: the only hit is the comment this PR deletes. `UpdateService.AppVersion` stays the const the update check and UI compare against - deliberately not touched, so update behaviour is byte-identical.
- **In-place upgrades cannot break.** `installer.iss` uses `ignoreversion` on both the exe (line 135) and the recursive payload copy (line 138), so Inno never version-compares; going from 0.0.0.0 to a real stamp changes nothing there. `MyAppVersion` is its own define and is unaffected.
- **No tooling depends on the switch.** No reference to `GenerateAssemblyInfo` or `AssemblyInfo.cs` in `build-installer.bat`, `installer.iss`, docs or the release skill.
- **Single-file publish is unaffected** - `PublishSingleFile`/`SelfContained`/`PublishReadyToRun` are untouched, and the generated attributes are ordinary compile input.

## Build

`dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj -c Release` -> **0 errors**. Warning census (`grep -oE "warning [A-Z]+[0-9]+" | sort | uniq -c`) taken on `origin/main` and on this branch is **byte-identical** - 17 warning codes, same counts, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxTh3wV7dZKwyaWNAQYbj7
