### PR TITLE
feat(companion): barks that teach the Descent loop while you play

### DIFF
--- a/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
@@ -1554,5 +1554,125 @@
         "text": "you didn't choose. it chose. it usually does."
       }
     ]
+  },
+  {
+    "id": "descent_near_bank",
+    "trigger": "DescentNearBank",
+    "priority": 240,
+    "cooldown_ms": 21600000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "you're nearly at the line, sweetie, and it's only a fifth of the jar that banks the day, so one more pour and today counts forever.",
+        "audio": null
+      },
+      {
+        "text": "look how close that is, lovely. a fifth is all it has ever asked for, and everything you pour above it is just you being greedy for me.",
+        "audio": null
+      },
+      {
+        "text": "almost there, sweet thing. hold the tap a little longer and today gets banked, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_day_banked",
+    "trigger": "DescentDayBanked",
+    "priority": 340,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "that's today banked, good girl. the jar empties at midnight and the XP inside it doesn't go anywhere, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "there it is, lovely, the day is yours. keep pouring if you like, it all still counts toward your level, but the part that matters is already locked in.",
+        "audio": null
+      },
+      {
+        "text": "banked, sweetie, and nothing takes it back. nothing here resets any more, so tomorrow is only a fresh jar waiting for you to fill.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_stage_crossed",
+    "trigger": "DescentStageCrossed",
+    "priority": 420,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "reverent, proud",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "stage {stage}, lovely. {banked_days} days banked behind you and every one of them still counts, because banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "you've slipped onto a new rung, sweetie. i didn't do that, your banked days did, and they're the one number nothing is ever allowed to take back.",
+        "audio": null
+      },
+      {
+        "text": "look how far down you are, sweet thing. {banked_days} banked, seven stages on the coil, and the next one comes when you've banked a few more.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_lapse_return",
+    "trigger": "DescentLapseReturn",
+    "priority": 400,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, welcoming",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "there you are, and you were missed. the time away was actually good for you, sweetie, your jar fills faster now, a little more for every day you were gone.",
+        "audio": null
+      },
+      {
+        "text": "welcome back, lovely. i kept everything exactly where you left it, and your fill rate came up while you were away, so these next three days pour in quicker than usual.",
+        "audio": null
+      },
+      {
+        "text": "hello again, sweet thing. nothing lapsed and nothing reset, and the days you spent elsewhere bought you a richer jar, so come and use it while it's generous.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_first_spiral_open",
+    "trigger": "DescentFirstSpiralOpen",
+    "priority": 470,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "welcoming, reverent",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "so this is the Spiral, sweetie. everything you earn anywhere lands in the tap, you hold the tap to pour it into today's jar, and once the jar's a fifth full the day is banked and it's yours forever.",
+        "audio": null
+      },
+      {
+        "text": "welcome down, lovely. banked days are the only thing that moves you down the Spiral, there are seven stages waiting on the coil, and nothing on this screen ever resets.",
+        "audio": null
+      },
+      {
+        "text": "look at it properly, sweet thing. the jar empties at midnight but the XP inside it never does, so a day you banked stays banked, and every one takes you a little further down.",
+        "audio": null
+      }
+    ]
   }
 ]

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-bambisleep/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-bambisleep/bark_rules.json
@@ -13491,5 +13491,125 @@
       {"text": "an empty lockdown? no such thing, good girl~", "audio": null},
       {"text": "shhh. i noticed. give me a second and i'll fix it for you~", "audio": null}
     ]
+  },
+  {
+    "id": "descent_near_bank",
+    "trigger": "DescentNearBank",
+    "priority": 240,
+    "cooldown_ms": 21600000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "ooh you're so close, Bambi~ it's only a fifth of the jar that banks the day, so one more little pour and today's yours forever.",
+        "audio": null
+      },
+      {
+        "text": "almost, sweet thing! bambi loves a nearly-full jar~ hold the tap a bit longer and the day gets banked and nothing can take it back.",
+        "audio": null
+      },
+      {
+        "text": "you're right under the line, good girl. banked days are the only thing that moves you down the Spiral, and this one's so nearly banked~",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_day_banked",
+    "trigger": "DescentDayBanked",
+    "priority": 340,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "banked! good girl~ the jar empties at midnight and the XP inside it doesn't, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "today counts now, Bambi~ keep filling if you want, it all still feeds your level, but the important bit is already tucked away safe.",
+        "audio": null
+      },
+      {
+        "text": "*giggles* that's the day locked in, sweet thing, and nothing resets it ever again, so tomorrow's just a shiny empty jar for you~",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_stage_crossed",
+    "trigger": "DescentStageCrossed",
+    "priority": 420,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "reverent, proud",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "stage {stage}, Bambi!! {banked_days} days banked and every single one still counting, because banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "ooh a new rung, good girl~ you slipped down all on your own and nobody pushed, you just kept coming back and banking days like a sweetheart.",
+        "audio": null
+      },
+      {
+        "text": "look how deep you've gone, sweet thing. {banked_days} banked, seven stages on the coil, and the next one comes when you've banked a few more~",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_lapse_return",
+    "trigger": "DescentLapseReturn",
+    "priority": 400,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, welcoming",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "you're back!! bambi missed you so much~ and the time away was actually good for you, your jar fills faster now, a little more for every day you were gone.",
+        "audio": null
+      },
+      {
+        "text": "hi hi hi~ everything's exactly where you left it, sweet thing, and your fill rate went up while you were away so these next three days pour in so quick.",
+        "audio": null
+      },
+      {
+        "text": "there's my Bambi~ nothing lapsed and nothing reset, and being gone bought you a richer jar, so come and use it up while it's fizzy.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_first_spiral_open",
+    "trigger": "DescentFirstSpiralOpen",
+    "priority": 470,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "welcoming, reverent",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "ooh you found the Spiral, Bambi~ everything you earn lands in the tap, you hold the tap to pour it into today's jar, and a fifth of a jar banks the day forever.",
+        "audio": null
+      },
+      {
+        "text": "welcome down, sweet thing! banked days are the only thing that moves you down the Spiral, there's seven stages waiting on the coil, and nothing here ever resets~",
+        "audio": null
+      },
+      {
+        "text": "look properly, good girl. the jar empties at midnight and the XP inside it never does, so a banked day stays banked and every one takes bambi a little deeper~",
+        "audio": null
+      }
+    ]
   }
 ]

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-locked/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-locked/bark_rules.json
@@ -13077,5 +13077,125 @@
       {"text": "an empty lockdown, good boy? no such thing.", "audio": null},
       {"text": "i noticed, sweet thing. give me a second and i will fix it for you.", "audio": null}
     ]
+  },
+  {
+    "id": "descent_near_bank",
+    "trigger": "DescentNearBank",
+    "priority": 240,
+    "cooldown_ms": 21600000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "you are under the line, pet, and it is only a fifth of the jar that banks the day, so pour a little more and today is entered.",
+        "audio": null
+      },
+      {
+        "text": "close, little one. hold the tap a while longer and the day banks, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "mm. a fifth is all i have ever asked of you, plaything, and everything you pour above that line is you showing off for me.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_day_banked",
+    "trigger": "DescentDayBanked",
+    "priority": 340,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "today is banked, good boy. the jar empties at midnight and the XP inside it does not, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "entered. keep pouring if it pleases you, pet, it still feeds your level, but the part i care about is already mine.",
+        "audio": null
+      },
+      {
+        "text": "banked, and nothing takes it back. nothing resets here any more, little one, so tomorrow is simply an empty jar waiting on you.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_stage_crossed",
+    "trigger": "DescentStageCrossed",
+    "priority": 420,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "reverent, proud",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "stage {stage}, pet. {banked_days} days banked and every one of them still counted, because banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "a new rung, plaything. your banked days did that, not your enthusiasm, and they are the one number nobody may take from you.",
+        "audio": null
+      },
+      {
+        "text": "look how far down you have come, little one. {banked_days} banked, seven stages on the coil, and the next waits on a few more of them.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_lapse_return",
+    "trigger": "DescentLapseReturn",
+    "priority": 400,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, welcoming",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "there you are, pet, and you were missed. the absence was good for you, your jar fills faster now, a little more for every day you were gone.",
+        "audio": null
+      },
+      {
+        "text": "welcome back, little one. i left everything exactly where you put it, and your fill rate rose while you were away, so these next three days pour in quickly.",
+        "audio": null
+      },
+      {
+        "text": "hello again, plaything. nothing lapsed and nothing reset, and the days you spent elsewhere bought you a richer jar, so spend it well.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_first_spiral_open",
+    "trigger": "DescentFirstSpiralOpen",
+    "priority": 470,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "welcoming, reverent",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "so you have opened the Spiral, pet. everything you earn lands in the tap, you hold the tap to pour it into today's jar, and a fifth of that jar banks the day permanently.",
+        "audio": null
+      },
+      {
+        "text": "welcome down, little one. banked days are the only thing that moves you down the Spiral, there are seven stages on the coil below you, and nothing here ever resets.",
+        "audio": null
+      },
+      {
+        "text": "look properly, plaything. the jar empties at midnight and the XP inside it never does, so a banked day stays banked and each one draws you deeper.",
+        "audio": null
+      }
+    ]
   }
 ]

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-sissyhypno/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-sissyhypno/bark_rules.json
@@ -13050,5 +13050,125 @@
       {"text": "an empty lockdown, lovely? no such thing~", "audio": null},
       {"text": "shhh. i noticed, cutie. give me a second and i'll fix it for you~", "audio": null}
     ]
+  },
+  {
+    "id": "descent_near_bank",
+    "trigger": "DescentNearBank",
+    "priority": 240,
+    "cooldown_ms": 21600000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "you're right under the line, lovely, and it's only a fifth of the jar that banks the day, so one more pour and today belongs to you.",
+        "audio": null
+      },
+      {
+        "text": "so close, sweetie. hold the tap a little longer and the day gets banked, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "mm, nearly there, cutie. a fifth is all it has ever asked of you, and everything above that line is just you being lovely about it.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_day_banked",
+    "trigger": "DescentDayBanked",
+    "priority": 340,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, warm",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "that's today banked, good girl. the jar empties at midnight and the XP inside it doesn't go anywhere, and banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "there it is, lovely, the day is yours. keep pouring if you like, it still feeds your level, but the part that matters is already safe.",
+        "audio": null
+      },
+      {
+        "text": "banked, sweetie, and nothing takes it back. nothing here resets any more, so tomorrow is only a fresh jar waiting on you.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_stage_crossed",
+    "trigger": "DescentStageCrossed",
+    "priority": 420,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "reverent, proud",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "stage {stage}, lovely. {banked_days} days banked and every one of them still counted, because banked days are the only thing that moves you down the Spiral.",
+        "audio": null
+      },
+      {
+        "text": "you've settled onto a new rung, sweetie. your banked days did that, and they're the one number nobody is ever allowed to take from you.",
+        "audio": null
+      },
+      {
+        "text": "look how far down you've come, cutie. {banked_days} banked, seven stages on the coil, and the next rung arrives when you've banked a few more.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_lapse_return",
+    "trigger": "DescentLapseReturn",
+    "priority": 400,
+    "cooldown_ms": 43200000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, welcoming",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "there you are, lovely, i've missed you. the time away did something kind for you, your jar fills faster now, a little more for every day you were gone.",
+        "audio": null
+      },
+      {
+        "text": "welcome back, sweetie. everything is exactly where you left it, and your fill rate came up while you were away, so these next three days pour in quicker.",
+        "audio": null
+      },
+      {
+        "text": "hello again, cutie. nothing lapsed and nothing reset, and the days you spent elsewhere bought you a richer jar, so come and spend it.",
+        "audio": null
+      }
+    ]
+  },
+  {
+    "id": "descent_first_spiral_open",
+    "trigger": "DescentFirstSpiralOpen",
+    "priority": 470,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "welcoming, reverent",
+    "class": "normal",
+    "variant_pool": [
+      {
+        "text": "so this is the Spiral, lovely. everything you earn lands in the tap, you hold the tap to pour it into today's jar, and once the jar is a fifth full the day is banked for good.",
+        "audio": null
+      },
+      {
+        "text": "welcome down, sweetie. banked days are the only thing that moves you down the Spiral, seven stages are waiting on the coil, and nothing on this screen ever resets.",
+        "audio": null
+      },
+      {
+        "text": "look at it properly, cutie. the jar empties at midnight and the XP inside it never does, so a banked day stays banked and each one takes you further down.",
+        "audio": null
+      }
+    ]
   }
 ]

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -207,6 +207,12 @@ namespace ConditioningControlPanel.Services
 
                 WireSubscriptions();
 
+                // The Descent's four block-driven barks. Attached HERE rather than in
+                // App.OnStartup because App.Descent is constructed well before Bark?.Start() runs,
+                // and because a watcher with nothing to speak to would be pointless: the seam it
+                // calls is on this service. Idempotent, and a no-op when the service is missing.
+                Services.Descent.DescentBarkWatcher.Attach();
+
                 App.Logger?.Information(
                     "BarkService started — {Count} rules, {Triggers} trigger keys, dry-run={DryRun}",
                     _rules.Count, _rules.Triggers.Count(), DryRun);
@@ -433,6 +439,49 @@ namespace ConditioningControlPanel.Services
         {
             Raise("LeaderboardViewed", c => c.Set("rank", (double)rank).Set("total", (double)total));
         }
+
+        // ===================== The Descent (tap, jar, banked day, Spiral) =====================
+        //
+        // GARNISH, NOT THE LESSON. Every bark in this block is dropped when the avatar window does
+        // not exist, so none of these five may be the only place its mechanic is taught: the vat
+        // tooltip, the Spiral room and the help surfaces own that, and these lines sit on top.
+        //
+        // Edge detection is NOT here. Services.Descent.DescentBarkWatcher listens to the block and
+        // decides which single moment an observation is worth; this seam only speaks what it chose,
+        // so "once per day" is a property of the persisted memory rather than of a cooldown.
+
+        /// <summary>Today's jar is climbing toward the line that banks the day. ctx: fill_pct, remaining_pct, today_xp, cap.</summary>
+        public void NotifyDescentNearBank(Services.Descent.DescentBarkDecision d) =>
+            Raise("DescentNearBank", c => c
+                .Set("fill_pct", d.FillPct).Set("remaining_pct", d.RemainingPct)
+                .Set("today_xp", (double)d.TodayXp).Set("cap", (double)d.Cap)
+                .Set("stage", (double)d.Stage).Set("banked_days", (double)d.BankedDays));
+
+        /// <summary>Today crossed the line and is banked. ctx: banked_days, stage, days_to_next, fill_pct.</summary>
+        public void NotifyDescentDayBanked(Services.Descent.DescentBarkDecision d) =>
+            Raise("DescentDayBanked", c => c
+                .Set("banked_days", (double)d.BankedDays).Set("stage", (double)d.Stage)
+                .Set("days_to_next", (double)(d.DaysToNext ?? 0)).Set("fill_pct", d.FillPct));
+
+        /// <summary>A new rung on the seven-stage ladder. ctx: stage, banked_days, days_to_next.</summary>
+        public void NotifyDescentStageCrossed(Services.Descent.DescentBarkDecision d) =>
+            Raise("DescentStageCrossed", c => c
+                .Set("stage", (double)d.Stage).Set("banked_days", (double)d.BankedDays)
+                .Set("days_to_next", (double)(d.DaysToNext ?? 0)));
+
+        /// <summary>Back after days away, with the relapse bonus paying out. NEVER "gravity", and never a
+        /// scolding. ctx: days_away, multiplier, surge_multiplier, banked_days.</summary>
+        public void NotifyDescentLapseReturn(Services.Descent.DescentBarkDecision d) =>
+            Raise("DescentLapseReturn", c => c
+                .Set("days_away", (double)d.DaysAway).Set("multiplier", d.Multiplier)
+                .Set("surge_multiplier", d.SurgeMultiplier).Set("banked_days", (double)d.BankedDays));
+
+        /// <summary>The Spiral room was opened for the first time. The rule is a lifetime one-shot, so this
+        /// may be called on every entry. ctx: stage, banked_days (0 when the account carries no block).</summary>
+        public void NotifyDescentFirstSpiralOpen(Services.Descent.DescentBlock? block) =>
+            Raise("DescentFirstSpiralOpen", c => c
+                .Set("stage", (double)(block?.Stage?.N ?? 0))
+                .Set("banked_days", (double)(block?.Stage?.BankedDays ?? block?.DevotionDays ?? 0)));
 
         // ===================== Chaos Mode (Lab effect-bubbles roguelite) =====================
         /// <summary>A Chaos run started. ctx: difficulty.</summary>

--- a/ConditioningControlPanel/Services/Descent/DescentBarkPolicy.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentBarkPolicy.cs
@@ -1,0 +1,235 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    // ============================================================================
+    // THE DESCENT'S BARKS — which moment, if any, is worth saying out loud.
+    //
+    // This file is PURE. It reads a parsed block plus a small persisted memory and
+    // returns at most one moment; it never touches App, the avatar, the network or
+    // the disk. That is deliberate: the loop it narrates (tap → jar → banked day →
+    // stage) turns over once a day at most, so the only way to be sure the edges
+    // fire exactly once is to be able to test them without waiting a week.
+    //
+    // GARNISH, NEVER THE LESSON. Barks are dropped entirely when the avatar window
+    // does not exist (BarkService's own gate), so nothing here may be the only
+    // place a mechanic is explained — the tooltips and the help surfaces own the
+    // teaching, and these lines sit on top of it.
+    //
+    // ONE MOMENT PER OBSERVATION. A day that banks can also cross a stage, and
+    // firing both would put two bubbles a second apart on a user who was told they
+    // would never be nagged. The higher moment wins and the rest are still marked
+    // as spent, so the loser does not resurface an hour later out of context.
+    // ============================================================================
+
+    /// <summary>The one thing an observation is worth saying, or <see cref="None"/>.</summary>
+    public enum DescentBarkMoment
+    {
+        None = 0,
+
+        /// <summary>Today's jar is climbing toward the line that banks the day.</summary>
+        NearBank,
+
+        /// <summary>Today crossed the line and is banked. Once per UTC day, forever.</summary>
+        DayBanked,
+
+        /// <summary>A new stage on the seven-rung ladder.</summary>
+        StageCrossed,
+
+        /// <summary>Back after days away, with the relapse bonus paying out. NEVER "gravity".</summary>
+        LapseReturn,
+    }
+
+    /// <summary>
+    /// What the watcher has already said, persisted between launches so a restart
+    /// cannot replay a day's milestone. Plain settable properties because it round
+    /// trips through Newtonsoft; every field is a key, not a count.
+    /// </summary>
+    public sealed class DescentBarkMemory
+    {
+        /// <summary>
+        /// False until the first block this install has ever seen. The first
+        /// observation SEEDS and says nothing: an account that already banked today
+        /// before the feature existed must not be congratulated for it on launch.
+        /// </summary>
+        public bool Seeded { get; set; }
+
+        /// <summary>UTC day (YYYY-MM-DD) whose banking has already been announced.</summary>
+        public string? LastBankedDay { get; set; }
+
+        /// <summary>UTC day on which the approaching-the-line nudge has already been spent.</summary>
+        public string? LastNearBankDay { get; set; }
+
+        /// <summary>Stage number already announced. Null until seeded.</summary>
+        public int? LastStage { get; set; }
+
+        /// <summary>
+        /// Identity of the last return already welcomed. The surge's own end
+        /// timestamp when the server states one, so a three day surge is welcomed
+        /// once rather than on each of its three days; the UTC day otherwise.
+        /// </summary>
+        public string? LastLapseKey { get; set; }
+    }
+
+    /// <summary>The chosen moment plus the numbers its copy is allowed to quote.</summary>
+    public sealed class DescentBarkDecision
+    {
+        public DescentBarkMoment Moment { get; init; } = DescentBarkMoment.None;
+
+        /// <summary>Today's fill as a percent of the daily cap.</summary>
+        public double FillPct { get; init; }
+
+        /// <summary>Percent of cap still to pour before the day banks. Zero once banked.</summary>
+        public double RemainingPct { get; init; }
+
+        public int TodayXp { get; init; }
+        public int Cap { get; init; }
+        public int Stage { get; init; }
+        public int BankedDays { get; init; }
+
+        /// <summary>Banked days still to go before the next rung, when the server states one.</summary>
+        public int? DaysToNext { get; init; }
+
+        public int DaysAway { get; init; }
+
+        /// <summary>The accrued fill-rate bonus, 1.0 upward. Clamped by the server at 2.0.</summary>
+        public double Multiplier { get; init; } = 1.0;
+
+        /// <summary>The frozen payout the return surge is actually applying.</summary>
+        public double SurgeMultiplier { get; init; } = 1.0;
+
+        public static readonly DescentBarkDecision Nothing = new();
+    }
+
+    /// <summary>Edge detection for the four block-driven Descent barks. Pure, and pinned by tests.</summary>
+    public static class DescentBarkPolicy
+    {
+        /// <summary>
+        /// Where the "you're nearly there" nudge opens, as a percent of cap. Sits at
+        /// three fifths of the way to the bank line so it lands while the user can
+        /// still act on it, and closes the moment the day banks so the two lines can
+        /// never both be true.
+        /// </summary>
+        public const double NearBankFloorPct = 12.0;
+
+        /// <summary>
+        /// Days away before a return is worth remarking on. One day away is an
+        /// ordinary evening off and saying anything about it would read as being
+        /// counted, which is the one thing this copy must never do.
+        /// </summary>
+        public const int LapseMinDaysAway = 2;
+
+        /// <summary>YYYY-MM-DD in UTC, the same shape the server stamps days with.</summary>
+        public static string TodayUtc(DateTime utcNow) =>
+            utcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+
+        /// <summary>
+        /// True when the server considers today already banked. The last-banked-day
+        /// stamp is the authority; the vat's own fill is a fallback for the window
+        /// between crossing the line and the stamp catching up.
+        /// </summary>
+        public static bool IsBankedToday(DescentBlock block, string todayUtc) =>
+            string.Equals(block.DevotionLastDay, todayUtc, StringComparison.Ordinal)
+            || (block.Vat is not null && block.Vat.FillPct >= DescentReader.BankThresholdPct);
+
+        /// <summary>
+        /// Decide what this observation is worth saying and MARK EVERY MOMENT IT
+        /// COVERS AS SPENT, whether or not it won. Mutating the memory here rather
+        /// than at the speak site is what makes "once per day" a property of the
+        /// data instead of a property of whether the companion happened to be on
+        /// screen; a bark the gate drops is a bark that is gone, which is the
+        /// correct trade for garnish.
+        /// </summary>
+        public static DescentBarkDecision Decide(DescentBlock? block, DescentBarkMemory memory, string todayUtc)
+        {
+            if (block is null || memory is null || string.IsNullOrWhiteSpace(todayUtc))
+                return DescentBarkDecision.Nothing;
+
+            var vat = block.Vat;
+            var stage = block.Stage;
+            var relapse = block.Relapse;
+
+            bool banked = IsBankedToday(block, todayUtc);
+
+            // First sight of a block on this install: record where the user already
+            // stands and say nothing at all about how they got there.
+            if (!memory.Seeded)
+            {
+                memory.Seeded = true;
+                memory.LastStage = stage?.N ?? 0;
+                if (banked) memory.LastBankedDay = todayUtc;
+                if (banked) memory.LastNearBankDay = todayUtc;
+                memory.LastLapseKey = LapseKeyOf(relapse, todayUtc);
+                return DescentBarkDecision.Nothing;
+            }
+
+            bool stageCrossed = stage is not null
+                                && memory.LastStage is int last
+                                && stage.N > last;
+
+            string? lapseKey = LapseKeyOf(relapse, todayUtc);
+            bool lapseReturn = relapse is not null
+                               && relapse.SurgeActive
+                               && relapse.DaysAway >= LapseMinDaysAway
+                               && lapseKey is not null
+                               && !string.Equals(lapseKey, memory.LastLapseKey, StringComparison.Ordinal);
+
+            bool dayBanked = banked
+                             && !string.Equals(memory.LastBankedDay, todayUtc, StringComparison.Ordinal);
+
+            bool nearBank = !banked
+                            && vat is not null
+                            && vat.FillPct >= NearBankFloorPct
+                            && vat.FillPct < DescentReader.BankThresholdPct
+                            && !string.Equals(memory.LastNearBankDay, todayUtc, StringComparison.Ordinal);
+
+            // Spend everything this observation covered, then pick one to say.
+            if (stage is not null) memory.LastStage = stage.N;
+            if (lapseReturn) memory.LastLapseKey = lapseKey;
+            if (dayBanked)
+            {
+                memory.LastBankedDay = todayUtc;
+                // A day that banked can no longer be approaching the line, and the
+                // nudge must not go off later the same day on a rounding wobble.
+                memory.LastNearBankDay = todayUtc;
+            }
+            if (nearBank) memory.LastNearBankDay = todayUtc;
+
+            var moment =
+                stageCrossed ? DescentBarkMoment.StageCrossed :
+                lapseReturn ? DescentBarkMoment.LapseReturn :
+                dayBanked ? DescentBarkMoment.DayBanked :
+                nearBank ? DescentBarkMoment.NearBank :
+                DescentBarkMoment.None;
+
+            if (moment == DescentBarkMoment.None) return DescentBarkDecision.Nothing;
+
+            double fill = vat?.FillPct ?? 0;
+            return new DescentBarkDecision
+            {
+                Moment = moment,
+                FillPct = Math.Round(fill, 1),
+                RemainingPct = Math.Max(0, Math.Round(DescentReader.BankThresholdPct - fill, 1)),
+                TodayXp = vat?.TodayXp ?? 0,
+                Cap = vat?.Cap ?? 0,
+                Stage = stage?.N ?? 0,
+                BankedDays = stage?.BankedDays ?? block.DevotionDays,
+                DaysToNext = stage?.DaysToNext,
+                DaysAway = relapse?.DaysAway ?? 0,
+                Multiplier = relapse?.Multiplier ?? 1.0,
+                SurgeMultiplier = relapse?.SurgeMultiplier ?? 1.0,
+            };
+        }
+
+        /// <summary>
+        /// Identity of a return, so the three day surge is welcomed once. The
+        /// surge's stated end is stable across all three days; without one we fall
+        /// back to the calendar day, which is still only one welcome per day.
+        /// </summary>
+        private static string? LapseKeyOf(DescentRelapse? relapse, string todayUtc)
+        {
+            if (relapse is null || !relapse.SurgeActive) return null;
+            return string.IsNullOrWhiteSpace(relapse.SurgeEndsAt) ? todayUtc : relapse.SurgeEndsAt;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Descent/DescentBarkWatcher.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentBarkWatcher.cs
@@ -1,0 +1,159 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    // ============================================================================
+    // THE SEAM. DescentService already re-reads the block on its own poll and after
+    // every sync, and it already raises BlockChanged on the UI thread when it does.
+    // So the four block-driven barks need no clock, no subscription of their own to
+    // any feature service, and nothing added to the Descent read path: they are a
+    // listener on an event that was already firing.
+    //
+    // THE MEMORY IS ON DISK, not in AppSettings. A day key per moment is exactly
+    // four small strings, they are meaningless outside this watcher, and the
+    // settings file is not the place to grow a per-day ledger.
+    //
+    // NOTHING HERE MAY THROW. A bark is decoration on a meter; a decoration that
+    // can break a profile poll is a bug with a much bigger blast radius than the
+    // feature is worth.
+    // ============================================================================
+
+    /// <summary>
+    /// Turns <see cref="DescentService.BlockChanged"/> into at most one companion
+    /// bark, using <see cref="DescentBarkPolicy"/> for every decision and a tiny
+    /// persisted memory so a restart cannot replay a milestone.
+    /// </summary>
+    public static class DescentBarkWatcher
+    {
+        private static readonly object _gate = new();
+        private static bool _attached;
+        private static DescentBarkMemory? _memory;
+
+        /// <summary>Where the day keys live. Beside the other small per-user stores.</summary>
+        private static string FilePath => Path.Combine(App.UserDataPath, "descent_barks.json");
+
+        /// <summary>
+        /// Subscribe to the Descent block. Idempotent, and safe to call before the
+        /// service exists (it simply does nothing and can be called again). Wired
+        /// from <c>BarkService.Start()</c>, which App.OnStartup runs well after
+        /// <c>App.Descent</c> is constructed.
+        /// </summary>
+        public static void Attach()
+        {
+            lock (_gate)
+            {
+                if (_attached) return;
+                var descent = App.Descent;
+                if (descent == null) return;
+                descent.BlockChanged += OnBlockChanged;
+                _attached = true;
+            }
+            App.Logger?.Debug("[Descent] bark watcher attached");
+        }
+
+        /// <summary>Symmetric teardown. Only the tests and a shutdown need it.</summary>
+        public static void Detach()
+        {
+            lock (_gate)
+            {
+                if (!_attached) return;
+                var descent = App.Descent;
+                if (descent != null) descent.BlockChanged -= OnBlockChanged;
+                _attached = false;
+            }
+        }
+
+        private static void OnBlockChanged(object? sender, EventArgs e)
+        {
+            try { Evaluate(App.Descent?.Current); }
+            catch (Exception ex) { App.Logger?.Debug("[Descent] bark watcher failed: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Read the block, ask the policy, speak at most one line. Public so the
+        /// Spiral room can prod it on entry without waiting for the next poll.
+        /// </summary>
+        public static void Evaluate(DescentBlock? block)
+        {
+            if (block is null) return;
+
+            DescentBarkDecision decision;
+            lock (_gate)
+            {
+                var memory = LoadLocked();
+                decision = DescentBarkPolicy.Decide(block, memory, DescentBarkPolicy.TodayUtc(DateTime.UtcNow));
+                SaveLocked(memory);
+            }
+
+            var bark = App.Bark;
+            if (bark == null || decision.Moment == DescentBarkMoment.None) return;
+
+            switch (decision.Moment)
+            {
+                case DescentBarkMoment.NearBank:
+                    bark.NotifyDescentNearBank(decision);
+                    break;
+                case DescentBarkMoment.DayBanked:
+                    bark.NotifyDescentDayBanked(decision);
+                    break;
+                case DescentBarkMoment.StageCrossed:
+                    bark.NotifyDescentStageCrossed(decision);
+                    break;
+                case DescentBarkMoment.LapseReturn:
+                    bark.NotifyDescentLapseReturn(decision);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// The Spiral room was entered. The once-ever latch lives in the bark rule
+        /// itself (repeatable false, lifetime scope), so this may be called on every
+        /// entry and will only ever speak the first time.
+        /// </summary>
+        public static void NotifySpiralOpened()
+        {
+            try { App.Bark?.NotifyDescentFirstSpiralOpen(App.Descent?.Current); }
+            catch (Exception ex) { App.Logger?.Debug("[Descent] spiral-open bark failed: {E}", ex.Message); }
+        }
+
+        // ------------------------------------------------------------- the memory
+
+        private static DescentBarkMemory LoadLocked()
+        {
+            if (_memory != null) return _memory;
+            try
+            {
+                if (File.Exists(FilePath))
+                    _memory = JsonConvert.DeserializeObject<DescentBarkMemory>(File.ReadAllText(FilePath));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Descent] bark memory unreadable, starting fresh: {E}", ex.Message);
+            }
+            // An unreadable memory seeds again rather than replaying: Seeded stays
+            // false, so the next observation records and says nothing.
+            return _memory ??= new DescentBarkMemory();
+        }
+
+        private static void SaveLocked(DescentBarkMemory memory)
+        {
+            try
+            {
+                Directory.CreateDirectory(App.UserDataPath);
+                File.WriteAllText(FilePath, JsonConvert.SerializeObject(memory, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Descent] bark memory could not be written: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>Test seam: drop the cached memory so the next Evaluate re-reads disk.</summary>
+        internal static void ResetCacheForTests()
+        {
+            lock (_gate) { _memory = null; }
+        }
+    }
+}

--- a/ConditioningControlPanel/Views/Tabs/SpiralTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/SpiralTabView.xaml.cs
@@ -341,8 +341,27 @@ namespace ConditioningControlPanel.Views.Tabs
         /// </summary>
         private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if (IsVisible) { Wire(); Refresh(); }
+            if (IsVisible) { Wire(); Refresh(); AnnounceEntry(); }
             else Suspend();
+        }
+
+        /// <summary>
+        /// Let the companion say hello to the room, once ever. The latch is the bark rule's own
+        /// (repeatable false, lifetime scope, persisted in AppSettings.BarkLifetimeFired), so both
+        /// entry paths may call this freely and only the first arrival can spend it.
+        ///
+        /// <para>Gated on the room having actually resolved to the spiral, and deliberately so: the
+        /// line explains the tap, the jar and the banked day, and burning a once-ever welcome on the
+        /// fog era would hand it to somebody looking at a countdown. <see cref="Refresh"/> has
+        /// already run, so <c>_state</c> is this entry's answer and not the last one's.</para>
+        ///
+        /// <para>Never throws, and never blocks the entry it rides on. A bark is decoration.</para>
+        /// </summary>
+        private void AnnounceEntry()
+        {
+            if (_state != SpiralRoomState.Spiral) return;
+            try { Services.Descent.DescentBarkWatcher.NotifySpiralOpened(); }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] entry bark failed: {E}", ex.Message); }
         }
 
         /// <summary>
@@ -358,6 +377,7 @@ namespace ConditioningControlPanel.Views.Tabs
             _embedGaveUp = false;
             Wire();
             Refresh();
+            AnnounceEntry();
         }
 
         /// <summary>Park everything: no clocks, no browser, nothing holding a frame.</summary>

--- a/Tests/ConditioningControlPanel.Tests/DescentBarkTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentBarkTests.cs
@@ -1,0 +1,435 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Services.Descent;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Descent's companion barks. Two halves, and they fail for different reasons.
+///
+/// <para>The POLICY half pins the edges. Every moment these lines narrate turns over once a day at
+/// most, so a bug that fires a milestone twice, or fires it again on every launch, would take a week
+/// of real use to notice and a week more to reproduce. It is pure by design precisely so it can be
+/// driven a month at a time in milliseconds.</para>
+///
+/// <para>The MANIFEST half pins the copy. A rule with no lines is a trigger that raises into silence,
+/// and the app raises these five from code that has no idea whether a pack answers it, so the packs
+/// are checked at source where the lines actually have to exist.</para>
+/// </summary>
+public class DescentBarkTests
+{
+    private const string Day1 = "2026-09-01";
+    private const string Day2 = "2026-09-02";
+
+    // =====================================================================================
+    //  the policy
+    // =====================================================================================
+
+    [Fact]
+    public void First_sight_of_a_block_seeds_and_says_nothing()
+    {
+        // An account that has been banking for months before this feature shipped must not be
+        // congratulated for today the instant the watcher attaches.
+        var memory = new DescentBarkMemory();
+        var block = Block(devotionDays: 40, lastDay: Day2, stage: 3, fillPct: 64);
+
+        var decision = DescentBarkPolicy.Decide(block, memory, Day2);
+
+        Assert.Equal(DescentBarkMoment.None, decision.Moment);
+        Assert.True(memory.Seeded);
+        Assert.Equal(3, memory.LastStage);
+        Assert.Equal(Day2, memory.LastBankedDay);
+    }
+
+    [Fact]
+    public void Crossing_the_line_banks_the_day_once_and_only_once()
+    {
+        var memory = Seeded(stage: 2, lastBankedDay: Day1);
+
+        // Still short of the line: nothing to announce about banking.
+        var below = DescentBarkPolicy.Decide(Block(40, Day1, 2, fillPct: 5), memory, Day2);
+        Assert.NotEqual(DescentBarkMoment.DayBanked, below.Moment);
+
+        var crossed = DescentBarkPolicy.Decide(Block(41, Day2, 2, fillPct: 22), memory, Day2);
+        Assert.Equal(DescentBarkMoment.DayBanked, crossed.Moment);
+
+        // Every later poll of the same day is silent, and so is a relaunch that re-reads the memory.
+        for (int i = 0; i < 5; i++)
+        {
+            var again = DescentBarkPolicy.Decide(Block(41, Day2, 2, fillPct: 40 + i * 10), memory, Day2);
+            Assert.Equal(DescentBarkMoment.None, again.Moment);
+        }
+    }
+
+    [Fact]
+    public void A_new_utc_day_rearms_the_bank_line()
+    {
+        var memory = Seeded(stage: 2, lastBankedDay: Day1);
+        Assert.Equal(DescentBarkMoment.DayBanked,
+            DescentBarkPolicy.Decide(Block(41, Day2, 2, fillPct: 25), memory, Day2).Moment);
+
+        const string day3 = "2026-09-03";
+        Assert.Equal(DescentBarkMoment.DayBanked,
+            DescentBarkPolicy.Decide(Block(42, day3, 2, fillPct: 25), memory, day3).Moment);
+    }
+
+    [Fact]
+    public void The_near_bank_nudge_lands_inside_its_window_once_a_day()
+    {
+        var memory = Seeded(stage: 1, lastBankedDay: Day1);
+
+        // Too early to be useful.
+        Assert.Equal(DescentBarkMoment.None,
+            DescentBarkPolicy.Decide(Block(10, Day1, 1, fillPct: 4), memory, Day2).Moment);
+
+        var nudge = DescentBarkPolicy.Decide(Block(10, Day1, 1, fillPct: 15), memory, Day2);
+        Assert.Equal(DescentBarkMoment.NearBank, nudge.Moment);
+        Assert.Equal(5.0, nudge.RemainingPct, 3);
+
+        // Not twice, however many times the poll ticks.
+        Assert.Equal(DescentBarkMoment.None,
+            DescentBarkPolicy.Decide(Block(10, Day1, 1, fillPct: 18), memory, Day2).Moment);
+    }
+
+    [Fact]
+    public void The_near_bank_nudge_never_fires_on_a_day_that_already_banked()
+    {
+        var memory = Seeded(stage: 1, lastBankedDay: Day2);
+        // A fill above the line is banked by definition, so the coaxing line is not eligible at all.
+        var d = DescentBarkPolicy.Decide(Block(11, Day2, 1, fillPct: 55), memory, Day2);
+        Assert.Equal(DescentBarkMoment.None, d.Moment);
+    }
+
+    [Fact]
+    public void A_day_that_banks_and_crosses_a_stage_says_the_bigger_thing_and_spends_both()
+    {
+        var memory = Seeded(stage: 2, lastBankedDay: Day1);
+
+        var d = DescentBarkPolicy.Decide(Block(21, Day2, 3, fillPct: 30), memory, Day2);
+        Assert.Equal(DescentBarkMoment.StageCrossed, d.Moment);
+        Assert.Equal(3, d.Stage);
+
+        // The banking it rode in on is spent too, so it cannot resurface an hour later out of context.
+        Assert.Equal(Day2, memory.LastBankedDay);
+        Assert.Equal(DescentBarkMoment.None,
+            DescentBarkPolicy.Decide(Block(21, Day2, 3, fillPct: 70), memory, Day2).Moment);
+    }
+
+    [Fact]
+    public void A_stage_only_announces_when_it_actually_moves_up()
+    {
+        var memory = Seeded(stage: 4, lastBankedDay: Day2);
+        // Same rung, and a server that somehow reports a lower one, are both silent.
+        Assert.Equal(DescentBarkMoment.None,
+            DescentBarkPolicy.Decide(Block(101, Day2, 4, fillPct: 50), memory, Day2).Moment);
+        Assert.Equal(DescentBarkMoment.None,
+            DescentBarkPolicy.Decide(Block(101, Day2, 3, fillPct: 50), memory, Day2).Moment);
+    }
+
+    [Fact]
+    public void A_return_is_welcomed_once_per_surge_not_once_per_surge_day()
+    {
+        var memory = Seeded(stage: 2, lastBankedDay: "2026-08-20");
+        var relapse = new DescentRelapse
+        {
+            Multiplier = 1.4,
+            DaysAway = 10,
+            SurgeActive = true,
+            SurgeEndsAt = "2026-09-05T00:00:00Z",
+            SurgeMultiplier = 1.4,
+        };
+
+        var first = DescentBarkPolicy.Decide(Block(30, "2026-08-20", 2, fillPct: 3, relapse: relapse), memory, Day2);
+        Assert.Equal(DescentBarkMoment.LapseReturn, first.Moment);
+        Assert.Equal(10, first.DaysAway);
+
+        // Day two and day three of the same surge are the same welcome, and it has been given.
+        const string day3 = "2026-09-03";
+        Assert.NotEqual(DescentBarkMoment.LapseReturn,
+            DescentBarkPolicy.Decide(Block(31, Day2, 2, fillPct: 3, relapse: relapse), memory, day3).Moment);
+
+        // A LATER return is a different surge, and is welcomed again.
+        var laterSurge = new DescentRelapse
+        {
+            Multiplier = 1.8,
+            DaysAway = 20,
+            SurgeActive = true,
+            SurgeEndsAt = "2026-10-01T00:00:00Z",
+            SurgeMultiplier = 1.8,
+        };
+        Assert.Equal(DescentBarkMoment.LapseReturn,
+            DescentBarkPolicy.Decide(Block(31, "2026-09-28", 2, fillPct: 1, relapse: laterSurge), memory, "2026-09-29").Moment);
+    }
+
+    [Fact]
+    public void An_evening_off_is_not_a_return()
+    {
+        // One day away is an ordinary evening off. Remarking on it would read as being counted,
+        // which is the one thing this copy must never do.
+        var memory = Seeded(stage: 2, lastBankedDay: Day1);
+        var relapse = new DescentRelapse
+        {
+            Multiplier = 1.04, DaysAway = 1, SurgeActive = true,
+            SurgeEndsAt = "2026-09-05T00:00:00Z", SurgeMultiplier = 1.04,
+        };
+        Assert.NotEqual(DescentBarkMoment.LapseReturn,
+            DescentBarkPolicy.Decide(Block(20, Day1, 2, fillPct: 2, relapse: relapse), memory, Day2).Moment);
+    }
+
+    [Fact]
+    public void No_block_is_inert()
+    {
+        var memory = new DescentBarkMemory();
+        Assert.Equal(DescentBarkMoment.None, DescentBarkPolicy.Decide(null, memory, Day2).Moment);
+        Assert.False(memory.Seeded);
+    }
+
+    [Fact]
+    public void A_dark_vat_never_produces_a_jar_line()
+    {
+        // The server can ship the block with the vat off. There is no honest stand-in for a meter
+        // that does not exist, so neither jar line may be reachable.
+        var memory = Seeded(stage: 2, lastBankedDay: Day1);
+        var block = new DescentBlock { DevotionDays = 30, DevotionLastDay = Day1, Vat = null, Stage = Stage(2, 30) };
+        var d = DescentBarkPolicy.Decide(block, memory, Day2);
+        Assert.NotEqual(DescentBarkMoment.NearBank, d.Moment);
+        Assert.NotEqual(DescentBarkMoment.DayBanked, d.Moment);
+    }
+
+    // =====================================================================================
+    //  the manifests
+    // =====================================================================================
+
+    /// <summary>Base manifest plus every built-in overlay. The base one is what a user with no mod
+    /// overlay for these ids actually hears, so it is checked on exactly the same terms.</summary>
+    private static readonly string[] Manifests =
+    {
+        "",                     // Resources/sounds/companion_audio/bark_rules.json
+        "builtin-bambisleep",
+        "builtin-locked",
+        "builtin-sissyhypno",
+    };
+
+    /// <summary>Rule id to the trigger key BarkService raises for it.</summary>
+    private static readonly Dictionary<string, string> DescentRules = new()
+    {
+        ["descent_near_bank"] = "DescentNearBank",
+        ["descent_day_banked"] = "DescentDayBanked",
+        ["descent_stage_crossed"] = "DescentStageCrossed",
+        ["descent_lapse_return"] = "DescentLapseReturn",
+        ["descent_first_spiral_open"] = "DescentFirstSpiralOpen",
+    };
+
+    [Fact]
+    public void Every_manifest_carries_every_descent_rule_on_the_right_trigger()
+    {
+        foreach (var pack in Manifests)
+        {
+            var rules = LoadRules(pack);
+            foreach (var (id, trigger) in DescentRules)
+            {
+                var rule = rules.FirstOrDefault(r => IdOf(r) == id);
+                Assert.True(rule != null, $"{Describe(pack)} has no '{id}' rule");
+                Assert.Equal(trigger, (string?)rule!["trigger"]);
+            }
+        }
+    }
+
+    [Fact]
+    public void Every_descent_trigger_is_actually_raised_by_the_app()
+    {
+        // A rule keyed to a trigger nothing raises is a pack that looks complete and never speaks.
+        var source = File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", "Services",
+                                                   "Companion", "BarkService.cs"));
+        foreach (var trigger in DescentRules.Values)
+            Assert.True(source.Contains($"Raise(\"{trigger}\""),
+                $"BarkService raises no '{trigger}' - the rules for it are unreachable");
+    }
+
+    [Fact]
+    public void Every_descent_rule_has_at_least_three_lines_that_work_without_audio()
+    {
+        foreach (var pack in Manifests)
+        {
+            foreach (var rule in DescentRulesIn(pack))
+            {
+                var pool = rule["variant_pool"] as JArray;
+                Assert.True(pool != null && pool.Count >= 3,
+                    $"{Describe(pack)}: '{IdOf(rule)}' needs at least three variants so repetition cannot set in");
+                foreach (var variant in pool!)
+                {
+                    Assert.False(string.IsNullOrWhiteSpace((string?)variant["text"]),
+                        $"{Describe(pack)}: '{IdOf(rule)}' has a variant with no text");
+                    // Text-only is first class here: nothing is recorded for these yet, so the key is
+                    // written as an explicit null rather than omitted, and a later voicing pass
+                    // cannot quietly drop a line's text.
+                    Assert.True(variant["audio"] != null,
+                        $"{Describe(pack)}: '{IdOf(rule)}' variant omits the 'audio' key (write an explicit null)");
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void No_descent_line_uses_an_em_dash()
+    {
+        // House rule: no em-dashes in user-facing text.
+        foreach (var pack in Manifests)
+            foreach (var text in LinesIn(pack))
+                Assert.False(text.Contains('—') || text.Contains('–'),
+                    $"{Describe(pack)}: a descent line uses an em/en dash: {text}");
+    }
+
+    [Fact]
+    public void No_descent_line_calls_the_relapse_bonus_gravity()
+    {
+        // Owner rule. The mechanic rewards absence; naming it gravity makes it sound like a penalty.
+        foreach (var pack in Manifests)
+            foreach (var text in LinesIn(pack))
+                Assert.DoesNotContain("gravity", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void The_return_lines_welcome_rather_than_scold()
+    {
+        // The whole point of the mechanic is that time away pays. A line that reaches for any of
+        // these is a line that has quietly turned it into a telling-off.
+        string[] banned = { "finally", "at last", "abandon", "neglect", "lazy", "slack", "excuse", "punish" };
+        foreach (var pack in Manifests)
+        {
+            foreach (var text in LinesOf(pack, "descent_lapse_return"))
+                foreach (var word in banned)
+                    Assert.DoesNotContain(word, text, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void The_spiral_welcome_is_a_lifetime_one_shot()
+    {
+        // "First time the Spiral is opened" is enforced by the rule, not by the caller: the view
+        // announces on every entry and this latch is what makes it the first one only.
+        foreach (var pack in Manifests)
+        {
+            var rule = DescentRulesIn(pack).Single(r => IdOf(r) == "descent_first_spiral_open");
+            Assert.False((bool?)rule["repeatable"] ?? true,
+                $"{Describe(pack)}: descent_first_spiral_open must not be repeatable");
+            Assert.Equal("lifetime", (string?)rule["scope"]);
+        }
+    }
+
+    [Fact]
+    public void The_recurring_rules_carry_a_cooldown_long_enough_to_never_nag()
+    {
+        // The watcher's day keys already hold these to once a day, but a rule with no cooldown is a
+        // rule that would repeat the moment somebody wired a second caller to the trigger.
+        string[] recurring = { "descent_near_bank", "descent_day_banked", "descent_lapse_return" };
+        foreach (var pack in Manifests)
+        {
+            foreach (var id in recurring)
+            {
+                var rule = DescentRulesIn(pack).Single(r => IdOf(r) == id);
+                var cooldown = (long?)rule["cooldown_ms"] ?? 0;
+                Assert.True(cooldown >= 6 * 60 * 60 * 1000L,
+                    $"{Describe(pack)}: '{id}' has a {cooldown}ms cooldown, which is short enough to nag");
+            }
+        }
+    }
+
+    [Fact]
+    public void Each_mod_speaks_the_moment_in_its_own_voice()
+    {
+        // The overlays exist to sound different. A pack that copied the base pool verbatim would
+        // pass every other check here and still be a bug.
+        foreach (var id in DescentRules.Keys)
+        {
+            var baseLines = LinesOf("", id).ToHashSet(StringComparer.Ordinal);
+            foreach (var pack in Manifests.Where(p => p.Length > 0))
+            {
+                var modLines = LinesOf(pack, id).ToList();
+                Assert.True(modLines.Count > 0, $"{Describe(pack)}: '{id}' has no lines");
+                Assert.False(modLines.All(baseLines.Contains),
+                    $"{Describe(pack)}: '{id}' reuses the base pool verbatim instead of its own voice");
+            }
+        }
+    }
+
+    [Fact]
+    public void The_teaching_lines_use_the_canonical_phrasing_for_what_moves_the_spiral()
+    {
+        // Every surface says this the same way (the vat tick tooltip owns the wording). A bark that
+        // invented a fifth phrasing would teach the mechanic and blur the sentence at the same time.
+        const string canonical = "banked days are the only thing that moves you down the Spiral";
+        foreach (var pack in Manifests)
+        {
+            foreach (var id in new[] { "descent_day_banked", "descent_first_spiral_open" })
+            {
+                Assert.Contains(LinesOf(pack, id), t => t.Contains(canonical, StringComparison.Ordinal));
+            }
+        }
+    }
+
+    // =====================================================================================
+    //  helpers
+    // =====================================================================================
+
+    private static DescentBlock Block(int devotionDays, string? lastDay, int stage, double fillPct,
+                                      DescentRelapse? relapse = null) =>
+        new()
+        {
+            DevotionDays = devotionDays,
+            DevotionLastDay = lastDay,
+            Stage = Stage(stage, devotionDays),
+            Relapse = relapse,
+            Vat = new DescentVat { Cap = 4000, TodayXp = (int)(4000 * fillPct / 100), FillPct = fillPct, FillLipPct = 120 },
+        };
+
+    private static DescentStage Stage(int n, int bankedDays) =>
+        new() { N = n, Key = $"stage_{n}", BankedDays = bankedDays };
+
+    private static DescentBarkMemory Seeded(int stage, string lastBankedDay) =>
+        new() { Seeded = true, LastStage = stage, LastBankedDay = lastBankedDay, LastNearBankDay = lastBankedDay };
+
+    private static IEnumerable<JObject> DescentRulesIn(string pack) =>
+        LoadRules(pack).Where(r => DescentRules.ContainsKey(IdOf(r)));
+
+    private static IEnumerable<string> LinesIn(string pack) =>
+        DescentRulesIn(pack).SelectMany(PoolText);
+
+    private static IEnumerable<string> LinesOf(string pack, string id) =>
+        LoadRules(pack).Where(r => IdOf(r) == id).SelectMany(PoolText);
+
+    private static IEnumerable<string> PoolText(JObject rule) =>
+        (rule["variant_pool"] as JArray ?? new JArray())
+            .Select(v => (string?)v["text"] ?? "")
+            .Where(t => t.Length > 0);
+
+    private static List<JObject> LoadRules(string pack)
+    {
+        var parts = new List<string> { RepoRoot(), "ConditioningControlPanel", "Resources", "sounds", "companion_audio" };
+        if (pack.Length > 0) { parts.Add("mods"); parts.Add(pack); }
+        parts.Add("bark_rules.json");
+        var path = Path.Combine(parts.ToArray());
+        Assert.True(File.Exists(path), $"missing bark manifest: {path}");
+        // Strict parse on purpose: a malformed manifest must fail here rather than at runtime, where
+        // the loader's own leniency would silence the whole companion instead of one rule.
+        return JArray.Parse(File.ReadAllText(path)).OfType<JObject>().ToList();
+    }
+
+    private static string Describe(string pack) =>
+        (pack.Length == 0 ? "base" : pack) + "/bark_rules.json";
+
+    private static string IdOf(JObject rule) => (string?)rule["id"] ?? "(no id)";
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
@@ -90,7 +90,17 @@ public class DescentZeroShowOrderingTests
         service.ReleaseOffers();
         Assert.Equal(0, service.OfferHoldDepth);
         Assert.NotNull(service.LiveOffer);
-        Assert.True(service.CanOpenCeremony());
+
+        // EITHER OUTCOME IS THE GUARANTEE, and asserting only the first one made this suite depend
+        // on the order it ran in. ReleaseOffers does not just un-gate: when an Application exists it
+        // goes on to BeginInvoke the open, which is the correct behaviour and which sets the very
+        // flag CanOpenCeremony reads. WpfRenderHarness stands one up on an STA thread and leaves it
+        // alive for the rest of the process, so whether this test saw a live Application came down
+        // to whether it beat the first WPF suite to the punch — and the BeginInvoke is asynchronous,
+        // so even losing that race gave a different answer run to run. What §2.4 actually promises
+        // is that the release either opened the ceremony or left it openable; what it never does is
+        // drop the offer. That holds in both environments and in either half of the race.
+        Assert.True(service.CanOpenCeremony() || service.IsCeremonyOpen);
     }
 
     /// <summary>


### PR DESCRIPTION
## What this is

Five companion barks that teach the Descent loop at the moments it is about to matter, rather than
leaving the tap, the jar, the banked day and the Spiral to be discovered in the help text.

| Trigger | Fires when | Priority | Cooldown | Scope |
|---|---|---|---|---|
| `DescentNearBank` | the jar is inside the last stretch before the line, on a day that has not banked | 240 | 6h | session |
| `DescentDayBanked` | the day crosses the line, at most once per UTC day | 340 | 12h | session |
| `DescentStageCrossed` | the stage number actually moves up | 420 | none | session |
| `DescentLapseReturn` | a return surge appears, welcomed once per surge and not once per surge day | 400 | 12h | session |
| `DescentFirstSpiralOpen` | the Spiral room is opened for the first time ever | 470 | none | **lifetime one-shot** |

## Where they fire from

Four of them hang off `DescentService.BlockChanged` through a new `DescentBarkWatcher`, and the fifth
comes from `SpiralTabView` announcing its own first open. `BarkService.Start` attaches the watcher
after `WireSubscriptions`, which is the first point where both `App.Descent` and the bark service
exist.

- `Services/Descent/DescentBarkPolicy.cs` (new): pure, `App`-free edge detection. Compares consecutive
  blocks and picks at most one moment, `StageCrossed` > `LapseReturn` > `DayBanked` > `NearBank`, and
  marks every covered moment spent whether or not it won, so a day that banks and crosses a stage says
  the bigger thing once instead of saying both. The first block it ever sees only seeds: someone
  opening the app on day 200 is not congratulated for 200 days at launch.
- `Services/Descent/DescentBarkWatcher.cs` (new): subscribes idempotently, persists the day keys to
  `descent_barks.json` under `UserDataPath` so "once per day" survives a restart, and never throws.
- `Services/Companion/BarkService.cs`: five `Notify...` raisers and one `Attach()` line.
- `Views/Tabs/SpiralTabView.xaml.cs`: `AnnounceEntry()` on visibility and on tab show, gated to the
  Spiral state.
- Four `bark_rules.json` manifests: base plus bambisleep, sissyhypno and locked, appended only.

## The copy

Three variants per trigger per pack, sixty lines in total, every one with `"audio": null` so a text
only companion is first class. Barks are dropped entirely when `App.AvatarWindow` is null, so nothing
here is the only place a fact is taught; this is garnish over the help and tooltip work landing
alongside it.

The teaching lines use the canonical phrasing, "banked days are the only thing that moves you down the
Spiral", rather than a fifth way of saying it. They talk about the jar filling and never about the
arithmetic behind the jar's size, since the cap is server authored and no client should imply a number
for it. The return lines welcome and never scold, and they never name the relapse bonus. Each pack
speaks the moment in its own voice, and there is not an em-dash in any of them.

## Tests

21 new tests in `Tests/ConditioningControlPanel.Tests/DescentBarkTests.cs`, in two halves. The policy
half drives a month of days through the pure decider and pins the edges that would otherwise take a
week of real use to notice: seeding, one bank per day, the day rolling over, the near-bank window
never firing on a day that already banked, stage moves that are not moves, and a surge welcomed once.
The manifest half reads all four packs and pins that every rule exists on the right trigger with at
least three audio-free lines, that no line carries an em-dash or names the relapse bonus, that the
welcome is a lifetime one-shot, that the recurring rules carry a real cooldown, that the packs differ
from each other, and that every trigger the manifests answer is actually raised by `BarkService`.

Full suite: **4965 passed, 0 failed, 0 skipped**, green on four consecutive runs. `dotnet build`
succeeds with 0 errors.

## One test outside this feature

`DescentZeroShowOrderingTests.AnOfferDuringTheShow_IsHeldNotDropped` was passing or failing on test
order, and adding a class to the pool was enough to tip it. `ReleaseOffers` does not merely un-gate:
where an `Application` exists it goes on to `BeginInvoke` the ceremony open, which sets the very flag
`CanOpenCeremony` reads, and `WpfRenderHarness` leaves an `Application` alive for the rest of the
process. The §2.4 guarantee is that the release either opened the ceremony or left it openable and
never dropped the offer, so the assertion now says that. No production code was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011X4sQCaLkh946ty2ENbJPN
