### PR TITLE
test(descent): ZeroShow ordering test accepts opened as well as openable

### DIFF
--- a/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentZeroShowOrderingTests.cs
@@ -90,7 +90,17 @@ public class DescentZeroShowOrderingTests
         service.ReleaseOffers();
         Assert.Equal(0, service.OfferHoldDepth);
         Assert.NotNull(service.LiveOffer);
-        Assert.True(service.CanOpenCeremony());
+
+        // EITHER OUTCOME IS THE GUARANTEE, and asserting only the first one made this suite depend
+        // on the order it ran in. ReleaseOffers does not just un-gate: when an Application exists it
+        // goes on to BeginInvoke the open, which is the correct behaviour and which sets the very
+        // flag CanOpenCeremony reads. WpfRenderHarness stands one up on an STA thread and leaves it
+        // alive for the rest of the process, so whether this test saw a live Application came down
+        // to whether it beat the first WPF suite to the punch — and the BeginInvoke is asynchronous,
+        // so even losing that race gave a different answer run to run. What §2.4 actually promises
+        // is that the release either opened the ceremony or left it openable; what it never does is
+        // drop the offer. That holds in both environments and in either half of the race.
+        Assert.True(service.CanOpenCeremony() || service.IsCeremonyOpen);
     }
 
     /// <summary>


### PR DESCRIPTION
Test-only. `AnOfferDuringTheShow_IsHeldNotDropped` failed deterministically in full-suite runs (green alone) because `ReleaseOffers()` opens the ceremony when a WPF `Application` exists, flipping `_ceremonyOpen` before the final `Assert.True(service.CanOpenCeremony())` reads it. The assertion now states the actual §2.4 guarantee: opened or still openable, never dropped.

Lifted verbatim from #471 (session d4's diagnosis) so the CI gate is green before 6.9.1 rather than waiting on the barks feature. #471 can keep or drop its copy of the hunk; it merges clean either way.

Descent test classes: 465 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
