### PR TITLE
release: bump to v6.9.1 - The Spiral

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>ConditioningControlPanel</AssemblyName>
     <RootNamespace>ConditioningControlPanel</RootNamespace>
-    <Version>6.9.0</Version>
+    <Version>6.9.1</Version>
     <Company>CodeBambi</Company>
     <Product>Conditioning Control Panel</Product>
     <Description>A professional visual conditioning application with gamification features.</Description>

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "Wenn dir das Projekt gefällt, ",
   "label_consider_supporting_it": "unterstütze es gerne",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Ein besonderer Dank an Platinum Puppets für die bereitgestellten Audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -1139,6 +1139,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "If you love the project please ",
   "label_consider_supporting_it": "consider supporting it",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "A special thanks to Platinum Puppets for providing the audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "Si te encanta el proyecto, por favor ",
   "label_consider_supporting_it": "considera apoyarlo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un agradecimiento especial a Platinum Puppets por proporcionar los audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "Si tu aimes ce projet, ",
   "label_consider_supporting_it": "pense à le soutenir",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un merci spécial aux Platinum Puppets pour les audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "このプロジェクトが気に入ったら",
   "label_consider_supporting_it": "ぜひ支援をご検討ください",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Platinum Puppetsのオーディオ提供に感謝します ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "이 프로젝트가 마음에 드셨다면 ",
   "label_consider_supporting_it": "후원을 고려해 주세요",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "오디오를 제공해 주신 Platinum Puppets에게 특별히 감사드려요 ❤️",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "Se você ama o projeto, por favor ",
   "label_consider_supporting_it": "considere apoiá-lo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Um agradecimento especial às Platinum Puppets por fornecerem os áudios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -362,6 +362,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "Если тебе нравится проект, ",
   "label_consider_supporting_it": "поддержи его",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Особая благодарность Platinum Puppets за предоставленные аудио ❤️",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -952,6 +952,8 @@
   "tooltip_v6_8_6_relapse_pt_2": "v6.8.6 - Relapse (pt. 2)",
   "btn_v6_9_0_is_out": "💖 v6.9.0 IS OUT! 💖",
   "tooltip_v6_9_0_the_spiral": "v6.9.0 - The Spiral",
+  "btn_v6_9_1_is_out": "💖 v6.9.1 IS OUT! 💖",
+  "tooltip_v6_9_1_the_spiral": "v6.9.1 - The Spiral",
   "label_if_you_love_the_project_please": "如果你喜欢这个项目，请",
   "label_consider_supporting_it": "考虑支持它",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "特别感谢 Platinum Puppets 提供音频 ❤️",

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -2011,8 +2011,8 @@
                             </Style>
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>
-                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_9_0_is_out}"
-                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_9_0_the_spiral}"
+                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_9_1_is_out}"
+                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_9_1_the_spiral}"
                             FontSize="11" FontWeight="Bold" Cursor="Hand">
                         <Button.Style>
                             <Style TargetType="Button">

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -20,15 +20,15 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Current application version - UPDATE THIS WHEN BUMPING VERSION
         /// </summary>
-        public const string AppVersion = "6.9.0";
+        public const string AppVersion = "6.9.1";
 
         /// <summary>
         /// Patch notes for the current version - UPDATE THIS WHEN BUMPING VERSION
         /// These are shown in the update dialog and can be used when GitHub release notes are unavailable.
         /// </summary>
-        public const string CurrentPatchNotes = @"v6.9.0 - The Spiral
+        public const string CurrentPatchNotes = @"v6.9.1 - The Spiral
 
-this is the big one. tomorrow, September 1st at 7pm UTC, the monthly wipe runs one final time and then it is gone forever. after the ceremony your level, your XP and your hours are yours for good. this is the version that carries you into that world, and i wanted it to feel special. it does :3
+this is the big one. on September 1st the Descent ceremony ran and the monthly wipe is gone forever. from here on your level, your XP and your hours are yours for good. this is the version that carries you into that world, and i wanted it to feel special. it does :3
 
 THE ARCADEMY
 - the campus takes center stage. classes that are secretly little games, a prize counter, your own locker, report cards, the works. wander around, get graded, get conditioned.
@@ -46,7 +46,7 @@ EVERYWHERE AT ONCE
 - the CCP Mobile public beta is live! grab the APK here: https://github.com/CodeBambi/CCP-Mobile-Releases/releases/latest
 
 THE DESCENT
-- September 1st, 7pm UTC. the board clears one final time and then never again. levels and hours carry forward from that moment on.
+- the wipe is gone. nothing clears any more, and levels and hours carry forward from here on.
 - the season recap card only shows if a reset actually happened to you, the countdown is honest and stands down when it is over, and if a stray reset order ever reaches the app after the Descent, the app refuses it. your progress does not roll back because a server hiccuped.
 
 NEW MOD: INFECTION CONTROL
@@ -56,7 +56,17 @@ NEW MOD: INFECTION CONTROL
 
 AND SOME FIXES
 - the updater now upgrades the copy you are actually running, the fade slider actually fades, escape always escapes when it should, muted means muted, tooltips are readable again, ghost mode stops freezing, and the menus behave.
-- full nerd changelog in the pull requests, numbers 380 through 445.";
+- full nerd changelog in the pull requests, numbers 380 through 445.
+
+6.9.1 HOTFIXES (the day after)
+- the ceremony's two doors fit on screen at high display scaling, and ""not tonight"" stops re-asking for the session.
+- your profile card shows which door you picked, with the +10% on the XP numbers if you cycled.
+- the board notice, the Spiral help card and EMI's barks all agree now: nothing was wiped and nothing resets.
+- bubbles have their own ""stare to pop"" switch on the bubble page.
+- a headset play/pause tap no longer ends a strict lock video.
+- a failed update download gets a proper box and a manual download button, and the exe carries its real version number.
+- flash audio unducks after a stop, reveal in explorer works with spaces, customize and privacy are hidden on other people's cards, OCR text stays out of the logs, and the single-digit age bypass is closed.
+- full nerd changelog in pull requests 451 through 475.";
 
         private const string GitHubOwner = "CodeBambi";
         private const string GitHubRepo = "Conditioning-Control-Panel---CSharp-WPF";

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -7,7 +7,7 @@ echo ============================================
 echo.
 
 :: Configuration
-set VERSION=6.9.0
+set VERSION=6.9.1
 set PROJECT_DIR=ConditioningControlPanel
 set PUBLISH_DIR=%PROJECT_DIR%\bin\Release\net8.0-windows10.0.19041.0\win-x64\publish
 set INSTALLER_OUTPUT=installer-output

--- a/installer.iss
+++ b/installer.iss
@@ -13,7 +13,7 @@
 ; - Store install path in registry for Velopack updates
 
 #define MyAppName "Conditioning Control Panel"
-#define MyAppVersion "6.9.0"
+#define MyAppVersion "6.9.1"
 #define MyAppPublisher "CodeBambi"
 #define MyAppURL "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF"
 #define MyAppExeName "ConditioningControlPanel.exe"

--- a/notes-v6.9.1.txt
+++ b/notes-v6.9.1.txt
@@ -1,0 +1,41 @@
+v6.9.1 - The Spiral
+
+this is the big one. on September 1st the Descent ceremony ran and the monthly wipe is gone forever. from here on your level, your XP and your hours are yours for good. this is the version that carries you into that world, and i wanted it to feel special. it does :3
+
+THE ARCADEMY
+- the campus takes center stage. classes that are secretly little games, a prize counter, your own locker, report cards, the works. wander around, get graded, get conditioned.
+- EMI runs the halls. she deals commentary, hands out hints in Daily Trigger, and cameos in Impulse Control when you least expect her.
+- your Sparks wallet follows you around the whole campus, and it now tells you WHY it refused a purchase instead of just refusing.
+- faster on phones, prettier in portrait, and the flash guard slider finally says which way is gentler.
+
+EMI'S DESK
+- EMI got out of the school. summon her onto your desktop: a little ring on the edge of your screen opens into her CRT glass and she just hangs out. reacts to what the app is doing to you. picks up props. lives her life.
+- we wrote her a whole handbook together. Ask EMI anything about the app and she answers, in all 9 languages. it is the new guide and she is very proud of it.
+- new users get a proper first contact from her now instead of silence.
+
+EVERYWHERE AT ONCE
+- one account, everywhere. desktop, the web at cclabs.app, and now your phone. XP, wallet, presence, profile, it all connects.
+- the CCP Mobile public beta is live! grab the APK here: https://github.com/CodeBambi/CCP-Mobile-Releases/releases/latest
+
+THE DESCENT
+- the wipe is gone. nothing clears any more, and levels and hours carry forward from here on.
+- the season recap card only shows if a reset actually happened to you, the countdown is honest and stands down when it is over, and if a stray reset order ever reaches the app after the Descent, the app refuses it. your progress does not roll back because a server hiccuped.
+
+NEW MOD: INFECTION CONTROL
+- a sixth mod joins the shelf, created by Miss Jenny. Nurse Amber runs the ward with over 330 freshly voiced lines: barks, mantra takeovers, her own flash voicelines, and her voice all the way down the Rabbit Hole.
+- her own spiral, her own colors, and she comments on nearly everything you do.
+- like the other built-ins the audio arrives as a downloadable pack so the installer stays lean.
+
+AND SOME FIXES
+- the updater now upgrades the copy you are actually running, the fade slider actually fades, escape always escapes when it should, muted means muted, tooltips are readable again, ghost mode stops freezing, and the menus behave.
+- full nerd changelog in the pull requests, numbers 380 through 445.
+
+6.9.1 HOTFIXES (the day after)
+- the ceremony's two doors fit on screen at high display scaling, and "not tonight" stops re-asking for the session.
+- your profile card shows which door you picked, with the +10% on the XP numbers if you cycled.
+- the board notice, the Spiral help card and EMI's barks all agree now: nothing was wiped and nothing resets.
+- bubbles have their own "stare to pop" switch on the bubble page.
+- a headset play/pause tap no longer ends a strict lock video.
+- a failed update download gets a proper box and a manual download button, and the exe carries its real version number.
+- flash audio unducks after a stop, reveal in explorer works with spaces, customize and privacy are hidden on other people's cards, OCR text stays out of the logs, and the single-digit age bypass is closed.
+- full nerd changelog in pull requests 451 through 475.


### PR DESCRIPTION
Version bump for the v6.9.1 day-after hotfix. Subtitle stays "The Spiral" per the owner.

- csproj `<Version>`, `UpdateService.AppVersion`, `installer.iss`, `build-installer.bat`, `BtnUpdateAvailable` loc keys, 2 new keys x 9 language files (strict JSON, 2 lines each, no line-ending churn).
- `CurrentPatchNotes`: 6.9.0 text with the two "wipe runs one final time" sentences corrected (it never ran) and a short 6.9.1 hotfix block appended.
- `notes-v6.9.1.txt` added at repo root for the GitHub release body and the Discord announce.

Release candidate verified at bf1af1ccf: 5095 tests, clean publish smoke PASS, four play-tests CONFIRMED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAKYEPfJtJxZiYwhqqz7J
