### PR TITLE
fix(build): scope self-contained packaging to publish (NETSDK1151 / MSB3030); pin SDK

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -17,7 +17,14 @@
     <ApplicationIcon>Resources\app.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
+    <!-- Self-contained packaging is a PUBLISH-only concern. A plain "dotnet build" of the
+         solution pulls in the non-self-contained Tests project, and a non-self-contained
+         executable cannot reference a self-contained one: this surfaces as NETSDK1151 on the
+         .NET 10 SDK, and as MSB3030 (cannot copy singlefilehost.exe) on some setups. Default
+         off for build/run; the shipping build turns it on via -p:CcpPublish=true
+         (build-installer.bat). An explicit self-contained flag on a publish still overrides it. -->
+    <CcpPublish Condition="'$(CcpPublish)' == ''">false</CcpPublish>
+    <SelfContained>$(CcpPublish)</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -46,7 +46,7 @@ mkdir "%INSTALLER_OUTPUT%" 2>nul
 echo.
 echo [2/4] Building application (Release)...
 cd %PROJECT_DIR%
-dotnet publish -c Release -r win-x64 --self-contained true
+dotnet publish -c Release -r win-x64 --self-contained true -p:CcpPublish=true
 if errorlevel 1 (
     echo ERROR: Build failed!
     pause

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/installer.iss
+++ b/installer.iss
@@ -3,7 +3,7 @@
 ;
 ; Requirements:
 ; 1. Install Inno Setup from https://jrsoftware.org/isinfo.php
-; 2. Build the app first: dotnet publish -c Release
+; 2. Build the app first: dotnet publish -c Release -r win-x64 --self-contained true
 ; 3. Compile this script with Inno Setup Compiler
 ;
 ; The installer will:


### PR DESCRIPTION
## Problem

A plain `dotnet build` of the solution fails: `ConditioningControlPanel.csproj` sets
`<SelfContained>true</SelfContained>` unconditionally, so it builds as a self-contained
executable, and the non-self-contained `ConditioningControlPanel.Tests` project can't
reference one. It surfaces as **NETSDK1151** on the .NET 10 SDK and as **MSB3030 ("cannot
copy singlefilehost.exe")** on some setups. `.github/workflows/build.yml` currently works
around it with `-p:ValidateExecutableReferencesMatchSelfContained=false`.

## Change

- **csproj**: gate `SelfContained` behind a `CcpPublish` property (default `false`). Plain
  `dotnet build` / `dotnet run` is now framework-dependent; a publish opts back in.
- **build-installer.bat**: pass `-p:CcpPublish=true` (alongside the existing
  `--self-contained true`, which also still forces it).
- **installer.iss**: the "build first" comment now shows the full
  `dotnet publish -c Release -r win-x64 --self-contained true`.
- **global.json** (new): pin the SDK to the `8.0.4xx` feature band,
  `rollForward: latestFeature`. Requires the .NET 8 SDK locally (CI already installs
  `8.0.x`); makes the build environment explicit instead of "whatever's installed".

Once merged, the `ValidateExecutableReferencesMatchSelfContained=false` flag in
`build.yml` is redundant and can be dropped in a follow-up.

## Verification

`dotnet build` at the solution root then succeeds with 0 errors and the Tests project
builds. (Not verified on the author's machine for this branch — `global.json`'s
`latestFeature` needs an 8.x SDK the author doesn't have installed yet; CI is the check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
