### PR TITLE
P0 warning cleanup: scrub-jitter bug fix + IL3000 / CS0649 / CS4014

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -45,7 +45,7 @@ namespace ConditioningControlPanel
         /// </summary>
         private async void OnActivityChanged(object? sender, ActivityChangedEventArgs e)
         {
-            if (!Dispatcher.CheckAccess()) { Dispatcher.BeginInvoke(new Action(() => OnActivityChanged(sender, e))); return; }
+            if (!Dispatcher.CheckAccess()) { _ = Dispatcher.BeginInvoke(new Action(() => OnActivityChanged(sender, e))); return; }
             // async void: a leaked exception (especially from the post-await
             // continuation) escapes to the dispatcher and kills the whole
             // process. Guard the entire body and bail if the app is tearing
@@ -166,7 +166,7 @@ namespace ConditioningControlPanel
         /// </summary>
         private async void OnStillOnActivity(object? sender, ActivityChangedEventArgs e)
         {
-            if (!Dispatcher.CheckAccess()) { Dispatcher.BeginInvoke(new Action(() => OnStillOnActivity(sender, e))); return; }
+            if (!Dispatcher.CheckAccess()) { _ = Dispatcher.BeginInvoke(new Action(() => OnStillOnActivity(sender, e))); return; }
             // async void: guard the whole body so a leaked exception can't kill
             // the process, and bail if the app is tearing down. (#386)
             try
@@ -363,7 +363,7 @@ namespace ConditioningControlPanel
 
         private async void OnVideoEnded(object? sender, EventArgs e)
         {
-            if (!Dispatcher.CheckAccess()) { Dispatcher.BeginInvoke(new Action(() => OnVideoEnded(sender, e))); return; }
+            if (!Dispatcher.CheckAccess()) { _ = Dispatcher.BeginInvoke(new Action(() => OnVideoEnded(sender, e))); return; }
             // Z-order after video end: native ownership keeps the attached pair together.
 
             if (App.Settings?.Current?.AiChatEnabled == true && App.Ai?.IsAvailable == true)

--- a/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
@@ -215,7 +215,7 @@ public sealed class ChaosFlashOverlay : Window
 
                     var dispatcher = Application.Current?.Dispatcher;
                     if (dispatcher == null || dispatcher.HasShutdownStarted) return;
-                    dispatcher.BeginInvoke(() =>
+                    _ = dispatcher.BeginInvoke(() =>
                     {
                         // A newer wash (or a clear/teardown) may have superseded this decode.
                         try { if (gen == _displayGen) _img.Source = bmp; } catch { }

--- a/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
@@ -410,7 +410,7 @@ public sealed class ChaosGifCascadeOverlay : Window
 
                         var dispatcher = Application.Current?.Dispatcher;
                         if (dispatcher == null || dispatcher.HasShutdownStarted) return;
-                        dispatcher.BeginInvoke(() => { try { img.Source = bmp; } catch { } });
+                        _ = dispatcher.BeginInvoke(() => { try { img.Source = bmp; } catch { } });
                     }
                     catch (Exception ex) { App.Logger?.Debug("GifCascade decode: {E}", ex.Message); }
                 });

--- a/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
@@ -72,7 +72,7 @@ namespace ConditioningControlPanel
                 {
                     // Defer revert so it runs after the dialog's event stack fully unwinds,
                     // preventing WPF toggle animation from getting stuck in the ON position.
-                    Dispatcher.BeginInvoke(new Action(() =>
+                    _ = Dispatcher.BeginInvoke(new Action(() =>
                     {
                         _isLoading = true;
                         RemoteControlTab.ChkRemoteControlEnabled.IsChecked = false;

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -1034,7 +1034,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     if (uri == null) return;
                     var disp = Application.Current?.Dispatcher;
                     if (disp == null || disp.HasShutdownStarted) return;
-                    disp.BeginInvoke(() => { try { PostDiscordEcho(); } catch { } });
+                    _ = disp.BeginInvoke(() => { try { PostDiscordEcho(); } catch { } });
                 });
             }
             catch (Exception ex) { App.Logger?.Debug("GoonHostService.KickOwnAvatarRefresh: {E}", ex.Message); }

--- a/ConditioningControlPanel/Services/StartupManager.cs
+++ b/ConditioningControlPanel/Services/StartupManager.cs
@@ -16,8 +16,6 @@ namespace ConditioningControlPanel.Services
 
         private static string StartupFolderPath => Environment.GetFolderPath(Environment.SpecialFolder.Startup);
         private static string ShortcutPath => Path.Combine(StartupFolderPath, ShortcutName);
-        private static string ApplicationPath => System.Reflection.Assembly.GetExecutingAssembly().Location
-            .Replace(".dll", ".exe"); // Handle both .exe and .dll scenarios
 
         /// <summary>
         /// Checks if the application is registered to start with Windows.
@@ -115,19 +113,8 @@ namespace ConditioningControlPanel.Services
                 return processPath;
             }
 
-            // Fallback: construct from assembly location
-            var assemblyLocation = System.Reflection.Assembly.GetExecutingAssembly().Location;
-            if (!string.IsNullOrEmpty(assemblyLocation))
-            {
-                // For .NET Core/.NET 5+ single-file apps, the assembly location might be empty or point to .dll
-                var exePath = assemblyLocation.Replace(".dll", ".exe");
-                if (File.Exists(exePath))
-                {
-                    return exePath;
-                }
-            }
-
-            // Try AppContext.BaseDirectory
+            // Fallback: AppContext.BaseDirectory + the app name. Assembly.Location is
+            // deliberately not consulted — it is empty in a single-file build (IL3000).
             var baseDir = AppContext.BaseDirectory;
             var appName = AppDomain.CurrentDomain.FriendlyName;
             if (!appName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))

--- a/ConditioningControlPanel/Views/Controls/Companion/Runtime/ChatThresholdRuntimeVm.cs
+++ b/ConditioningControlPanel/Views/Controls/Companion/Runtime/ChatThresholdRuntimeVm.cs
@@ -392,7 +392,7 @@ namespace ConditioningControlPanel.Views.Controls.Companion.Runtime
             var dispatcher = System.Windows.Application.Current?.Dispatcher;
             if (dispatcher == null || dispatcher.HasShutdownStarted) return;
 
-            dispatcher.BeginInvoke(new Action(() =>
+            _ = dispatcher.BeginInvoke(new Action(() =>
             {
                 IsThinking = false;
                 Sync();

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -32,7 +32,6 @@ namespace ConditioningControlPanel.Views.Deeper
         private BrowserVideoTimeSource? _videoSource;
         private DispatcherTimer? _uiTimer;
         private float[]? _peaks;
-        private bool _isScrubbing;
         private bool _suppressVolumeSync;
         private bool _videoBrowserReady;
         // Exactly one file:// URL we just asked the WebView2 to navigate to from
@@ -883,7 +882,10 @@ namespace ConditioningControlPanel.Views.Deeper
 
         private void UiTimer_Tick(object? sender, EventArgs e)
         {
-            if (_isScrubbing) return;
+            // Suspend playhead writes while the user is dragging the mini-timeline scrubber
+            // (Mission3.cs), otherwise the tick fights the drag. _miniScrubbing is the live
+            // flag; the old _isScrubbing was never assigned.
+            if (_miniScrubbing) return;
             // Reparent in progress — touching VideoBrowser now would race with
             // the WebView2 swap and can throw against an unattached browser.
             if (_fsTransitionInFlight) return;


### PR DESCRIPTION
Three small commits, one real bug fix, the rest warning cleanup with **no behaviour change**.

| Commit | Warning | Behaviour |
|---|---|---|
| `fix(startup): drop dead Assembly.Location path resolution` | `IL3000` ×2 | none — `Register()` already resolves via `Environment.ProcessPath` → `AppContext.BaseDirectory`; the removed property is `private`, referenced nowhere, and the removed `GetExecutablePath` branch is unreachable in a single-file build |
| `fix(deeper): suspend playhead writes during mini-timeline scrub` | `CS0649` | **fixed:** `EnhancementPlayerWindow.UiTimer_Tick` gated on `_isScrubbing`, which is declared but never assigned. `Mission3.cs` uses `_miniScrubbing` for the real drag lifecycle. Dragging the mini-timeline scrubber fought the per-tick playhead update (jitter). Guard now points at `_miniScrubbing`; dead field removed. |
| `chore: discard deliberate fire-and-forget Dispatcher.BeginInvoke results` | `CS4014` ×8 | none — `DispatcherOperation` is awaitable, so the compiler flags these un-awaited `BeginInvoke` calls. All are intentional non-blocking UI marshals (wrong-thread re-post guards, deferred reverts, decode→display hops) with shutdown-guarded continuations. `await` would change semantics; `_ =` states the intent. Files: `ChaosFlashOverlay`, `ChaosGifCascadeOverlay`, `AvatarTubeWindow.Reactions` (×3), `ChatThresholdRuntimeVm`, `GoonHostService`, `MainWindow.RemoteControl`. |

## Verification

`dotnet build ConditioningControlPanel/ConditioningControlPanel.csproj --no-incremental`:
succeeds, 0 errors; `CS4014` / `CS0649` / `IL3000` no longer appear in the output.

(A `FlashWindow.VisualOpacity` → `FadeAlpha` rename for `CS0108` was dropped from this set
— `FlashWindow` now has `VisualOpacity` and `FadeAlpha` as distinct members, so the rename
no longer applies. `CS0108` is left as-is for a separate decision.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
