### PR TITLE
refactor: route logger-only files through Serilog; scan both product roots in source guards

### DIFF
--- a/ConditioningControlPanel/Helpers/ExplorerLauncher.cs
+++ b/ConditioningControlPanel/Helpers/ExplorerLauncher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using Serilog;
 
 namespace ConditioningControlPanel.Helpers
 {
@@ -58,7 +59,7 @@ namespace ConditioningControlPanel.Helpers
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "ExplorerLauncher: reveal failed for {Path}", path);
+                Log.Warning(ex, "ExplorerLauncher: reveal failed for {Path}", path);
                 return false;
             }
         }
@@ -75,7 +76,7 @@ namespace ConditioningControlPanel.Helpers
             {
                 if (!Directory.Exists(directory))
                 {
-                    App.Logger?.Debug("ExplorerLauncher: folder no longer exists: {Dir}", directory);
+                    Log.Debug("ExplorerLauncher: folder no longer exists: {Dir}", directory);
                     return false;
                 }
 
@@ -84,7 +85,7 @@ namespace ConditioningControlPanel.Helpers
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "ExplorerLauncher: open folder failed for {Dir}", directory);
+                Log.Warning(ex, "ExplorerLauncher: open folder failed for {Dir}", directory);
                 return false;
             }
         }
@@ -145,7 +146,7 @@ namespace ConditioningControlPanel.Helpers
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "ExplorerLauncher: explorer.exe failed to start for {Args}", arguments);
+                Log.Warning(ex, "ExplorerLauncher: explorer.exe failed to start for {Args}", arguments);
                 return false;
             }
         }

--- a/ConditioningControlPanel/Helpers/MediaTypeSniffer.cs
+++ b/ConditioningControlPanel/Helpers/MediaTypeSniffer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Serilog;
 
 namespace ConditioningControlPanel.Helpers;
 
@@ -259,7 +260,7 @@ public static class MediaTypeSniffer
         var fallback = Normalize(fallbackExtension) ?? DefaultVideoExtension;
         try
         {
-            App.Logger?.Warning(
+            Log.Warning(
                 "MediaTypeSniffer[{Context}]: could not identify media from content-type '{Ct}', magic bytes or url path — defaulting to {Ext} for {Url}",
                 context, contentType ?? "(none)", fallback, Redact(url));
         }
@@ -280,7 +281,7 @@ public static class MediaTypeSniffer
         var fallback = Normalize(fallbackExtension) ?? DefaultVideoExtension;
         try
         {
-            App.Logger?.Warning(
+            Log.Warning(
                 "MediaTypeSniffer[{Context}]: could not identify {File} from content-type '{Ct}', magic bytes or url path — defaulting to {Ext}",
                 context, filePath ?? "(none)", contentType ?? "(none)", fallback);
         }

--- a/ConditioningControlPanel/Lab/GazeMinigame/AssetPack.cs
+++ b/ConditioningControlPanel/Lab/GazeMinigame/AssetPack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Lab.GazeMinigame
 {
@@ -52,7 +53,7 @@ namespace ConditioningControlPanel.Lab.GazeMinigame
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "AssetPack.FromFolder: enumeration failed for {Path}", folderPath);
+                Log.Warning(ex, "AssetPack.FromFolder: enumeration failed for {Path}", folderPath);
                 return null;
             }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.AmbientFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.AmbientFx.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ConditioningControlPanel.Controls;
+using Serilog;
 
 namespace ConditioningControlPanel
 {
@@ -29,7 +30,7 @@ namespace ConditioningControlPanel
                     _tabFxCanvases[tab] = list = new List<AmbientFxCanvas>();
                 if (!list.Contains(canvas)) list.Add(canvas);
             }
-            catch (Exception ex) { App.Logger?.Debug("RegisterTabFx: {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("RegisterTabFx: {E}", ex.Message); }
         }
 
         /// <summary>Pauses every registered canvas that does not belong to the incoming tab, and
@@ -49,7 +50,7 @@ namespace ConditioningControlPanel
                     }
                 }
             }
-            catch (Exception ex) { App.Logger?.Debug("SwitchTabFx: {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("SwitchTabFx: {E}", ex.Message); }
         }
     }
 }

--- a/ConditioningControlPanel/Models/AiCommandData.cs
+++ b/ConditioningControlPanel/Models/AiCommandData.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ConditioningControlPanel.Models.CommandData;
+using Serilog;
 
 namespace ConditioningControlPanel.Models
 {
@@ -42,13 +43,13 @@ namespace ConditioningControlPanel.Models
                 }
                 catch (Exception inner)
                 {
-                    App.Logger?.Warning(inner, "AiCommandData: brace-recovery parse failed for: {Json}", json);
+                    Log.Warning(inner, "AiCommandData: brace-recovery parse failed for: {Json}", json);
                     return null;
                 }
             }
             catch (Exception e)
             {
-                App.Logger?.Warning(e, "AiCommandData: parse failed for: {Json}", json);
+                Log.Warning(e, "AiCommandData: parse failed for: {Json}", json);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Models/KeywordAction.cs
+++ b/ConditioningControlPanel/Models/KeywordAction.cs
@@ -1,6 +1,7 @@
 using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Models
 {
@@ -186,7 +187,7 @@ namespace ConditioningControlPanel.Models
             {
                 // Unknown action type — skip gracefully. Log and return null so the
                 // containing list Where-filter can drop it.
-                App.Logger?.Warning("KeywordActionConverter: Unknown action type '{Type}'", typeName);
+                Log.Warning("KeywordActionConverter: Unknown action type '{Type}'", typeName);
                 return null;
             }
 

--- a/ConditioningControlPanel/Services/AIService/AiMeter.cs
+++ b/ConditioningControlPanel/Services/AIService/AiMeter.cs
@@ -1,3 +1,5 @@
+using Serilog;
+
 namespace ConditioningControlPanel.Services.AIService
 {
     /// <summary>
@@ -61,13 +63,13 @@ namespace ConditioningControlPanel.Services.AIService
         {
             if (cachedInputTokens == null && tokensRemainingToday == null)
             {
-                App.Logger?.Information(
+                Log.Information(
                     "[AI-METER] provider={Provider} purpose={Purpose} in_tok~{InTokens} out_tok~{OutTokens} ms={ElapsedMs} outcome={Outcome}",
                     provider, purpose, ApproxTokens(inputChars), ApproxTokens(outputChars), elapsedMs, outcome);
                 return;
             }
 
-            App.Logger?.Information(
+            Log.Information(
                 "[AI-METER] provider={Provider} purpose={Purpose} in_tok~{InTokens} out_tok~{OutTokens} ms={ElapsedMs} outcome={Outcome} cached_in={CachedIn} tok_left={TokensLeft}",
                 provider, purpose, ApproxTokens(inputChars), ApproxTokens(outputChars), elapsedMs, outcome,
                 cachedInputTokens ?? -1, tokensRemainingToday ?? -1);

--- a/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
+++ b/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -310,7 +311,7 @@ namespace ConditioningControlPanel.Services
             if (droppedSentences == 0) return text;
 
             var result = Regex.Replace(kept.ToString(), @"\s{2,}", " ").Trim();
-            App.Logger?.Information(
+            Log.Information(
                 "[AI-LINK] dropped {Count} sentence(s) carrying a link the app never issued", droppedSentences);
             return result;
         }
@@ -329,13 +330,13 @@ namespace ConditioningControlPanel.Services
                 var entries = pool ?? Companion.CompanionLinkIndex.CurrentEntries();
                 var result = Companion.CompanionTitleMatcher.RewriteOffPoolTitles(text, entries, out var rewritten);
                 if (rewritten > 0)
-                    App.Logger?.Information(
+                    Log.Information(
                         "[AI-LINK] rewrote {Count} invented title(s) to the nearest pool video", rewritten);
                 return result;
             }
             catch (System.Exception ex)
             {
-                App.Logger?.Debug("RewriteOffPoolTitles failed: {Error}", ex.Message);
+                Log.Debug("RewriteOffPoolTitles failed: {Error}", ex.Message);
                 return text;
             }
         }

--- a/ConditioningControlPanel/Services/AIService/Enrichment/KnowledgeService.cs
+++ b/ConditioningControlPanel/Services/AIService/Enrichment/KnowledgeService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using ConditioningControlPanel.Models.AiEnrichment;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.AIService.Enrichment
 {
@@ -33,12 +34,12 @@ namespace ConditioningControlPanel.Services.AIService.Enrichment
                 {
                     var json = File.ReadAllText(filePath);
                     _context = JsonSerializer.Deserialize<List<Knowledge>>(json, options) ?? new();
-                    App.Logger?.Information("KnowledgeService: Loaded {Count} entries from {FilePath}", _context.Count, filePath);
+                    Log.Information("KnowledgeService: Loaded {Count} entries from {FilePath}", _context.Count, filePath);
                     return;
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "KnowledgeService: Error loading {FilePath}, falling back", filePath);
+                    Log.Warning(ex, "KnowledgeService: Error loading {FilePath}, falling back", filePath);
                 }
             }
 
@@ -49,12 +50,12 @@ namespace ConditioningControlPanel.Services.AIService.Enrichment
                 {
                     var json = File.ReadAllText(projectAssetsPath);
                     _context = JsonSerializer.Deserialize<List<Knowledge>>(json, options) ?? new();
-                    App.Logger?.Information("KnowledgeService: Loaded {Count} entries from project assets {FilePath}", _context.Count, projectAssetsPath);
+                    Log.Information("KnowledgeService: Loaded {Count} entries from project assets {FilePath}", _context.Count, projectAssetsPath);
                     return;
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "KnowledgeService: Error loading project assets {FilePath}", projectAssetsPath);
+                    Log.Warning(ex, "KnowledgeService: Error loading project assets {FilePath}", projectAssetsPath);
                 }
             }
 
@@ -69,16 +70,16 @@ namespace ConditioningControlPanel.Services.AIService.Enrichment
                     using var reader = new StreamReader(stream);
                     var json = reader.ReadToEnd();
                     _context = JsonSerializer.Deserialize<List<Knowledge>>(json, options) ?? new();
-                    App.Logger?.Information("KnowledgeService: Loaded {Count} entries from embedded resource", _context.Count);
+                    Log.Information("KnowledgeService: Loaded {Count} entries from embedded resource", _context.Count);
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Error(ex, "KnowledgeService: Error loading embedded resource");
+                    Log.Error(ex, "KnowledgeService: Error loading embedded resource");
                 }
             }
             else
             {
-                App.Logger?.Debug("KnowledgeService: No knowledge.json found — using empty knowledge base");
+                Log.Debug("KnowledgeService: No knowledge.json found — using empty knowledge base");
             }
         }
 

--- a/ConditioningControlPanel/Services/AIService/OllamaSetupService.cs
+++ b/ConditioningControlPanel/Services/AIService/OllamaSetupService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.AIService
 {
@@ -327,7 +328,7 @@ namespace ConditioningControlPanel.Services.AIService
 
             if (proc.ExitCode != 0)
             {
-                App.Logger?.Warning("OllamaSetup.exe exited with code {Code}", proc.ExitCode);
+                Log.Warning("OllamaSetup.exe exited with code {Code}", proc.ExitCode);
                 return false;
             }
 
@@ -411,7 +412,7 @@ namespace ConditioningControlPanel.Services.AIService
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "Failed to spawn `ollama serve`");
+                Log.Warning(ex, "Failed to spawn `ollama serve`");
                 // Start() (or a Begin*ReadLine) can throw after the Process object exists.
                 // If it never became the tracked server, tear it down here so we neither
                 // leak the handle nor orphan a process that did in fact start.
@@ -434,7 +435,7 @@ namespace ConditioningControlPanel.Services.AIService
                 {
                     if (started.HasExited)
                     {
-                        App.Logger?.Warning(
+                        Log.Warning(
                             "`ollama serve` exited with code {Code} before binding {Host}. Server output:{Nl}{Tail}",
                             started.ExitCode, host, Environment.NewLine, GetServerLogTail());
                         return false;
@@ -445,7 +446,7 @@ namespace ConditioningControlPanel.Services.AIService
                 await Task.Delay(1000, ct);
             }
 
-            App.Logger?.Warning(
+            Log.Warning(
                 "`ollama serve` did not answer {Host} within 30s. Server output:{Nl}{Tail}",
                 host, Environment.NewLine, GetServerLogTail());
             return false;
@@ -473,7 +474,7 @@ namespace ConditioningControlPanel.Services.AIService
                 }
 
                 if (Interlocked.Increment(ref _serverLogLinesLogged) <= ServerLogLinesToLog)
-                    App.Logger?.Debug("[ollama serve] {Line}", line);
+                    Log.Debug("[ollama serve] {Line}", line);
             }
             catch
             {
@@ -519,7 +520,7 @@ namespace ConditioningControlPanel.Services.AIService
             {
                 // Already gone, never started, or the handle is disposed — all expected.
                 // Logged rather than silent so a genuinely stuck process leaves a trace.
-                App.Logger?.Debug("Could not stop {Context}: {Error}", context, ex.Message);
+                Log.Debug("Could not stop {Context}: {Error}", context, ex.Message);
             }
             finally
             {
@@ -586,18 +587,18 @@ namespace ConditioningControlPanel.Services.AIService
 
             if (!IsLoopbackHost(host))
             {
-                App.Logger?.Information(
+                Log.Information(
                     "Ollama host {Host} is not reachable and is not local — not spawning a server for it", host);
                 return false;
             }
 
             if (FindOllamaCli() == null)
             {
-                App.Logger?.Information("Ollama is not reachable at {Host} and no CLI is installed to start", host);
+                Log.Information("Ollama is not reachable at {Host} and no CLI is installed to start", host);
                 return false;
             }
 
-            App.Logger?.Information("Ollama not reachable at {Host} — starting the headless server", host);
+            Log.Information("Ollama not reachable at {Host} — starting the headless server", host);
             return await TryStartHeadlessServerAsync(host, ct);
         }
 
@@ -731,7 +732,7 @@ namespace ConditioningControlPanel.Services.AIService
             catch (Exception ex)
             {
                 sw.Stop();
-                App.Logger?.Warning(ex, "Smoke test failed (model={Model})", model);
+                Log.Warning(ex, "Smoke test failed (model={Model})", model);
                 return (false, sw.Elapsed, "");
             }
         }

--- a/ConditioningControlPanel/Services/AppClusterMap.cs
+++ b/ConditioningControlPanel/Services/AppClusterMap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -70,7 +71,7 @@ namespace ConditioningControlPanel.Services
                 var size = new FileInfo(path).Length;
                 if (size > MaxFileBytes)
                 {
-                    App.Logger?.Warning("AppClusterMap: override is {Bytes} bytes (cap {Cap}) — using embedded defaults",
+                    Log.Warning("AppClusterMap: override is {Bytes} bytes (cap {Cap}) — using embedded defaults",
                         size, MaxFileBytes);
                     return;
                 }
@@ -89,17 +90,17 @@ namespace ConditioningControlPanel.Services
                     if (_clusters.ContainsKey(required)) continue;
                     if (!DefaultClusters.TryGetValue(required, out var embedded)) continue;
                     _clusters[required] = embedded;
-                    App.Logger?.Warning(
+                    Log.Warning(
                         "AppClusterMap: override omitted the '{Cluster}' cluster — re-injected the embedded terms",
                         required);
                 }
 
-                App.Logger?.Information("AppClusterMap: loaded {Clusters} clusters, {Apps} bespoke apps from {Path}",
+                Log.Information("AppClusterMap: loaded {Clusters} clusters, {Apps} bespoke apps from {Path}",
                     _clusters.Count, _apps.Count, path);
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "AppClusterMap: failed to load override — using embedded defaults");
+                Log.Warning(ex, "AppClusterMap: failed to load override — using embedded defaults");
                 _clusters = DefaultClusters;
                 _apps = DefaultApps;
             }

--- a/ConditioningControlPanel/Services/Awareness/AwarenessAngleCards.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessAngleCards.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Awareness
 {
@@ -253,7 +254,7 @@ namespace ConditioningControlPanel.Services.Awareness
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "AwarenessAngleCards: embedded deck could not be read");
+                Log.Error(ex, "AwarenessAngleCards: embedded deck could not be read");
             }
 
             _embedded = (json == null ? null : Parse(json, isEmbedded: true)) ?? MinimalDeck();
@@ -272,7 +273,7 @@ namespace ConditioningControlPanel.Services.Awareness
                 var info = new FileInfo(path);
                 if (info.Length > MaxFileBytes)
                 {
-                    App.Logger?.Warning(
+                    Log.Warning(
                         "AwarenessAngleCards: override is {Bytes} bytes (cap {Cap}) — using the built-in deck",
                         info.Length, MaxFileBytes);
                     return embedded;
@@ -281,20 +282,20 @@ namespace ConditioningControlPanel.Services.Awareness
                 var parsed = Parse(File.ReadAllText(path), isEmbedded: false);
                 if (parsed == null)
                 {
-                    App.Logger?.Warning(
+                    Log.Warning(
                         "AwarenessAngleCards: override at {Path} did not survive validation — using the built-in deck",
                         path);
                     return embedded;
                 }
 
-                App.Logger?.Information(
+                Log.Information(
                     "AwarenessAngleCards: loaded {Keys} card key(s), {Personas} persona(s) from {Path}",
                     parsed.Clusters.Count, parsed.Personas.Count, path);
                 return parsed;
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "AwarenessAngleCards: override load failed — using the built-in deck");
+                Log.Warning(ex, "AwarenessAngleCards: override load failed — using the built-in deck");
                 return embedded;
             }
         }
@@ -312,7 +313,7 @@ namespace ConditioningControlPanel.Services.Awareness
             try { root = JObject.Parse(json); }
             catch (Exception ex)
             {
-                App.Logger?.Warning("AwarenessAngleCards: deck did not parse ({Error})", ex.Message);
+                Log.Warning("AwarenessAngleCards: deck did not parse ({Error})", ex.Message);
                 return null;
             }
 
@@ -463,7 +464,7 @@ namespace ConditioningControlPanel.Services.Awareness
         /// </summary>
         private static AwarenessAngleDeck MinimalDeck()
         {
-            App.Logger?.Error(
+            Log.Error(
                 "AwarenessAngleCards: embedded deck '{Resource}' is missing from the assembly — " +
                 "awareness reactions will be generic until it is restored", EmbeddedResourceName);
 

--- a/ConditioningControlPanel/Services/Awareness/AwarenessIntensityMigration.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessIntensityMigration.cs
@@ -1,4 +1,5 @@
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Awareness
 {
@@ -61,7 +62,7 @@ namespace ConditioningControlPanel.Services.Awareness
             if (cooldown <= ShippedDefaultCooldownSeconds)
             {
                 settings.AwarenessIntensityMigrated = true;
-                App.Logger?.Information(
+                Log.Information(
                     "Awareness: reaction cooldown was still the shipped {Seconds}s default — keeping intensity {Intensity}",
                     cooldown, settings.AwarenessIntensity);
                 return true;
@@ -71,7 +72,7 @@ namespace ConditioningControlPanel.Services.Awareness
             settings.AwarenessIntensity = mapped;
             settings.AwarenessIntensityMigrated = true;
 
-            App.Logger?.Information(
+            Log.Information(
                 "Awareness: migrated the {Seconds}s reaction cooldown to intensity {Intensity}",
                 cooldown, mapped);
             return true;

--- a/ConditioningControlPanel/Services/Awareness/AwarenessLive.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessLive.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Awareness
 {
@@ -90,7 +91,7 @@ namespace ConditioningControlPanel.Services.Awareness
             }
 
             try { FramePublished?.Invoke(null, EventArgs.Empty); }
-            catch (Exception ex) { App.Logger?.Debug("AwarenessLive: a FramePublished subscriber threw: {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("AwarenessLive: a FramePublished subscriber threw: {E}", ex.Message); }
         }
 
         /// <summary>Forgets the last frame. Part of <see cref="WipeEverything"/>; separate so tests can be blunt.</summary>
@@ -138,7 +139,7 @@ namespace ConditioningControlPanel.Services.Awareness
             if (ledger != null)
             {
                 try { ledger.Wipe(); }
-                catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: ledger wipe failed"); }
+                catch (Exception ex) { Log.Warning(ex, "AwarenessLive: ledger wipe failed"); }
             }
             else
             {
@@ -149,22 +150,22 @@ namespace ConditioningControlPanel.Services.Awareness
             if (memory != null)
             {
                 try { _ = memory.ForgetAsync(null); }
-                catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: memory forget failed"); }
+                catch (Exception ex) { Log.Warning(ex, "AwarenessLive: memory forget failed"); }
             }
 
             // The in-RAM half of the erasure. Without this the observer still holds the app it had
             // committed to and the candidate it was about to cut, and could speak about what was just
             // wiped on its very next tick.
             try { ResetObserverState?.Invoke(); }
-            catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: observer state reset failed"); }
+            catch (Exception ex) { Log.Warning(ex, "AwarenessLive: observer state reset failed"); }
 
             // The other in-RAM half: the cooldown ledger's per-app last-spoke times and the scorer's
             // repetition counters, both keyed by the app ids that were just erased.
             try { ResetPacingState?.Invoke(); }
-            catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: pacing state reset failed"); }
+            catch (Exception ex) { Log.Warning(ex, "AwarenessLive: pacing state reset failed"); }
 
             Clear();
-            App.Logger?.Information("Awareness: everything she noticed has been erased");
+            Log.Information("Awareness: everything she noticed has been erased");
         }
 
         /// <summary>
@@ -178,13 +179,13 @@ namespace ConditioningControlPanel.Services.Awareness
             var id = AwarenessText.SanitizeId(appId);
 
             try { Ledger?.Forget(id); }
-            catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: ledger forget failed"); }
+            catch (Exception ex) { Log.Warning(ex, "AwarenessLive: ledger forget failed"); }
 
             try { _ = Memory?.ForgetAsync(id); }
-            catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: memory forget failed"); }
+            catch (Exception ex) { Log.Warning(ex, "AwarenessLive: memory forget failed"); }
 
             try { ForgetPacingState?.Invoke(id); }
-            catch (Exception ex) { App.Logger?.Warning(ex, "AwarenessLive: pacing forget failed"); }
+            catch (Exception ex) { Log.Warning(ex, "AwarenessLive: pacing forget failed"); }
 
             lock (Lock)
             {
@@ -207,7 +208,7 @@ namespace ConditioningControlPanel.Services.Awareness
             try { path = ActivityLedger.DefaultLedgerPath; }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "AwarenessLive: could not resolve the ledger path");
+                Log.Warning(ex, "AwarenessLive: could not resolve the ledger path");
                 return;
             }
 
@@ -219,7 +220,7 @@ namespace ConditioningControlPanel.Services.Awareness
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "AwarenessLive: failed to delete {File}", file);
+                    Log.Warning(ex, "AwarenessLive: failed to delete {File}", file);
                 }
             }
         }

--- a/ConditioningControlPanel/Services/Awareness/AwarenessPause.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessPause.cs
@@ -1,4 +1,5 @@
 using System;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Awareness
 {
@@ -68,7 +69,7 @@ namespace ConditioningControlPanel.Services.Awareness
                 if (_until == null || end > _until.Value) _until = end;
             }
 
-            App.Logger?.Information("Awareness: paused for {Minutes} minute(s)", (int)duration.TotalMinutes);
+            Log.Information("Awareness: paused for {Minutes} minute(s)", (int)duration.TotalMinutes);
         }
 
         /// <summary>Lifts the pause immediately.</summary>
@@ -80,7 +81,7 @@ namespace ConditioningControlPanel.Services.Awareness
                 was = _until != null;
                 _until = null;
             }
-            if (was) App.Logger?.Information("Awareness: pause lifted");
+            if (was) Log.Information("Awareness: pause lifted");
         }
     }
 }

--- a/ConditioningControlPanel/Services/Awareness/SmtcMediaWatcher.cs
+++ b/ConditioningControlPanel/Services/Awareness/SmtcMediaWatcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Media.Control;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Awareness
 {
@@ -82,18 +83,18 @@ namespace ConditioningControlPanel.Services.Awareness
 
                     if (!_available)
                     {
-                        App.Logger?.Debug("AwarenessObserver: SMTC returned no session manager - media signal off");
+                        Log.Debug("AwarenessObserver: SMTC returned no session manager - media signal off");
                         return;
                     }
 
                     _timer = new Timer(_ => Poll(), null, TimeSpan.Zero, PollInterval);
-                    App.Logger?.Debug("AwarenessObserver: SMTC media watcher armed");
+                    Log.Debug("AwarenessObserver: SMTC media watcher armed");
                 }
                 catch (Exception ex)
                 {
                     // Denied, unsupported, or the WinRT activation failed. Feature-off, not a crash.
                     _available = false;
-                    App.Logger?.Debug("AwarenessObserver: SMTC unavailable - {Error}", ex.Message);
+                    Log.Debug("AwarenessObserver: SMTC unavailable - {Error}", ex.Message);
                 }
             });
         }
@@ -140,7 +141,7 @@ namespace ConditioningControlPanel.Services.Awareness
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("AwarenessObserver: SMTC read failed - {Error}", ex.Message);
+                    Log.Debug("AwarenessObserver: SMTC read failed - {Error}", ex.Message);
                 }
                 finally
                 {

--- a/ConditioningControlPanel/Services/Awareness/WorthinessScorer.cs
+++ b/ConditioningControlPanel/Services/Awareness/WorthinessScorer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Awareness
 {
@@ -220,7 +221,7 @@ namespace ConditioningControlPanel.Services.Awareness
             // logs/app-.log, which "forget everything" does not erase and which the bug-report flow
             // asks users to attach. The legacy service kept its equivalent readout at Debug for
             // exactly this reason; matching it is the fix, not inventing a second discipline.
-            App.Logger?.Debug(result.LogLine);
+            Log.Debug(result.LogLine);
             return result;
         }
 

--- a/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Bark
 {
@@ -81,15 +82,15 @@ namespace ConditioningControlPanel.Services.Bark
                     if (rule != null && rule.IsValid())
                         rules.Add(rule);
                     else
-                        App.Logger?.Warning("BarkRuleLoader: merged rule invalid after merge (id='{Id}')", rule?.Id);
+                        Log.Warning("BarkRuleLoader: merged rule invalid after merge (id='{Id}')", rule?.Id);
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "BarkRuleLoader: failed to materialize a merged rule");
+                    Log.Warning(ex, "BarkRuleLoader: failed to materialize a merged rule");
                 }
             }
 
-            App.Logger?.Information(
+            Log.Information(
                 "BarkRuleLoader: loaded {Total} rules ({Base} base, {Mod} mod-overlay from {Source}; field-level merge)",
                 rules.Count, baseCount, modCount,
                 Services.Companion.CompanionContentResolver.Describe(modPick.Source));
@@ -118,7 +119,7 @@ namespace ConditioningControlPanel.Services.Bark
                     var id = obj.Value<string>("id");
                     if (string.IsNullOrWhiteSpace(id))
                     {
-                        App.Logger?.Warning("BarkRuleLoader: skipped a rule with no id in {Source} manifest", source);
+                        Log.Warning("BarkRuleLoader: skipped a rule with no id in {Source} manifest", source);
                         continue;
                     }
 
@@ -133,7 +134,7 @@ namespace ConditioningControlPanel.Services.Bark
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "BarkRuleLoader: failed to read {Source} manifest at {Path}", source, path);
+                Log.Warning(ex, "BarkRuleLoader: failed to read {Source} manifest at {Path}", source, path);
                 return 0;
             }
         }

--- a/ConditioningControlPanel/Services/Chaos/ChaosRevealService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosRevealService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Chaos;
 
@@ -105,12 +106,12 @@ public static class RevealService
                 if (ChaosMeta.State.SeenReveals.Contains(id)) continue;
                 if (!ChaosMeta.State.PendingReveals.Add(id)) continue;
                 changed = true;
-                App.Logger?.Information("Chaos reveal pending: {Id} ({Reason})", id, reason);
+                Log.Information("Chaos reveal pending: {Id} ({Reason})", id, reason);
                 try { Pending?.Invoke(id); } catch { }
             }
             if (changed) ChaosMeta.Save();
         }
-        catch (Exception ex) { App.Logger?.Warning("RevealService.Sync failed ({E})", ex.Message); }
+        catch (Exception ex) { Log.Warning("RevealService.Sync failed ({E})", ex.Message); }
     }
 
     /// <summary>Snapshot of ids awaiting their flash (dollhouse open). Does not mutate state.</summary>

--- a/ConditioningControlPanel/Services/Companion/Brain/ChatSession.cs
+++ b/ConditioningControlPanel/Services/Companion/Brain/ChatSession.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ConditioningControlPanel.Services.AIService;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Companion.Brain
 {
@@ -215,7 +216,7 @@ namespace ConditioningControlPanel.Services.Companion.Brain
             var handler = TurnsChanged;
             if (handler == null) return;
             try { handler(this, EventArgs.Empty); }
-            catch (Exception ex) { App.Logger?.Debug("ChatSession: TurnsChanged handler threw: {Error}", ex.Message); }
+            catch (Exception ex) { Log.Debug("ChatSession: TurnsChanged handler threw: {Error}", ex.Message); }
         }
 
         /// <summary>The dialogue subset, in order — exactly what is allowed to reach disk.</summary>

--- a/ConditioningControlPanel/Services/Content/MergeJournal.cs
+++ b/ConditioningControlPanel/Services/Content/MergeJournal.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -77,7 +78,7 @@ namespace ConditioningControlPanel.Services
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("MergeJournal: could not remove tree {Path}: {Error}", tree, ex.Message);
+                    Log.Debug("MergeJournal: could not remove tree {Path}: {Error}", tree, ex.Message);
                 }
             }
 
@@ -91,7 +92,7 @@ namespace ConditioningControlPanel.Services
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("MergeJournal: could not remove {Path}: {Error}", file, ex.Message);
+                    Log.Debug("MergeJournal: could not remove {Path}: {Error}", file, ex.Message);
                 }
             }
 
@@ -111,7 +112,7 @@ namespace ConditioningControlPanel.Services
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("MergeJournal: left {Path} in place: {Error}", dir, ex.Message);
+                    Log.Debug("MergeJournal: left {Path} in place: {Error}", dir, ex.Message);
                 }
             }
 

--- a/ConditioningControlPanel/Services/DailyFreeService.cs
+++ b/ConditioningControlPanel/Services/DailyFreeService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -101,7 +102,7 @@ namespace ConditioningControlPanel.Services
                 if (due < TimeSpan.FromSeconds(1)) due = TimeSpan.FromSeconds(1);
                 _dayRollTimer.Change(due, Timeout.InfiniteTimeSpan);
             }
-            catch (Exception ex) { App.Logger?.Debug("DailyFree: day-roll re-arm failed: {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("DailyFree: day-roll re-arm failed: {E}", ex.Message); }
         }
 
         /// <summary>
@@ -116,13 +117,13 @@ namespace ConditioningControlPanel.Services
                 var stamp = LocalDateStamp();
                 if (stamp == _dayRollLastStamp) return;
                 _dayRollLastStamp = stamp;
-                App.Logger?.Information("DailyFree: local day rolled over to {Date}", stamp);
+                Log.Information("DailyFree: local day rolled over to {Date}", stamp);
                 // Yesterday's override must not survive the rollover, and the seeded pick has
                 // already moved on by itself - so this is a repaint signal, not an invalidation.
                 _ = RefreshAsync();
                 TodayChanged?.Invoke();
             }
-            catch (Exception ex) { App.Logger?.Debug("DailyFree: day-roll tick failed: {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("DailyFree: day-roll tick failed: {E}", ex.Message); }
             finally { ArmDayRollTimer(); }
         }
 
@@ -289,7 +290,7 @@ namespace ConditioningControlPanel.Services
                 // benched pool members (haptics, voice) are already wired.
                 if (!OverridableKeys.Contains(key))
                 {
-                    App.Logger?.Warning("DailyFree: server override '{Key}' not in pool, ignoring", key);
+                    Log.Warning("DailyFree: server override '{Key}' not in pool, ignoring", key);
                     return;
                 }
 
@@ -297,12 +298,12 @@ namespace ConditioningControlPanel.Services
                 _serverKey = key;
                 _serverKeyForDate = LocalDateStamp();
                 _lastFetchUtc = DateTime.UtcNow;
-                App.Logger?.Information("DailyFree: server override for {Date}: {Key}", _serverKeyForDate, key);
+                Log.Information("DailyFree: server override for {Date}: {Key}", _serverKeyForDate, key);
                 if (changed) TodayChanged?.Invoke();
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("DailyFree: override fetch failed (seeded pick stands): {E}", ex.Message);
+                Log.Debug("DailyFree: override fetch failed (seeded pick stands): {E}", ex.Message);
             }
         }
     }

--- a/ConditioningControlPanel/Services/Deeper/EnhancementFetcher.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementFetcher.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using ConditioningControlPanel.Models.Deeper;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Deeper
 {
@@ -74,7 +75,7 @@ namespace ConditioningControlPanel.Services.Deeper
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: malformed url ({Url})", UrlSafety.RedactUrl(url));
+                    Log.Debug("EnhancementFetcher: malformed url ({Url})", UrlSafety.RedactUrl(url));
                     return null;
                 }
 
@@ -83,7 +84,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 // host their ccpenh.json on https hosts (gist, github pages, etc.).
                 if (uri.Scheme != Uri.UriSchemeHttps)
                 {
-                    App.Logger?.Debug("EnhancementFetcher: rejecting non-https url ({Url})", UrlSafety.RedactUrl(url));
+                    Log.Debug("EnhancementFetcher: rejecting non-https url ({Url})", UrlSafety.RedactUrl(url));
                     return null;
                 }
 
@@ -91,7 +92,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 // ULA before issuing the GET; re-checked per hop on redirect.
                 if (!await UrlSafety.IsSafePublicHttpsAsync(uri, ct).ConfigureAwait(false))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: rejecting unsafe host {Host}", uri.Host);
+                    Log.Debug("EnhancementFetcher: rejecting unsafe host {Host}", uri.Host);
                     return null;
                 }
 
@@ -121,14 +122,14 @@ namespace ConditioningControlPanel.Services.Deeper
                 using var _resp = finalResp;
                 if (!_resp.IsSuccessStatusCode)
                 {
-                    App.Logger?.Debug("EnhancementFetcher: HTTP {Status} for {Url}", (int)_resp.StatusCode, UrlSafety.RedactUrl(url));
+                    Log.Debug("EnhancementFetcher: HTTP {Status} for {Url}", (int)_resp.StatusCode, UrlSafety.RedactUrl(url));
                     return null;
                 }
 
                 var contentLength = _resp.Content.Headers.ContentLength;
                 if (contentLength.HasValue && contentLength.Value > MaxResponseBytes)
                 {
-                    App.Logger?.Debug("EnhancementFetcher: response too large ({Size} bytes) for {Url}", contentLength.Value, UrlSafety.RedactUrl(url));
+                    Log.Debug("EnhancementFetcher: response too large ({Size} bytes) for {Url}", contentLength.Value, UrlSafety.RedactUrl(url));
                     return null;
                 }
 
@@ -145,7 +146,7 @@ namespace ConditioningControlPanel.Services.Deeper
                     }
                     if (read > MaxResponseBytes)
                     {
-                        App.Logger?.Debug("EnhancementFetcher: response exceeded {Cap} bytes (truncated read) for {Url}", MaxResponseBytes, UrlSafety.RedactUrl(url));
+                        Log.Debug("EnhancementFetcher: response exceeded {Cap} bytes (truncated read) for {Url}", MaxResponseBytes, UrlSafety.RedactUrl(url));
                         return null;
                     }
                     json = System.Text.Encoding.UTF8.GetString(buffer, 0, read);
@@ -155,7 +156,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 // (some HT users embed arbitrary URLs in descriptions).
                 if (!json.Contains(Enhancement.SchemaTag, StringComparison.OrdinalIgnoreCase))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: schema sniff failed for {Url}", UrlSafety.RedactUrl(url));
+                    Log.Debug("EnhancementFetcher: schema sniff failed for {Url}", UrlSafety.RedactUrl(url));
                     return null;
                 }
 
@@ -163,18 +164,18 @@ namespace ConditioningControlPanel.Services.Deeper
                 var issues = EnhancementValidator.Validate(enh);
                 if (issues.Exists(i => i.Severity == ValidationSeverity.Error))
                 {
-                    App.Logger?.Debug("EnhancementFetcher: validation failed for {Url}", UrlSafety.RedactUrl(url));
+                    Log.Debug("EnhancementFetcher: validation failed for {Url}", UrlSafety.RedactUrl(url));
                     return null;
                 }
 
                 lock (_gate) _cache[url] = enh;
-                App.Logger?.Information("EnhancementFetcher: cached '{Name}' from {Url}", enh.Metadata?.Name, UrlSafety.RedactUrl(url));
+                Log.Information("EnhancementFetcher: cached '{Name}' from {Url}", enh.Metadata?.Name, UrlSafety.RedactUrl(url));
                 return enh;
             }
             catch (TaskCanceledException) { return null; }
             catch (Exception ex)
             {
-                App.Logger?.Debug("EnhancementFetcher: fetch failed for {Url} - {Error}", UrlSafety.RedactUrl(url), ex.Message);
+                Log.Debug("EnhancementFetcher: fetch failed for {Url} - {Error}", UrlSafety.RedactUrl(url), ex.Message);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/Deeper/EnhancementMediaBundler.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementMediaBundler.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using ConditioningControlPanel.Models.Deeper;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Deeper
 {
@@ -156,7 +157,7 @@ namespace ConditioningControlPanel.Services.Deeper
             catch (Exception ex)
             {
                 TryDelete(tmpPath);
-                App.Logger?.Warning(ex, "EnhancementMediaBundler.Export injection failed: {Path}", destPath);
+                Log.Warning(ex, "EnhancementMediaBundler.Export injection failed: {Path}", destPath);
                 return BundleResult.Fail($"Failed to inject metadata: {ex.Message}");
             }
         }
@@ -225,13 +226,13 @@ namespace ConditioningControlPanel.Services.Deeper
             catch (EnhancementLoadException ex)
             {
                 error = ex.Message;
-                App.Logger?.Debug("EnhancementMediaBundler.TryExtract: schema/parse error: {Error}", ex.Message);
+                Log.Debug("EnhancementMediaBundler.TryExtract: schema/parse error: {Error}", ex.Message);
                 return false;
             }
             catch (Exception ex)
             {
                 error = ex.Message;
-                App.Logger?.Debug("EnhancementMediaBundler.TryExtract failed: {Error}", ex.Message);
+                Log.Debug("EnhancementMediaBundler.TryExtract failed: {Error}", ex.Message);
                 return false;
             }
         }
@@ -569,7 +570,7 @@ namespace ConditioningControlPanel.Services.Deeper
             // encounter it we just log and bail; the file gets a fresh tag.
             if (unsync)
             {
-                App.Logger?.Debug("ID3v2 tag uses unsynchronisation — frames not parsed.");
+                Log.Debug("ID3v2 tag uses unsynchronisation — frames not parsed.");
                 return result;
             }
             int tagSize = ReadSynchsafe(tag, 6);

--- a/ConditioningControlPanel/Services/Deeper/HtMetadataFetcher.cs
+++ b/ConditioningControlPanel/Services/Deeper/HtMetadataFetcher.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Deeper
 {
@@ -82,7 +83,7 @@ namespace ConditioningControlPanel.Services.Deeper
                 {
                     if (!await UrlSafety.IsSafePublicHttpsAsync(current, linked.Token).ConfigureAwait(false))
                     {
-                        App.Logger?.Debug("HtMetadataFetcher: rejecting unsafe host {Host}", current.Host);
+                        Log.Debug("HtMetadataFetcher: rejecting unsafe host {Host}", current.Host);
                         return null;
                     }
 
@@ -136,7 +137,7 @@ namespace ConditioningControlPanel.Services.Deeper
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("HtMetadataFetcher: {Error}", ex.Message);
+                Log.Debug("HtMetadataFetcher: {Error}", ex.Message);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/Deeper/MandatoryVideoEnhancementScanner.cs
+++ b/ConditioningControlPanel/Services/Deeper/MandatoryVideoEnhancementScanner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using ConditioningControlPanel.Models.Deeper;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Deeper
 {
@@ -87,7 +88,7 @@ namespace ConditioningControlPanel.Services.Deeper
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("MandatoryVideoEnhancementScanner: scan failed: {Error}", ex.Message);
+                Log.Debug("MandatoryVideoEnhancementScanner: scan failed: {Error}", ex.Message);
             }
             return new ScanResult(anyEnhanced, anyWebcam);
         }

--- a/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Fyp.Online;
 
@@ -102,7 +103,7 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
             // The subreddit doesn't exist on scrolller (or was removed): not an error,
             // a dead channel. Caller retires it for the session.
             channel.Dead = true;
-            App.Logger?.Information("[FYP online] r/{Sub} does not resolve on scrolller — channel retired", channel.Name);
+            Log.Information("[FYP online] r/{Sub} does not resolve on scrolller — channel retired", channel.Name);
             return new FeedPage();
         }
 
@@ -157,12 +158,12 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
         var node = data["getSubreddit"];
         if (node == null || node.Type == JTokenType.Null)
         {
-            App.Logger?.Debug("[FYP online] probe r/{Sub}: not on scrolller", sub);
+            Log.Debug("[FYP online] probe r/{Sub}: not on scrolller", sub);
             return new SubProbe { Ok = false };
         }
 
         int? videos = (int?)node["videoCount"];
-        App.Logger?.Debug("[FYP online] probe r/{Sub}: ok, {N} videos", sub, videos);
+        Log.Debug("[FYP online] probe r/{Sub}: ok, {N} videos", sub, videos);
         // videoCount 0 is still Ok — the sub exists and has stills; the picker says so rather
         // than pretending the sub is missing.
         return new SubProbe { Ok = true, VideoCount = videos };
@@ -280,7 +281,7 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
         // don't, the entry is dropped here rather than dying downstream as a black tile.
         if (!RemoteMediaFormats.Validate(entry, out var reason))
         {
-            App.Logger?.Debug("[FYP online] dropped r/{Sub} post {Post}: {Reason}", sub, postId, reason);
+            Log.Debug("[FYP online] dropped r/{Sub} post {Post}: {Reason}", sub, postId, reason);
             return null;
         }
         return entry;
@@ -337,14 +338,14 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
-                App.Logger?.Warning("[FYP online] scrolller API HTTP {Code}: {Body}",
+                Log.Warning("[FYP online] scrolller API HTTP {Code}: {Body}",
                     (int)resp.StatusCode, text.Length > 200 ? text[..200] : text);
                 return null;
             }
             var parsed = JObject.Parse(text);
             if (parsed["errors"] is JArray { Count: > 0 } errors)
             {
-                App.Logger?.Warning("[FYP online] scrolller GraphQL error: {E}",
+                Log.Warning("[FYP online] scrolller GraphQL error: {E}",
                     (string?)errors[0]?["message"] ?? "unknown");
                 return null;
             }
@@ -353,7 +354,7 @@ query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $
         catch (OperationCanceledException) { return null; }
         catch (Exception ex)
         {
-            App.Logger?.Warning("[FYP online] scrolller request failed: {E}", ex.Message);
+            Log.Warning("[FYP online] scrolller request failed: {E}", ex.Message);
             return null;
         }
         finally { RequestGate.Release(); }

--- a/ConditioningControlPanel/Services/GoonGame/GoonLoopbackTransport.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonLoopbackTransport.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -213,7 +214,7 @@ namespace ConditioningControlPanel.Services.GoonGame
         public void SimulateOutage(int ms)
         {
             lock (_linkGate) _outageUntilLocalMs = Environment.TickCount64 + Math.Max(0, ms);
-            App.Logger?.Information("[{Tag}] Simulating a {Ms}ms outage", Tag, ms);
+            Log.Information("[{Tag}] Simulating a {Ms}ms outage", Tag, ms);
         }
 
         /// <summary>Frames written but not yet delivered. Handy in a test assertion.</summary>
@@ -244,7 +245,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 catch (OperationCanceledException) { /* closed */ }
                 catch (Exception ex)
                 {
-                    App.Logger?.Error(ex, "[{Tag}] Loopback pump died", Tag);
+                    Log.Error(ex, "[{Tag}] Loopback pump died", Tag);
                 }
             });
         }

--- a/ConditioningControlPanel/Services/GoonGame/GoonScoring.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonScoring.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Serilog;
 
 // ============================================================================
 // GOON GAME — Phase B. Score ticks, attention/interaction multiplier, charge
@@ -223,7 +224,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             if (Charges >= GoonConsts.ChargeCap) return;
             Charges++;
             ChargesEarned++;
-            App.Logger?.Debug("[GG] charge +1 ({Reason}) -> {Charges}", reason, Charges);
+            Log.Debug("[GG] charge +1 ({Reason}) -> {Charges}", reason, Charges);
             ChargesChanged?.Invoke(this, Charges);
         }
 

--- a/ConditioningControlPanel/Services/GoonGame/GoonSuddenDeath.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonSuddenDeath.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 // ============================================================================
 // GOON GAME — Phase D. The synchronized sudden-death harness.
@@ -115,7 +116,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             var token = _cts.Token;
 
-            App.Logger?.Information("[GG] sudden death: starting ladder (host={Host}, modes {Local}/{Remote}, net loss {Net})",
+            Log.Information("[GG] sudden death: starting ladder (host={Host}, modes {Local}/{Remote}, net loss {Net})",
                 ctx.IsHost, ctx.LocalMode, ctx.RemoteMode, netLossThreshold);
 
             try
@@ -149,7 +150,7 @@ namespace ConditioningControlPanel.Services.GoonGame
 
                     var lateBy = clock.NowMatchMs - agreed.FireAtMatchMs;
                     if (lateBy > 0)
-                        App.Logger?.Warning("[GG] sudden death: round {Round} schedule was already {Late}ms in the past — firing now", roundNo, lateBy);
+                        Log.Warning("[GG] sudden death: round {Round} schedule was already {Late}ms in the past — firing now", roundNo, lateBy);
                     else
                         await GoonSchedule.WaitUntilMatchMsAsync(clock, agreed.FireAtMatchMs, token).ConfigureAwait(false);
 
@@ -161,7 +162,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     var raw = await _results.WaitAsync(roundNo, GoonRoundConsts.PeerResultTimeoutMs, token).ConfigureAwait(false);
                     if (raw == null)
                     {
-                        App.Logger?.Warning("[GG] sudden death: no peer result for round {Round} within {Ms}ms", roundNo, GoonRoundConsts.PeerResultTimeoutMs);
+                        Log.Warning("[GG] sudden death: no peer result for round {Round} within {Ms}ms", roundNo, GoonRoundConsts.PeerResultTimeoutMs);
                         RaiseAborted("peer_result_timeout");
                         return;
                     }
@@ -188,7 +189,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         Peer = peer,
                     };
 
-                    App.Logger?.Information(
+                    Log.Information(
                         "[GG] sudden death: round {Round} ({Kind}, difficulty {Diff}) -> {Verdict}, net {Net}",
                         roundNo, kind, difficulty, verdict, NetScore);
 
@@ -198,7 +199,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     if (NetScore <= -netLossThreshold || NetScore >= netLossThreshold)
                     {
                         var localLost = NetScore <= -netLossThreshold;
-                        App.Logger?.Information("[GG] sudden death: net loss reached after {Rounds} rounds (local lost = {Lost})", roundNo, localLost);
+                        Log.Information("[GG] sudden death: net loss reached after {Rounds} rounds (local lost = {Lost})", roundNo, localLost);
                         GoonUi.Invoke(() => NetLossReached?.Invoke(this, localLost), "NetLossReached");
                         return;
                     }
@@ -213,7 +214,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "[GG] sudden death: ladder failed");
+                Log.Error(ex, "[GG] sudden death: ladder failed");
                 RaiseAborted("error: " + ex.Message);
             }
             finally
@@ -246,7 +247,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning("[GG] sudden death: StopAsync wait threw: {Error}", ex.Message);
+                Log.Warning("[GG] sudden death: StopAsync wait threw: {Error}", ex.Message);
             }
         }
 
@@ -265,7 +266,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     break;
                 case MercyMsg:
                     // The match engine also handles this; aborting here just stops the ladder sooner.
-                    App.Logger?.Information("[GG] sudden death: peer mercied mid-ladder — stopping rounds");
+                    Log.Information("[GG] sudden death: peer mercied mid-ladder — stopping rounds");
                     _abortReason = "peer_mercy";
                     try { _cts?.Cancel(); } catch (ObjectDisposedException) { }
                     break;
@@ -369,7 +370,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         };
                     }
 
-                    App.Logger?.Warning("[GG] sudden death: guest did not return a seed half for round {Round} (attempt {Attempt})", roundNo, attempt + 1);
+                    Log.Warning("[GG] sudden death: guest did not return a seed half for round {Round} (attempt {Attempt})", roundNo, attempt + 1);
                 }
                 return null;
             }
@@ -379,7 +380,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             var proposal = await _schedules.WaitAsync(roundNo, GoonRoundConsts.ScheduleWaitTimeoutMs, ct).ConfigureAwait(false);
             if (proposal == null)
             {
-                App.Logger?.Warning("[GG] sudden death: no round {Round} proposal from host within {Ms}ms", roundNo, GoonRoundConsts.ScheduleWaitTimeoutMs);
+                Log.Warning("[GG] sudden death: no round {Round} proposal from host within {Ms}ms", roundNo, GoonRoundConsts.ScheduleWaitTimeoutMs);
                 return null;
             }
 
@@ -391,7 +392,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 // mismatch means the two sides disagree about the modes or about the intersection.
                 // A kind outside the intersection lands here too — same warn-but-follow treatment.
                 var outsideCaps = !IsAllowed(proposal.Kind, ctx.AllowedRoundKinds);
-                App.Logger?.Warning("[GG] sudden death: host proposed {Actual} for round {Round}, expected {Expected}{Caps} — following the host",
+                Log.Warning("[GG] sudden death: host proposed {Actual} for round {Round}, expected {Expected}{Caps} — following the host",
                     proposal.Kind, roundNo, expected, outsideCaps ? " (outside the caps intersection)" : "");
             }
 
@@ -519,7 +520,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             catch (Exception ex)
             {
                 // A broken round is a round we did not complete, not a crashed match.
-                App.Logger?.Error(ex, "[GG] sudden death: round {Round} ({Kind}) threw", roundNo, kind);
+                Log.Error(ex, "[GG] sudden death: round {Round} ({Kind}) threw", roundNo, kind);
                 return new RoundResultMsg { RoundNo = roundNo, Completed = false, ElapsedMs = 0 };
             }
         }
@@ -546,7 +547,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             catch (Exception ex)
             {
                 // Losing a send is survivable: the schedule retry / result timeout paths cover it.
-                App.Logger?.Warning("[GG] sudden death: send of {Type} failed: {Error}", msg.Type, ex.Message);
+                Log.Warning("[GG] sudden death: send of {Type} failed: {Error}", msg.Type, ex.Message);
             }
         }
 
@@ -565,7 +566,7 @@ namespace ConditioningControlPanel.Services.GoonGame
 
         private void RaiseAborted(string reason)
         {
-            App.Logger?.Information("[GG] sudden death: ladder aborted ({Reason})", reason);
+            Log.Information("[GG] sudden death: ladder aborted ({Reason})", reason);
             GoonUi.Invoke(() => Aborted?.Invoke(this, reason), "Aborted");
         }
 

--- a/ConditioningControlPanel/Services/GoonGame/GoonVectorDumper.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonVectorDumper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -72,7 +73,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             var dir = Path.GetDirectoryName(path);
             if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
             File.WriteAllText(path, root.ToString(Formatting.Indented));
-            App.Logger?.Information("GoonVectorDumper: wrote parity vectors -> {Path}", path);
+            Log.Information("GoonVectorDumper: wrote parity vectors -> {Path}", path);
             return path;
         }
 

--- a/ConditioningControlPanel/Services/GoonGame/GoonWire.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonWire.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -110,7 +111,7 @@ namespace ConditioningControlPanel.Services.GoonGame
 
             if (Encoding.UTF8.GetByteCount(json) > MaxWireBytes)
             {
-                App.Logger?.Warning("[{Tag}] Dropping oversize frame ({Chars} chars, cap {Cap} bytes)",
+                Log.Warning("[{Tag}] Dropping oversize frame ({Chars} chars, cap {Cap} bytes)",
                     logTag, json.Length, MaxWireBytes);
                 return null;
             }
@@ -121,7 +122,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 var t = obj["t"]?.Value<string>();
                 if (string.IsNullOrEmpty(t))
                 {
-                    App.Logger?.Warning("[{Tag}] Frame has no \"t\" discriminator", logTag);
+                    Log.Warning("[{Tag}] Frame has no \"t\" discriminator", logTag);
                     return null;
                 }
 
@@ -129,14 +130,14 @@ namespace ConditioningControlPanel.Services.GoonGame
                 {
                     // A newer peer sending a message kind we don't know about. Forward-compatible
                     // by design: ignore it and keep the channel alive.
-                    App.Logger?.Information("[{Tag}] Ignoring unknown message type '{T}'", logTag, t);
+                    Log.Information("[{Tag}] Ignoring unknown message type '{T}'", logTag, t);
                     return null;
                 }
 
                 var v = obj["v"]?.Value<int?>() ?? GoonConsts.ProtocolVersion;
                 if (v > GoonConsts.ProtocolVersion)
                 {
-                    App.Logger?.Information("[{Tag}] Peer speaks protocol v{Peer} (we are v{Ours}) — parsing anyway",
+                    Log.Information("[{Tag}] Peer speaks protocol v{Peer} (we are v{Ours}) — parsing anyway",
                         logTag, v, GoonConsts.ProtocolVersion);
                 }
 
@@ -146,7 +147,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "[{Tag}] Unparseable frame ({Chars} chars)", logTag, json.Length);
+                Log.Warning(ex, "[{Tag}] Unparseable frame ({Chars} chars)", logTag, json.Length);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/GoonGame/MatchClock.cs
+++ b/ConditioningControlPanel/Services/GoonGame/MatchClock.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -151,7 +152,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             catch (OperationCanceledException) { /* channel going away */ }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "[{Tag}] Failed to answer clock ping {Seq}", _tag, ping.Seq);
+                Log.Warning(ex, "[{Tag}] Failed to answer clock ping {Seq}", _tag, ping.Seq);
             }
         }
 
@@ -186,7 +187,7 @@ namespace ConditioningControlPanel.Services.GoonGame
             if (_disposed) return false;
             if (_send == null)
             {
-                App.Logger?.Warning("[{Tag}] SyncAsync with no transport attached", _tag);
+                Log.Warning("[{Tag}] SyncAsync with no transport attached", _tag);
                 return false;
             }
 
@@ -223,7 +224,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 catch (OperationCanceledException) { return false; }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "[{Tag}] Clock ping {Seq} failed to send", _tag, seq);
+                    Log.Warning(ex, "[{Tag}] Clock ping {Seq} failed to send", _tag, seq);
                     lock (_gate) _pending.Remove(seq);
                     continue;
                 }
@@ -258,7 +259,7 @@ namespace ConditioningControlPanel.Services.GoonGame
 
                 if (_samples.Count < MinUsableSamples)
                 {
-                    App.Logger?.Warning("[{Tag}] Clock sync got only {N} usable samples ({Stale} unanswered) — not adopting",
+                    Log.Warning("[{Tag}] Clock sync got only {N} usable samples ({Stale} unanswered) — not adopting",
                         _tag, _samples.Count, stale);
                     return false;
                 }
@@ -277,7 +278,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 // dragging a good offset around.
                 if (_synced && byRtt[0].Rtt > _bestRttMs * ResyncRttRejectFactor && _bestRttMs < double.MaxValue)
                 {
-                    App.Logger?.Information("[{Tag}] Rejecting resync — best RTT {Rtt:F0}ms vs baseline {Base:F0}ms",
+                    Log.Information("[{Tag}] Rejecting resync — best RTT {Rtt:F0}ms vs baseline {Base:F0}ms",
                         _tag, byRtt[0].Rtt, _bestRttMs);
                     _samples.Clear();
                     return false;
@@ -301,14 +302,14 @@ namespace ConditioningControlPanel.Services.GoonGame
                     // Not an error: already-scheduled fires re-read the clock as they wait, so a
                     // correction lands on them too. Logged because a big jump is worth seeing when
                     // someone reports a desynced round.
-                    App.Logger?.Information("[{Tag}] Clock corrected by {Delta}ms (offset {Offset}ms, rtt {Rtt:F0}ms)",
+                    Log.Information("[{Tag}] Clock corrected by {Delta}ms (offset {Offset}ms, rtt {Rtt:F0}ms)",
                         _tag, delta, newOffset, medianRtt);
                 }
             }
 
             if (firstSync)
             {
-                App.Logger?.Information("[{Tag}] Clock synced: offset={Offset}ms rtt={Rtt:F0}ms master={Master}",
+                Log.Information("[{Tag}] Clock synced: offset={Offset}ms rtt={Rtt:F0}ms master={Master}",
                     _tag, newOffset, medianRtt, _isClockMaster);
                 GoonDispatch.Post(() => Synced?.Invoke(this, EventArgs.Empty));
             }
@@ -331,7 +332,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 catch (OperationCanceledException) { }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning(ex, "[{Tag}] Clock resync failed", _tag);
+                    Log.Warning(ex, "[{Tag}] Clock resync failed", _tag);
                 }
             }, null, GoonConsts.ClockResyncIntervalMs, GoonConsts.ClockResyncIntervalMs);
         }
@@ -372,14 +373,14 @@ namespace ConditioningControlPanel.Services.GoonGame
 
             if (!IsSynced)
             {
-                App.Logger?.Warning("[{Tag}] Refusing to schedule '{Label}' — clock not synced", _tag, label);
+                Log.Warning("[{Tag}] Refusing to schedule '{Label}' — clock not synced", _tag, label);
                 return null;
             }
 
             var lead = fireAtMatchMs - NowMatchMs;
             if (lead < GoonConsts.MinScheduleBufferMs)
             {
-                App.Logger?.Warning("[{Tag}] Refusing to schedule '{Label}' — only {Lead}ms lead (need {Min}ms)",
+                Log.Warning("[{Tag}] Refusing to schedule '{Label}' — only {Lead}ms lead (need {Min}ms)",
                     _tag, label, lead, GoonConsts.MinScheduleBufferMs);
                 return null;
             }
@@ -434,7 +435,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         var slip = _clock.NowMatchMs - _fireAtMatchMs;
                         if (slip > 250)
                         {
-                            App.Logger?.Information("[{Tag}] Scheduled '{Label}' fired {Slip}ms late",
+                            Log.Information("[{Tag}] Scheduled '{Label}' fired {Slip}ms late",
                                 _clock._tag, _label, slip);
                         }
                         _action();
@@ -443,7 +444,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 catch (OperationCanceledException) { /* disposed */ }
                 catch (Exception ex)
                 {
-                    App.Logger?.Error(ex, "[{Tag}] Scheduled fire '{Label}' failed", _clock._tag, _label);
+                    Log.Error(ex, "[{Tag}] Scheduled fire '{Label}' failed", _clock._tag, _label);
                 }
             }
 

--- a/ConditioningControlPanel/Services/GoonGame/Rounds/BubbleRaceRound.cs
+++ b/ConditioningControlPanel/Services/GoonGame/Rounds/BubbleRaceRound.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -103,7 +104,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     ? (int)Math.Min(spec.TimeoutMs, sw.ElapsedMilliseconds)
                     : spec.TimeoutMs;
 
-                App.Logger?.Information(
+                Log.Information(
                     "GoonSuddenDeath: bubble race round {Round} -> {Popped}/{Total} in {Ms}ms",
                     ctx.RoundNo, count, spec.Count, elapsed);
 

--- a/ConditioningControlPanel/Services/GoonGame/Rounds/QuickDrawRound.cs
+++ b/ConditioningControlPanel/Services/GoonGame/Rounds/QuickDrawRound.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -96,7 +97,7 @@ namespace ConditioningControlPanel.Services.GoonGame
 
                 if (!signalled)
                 {
-                    App.Logger?.Information("GoonSuddenDeath: quick-draw round {Round} timed out at {Ms}ms", ctx.RoundNo, spec.TimeLimitMs);
+                    Log.Information("GoonSuddenDeath: quick-draw round {Round} timed out at {Ms}ms", ctx.RoundNo, spec.TimeLimitMs);
                     return new RoundResultMsg { RoundNo = ctx.RoundNo, Completed = false, ElapsedMs = spec.TimeLimitMs };
                 }
 

--- a/ConditioningControlPanel/Services/GoonGame/Rounds/ReactionDuelRound.cs
+++ b/ConditioningControlPanel/Services/GoonGame/Rounds/ReactionDuelRound.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -146,7 +147,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 if (!got)
                 {
                     lock (gate) { settled = true; }
-                    App.Logger?.Information("GoonSuddenDeath: reaction duel round {Round} — no input within {Ms}ms", ctx.RoundNo, spec.MaxResponseMs);
+                    Log.Information("GoonSuddenDeath: reaction duel round {Round} — no input within {Ms}ms", ctx.RoundNo, spec.MaxResponseMs);
                     return new RoundResultMsg
                     {
                         RoundNo = ctx.RoundNo,
@@ -159,7 +160,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 var reactionMs = pressed.Task.Result;
                 var suspect = reactionMs < GoonConsts.SuspectReactionMs;
                 if (suspect)
-                    App.Logger?.Warning("GoonSuddenDeath: reaction {Ms}ms is below the suspect floor ({Floor}ms) — scoring it, badged", reactionMs, GoonConsts.SuspectReactionMs);
+                    Log.Warning("GoonSuddenDeath: reaction {Ms}ms is below the suspect floor ({Floor}ms) — scoring it, badged", reactionMs, GoonConsts.SuspectReactionMs);
 
                 return new RoundResultMsg
                 {
@@ -180,7 +181,7 @@ namespace ConditioningControlPanel.Services.GoonGame
 
         private static RoundResultMsg FalseStartResult(GoonRoundContext ctx, Stopwatch sw)
         {
-            App.Logger?.Information("GoonSuddenDeath: reaction duel round {Round} lost to a false start at {Ms}ms", ctx.RoundNo, sw.ElapsedMilliseconds);
+            Log.Information("GoonSuddenDeath: reaction duel round {Round} lost to a false start at {Ms}ms", ctx.RoundNo, sw.ElapsedMilliseconds);
             return new RoundResultMsg
             {
                 RoundNo = ctx.RoundNo,

--- a/ConditioningControlPanel/Services/GoonGame/Rounds/StaringContestRound.cs
+++ b/ConditioningControlPanel/Services/GoonGame/Rounds/StaringContestRound.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -125,7 +126,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     ? spec.DurationMs
                     : (int)Math.Min(spec.DurationMs, sw.ElapsedMilliseconds);
 
-                App.Logger?.Information(
+                Log.Information(
                     "GoonSuddenDeath: staring contest round {Round} -> {Outcome} at {Ms}ms (attention {Pct}%)",
                     ctx.RoundNo, survived ? "survived" : "blinked", elapsed, attentionPct);
 

--- a/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
+++ b/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using ConditioningControlPanel.Services.Transfer;
 using Newtonsoft.Json;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.GoonGame
 {
@@ -189,11 +190,11 @@ namespace ConditioningControlPanel.Services.GoonGame
                 catch (Exception ex)
                 {
                     // A dead index costs the user a re-transfer, nothing more.
-                    App.Logger?.Warning("TransferInboxStore: index load failed ({E}) - starting fresh", ex.Message);
+                    Log.Warning("TransferInboxStore: index load failed ({E}) - starting fresh", ex.Message);
                     _index = new InboxIndex();
                 }
                 SweepLocked();
-                App.Logger?.Information("TransferInboxStore: {N} received artifacts, {MB:F1} MB",
+                Log.Information("TransferInboxStore: {N} received artifacts, {MB:F1} MB",
                     _index.Entries.Count, _usedBytes / 1048576.0);
             }
         }
@@ -222,7 +223,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     foreach (var f in Directory.EnumerateFiles(TmpDir, PartPrefix + "*.part"))
                         TryDelete(f, "stale partial");
             }
-            catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.Sweep(tmp): {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("TransferInboxStore.Sweep(tmp): {E}", ex.Message); }
 
             SaveLocked();
         }
@@ -239,11 +240,11 @@ namespace ConditioningControlPanel.Services.GoonGame
                 Directory.CreateDirectory(RecvDir);
                 foreach (var f in Directory.EnumerateFiles(RecvDir)) { TryDelete(f, why); n++; }
             }
-            catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.Purge(recv): {E}", ex.Message); }
+            catch (Exception ex) { Log.Debug("TransferInboxStore.Purge(recv): {E}", ex.Message); }
             _index.Entries.Clear();
             RecountLocked();
             if (n > 0)
-                App.Logger?.Information("TransferInboxStore: purged {N} received artifact(s) ({Why})", n, why);
+                Log.Information("TransferInboxStore: purged {N} received artifact(s) ({Why})", n, why);
         }
 
         /// <summary>
@@ -262,7 +263,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                     SaveLocked();
                 }
             }
-            catch (Exception ex) { App.Logger?.Warning("TransferInboxStore.PurgeCommittedSafe: {E}", ex.Message); }
+            catch (Exception ex) { Log.Warning("TransferInboxStore.PurgeCommittedSafe: {E}", ex.Message); }
         }
 
         private static void TryDelete(string path, string why)
@@ -271,9 +272,9 @@ namespace ConditioningControlPanel.Services.GoonGame
             try
             {
                 File.Delete(path);
-                App.Logger?.Information("TransferInboxStore: deleted {File} ({Why})", Path.GetFileName(path), why);
+                Log.Information("TransferInboxStore: deleted {File} ({Why})", Path.GetFileName(path), why);
             }
-            catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.TryDelete({P}): {E}", path, ex.Message); }
+            catch (Exception ex) { Log.Debug("TransferInboxStore.TryDelete({P}): {E}", path, ex.Message); }
         }
 
         private void RecountLocked()
@@ -292,7 +293,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 File.WriteAllText(tmp, JsonConvert.SerializeObject(_index, Formatting.None));
                 File.Move(tmp, IndexPath, overwrite: true);
             }
-            catch (Exception ex) { App.Logger?.Warning("TransferInboxStore: index save failed: {E}", ex.Message); }
+            catch (Exception ex) { Log.Warning("TransferInboxStore: index save failed: {E}", ex.Message); }
         }
 
         // ---- reads ----------------------------------------------------------------
@@ -422,7 +423,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning("TransferInboxStore.Begin({Sha}): {E}", sha, ex.Message);
+                    Log.Warning("TransferInboxStore.Begin({Sha}): {E}", sha, ex.Message);
                     return "io-failed";
                 }
             }
@@ -467,7 +468,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 }
                 catch (Exception ex)
                 {
-                    App.Logger?.Warning("TransferInboxStore.AppendChunk({Id}): {E}", id, ex.Message);
+                    Log.Warning("TransferInboxStore.AppendChunk({Id}): {E}", id, ex.Message);
                     return "io-failed";
                 }
             }
@@ -547,20 +548,20 @@ namespace ConditioningControlPanel.Services.GoonGame
                         RecountLocked();
                         SaveLocked();
                     }
-                    App.Logger?.Information("TransferInboxStore: received {Sha}.{Ext} ({KB} KB)",
+                    Log.Information("TransferInboxStore: received {Sha}.{Ext} ({KB} KB)",
                         s.Sha[..12], ext, len / 1024);
                     return (true, s.Sha, ext, RecvUrl(s.Sha, ext), null);
                 }
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning("TransferInboxStore.Commit({Id}): {E}", id, ex.Message);
+                Log.Warning("TransferInboxStore.Commit({Id}): {E}", id, ex.Message);
                 error = "io-failed";
             }
 
             lock (_lock) _sessions.Remove(id!);
             TryDelete(s.PartPath, "commit failed: " + error);
-            App.Logger?.Information("TransferInboxStore: commit rejected ({Error}) for {Sha}", error, s.Sha[..12]);
+            Log.Information("TransferInboxStore: commit rejected ({Error}) for {Sha}", error, s.Sha[..12]);
             return (false, s.Sha, "", null, error ?? "io-failed");
         }
 
@@ -593,7 +594,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                 var p = Path.Combine(RecvDir, sha + "." + (e?.Ext ?? ""));
                 if (File.Exists(p)) File.Delete(p);
             }
-            catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.Drop({Sha}): {E}", sha, ex.Message); }
+            catch (Exception ex) { Log.Debug("TransferInboxStore.Drop({Sha}): {E}", sha, ex.Message); }
             return true;
         }
 

--- a/ConditioningControlPanel/Services/Haptics/Core/MockProviderV2.cs
+++ b/ConditioningControlPanel/Services/Haptics/Core/MockProviderV2.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Haptics.Core
 {
@@ -57,7 +58,7 @@ namespace ConditioningControlPanel.Services.Haptics.Core
                 foreach (var d in _devices) _levels[d.Id] = new double[d.Actuators.Count];
                 IsConnected = true;
             }
-            App.Logger?.Information("MockProviderV2: 3 virtual toys online");
+            Log.Information("MockProviderV2: 3 virtual toys online");
             Raise();
             MockToast.Post("Mock haptics connected\nLush / Edge / Solace");
             return Task.FromResult(true);

--- a/ConditioningControlPanel/Services/Haptics/LovenseProvider.cs
+++ b/ConditioningControlPanel/Services/Haptics/LovenseProvider.cs
@@ -73,7 +73,7 @@ namespace ConditioningControlPanel.Services.Haptics
         {
             try
             {
-                App.Logger?.Information("Connecting to Lovense in {Mode} mode at {Url}", _mode, _baseUrl);
+                Log.Information("Connecting to Lovense in {Mode} mode at {Url}", _mode, _baseUrl);
                 
                 string content;
                 if (_mode == LovenseConnectionMode.Lan)
@@ -90,7 +90,7 @@ namespace ConditioningControlPanel.Services.Haptics
                     content = await response.Content.ReadAsStringAsync();
                 }
 
-                App.Logger?.Information("Lovense response: {Content}", content);
+                Log.Information("Lovense response: {Content}", content);
                 using var doc = JsonDocument.Parse(content);
                 var root = doc.RootElement;
 
@@ -119,7 +119,7 @@ namespace ConditioningControlPanel.Services.Haptics
             catch (Exception ex)
             {
                 Error?.Invoke(this, $"Connection failed: {ex.Message}");
-                App.Logger?.Error(ex, "Lovense connection failed");
+                Log.Error(ex, "Lovense connection failed");
                 return false;
             }
         }
@@ -140,7 +140,7 @@ namespace ConditioningControlPanel.Services.Haptics
                     
                 ConnectedDevices.Add(displayName);
                 DeviceDiscovered?.Invoke(this, displayName);
-                App.Logger?.Information("Found toy: {Id} - {Name}", _toyId, displayName);
+                Log.Information("Found toy: {Id} - {Name}", _toyId, displayName);
             }
             if (ConnectedDevices.Count > 0) 
             { 
@@ -189,7 +189,7 @@ namespace ConditioningControlPanel.Services.Haptics
         {
             if (!IsConnected || string.IsNullOrEmpty(_toyId))
             {
-                App.Logger?.Debug("Lovense.Vibrate: Not connected or no toyId");
+                Log.Debug("Lovense.Vibrate: Not connected or no toyId");
                 return;
             }
             try
@@ -218,12 +218,12 @@ namespace ConditioningControlPanel.Services.Haptics
                         return; // Skip - too soon
                     }
 
-                    App.Logger?.Information("Lovense SEND: level {Level}/20", i);
+                    Log.Information("Lovense SEND: level {Level}/20", i);
                     _lastSentLevel = i;
                     _lastSentTime = now;
                 }
 
-                App.Logger?.Debug("Lovense.Vibrate: intensity={Raw:F2} -> level={Level}/20, continuous={Continuous}",
+                Log.Debug("Lovense.Vibrate: intensity={Raw:F2} -> level={Level}/20, continuous={Continuous}",
                     intensity, i, continuous);
 
                 if (_mode == LovenseConnectionMode.Lan)
@@ -231,24 +231,24 @@ namespace ConditioningControlPanel.Services.Haptics
                     // Lovense Remote API requires timeSec parameter
                     var sec = Math.Max(1, durationMs / 1000);
                     var cmdJson = $"{{\"command\":\"Function\",\"action\":\"Vibrate:{i}\",\"timeSec\":{sec},\"apiVer\":1}}";
-                    App.Logger?.Information("Lovense sending: {Json}", cmdJson);
+                    Log.Information("Lovense sending: {Json}", cmdJson);
                     var json = new StringContent(cmdJson, Encoding.UTF8, "application/json");
                     var response = await _client.PostAsync($"{_baseUrl}/command", json);
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    App.Logger?.Information("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
+                    Log.Information("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
                 }
                 else
                 {
                     // For Lovense Connect (Local mode), use simpler command without timeSec
                     // The device maintains vibration until next command
                     var url = $"{_baseUrl}/command?command=Vibrate&action=Vibrate&intensity={i}&toy={_toyId}";
-                    App.Logger?.Debug("Lovense sending GET: {Url} (level {Level})", url, i);
+                    Log.Debug("Lovense sending GET: {Url} (level {Level})", url, i);
                     var response = await _client.GetAsync(url);
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    App.Logger?.Debug("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
+                    Log.Debug("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
                 }
             }
-            catch (Exception ex) { App.Logger?.Warning(ex, "Vibrate failed"); }
+            catch (Exception ex) { Log.Warning(ex, "Vibrate failed"); }
         }
 
         public async Task StopAsync()
@@ -267,7 +267,7 @@ namespace ConditioningControlPanel.Services.Haptics
                 }
                 _lastSentLevel = 0;
             }
-            catch (Exception ex) { App.Logger?.Warning(ex, "Stop failed"); }
+            catch (Exception ex) { Log.Warning(ex, "Stop failed"); }
         }
 
         /// <summary>
@@ -303,14 +303,14 @@ namespace ConditioningControlPanel.Services.Haptics
 
                 var durationSec = Math.Max(1, totalDurationMs / 1000);
 
-                App.Logger?.Information("Lovense.Pattern: {Count} levels, avg={Avg}, max={Max}, sending={Send} for {Duration}s",
+                Log.Information("Lovense.Pattern: {Count} levels, avg={Avg}, max={Max}, sending={Send} for {Duration}s",
                     levels.Length, avgLevel, maxLevel, levelToSend, durationSec);
 
                 // Skip if same level as before (unless it's been a while)
                 var timeSinceLastCmd = DateTime.UtcNow - _lastSentTime;
                 if (levelToSend == _lastSentLevel && timeSinceLastCmd.TotalMilliseconds < 1000)
                 {
-                    App.Logger?.Debug("Lovense.Pattern: Skipping same level {Level}", levelToSend);
+                    Log.Debug("Lovense.Pattern: Skipping same level {Level}", levelToSend);
                     return;
                 }
 
@@ -321,11 +321,11 @@ namespace ConditioningControlPanel.Services.Haptics
                 {
                     // Use standard Vibrate command with longer duration
                     var cmdJson = $"{{\"command\":\"Function\",\"action\":\"Vibrate:{levelToSend}\",\"timeSec\":{durationSec},\"apiVer\":1}}";
-                    App.Logger?.Information("Lovense sending: {Json}", cmdJson);
+                    Log.Information("Lovense sending: {Json}", cmdJson);
                     var json = new StringContent(cmdJson, Encoding.UTF8, "application/json");
                     var response = await _client.PostAsync($"{_baseUrl}/command", json);
                     var responseContent = await response.Content.ReadAsStringAsync();
-                    App.Logger?.Information("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
+                    Log.Information("Lovense response: {Status} - {Content}", response.StatusCode, responseContent);
                 }
                 else
                 {
@@ -335,7 +335,7 @@ namespace ConditioningControlPanel.Services.Haptics
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "Pattern vibrate failed");
+                Log.Warning(ex, "Pattern vibrate failed");
             }
         }
 

--- a/ConditioningControlPanel/Services/Haptics/LovenseToyEventsClient.cs
+++ b/ConditioningControlPanel/Services/Haptics/LovenseToyEventsClient.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using ConditioningControlPanel.Services.Haptics.Core;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Haptics
 {
@@ -206,7 +207,7 @@ namespace ConditioningControlPanel.Services.Haptics
                         opened = true;
                         var openedAt = DateTime.UtcNow;
                         ActiveEndpoint = candidate;
-                        App.Logger?.Information("Lovense Toy Events: connected to {Endpoint}", candidate);
+                        Log.Information("Lovense Toy Events: connected to {Endpoint}", candidate);
                         SetConnected(true);
 
                         await SessionAsync(ws, ct).ConfigureAwait(false);
@@ -230,21 +231,21 @@ namespace ConditioningControlPanel.Services.Haptics
                             MarkUnsupported(candidate);
                             if (AllCandidatesUnsupported())
                             {
-                                App.Logger?.Information(
+                                Log.Information(
                                     "Lovense Toy Events API not available at any endpoint (last: {Endpoint}, {Reason}) - " +
                                     "toy-button input is disabled for this Lovense Remote version. " +
                                     "Command output is unaffected.", candidate, ex.Message);
                             }
                             else
                             {
-                                App.Logger?.Debug(
+                                Log.Debug(
                                     "Lovense Toy Events: {Endpoint} has no /v1 listener ({Reason}) - trying the others.",
                                     candidate, ex.Message);
                             }
                         }
                         else
                         {
-                            App.Logger?.Debug("Lovense Toy Events: {Endpoint} unreachable ({Reason})",
+                            Log.Debug("Lovense Toy Events: {Endpoint} unreachable ({Reason})",
                                               candidate, ex.Message);
                         }
                     }
@@ -375,7 +376,7 @@ namespace ConditioningControlPanel.Services.Haptics
                 }
             }
             catch (OperationCanceledException) { }
-            catch (Exception ex) { App.Logger?.Debug("Lovense Toy Events ping stopped: {Reason}", ex.Message); }
+            catch (Exception ex) { Log.Debug("Lovense Toy Events ping stopped: {Reason}", ex.Message); }
         }
 
         private async Task SendTextAsync(ClientWebSocket ws, string json, CancellationToken ct)
@@ -410,7 +411,7 @@ namespace ConditioningControlPanel.Services.Haptics
                 catch (OperationCanceledException) { break; }
                 catch (Exception ex)
                 {
-                    App.Logger?.Debug("Lovense Toy Events receive ended: {Reason}", ex.Message);
+                    Log.Debug("Lovense Toy Events receive ended: {Reason}", ex.Message);
                     break;
                 }
 
@@ -425,7 +426,7 @@ namespace ConditioningControlPanel.Services.Haptics
 
                 if (frame.Length + result.Count > MaxFrameBytes)
                 {
-                    App.Logger?.Debug("Lovense Toy Events: message exceeded {Cap} bytes - dropped and resyncing.",
+                    Log.Debug("Lovense Toy Events: message exceeded {Cap} bytes - dropped and resyncing.",
                                       MaxFrameBytes);
                     frame.SetLength(0);
                     dropping = !result.EndOfMessage;
@@ -442,11 +443,11 @@ namespace ConditioningControlPanel.Services.Haptics
                 if (_loggedFrames < MaxLoggedFrames)
                 {
                     _loggedFrames++;
-                    App.Logger?.Debug("Lovense Toy Events frame: {Frame}", text);
+                    Log.Debug("Lovense Toy Events frame: {Frame}", text);
                 }
 
                 try { HandleFrame(text); }
-                catch (Exception ex) { App.Logger?.Debug("Lovense Toy Events parse failed: {Reason}", ex.Message); }
+                catch (Exception ex) { Log.Debug("Lovense Toy Events parse failed: {Reason}", ex.Message); }
             }
         }
 
@@ -579,7 +580,7 @@ namespace ConditioningControlPanel.Services.Haptics
         private void Raise(HapticToyEvent e)
         {
             try { ToyEvent?.Invoke(this, e); }
-            catch (Exception ex) { App.Logger?.Debug("Lovense ToyEvent handler threw: {Reason}", ex.Message); }
+            catch (Exception ex) { Log.Debug("Lovense ToyEvent handler threw: {Reason}", ex.Message); }
         }
 
         private void SetConnected(bool value)
@@ -587,7 +588,7 @@ namespace ConditioningControlPanel.Services.Haptics
             if (_connected == value) return;
             _connected = value;
             try { ConnectionChanged?.Invoke(this, value); }
-            catch (Exception ex) { App.Logger?.Debug("Lovense ToyEvents ConnectionChanged handler threw: {Reason}", ex.Message); }
+            catch (Exception ex) { Log.Debug("Lovense ToyEvents ConnectionChanged handler threw: {Reason}", ex.Message); }
         }
     }
 }

--- a/ConditioningControlPanel/Services/Media/Transfer/TransferCacheIndex.cs
+++ b/ConditioningControlPanel/Services/Media/Transfer/TransferCacheIndex.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using Newtonsoft.Json;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Transfer
 {
@@ -184,7 +185,7 @@ namespace ConditioningControlPanel.Services.Transfer
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("TransferCacheHash.Sha256File({Path}): {E}", path, ex.Message);
+                Log.Debug("TransferCacheHash.Sha256File({Path}): {E}", path, ex.Message);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/Media/Transfer/VideoTranscodeLane.cs
+++ b/ConditioningControlPanel/Services/Media/Transfer/VideoTranscodeLane.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Windows.Media.MediaProperties;
 using Windows.Media.Transcoding;
 using Windows.Storage;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Transfer
 {
@@ -73,7 +74,7 @@ namespace ConditioningControlPanel.Services.Transfer
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
-                App.Logger?.Debug("VideoTranscodeLane.ProbeAsync({Path}): {E}", path, ex.Message);
+                Log.Debug("VideoTranscodeLane.ProbeAsync({Path}): {E}", path, ex.Message);
                 return null;
             }
         }
@@ -193,7 +194,7 @@ namespace ConditioningControlPanel.Services.Transfer
             if (!prep.CanTranscode)
             {
                 TryDelete(tmpOut);
-                App.Logger?.Information("VideoTranscodeLane: cannot transcode {Path} ({Reason})",
+                Log.Information("VideoTranscodeLane: cannot transcode {Path} ({Reason})",
                     srcPath, prep.FailureReason);
                 throw new TranscodeUnsupportedException(TransferFailReasons.NoDecoder);
             }
@@ -220,7 +221,7 @@ namespace ConditioningControlPanel.Services.Transfer
             catch (Exception ex)
             {
                 TryDelete(tmpOut);
-                App.Logger?.Warning("VideoTranscodeLane: transcode of {Path} failed: {E}", srcPath, ex.Message);
+                Log.Warning("VideoTranscodeLane: transcode of {Path} failed: {E}", srcPath, ex.Message);
                 throw;
             }
         }

--- a/ConditioningControlPanel/Services/PhraseBackupService.cs
+++ b/ConditioningControlPanel/Services/PhraseBackupService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ConditioningControlPanel.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -140,14 +141,14 @@ namespace ConditioningControlPanel.Services
                 ObjectCreationHandling = ObjectCreationHandling.Replace,
                 Error = (sender, args) =>
                 {
-                    App.Logger?.Warning("Skipping unimportable phrase member '{Path}': {Error}",
+                    Log.Warning("Skipping unimportable phrase member '{Path}': {Error}",
                         args.ErrorContext.Path, args.ErrorContext.Error.Message);
                     args.ErrorContext.Handled = true;
                 }
             };
 
             JsonConvert.PopulateObject(filtered.ToString(), settings, populateSettings);
-            App.Logger?.Information("Imported phrases from {Path}", filePath);
+            Log.Information("Imported phrases from {Path}", filePath);
             return CountEntries(filtered);
         }
 

--- a/ConditioningControlPanel/Services/Possession/Scenes/PossessionSceneCatalog.cs
+++ b/ConditioningControlPanel/Services/Possession/Scenes/PossessionSceneCatalog.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ConditioningControlPanel.Services.Possession.Effects;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Possession.Scenes;
 
@@ -67,13 +68,13 @@ public sealed class PossessionSceneEffect : IPossessionEffect
         _live = true;
         try { await _scene.RunAsync(ctx, ctx.Host, _pick, ct).ConfigureAwait(true); }
         catch (OperationCanceledException) { }
-        catch (Exception ex) { App.Logger?.Warning("Possession scene {Id} threw: {Error}", Id, ex.Message); }
+        catch (Exception ex) { Log.Warning("Possession scene {Id} threw: {Error}", Id, ex.Message); }
     }
 
     public async Task UndoAsync(TimeSpan duration)
     {
         try { await _scene.UndoAsync(duration).ConfigureAwait(true); }
-        catch (Exception ex) { App.Logger?.Warning("Possession scene {Id} undo failed: {Error}", Id, ex.Message); }
+        catch (Exception ex) { Log.Warning("Possession scene {Id} undo failed: {Error}", Id, ex.Message); }
         finally { _live = false; }
     }
 }

--- a/ConditioningControlPanel/Services/Program/ProgramSessionBuilder.cs
+++ b/ConditioningControlPanel/Services/Program/ProgramSessionBuilder.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text.Json;
 using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Models.Program;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Program;
 
@@ -199,7 +200,7 @@ public static class ProgramSessionBuilder
         {
             if (!SettingsByName.TryGetValue(key, out var prop) || !prop.CanWrite)
             {
-                App.Logger?.Warning("Program day override targets unknown SessionSettings field '{Field}'", key);
+                Log.Warning("Program day override targets unknown SessionSettings field '{Field}'", key);
                 continue;
             }
 
@@ -212,7 +213,7 @@ public static class ProgramSessionBuilder
                 // into a string property would hand the rest of the app a null it assumes is "".
                 if (converted == null && Nullable.GetUnderlyingType(prop.PropertyType) == null)
                 {
-                    App.Logger?.Warning("Program day override for '{Field}' resolved to null and was skipped", key);
+                    Log.Warning("Program day override for '{Field}' resolved to null and was skipped", key);
                     continue;
                 }
 
@@ -220,7 +221,7 @@ public static class ProgramSessionBuilder
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "Program day override for '{Field}' could not be applied", key);
+                Log.Warning(ex, "Program day override for '{Field}' could not be applied", key);
             }
         }
     }

--- a/ConditioningControlPanel/Services/Session/SessionManager.cs
+++ b/ConditioningControlPanel/Services/Session/SessionManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -81,7 +82,7 @@ namespace ConditioningControlPanel.Services
             foreach (var def in customSessions)
             {
                 var session = def.ToSession();
-                App.Logger?.Debug("Loaded custom session: {Name}, BonusXP={XP}, Source={Source}",
+                Log.Debug("Loaded custom session: {Name}, BonusXP={XP}, Source={Source}",
                     session.Name, session.BonusXP, session.Source);
                 _sessions.Add(session);
             }

--- a/ConditioningControlPanel/Services/Speech/SileroVadGate.cs
+++ b/ConditioningControlPanel/Services/Speech/SileroVadGate.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using SherpaOnnx;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.Speech
 {
@@ -77,7 +78,7 @@ namespace ConditioningControlPanel.Services.Speech
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "SileroVadGate: init failed — falling back to the energy gate");
+                Log.Warning(ex, "SileroVadGate: init failed — falling back to the energy gate");
                 return null;
             }
         }
@@ -98,7 +99,7 @@ namespace ConditioningControlPanel.Services.Speech
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "SileroVadGate: update failed — passing audio through");
+                Log.Warning(ex, "SileroVadGate: update failed — passing audio through");
                 return true; // fail-open: worse to drop the user's speech than to skip gating
             }
         }

--- a/ConditioningControlPanel/Services/StartupManager.cs
+++ b/ConditioningControlPanel/Services/StartupManager.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -30,7 +31,7 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning("Could not check startup registration: {Error}", ex.Message);
+                Log.Warning("Could not check startup registration: {Error}", ex.Message);
                 return false;
             }
         }
@@ -46,7 +47,7 @@ namespace ConditioningControlPanel.Services
                 var exePath = GetExecutablePath();
                 if (string.IsNullOrEmpty(exePath) || !File.Exists(exePath))
                 {
-                    App.Logger?.Warning("Could not find executable path for startup registration");
+                    Log.Warning("Could not find executable path for startup registration");
                     return false;
                 }
 
@@ -54,12 +55,12 @@ namespace ConditioningControlPanel.Services
                 CreateShortcut(ShortcutPath, exePath, Path.GetDirectoryName(exePath) ?? "",
                     "Conditioning Control Panel", "--startup");
 
-                App.Logger?.Information("Registered for Windows startup: {Path}", ShortcutPath);
+                Log.Information("Registered for Windows startup: {Path}", ShortcutPath);
                 return true;
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "Failed to register for Windows startup");
+                Log.Error(ex, "Failed to register for Windows startup");
                 return false;
             }
         }
@@ -74,13 +75,13 @@ namespace ConditioningControlPanel.Services
                 if (File.Exists(ShortcutPath))
                 {
                     File.Delete(ShortcutPath);
-                    App.Logger?.Information("Unregistered from Windows startup");
+                    Log.Information("Unregistered from Windows startup");
                 }
                 return true;
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "Failed to unregister from Windows startup");
+                Log.Error(ex, "Failed to unregister from Windows startup");
                 return false;
             }
         }

--- a/ConditioningControlPanel/Services/UI/DisplayChangeCoordinator.cs
+++ b/ConditioningControlPanel/Services/UI/DisplayChangeCoordinator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Serilog;
 
 namespace ConditioningControlPanel.Services.UI
 {
@@ -34,7 +35,7 @@ namespace ConditioningControlPanel.Services.UI
         public static void NotifyDisplayChange(string reason)
         {
             Interlocked.Exchange(ref _quietUntilTick, Environment.TickCount64 + QuietMs);
-            App.Logger?.Debug("[DISPLAY] change ({Reason}) — pausing layered-window spawns for {Ms}ms", reason, QuietMs);
+            Log.Debug("[DISPLAY] change ({Reason}) — pausing layered-window spawns for {Ms}ms", reason, QuietMs);
         }
 
         /// <summary>True while spawns should be skipped (a display change happened within the last <see cref="QuietMs"/> ms).</summary>
@@ -49,14 +50,14 @@ namespace ConditioningControlPanel.Services.UI
         public static void BeginInteractiveMove()
         {
             Interlocked.Exchange(ref _interactiveMove, 1);
-            App.Logger?.Debug("[DISPLAY] interactive move started — quiescing z-order/layered reconcilers");
+            Log.Debug("[DISPLAY] interactive move started — quiescing z-order/layered reconcilers");
         }
 
         /// <summary>Main window left its modal move/size loop (WM_EXITSIZEMOVE).</summary>
         public static void EndInteractiveMove()
         {
             Interlocked.Exchange(ref _interactiveMove, 0);
-            App.Logger?.Debug("[DISPLAY] interactive move ended");
+            Log.Debug("[DISPLAY] interactive move ended");
         }
 
         /// <summary>True while the user is dragging/resizing the main window. During that loop a

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -279,12 +280,12 @@ namespace ConditioningControlPanel.Services
             try
             {
                 var line = FormatSurfaceLine(engine, monitor, primary, firstFrameMs, failureReason);
-                App.Logger?.Information("VideoSurface: {Surface}", line);
+                Log.Information("VideoSurface: {Surface}", line);
                 VideoDiag.Log("SURFACE", line);
             }
             catch (Exception ex)
             {
-                try { App.Logger?.Debug("VideoSurfaceHealth.Report failed: {E}", ex.Message); } catch { }
+                try { Log.Debug("VideoSurfaceHealth.Report failed: {E}", ex.Message); } catch { }
             }
         }
     }

--- a/ConditioningControlPanel/Services/Webcam/WebcamDeviceEnumerator.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamDeviceEnumerator.cs
@@ -57,14 +57,14 @@ namespace ConditioningControlPanel.Services
                 var devEnumType = Type.GetTypeFromCLSID(CLSID_SystemDeviceEnum);
                 if (devEnumType == null)
                 {
-                    App.Logger?.Warning("WebcamDeviceEnumerator: SystemDeviceEnum CLSID could not be resolved");
+                    Log.Warning("WebcamDeviceEnumerator: SystemDeviceEnum CLSID could not be resolved");
                     return devices;
                 }
 
                 devEnum = Activator.CreateInstance(devEnumType) as ICreateDevEnum;
                 if (devEnum == null)
                 {
-                    App.Logger?.Warning("WebcamDeviceEnumerator: ICreateDevEnum activation returned null");
+                    Log.Warning("WebcamDeviceEnumerator: ICreateDevEnum activation returned null");
                     return devices;
                 }
 
@@ -101,7 +101,7 @@ namespace ConditioningControlPanel.Services
                     }
                     catch (Exception ex)
                     {
-                        App.Logger?.Debug(ex, "WebcamDeviceEnumerator: failed to read FriendlyName for device {Index}", idx);
+                        Log.Debug(ex, "WebcamDeviceEnumerator: failed to read FriendlyName for device {Index}", idx);
                     }
                     finally
                     {
@@ -118,7 +118,7 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "WebcamDeviceEnumerator: enumeration threw");
+                Log.Warning(ex, "WebcamDeviceEnumerator: enumeration threw");
             }
             finally
             {

--- a/ConditioningControlPanel/Services/Webcam/WebcamWinRtEnumerator.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamWinRtEnumerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Devices.Enumeration;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -37,7 +38,7 @@ namespace ConditioningControlPanel.Services
 
                 if (!task.Wait(TimeSpan.FromSeconds(5)))
                 {
-                    App.Logger?.Warning("WebcamWinRtEnumerator: FindAllAsync timed out");
+                    Log.Warning("WebcamWinRtEnumerator: FindAllAsync timed out");
                     return devices;
                 }
 
@@ -49,11 +50,11 @@ namespace ConditioningControlPanel.Services
                     devices.Add(new WebcamDeviceEnumerator.WebcamDevice(idx, name));
                     idx++;
                 }
-                App.Logger?.Information("WebcamWinRtEnumerator: {Count} video-capture device(s) via WinRT", devices.Count);
+                Log.Information("WebcamWinRtEnumerator: {Count} video-capture device(s) via WinRT", devices.Count);
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning(ex, "WebcamWinRtEnumerator: enumeration threw");
+                Log.Warning(ex, "WebcamWinRtEnumerator: enumeration threw");
             }
             return devices;
         }

--- a/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
@@ -91,7 +91,7 @@ public class AwarenessConsentTests
     {
         var writers = SourceWriters("AwarenessModeEnabled")
             .Concat(SourceWriters("AwarenessConsentGiven"))
-            .Select(Path.GetFileName)
+            .Select(SourceRoots.Relative)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
@@ -100,12 +100,20 @@ public class AwarenessConsentTests
         // (#267's EnforceEntitlementLapse, extended for awareness in #1047) and is only allowed here
         // because it can only ever write FALSE — asserted below, so it cannot quietly become a second
         // door. Anything else on this list IS a second door.
+        //
+        // Keyed on the path relative to the REPO, not on the bare filename. The walk spans every
+        // product root now, so a filename is no longer a unique key: a CCP.Core/Models/AppSettings.cs
+        // added during the Core split would inherit this exemption and open a second door in
+        // silence. Whole-path keys also mean that moving a door to Core fails here loudly, which is
+        // the right moment to re-review whether it is still the only way in.
         var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "AppSettings.cs", "MainWindow.CompanionRoom.cs", "MainWindow.Patreon.cs"
+            "ConditioningControlPanel/Models/AppSettings.cs",
+            "ConditioningControlPanel/MainWindow/MainWindow.CompanionRoom.cs",
+            "ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs"
         };
 
-        var strays = writers.Where(f => !allowed.Contains(f!)).ToList();
+        var strays = writers.Where(f => !allowed.Contains(f)).ToList();
         Assert.True(strays.Count == 0,
             "awareness is switched on outside the consent gate in: " + string.Join(", ", strays));
     }
@@ -317,8 +325,6 @@ public class AwarenessConsentTests
                 if (i < 0) continue;
                 if (line.Contains(property + " ==", StringComparison.Ordinal)) continue;
                 if (line.TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
-                if (line.Contains("_" + char.ToLowerInvariant(property[0]) + property.Substring(1),
-                        StringComparison.Ordinal)) { /* the backing-field assignment inside the setter */ }
                 yield return file;
                 break;
             }

--- a/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
@@ -307,14 +307,10 @@ public class AwarenessConsentTests
     /// <summary>Files that ASSIGN <paramref name="property"/> (i.e. "Property =", not "Property ==").</summary>
     private static IEnumerable<string> SourceWriters(string property)
     {
-        foreach (var file in Directory.EnumerateFiles(SourceRoot(), "*.cs", SearchOption.AllDirectories))
+        // Every product root, not just the WPF head: a consent gate that moves to CCP.Core has to
+        // stay under this guard. Build output and nested worktrees are excluded by the helper.
+        foreach (var file in SourceRoots.EnumerateProductSources("*.cs"))
         {
-            if (file.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar) ||
-                file.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar) ||
-                // Nested git worktrees (e.g. .claude/worktrees/*) are other branches' sources —
-                // scanning them reports their files as second doors that do not exist on this tree.
-                file.Contains(Path.DirectorySeparatorChar + ".claude" + Path.DirectorySeparatorChar)) continue;
-
             foreach (var line in File.ReadLines(file))
             {
                 var i = line.IndexOf(property + " =", StringComparison.Ordinal);

--- a/Tests/ConditioningControlPanel.Tests/EmiMomentIdWiringTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiMomentIdWiringTests.cs
@@ -40,17 +40,10 @@ public class EmiMomentIdWiringTests
 
     private static string AppDir() => Path.Combine(RepoRoot(), "ConditioningControlPanel");
 
-    /// <summary>Every C# file that ships, ignoring build output.</summary>
-    private static IEnumerable<string> SourceFiles()
-    {
-        foreach (var path in Directory.EnumerateFiles(AppDir(), "*.cs", SearchOption.AllDirectories))
-        {
-            var rel = path.Substring(AppDir().Length).Replace('\\', '/');
-            if (rel.Contains("/bin/", StringComparison.OrdinalIgnoreCase)) continue;
-            if (rel.Contains("/obj/", StringComparison.OrdinalIgnoreCase)) continue;
-            yield return path;
-        }
-    }
+    /// <summary>Every C# file that ships, across every product root, ignoring build output. A
+    /// moment id raised from code that has moved to CCP.Core still has to be in the vocabulary,
+    /// so this walks the roots rather than the WPF head alone.</summary>
+    private static IEnumerable<string> SourceFiles() => SourceRoots.EnumerateProductSources("*.cs");
 
     // =====================================================================================
     //  the shipped vocabulary

--- a/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
@@ -110,8 +110,7 @@ public class FontFallbackTests
         var xaml = SourceFiles(".xaml").ToList();
 
         Assert.True(xaml.Count > 50,
-            "the XAML walk found only " + xaml.Count + " files across " +
-            string.Join(", ", SourceRoots.ProductDirectories.Select(Path.GetFileName)) +
+            "the XAML walk found only " + xaml.Count + " files across the product roots" +
             " - the scans in this suite would be passing vacuously");
         Assert.Contains(xaml, p => Path.GetFileName(p) == "MainWindow.xaml");
     }
@@ -125,9 +124,12 @@ public class FontFallbackTests
     public void No_markup_names_Cascadia_directly()
     {
         var offenders = SourceFiles(".xaml")
-            .Where(p => !p.EndsWith(Path.Combine("ConditioningControlPanel", "App.xaml"), StringComparison.OrdinalIgnoreCase))
+            // Each head's own App.xaml is the one allowed place: it holds the Font.Mono resource
+            // that FontGuard swaps. Matched on the filename, so a new head is exempt on arrival
+            // rather than failing this test the day it lands.
+            .Where(p => !string.Equals(Path.GetFileName(p), "App.xaml", StringComparison.OrdinalIgnoreCase))
             .Where(p => File.ReadAllText(p).Contains("Cascadia", StringComparison.OrdinalIgnoreCase))
-            .Select(p => Path.GetRelativePath(AppDir, p))
+            .Select(SourceRoots.Relative)
             .ToList();
 
         Assert.True(offenders.Count == 0,
@@ -154,7 +156,7 @@ public class FontFallbackTests
     {
         var staticUses = SourceFiles(".xaml")
             .Where(p => File.ReadAllText(p).Contains("StaticResource " + FontGuard.MonoResourceKey))
-            .Select(p => Path.GetRelativePath(AppDir, p))
+            .Select(SourceRoots.Relative)
             .ToList();
 
         Assert.True(staticUses.Count == 0,
@@ -183,7 +185,7 @@ public class FontFallbackTests
                 if (Regex.IsMatch(text, "FontFamily=\"" + Regex.Escape(face) + "\"") ||
                     Regex.IsMatch(text, "Property=\"FontFamily\"\\s+Value=\"" + Regex.Escape(face) + "\""))
                 {
-                    offenders.Add(Path.GetRelativePath(AppDir, path) + " -> " + face);
+                    offenders.Add(SourceRoots.Relative(path) + " -> " + face);
                 }
             }
         }

--- a/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
@@ -39,27 +39,10 @@ public class FontFallbackTests
 
     private static string AppDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
 
-    /// <summary>
-    /// Every shipped source file of the given extension.
-    ///
-    /// <para>The exclusions are matched on the path RELATIVE to the app folder, not the absolute
-    /// path. That distinction matters: agent worktrees live at
-    /// <c>ConditioningControlPanel/.claude/worktrees/&lt;id&gt;/</c>, so a suite running inside one
-    /// has ".claude" in every absolute path it sees. Filtering absolute paths would therefore
-    /// exclude the entire tree and pass vacuously in a worktree, while still needing to skip other
-    /// branches' worktrees in a normal checkout. Relative matching gets both right.</para>
-    /// </summary>
-    private static IEnumerable<string> SourceFiles(string extension)
-    {
-        var skip = new[] { "bin", "obj", ".claude" };
-        return Directory.EnumerateFiles(AppDir, "*" + extension, SearchOption.AllDirectories)
-            .Where(p =>
-            {
-                var segments = Path.GetRelativePath(AppDir, p)
-                    .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                return !segments.Any(s => skip.Contains(s, StringComparer.OrdinalIgnoreCase));
-            });
-    }
+    /// <summary>Every shipped source file of the given extension, across every product root — see
+    /// <see cref="SourceRoots"/> for the roots and the excluded directories.</summary>
+    private static IEnumerable<string> SourceFiles(string extension) =>
+        SourceRoots.EnumerateProductSources("*" + extension);
 
     // ------------------------------------------------------------------ the chain filter
 
@@ -117,8 +100,9 @@ public class FontFallbackTests
 
     /// <summary>
     /// The scans below are all "find me the offenders, expect none", which is exactly the shape
-    /// that passes for free when the file walk returns nothing. YouLibraryDoorTests silently does
-    /// this today inside an agent worktree. So: prove the walk actually sees the app first.
+    /// that passes for free when the file walk returns nothing. <see cref="SourceRoots"/> guards
+    /// the empty-walk and lost-root cases for every guard in the suite; this keeps the sharper
+    /// "and it found the actual markup" pin on top of it.
     /// </summary>
     [Fact]
     public void The_markup_scan_actually_finds_the_app()
@@ -126,7 +110,8 @@ public class FontFallbackTests
         var xaml = SourceFiles(".xaml").ToList();
 
         Assert.True(xaml.Count > 50,
-            "the XAML walk found only " + xaml.Count + " files under " + AppDir +
+            "the XAML walk found only " + xaml.Count + " files across " +
+            string.Join(", ", SourceRoots.ProductDirectories.Select(Path.GetFileName)) +
             " - the scans in this suite would be passing vacuously");
         Assert.Contains(xaml, p => Path.GetFileName(p) == "MainWindow.xaml");
     }

--- a/Tests/ConditioningControlPanel.Tests/HeaderBannerTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/HeaderBannerTests.cs
@@ -61,16 +61,11 @@ public class HeaderBannerTests
         // Three partials used to reach for TxtBannerTertiary by name (mod accent, lockdown
         // crimson, the rotation itself). The loc key is deliberately left in the nine language
         // files - it is inert once nothing binds it - so only the code is asserted here.
-        // .claude/worktrees/* holds OTHER BRANCHES' checkouts of this same repo. Scanning them
-        // means asserting against whatever anyone happened to leave lying around, so this test
-        // failed on a clean tree for anyone with an agent worktree still on disk. The same
-        // exclusion is already in PlayDoorRenderTests, YouLibraryDoorTests, AwarenessConsentTests
-        // and Phase8RedirectContractTests - this one was the straggler.
-        var stragglers = Directory
-            .EnumerateFiles(Path.Combine(RepoRoot(), "ConditioningControlPanel"), "*.cs", SearchOption.AllDirectories)
-            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
-                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
-                        && !f.Contains($"{Path.DirectorySeparatorChar}.claude{Path.DirectorySeparatorChar}"))
+        // This asserts ZERO offenders, which is the shape that passes for free when the walk is
+        // pointed at too few roots. SourceRoots covers every product project (and skips build
+        // output and the .claude/worktrees/* checkouts of other branches) so a re-added reference
+        // is caught wherever it lands, not only in the WPF head.
+        var stragglers = SourceRoots.EnumerateProductSources("*.cs")
             .Where(f => File.ReadAllText(f).Contains("TxtBannerTertiary", StringComparison.Ordinal))
             .ToArray();
 

--- a/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
@@ -91,7 +91,7 @@ public class Phase8RedirectContractTests
         Assert.Contains("ShowAppInfoPopup", m.Groups["body"].Value, StringComparison.Ordinal);
 
         // And the destination is a real method somewhere in the product.
-        Assert.Contains(ProductSources().Where(f => f.EndsWith(".cs")),
+        Assert.Contains(SourceRoots.EnumerateProductSources("*.cs"),
                         f => Regex.IsMatch(File.ReadAllText(f), @"void ShowAppInfoPopup\("));
     }
 
@@ -188,7 +188,7 @@ public class Phase8RedirectContractTests
         {
             var text = StripComments(File.ReadAllText(f));
             if (Regex.IsMatch(text, @"\b" + Regex.Escape(typeName) + @"\b"))
-                live.Add(Path.GetRelativePath(ProductDir, f));
+                live.Add(SourceRoots.Relative(f));
         }
 
         Assert.True(live.Count == 0,
@@ -213,7 +213,7 @@ public class Phase8RedirectContractTests
         {
             foreach (var (line, i) in StripComments(File.ReadAllText(f)).Split('\n').Select((l, i) => (l, i + 1)))
                 if (pattern.IsMatch(line))
-                    live.Add($"{Path.GetRelativePath(ProductDir, f)}:{i}");
+                    live.Add($"{SourceRoots.Relative(f)}:{i}");
         }
 
         Assert.True(live.Count == 0, $"{memberName} is demolished but still dereferenced: "

--- a/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
@@ -45,30 +45,12 @@ public class Phase8RedirectContractTests
 
     private static string TabNavigation() => ReadSource("MainWindow", "MainWindow.TabNavigation.cs");
 
-    /// <summary>Every .cs/.xaml under the product project, obj/bin and nested worktrees excluded.
-    ///
-    /// <para>The exclusion is matched on each file's path RELATIVE to <see cref="ProductDir"/>,
-    /// because it is about directories INSIDE the tree under test. Matching the absolute path — as
-    /// this did — silently emptied the whole walk inside an agent worktree, where the checkout
-    /// itself lives at <c>&lt;repo&gt;/.claude/worktrees/&lt;name&gt;/</c> and therefore gives every
-    /// file in the product a <c>.claude</c> segment. The demolition tests below then asserted
-    /// "nothing references this type" against zero files.</para></summary>
-    private static IEnumerable<string> ProductSources()
-    {
-        var skip = new[] { "obj", "bin", ".claude", "node_modules" };
-
-        var files = Directory.EnumerateFiles(ProductDir, "*.*", SearchOption.AllDirectories)
-                             .Where(f => f.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
-                                      || f.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase))
-                             .Where(f => !Path.GetRelativePath(ProductDir, f)
-                                              .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                                              .Any(segment => skip.Contains(segment, StringComparer.OrdinalIgnoreCase)))
-                             .ToList();
-
-        // A walk that finds nothing would make every assertion below vacuously true.
-        Assert.True(files.Count > 0, "the product source walk found no .cs/.xaml files under " + ProductDir);
-        return files;
-    }
+    /// <summary>Every .cs/.xaml across every product root, obj/bin and nested worktrees excluded —
+    /// see <see cref="SourceRoots"/>. A demolished type still referenced from a file that has moved
+    /// to CCP.Core is exactly the reference this must not stop seeing.</summary>
+    private static IEnumerable<string> ProductSources() =>
+        SourceRoots.EnumerateProductSources("*.cs")
+                   .Concat(SourceRoots.EnumerateProductSources("*.xaml"));
 
     /// <summary>Source with // and /* */ comments and XML comments stripped, so a tombstone note
     /// naming a demolished control can never masquerade as a live reference.</summary>

--- a/Tests/ConditioningControlPanel.Tests/PlayDoorRenderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PlayDoorRenderTests.cs
@@ -694,17 +694,9 @@ public class PlayDoorRenderTests
         });
     }
 
-    /// <summary>
-    /// The product's own C# sources. Build output is skipped for the obvious reason, and
-    /// <c>.claude/</c> because a developer's git worktrees live under it — those are other
-    /// branches' copies of this repo and asserting against them would fail on whatever anyone
-    /// happens to have checked out.
-    /// </summary>
-    private static IEnumerable<string> SourceFiles() =>
-        Directory.EnumerateFiles(Path.Combine(RepoRoot(), "ConditioningControlPanel"), "*.cs", SearchOption.AllDirectories)
-                 .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
-                             && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
-                             && !f.Contains($"{Path.DirectorySeparatorChar}.claude{Path.DirectorySeparatorChar}"));
+    /// <summary>The product's own C# sources, across every product root — see
+    /// <see cref="SourceRoots"/> for which roots and which directories it skips.</summary>
+    private static IEnumerable<string> SourceFiles() => SourceRoots.EnumerateProductSources("*.cs");
 
     private static IEnumerable<string> BuiltInModRuleFiles()
     {

--- a/Tests/ConditioningControlPanel.Tests/ShortWalkTourTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ShortWalkTourTests.cs
@@ -91,11 +91,10 @@ public class ShortWalkTourTests : IDisposable
         svc.Start(TutorialType.ShortWalk);
 
         var names = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var path in Directory.EnumerateFiles(AppDir(), "*.xaml", SearchOption.AllDirectories))
+        // Every product root, so a view that moves out of the WPF head keeps feeding this set
+        // rather than quietly turning its own tour targets into "dead" names.
+        foreach (var path in SourceRoots.EnumerateProductSources("*.xaml"))
         {
-            var rel = path.Substring(AppDir().Length).Replace('\\', '/');
-            if (rel.Contains("/bin/", StringComparison.OrdinalIgnoreCase)) continue;
-            if (rel.Contains("/obj/", StringComparison.OrdinalIgnoreCase)) continue;
             foreach (Match m in Regex.Matches(File.ReadAllText(path), @"x:Name=""([A-Za-z_][A-Za-z0-9_]*)"""))
                 names.Add(m.Groups[1].Value);
         }

--- a/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
+++ b/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Where the guard tests look for product source.
+///
+/// <para><b>Why this exists.</b> A dozen tests in this suite are source-scanning guards: they walk
+/// the product's <c>.cs</c>/<c>.xaml</c> files on disk and grep them to assert a project-wide
+/// invariant ("every awareness line has a consent gate", "every EMI moment id is wired up"). Each
+/// had computed its own scan root as the <c>ConditioningControlPanel/</c> directory. The app is
+/// being split so a platform-agnostic <c>CCP.Core</c> can be shared with future Linux/VR heads, and
+/// <c>CCP.Core/</c> is a SIBLING of that directory rather than a child — so every file that moves
+/// to Core silently drops out of those scans. The guard then greps zero relevant files, finds zero
+/// violations, and passes green while checking nothing. That is a safety net lost without a single
+/// red test, which is the worst way to lose one.</para>
+///
+/// <para>So the roots live here, once, and every guard reads them from here. When the next head
+/// lands (<c>CCP.Avalonia</c>), nothing below needs editing — see
+/// <see cref="ProductDirectories"/>.</para>
+/// </summary>
+internal static class SourceRoots
+{
+    /// <summary>Directories that are never product source, matched per path SEGMENT.
+    ///
+    /// <para><c>.claude</c> is in here because agent worktrees check the whole repo out under
+    /// <c>&lt;repo&gt;/.claude/worktrees/&lt;name&gt;/</c> — those are other branches' copies of
+    /// this same tree, and asserting against them fails on whatever anyone happens to have on
+    /// disk.</para></summary>
+    private static readonly string[] SkipSegments = { "bin", "obj", ".claude", "node_modules" };
+
+    private static string? _repoRoot;
+
+    /// <summary>The repository root, found by walking up from the test binary to the solution file.
+    ///
+    /// <para>Anchoring on the <c>.sln</c> rather than on <c>ConditioningControlPanel/</c> is the
+    /// point: the repo root is what stays put while projects are added and files move between
+    /// them. Inside an agent worktree the nearest <c>.sln</c> is that worktree's own, which is the
+    /// tree under test — correct, and the same root the old per-class walkers found.</para></summary>
+    internal static string RepoRoot
+    {
+        get
+        {
+            if (_repoRoot != null) return _repoRoot;
+
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !Directory.EnumerateFiles(dir.FullName, "*.sln").Any())
+                dir = dir.Parent;
+
+            Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+            return _repoRoot = dir!.FullName;
+        }
+    }
+
+    /// <summary>Every product project root: today <c>ConditioningControlPanel/</c> and
+    /// <c>CCP.Core/</c>, tomorrow <c>CCP.Avalonia/</c> too, with no edit here.
+    ///
+    /// <para>Discovered as the repo-root directories holding a <c>.csproj</c> DIRECTLY. That one
+    /// rule also excludes the things it should: this test project lives at
+    /// <c>Tests/ConditioningControlPanel.Tests/</c> and the generators at
+    /// <c>Tools/&lt;name&gt;/</c>, both a level deeper, so neither <c>Tests/</c> nor <c>Tools/</c>
+    /// has a <c>.csproj</c> of its own. A new head dropped at the repo root joins automatically; a
+    /// new head nested under a folder would not, so put heads at the root.</para></summary>
+    internal static IEnumerable<string> ProductDirectories
+    {
+        get
+        {
+            var roots = Directory.EnumerateDirectories(RepoRoot)
+                                 .Where(d => Directory.EnumerateFiles(d, "*.csproj").Any())
+                                 .OrderBy(d => d, StringComparer.Ordinal)
+                                 .ToList();
+
+            // The whole reason this class exists. If discovery ever quietly finds only the WPF head,
+            // a *.cs scan still returns ~1500 files and every "found no violations" assertion below
+            // it passes — while no longer covering a single file that has moved to Core.
+            Assert.True(roots.Count >= 2,
+                $"expected at least the WPF head and CCP.Core under {RepoRoot}, found: " +
+                (roots.Count == 0 ? "(none)" : string.Join(", ", roots.Select(Path.GetFileName))));
+
+            return roots;
+        }
+    }
+
+    /// <summary>Product source files matching <paramref name="searchPattern"/> (e.g. <c>"*.cs"</c>)
+    /// across every product root, build output and nested worktrees excluded.
+    ///
+    /// <para>Exclusions are matched on each file's path RELATIVE to its own product root, because
+    /// they are about directories INSIDE the tree under test. Matching the absolute path — as
+    /// several of these guards used to — silently empties the entire walk inside an agent worktree,
+    /// where the checkout itself sits under a <c>.claude</c> segment.</para></summary>
+    internal static IReadOnlyList<string> EnumerateProductSources(string searchPattern)
+    {
+        var files = ProductDirectories
+            .SelectMany(root => Directory
+                .EnumerateFiles(root, searchPattern, SearchOption.AllDirectories)
+                .Where(f => !Path.GetRelativePath(root, f)
+                                 .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                                 .Any(segment => SkipSegments.Contains(segment, StringComparer.OrdinalIgnoreCase))))
+            .ToList();
+
+        // A walk that finds nothing makes every assertion built on it vacuously true.
+        Assert.True(files.Count > 0,
+            $"the product source walk found no {searchPattern} files under {RepoRoot}");
+
+        return files;
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
+++ b/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,6 +35,11 @@ internal static class SourceRoots
     private static readonly string[] SkipSegments = { "bin", "obj", ".claude", "node_modules" };
 
     private static string? _repoRoot;
+    private static IReadOnlyList<string>? _productDirectories;
+
+    // The tree cannot change while the suite runs, so each walk is done once. Without this
+    // the suite re-walks ~1500 files per call, and some guards call in a Theory loop.
+    private static readonly ConcurrentDictionary<string, IReadOnlyList<string>> SourcesByPattern = new(StringComparer.Ordinal);
 
     /// <summary>The repository root, found by walking up from the test binary to the solution file.
     ///
@@ -65,10 +71,12 @@ internal static class SourceRoots
     /// <c>Tools/&lt;name&gt;/</c>, both a level deeper, so neither <c>Tests/</c> nor <c>Tools/</c>
     /// has a <c>.csproj</c> of its own. A new head dropped at the repo root joins automatically; a
     /// new head nested under a folder would not, so put heads at the root.</para></summary>
-    internal static IEnumerable<string> ProductDirectories
+    internal static IReadOnlyList<string> ProductDirectories
     {
         get
         {
+            if (_productDirectories != null) return _productDirectories;
+
             var roots = Directory.EnumerateDirectories(RepoRoot)
                                  .Where(d => Directory.EnumerateFiles(d, "*.csproj").Any())
                                  .OrderBy(d => d, StringComparer.Ordinal)
@@ -81,7 +89,7 @@ internal static class SourceRoots
                 $"expected at least the WPF head and CCP.Core under {RepoRoot}, found: " +
                 (roots.Count == 0 ? "(none)" : string.Join(", ", roots.Select(Path.GetFileName))));
 
-            return roots;
+            return _productDirectories = roots;
         }
     }
 
@@ -92,7 +100,10 @@ internal static class SourceRoots
     /// they are about directories INSIDE the tree under test. Matching the absolute path — as
     /// several of these guards used to — silently empties the entire walk inside an agent worktree,
     /// where the checkout itself sits under a <c>.claude</c> segment.</para></summary>
-    internal static IReadOnlyList<string> EnumerateProductSources(string searchPattern)
+    internal static IReadOnlyList<string> EnumerateProductSources(string searchPattern) =>
+        SourcesByPattern.GetOrAdd(searchPattern, Walk);
+
+    private static IReadOnlyList<string> Walk(string searchPattern)
     {
         var files = ProductDirectories
             .SelectMany(root => Directory
@@ -108,4 +119,14 @@ internal static class SourceRoots
 
         return files;
     }
+
+    /// <summary>A product file's path relative to the repo root, forward-slashed, e.g.
+    /// <c>ConditioningControlPanel/Models/AppSettings.cs</c>.
+    ///
+    /// <para>Use this — never <see cref="Path.GetFileName(string)"/> — to key an allow list or to
+    /// print an offender. Now that the walk spans several roots a bare filename is no longer
+    /// unique: a same-named file in another head would silently inherit the first one's
+    /// exemption.</para></summary>
+    internal static string Relative(string file) =>
+        Path.GetRelativePath(RepoRoot, file).Replace(Path.DirectorySeparatorChar, '/');
 }

--- a/Tests/ConditioningControlPanel.Tests/YouLibraryDoorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/YouLibraryDoorTests.cs
@@ -54,22 +54,9 @@ public class YouLibraryDoorTests
     private static string ReadSource(params string[] parts) =>
         File.ReadAllText(Path.Combine(new[] { ProductDir }.Concat(parts).ToArray()));
 
-    /// <summary>Build output and nested agent worktrees, matched on the path RELATIVE to the
-    /// product directory.</summary>
-    ///
-    /// <para>Matching the ABSOLUTE path is the bug this replaces: an agent worktree checks the whole
-    /// repo out under <c>&lt;repo&gt;/.claude/worktrees/&lt;name&gt;/</c>, so every file's absolute
-    /// path carries a <c>.claude</c> segment and the walk excluded all of them — the source scan
-    /// below then "passed" against an empty set in a worktree and only really ran on a normal
-    /// checkout. The exclusion is about directories INSIDE the tree under test, so only the
-    /// relative path may decide it.</para>
-    private static bool IsExcludedSource(string file)
-    {
-        var skip = new[] { "obj", "bin", ".claude" };
-        return Path.GetRelativePath(ProductDir, file)
-                   .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                   .Any(segment => skip.Contains(segment, StringComparer.OrdinalIgnoreCase));
-    }
+    // The product source walk (and the exclusions that used to live here — build output, and the
+    // nested agent worktrees under .claude/ that are other branches' copies of this same tree)
+    // now lives in SourceRoots, so it covers CCP.Core as well as the WPF head.
 
     private static string MainWindowXaml() => ReadSource("MainWindow", "MainWindow.xaml");
 
@@ -138,11 +125,7 @@ public class YouLibraryDoorTests
         // The handler has to exist somewhere in the product. XAML Click= is compile-checked, so
         // this is belt-and-braces — but it is also the assertion that fails loudly if someone
         // "simplifies" a row by pointing it at a new duplicate launcher instead of the real one.
-        var sources = Directory
-            .EnumerateFiles(ProductDir, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !IsExcludedSource(f))
-            .ToList();
-        Assert.True(sources.Count > 0, "the product source walk found no .cs files under " + ProductDir);
+        var sources = SourceRoots.EnumerateProductSources("*.cs");
 
         var found = sources.Any(f => Regex.IsMatch(File.ReadAllText(f), @"\bvoid\s+" + handler + @"\s*\("));
         Assert.True(found, handler + " is bound in MainWindow.xaml but defined nowhere");


### PR DESCRIPTION
Layer 02 of the port stack. Routes files that only need a logger through Serilog's static Log and makes the source-guard tests scan both product roots, so the head/Core split that follows has a test that sees both trees.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351