### PR TITLE
refactor(tests): resolve pinned source files through SourceRoots

### DIFF
--- a/Tests/ConditioningControlPanel.Tests/ArcademyAnimatedWebpHintTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ArcademyAnimatedWebpHintTests.cs
@@ -206,8 +206,7 @@ public class ArcademyAnimatedWebpHintTests
         // The extension cannot say which lane a webp belongs to, so it is a candidate for both
         // and the probe decides. Dropping it back out of the loop lane would leave an
         // animated-webp-only library with an empty loop pool and a dead-looking wall.
-        var host = File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel",
-            "Services", "Arcademy", "ArcademyHostService.cs"));
+        var host = SourceRoots.ReadProductFile("Services", "Arcademy", "ArcademyHostService.cs");
         var loop = Regex.Match(host, @"LocalLoopExts\s*=\s*\{(?<body>[^}]*)\}");
         Assert.True(loop.Success, "LocalLoopExts is no longer an array initialiser");
         Assert.Contains("\".webp\"", loop.Groups["body"].Value, StringComparison.Ordinal);

--- a/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
@@ -123,7 +123,7 @@ public class AwarenessConsentTests
     {
         // The shutoff shares the allow list above with the consent gate, so its one privilege has
         // to be pinned: it may write the enable false, and it may never write it true.
-        var source = File.ReadAllText(Path.Combine(SourceRoot(), "MainWindow", "MainWindow.Patreon.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.Patreon.cs");
 
         // (char)10 is the line feed, spelled without an escape so the split survives however this
         // file's own line endings land.
@@ -148,7 +148,7 @@ public class AwarenessConsentTests
         // observed, behind a padlock that covered the only toggle on that page. A source scan rather
         // than a call, because App.Patreon cannot be stood up headlessly and the regression this
         // guards is a term going MISSING from an expression.
-        var source = File.ReadAllText(Path.Combine(SourceRoot(), "Services", "Awareness", "AwarenessObserver.cs"));
+        var source = SourceRoots.ReadProductFile("Services", "Awareness", "AwarenessObserver.cs");
 
         Assert.Contains("HasEntitlement && s.UseAwarenessV2", source, StringComparison.Ordinal);
         Assert.Contains("App.Patreon?.HasPremiumAccess == true", source, StringComparison.Ordinal);
@@ -170,8 +170,8 @@ public class AwarenessConsentTests
     {
         // Start()-time checks are not enough: entitlement lapses mid-run (midnight rotation, an
         // expiring subscription, a logout) and both of these timers outlive the check that armed them.
-        var observer = File.ReadAllText(Path.Combine(SourceRoot(), "Services", "Awareness", "AwarenessObserver.cs"));
-        var legacy = File.ReadAllText(Path.Combine(SourceRoot(), "Services", "UI", "WindowAwarenessService.cs"));
+        var observer = SourceRoots.ReadProductFile("Services", "Awareness", "AwarenessObserver.cs");
+        var legacy = SourceRoots.ReadProductFile("Services", "UI", "WindowAwarenessService.cs");
 
         var observerTick = observer[observer.IndexOf("private void OnPollTick", StringComparison.Ordinal)..];
         Assert.Contains("if (!IsEnabled) return;", observerTick[..1400], StringComparison.Ordinal);
@@ -191,7 +191,7 @@ public class AwarenessConsentTests
         // Flipping the setting without stopping the service would leave the poll running until the
         // next relaunch — the half-fix that would make #1047 look repaired while the eyes stayed open.
         // Stop() on the legacy service is what chains through to the observer's Stop() and the ledger.
-        var source = File.ReadAllText(Path.Combine(SourceRoot(), "MainWindow", "MainWindow.Patreon.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.Patreon.cs");
 
         var write = source.IndexOf("settings.AwarenessModeEnabled = false;", StringComparison.Ordinal);
         Assert.True(write > 0, "the lapse shutoff no longer switches Awareness Mode off");
@@ -204,7 +204,7 @@ public class AwarenessConsentTests
     [Fact]
     public void TheGatedPathActuallyCallsTheGate()
     {
-        var source = File.ReadAllText(Path.Combine(SourceRoot(), "MainWindow", "MainWindow.CompanionRoom.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.CompanionRoom.cs");
 
         Assert.Contains("AwarenessConsentDialog.EnsureConsent", source, StringComparison.Ordinal);
         // …and a decline has to be able to stop it, which a void method could not express.
@@ -214,7 +214,7 @@ public class AwarenessConsentTests
     [Fact]
     public void TheOldSilentAutoConsentIsGone()
     {
-        var source = File.ReadAllText(Path.Combine(SourceRoot(), "MainWindow", "MainWindow.Patreon.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.Patreon.cs");
 
         // The comment that documented the auto-consent must not outlive the behaviour: a stale comment
         // describing data handling the code no longer does was the single most repeated finding of the
@@ -329,20 +329,5 @@ public class AwarenessConsentTests
                 break;
             }
         }
-    }
-
-    /// <summary>The app project directory, found by walking up from the test binary.</summary>
-    private static string SourceRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null)
-        {
-            var candidate = Path.Combine(dir.FullName, "ConditioningControlPanel", "ConditioningControlPanel.csproj");
-            if (File.Exists(candidate)) return Path.GetDirectoryName(candidate)!;
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException(
-            "ConditioningControlPanel project not found above " + AppContext.BaseDirectory);
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/AwarenessReviewFixTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessReviewFixTests.cs
@@ -556,8 +556,8 @@ public class AwarenessReviewFixTests : IDisposable
     [Fact]
     public void NoDenyListWriter_SeedsItselfFromTheRawSetting()
     {
-        var source = ReadSource("ConditioningControlPanel", "Views", "Controls", "Companion", "Runtime",
-            "AwarenessPrivacyRuntimeVm.cs");
+        var source = SourceRoots.ReadProductFile("Views", "Controls", "Companion", "Runtime",
+                                                 "AwarenessPrivacyRuntimeVm.cs");
 
         Assert.DoesNotContain("new List<string>(settings.AwarenessDenyList", source, StringComparison.Ordinal);
     }
@@ -706,7 +706,7 @@ public class AwarenessReviewFixTests : IDisposable
     [Fact]
     public void TheObserversEnabledPredicate_RequiresTheV2Consent()
     {
-        var source = ReadSource("ConditioningControlPanel", "Services", "Awareness", "AwarenessObserver.cs");
+        var source = SourceRoots.ReadProductFile("Services", "Awareness", "AwarenessObserver.cs");
         var predicate = Between(source, "public static bool IsEnabled", "/// <summary>\n        /// Starts the ledger");
 
         Assert.Contains("UseAwarenessV2", predicate, StringComparison.Ordinal);
@@ -769,7 +769,7 @@ public class AwarenessReviewFixTests : IDisposable
     [Fact]
     public void ThereIsExactlyOneAwarenessReplyParser()
     {
-        var source = ReadSource("ConditioningControlPanel", "Services", "Companion", "Brain", "AwarenessSpeech.cs");
+        var source = SourceRoots.ReadProductFile("Services", "Companion", "Brain", "AwarenessSpeech.cs");
 
         Assert.DoesNotContain("\"ALT:\"", source, StringComparison.Ordinal);
         Assert.Contains("AwarenessReactionService.Parse", source, StringComparison.Ordinal);
@@ -793,9 +793,6 @@ public class AwarenessReviewFixTests : IDisposable
 
     private static string LanguagesDir =>
         Path.Combine(RepoRoot, "ConditioningControlPanel", "Localization", "Languages");
-
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { RepoRoot }.Concat(parts).ToArray()));
 
     private static string ReadEnglishKey(string key)
     {

--- a/Tests/ConditioningControlPanel.Tests/CompanionAvatarArtTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionAvatarArtTests.cs
@@ -193,8 +193,7 @@ public class CompanionAvatarArtTests
         return dir!.FullName;
     }
 
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     private static string HeroCardXaml() => AppFile("Views", "Controls", "Companion", "CompanionHeroCard.xaml");
     private static string HeroCardCode() => AppFile("Views", "Controls", "Companion", "CompanionHeroCard.xaml.cs");

--- a/Tests/ConditioningControlPanel.Tests/CompanionPermissionsAndKeywordsRenderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionPermissionsAndKeywordsRenderTests.cs
@@ -381,7 +381,7 @@ public class CompanionPermissionsAndKeywordsRenderTests
                      Path.Combine("Views", "Controls", "Companion", "KeywordTriggersPanel.xaml")
                  })
         {
-            var xaml = File.ReadAllText(Path.Combine(SourceRoot(), relative));
+            var xaml = SourceRoots.ReadProductFile(relative);
             Assert.DoesNotContain("<Storyboard", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("RepeatBehavior", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("BeginStoryboard", xaml, StringComparison.Ordinal);
@@ -399,7 +399,7 @@ public class CompanionPermissionsAndKeywordsRenderTests
                      Path.Combine("Views", "Controls", "Companion", "KeywordTriggersPanel.xaml")
                  })
         {
-            var xaml = File.ReadAllText(Path.Combine(SourceRoot(), relative));
+            var xaml = SourceRoots.ReadProductFile(relative);
             Assert.DoesNotContain("CmbMicDevice", xaml, StringComparison.Ordinal);
             Assert.DoesNotContain("CmbWebcamDevice", xaml, StringComparison.Ordinal);
         }
@@ -411,8 +411,7 @@ public class CompanionPermissionsAndKeywordsRenderTests
         // PLAN §Phase-2's exit rule is one editor per property, and the six masters below live a few
         // hundred pixels above on the SAME page. Re-hosting them would put two editors for
         // ScreenOcrEnabled / KeywordGlobalCooldownSeconds / KeywordHighlightEnabled on one screen.
-        var xaml = File.ReadAllText(Path.Combine(SourceRoot(),
-            "Views", "Controls", "Companion", "KeywordTriggersPanel.xaml"));
+        var xaml = SourceRoots.ReadProductFile("Views", "Controls", "Companion", "KeywordTriggersPanel.xaml");
 
         foreach (var master in new[]
                  {
@@ -424,19 +423,5 @@ public class CompanionPermissionsAndKeywordsRenderTests
             Assert.False(xaml.Contains("x:Name=\"" + master + "\"", StringComparison.Ordinal),
                 $"{master} is a master that lives on the Awareness page above — the drawer must follow it, not duplicate it");
         }
-    }
-
-    private static string SourceRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null)
-        {
-            var candidate = Path.Combine(dir.FullName, "ConditioningControlPanel", "ConditioningControlPanel.csproj");
-            if (File.Exists(candidate)) return Path.GetDirectoryName(candidate)!;
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException(
-            "ConditioningControlPanel project not found above " + AppContext.BaseDirectory);
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/CornerGifAdmissionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CornerGifAdmissionTests.cs
@@ -202,15 +202,6 @@ public class CornerGifAdmissionTests
 
     // ---- both standalone entry points ask the same question ----
 
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
     /// <summary>
     /// CornerGifService admits a standalone slot from TWO places: RefreshOverlays (every slot, after
     /// a config change) and RefreshSlot (ONE slot, the live size/opacity slider edit). The rule was
@@ -225,8 +216,7 @@ public class CornerGifAdmissionTests
     [InlineData("RefreshSlot")]
     public void BothStandaloneEntryPoints_ShareTheAdmissionRule(string method)
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "Services", "CornerGifService.cs"));
+        var source = SourceRoots.ReadProductFile("Services", "CornerGifService.cs");
 
         var start = source.IndexOf("public void " + method + "(", StringComparison.Ordinal);
         Assert.True(start >= 0, method + " was renamed - update this test with it");
@@ -243,8 +233,7 @@ public class CornerGifAdmissionTests
 
     // ---- handing the corner back ----
 
-    private static string SessionEngineSource() => File.ReadAllText(Path.Combine(
-        RepoRoot(), "ConditioningControlPanel", "Services", "Session", "SessionEngine.cs"));
+    private static string SessionEngineSource() => SourceRoots.ReadProductFile("Services", "Session", "SessionEngine.cs");
 
     private static string MemberBody(string source, string signature)
     {
@@ -376,8 +365,7 @@ public class CornerGifAdmissionTests
     [Fact]
     public void ThePanicPass_SweepsTheStandaloneSlotsAfterTheSessionOverlay()
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml.cs");
         var start = source.IndexOf("private void PanicStopEverySurface()", StringComparison.Ordinal);
         Assert.True(start >= 0, "PanicStopEverySurface was renamed - update this test with it");
         var end = source.IndexOf("        /// <summary>", start, StringComparison.Ordinal);
@@ -403,8 +391,7 @@ public class CornerGifAdmissionTests
     [InlineData("RefreshSlot")]
     public void TheStandaloneSideAlsoReAsksTheSessionAdmission(string method)
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "Services", "CornerGifService.cs"));
+        var source = SourceRoots.ReadProductFile("Services", "CornerGifService.cs");
         var start = source.IndexOf("public void " + method + "(", StringComparison.Ordinal);
         Assert.True(start >= 0, method + " was renamed - update this test with it");
         var end = source.IndexOf("        /// <summary>", start, StringComparison.Ordinal);
@@ -454,8 +441,7 @@ public class CornerGifAdmissionTests
     [Fact]
     public void DeferredRealization_ReAsksTheAdmissionRule()
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "Services", "CornerGifService.cs"));
+        var source = SourceRoots.ReadProductFile("Services", "CornerGifService.cs");
         var start = source.IndexOf("private void ScheduleRealize(", StringComparison.Ordinal);
         Assert.True(start >= 0, "ScheduleRealize was renamed - update this test with it");
         var end = source.IndexOf("        /// <summary>", start, StringComparison.Ordinal);
@@ -473,8 +459,7 @@ public class CornerGifAdmissionTests
     [Fact]
     public void TheFullscreenSpiralGoingDown_ReAsksTheSessionAdmission()
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "Services", "Notifications", "OverlayService.cs"));
+        var source = SourceRoots.ReadProductFile("Services", "Notifications", "OverlayService.cs");
         var start = source.IndexOf("internal void StopSpiral()", StringComparison.Ordinal);
         Assert.True(start >= 0, "StopSpiral was renamed - update this test with it");
         var body = source[start..source.IndexOf("\n    private void UpdateSpiralOpacity()", start, StringComparison.Ordinal)];

--- a/Tests/ConditioningControlPanel.Tests/EmiCodexTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiCodexTests.cs
@@ -654,8 +654,7 @@ public class EmiCodexTests
     [Fact]
     public void The_offer_of_the_book_is_actually_fired_from_somewhere()
     {
-        var narrator = File.ReadAllText(
-            Path.Combine(AppDir(), "Services", "EmiDesk", "EmiTourNarrator.cs"));
+        var narrator = SourceRoots.ReadProductFile("Services", "EmiDesk", "EmiTourNarrator.cs");
         Assert.Contains("EmiCodex.MaybeOfferSoon(", narrator);
     }
 
@@ -688,8 +687,7 @@ public class EmiCodexTests
     [Fact]
     public void The_tour_ending_still_speaks_for_itself()
     {
-        var narrator = File.ReadAllText(
-            Path.Combine(AppDir(), "Services", "EmiDesk", "EmiTourNarrator.cs"));
+        var narrator = SourceRoots.ReadProductFile("Services", "EmiDesk", "EmiTourNarrator.cs");
         Assert.Contains("desk.Fire(\"tourFinished\")", narrator);
         Assert.Contains("desk.Fire(\"tourSkipped\")", narrator);
     }
@@ -702,10 +700,10 @@ public class EmiCodexTests
     [Fact]
     public void Neither_body_of_the_book_is_a_layered_window()
     {
-        var xaml = File.ReadAllText(Path.Combine(AppDir(), "Windows", "EmiCodexWindow.xaml"));
+        var xaml = SourceRoots.ReadProductFile("Windows", "EmiCodexWindow.xaml");
         Assert.Contains("AllowsTransparency=\"False\"", xaml);
 
-        var host = File.ReadAllText(Path.Combine(AppDir(), "Chaos", "ChaosWebViewHost.cs"));
+        var host = SourceRoots.ReadProductFile("Chaos", "ChaosWebViewHost.cs");
         Assert.Contains("AllowsTransparency = false", host);
     }
 
@@ -717,7 +715,7 @@ public class EmiCodexTests
     [Fact]
     public void The_bundle_is_mapped_deny()
     {
-        var src = File.ReadAllText(Path.Combine(AppDir(), "Services", "EmiDesk", "EmiCodex.cs"));
+        var src = SourceRoots.ReadProductFile("Services", "EmiDesk", "EmiCodex.cs");
         Assert.Contains("CoreWebView2HostResourceAccessKind.Deny", src);
         Assert.DoesNotContain("CoreWebView2HostResourceAccessKind.Allow", src);
     }
@@ -730,7 +728,7 @@ public class EmiCodexTests
     [Fact]
     public void The_codex_does_not_build_its_own_browser()
     {
-        var src = File.ReadAllText(Path.Combine(AppDir(), "Services", "EmiDesk", "EmiCodex.cs"));
+        var src = SourceRoots.ReadProductFile("Services", "EmiDesk", "EmiCodex.cs");
         Assert.Contains("new ChaosWebViewHost(", src);
         Assert.DoesNotContain("new WebView2", src);
         Assert.DoesNotContain("EnsureCoreWebView2Async", src);
@@ -744,7 +742,7 @@ public class EmiCodexTests
     [Fact]
     public void The_runtime_is_probed_before_anything_is_built()
     {
-        var src = File.ReadAllText(Path.Combine(AppDir(), "Services", "EmiDesk", "EmiCodex.cs"));
+        var src = SourceRoots.ReadProductFile("Services", "EmiDesk", "EmiCodex.cs");
         int probe = src.IndexOf("GetAvailableBrowserVersionString", StringComparison.Ordinal);
         int build = src.IndexOf("new ChaosWebViewHost(", StringComparison.Ordinal);
         Assert.True(probe > 0, "the WebView2 runtime is never probed");

--- a/Tests/ConditioningControlPanel.Tests/EmiDeskFarewellTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiDeskFarewellTests.cs
@@ -80,7 +80,7 @@ public class EmiDeskFarewellTests
     [Fact]
     public void TheHostSaysGoodbyeBeforeItAnnouncesTheOpen()
     {
-        var path = Path.Combine(AppDir(), "Services", "Arcademy", "ArcademyHostService.cs");
+        var path = SourceRoots.FindProductFile("Services", "Arcademy", "ArcademyHostService.cs");
         Assert.True(File.Exists(path), "ArcademyHostService.cs is missing at " + path);
 
         var src = File.ReadAllText(path);

--- a/Tests/ConditioningControlPanel.Tests/EmiDeskLayerOrderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiDeskLayerOrderTests.cs
@@ -30,17 +30,7 @@ namespace ConditioningControlPanel.Tests;
 [Collection(CompanionWpfRenderCollection.Name)]
 public class EmiDeskLayerOrderTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string Read(params string[] parts) =>
-        File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", Path.Combine(parts)));
+    private static string Read(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     /// <summary>Runs a body against a freshly built widget, and always tears it down.</summary>
     private static void WithWidget(Action<EmiDeskWindow> body)
@@ -249,7 +239,10 @@ public class EmiDeskLayerOrderTests
             "the overlay must be authored after FaceLayer in the XAML source too, so a reader sees "
             + "the order without running anything");
 
-        var claude = Read("CLAUDE.md");
+        // Pinned to the WPF head on purpose: CCP.Core keeps its own CLAUDE.md, and a shared
+        // reader would have to guess between them.
+        var claude = File.ReadAllText(
+            Path.Combine(SourceRoots.RepoRoot, "ConditioningControlPanel", "CLAUDE.md"));
         Assert.Contains("outfit / skin layer is the TOPMOST thing", claude);
         Assert.Contains("OutfitOverImage", claude);
     }

--- a/Tests/ConditioningControlPanel.Tests/EmiDeskLayerOrderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiDeskLayerOrderTests.cs
@@ -239,8 +239,9 @@ public class EmiDeskLayerOrderTests
             "the overlay must be authored after FaceLayer in the XAML source too, so a reader sees "
             + "the order without running anything");
 
-        // Pinned to the WPF head on purpose: CCP.Core keeps its own CLAUDE.md, and a shared
-        // reader would have to guess between them.
+        // Pinned to the WPF head on purpose. This is the head's own working doc, not product
+        // source, and any other root that grows a CLAUDE.md would make a multi-root probe
+        // ambiguous — a red test on someone else's unit, for a file that never moves.
         var claude = File.ReadAllText(
             Path.Combine(SourceRoots.RepoRoot, "ConditioningControlPanel", "CLAUDE.md"));
         Assert.Contains("outfit / skin layer is the TOPMOST thing", claude);

--- a/Tests/ConditioningControlPanel.Tests/EmiDeskLiveRunRegressionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiDeskLiveRunRegressionTests.cs
@@ -16,17 +16,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class EmiDeskLiveRunRegressionTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string Read(params string[] parts) =>
-        File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", Path.Combine(parts)));
+    private static string Read(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     [Fact]
     public void A_summon_interrupted_by_the_mute_prompt_cannot_finish()

--- a/Tests/ConditioningControlPanel.Tests/EmiGestureAndPinWiringTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiGestureAndPinWiringTests.cs
@@ -26,17 +26,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class EmiGestureAndPinWiringTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string Read(params string[] parts) =>
-        File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", Path.Combine(parts)));
+    private static string Read(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     // ---------------------------------------------------------------- the gestures
 
@@ -131,7 +121,8 @@ public class EmiGestureAndPinWiringTests
         // The hover glyph is her CARDS everywhere a user can read it.
         foreach (var lang in new[] { "en", "de", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-CN" })
         {
-            var json = Read("Localization", "Languages", lang + ".json");
+            var json = File.ReadAllText(Path.Combine(
+                SourceRoots.RepoRoot, "ConditioningControlPanel", "Localization", "Languages", lang + ".json"));
             foreach (var line in json.Split('\n'))
             {
                 if (!line.Contains("emi_desk", StringComparison.Ordinal)) continue;

--- a/Tests/ConditioningControlPanel.Tests/EmiRingCatalogueTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/EmiRingCatalogueTests.cs
@@ -173,16 +173,15 @@ public class EmiRingCatalogueTests
     {
         // Source tripwire: these launchers are the only way in for their features, so the counter
         // line inside each of them is the whole of "an open is an open, wherever it came from".
-        var root = Path.Combine(RepoRoot(), "ConditioningControlPanel", "Services");
         var expected = new (string File, string Id)[]
         {
-            (Path.Combine(root, "Arcademy", "ArcademyHostService.cs"), "arcademy"),
-            (Path.Combine(root, "Chaos", "DtrhHostService.cs"), "dtrh"),
-            (Path.Combine(root, "Chaos", "LoomHostService.cs"), "loom"),
-            (Path.Combine(root, "Fyp", "FypHostService.cs"), "fyp"),
-            (Path.Combine(root, "Quiz", "IntakeHostService.cs"), "intake"),
-            (Path.Combine(root, "GoonGame", "GoonHostService.cs"), "goon"),
-            (Path.Combine(root, "JustDrop", "JustDropHostService.cs"), "justdrop"),
+            (SourceRoots.FindProductFile("Services", "Arcademy", "ArcademyHostService.cs"), "arcademy"),
+            (SourceRoots.FindProductFile("Services", "Chaos", "DtrhHostService.cs"), "dtrh"),
+            (SourceRoots.FindProductFile("Services", "Chaos", "LoomHostService.cs"), "loom"),
+            (SourceRoots.FindProductFile("Services", "Fyp", "FypHostService.cs"), "fyp"),
+            (SourceRoots.FindProductFile("Services", "Quiz", "IntakeHostService.cs"), "intake"),
+            (SourceRoots.FindProductFile("Services", "GoonGame", "GoonHostService.cs"), "goon"),
+            (SourceRoots.FindProductFile("Services", "JustDrop", "JustDropHostService.cs"), "justdrop"),
         };
 
         foreach (var (file, id) in expected)
@@ -195,8 +194,9 @@ public class EmiRingCatalogueTests
     [Fact]
     public void The_two_navigation_chokepoints_still_call_the_counter()
     {
-        var mw = Path.Combine(RepoRoot(), "ConditioningControlPanel", "MainWindow");
-        Assert.Contains("EmiTargets.NoteTabOpened(", File.ReadAllText(Path.Combine(mw, "MainWindow.TabNavigation.cs")));
-        Assert.Contains("EmiTargets.NoteRackOpened(", File.ReadAllText(Path.Combine(mw, "MainWindow.Presets.cs")));
+        Assert.Contains("EmiTargets.NoteTabOpened(",
+                        SourceRoots.ReadProductFile("MainWindow", "MainWindow.TabNavigation.cs"));
+        Assert.Contains("EmiTargets.NoteRackOpened(",
+                        SourceRoots.ReadProductFile("MainWindow", "MainWindow.Presets.cs"));
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FontFallbackTests.cs
@@ -28,17 +28,6 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class FontFallbackTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string AppDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
-
     /// <summary>Every shipped source file of the given extension, across every product root — see
     /// <see cref="SourceRoots"/> for the roots and the excluded directories.</summary>
     private static IEnumerable<string> SourceFiles(string extension) =>
@@ -145,7 +134,7 @@ public class FontFallbackTests
     [Fact]
     public void App_xaml_declares_the_mono_resource_and_agrees_with_the_guard()
     {
-        var appXaml = File.ReadAllText(Path.Combine(AppDir, "App.xaml"));
+        var appXaml = SourceRoots.ReadProductFile("App.xaml");
 
         Assert.Contains("x:Key=\"" + FontGuard.MonoResourceKey + "\"", appXaml);
         Assert.Contains(FontGuard.MonoChain, appXaml);

--- a/Tests/ConditioningControlPanel.Tests/HeaderBannerTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/HeaderBannerTests.cs
@@ -20,17 +20,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class HeaderBannerTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+    private static string ReadSource(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     private static string MainWindowXaml() => ReadSource("MainWindow", "MainWindow.xaml");
 

--- a/Tests/ConditioningControlPanel.Tests/IntakeSpeechBridgeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/IntakeSpeechBridgeTests.cs
@@ -37,8 +37,8 @@ public class IntakeSpeechBridgeTests
     private static string Read(params string[] parts) =>
         File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
 
-    private static string Host() => Read("Services", "Quiz", "IntakeHostService.cs");
-    private static string HostSpeech() => Read("Services", "Quiz", "IntakeHostService.Speech.cs");
+    private static string Host() => SourceRoots.ReadProductFile("Services", "Quiz", "IntakeHostService.cs");
+    private static string HostSpeech() => SourceRoots.ReadProductFile("Services", "Quiz", "IntakeHostService.Speech.cs");
     private static string Shim() => Read("Resources", "web", "intake", "web-shim.js");
     private static string Beats() => Read("Resources", "web", "intake", "render", "beats.js");
     private static string Boot() => Read("Resources", "web", "intake", "boot.js");

--- a/Tests/ConditioningControlPanel.Tests/LockdownDoseKeeperTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LockdownDoseKeeperTests.cs
@@ -206,17 +206,7 @@ public class LockdownDoseKeeperTests
     //  Source pins - the runtime half is WPF-bound, so these hold the shape the play-test verified
     // =============================================================================================
 
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string Source(params string[] parts)
-        => File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+    private static string Source(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     [Fact]
     public void Restore_MarshalsBeforeReadingTheWindow_AndOwnsTheRecoveryFile()

--- a/Tests/ConditioningControlPanel.Tests/LockdownEmergencyExitTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LockdownEmergencyExitTests.cs
@@ -107,8 +107,8 @@ public class LockdownEmergencyExitTests
         return File.ReadAllText(path);
     }
 
-    private static string LockdownSource() => Source("Services", "Haptics", "LockdownService.cs");
-    private static string HostSource() => Source("Services", "EmergencyExit", "EmergencyExitHostService.cs");
+    private static string LockdownSource() => SourceRoots.ReadProductFile("Services", "Haptics", "LockdownService.cs");
+    private static string HostSource() => SourceRoots.ReadProductFile("Services", "EmergencyExit", "EmergencyExitHostService.cs");
     private static string GameSource(string id) => Source("Resources", "web", "emergency-exit", "games", id + ".js");
 
     /// <summary>The body of a method, from its signature to the next method at the same indent.</summary>
@@ -251,7 +251,7 @@ public class LockdownEmergencyExitTests
     [InlineData("MainWindow.PremiumRail.cs")]
     public void BothConsentDialogs_SayTheEmergencyExitCanRestartTheTimer(string file)
     {
-        var src = Source("MainWindow", file);
+        var src = SourceRoots.ReadProductFile("MainWindow", file);
         Assert.Contains("The Emergency Exit button is a gamble", src);
         Assert.Contains("the timer restarts at its FULL length", src);
     }

--- a/Tests/ConditioningControlPanel.Tests/ModArtFramingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModArtFramingTests.cs
@@ -329,17 +329,7 @@ public class ModArtFramingTests
     // one — a visible flicker no other test would catch. This repo already answers that hazard with
     // source-scraping tests (PlayDoorRenderTests.PlayHeroMapFeedsEveryHeroBrush), so this does too.
 
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+    private static string ReadSource(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     /// <summary>The x:Key of each rail brush, the file it paints and the surface it is bound to.</summary>
     public static TheoryData<string, string, string> RailBrushKeys() => new()

--- a/Tests/ConditioningControlPanel.Tests/ModAwareDecodedArtTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModAwareDecodedArtTests.cs
@@ -164,8 +164,7 @@ public class ModAwareDecodedArtTests
         return dir!.FullName;
     }
 
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     [Fact]
     public void EveryDoorMedallionIsNamedAndItsArtIsOnDisk()

--- a/Tests/ConditioningControlPanel.Tests/ModAwarePremiumPlateTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModAwarePremiumPlateTests.cs
@@ -57,8 +57,7 @@ public class ModAwarePremiumPlateTests
         return dir!.FullName;
     }
 
-    private static string TabPath(string file)
-        => Path.Combine(RepoRoot(), "ConditioningControlPanel", "Views", "Tabs", file);
+    private static string TabPath(string file) => SourceRoots.FindProductFile("Views", "Tabs", file);
 
     private static string TabText(string file) => File.ReadAllText(TabPath(file));
 
@@ -201,7 +200,7 @@ public class ModAwarePremiumPlateTests
         Assert.Contains("\"features/bambi takeover.png\"", cs, StringComparison.Ordinal);
         Assert.Contains("\"features/takeover.png\"", cs, StringComparison.Ordinal);
 
-        var main = File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml.cs"));
+        var main = SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml.cs");
         Assert.Contains("\"features/bambi takeover.png\"", main, StringComparison.Ordinal);
         Assert.Contains("BuiltInMods.BambiSleepId", main, StringComparison.Ordinal);
     }

--- a/Tests/ConditioningControlPanel.Tests/ModAwareSurfaceSweepTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModAwareSurfaceSweepTests.cs
@@ -19,17 +19,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class ModAwareSurfaceSweepTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     /// <summary>The text between two anchors, so an assertion cannot pass on a match somewhere else in the file.</summary>
     private static string Body(string source, string startAnchor, string endAnchor)

--- a/Tests/ConditioningControlPanel.Tests/ModAwareVaultTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModAwareVaultTests.cs
@@ -425,8 +425,7 @@ public class ModAwareVaultTests
         return dir!.FullName;
     }
 
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     /// <summary>The source between two anchors, so a scrape fails loudly when the file is reorganized.</summary>
     private static string Body(string source, string from, string to)

--- a/Tests/ConditioningControlPanel.Tests/ModManagerWordmarkTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModManagerWordmarkTests.cs
@@ -35,8 +35,7 @@ public class ModManagerWordmarkTests
         return dir!.FullName;
     }
 
-    private static string MainWindowXaml() =>
-        File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml"));
+    private static string MainWindowXaml() => SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml");
 
     /// <summary>The whole &lt;Button x:Name="BtnManageMods"&gt; element, template included.</summary>
     private static string ButtonBlock()
@@ -121,4 +120,4 @@ public class ModManagerWordmarkTests
                 "\" - the hardcoded M / D MANAGER split in MainWindow.xaml no longer spells it");
         }
     }
-}
+}

--- a/Tests/ConditioningControlPanel.Tests/ModManagerWordmarkTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModManagerWordmarkTests.cs
@@ -120,4 +120,4 @@ public class ModManagerWordmarkTests
                 "\" - the hardcoded M / D MANAGER split in MainWindow.xaml no longer spells it");
         }
     }
-}
+}

--- a/Tests/ConditioningControlPanel.Tests/NavRailFlyoutTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/NavRailFlyoutTests.cs
@@ -23,17 +23,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class NavRailFlyoutTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     private static string NavRailSource() => AppFile("MainWindow", "MainWindow.NavRail.cs");
 

--- a/Tests/ConditioningControlPanel.Tests/PageAdornerScopeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PageAdornerScopeTests.cs
@@ -28,17 +28,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class PageAdornerScopeTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string MainWindowXaml()
-        => File.ReadAllText(Path.Combine(RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml"));
+    private static string MainWindowXaml() => SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml");
 
     [Fact]
     public void EveryTabViewSitsInsideThePageAdornerDecorator()

--- a/Tests/ConditioningControlPanel.Tests/PaletteDoorParityTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PaletteDoorParityTests.cs
@@ -25,17 +25,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class PaletteDoorParityTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+    private static string ReadSource(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     private static string TabNavigationSource() => ReadSource("MainWindow", "MainWindow.TabNavigation.cs");
 

--- a/Tests/ConditioningControlPanel.Tests/PanicPolicyTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PanicPolicyTests.cs
@@ -402,19 +402,9 @@ public class PanicPolicyTests
     // CAN be pinned is that the surfaces the brief lists are all named in it, and that the two
     // things it must NOT do stay out. Both regressions below were shipped once and caught in review.
 
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
     private static string PanicStopEverySurfaceBody()
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml.cs");
         var start = source.IndexOf("private void PanicStopEverySurface()", StringComparison.Ordinal);
         Assert.True(start >= 0, "PanicStopEverySurface was renamed - update this test with it");
         var end = source.IndexOf("        /// <summary>", start, StringComparison.Ordinal);
@@ -487,8 +477,7 @@ public class PanicPolicyTests
     [Fact]
     public void TheGameProbe_IsSampledBeforeTheStopPass()
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml.cs");
         var probe = source.IndexOf("bool gameOwnedTheScreen = AnyGameSurfaceOwnsTheScreen();", StringComparison.Ordinal);
         Assert.True(probe >= 0, "the pre-stop game probe is gone - the exit-tap guard cannot work without it");
         var stop = source.IndexOf("PanicStopEverySurface();", probe, StringComparison.Ordinal);
@@ -507,8 +496,7 @@ public class PanicPolicyTests
     [InlineData("JustDropHostService.IsActive")]
     public void TheGameProbe_CoversEveryHandOffSurface(string call)
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml.cs");
         var start = source.IndexOf("private static bool AnyGameSurfaceOwnsTheScreen()", StringComparison.Ordinal);
         Assert.True(start >= 0, "AnyGameSurfaceOwnsTheScreen was renamed - update this test with it");
         var end = source.IndexOf("        /// <summary>", start, StringComparison.Ordinal);

--- a/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/Phase8RedirectContractTests.cs
@@ -29,19 +29,9 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class Phase8RedirectContractTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string ProductDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
-
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { ProductDir }.Concat(parts).ToArray()));
+    /// <summary>Product source by path relative to a product root, so a file that has moved to
+    /// CCP.Core still resolves — see <see cref="SourceRoots.FindProductFile"/>.</summary>
+    private static string ReadSource(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     private static string TabNavigation() => ReadSource("MainWindow", "MainWindow.TabNavigation.cs");
 

--- a/Tests/ConditioningControlPanel.Tests/PlayDoorRenderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PlayDoorRenderTests.cs
@@ -345,8 +345,7 @@ public class PlayDoorRenderTests
     [Fact]
     public void PlayHeroMapFeedsEveryHeroBrush()
     {
-        var source = File.ReadAllText(Path.Combine(
-            RepoRoot(), "ConditioningControlPanel", "MainWindow", "MainWindow.xaml.cs"));
+        var source = SourceRoots.ReadProductFile("MainWindow", "MainWindow.xaml.cs");
 
         var start = source.IndexOf("var playHeroMap", StringComparison.Ordinal);
         Assert.True(start >= 0, "playHeroMap is gone from MainWindow.xaml.cs - the Play wall no longer repaints on a mod switch");

--- a/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
+++ b/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
@@ -144,11 +144,14 @@ internal static class SourceRoots
             $"'{relative}' is in none of the product roots searched: " +
             string.Join(", ", ProductDirectories.Select(Path.GetFileName)));
 
-        // A half-finished move genuinely leaves the same relative path in two roots. Silently
-        // taking the first would assert against the stale copy and pass — so refuse to guess.
+        // Two roots holding one relative path means either a half-finished move (delete the stale
+        // copy) or one real file per head (then the test has to say which head it means — e.g.
+        // GlobalUsings.cs and Properties/AssemblyInfo.cs are already legitimately in both roots).
+        // Taking the first silently would assert against the wrong copy and pass, so make the
+        // author choose rather than guess for them.
         Assert.True(hits.Count == 1,
-            $"'{relative}' exists in more than one product root, so nothing can say which copy a "
-            + "test means — finish the move and delete the other: " + string.Join(", ", hits));
+            $"'{relative}' exists in more than one product root, so nothing can say which copy this "
+            + "test means — finish the move, or pin the test to one head: " + string.Join(", ", hits));
 
         return hits[0];
     }

--- a/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
+++ b/Tests/ConditioningControlPanel.Tests/SourceRoots.cs
@@ -120,6 +120,43 @@ internal static class SourceRoots
         return files;
     }
 
+    /// <summary>The absolute path to ONE product file, given its path relative to a product root
+    /// (e.g. <c>FindProductFile("Services", "ChromeFxNav.cs")</c>), probed across every root in
+    /// <see cref="ProductDirectories"/>.
+    ///
+    /// <para><b>Why this exists.</b> <see cref="EnumerateProductSources"/> fixed the guards that
+    /// SCAN a directory. The ones that read ONE KNOWN FILE were left alone because they fail loudly
+    /// rather than passing vacuously — true, but the cost landed on the wrong people: ~20 test
+    /// classes pinned a file to <c>ConditioningControlPanel/</c> by name, so every unit of the Core
+    /// migration tripped a fresh red test that had nothing to do with it, one at a time. One unit
+    /// had to abandon a file it could otherwise have moved. Probing every root means a file's home
+    /// stops being a test's business.</para></summary>
+    internal static string FindProductFile(params string[] relativeParts)
+    {
+        var relative = Path.Combine(relativeParts);
+        var hits = ProductDirectories.Select(root => Path.Combine(root, relative))
+                                     .Where(File.Exists)
+                                     .ToList();
+
+        // Naming the roots is the point: "in none of CCP.Core, ConditioningControlPanel" says the
+        // file was renamed or deleted. A bare absolute path says only that some path was wrong.
+        Assert.True(hits.Count > 0,
+            $"'{relative}' is in none of the product roots searched: " +
+            string.Join(", ", ProductDirectories.Select(Path.GetFileName)));
+
+        // A half-finished move genuinely leaves the same relative path in two roots. Silently
+        // taking the first would assert against the stale copy and pass — so refuse to guess.
+        Assert.True(hits.Count == 1,
+            $"'{relative}' exists in more than one product root, so nothing can say which copy a "
+            + "test means — finish the move and delete the other: " + string.Join(", ", hits));
+
+        return hits[0];
+    }
+
+    /// <summary>The text of ONE product file, located by <see cref="FindProductFile"/>.</summary>
+    internal static string ReadProductFile(params string[] relativeParts) =>
+        File.ReadAllText(FindProductFile(relativeParts));
+
     /// <summary>A product file's path relative to the repo root, forward-slashed, e.g.
     /// <c>ConditioningControlPanel/Models/AppSettings.cs</c>.
     ///

--- a/Tests/ConditioningControlPanel.Tests/SpiralGlyphProgressTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SpiralGlyphProgressTests.cs
@@ -96,17 +96,7 @@ public class SpiralGlyphProgressTests
     //  bug class).
     // =====================================================================================
 
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel", "Resources")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(RepoRoot(), Path.Combine("ConditioningControlPanel", Path.Combine(parts))));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     /// <summary>The element's own opening tag, so a Collapsed somewhere else in the file
     /// cannot satisfy the assertion.</summary>

--- a/Tests/ConditioningControlPanel.Tests/SpiralRoomTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SpiralRoomTests.cs
@@ -503,8 +503,7 @@ public class SpiralRoomTests
 
     private static string ProductDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
 
-    private static string AppFile(params string[] parts)
-        => File.ReadAllText(Path.Combine(new[] { ProductDir }.Concat(parts).ToArray()));
+    private static string AppFile(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     /// <summary>
     /// THE WINDOW IS GONE. <c>SpiralMapWindow</c> was deleted, not merely bypassed: a second door

--- a/Tests/ConditioningControlPanel.Tests/StudioModArtRenderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/StudioModArtRenderTests.cs
@@ -272,7 +272,7 @@ public class StudioModArtRenderTests
     }
 
     private static string StudioTabViewCodeBehind() =>
-        Path.Combine(RepoRoot(), "ConditioningControlPanel", "Views", "Tabs", "StudioTabView.xaml.cs");
+        SourceRoots.FindProductFile("Views", "Tabs", "StudioTabView.xaml.cs");
 
     /// <summary>
     /// Every feature-page XAML that paints itself from a <c>Resources/features/</c> tile, wherever

--- a/Tests/ConditioningControlPanel.Tests/WardenTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/WardenTests.cs
@@ -14,17 +14,7 @@ namespace ConditioningControlPanel.Tests;
 /// </summary>
 public class WardenTests
 {
-    private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel")))
-            dir = dir.Parent;
-        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
-        return dir!.FullName;
-    }
-
-    private static string Source(params string[] parts)
-        => File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+    private static string Source(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     private static string WardenSource() => Source("Services", "Possession", "Warden.cs");
 

--- a/Tests/ConditioningControlPanel.Tests/WebNudgeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/WebNudgeTests.cs
@@ -29,8 +29,7 @@ public class WebNudgeTests
         return dir!.FullName;
     }
 
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+    private static string ReadSource(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     // =====================================================================================
     //  1. the Web App door is a launcher, not a tab

--- a/Tests/ConditioningControlPanel.Tests/YouLibraryDoorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/YouLibraryDoorTests.cs
@@ -49,10 +49,7 @@ public class YouLibraryDoorTests
         return dir!.FullName;
     }
 
-    private static string ProductDir => Path.Combine(RepoRoot(), "ConditioningControlPanel");
-
-    private static string ReadSource(params string[] parts) =>
-        File.ReadAllText(Path.Combine(new[] { ProductDir }.Concat(parts).ToArray()));
+    private static string ReadSource(params string[] parts) => SourceRoots.ReadProductFile(parts);
 
     // The product source walk (and the exclusions that used to live here — build output, and the
     // nested agent worktrees under .claude/ that are other branches' copies of this same tree)


### PR DESCRIPTION
Layer 05. Tests that read source files by path now go through `SourceRoots`, so a file that moved to Core is still found. Includes the CRLF-preserving fix for one wordmark test.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351