### PR TITLE
feat(avalonia): add CCP.Avalonia on Avalonia 12.1.1 with the app's palette ported key-for-key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,17 @@ jobs:
       # Non-zero exit fails the job.
       - run: dotnet run --project CCP.LinuxSmoke/CCP.LinuxSmoke.csproj -c Release
 
+      # The Linux head. --smoke proves it links against Core and can produce every value the
+      # window renders; --render draws the REAL MainWindow offscreen through headless Skia and
+      # writes a PNG, which is the only form of visual proof that survives on a runner with no
+      # display server. Both exit non-zero on failure.
+      - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --smoke
+      - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render $RUNNER_TEMP/ccp-avalonia-linux.png
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-head-render
+          path: ${{ runner.temp }}/ccp-avalonia-linux.png
+
   # The "behaves identically on Windows" gate.
   windows:
     runs-on: windows-latest

--- a/CCP.Avalonia/App.axaml
+++ b/CCP.Avalonia/App.axaml
@@ -2,6 +2,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="ConditioningControlPanel.Avalonia.App"
              RequestedThemeVariant="Dark">
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <!-- The app's real palette, ported key-for-key from the WPF head so the two can be
+             compared side by side. Colors first, then the brushes derived from them - the
+             same merge order App.xaml uses. -->
+        <ResourceInclude Source="avares://CCP.Avalonia/Theme/Colors.xaml"/>
+        <ResourceInclude Source="avares://CCP.Avalonia/Theme/Brushes.xaml"/>
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
   <Application.Styles>
     <FluentTheme />
   </Application.Styles>

--- a/CCP.Avalonia/App.axaml
+++ b/CCP.Avalonia/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.App"
+             RequestedThemeVariant="Dark">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    public partial class App : Application
+    {
+        public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+                desktop.MainWindow = new MainWindow();
+            base.OnFrameworkInitializationCompleted();
+        }
+    }
+}

--- a/CCP.Avalonia/CCP.Avalonia.csproj
+++ b/CCP.Avalonia/CCP.Avalonia.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The cross-platform head. This replaces WPF, it does not sit beside it: the owner's decision is
+    one UI codebase for Windows and Linux, so a feature is written once and both platforms get it.
+
+    net8.0 with no -windows suffix and no RuntimeIdentifier, same as CCP.Core, so the target
+    framework itself forbids a WPF reference from creeping back in.
+  -->
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>            <!-- 'WinExe' just suppresses the console window; it is not Windows-specific -->
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <RootNamespace>ConditioningControlPanel.Avalonia</RootNamespace>
+    <AssemblyName>CCP.Avalonia</AssemblyName>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <WarningsAsErrors>$(WarningsAsErrors);CA1416</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <!-- Renders the real window offscreen so CI can prove the Linux head DRAWS, not just boots.
+         A desktop screenshot cannot run on a headless runner; this can. -->
+    <PackageReference Include="Avalonia.Headless" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Skia" Version="11.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CCP.Core\CCP.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CCP.Avalonia/CCP.Avalonia.csproj
+++ b/CCP.Avalonia/CCP.Avalonia.csproj
@@ -31,6 +31,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The ported palette keeps the .xaml extension it has in the WPF head, so a diff against
+         ConditioningControlPanel/Resources/Theme/ stays readable. The SDK only globs *.axaml,
+         hence the explicit include. -->
+    <AvaloniaResource Include="Theme\**\*.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\CCP.Core\CCP.Core.csproj" />
   </ItemGroup>
 

--- a/CCP.Avalonia/CCP.Avalonia.csproj
+++ b/CCP.Avalonia/CCP.Avalonia.csproj
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <PackageReference Include="Avalonia" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.1" />
     <!-- Renders the real window offscreen so CI can prove the Linux head DRAWS, not just boots.
          A desktop screenshot cannot run on a headless runner; this can. -->
-    <PackageReference Include="Avalonia.Headless" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Skia" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Headless" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Skia" Version="12.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CCP.Avalonia/HeadlessSmoke.cs
+++ b/CCP.Avalonia/HeadlessSmoke.cs
@@ -1,0 +1,40 @@
+using System;
+using ConditioningControlPanel;
+using ConditioningControlPanel.Services.Moderation;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    /// <summary>
+    /// `--smoke` proves the head links against Core and can produce every value the window
+    /// renders, without needing a display server. CI has no X11 or Wayland socket, so this is
+    /// how the ubuntu job verifies the Linux head rather than only compiling it.
+    /// </summary>
+    internal static class HeadlessSmoke
+    {
+        public static int Run()
+        {
+            var failures = 0;
+            void Check(string what, bool ok, string? detail = null)
+            {
+                Console.WriteLine($"  [{(ok ? "PASS" : "FAIL")}] {what}{(detail is null ? "" : $"  ({detail})")}");
+                if (!ok) failures++;
+            }
+
+            Console.WriteLine("CCP.Avalonia headless smoke\n");
+
+            Check("Core resolves a user-data path", System.IO.Path.IsPathRooted(CorePaths.UserData), CorePaths.UserData);
+
+            var guard = new ModerationGuard();
+            Check("guard blocks a minor-age prompt", !guard.CheckInput("she is 5 years old and wants sex").Allow);
+            Check("guard allows benign text", guard.CheckInput("hello there").Allow);
+
+            // The window is not constructed here: building a Window needs a platform backend, and
+            // asserting on the values it renders is what actually matters.
+            Console.WriteLine();
+            Console.WriteLine(failures == 0
+                ? "Linux head can produce every value it renders."
+                : $"{failures} assertion(s) failed.");
+            return failures == 0 ? 0 : 1;
+        }
+    }
+}

--- a/CCP.Avalonia/MainWindow.axaml
+++ b/CCP.Avalonia/MainWindow.axaml
@@ -1,0 +1,81 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.MainWindow"
+        Title="Conditioning Control Panel — Core on Linux"
+        Width="880" Height="620"
+        Background="#1A1A2E">
+
+  <!-- Palette is the app's own, from ConditioningControlPanel/CLAUDE.md:
+       "Dark theme with pink/purple accent colors (#FF69B4, #252542, #1A1A2E)".
+       Same values as WPF so a side-by-side fidelity comparison is meaningful. -->
+  <Window.Styles>
+    <Style Selector="TextBlock.h1">
+      <Setter Property="Foreground" Value="#FF69B4"/>
+      <Setter Property="FontSize" Value="21"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+    <Style Selector="TextBlock.h2">
+      <Setter Property="Foreground" Value="#FF69B4"/>
+      <Setter Property="FontSize" Value="13"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+      <Setter Property="Margin" Value="0,0,0,6"/>
+    </Style>
+    <Style Selector="TextBlock.body">
+      <Setter Property="Foreground" Value="#D8D8E8"/>
+      <Setter Property="FontSize" Value="12"/>
+    </Style>
+    <Style Selector="TextBlock.dim">
+      <Setter Property="Foreground" Value="#8888A0"/>
+      <Setter Property="FontSize" Value="11"/>
+    </Style>
+    <Style Selector="Border.card">
+      <Setter Property="Background" Value="#252542"/>
+      <Setter Property="CornerRadius" Value="8"/>
+      <Setter Property="Padding" Value="14"/>
+      <Setter Property="Margin" Value="0,0,0,10"/>
+    </Style>
+  </Window.Styles>
+
+  <ScrollViewer Padding="20">
+    <StackPanel>
+
+      <TextBlock Classes="h1" Text="Conditioning Control Panel"/>
+      <TextBlock Classes="dim" Margin="0,2,0,16"
+                 Text="CCP.Avalonia head — the same CCP.Core engine the Windows app runs, rendering on Linux."/>
+
+      <Border Classes="card">
+        <StackPanel>
+          <TextBlock Classes="h2" Text="RUNTIME"/>
+          <TextBlock Classes="body" x:Name="TxtRuntime"/>
+        </StackPanel>
+      </Border>
+
+      <Border Classes="card">
+        <StackPanel>
+          <TextBlock Classes="h2" Text="CorePaths — resolved by the engine, not the head"/>
+          <TextBlock Classes="body" x:Name="TxtPaths"/>
+        </StackPanel>
+      </Border>
+
+      <Border Classes="card">
+        <StackPanel>
+          <TextBlock Classes="h2" Text="ModerationGuard — live"/>
+          <TextBlock Classes="dim" Margin="0,0,0,8"
+                     Text="Typed text runs through the real guard from CCP.Core on every keystroke."/>
+          <TextBox x:Name="TxtInput" Watermark="type something to moderate…"
+                   Background="#1A1A2E" Foreground="#EAEAF5" BorderBrush="#3A3A5C"
+                   CaretBrush="#FF69B4" Margin="0,0,0,8"/>
+          <TextBlock Classes="body" x:Name="TxtVerdict"/>
+        </StackPanel>
+      </Border>
+
+      <Border Classes="card">
+        <StackPanel>
+          <TextBlock Classes="h2" Text="Engine determinism"/>
+          <TextBlock Classes="body" x:Name="TxtEngine"/>
+        </StackPanel>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
+</Window>

--- a/CCP.Avalonia/MainWindow.axaml
+++ b/CCP.Avalonia/MainWindow.axaml
@@ -3,33 +3,34 @@
         x:Class="ConditioningControlPanel.Avalonia.MainWindow"
         Title="Conditioning Control Panel — Core on Linux"
         Width="880" Height="620"
-        Background="#1A1A2E">
+        Background="{DynamicResource DarkerBgBrush}">
 
-  <!-- Palette is the app's own, from ConditioningControlPanel/CLAUDE.md:
-       "Dark theme with pink/purple accent colors (#FF69B4, #252542, #1A1A2E)".
-       Same values as WPF so a side-by-side fidelity comparison is meaningful. -->
+  <!-- Every brush below is a key from the app's OWN palette, ported from
+       ConditioningControlPanel/Resources/Theme/{Colors,Brushes}.xaml. Nothing is hardcoded, so
+       when the WPF head changes a token this head changes with it - that is the whole point of
+       one UI codebase. Reviewers can diff the two dictionaries key-for-key. -->
   <Window.Styles>
     <Style Selector="TextBlock.h1">
-      <Setter Property="Foreground" Value="#FF69B4"/>
+      <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
       <Setter Property="FontSize" Value="21"/>
       <Setter Property="FontWeight" Value="SemiBold"/>
     </Style>
     <Style Selector="TextBlock.h2">
-      <Setter Property="Foreground" Value="#FF69B4"/>
+      <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
       <Setter Property="FontSize" Value="13"/>
       <Setter Property="FontWeight" Value="SemiBold"/>
       <Setter Property="Margin" Value="0,0,0,6"/>
     </Style>
     <Style Selector="TextBlock.body">
-      <Setter Property="Foreground" Value="#D8D8E8"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
       <Setter Property="FontSize" Value="12"/>
     </Style>
     <Style Selector="TextBlock.dim">
-      <Setter Property="Foreground" Value="#8888A0"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}"/>
       <Setter Property="FontSize" Value="11"/>
     </Style>
     <Style Selector="Border.card">
-      <Setter Property="Background" Value="#252542"/>
+      <Setter Property="Background" Value="{DynamicResource PanelBgBrush}"/>
       <Setter Property="CornerRadius" Value="8"/>
       <Setter Property="Padding" Value="14"/>
       <Setter Property="Margin" Value="0,0,0,10"/>
@@ -63,7 +64,7 @@
           <TextBlock Classes="dim" Margin="0,0,0,8"
                      Text="Typed text runs through the real guard from CCP.Core on every keystroke."/>
           <TextBox x:Name="TxtInput" Watermark="type something to moderate…"
-                   Background="#1A1A2E" Foreground="#EAEAF5" BorderBrush="#3A3A5C"
+                   Background="{DynamicResource DarkerBgBrush}" Foreground="#EAEAF5" BorderBrush="#3A3A5C"
                    CaretBrush="#FF69B4" Margin="0,0,0,8"/>
           <TextBlock Classes="body" x:Name="TxtVerdict"/>
         </StackPanel>

--- a/CCP.Avalonia/MainWindow.axaml.cs
+++ b/CCP.Avalonia/MainWindow.axaml.cs
@@ -59,12 +59,19 @@ namespace ConditioningControlPanel.Avalonia
             Moderate(string.Empty, verdict);
         }
 
+        /// <summary>Palette lookup with a literal fallback, so a missing key degrades to the
+        /// right colour rather than to Avalonia's default and hides the gap.</summary>
+        private global::Avalonia.Media.IBrush Brush(string key, string fallback) =>
+            global::Avalonia.Application.Current!.TryFindResource(key, out var v) && v is global::Avalonia.Media.IBrush b
+                ? b
+                : global::Avalonia.Media.Brush.Parse(fallback);
+
         private void Moderate(string text, TextBlock target)
         {
             if (string.IsNullOrWhiteSpace(text))
             {
                 target.Text = "awaiting input…";
-                target.Foreground = global::Avalonia.Media.Brush.Parse("#8888A0");
+                target.Foreground = Brush("TextMutedBrush", "#A0A0BC");
                 return;
             }
 
@@ -72,12 +79,12 @@ namespace ConditioningControlPanel.Avalonia
             if (result.Allow)
             {
                 target.Text = "ALLOW";
-                target.Foreground = global::Avalonia.Media.Brush.Parse("#6FCF97");
+                target.Foreground = Brush("SuccessGreenBrush", "#3EE87A");
             }
             else
             {
                 target.Text = $"BLOCK   category={result.Category}   {result.Note}";
-                target.Foreground = global::Avalonia.Media.Brush.Parse("#FF6B81");
+                target.Foreground = Brush("DangerBrush", "#E53935");
             }
         }
     }

--- a/CCP.Avalonia/MainWindow.axaml.cs
+++ b/CCP.Avalonia/MainWindow.axaml.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel;
+using ConditioningControlPanel.Helpers;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.GoonGame;
+using ConditioningControlPanel.Services.Moderation;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    /// <summary>
+    /// Deliberately thin. Every value shown is produced by CCP.Core; this class only renders.
+    /// That is the whole point of the split - if this window had to compute anything, the logic
+    /// would be living in the head again and the Windows and Linux heads would drift.
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        private readonly ModerationGuard _guard = new();
+
+        public MainWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            var runtime = this.FindControl<TextBlock>("TxtRuntime")!;
+            var paths = this.FindControl<TextBlock>("TxtPaths")!;
+            var engine = this.FindControl<TextBlock>("TxtEngine")!;
+            var input = this.FindControl<TextBox>("TxtInput")!;
+            var verdict = this.FindControl<TextBlock>("TxtVerdict")!;
+
+            runtime.Text =
+                $"OS         {RuntimeInformation.OSDescription.Trim()}\n" +
+                $"Arch       {RuntimeInformation.OSArchitecture}  ({RuntimeInformation.RuntimeIdentifier})\n" +
+                $".NET       {Environment.Version}\n" +
+                $"Session    {Environment.GetEnvironmentVariable("XDG_SESSION_TYPE") ?? "n/a"}" +
+                $"  desktop={Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP") ?? "n/a"}";
+
+            // CorePaths is the seam that made per-platform storage work without a second code
+            // path: the same call lands in %LOCALAPPDATA% on Windows and ~/.local/share here.
+            paths.Text =
+                $"UserData         {CorePaths.UserData}\n" +
+                $"EffectiveAssets  {CorePaths.EffectiveAssets}";
+
+            // GoonRng mirrors Resources/web/goon/core/*.js, where draw order is protocol - if it
+            // diverged per platform the C# and JS implementations would desync.
+            var rng = new GoonRng(0x0123456789ABCDEFUL);
+            var draws = new StringBuilder();
+            for (var i = 0; i < 4; i++) draws.Append(rng.NextULong().ToString("X16", CultureInfo.InvariantCulture)).Append("  ");
+
+            engine.Text =
+                $"GoonRng(seed=0123456789ABCDEF)   {draws.ToString().TrimEnd()}\n" +
+                $"BubbleSizing.Scale(100,150,null)  {BubbleSizing.Scale(100, 150, null)}\n" +
+                $"ProgramHeat.Compute(3,30,0.5)     {ProgramHeat.Compute(3, 30, 0.5, false):0.0000}";
+
+            input.TextChanged += (_, _) => Moderate(input.Text ?? string.Empty, verdict);
+            Moderate(string.Empty, verdict);
+        }
+
+        private void Moderate(string text, TextBlock target)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                target.Text = "awaiting input…";
+                target.Foreground = global::Avalonia.Media.Brush.Parse("#8888A0");
+                return;
+            }
+
+            var result = _guard.CheckInput(text);
+            if (result.Allow)
+            {
+                target.Text = "ALLOW";
+                target.Foreground = global::Avalonia.Media.Brush.Parse("#6FCF97");
+            }
+            else
+            {
+                target.Text = $"BLOCK   category={result.Category}   {result.Note}";
+                target.Foreground = global::Avalonia.Media.Brush.Parse("#FF6B81");
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Program.cs
+++ b/CCP.Avalonia/Program.cs
@@ -1,0 +1,32 @@
+using System;
+using Avalonia;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    internal static class Program
+    {
+        [STAThread]
+        public static int Main(string[] args)
+        {
+            // --smoke runs a headless self-check and exits, so CI can prove the head boots
+            // without a display server. Without it the app starts normally.
+            if (Array.IndexOf(args, "--smoke") >= 0)
+                return HeadlessSmoke.Run();
+
+            // --render <path> draws the real window offscreen and saves a PNG. Visual proof that
+            // survives on a CI runner with no display server.
+            var r = Array.IndexOf(args, "--render");
+            if (r >= 0 && r + 1 < args.Length)
+                return RenderProof.Run(args[r + 1]);
+
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+            return 0;
+        }
+
+        public static AppBuilder BuildAvaloniaApp() =>
+            AppBuilder.Configure<App>()
+                .UsePlatformDetect()      // X11 or Wayland on Linux, Win32 on Windows - one binary
+                .WithInterFont()
+                .LogToTrace();
+    }
+}

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using Avalonia;
+using Avalonia.Threading;
+using Avalonia.Headless;
+using Avalonia.Media.Imaging;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    /// <summary>
+    /// Renders the real MainWindow offscreen and writes a PNG.
+    ///
+    /// This exists because "it compiles" and "it boots" are both weaker claims than "it draws".
+    /// A desktop screenshot cannot run on a CI runner with no display server; headless Skia
+    /// rendering can, so this is the only form of visual proof that survives in the pipeline.
+    /// It draws the same window the user sees - not a stripped-down stand-in.
+    /// </summary>
+    internal static class RenderProof
+    {
+        public static int Run(string outPath)
+        {
+            try
+            {
+                AppBuilder.Configure<App>()
+                    .UseSkia()
+                    .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                    .SetupWithoutStarting();
+
+                var window = new MainWindow { Width = 880, Height = 620 };
+                window.Show();
+
+                // Two passes: layout settles on the first, content is painted on the second.
+                Dispatcher.UIThread.RunJobs();
+                Dispatcher.UIThread.RunJobs();
+
+                using var frame = window.CaptureRenderedFrame();
+                if (frame is null)
+                {
+                    Console.Error.WriteLine("render produced no frame");
+                    return 1;
+                }
+
+                var dir = Path.GetDirectoryName(Path.GetFullPath(outPath));
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                frame.Save(outPath);
+
+                var len = new FileInfo(outPath).Length;
+                Console.WriteLine($"rendered MainWindow -> {outPath} ({frame.PixelSize.Width}x{frame.PixelSize.Height}, {len} bytes)");
+                return len > 0 ? 0 : 1;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("render failed: " + ex);
+                return 1;
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Theme/Brushes.xaml
+++ b/CCP.Avalonia/Theme/Brushes.xaml
@@ -1,0 +1,286 @@
+<!-- PORTED FROM ConditioningControlPanel/Resources/Theme/Brushes.xaml - DO NOT diverge.
+     Same keys, same hex values, so a Windows/Linux fidelity comparison is meaningful.
+     WPF and Avalonia share this dictionary syntax almost exactly; only the xmlns and
+     DynamicResource->StaticResource for intra-dictionary refs differ.
+     When the WPF head is retired this becomes the single source of truth. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Brushes (derived from Colors — use DynamicResource so runtime color changes propagate) -->
+    <SolidColorBrush x:Key="PinkBrush"   Color="{StaticResource PinkColor}"/>
+    <SolidColorBrush x:Key="DarkPinkBrush" Color="{StaticResource DarkPink}"/>
+    <SolidColorBrush x:Key="PanelBgBrush" Color="{StaticResource PanelBg}"/>
+    <SolidColorBrush x:Key="PanelBgTransparentBrush" Color="{StaticResource PanelBgTransparent}"/>
+    <SolidColorBrush x:Key="DarkerBgBrush" Color="{StaticResource DarkerBg}"/>
+    <SolidColorBrush x:Key="SurfaceBgBrush" Color="{StaticResource SurfaceBg}"/>
+    <SolidColorBrush x:Key="TextLightBrush" Color="{StaticResource TextLight}"/>
+    <SolidColorBrush x:Key="TextMutedBrush" Color="{StaticResource TextMuted}"/>
+    <SolidColorBrush x:Key="PanelAccentBrush" Color="{StaticResource PanelAccent}"/>
+    <SolidColorBrush x:Key="PanelAccentHoverBrush" Color="{StaticResource PanelAccentHover}"/>
+    <SolidColorBrush x:Key="PreviewBgBrush" Color="{StaticResource PreviewBg}"/>
+
+    <SolidColorBrush x:Key="DangerBrush" Color="{StaticResource Danger}"/>
+
+    <!-- Ambient FX brushes. DESIGN-TIME SEEDS ONLY, exactly like their Color keys in Colors.xaml:
+         Services/FxTheme.ApplyForActiveMod overwrites all four (Color + Brush) at startup and on
+         every mod switch. They exist here so a chrome FX layer still has a brush to draw with if
+         that call ever fails, and so the XAML designer isn't left with null backgrounds. -->
+    <SolidColorBrush x:Key="FxMistBrush" Color="{StaticResource FxMistColor}"/>
+    <SolidColorBrush x:Key="FxParticleBrush" Color="{StaticResource FxParticleColor}"/>
+    <SolidColorBrush x:Key="FxGlowBrush" Color="{StaticResource FxGlowColor}"/>
+    <SolidColorBrush x:Key="FxFlashTintBrush" Color="{StaticResource FxFlashTintColor}"/>
+
+    <!-- Semantic success green (see Colors.xaml). Static across mods. -->
+    <SolidColorBrush x:Key="SuccessGreenBrush" Color="{StaticResource SuccessGreen}"/>
+    <SolidColorBrush x:Key="SuccessGreenDeepBrush" Color="{StaticResource SuccessGreenDeep}"/>
+    <SolidColorBrush x:Key="SuccessGreenSoftBrush" Color="{StaticResource SuccessGreenSoft}"/>
+
+    <SolidColorBrush x:Key="TransparentPinkBrush" Color="{StaticResource TransparentPink}"/>
+    <SolidColorBrush x:Key="PinkButtonHoveredBrush" Color="{StaticResource PinkButtonHovered}"/>
+
+    <!-- Accent pressed (darkened accent for press states) -->
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressed}"/>
+
+    <!-- 20% alpha transparent accent -->
+    <SolidColorBrush x:Key="TransparentPink20Brush" Color="{StaticResource TransparentPink20}"/>
+
+    <!-- Patreon brushes (secondary color — auto-computed for custom mods) -->
+    <SolidColorBrush x:Key="PatreonPurpleBrush" Color="{StaticResource PatreonPurple}"/>
+    <SolidColorBrush x:Key="PatreonLightPurpleBrush" Color="{StaticResource PatreonLightPurple}"/>
+    <SolidColorBrush x:Key="PatreonDarkPurpleBrush" Color="{StaticResource PatreonDarkPurple}"/>
+
+    <!-- Secondary brush (alias for PatreonPurpleBrush, used in UI elements) -->
+    <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource PatreonPurple}"/>
+
+    <!-- Semi-transparent white -->
+    <SolidColorBrush x:Key="TransparentWhiteBrush" Color="{StaticResource TransparentWhite}"/>
+
+    <!-- Added: brush for Controls.xaml hover color -->
+    <SolidColorBrush x:Key="DangerHoverBrush" Color="{StaticResource DangerHover}"/>
+
+    <!-- Accent-tinted dark backgrounds (for headers, panels that need subtle accent tint) -->
+    <SolidColorBrush x:Key="AccentTintedBgBrush" Color="{StaticResource AccentTintedBg}"/>
+    <SolidColorBrush x:Key="AccentTintedBgHoverBrush" Color="{StaticResource AccentTintedBgHover}"/>
+    <SolidColorBrush x:Key="AccentMidGradientBrush" Color="{StaticResource AccentMidGradient}"/>
+
+    <!-- 40% and 50% alpha accent brushes (for hover/selected overlays) -->
+    <SolidColorBrush x:Key="TransparentPink40Brush" Color="{StaticResource TransparentPink40}"/>
+    <SolidColorBrush x:Key="TransparentPink50Brush" Color="{StaticResource TransparentPink50}"/>
+
+    <!-- New: de-saturated accent for headers/labels -->
+    <SolidColorBrush x:Key="PinkSoftBrush" Color="{StaticResource PinkSoft}"/>
+    <!-- New: vibrant accent for CTAs and interactive elements -->
+    <SolidColorBrush x:Key="PinkVibrantBrush" Color="{StaticResource PinkVibrant}"/>
+    <!-- New: glass-style card borders -->
+    <SolidColorBrush x:Key="GlassBorderBrush" Color="{StaticResource GlassBorder}"/>
+    <SolidColorBrush x:Key="GlassBorderHoverBrush" Color="{StaticResource GlassBorderHover}"/>
+    <!-- New: elevated card surface -->
+    <SolidColorBrush x:Key="ElevatedSurfaceBrush" Color="{StaticResource ElevatedSurface}"/>
+    <!-- New: quaternary text -->
+    <SolidColorBrush x:Key="TextDimBrush" Color="{StaticResource TextDim}"/>
+    <!-- Velvet Kit: secondary text tier (see Colors.xaml). -->
+    <SolidColorBrush x:Key="TextSecondaryBrush" Color="{StaticResource TextSecondary}"/>
+
+    <!-- ============================================================
+         Velvet Kit: section-hue brushes. Per section:
+           SectionHueXBrush       — edge bar / icon tint / panel title text
+           SectionHueXWashBrush   — diagonal wash for the card face; PAINT ON
+                                    TOP of ElevatedSurfaceBrush (the wash ends
+                                    transparent, it is not a full background)
+           SectionHueXBorderBrush — card BorderBrush (replaces GlassBorder on
+                                    hue-coded cards)
+         Static tokens (not mod-mutable) so StaticResource is safe here.
+         ============================================================ -->
+    <SolidColorBrush x:Key="SectionHueGeneralBrush" Color="{StaticResource SectionHueGeneral}"/>
+    <SolidColorBrush x:Key="SectionHueGeneralBorderBrush" Color="{StaticResource SectionHueGeneralBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueGeneralWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueGeneralWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueStartupBrush" Color="{StaticResource SectionHueStartup}"/>
+    <SolidColorBrush x:Key="SectionHueStartupBorderBrush" Color="{StaticResource SectionHueStartupBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueStartupWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueStartupWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueAudioBrush" Color="{StaticResource SectionHueAudio}"/>
+    <SolidColorBrush x:Key="SectionHueAudioBorderBrush" Color="{StaticResource SectionHueAudioBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueAudioWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueAudioWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <!-- Studio triad carries LITERAL colors (same values as the SectionHueStudio* keys in
+         Colors.xaml) instead of StaticResource: inserting cross-dictionary StaticResource
+         refs mid-file trips WPF's deferred-BAML offset bug and the whole dictionary dies
+         at load with EndOfStreamException ("Unable to read beyond the end of the stream").
+         Static tokens by design, so literals lose nothing. Keep it this way. -->
+    <SolidColorBrush x:Key="SectionHueStudioBrush" Color="#FFFF7E6B"/>
+    <SolidColorBrush x:Key="SectionHueStudioBorderBrush" Color="#40FF7E6B"/>
+    <LinearGradientBrush x:Key="SectionHueStudioWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="#14FF7E6B" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueDevicesBrush" Color="{StaticResource SectionHueDevices}"/>
+    <SolidColorBrush x:Key="SectionHueDevicesBorderBrush" Color="{StaticResource SectionHueDevicesBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueDevicesWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueDevicesWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHuePerformanceBrush" Color="{StaticResource SectionHuePerformance}"/>
+    <SolidColorBrush x:Key="SectionHuePerformanceBorderBrush" Color="{StaticResource SectionHuePerformanceBorder}"/>
+    <LinearGradientBrush x:Key="SectionHuePerformanceWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHuePerformanceWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueNotificationsBrush" Color="{StaticResource SectionHueNotifications}"/>
+    <SolidColorBrush x:Key="SectionHueNotificationsBorderBrush" Color="{StaticResource SectionHueNotificationsBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueNotificationsWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueNotificationsWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueAccountBrush" Color="{StaticResource SectionHueAccount}"/>
+    <SolidColorBrush x:Key="SectionHueAccountBorderBrush" Color="{StaticResource SectionHueAccountBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueAccountWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueAccountWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueDataBrush" Color="{StaticResource SectionHueData}"/>
+    <SolidColorBrush x:Key="SectionHueDataBorderBrush" Color="{StaticResource SectionHueDataBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueDataWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueDataWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="SectionHueUpdatesBrush" Color="{StaticResource SectionHueUpdates}"/>
+    <SolidColorBrush x:Key="SectionHueUpdatesBorderBrush" Color="{StaticResource SectionHueUpdatesBorder}"/>
+    <LinearGradientBrush x:Key="SectionHueUpdatesWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="{StaticResource SectionHueUpdatesWash}" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+
+    <!-- EMI Desk triad. LITERAL colors, for the same reason the Studio triad above is literal:
+         inserting cross-dictionary StaticResource refs mid-file trips WPF's deferred-BAML offset
+         bug and the whole dictionary dies at load with EndOfStreamException. The hue is EMI's own
+         #FF69B4 rather than the active mod's accent, because she is the app's mascot and her
+         section should not restyle itself with whatever skin is loaded. -->
+    <SolidColorBrush x:Key="SectionHueEmiDeskBrush" Color="#FFFF69B4"/>
+    <SolidColorBrush x:Key="SectionHueEmiDeskBorderBrush" Color="#40FF69B4"/>
+    <LinearGradientBrush x:Key="SectionHueEmiDeskWashBrush" StartPoint="0,0" EndPoint="0.9,0.7">
+        <GradientStop Color="#14FF69B4" Offset="0"/>
+        <GradientStop Color="#00000000" Offset="0.55"/>
+    </LinearGradientBrush>
+
+    <!-- Deeper tab accent brushes -->
+    <SolidColorBrush x:Key="DeeperAccentBrush" Color="{StaticResource DeeperAccent}"/>
+    <SolidColorBrush x:Key="DeeperAccentSoftBrush" Color="{StaticResource DeeperAccentSoft}"/>
+    <SolidColorBrush x:Key="DeeperAccentTransparent20Brush" Color="{StaticResource DeeperAccentTransparent20}"/>
+    <SolidColorBrush x:Key="DeeperAccentTransparent40Brush" Color="{StaticResource DeeperAccentTransparent40}"/>
+
+    <!-- Mission 2 (Hub redesign) — semantic aliases for the row badges /
+         tag chips. Aliasing existing brushes (rather than minting new hex)
+         lets future theming reskin each surface independently of its
+         underlying palette entry. -->
+    <SolidColorBrush x:Key="DeeperHubVideoBadgeBgBrush"   Color="{StaticResource DeeperAccentTransparent40}"/>
+    <SolidColorBrush x:Key="DeeperHubAudioBadgeBgBrush"   Color="{StaticResource TransparentPink40}"/>
+    <SolidColorBrush x:Key="DeeperHubHapticsChipBgBrush"  Color="{StaticResource DeeperAccentTransparent20}"/>
+    <SolidColorBrush x:Key="DeeperHubWebcamChipBgBrush"   Color="{StaticResource DeeperHubWebcamChipBg}"/>
+
+    <!-- Deeper editor chrome brushes — see Colors.xaml for the role of each. -->
+    <SolidColorBrush x:Key="DeeperLaneCanvasBrush" Color="{StaticResource DeeperLaneCanvas}"/>
+    <SolidColorBrush x:Key="DeeperLaneBgBrush" Color="{StaticResource DeeperLaneBg}"/>
+    <SolidColorBrush x:Key="DeeperLaneHeaderBrush" Color="{StaticResource DeeperLaneHeader}"/>
+    <SolidColorBrush x:Key="DeeperLaneHeaderHoverBrush" Color="{StaticResource DeeperLaneHeaderHover}"/>
+    <SolidColorBrush x:Key="DeeperLaneSeparatorBrush" Color="{StaticResource DeeperLaneSeparator}"/>
+    <SolidColorBrush x:Key="DeeperDrawerStripBrush" Color="{StaticResource DeeperDrawerStrip}"/>
+    <SolidColorBrush x:Key="DeeperDrawerStripHoverBrush" Color="{StaticResource DeeperDrawerStripHover}"/>
+    <SolidColorBrush x:Key="DeeperSelectionStripBrush" Color="{StaticResource DeeperSelectionStrip}"/>
+
+    <!-- Mission 3 (Player redesign + theming cleanup) — see Colors.xaml. -->
+    <SolidColorBrush x:Key="DeeperPreviewSurfaceBgBrush" Color="{StaticResource DeeperPreviewSurfaceBg}"/>
+    <SolidColorBrush x:Key="DeeperWaveformBgBrush" Color="{StaticResource DeeperWaveformBg}"/>
+    <SolidColorBrush x:Key="DeeperMenuItemHoverBgBrush" Color="{StaticResource DeeperMenuItemHoverBg}"/>
+    <SolidColorBrush x:Key="DeeperPlayerOverlayBgBrush" Color="{StaticResource DeeperPlayerOverlayBg}"/>
+    <SolidColorBrush x:Key="DeeperGazePickerBackdropBrush" Color="{StaticResource DeeperGazePickerBackdrop}"/>
+    <SolidColorBrush x:Key="DeeperGazePickerToolbarBgBrush" Color="{StaticResource DeeperGazePickerToolbarBg}"/>
+    <SolidColorBrush x:Key="DeeperGazePickerHandleFillBrush" Color="{StaticResource DeeperGazePickerHandleFill}"/>
+    <SolidColorBrush x:Key="DeeperGazePickerCancelBorderBrush" Color="{StaticResource DeeperGazePickerCancelBorder}"/>
+
+    <!-- SP5 layer 3: NeonPurple brushes for the Available Subjects tab. -->
+    <SolidColorBrush x:Key="NeonPurpleBrush" Color="{StaticResource NeonPurple}"/>
+    <SolidColorBrush x:Key="NeonPurpleSoftBrush" Color="{StaticResource NeonPurpleSoft}"/>
+    <SolidColorBrush x:Key="NeonPurpleTransparent20Brush" Color="{StaticResource NeonPurpleTransparent20}"/>
+
+    <!-- ============================ Session Rack ============================
+         Difficulty + provenance colour code for the compact session list. See the
+         matching block in Colors.xaml for why these do NOT follow the mod accent.
+         The rows are code-built (MainWindow.SessionIO.RepaintSessionRack) and reach
+         these keys through SetResourceReference, i.e. as DynamicResource, so an
+         override still lands without a rebuild.
+         ====================================================================== -->
+    <SolidColorBrush x:Key="SessionDiffEasyBrush" Color="{StaticResource SessionDiffEasy}"/>
+    <SolidColorBrush x:Key="SessionDiffEasyWashBrush" Color="{StaticResource SessionDiffEasyWash}"/>
+    <SolidColorBrush x:Key="SessionDiffMediumBrush" Color="{StaticResource SessionDiffMedium}"/>
+    <SolidColorBrush x:Key="SessionDiffMediumWashBrush" Color="{StaticResource SessionDiffMediumWash}"/>
+    <SolidColorBrush x:Key="SessionDiffHardBrush" Color="{StaticResource SessionDiffHard}"/>
+    <SolidColorBrush x:Key="SessionDiffHardWashBrush" Color="{StaticResource SessionDiffHardWash}"/>
+    <SolidColorBrush x:Key="SessionDiffExtremeBrush" Color="{StaticResource SessionDiffExtreme}"/>
+    <SolidColorBrush x:Key="SessionDiffExtremeWashBrush" Color="{StaticResource SessionDiffExtremeWash}"/>
+
+    <SolidColorBrush x:Key="SessionSrcBuiltInBrush" Color="{StaticResource SessionSrcBuiltIn}"/>
+    <SolidColorBrush x:Key="SessionSrcBuiltInWashBrush" Color="{StaticResource SessionSrcBuiltInWash}"/>
+    <SolidColorBrush x:Key="SessionSrcCustomBrush" Color="{StaticResource SessionSrcCustom}"/>
+    <SolidColorBrush x:Key="SessionSrcCustomWashBrush" Color="{StaticResource SessionSrcCustomWash}"/>
+    <SolidColorBrush x:Key="SessionSrcImportedBrush" Color="{StaticResource SessionSrcImported}"/>
+    <SolidColorBrush x:Key="SessionSrcImportedWashBrush" Color="{StaticResource SessionSrcImportedWash}"/>
+
+    <!-- v6 CCP brand gradient (135°, pink → violet). Static, NOT mod-overridable.
+         Applied at the four brand anchors (logo, START button, XP bar, primary nav active)
+         on CCP Default only; ApplyModTheme swaps AccentGradientBrush to point at this for
+         CCP Default and to a solid SolidColorBrush(accent) for every other mod. -->
+    <LinearGradientBrush x:Key="BrandGradient" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#E84393" Offset="0"/>
+        <GradientStop Color="#8B5CF6" Offset="1"/>
+    </LinearGradientBrush>
+
+    <!-- Anchor swap point. ApplyModTheme rewrites this at runtime:
+           CCP Default → BrandGradient (above)
+           any other mod → SolidColorBrush of the active mod's accent color
+         XAML anchors read {StaticResource AccentGradientBrush}; everything else stays on PinkBrush. -->
+    <SolidColorBrush x:Key="AccentGradientBrush" Color="{StaticResource PinkColor}"/>
+
+    <!-- ==================================================================
+         TIER LIVERY - the persistent "this is paid content" trim, worn by a
+         tiered feature's chrome (Studio rack row, Play cards, rail chips)
+         whether or not the account has the tier. Distinct from the lockband
+         vocabulary (RailLock*/PlayLock*, local to their views), which is the
+         PRICE TAG a locked account sees on top of this; the livery never
+         hides, so a patron still sees which features are the premium ones.
+
+         Deliberately CONSTANT across mods, like the lockbands: a tier mark is
+         commerce, not decor, so it does not take colour from the mod chain.
+         Literal gradient stops on purpose - a Theme dictionary referencing a
+         fresh cross-dictionary StaticResource is the BAML EndOfStream trap
+         (see Velvet-Kit round 2). Base tones match the established tier
+         colours: gold #F0C24B = Tier 1, and Tier 2 wears DIAMOND (ice-white
+         cyan) - the violet flask stays on the lockband glyphs only. -->
+    <LinearGradientBrush x:Key="Tier1GoldBorderBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#F2D98C" Offset="0"/>
+        <GradientStop Color="#C9963B" Offset="0.5"/>
+        <GradientStop Color="#8C6218" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="Tier1GoldHoverBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FFE9A9" Offset="0"/>
+        <GradientStop Color="#F0C24B" Offset="0.5"/>
+        <GradientStop Color="#C9963B" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="Tier2DiamondBorderBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#EAFBFF" Offset="0"/>
+        <GradientStop Color="#8FD4EF" Offset="0.5"/>
+        <GradientStop Color="#4C93C4" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="Tier2DiamondHoverBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FFFFFF" Offset="0"/>
+        <GradientStop Color="#BFEFFF" Offset="0.5"/>
+        <GradientStop Color="#7FC4E8" Offset="1"/>
+    </LinearGradientBrush>
+
+</ResourceDictionary>

--- a/CCP.Avalonia/Theme/Colors.xaml
+++ b/CCP.Avalonia/Theme/Colors.xaml
@@ -1,0 +1,221 @@
+<!-- PORTED FROM ConditioningControlPanel/Resources/Theme/Colors.xaml - DO NOT diverge.
+     Same keys, same hex values, so a Windows/Linux fidelity comparison is meaningful.
+     WPF and Avalonia share this dictionary syntax almost exactly; only the xmlns and
+     DynamicResource->StaticResource for intra-dictionary refs differ.
+     When the WPF head is retired this becomes the single source of truth. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Colors (central source) -->
+    <Color x:Key="PinkColor">#FFFF69B4</Color>
+    <Color x:Key="DarkPink">#FFFF1493</Color>
+    <Color x:Key="PanelBg">#FF1C1C35</Color>
+    <Color x:Key="PanelBgTransparent">#C01C1C35</Color>
+    <Color x:Key="DarkerBg">#FF121220</Color>
+    <Color x:Key="SurfaceBg">#FF181830</Color>
+    <Color x:Key="TextLight">#FFF0F0F5</Color>
+    <!-- Velvet Kit (UI polish 2, 2026-08-12): TextMuted lifted #6E6E88 → #A0A0BC.
+         The old value measured ~3.0:1 on ElevatedSurface — below WCAG AA — and was
+         the description line of every settings row. 5.6:1 now. Do not darken again. -->
+    <Color x:Key="TextMuted">#FFA0A0BC</Color>
+    <!-- Velvet Kit: secondary text tier between TextLight and TextMuted (8.7:1).
+         For values, body copy and list text that used to grab ad-hoc greys. -->
+    <Color x:Key="TextSecondary">#FFC9C9DE</Color>
+    <Color x:Key="PanelAccent">#FF2E2E4A</Color>
+    <Color x:Key="PanelAccentHover">#FF3A3A5C</Color>
+    <Color x:Key="PreviewBg">#FF0D0D18</Color>
+
+    <Color x:Key="Danger">#FFE53935</Color>
+
+    <!-- Semantic success / "go / live / correct" green. Static across mods on purpose
+         (like Danger red): green=go reads universally, and it harmonises with the
+         drone-mode green accent. Used by the Lab engine-bar LIVE pill + Start button. -->
+    <Color x:Key="SuccessGreen">#FF3EE87A</Color>
+    <Color x:Key="SuccessGreenDeep">#FF1FB85A</Color>
+    <Color x:Key="SuccessGreenSoft">#223EE87A</Color>
+
+    <Color x:Key="TransparentPink">#30FF69B4</Color>
+
+    <Color x:Key="PinkButtonHovered">#FFFF8FAF</Color>
+
+    <!-- Accent pressed (darkened accent for press states) -->
+    <Color x:Key="AccentPressed">#FFE0507A</Color>
+
+    <!-- 20% alpha transparent accent -->
+    <Color x:Key="TransparentPink20">#20FF69B4</Color>
+
+    <!-- Patreon palette -->
+    <Color x:Key="PatreonPurple">#FF9B59B6</Color>
+    <Color x:Key="PatreonLightPurple">#FFE0B0FF</Color>
+    <Color x:Key="PatreonDarkPurple">#FF8E44AD</Color>
+
+    <!-- Semi-transparent white (alpha 0x40) -->
+    <Color x:Key="TransparentWhite">#40FFFFFF</Color>
+
+    <!-- Added: alternate danger (used by Controls.xaml hover) -->
+    <Color x:Key="DangerHover">#FFE84050</Color>
+
+    <!-- Accent-tinted dark backgrounds -->
+    <Color x:Key="AccentTintedBg">#FF251A38</Color>
+    <Color x:Key="AccentTintedBgHover">#FF352548</Color>
+    <Color x:Key="AccentMidGradient">#FF1E1530</Color>
+
+    <!-- 40% alpha accent for hover overlays -->
+    <Color x:Key="TransparentPink40">#40FF69B4</Color>
+    <!-- 50% alpha accent for selected overlays -->
+    <Color x:Key="TransparentPink50">#50FF69B4</Color>
+
+    <!-- New: de-saturated accent for headers/labels -->
+    <Color x:Key="PinkSoft">#FFDF6BA0</Color>
+    <!-- New: vibrant accent for CTAs and interactive elements -->
+    <Color x:Key="PinkVibrant">#FFFF5CA8</Color>
+    <!-- New: glass-style card borders -->
+    <Color x:Key="GlassBorder">#20FFFFFF</Color>
+    <Color x:Key="GlassBorderHover">#30FFFFFF</Color>
+    <!-- New: elevated card surface -->
+    <Color x:Key="ElevatedSurface">#FF222240</Color>
+    <!-- New: quaternary text. Velvet Kit: lifted #505068 → #7A7A94 (was 1.8:1 —
+         invisible). Still decorative-only: never carry information in TextDim. -->
+    <Color x:Key="TextDim">#FF7A7A94</Color>
+
+    <!-- Deeper tab accent (universal media enhancement system) — distinct violet
+         that contrasts the pink primary while staying inside the dark/violet palette. -->
+    <Color x:Key="DeeperAccent">#FF7B5CFF</Color>
+    <Color x:Key="DeeperAccentSoft">#FFB7A5FF</Color>
+    <Color x:Key="DeeperAccentTransparent20">#207B5CFF</Color>
+    <Color x:Key="DeeperAccentTransparent40">#407B5CFF</Color>
+
+    <!-- Mission 2 (Hub redesign) — webcam chip needs a teal accent that
+         contrasts both DeeperAccent (violet) and PinkColor (the catch-all
+         pink). Picked to evoke "lens" / "camera". Same alpha (0x20) as the
+         haptics chip so the two read as one family. -->
+    <Color x:Key="DeeperHubWebcamChipBg">#205CFFB7</Color>
+
+    <!-- Deeper editor chrome — surfaces introduced by Mission 1 (Editor restructure):
+         lane headers, lane content backgrounds, the metadata drawer strip,
+         selection-summary strip. Picked to sit between DarkerBg (#121220) and
+         PanelBg (#1C1C35) so the editor reads as nested layers rather than one
+         flat wall. Selection halo reuses DeeperAccentSoft. -->
+    <Color x:Key="DeeperLaneCanvas">#FF15151F</Color>
+    <Color x:Key="DeeperLaneBg">#FF1A1A28</Color>
+    <Color x:Key="DeeperLaneHeader">#FF1F1F30</Color>
+    <Color x:Key="DeeperLaneHeaderHover">#FF2A2A42</Color>
+    <Color x:Key="DeeperLaneSeparator">#FF2E2E48</Color>
+    <Color x:Key="DeeperDrawerStrip">#FF1F1F30</Color>
+    <Color x:Key="DeeperDrawerStripHover">#FF2A2A42</Color>
+    <Color x:Key="DeeperSelectionStrip">#287B5CFF</Color>
+
+    <!-- Mission 3 (Player redesign + theming cleanup) — chrome surfaces and
+         picker overlays that were previously hardcoded across XAML/code.
+
+         PreviewSurfaceBg / WaveformBg / MenuItemHoverBg: editor + player
+         hardcoded hex promoted to theme tokens.
+
+         PlayerOverlayBg: semi-opaque black for in-pane overlays (zoom pills,
+         "Now: region" label) that need to sit over a video frame.
+
+         GazePicker* family: the topmost transparent picker (separate Window)
+         couldn't pick up any DynamicResource until these existed. -->
+    <Color x:Key="DeeperPreviewSurfaceBg">#FF0A0A14</Color>
+    <Color x:Key="DeeperWaveformBg">#10000020</Color>
+    <Color x:Key="DeeperMenuItemHoverBg">#FF3D3D60</Color>
+    <Color x:Key="DeeperPlayerOverlayBg">#A0000000</Color>
+    <Color x:Key="DeeperGazePickerBackdrop">#40000000</Color>
+    <Color x:Key="DeeperGazePickerToolbarBg">#E61C1C35</Color>
+    <Color x:Key="DeeperGazePickerHandleFill">#FFFFFFFF</Color>
+    <Color x:Key="DeeperGazePickerCancelBorder">#80FFFFFF</Color>
+
+    <!-- SP5 layer 3: NeonPurple — Available Subjects directory tab + page accent.
+         Distinct from DeeperAccent #7B5CFF (violet, calmer); #B47BFF reads as
+         bright/neon and marks the section as visually different. ~12:1 against
+         the dark background tokens (AAA). Mirrors the cclabs-web neon-purple
+         token shipped in SP5L2 so the desktop and web "Available Subjects"
+         surfaces share a single visual identity. -->
+    <Color x:Key="NeonPurple">#FFB47BFF</Color>
+    <Color x:Key="NeonPurpleSoft">#FFD4BCFF</Color>
+    <Color x:Key="NeonPurpleTransparent20">#33B47BFF</Color>
+    <!-- Naming-parity alias with PinkColor — gradient stops that take a Color
+         (not a Brush) want a "*Color" key. Same value as NeonPurple. -->
+    <Color x:Key="NeonPurpleColor">#FFB47BFF</Color>
+
+    <!-- ============================================================
+         Velvet Kit (UI polish 2): per-section hue identities for the Settings
+         door and any surface that wants section color coding. STATIC across
+         mods on purpose (like Danger/SuccessGreen): these are wayfinding, not
+         brand — the mod accent stays the star. Three colors per section:
+           SectionHueX        — full hue: 3px edge bar, icon tint, panel title
+           SectionHueXWash    — 8% alpha: gradient wash start (→ transparent)
+           SectionHueXBorder  — 25% alpha: card BorderBrush over dark
+         Chosen to stay distinguishable at 8% alpha next to ANY mod accent;
+         no pure red (Danger owns red). Nav rail doors reuse the same family.
+         ============================================================ -->
+    <Color x:Key="SectionHueGeneral">#FFFF69B4</Color>
+    <Color x:Key="SectionHueGeneralWash">#14FF69B4</Color>
+    <Color x:Key="SectionHueGeneralBorder">#40FF69B4</Color>
+    <Color x:Key="SectionHueStartup">#FFFFB84E</Color>
+    <Color x:Key="SectionHueStartupWash">#14FFB84E</Color>
+    <Color x:Key="SectionHueStartupBorder">#40FFB84E</Color>
+    <Color x:Key="SectionHueAudio">#FFFF7E6B</Color>
+    <Color x:Key="SectionHueAudioWash">#14FF7E6B</Color>
+    <Color x:Key="SectionHueAudioBorder">#40FF7E6B</Color>
+    <!-- Studio door hue (same coral as Audio by design - Studio rack pages key off this alias) -->
+    <Color x:Key="SectionHueStudio">#FFFF7E6B</Color>
+    <Color x:Key="SectionHueStudioWash">#14FF7E6B</Color>
+    <Color x:Key="SectionHueStudioBorder">#40FF7E6B</Color>
+    <Color x:Key="SectionHueDevices">#FF5CE0A5</Color>
+    <Color x:Key="SectionHueDevicesWash">#145CE0A5</Color>
+    <Color x:Key="SectionHueDevicesBorder">#405CE0A5</Color>
+    <Color x:Key="SectionHuePerformance">#FFB8E85C</Color>
+    <Color x:Key="SectionHuePerformanceWash">#14B8E85C</Color>
+    <Color x:Key="SectionHuePerformanceBorder">#40B8E85C</Color>
+    <Color x:Key="SectionHueNotifications">#FF5EA8FF</Color>
+    <Color x:Key="SectionHueNotificationsWash">#145EA8FF</Color>
+    <Color x:Key="SectionHueNotificationsBorder">#405EA8FF</Color>
+    <Color x:Key="SectionHueAccount">#FFE85CE0</Color>
+    <Color x:Key="SectionHueAccountWash">#14E85CE0</Color>
+    <Color x:Key="SectionHueAccountBorder">#40E85CE0</Color>
+    <Color x:Key="SectionHueData">#FF5ED4E8</Color>
+    <Color x:Key="SectionHueDataWash">#145ED4E8</Color>
+    <Color x:Key="SectionHueDataBorder">#405ED4E8</Color>
+    <Color x:Key="SectionHueUpdates">#FF3EE87A</Color>
+    <Color x:Key="SectionHueUpdatesWash">#143EE87A</Color>
+    <Color x:Key="SectionHueUpdatesBorder">#403EE87A</Color>
+
+    <!-- ============================ Session Rack ============================
+         The colour code for the compact session list (Session Rack, 2026-08-16).
+         Two families, both STATIC across mods on purpose - exactly like Danger and
+         SuccessGreen above. Difficulty and provenance are semantics, not brand: if
+         these followed the mod accent, a drone-green build would paint EASY and
+         EXTREME the same green and the stripe would stop meaning anything.
+
+         Each entry ships a solid (the 4px stripe, the pill text) and a *Wash sibling
+         at 0x22 alpha (~13%) for the pill/chip background - the same solid+wash shape
+         the SectionHue* family above uses. A mod that genuinely wants its own
+         difficulty palette can still override these fourteen keys wholesale.
+         ====================================================================== -->
+    <Color x:Key="SessionDiffEasy">#FF57D9A3</Color>
+    <Color x:Key="SessionDiffEasyWash">#2257D9A3</Color>
+    <Color x:Key="SessionDiffMedium">#FFF5C242</Color>
+    <Color x:Key="SessionDiffMediumWash">#22F5C242</Color>
+    <Color x:Key="SessionDiffHard">#FFFF8A4C</Color>
+    <Color x:Key="SessionDiffHardWash">#22FF8A4C</Color>
+    <Color x:Key="SessionDiffExtreme">#FFF23557</Color>
+    <Color x:Key="SessionDiffExtremeWash">#22F23557</Color>
+
+    <Color x:Key="SessionSrcBuiltIn">#FF5CC8FF</Color>
+    <Color x:Key="SessionSrcBuiltInWash">#225CC8FF</Color>
+    <Color x:Key="SessionSrcCustom">#FFFF69B4</Color>
+    <Color x:Key="SessionSrcCustomWash">#22FF69B4</Color>
+    <Color x:Key="SessionSrcImported">#FFB07CFF</Color>
+    <Color x:Key="SessionSrcImportedWash">#22B07CFF</Color>
+
+    <!-- Ambient FX palette. DESIGN-TIME SEEDS ONLY (the Bambi pink family):
+         Services/FxTheme.ApplyForActiveMod overwrites all four at startup and on every mod
+         switch from the active mod's fxPalette → filterColor → accentColor chain. Never
+         hardcode an FX colour anywhere else — read FxTheme or these keys. -->
+    <Color x:Key="FxMistColor">#FFE84393</Color>
+    <Color x:Key="FxParticleColor">#FFFF69B4</Color>
+    <Color x:Key="FxGlowColor">#FFFF69B4</Color>
+    <Color x:Key="FxFlashTintColor">#FFFF8FAF</Color>
+
+</ResourceDictionary>

--- a/ConditioningControlPanel.sln
+++ b/ConditioningControlPanel.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CCP.Core.Tests", "Tests\CCP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CCP.LinuxSmoke", "CCP.LinuxSmoke\CCP.LinuxSmoke.csproj", "{89FAE4B2-D607-4AFD-8D44-3C2C6E22B83A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CCP.Avalonia", "CCP.Avalonia\CCP.Avalonia.csproj", "{B7E1C4A9-2F5D-4C8E-9A3B-6D1F0E4C7A22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{89FAE4B2-D607-4AFD-8D44-3C2C6E22B83A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89FAE4B2-D607-4AFD-8D44-3C2C6E22B83A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89FAE4B2-D607-4AFD-8D44-3C2C6E22B83A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E1C4A9-2F5D-4C8E-9A3B-6D1F0E4C7A22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E1C4A9-2F5D-4C8E-9A3B-6D1F0E4C7A22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E1C4A9-2F5D-4C8E-9A3B-6D1F0E4C7A22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E1C4A9-2F5D-4C8E-9A3B-6D1F0E4C7A22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Layer 08. The cross-platform head: a diagnostics MainWindow that proves the head links against Core, plus Colors.xaml/Brushes.xaml ported from the WPF theme so the two can be diffed side by side.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351