### PR TITLE
feat(avalonia): app shell, porting mapping docs, bucket list, agent config

### DIFF
--- a/CCP.Avalonia/Program.cs
+++ b/CCP.Avalonia/Program.cs
@@ -23,7 +23,7 @@ namespace ConditioningControlPanel.Avalonia
             // against its WPF original.
             var rv = Array.IndexOf(args, "--render-view");
             if (rv >= 0 && rv + 1 < args.Length)
-                return RenderProof.Run(args[rv + 1], () => new Views.Tabs.AchievementsTabView());
+                return RenderProof.Run(args[rv + 1], () => new Views.AppShell());
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
             return 0;

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -41,8 +41,9 @@ namespace ConditioningControlPanel.Avalonia
                 if (viewFactory is not null)
                 {
                     window.Content = viewFactory();
-                    window.Width = 720;
-                    window.Height = 760;
+                    // Wide enough that the shell's 196px rail plus content is not clipped.
+                    window.Width = 1100;
+                    window.Height = 780;
                 }
                 window.Show();
 

--- a/CCP.Avalonia/Views/AppShell.axaml
+++ b/CCP.Avalonia/Views/AppShell.axaml
@@ -1,0 +1,56 @@
+<!-- The app shell: left nav rail + content host, ported from MainWindow.xaml's nav-door layout.
+
+     Faithful in the things that define the app's identity: the eight doors, their order, their
+     per-door hue (taken from MainWindow.xaml's BorderBrush on each DoorX button), the 56px
+     collapsed rail width, and the palette.
+
+     NOT yet faithful: the medallion itself. Each WPF door is an Ellipse glow + Border tile +
+     64px icon Viewbox + label host, whose child ORDER AND TYPES are load-bearing - NavRail.cs
+     picks them out by type, and ChromeFx nudges the first Image/Viewbox on hover. Reproducing
+     that needs the icon art and the hover/nudge behaviour, which is its own change. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.AppShell"
+             xmlns:tabs="clr-namespace:ConditioningControlPanel.Avalonia.Views.Tabs">
+  <UserControl.Styles>
+    <Style Selector="Button.door">
+      <Setter Property="Height" Value="46"/>
+      <Setter Property="HorizontalAlignment" Value="Stretch"/>
+      <Setter Property="HorizontalContentAlignment" Value="Left"/>
+      <Setter Property="Padding" Value="10,0"/>
+      <Setter Property="Margin" Value="6,4"/>
+      <Setter Property="BorderThickness" Value="0,0,0,0"/>
+      <Setter Property="CornerRadius" Value="10"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+      <Setter Property="FontSize" Value="13"/>
+    </Style>
+  </UserControl.Styles>
+
+  <Grid ColumnDefinitions="196,*">
+
+    <!-- NAV RAIL -->
+    <Border Grid.Column="0" Background="{DynamicResource PanelBgBrush}">
+      <ScrollViewer>
+        <StackPanel Margin="0,10">
+          <TextBlock Text="Conditioning Control Panel" Foreground="{DynamicResource PinkBrush}"
+                     FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap" Margin="14,4,14,14"/>
+
+          <!-- Door order and hues are MainWindow.xaml's, not invented. -->
+          <Button Classes="door" Background="#22FF69B4" BorderBrush="#FF69B4" BorderThickness="0,0,0,2" Content="Home"/>
+          <Button Classes="door" Background="#22B8E85C" BorderBrush="#B8E85C" BorderThickness="0,0,0,2" Content="Play"/>
+          <Button Classes="door" Background="#22FF7E6B" BorderBrush="#FF7E6B" BorderThickness="0,0,0,2" Content="Studio"/>
+          <Button Classes="door" Background="#22E85CE0" BorderBrush="#E85CE0" BorderThickness="0,0,0,2" Content="Companion"/>
+          <Button Classes="door" Background="#225ED4E8" BorderBrush="#5ED4E8" BorderThickness="0,0,0,2" Content="Library"/>
+          <Button Classes="door" Background="#225EA8FF" BorderBrush="#5EA8FF" BorderThickness="0,0,0,2" Content="You"/>
+          <Button Classes="door" Background="#225EC8F2" BorderBrush="#5EC8F2" BorderThickness="0,0,0,2" Content="Web App"/>
+          <Button Classes="door" Background="#225CE0A5" BorderBrush="#5CE0A5" BorderThickness="0,0,0,2" Content="Settings"/>
+        </StackPanel>
+      </ScrollViewer>
+    </Border>
+
+    <!-- CONTENT -->
+    <Border Grid.Column="1" Background="{DynamicResource DarkerBgBrush}" Padding="14">
+      <tabs:AchievementsTabView/>
+    </Border>
+  </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/AppShell.axaml.cs
+++ b/CCP.Avalonia/Views/AppShell.axaml.cs
@@ -1,0 +1,14 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views
+{
+    /// <summary>
+    /// Left nav rail plus content host. Currently shows one ported view; the doors are static
+    /// until more views land, because a router with one destination is not a router.
+    /// </summary>
+    public partial class AppShell : UserControl
+    {
+        public AppShell() => AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,24 @@ Three things that will bite, all found by rendering rather than by reading:
    dependency and those `pack://` URIs to a plain `<TextBlock Text="🔒"/>` on that head.
    `BoolToVisibility` (~27 usages) likewise disappears: Avalonia binds `IsVisible` to a bool directly.
 
+## What actually remains in the UI
+
+Measured across all 183 `.xaml` files and their code-behind (131,562 LOC), bucketed by what blocks
+each one. "192 views to port" is the wrong mental model - they are not uniformly hard:
+
+| Bucket | Files | % | LOC | What it needs |
+|---|---:|---:|---:|---|
+| **A. straight port** | 62 | 33% | 23,604 | Nothing. The mapping above applies. |
+| **B. custom control first** | 44 | 24% | 31,977 | Its `fx:`/`cmp:`/`helpers:` control ported first. |
+| **D. WebView2-hosted** | 12 | 6% | 29,435 | `Avalonia.Controls.WebView` (12.x only - the reason the head targets 12). |
+| **E. Win32 / layered window** | 65 | 35% | 46,546 | Per-platform reimplementation, or dropping where the platform forbids it. |
+
+Bucket E is the Chaos overlays, the compositor and the click-through transparent windows. Those are
+not ports - Wayland and Quest do not permit desktop-wide always-on-top click-through surfaces at all.
+Plan to reimplement per platform or to lose the feature there, and decide which before starting.
+
+Bucket A is where to work first: a third of the UI, and the procedure is already written down.
+
 ## Moving a file into Core
 
 Pure `git mv`, zero content edits, namespace unchanged. Verify with `git diff -M --stat` showing a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,36 @@ that combination fails with `NETSDK1191`.
 The Windows test suite cannot execute on Linux (`win-x64` testhost). Compile-verify locally; CI runs
 it on `windows-latest`.
 
+## Porting a WPF view to Avalonia
+
+Measured on the first ported view (`Views/Tabs/AchievementsTabView`). The mapping:
+
+| WPF | Avalonia |
+|---|---|
+| `Style="{StaticResource X}"` | `Theme="{StaticResource X}"` |
+| `<Style x:Key TargetType>` | `<ControlTheme x:Key TargetType>` |
+| `Visibility="Collapsed"` | `IsVisible="False"` |
+| `Panel.ZIndex` | `ZIndex` |
+| `{loc:Str key}` | a binding - `LocExtension` is a WPF `MarkupExtension` and stays in the head |
+
+Three things that will bite, all found by rendering rather than by reading:
+
+1. **Avalonia's `Button` parses `_` in `Content` as an access key.** `btn_visit_patreon` renders as
+   "btnvisit_patreon" with a stray underline. WPF only does this with `RecognizesAccessKey`, so it
+   never bit the original - but every loc key here is snake_case. Put a `TextBlock` inside the
+   button, which opts out.
+
+2. **Read the code-behind before writing a binding.** `{loc:Str …}` covers only static strings;
+   anything with a number in it is set from code with `Loc.GetF` and format arguments. Inventing a
+   key name produces a plausible-looking string that is also structurally wrong.
+
+3. **`EmojiToImageSource` is not needed on Avalonia.** It exists because "WPF's TextBlock can't
+   render COLR/CPAL color fonts" (see `Helpers/EmojiImage.cs`), so the app ships Twemoji SVGs and
+   renders them through SharpVectors from `pack://` URIs. Avalonia renders colour emoji natively -
+   verified on Linux with Noto Color Emoji. That collapses ~103 converter usages, the SharpVectors
+   dependency and those `pack://` URIs to a plain `<TextBlock Text="🔒"/>` on that head.
+   `BoolToVisibility` (~27 usages) likewise disappears: Avalonia binds `IsVisible` to a bool directly.
+
 ## Moving a file into Core
 
 Pure `git mv`, zero content edits, namespace unchanged. Verify with `git diff -M --stat` showing a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,3 +131,17 @@ Bucket A is where to work first: a third of the UI, and the procedure is already
 Pure `git mv`, zero content edits, namespace unchanged. Verify with `git diff -M --stat` showing a
 rename at 100% similarity, then build both projects. If Core rejects the file, leave it in the head
 and record why — a partial move is a correct outcome, not a failure.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on the upstream repo `CodeBambi/Conditioning-Control-Panel---CSharp-WPF`, via `gh` with an explicit `--repo`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical labels, unchanged (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` at the repo root and ADRs in `docs/adr/`. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,26 @@ Pure `git mv`, zero content edits, namespace unchanged. Verify with `git diff -M
 rename at 100% similarity, then build both projects. If Core rejects the file, leave it in the head
 and record why — a partial move is a correct outcome, not a failure.
 
+## Stacked PRs
+
+Every change to this repo lands as a layer of the port's stacked-PR chain, never as a direct push
+to `main`. One-time setup per clone:
+
+```bash
+gh extension install github/gh-stack
+gh skill install github/gh-stack gh-stack --agent claude-code   # agent instructions, gitignored under .claude/
+git config rerere.enabled true
+```
+
+A layer is one concern, ≤ ~1,000 changed lines (rename-aware), and builds and renders on its
+own. Use the non-interactive forms only: `gh stack view --json`, `gh stack submit --auto`,
+`gh stack merge <pr> --yes`.
+
 ## Agent skills
 
 ### Issue tracker
 
-GitHub Issues on the upstream repo `CodeBambi/Conditioning-Control-Panel---CSharp-WPF`, via `gh` with an explicit `--repo`. See `docs/agents/issue-tracker.md`.
+GitHub Issues on this repo, via `gh`. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comment "..."`
+
+Issues live on the **upstream** repo `CodeBambi/Conditioning-Control-Panel---CSharp-WPF`, not on `origin` (the fork). `gh` resolves the fork by default, so every `gh issue` / `gh pr` / `gh api` call must pass `--repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF` (or the `repos/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/...` path). Do not `gh repo set-default` to upstream: that would also redirect `gh pr create`.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comments` and `gh pr diff --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF`, `gh pr edit --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --add-label`/`--remove-label`, `gh pr close --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF 42` and fall back to `gh issue view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <n> --body "<answer>"`, then `gh issue close --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,14 +4,14 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
-- **Comment on an issue**: `gh issue comment --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --body "..."`
-- **Apply / remove labels**: `gh issue edit --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comment "..."`
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
 
-Issues live on the **upstream** repo `CodeBambi/Conditioning-Control-Panel---CSharp-WPF`, not on `origin` (the fork). `gh` resolves the fork by default, so every `gh issue` / `gh pr` / `gh api` call must pass `--repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF` (or the `repos/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/...` path). Do not `gh repo set-default` to upstream: that would also redirect `gh pr create`.
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
 
 ## Pull requests as a triage surface
 
@@ -19,11 +19,11 @@ Issues live on the **upstream** repo `CodeBambi/Conditioning-Control-Panel---CSh
 
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
-- **Read a PR**: `gh pr view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comments` and `gh pr diff --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
-- **Comment / label / close**: `gh pr comment --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF`, `gh pr edit --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --add-label`/`--remove-label`, `gh pr close --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF`.
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
-GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF 42` and fall back to `gh issue view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF 42`.
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
 
 ## When a skill says "publish to the issue tracker"
 
@@ -31,15 +31,15 @@ Create a GitHub issue.
 
 ## When a skill says "fetch the relevant ticket"
 
-Run `gh issue view --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <number> --comments`.
+Run `gh issue view <number> --comments`.
 
 ## Wayfinding operations
 
 Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
 
-- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --label wayfinder:map`.
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
 - **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
-- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
-- **Frontier query**: list the map's open children (`gh issue list --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
-- **Claim**: `gh issue edit --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <n> --add-assignee @me`, the session's first write.
-- **Resolve**: `gh issue comment --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <n> --body "<answer>"`, then `gh issue close --repo CodeBambi/Conditioning-Control-Panel---CSharp-WPF <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Layer 11. The nav-rail shell, the WPF-to-Avalonia mapping and its traps in CLAUDE.md, the 183-view bucket list, the docs/agents config (issue tracker is this repo), and the stacked-PR setup notes.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351