### PR TITLE
feat(avalonia): port first bucket-A dialogs and Workshop cells

### DIFF
--- a/.github/scripts/url-dialog-pair.ps1
+++ b/.github/scripts/url-dialog-pair.ps1
@@ -122,7 +122,7 @@ try {
     $commit = Require-Success (Invoke-Owned $git @('-C', $repo, 'cat-file', '-p', 'HEAD') $repo 'commit-object') # Real parents even with shallow checkout.
     Save-Json "$root/identity.json" @{ checkout = $identity; commitObject = $commit; githubSha = $env:GITHUB_SHA; os = [Environment]::OSVersion.VersionString; powershell = "$($PSVersionTable.PSVersion)" }
     # Freeze the reviewed safe Program/App/null-lifetime route and every product dependency.
-    foreach ($entry in @(@('CCP.Avalonia', '96e91bd4e8cdb0b055166bd93d5e42f2ef02d6dd'), @('CCP.Core', '287515eeafb5dacc3c8f2412d5be8bc92ff457c2'))) {
+    foreach ($entry in @(@('CCP.Avalonia', '21fe3798a701c3e8d6dafc365621ec081810ec6e'), @('CCP.Core', '287515eeafb5dacc3c8f2412d5be8bc92ff457c2'))) {
         $tree = Require-Success (Invoke-Owned $git @('-C', $repo, 'rev-parse', "HEAD:$($entry[0])") $repo "tree-$($entry[0])")
         if ($tree -ne $entry[1]) { throw "Unreviewed source tree: $($entry[0])" }
     }

--- a/CCP.Avalonia/Theme/Styles.xaml
+++ b/CCP.Avalonia/Theme/Styles.xaml
@@ -87,4 +87,45 @@
     <Setter Property="VerticalAlignment" Value="Center"/>
   </ControlTheme>
 
+  <!-- Views/Controls/Companion/Runtime/WorkshopCellTheme.xaml:27. That dictionary is merged into
+       each Workshop cell through a pack:// URI, which Avalonia has no equivalent for, so the keys
+       the ported cells use live here with the head's other keyed styles. Setters copied exactly. -->
+  <ControlTheme x:Key="CmpCellHintStyle" TargetType="TextBlock">
+    <Setter Property="FontSize" Value="10"/>
+    <Setter Property="Foreground" Value="#FF8F88AD"/>
+    <Setter Property="TextWrapping" Value="Wrap"/>
+    <Setter Property="Margin" Value="0,1,0,0"/>
+  </ControlTheme>
+
+  <!-- WorkshopCellTheme.xaml:43. A quiet, full-width action button - the Workshop's own idiom for
+       "this opens a dialog". The WPF ControlTemplate.Triggers become nested selectors, and the
+       ContentPresenter binds Content explicitly: Avalonia's does not do it implicitly. -->
+  <ControlTheme x:Key="CmpCellButtonStyle" TargetType="Button">
+    <Setter Property="Background" Value="#FF1C1A2E"/>
+    <Setter Property="Foreground" Value="#FFD8D2EA"/>
+    <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+    <Setter Property="BorderThickness" Value="1"/>
+    <Setter Property="Padding" Value="8,4"/>
+    <Setter Property="FontSize" Value="11"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="6" Padding="{TemplateBinding Padding}">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#Chrome">
+      <Setter Property="Background" Value="#FF2A2440"/>
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Opacity" Value="0.45"/>
+    </Style>
+  </ControlTheme>
+
 </ResourceDictionary>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml
@@ -1,0 +1,86 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopCellTheme.xaml.
+     Keys, setters, values, order and comments are preserved so the two diff cleanly. Deviations,
+     all forced by real WPF/Avalonia differences:
+
+       <Style x:Key TargetType>     ->  <ControlTheme x:Key TargetType>   (a keyed, reusable style)
+       ControlTemplate.Triggers     ->  nested <Style Selector="^:pointerover|^:disabled">
+                                        (Avalonia has no triggers; pseudo-classes replace them)
+       <ContentPresenter/>          ->  <ContentPresenter Name="PART_ContentPresenter" .../>
+                                        (Avalonia's ContentControl only feeds a presenter carrying
+                                        that name; the WPF original gets its content implicitly)
+
+     Consumers write  Theme="{StaticResource CmpCellLabelStyle}"  where WPF writes Style=, and merge
+     this file with
+       <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml"/>
+     in place of the WPF pack:// URI. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- ================================================================
+         Interior styling for the Z8 Workshop's re-parented legacy cells.
+
+         The controls inside a Workshop cell are the ones the old accordions
+         shipped (design §6: "a container move, not a rebuild"), so they keep
+         their own app-level styles — ToggleStyle, PinkSlider, the combo box,
+         the help buttons. What they did NOT keep is the old accordion's
+         typography: at 340px wide a cell has room for a 10.5px label and a
+         value, not a 16px settings row.
+
+         These three styles are that reconciliation, and nothing else. They
+         are deliberately here rather than in CompanionTheme.xaml: that
+         dictionary is the ZONE theme, shared with the design-time gallery,
+         and the gallery never renders one of these cells.
+         ================================================================ -->
+
+    <ControlTheme x:Key="CmpCellLabelStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Foreground" Value="#FFD8D2EA"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="CmpCellHintStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="10"/>
+        <Setter Property="Foreground" Value="#FF8F88AD"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="Margin" Value="0,1,0,0"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="CmpCellValueStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="#FFFF8FD0"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+    </ControlTheme>
+
+    <!-- A quiet, full-width action button — the Workshop's own idiom for "this opens a dialog". -->
+    <ControlTheme x:Key="CmpCellButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="#FF1C1A2E"/>
+        <Setter Property="Foreground" Value="#FFD8D2EA"/>
+        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="6" Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover /template/ Border#Chrome">
+            <Setter Property="Background" Value="#FF2A2440"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.45"/>
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml
@@ -1,0 +1,82 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopCommunityCell.xaml.
+     Structure, order, spacing and every resource key are preserved so the two can be diffed.
+     Deviations, all forced:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       {loc:Str key}                ->  {Binding LocX}               (LocExtension is a WPF
+                                        MarkupExtension and stays in the head; the strings still
+                                        come from CCP.Core's Loc, via the VM)
+       Content="{loc:Str …}"        ->  a <TextBlock> child          (Avalonia's Button reads "_" in
+                                        Content as an access key and every key here is snake_case)
+       Click="Handler"              ->  wired in the constructor
+       the merged WorkshopCellTheme -> CmpCellHintStyle / CmpCellButtonStyle moved to
+                                       Theme/Styles.xaml, where this head keeps its keyed styles.
+                                       pack:// URIs do not exist on Avalonia. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime.WorkshopCommunityCell"
+             x:DataType="vm:WorkshopCommunityCellViewModel"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime"
+             mc:Ignorable="d" d:DesignWidth="312">
+
+    <!-- ================================================================
+         Z8 · COMMUNITY — browse / import / export / refresh plus the
+         installed list, moved whole. Z4's expert door links to the same
+         browse dialog; this cell owns the controls.
+         ================================================================ -->
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <Border Background="#FF6B6B" CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
+                <TextBlock Text="{Binding LocBeta}" Foreground="White" FontSize="9" FontWeight="Bold"/>
+            </Border>
+            <Button x:Name="HelpBtnPrompts" Theme="{DynamicResource HelpButtonStyle}"
+                    VerticalAlignment="Center" Margin="7,0,0,0" Tag="CommunityPrompts"/>
+        </StackPanel>
+
+        <Grid Margin="0,0,0,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="BtnBrowsePrompts" Grid.Column="0"
+                    Theme="{StaticResource CmpCellButtonStyle}" Margin="0,0,3,0">
+                <TextBlock Text="{Binding LocBrowse}"/>
+            </Button>
+            <Button x:Name="BtnImportPrompt" Grid.Column="1"
+                    Theme="{StaticResource CmpCellButtonStyle}" Margin="3,0,3,0">
+                <TextBlock Text="{Binding LocImport}"/>
+            </Button>
+            <Button x:Name="BtnExportPrompt" Grid.Column="2"
+                    Theme="{StaticResource CmpCellButtonStyle}" Margin="3,0,0,0">
+                <TextBlock Text="{Binding LocExport}"/>
+            </Button>
+        </Grid>
+
+        <Grid Margin="0,0,0,5">
+            <TextBlock Text="{Binding LocInstalledPrompts}" Theme="{StaticResource CmpCellHintStyle}"
+                       VerticalAlignment="Center"/>
+            <Button x:Name="BtnRefreshPrompts"
+                    HorizontalAlignment="Right" Background="Transparent"
+                    Foreground="{DynamicResource TextMutedBrush}" BorderThickness="0"
+                    FontSize="10.5" Padding="6,1" Cursor="Hand">
+                <TextBlock Text="{Binding LocRefresh}"/>
+            </Button>
+        </Grid>
+
+        <Border CornerRadius="7" Padding="7" MinHeight="60" MaxHeight="140"
+                BorderBrush="#22808080" BorderThickness="1" Background="#FF14121F">
+            <ScrollViewer x:Name="InstalledPromptsScroll" VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="InstalledPromptsPanel">
+                    <TextBlock x:Name="TxtNoInstalledPrompts"
+                               Text="{Binding LocNoPromptsInstalled}"
+                               Foreground="#505050" FontSize="10.5" FontStyle="Italic"
+                               HorizontalAlignment="Center" Margin="0,14,0,0"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml.cs
@@ -1,0 +1,49 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>Z8 · COMMUNITY. See the XAML header. Pure forwarding.</summary>
+    public partial class WorkshopCommunityCell : UserControl
+    {
+        // The WPF cell forwards each click to MainWindow (Window.GetWindow(this) is MainWindow).
+        // This head has no MainWindow API surface yet and the cell must not grow App. coupling, so
+        // the four actions leave the cell as events and the host wires them - the same contract,
+        // one indirection later.
+        public event EventHandler? BrowsePromptsRequested;
+        public event EventHandler? ImportPromptRequested;
+        public event EventHandler? ExportPromptRequested;
+        public event EventHandler? RefreshPromptsRequested;
+
+        public WorkshopCommunityCell()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new WorkshopCommunityCellViewModel();
+
+            this.FindControl<Button>("BtnBrowsePrompts")!.Click += (_, _) => BrowsePromptsRequested?.Invoke(this, EventArgs.Empty);
+            this.FindControl<Button>("BtnImportPrompt")!.Click += (_, _) => ImportPromptRequested?.Invoke(this, EventArgs.Empty);
+            this.FindControl<Button>("BtnExportPrompt")!.Click += (_, _) => ExportPromptRequested?.Invoke(this, EventArgs.Empty);
+            this.FindControl<Button>("BtnRefreshPrompts")!.Click += (_, _) => RefreshPromptsRequested?.Invoke(this, EventArgs.Empty);
+
+            // CompanionWheelRelay.Attach(InstalledPromptsScroll) is NOT ported: it works around
+            // WPF's ScrollViewer marking every wheel notch handled even when it cannot scroll.
+            // Avalonia's ScrollViewer.IsScrollChainingEnabled (default true) already passes an
+            // unusable notch to the parent scroll, which is exactly what the relay re-implements.
+        }
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding.</summary>
+    public sealed class WorkshopCommunityCellViewModel
+    {
+        public string LocBeta => Loc.Get("label_beta");
+        public string LocBrowse => Loc.Get("btn_browse");
+        public string LocImport => Loc.Get("btn_import");
+        public string LocExport => Loc.Get("btn_export");
+        public string LocInstalledPrompts => Loc.Get("label_installed_prompts");
+        public string LocRefresh => Loc.Get("btn_refresh");
+        public string LocNoPromptsInstalled => Loc.Get("label_no_prompts_installed_yet");
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml
@@ -1,0 +1,59 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopLibraryCell.xaml.
+     Structure, order, spacing, comments and every resource key are preserved so the two can be
+     diffed. Documented deviations, all forced:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       {loc:Str key}                 ->  {Binding LocX}               (LocExtension is a WPF
+                                         MarkupExtension and stays in the head)
+       Content="{loc:Str ...}"       ->  a TextBlock child            (Avalonia parses "_" in
+                                         Content as an access key - see CLAUDE.md)
+       Click="Handler"               ->  wired in the constructor
+       x:FieldModifier="internal"    ->  dropped                      (the internal consumers -
+                                         CompanionTabView's passthroughs and MainWindow - are the
+                                         WPF head's; controls are reached with FindControl here)
+       UserControl.Resources merge   ->  dropped                      (WorkshopCellTheme.xaml's two
+                                         keys used here now live app-level in Theme/Styles.xaml) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime.WorkshopLibraryCell"
+             x:DataType="vm:WorkshopLibraryCellViewModel"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" d:DesignWidth="312">
+
+    <!-- ================================================================
+         Z8 · HER LIBRARY — the per-mod Hypnotube link pool, moved whole.
+         The scope signpost comes with it: these links are mod-scoped
+         while everything around them is global, and losing that line in
+         the move would have been the one genuinely confusing drop.
+         ================================================================ -->
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="{Binding LocLabelCurrentMode}" Theme="{StaticResource CmpCellHintStyle}" VerticalAlignment="Center"/>
+            <TextBlock x:Name="TxtHypnotubeModeLabel" Text="{Binding LocLabelBambiSleep}"
+                       FontSize="10" FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
+                       VerticalAlignment="Center" Margin="3,0,0,0"/>
+            <Button x:Name="HelpBtnVideoLinks" Theme="{StaticResource HelpButtonStyle}"
+                    VerticalAlignment="Center" Margin="6,0,0,0" Tag="HypnotubeLinks"/>
+        </StackPanel>
+
+        <TextBlock Text="{Binding LocLabelVideoLinksPoolDesc}" Theme="{StaticResource CmpCellHintStyle}" Margin="0,0,0,5"/>
+
+        <Border CornerRadius="7" Padding="6" MinHeight="52" MaxHeight="200" Margin="0,0,0,6"
+                BorderBrush="#22808080" BorderThickness="1" Background="#FF14121F">
+            <ScrollViewer x:Name="LinkPoolScroll" VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="VideoLinkPoolPanel">
+                    <TextBlock x:Name="TxtNoVideoLinks" Text="{Binding LocLabelNoVideoLinksYet}"
+                               Foreground="#505050" FontSize="10.5" FontStyle="Italic"
+                               HorizontalAlignment="Center" Margin="0,12,0,12"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <Button x:Name="BtnAddVideoLink" Theme="{StaticResource CmpCellButtonStyle}">
+            <TextBlock Text="{Binding LocBtnAddLinkToPool}"/>
+        </Button>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml.cs
@@ -1,0 +1,43 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>Z8 · HER LIBRARY. See the XAML header. Pure forwarding.</summary>
+    public partial class WorkshopLibraryCell : UserControl
+    {
+        /// <summary>
+        /// Port of the WPF code-behind's <c>Window.GetWindow(this) is MainWindow mw</c> forward:
+        /// the host owns the link pool, the cell only reports the click. The Avalonia shell is not
+        /// this view's business, so that coupling becomes an event rather than a window cast.
+        /// </summary>
+        public event EventHandler? AddVideoLinkRequested;
+
+        public WorkshopLibraryCell()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new WorkshopLibraryCellViewModel();
+
+            // CompanionWheelRelay is NOT ported: it patches WPF's ScrollViewer marking every wheel
+            // notch handled even when it has nothing left to scroll. Avalonia chains the notch on
+            // to the parent itself (ScrollViewer.IsScrollChainingEnabled, default true), so the
+            // bug the relay exists for does not occur on this head.
+            this.FindControl<Button>("BtnAddVideoLink")!.Click +=
+                (_, _) => AddVideoLinkRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>Strings for the view. See AchievementsTabViewModel for why this class exists.</summary>
+    public sealed class WorkshopLibraryCellViewModel
+    {
+        public string LocLabelCurrentMode => Loc.Get("label_current_mode");
+        // Placeholder only, exactly as in WPF: the host overwrites TxtHypnotubeModeLabel.Text with
+        // the active content mode (MainWindow.xaml.cs:3029).
+        public string LocLabelBambiSleep => Loc.Get("label_bambi_sleep");
+        public string LocLabelVideoLinksPoolDesc => Loc.Get("label_video_links_pool_desc");
+        public string LocLabelNoVideoLinksYet => Loc.Get("label_no_video_links_yet");
+        public string LocBtnAddLinkToPool => Loc.Get("btn_add_link_to_pool");
+    }
+}


### PR DESCRIPTION
Layer 12. KnowledgeLinkEditorDialog, ChatShortcutCaptureDialog, UpdateProgress/UrlPrompt dialogs, WorkshopCellTheme, WorkshopCommunityCell, WorkshopLibraryCell.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351