### PR TITLE
feat(avalonia): port WorkshopTriggersCell, AttentionCheckControl, TextEditorDialog

### DIFF
--- a/CCP.Avalonia/App.axaml
+++ b/CCP.Avalonia/App.axaml
@@ -12,6 +12,11 @@
         <ResourceInclude Source="avares://CCP.Avalonia/Theme/Brushes.xaml"/>
         <!-- Keyed styles the views are written against, as ControlThemes. -->
         <ResourceInclude Source="avares://CCP.Avalonia/Theme/Styles.xaml"/>
+        <!-- The Workshop cells' interior typography. Kept beside the cells rather than folded
+             into Styles.xaml, matching the WPF head where all six Workshop*Cell views merge
+             this same dictionary. Merged once here so every cell resolves the keys without
+             each repeating a ResourceInclude. -->
+        <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml"/>
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </Application.Resources>

--- a/CCP.Avalonia/Theme/Styles.xaml
+++ b/CCP.Avalonia/Theme/Styles.xaml
@@ -87,4 +87,45 @@
     <Setter Property="VerticalAlignment" Value="Center"/>
   </ControlTheme>
 
+  <!-- Views/Controls/Companion/Runtime/WorkshopCellTheme.xaml:27. That dictionary is merged into
+       each Workshop cell through a pack:// URI, which Avalonia has no equivalent for, so the keys
+       the ported cells use live here with the head's other keyed styles. Setters copied exactly. -->
+  <ControlTheme x:Key="CmpCellHintStyle" TargetType="TextBlock">
+    <Setter Property="FontSize" Value="10"/>
+    <Setter Property="Foreground" Value="#FF8F88AD"/>
+    <Setter Property="TextWrapping" Value="Wrap"/>
+    <Setter Property="Margin" Value="0,1,0,0"/>
+  </ControlTheme>
+
+  <!-- WorkshopCellTheme.xaml:43. A quiet, full-width action button - the Workshop's own idiom for
+       "this opens a dialog". The WPF ControlTemplate.Triggers become nested selectors, and the
+       ContentPresenter binds Content explicitly: Avalonia's does not do it implicitly. -->
+  <ControlTheme x:Key="CmpCellButtonStyle" TargetType="Button">
+    <Setter Property="Background" Value="#FF1C1A2E"/>
+    <Setter Property="Foreground" Value="#FFD8D2EA"/>
+    <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+    <Setter Property="BorderThickness" Value="1"/>
+    <Setter Property="Padding" Value="8,4"/>
+    <Setter Property="FontSize" Value="11"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="6" Padding="{TemplateBinding Padding}">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#Chrome">
+      <Setter Property="Background" Value="#FF2A2440"/>
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Opacity" Value="0.45"/>
+    </Style>
+  </ControlTheme>
+
 </ResourceDictionary>

--- a/CCP.Avalonia/Theme/Styles.xaml
+++ b/CCP.Avalonia/Theme/Styles.xaml
@@ -87,44 +87,114 @@
     <Setter Property="VerticalAlignment" Value="Center"/>
   </ControlTheme>
 
-  <!-- Views/Controls/Companion/Runtime/WorkshopCellTheme.xaml:27. That dictionary is merged into
-       each Workshop cell through a pack:// URI, which Avalonia has no equivalent for, so the keys
-       the ported cells use live here with the head's other keyed styles. Setters copied exactly. -->
-  <ControlTheme x:Key="CmpCellHintStyle" TargetType="TextBlock">
-    <Setter Property="FontSize" Value="10"/>
-    <Setter Property="Foreground" Value="#FF8F88AD"/>
-    <Setter Property="TextWrapping" Value="Wrap"/>
-    <Setter Property="Margin" Value="0,1,0,0"/>
-  </ControlTheme>
-
-  <!-- WorkshopCellTheme.xaml:43. A quiet, full-width action button - the Workshop's own idiom for
-       "this opens a dialog". The WPF ControlTemplate.Triggers become nested selectors, and the
-       ContentPresenter binds Content explicitly: Avalonia's does not do it implicitly. -->
-  <ControlTheme x:Key="CmpCellButtonStyle" TargetType="Button">
-    <Setter Property="Background" Value="#FF1C1A2E"/>
-    <Setter Property="Foreground" Value="#FFD8D2EA"/>
-    <Setter Property="BorderBrush" Value="#33FFFFFF"/>
-    <Setter Property="BorderThickness" Value="1"/>
-    <Setter Property="Padding" Value="8,4"/>
-    <Setter Property="FontSize" Value="11"/>
+  <!-- Controls.xaml:36. The press-feedback Storyboards (scale 0.97 in, BackEase out) become a
+       :pressed RenderTransform: Avalonia has no Trigger EnterActions/ExitActions, and the
+       HelpButtonStyle above already sets the precedent of reproducing the visual rather than
+       guessing at unmappable trigger machinery.
+       WPF's bare <ContentPresenter/> also has to name what it presents on Avalonia. -->
+  <ControlTheme x:Key="ActionButton" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="Foreground" Value="White"/>
+    <Setter Property="FontWeight" Value="Bold"/>
+    <Setter Property="FontSize" Value="12"/>
+    <Setter Property="Padding" Value="15,8"/>
     <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="Template">
       <ControlTemplate TargetType="Button">
-        <Border x:Name="Chrome" Background="{TemplateBinding Background}"
-                BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}"
-                CornerRadius="6" Padding="{TemplateBinding Padding}">
+        <Border x:Name="border" CornerRadius="8" Padding="{TemplateBinding Padding}"
+                Background="{TemplateBinding Background}"
+                RenderTransformOrigin="50%,50%">
           <ContentPresenter Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             HorizontalAlignment="Center" VerticalAlignment="Center"/>
         </Border>
       </ControlTemplate>
     </Setter>
-    <Style Selector="^:pointerover /template/ Border#Chrome">
-      <Setter Property="Background" Value="#FF2A2440"/>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource DarkPinkBrush}"/>
     </Style>
-    <Style Selector="^:disabled">
-      <Setter Property="Opacity" Value="0.45"/>
+    <Style Selector="^:pressed /template/ Border#border">
+      <Setter Property="RenderTransform" Value="scale(0.97)"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- Controls.xaml:95. Same shape as ActionButton, different palette. -->
+  <ControlTheme x:Key="SecondaryButton" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
+    <Setter Property="Foreground" Value="White"/>
+    <Setter Property="FontSize" Value="12"/>
+    <Setter Property="Padding" Value="12,8"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="BorderThickness" Value="0"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="border" CornerRadius="8" Padding="{TemplateBinding Padding}"
+                Background="{TemplateBinding Background}"
+                RenderTransformOrigin="50%,50%">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+    </Style>
+    <Style Selector="^:pressed /template/ Border#border">
+      <Setter Property="RenderTransform" Value="scale(0.97)"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- Controls.xaml:372. The hover trigger sets Background on the Button itself, which the
+       template picks up through the TemplateBinding - so no /template/ selector here. -->
+  <ControlTheme x:Key="DangerButton" TargetType="Button">
+    <Setter Property="Background" Value="#FF4757"/>
+    <Setter Property="Foreground" Value="White"/>
+    <Setter Property="FontSize" Value="12"/>
+    <Setter Property="Padding" Value="12,8"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="BorderThickness" Value="0"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border Background="{TemplateBinding Background}" CornerRadius="8" Padding="{TemplateBinding Padding}">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="#E84050"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- Controls.xaml:396. Trigger order is preserved because it is load-bearing: the plain
+       :pointerover rule follows :checked, and the MultiTrigger equivalent (:pointerover:checked)
+       comes last so a hovered checked box is DarkPink, exactly as in WPF. -->
+  <ControlTheme x:Key="ItemCheckBox" TargetType="CheckBox">
+    <Setter Property="Template">
+      <ControlTemplate TargetType="CheckBox">
+        <Grid>
+          <Border x:Name="border" Width="20" Height="20" CornerRadius="5"
+               Background="{DynamicResource PanelAccentBrush}" BorderThickness="0"/>
+          <Path x:Name="checkmark" Width="12" Height="12"
+             Stretch="Uniform" Fill="White" IsVisible="False"
+             Data="M9.86 3.14a.5.5 0 0 1 0 .72L4.5 9.22 1.64 6.36a.5.5 0 1 1 .72-.72L4.5 7.78l4.64-4.64a.5.5 0 0 1 .72 0z"/>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:checked /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+    </Style>
+    <Style Selector="^:checked /template/ Path#checkmark">
+      <Setter Property="IsVisible" Value="True"/>
+    </Style>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+    </Style>
+    <Style Selector="^:pointerover:checked /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource DarkPinkBrush}"/>
     </Style>
   </ControlTheme>
 

--- a/CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml
+++ b/CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml
@@ -1,0 +1,60 @@
+<!-- PORTED from ConditioningControlPanel/Controls/AttentionCheckControl.xaml.
+     Structure, order and spacing are preserved so the two can be compared directly. This view has
+     no loc strings, no keyed styles, no emoji and no buttons, so it needs no view-model and no new
+     theme key. Documented deviations, all forced by real WPF/Avalonia differences:
+
+       StrokeDashCap="Round"           ->  StrokeLineCap="Round"    (Avalonia has one cap for line
+                                           ends and dash ends; there is no separate StrokeDashCap)
+       StrokeDashArray="0 10000"       ->  "0,10000"                (Avalonia's list parser needs
+                                           commas; a space-separated list is AVLN1000 at build)
+       x:Name on the ScaleTransform    ->  dropped                  (AVLN2000: Avalonia can only
+                                           name a StyledElement, so the code-behind takes the
+                                           transform out of the TransformGroup instead)
+       RenderTransformOrigin="0.5,0.5" ->  "50%,50%"                (Avalonia parses bare numbers as
+                                           ABSOLUTE pixels; only a % is relative. Same origin, and
+                                           it is also Avalonia's default)
+       ShadowDepth="0"                 ->  OffsetX="0" OffsetY="0"  (Avalonia's DropShadowEffect
+                                           takes offsets, not depth+direction; same as the
+                                           AchievementsTabView port)
+       Storyboard (StartPulse)         ->  an Avalonia Animation in the code-behind -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AttentionCheckControl"
+             Width="84" Height="84"
+             Background="Transparent"
+             IsHitTestVisible="False">
+    <!-- Lifted from WebcamCalibrationWindow.xaml ring visuals so the
+         attention-check pop-in is visually identical to a calibration dot.
+         Click-through (IsHitTestVisible=False) — focus is captured by the
+         host window for gaze tracking; we don't want stray clicks. -->
+    <Grid>
+        <Ellipse x:Name="DotRingBg" Width="84" Height="84"
+                 Stroke="#33FFFFFF" StrokeThickness="3"/>
+        <Ellipse x:Name="DotRingFg" Width="84" Height="84"
+                 Stroke="#FFFF69B4" StrokeThickness="4"
+                 StrokeDashArray="0,10000" StrokeLineCap="Round"
+                 RenderTransformOrigin="50%,50%">
+            <Ellipse.RenderTransform>
+                <TransformGroup>
+                    <RotateTransform Angle="-90"/>
+                    <ScaleTransform ScaleX="1" ScaleY="1"/>
+                </TransformGroup>
+            </Ellipse.RenderTransform>
+            <Ellipse.Effect>
+                <DropShadowEffect Color="#FF69B4" BlurRadius="14" OffsetX="0" OffsetY="0" Opacity="0.7"/>
+            </Ellipse.Effect>
+        </Ellipse>
+        <Ellipse Width="44" Height="44">
+            <Ellipse.Fill>
+                <RadialGradientBrush>
+                    <GradientStop Color="#FFFFB6E1" Offset="0"/>
+                    <GradientStop Color="#FFFF69B4" Offset="0.6"/>
+                    <GradientStop Color="#FFC71585" Offset="1"/>
+                </RadialGradientBrush>
+            </Ellipse.Fill>
+            <Ellipse.Effect>
+                <DropShadowEffect Color="#FF69B4" BlurRadius="30" OffsetX="0" OffsetY="0" Opacity="0.9"/>
+            </Ellipse.Effect>
+        </Ellipse>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// Reusable visual for the Attention-Check mechanic: hot-pink progress
+    /// ring around a glowing dot, lifted from WebcamCalibrationWindow's
+    /// calibration target so the visual is instantly recognizable to users
+    /// who've completed calibration. The control is intrinsically 84x84 DIPs;
+    /// host it in a window at the desired screen position.
+    ///
+    /// Public surface:
+    ///   SetProgress(0..1)  — fills the foreground ring clockwise.
+    ///   StartPulse() / StopPulse() — gentle scale-pulse animation, useful
+    ///                                 to signal "look here" on first appear.
+    /// </summary>
+    public partial class AttentionCheckControl : UserControl
+    {
+        private readonly Ellipse _dotRingFg;
+        private readonly ScaleTransform _dotRingScale;
+        private CancellationTokenSource? _pulse;
+
+        public AttentionCheckControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _dotRingFg = this.FindControl<Ellipse>("DotRingFg")!;
+            // The transform is pulled out of the group rather than looked up by name: Avalonia
+            // rejects x:Name on a ScaleTransform outright (AVLN2000, only a StyledElement can be
+            // named), so the WPF markup's x:Name="DotRingScale" could not be kept.
+            _dotRingScale = ((TransformGroup)_dotRingFg.RenderTransform!).Children.OfType<ScaleTransform>().First();
+        }
+
+        /// <summary>
+        /// Sets the foreground-ring fill amount. progress is clamped to
+        /// [0, 1]; 0 = empty, 1 = full ring. Implementation mirrors
+        /// WebcamCalibrationWindow.UpdateProgressRing — same StrokeDashArray
+        /// math so the visual matches calibration exactly.
+        /// </summary>
+        public void SetProgress(double progress)
+        {
+            progress = Math.Clamp(progress, 0.0, 1.0);
+            double radius = (_dotRingFg.Width - _dotRingFg.StrokeThickness) / 2.0;
+            double perimeter = 2.0 * Math.PI * radius;
+            double units = perimeter / _dotRingFg.StrokeThickness;
+            double visible = progress * units;
+            double gap = Math.Max(0.001, units - visible);
+            _dotRingFg.StrokeDashArray = new AvaloniaList<double> { visible, gap };
+        }
+
+        public void StartPulse()
+        {
+            StopPulse();
+            // WPF's Storyboard + RepeatBehavior.Forever + AutoReverse is Avalonia's
+            // IterationCount.Infinite + PlaybackDirection.Alternate; same 420ms sine ease.
+            var sb = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(420),
+                IterationCount = IterationCount.Infinite,
+                PlaybackDirection = PlaybackDirection.Alternate,
+                Easing = new SineEaseInOut(),
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        Cue = new Cue(0d),
+                        Setters =
+                        {
+                            new Setter(ScaleTransform.ScaleXProperty, 1.0),
+                            new Setter(ScaleTransform.ScaleYProperty, 1.0),
+                        },
+                    },
+                    new KeyFrame
+                    {
+                        Cue = new Cue(1d),
+                        Setters =
+                        {
+                            new Setter(ScaleTransform.ScaleXProperty, 1.18),
+                            new Setter(ScaleTransform.ScaleYProperty, 1.18),
+                        },
+                    },
+                },
+            };
+            _pulse = new CancellationTokenSource();
+            // Target the ELLIPSE, not the transform: Avalonia's TransformAnimator casts its target
+            // to Visual and then finds the matching transform inside the visual's RenderTransform.
+            // Passing the ScaleTransform compiles and throws InvalidCastException at run time.
+            _ = sb.RunAsync(_dotRingFg, _pulse.Token);
+        }
+
+        public void StopPulse()
+        {
+            _pulse?.Cancel();
+            _pulse?.Dispose();
+            _pulse = null;
+            _dotRingScale.ScaleX = 1.0;
+            _dotRingScale.ScaleY = 1.0;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml
@@ -1,0 +1,86 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopCellTheme.xaml.
+     Keys, setters, values, order and comments are preserved so the two diff cleanly. Deviations,
+     all forced by real WPF/Avalonia differences:
+
+       <Style x:Key TargetType>     ->  <ControlTheme x:Key TargetType>   (a keyed, reusable style)
+       ControlTemplate.Triggers     ->  nested <Style Selector="^:pointerover|^:disabled">
+                                        (Avalonia has no triggers; pseudo-classes replace them)
+       <ContentPresenter/>          ->  <ContentPresenter Name="PART_ContentPresenter" .../>
+                                        (Avalonia's ContentControl only feeds a presenter carrying
+                                        that name; the WPF original gets its content implicitly)
+
+     Consumers write  Theme="{StaticResource CmpCellLabelStyle}"  where WPF writes Style=, and merge
+     this file with
+       <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml"/>
+     in place of the WPF pack:// URI. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- ================================================================
+         Interior styling for the Z8 Workshop's re-parented legacy cells.
+
+         The controls inside a Workshop cell are the ones the old accordions
+         shipped (design §6: "a container move, not a rebuild"), so they keep
+         their own app-level styles — ToggleStyle, PinkSlider, the combo box,
+         the help buttons. What they did NOT keep is the old accordion's
+         typography: at 340px wide a cell has room for a 10.5px label and a
+         value, not a 16px settings row.
+
+         These three styles are that reconciliation, and nothing else. They
+         are deliberately here rather than in CompanionTheme.xaml: that
+         dictionary is the ZONE theme, shared with the design-time gallery,
+         and the gallery never renders one of these cells.
+         ================================================================ -->
+
+    <ControlTheme x:Key="CmpCellLabelStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Foreground" Value="#FFD8D2EA"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="CmpCellHintStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="10"/>
+        <Setter Property="Foreground" Value="#FF8F88AD"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="Margin" Value="0,1,0,0"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="CmpCellValueStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="#FFFF8FD0"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+    </ControlTheme>
+
+    <!-- A quiet, full-width action button — the Workshop's own idiom for "this opens a dialog". -->
+    <ControlTheme x:Key="CmpCellButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="#FF1C1A2E"/>
+        <Setter Property="Foreground" Value="#FFD8D2EA"/>
+        <Setter Property="BorderBrush" Value="#33FFFFFF"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="6" Padding="{TemplateBinding Padding}">
+                    <ContentPresenter Name="PART_ContentPresenter"
+                                      Content="{TemplateBinding Content}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover /template/ Border#Chrome">
+            <Setter Property="Background" Value="#FF2A2440"/>
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.45"/>
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml
@@ -1,0 +1,82 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopCommunityCell.xaml.
+     Structure, order, spacing and every resource key are preserved so the two can be diffed.
+     Deviations, all forced:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       {loc:Str key}                ->  {Binding LocX}               (LocExtension is a WPF
+                                        MarkupExtension and stays in the head; the strings still
+                                        come from CCP.Core's Loc, via the VM)
+       Content="{loc:Str …}"        ->  a <TextBlock> child          (Avalonia's Button reads "_" in
+                                        Content as an access key and every key here is snake_case)
+       Click="Handler"              ->  wired in the constructor
+       the merged WorkshopCellTheme -> CmpCellHintStyle / CmpCellButtonStyle moved to
+                                       Theme/Styles.xaml, where this head keeps its keyed styles.
+                                       pack:// URIs do not exist on Avalonia. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime.WorkshopCommunityCell"
+             x:DataType="vm:WorkshopCommunityCellViewModel"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime"
+             mc:Ignorable="d" d:DesignWidth="312">
+
+    <!-- ================================================================
+         Z8 · COMMUNITY — browse / import / export / refresh plus the
+         installed list, moved whole. Z4's expert door links to the same
+         browse dialog; this cell owns the controls.
+         ================================================================ -->
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <Border Background="#FF6B6B" CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
+                <TextBlock Text="{Binding LocBeta}" Foreground="White" FontSize="9" FontWeight="Bold"/>
+            </Border>
+            <Button x:Name="HelpBtnPrompts" Theme="{DynamicResource HelpButtonStyle}"
+                    VerticalAlignment="Center" Margin="7,0,0,0" Tag="CommunityPrompts"/>
+        </StackPanel>
+
+        <Grid Margin="0,0,0,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="BtnBrowsePrompts" Grid.Column="0"
+                    Theme="{StaticResource CmpCellButtonStyle}" Margin="0,0,3,0">
+                <TextBlock Text="{Binding LocBrowse}"/>
+            </Button>
+            <Button x:Name="BtnImportPrompt" Grid.Column="1"
+                    Theme="{StaticResource CmpCellButtonStyle}" Margin="3,0,3,0">
+                <TextBlock Text="{Binding LocImport}"/>
+            </Button>
+            <Button x:Name="BtnExportPrompt" Grid.Column="2"
+                    Theme="{StaticResource CmpCellButtonStyle}" Margin="3,0,0,0">
+                <TextBlock Text="{Binding LocExport}"/>
+            </Button>
+        </Grid>
+
+        <Grid Margin="0,0,0,5">
+            <TextBlock Text="{Binding LocInstalledPrompts}" Theme="{StaticResource CmpCellHintStyle}"
+                       VerticalAlignment="Center"/>
+            <Button x:Name="BtnRefreshPrompts"
+                    HorizontalAlignment="Right" Background="Transparent"
+                    Foreground="{DynamicResource TextMutedBrush}" BorderThickness="0"
+                    FontSize="10.5" Padding="6,1" Cursor="Hand">
+                <TextBlock Text="{Binding LocRefresh}"/>
+            </Button>
+        </Grid>
+
+        <Border CornerRadius="7" Padding="7" MinHeight="60" MaxHeight="140"
+                BorderBrush="#22808080" BorderThickness="1" Background="#FF14121F">
+            <ScrollViewer x:Name="InstalledPromptsScroll" VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="InstalledPromptsPanel">
+                    <TextBlock x:Name="TxtNoInstalledPrompts"
+                               Text="{Binding LocNoPromptsInstalled}"
+                               Foreground="#505050" FontSize="10.5" FontStyle="Italic"
+                               HorizontalAlignment="Center" Margin="0,14,0,0"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCommunityCell.axaml.cs
@@ -1,0 +1,49 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>Z8 · COMMUNITY. See the XAML header. Pure forwarding.</summary>
+    public partial class WorkshopCommunityCell : UserControl
+    {
+        // The WPF cell forwards each click to MainWindow (Window.GetWindow(this) is MainWindow).
+        // This head has no MainWindow API surface yet and the cell must not grow App. coupling, so
+        // the four actions leave the cell as events and the host wires them - the same contract,
+        // one indirection later.
+        public event EventHandler? BrowsePromptsRequested;
+        public event EventHandler? ImportPromptRequested;
+        public event EventHandler? ExportPromptRequested;
+        public event EventHandler? RefreshPromptsRequested;
+
+        public WorkshopCommunityCell()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new WorkshopCommunityCellViewModel();
+
+            this.FindControl<Button>("BtnBrowsePrompts")!.Click += (_, _) => BrowsePromptsRequested?.Invoke(this, EventArgs.Empty);
+            this.FindControl<Button>("BtnImportPrompt")!.Click += (_, _) => ImportPromptRequested?.Invoke(this, EventArgs.Empty);
+            this.FindControl<Button>("BtnExportPrompt")!.Click += (_, _) => ExportPromptRequested?.Invoke(this, EventArgs.Empty);
+            this.FindControl<Button>("BtnRefreshPrompts")!.Click += (_, _) => RefreshPromptsRequested?.Invoke(this, EventArgs.Empty);
+
+            // CompanionWheelRelay.Attach(InstalledPromptsScroll) is NOT ported: it works around
+            // WPF's ScrollViewer marking every wheel notch handled even when it cannot scroll.
+            // Avalonia's ScrollViewer.IsScrollChainingEnabled (default true) already passes an
+            // unusable notch to the parent scroll, which is exactly what the relay re-implements.
+        }
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding.</summary>
+    public sealed class WorkshopCommunityCellViewModel
+    {
+        public string LocBeta => Loc.Get("label_beta");
+        public string LocBrowse => Loc.Get("btn_browse");
+        public string LocImport => Loc.Get("btn_import");
+        public string LocExport => Loc.Get("btn_export");
+        public string LocInstalledPrompts => Loc.Get("label_installed_prompts");
+        public string LocRefresh => Loc.Get("btn_refresh");
+        public string LocNoPromptsInstalled => Loc.Get("label_no_prompts_installed_yet");
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml
@@ -1,0 +1,59 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopLibraryCell.xaml.
+     Structure, order, spacing, comments and every resource key are preserved so the two can be
+     diffed. Documented deviations, all forced:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       {loc:Str key}                 ->  {Binding LocX}               (LocExtension is a WPF
+                                         MarkupExtension and stays in the head)
+       Content="{loc:Str ...}"       ->  a TextBlock child            (Avalonia parses "_" in
+                                         Content as an access key - see CLAUDE.md)
+       Click="Handler"               ->  wired in the constructor
+       x:FieldModifier="internal"    ->  dropped                      (the internal consumers -
+                                         CompanionTabView's passthroughs and MainWindow - are the
+                                         WPF head's; controls are reached with FindControl here)
+       UserControl.Resources merge   ->  dropped                      (WorkshopCellTheme.xaml's two
+                                         keys used here now live app-level in Theme/Styles.xaml) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime.WorkshopLibraryCell"
+             x:DataType="vm:WorkshopLibraryCellViewModel"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" d:DesignWidth="312">
+
+    <!-- ================================================================
+         Z8 · HER LIBRARY — the per-mod Hypnotube link pool, moved whole.
+         The scope signpost comes with it: these links are mod-scoped
+         while everything around them is global, and losing that line in
+         the move would have been the one genuinely confusing drop.
+         ================================================================ -->
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="{Binding LocLabelCurrentMode}" Theme="{StaticResource CmpCellHintStyle}" VerticalAlignment="Center"/>
+            <TextBlock x:Name="TxtHypnotubeModeLabel" Text="{Binding LocLabelBambiSleep}"
+                       FontSize="10" FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
+                       VerticalAlignment="Center" Margin="3,0,0,0"/>
+            <Button x:Name="HelpBtnVideoLinks" Theme="{StaticResource HelpButtonStyle}"
+                    VerticalAlignment="Center" Margin="6,0,0,0" Tag="HypnotubeLinks"/>
+        </StackPanel>
+
+        <TextBlock Text="{Binding LocLabelVideoLinksPoolDesc}" Theme="{StaticResource CmpCellHintStyle}" Margin="0,0,0,5"/>
+
+        <Border CornerRadius="7" Padding="6" MinHeight="52" MaxHeight="200" Margin="0,0,0,6"
+                BorderBrush="#22808080" BorderThickness="1" Background="#FF14121F">
+            <ScrollViewer x:Name="LinkPoolScroll" VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="VideoLinkPoolPanel">
+                    <TextBlock x:Name="TxtNoVideoLinks" Text="{Binding LocLabelNoVideoLinksYet}"
+                               Foreground="#505050" FontSize="10.5" FontStyle="Italic"
+                               HorizontalAlignment="Center" Margin="0,12,0,12"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <Button x:Name="BtnAddVideoLink" Theme="{StaticResource CmpCellButtonStyle}">
+            <TextBlock Text="{Binding LocBtnAddLinkToPool}"/>
+        </Button>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopLibraryCell.axaml.cs
@@ -1,0 +1,43 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>Z8 · HER LIBRARY. See the XAML header. Pure forwarding.</summary>
+    public partial class WorkshopLibraryCell : UserControl
+    {
+        /// <summary>
+        /// Port of the WPF code-behind's <c>Window.GetWindow(this) is MainWindow mw</c> forward:
+        /// the host owns the link pool, the cell only reports the click. The Avalonia shell is not
+        /// this view's business, so that coupling becomes an event rather than a window cast.
+        /// </summary>
+        public event EventHandler? AddVideoLinkRequested;
+
+        public WorkshopLibraryCell()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new WorkshopLibraryCellViewModel();
+
+            // CompanionWheelRelay is NOT ported: it patches WPF's ScrollViewer marking every wheel
+            // notch handled even when it has nothing left to scroll. Avalonia chains the notch on
+            // to the parent itself (ScrollViewer.IsScrollChainingEnabled, default true), so the
+            // bug the relay exists for does not occur on this head.
+            this.FindControl<Button>("BtnAddVideoLink")!.Click +=
+                (_, _) => AddVideoLinkRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>Strings for the view. See AchievementsTabViewModel for why this class exists.</summary>
+    public sealed class WorkshopLibraryCellViewModel
+    {
+        public string LocLabelCurrentMode => Loc.Get("label_current_mode");
+        // Placeholder only, exactly as in WPF: the host overwrites TxtHypnotubeModeLabel.Text with
+        // the active content mode (MainWindow.xaml.cs:3029).
+        public string LocLabelBambiSleep => Loc.Get("label_bambi_sleep");
+        public string LocLabelVideoLinksPoolDesc => Loc.Get("label_video_links_pool_desc");
+        public string LocLabelNoVideoLinksYet => Loc.Get("label_no_video_links_yet");
+        public string LocBtnAddLinkToPool => Loc.Get("btn_add_link_to_pool");
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopTriggersCell.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopTriggersCell.axaml
@@ -1,0 +1,96 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopTriggersCell.xaml.
+     Structure, order, spacing and every resource key are preserved so the two diff cleanly.
+     Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"    (keyed styles are ControlThemes)
+       Style="{DynamicResource X}"  ->  Theme="{DynamicResource X}"   (same, resolved late)
+       {loc:Str key}                ->  {Binding LocX}                (LocExtension is a WPF
+                                        MarkupExtension and stays in the head; the strings still
+                                        come from CCP.Core's Loc, via the view model)
+       Visibility="Collapsed"       ->  IsVisible="False"
+       ToolTip="..."                ->  ToolTip.Tip="..."
+       Content="{loc:Str ...}"      ->  a <TextBlock> child (Avalonia's Button reads "_" in Content
+                                        as an access key, and every loc string here is snake_case)
+       pack:// merged dictionary    ->  avares:// ResourceInclude
+       Checked/Unchecked, Click,
+       ValueChanged, SelectionChanged -> wired in the constructor
+       DisplayMemberPath/
+       SelectedValuePath            ->  DisplayMemberBinding/SelectedValueBinding, as
+                                        ReflectionBinding: the item type (Models.PhrasePreset)
+                                        still lives in the WPF head, so it cannot be compiled. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime.WorkshopTriggersCell"
+             x:DataType="vm:WorkshopTriggersCellViewModel"
+             mc:Ignorable="d" d:DesignWidth="312">
+
+    <!-- ================================================================
+         Z8 · TRIGGERS & PHRASES — the System B keyword engine's mode
+         switch, its interval, the phrase editor, and the phrase-preset
+         shelf. Design §6 keeps all six controls; this is a container
+         move only.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopCellTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <StackPanel>
+        <Grid Margin="0,0,0,4">
+            <StackPanel Margin="0,0,44,0">
+                <TextBlock Text="{Binding LocTriggerMode}" Theme="{StaticResource CmpCellLabelStyle}"/>
+                <TextBlock Text="{Binding LocRandomPhrasesHint}" Theme="{StaticResource CmpCellHintStyle}"/>
+            </StackPanel>
+            <CheckBox x:Name="ChkTriggerModeCompanion" Theme="{DynamicResource ToggleStyle}"
+                      HorizontalAlignment="Right" VerticalAlignment="Center"/>
+        </Grid>
+
+        <StackPanel x:Name="TriggerSettingsPanelCompanion" IsVisible="False" Margin="0,0,0,9">
+            <Grid>
+                <TextBlock Text="{Binding LocInterval}" Theme="{StaticResource CmpCellLabelStyle}"/>
+                <TextBlock x:Name="TxtTriggerIntervalCompanion" Text="{Binding LocIntervalValue}"
+                           Theme="{StaticResource CmpCellValueStyle}" Foreground="#9370DB"/>
+            </Grid>
+            <Slider x:Name="SliderTriggerIntervalCompanion" Theme="{DynamicResource PinkSlider}"
+                    Minimum="10" Maximum="600" Value="60" Margin="0,4,0,6"/>
+            <Button x:Name="BtnEditTriggersCompanion"
+                    Theme="{StaticResource CmpCellButtonStyle}" HorizontalAlignment="Stretch">
+                <TextBlock Text="{Binding LocEditPhrases}"/>
+            </Button>
+        </StackPanel>
+
+        <Button x:Name="BtnManagePhrases" Theme="{StaticResource CmpCellButtonStyle}" Margin="0,0,0,6">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock Text="{Binding LocManagePhrases}" Foreground="#FFD8D2EA" FontSize="11"/>
+                <TextBlock x:Name="TxtPhraseCount" Text="{Binding LocPhraseCount}"
+                           Foreground="{DynamicResource PinkBrush}" FontWeight="SemiBold" FontSize="11" Margin="4,0,0,0"/>
+            </StackPanel>
+        </Button>
+
+        <ComboBox x:Name="CmbPhrasePresets" FontSize="11" Margin="0,0,0,5"
+                  Theme="{DynamicResource DarkComboBoxStyle}"
+                  DisplayMemberBinding="{ReflectionBinding DisplayText}"
+                  SelectedValueBinding="{ReflectionBinding Id}"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="0" Theme="{StaticResource CmpCellButtonStyle}"
+                    Margin="0,0,3,0" ToolTip.Tip="{Binding LocTooltipSavePreset}">
+                <TextBlock Text="{Binding LocSave}"/>
+            </Button>
+            <Button Grid.Column="1" Theme="{StaticResource CmpCellButtonStyle}"
+                    Margin="3,0,0,0" ToolTip.Tip="{Binding LocTooltipDeletePreset}">
+                <TextBlock Text="{Binding LocDelete}"/>
+            </Button>
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopTriggersCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopTriggersCell.axaml.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>Z8 · TRIGGERS &amp; PHRASES. See the XAML header.
+    ///
+    /// The WPF code-behind is pure forwarding: every handler walks up to MainWindow and calls the
+    /// matching internal method there. That target does not exist on this head - the phrase editor,
+    /// the preset store and the avatar trigger timer all hang off <c>App</c>/<c>MainWindow</c> in
+    /// the WPF project - so only the two behaviours that are purely local to this cell are wired:
+    /// the toggle showing the interval panel (MainWindow.Patreon.cs:1209) and the slider writing
+    /// its own value label (MainWindow.Patreon.cs:1235). Edit Phrases, Manage Phrases and the three
+    /// preset controls stay inert until that runtime crosses; they are not stubbed, so nothing here
+    /// pretends to work.</summary>
+    public partial class WorkshopTriggersCell : UserControl
+    {
+        public WorkshopTriggersCell()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new WorkshopTriggersCellViewModel();
+
+            var toggle = this.FindControl<CheckBox>("ChkTriggerModeCompanion")!;
+            var panel = this.FindControl<StackPanel>("TriggerSettingsPanelCompanion")!;
+            var slider = this.FindControl<Slider>("SliderTriggerIntervalCompanion")!;
+            var intervalText = this.FindControl<TextBlock>("TxtTriggerIntervalCompanion")!;
+
+            // WPF wired Checked/Unchecked separately; Avalonia has one event for both.
+            toggle.IsCheckedChanged += (_, _) => panel.IsVisible = toggle.IsChecked == true;
+            slider.ValueChanged += (_, _) => intervalText.Text = $"{(int)slider.Value}s";
+        }
+    }
+
+    /// <summary>
+    /// Supplies the strings the view binds to, every one from CCP.Core's <see cref="Loc"/> - the
+    /// same runtime and the same JSON the WPF head reads. This exists because WPF's {loc:Str key}
+    /// markup extension derives from System.Windows.Markup.MarkupExtension and stays in the head.
+    /// </summary>
+    public sealed class WorkshopTriggersCellViewModel
+    {
+        public string LocTriggerMode => Loc.Get("label_trigger_mode");
+        public string LocRandomPhrasesHint => Loc.Get("label_random_conditioning_phrases_with_audio");
+        public string LocInterval => Loc.Get("label_interval");
+
+        // Both of these are STATIC keys holding the at-rest value, not formatted strings: the WPF
+        // head overwrites them with plain interpolation once real data arrives
+        // ($"{value}s" at MainWindow.Patreon.cs:1235, $"{count} active" at :1132). No Loc.GetF
+        // anywhere on this cell, so there is no format key to look up.
+        public string LocIntervalValue => Loc.Get("label_60s");
+        public string LocPhraseCount => Loc.Get("label_0_active");
+
+        public string LocEditPhrases => Loc.Get("btn_edit_phrases_2");
+        public string LocManagePhrases => Loc.Get("label_manage_phrases");
+        public string LocSave => Loc.Get("btn_save");
+        public string LocDelete => Loc.Get("btn_delete");
+        public string LocTooltipSavePreset => Loc.Get("tooltip_save_current_phrase_config_as_a_preset");
+        public string LocTooltipDeletePreset => Loc.Get("tooltip_delete_selected_phrase_preset");
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml
@@ -1,0 +1,146 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/TextEditorDialog.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       Style="{StaticResource X}"     -> Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       {loc:Str key}                  -> {Binding LocX}               (LocExtension is a WPF
+                                         MarkupExtension and stays in the head)
+       Visibility="Collapsed"         -> IsVisible="False"
+       ResizeMode="CanResizeWithGrip" -> CanResize="True"             (Avalonia has no resize grip;
+                                         the window still resizes)
+       MouseLeftButtonDown            -> PointerPressed, wired in the constructor as one handler
+                                         on the ItemsControl (a DataTemplate has no name scope)
+       DataTemplate.Triggers          -> Classes.selected + the Border.selected style below
+                                         (Avalonia has no DataTriggers)
+       Checked/Unchecked              -> ToggleButton.IsCheckedChangedEvent, wired in the ctor
+       ToolTip="..."                  -> ToolTip.Tip="..."
+       <Window.Resources></Window.Resources>  dropped - it was empty in the original too.
+
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key and every loc key here is snake_case. See the porting notes in CLAUDE.md.
+     The buttons also gained x:Names, because the handlers are wired in the constructor. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.TextEditorDialog"
+        x:DataType="vm:TextEditorViewModel"
+        xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Title="{Binding LocDialogTextManager}"
+        Height="500" Width="550"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="True">
+
+    <Window.Styles>
+        <!-- The WPF DataTemplate.Triggers block, setters verbatim. Driven by
+             Classes.selected="{Binding IsSelected}" on the row Border. -->
+        <Style Selector="Border.selected">
+            <Setter Property="Background" Value="#3A2A5A"/>
+            <Setter Property="BorderBrush" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid Margin="15">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <Grid Grid.Row="0" Margin="0,0,0,15">
+            <TextBlock x:Name="TxtTitle" Text="{Binding LocDialogTextManager}" Foreground="{StaticResource PinkBrush}"
+                       FontSize="18" FontWeight="Bold" VerticalAlignment="Center"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="BtnSort" Theme="{StaticResource SecondaryButton}"
+                        Margin="0,0,8,0">
+                    <TextBlock Text="{Binding LocBtnSortAZ}"/>
+                </Button>
+                <Button x:Name="BtnToggleAll" Theme="{StaticResource SecondaryButton}">
+                    <TextBlock Text="{Binding LocBtnToggleAll}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <!-- Add New Item -->
+        <Grid Grid.Row="1" Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="TxtNewItem" Grid.Column="0"
+                     Background="{DynamicResource SurfaceBgBrush}" Foreground="White"
+                     BorderBrush="{StaticResource PinkBrush}" BorderThickness="1"
+                     Padding="10,8" FontSize="13" VerticalContentAlignment="Center"/>
+            <Button x:Name="BtnAdd" Grid.Column="1" Theme="{StaticResource ActionButton}"
+                    Margin="8,0,0,0">
+                <TextBlock Text="{Binding LocBtnAdd}"/>
+            </Button>
+        </Grid>
+
+        <!-- Item List -->
+        <Border Grid.Row="2" Background="{StaticResource PanelBgBrush}" CornerRadius="8">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="5">
+                <ItemsControl x:Name="ItemList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:TextItem">
+                            <Border x:Name="ItemBorder" Background="{DynamicResource SurfaceBgBrush}" CornerRadius="5"
+                                    Margin="3" Padding="10,8" Cursor="Hand"
+                                    Classes.selected="{Binding IsSelected}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <CheckBox Grid.Column="0" Theme="{StaticResource ItemCheckBox}"
+                                              IsChecked="{Binding IsEnabled, Mode=TwoWay}"
+                                              Margin="0,0,10,0"/>
+                                    <TextBlock Grid.Column="1" Text="{Binding Text}"
+                                               Foreground="White" FontSize="13"
+                                               VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="BtnRemove" Grid.Column="2" Text="✕" Foreground="{DynamicResource TextMutedBrush}"
+                                               FontSize="14" VerticalAlignment="Center"
+                                               Cursor="Hand"
+                                               ToolTip.Tip="{Binding $parent[Window].((vm:TextEditorViewModel)DataContext).LocTooltipRemoveItem}">
+                                        <TextBlock.Styles>
+                                            <!-- Shape-for-shape copy of the WPF Style.Triggers block. It was
+                                                 already dead there - a local Foreground outranks a style
+                                                 trigger - and it is dead here for the same reason. Kept so
+                                                 the two files still diff, not "fixed". -->
+                                            <Style Selector="TextBlock:pointerover">
+                                                <Setter Property="Foreground" Value="#FF4757"/>
+                                            </Style>
+                                        </TextBlock.Styles>
+                                    </TextBlock>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Footer Buttons -->
+        <Grid Grid.Row="3" Margin="0,15,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="BtnRemoveSelected" Grid.Column="0" Theme="{StaticResource DangerButton}">
+                <TextBlock Text="{Binding LocBtnRemoveSelected}"/>
+            </Button>
+            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                <Button x:Name="BtnCancel" Theme="{StaticResource SecondaryButton}"
+                        Margin="0,0,8,0">
+                    <TextBlock Text="{Binding LocBtnCancel}"/>
+                </Button>
+                <Button x:Name="BtnSave" Theme="{StaticResource ActionButton}">
+                    <TextBlock Text="{Binding LocBtnSave}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Dialog for editing text pools (subliminals, attention targets, etc.)
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/TextEditorDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> property becomes <c>Close(bool)</c> plus a <c>_dialogResult</c>
+    ///    field, because Avalonia carries the result through <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so
+    ///    <see cref="Ask"/> below is a minimal stand-in.
+    ///  - <c>OnClosing</c> cannot prompt synchronously: it cancels the close, awaits the prompt and
+    ///    closes again. <c>_dialogResult</c> is what stops it prompting twice.
+    ///  - The <c>ItemsSource = null; ItemsSource = _items;</c> refresh hacks are gone. TextItem
+    ///    raises PropertyChanged and the row highlight is a bound style class, so the list updates
+    ///    itself.
+    ///  - <c>_originalData</c> is dropped: the WPF original assigns it and never reads it.
+    /// </summary>
+    public partial class TextEditorDialog : Window
+    {
+        private readonly ObservableCollection<TextItem> _items;
+        private readonly TextBox _txtNewItem;
+        private readonly ItemsControl _itemList;
+        private bool _hasChanges = false;
+        private bool? _dialogResult;
+
+        /// <summary>
+        /// The edited data after Save is clicked
+        /// </summary>
+        public Dictionary<string, bool>? ResultData { get; private set; }
+
+        public TextEditorDialog(string title, Dictionary<string, bool> data)
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new TextEditorViewModel();
+
+            _txtNewItem = this.FindControl<TextBox>("TxtNewItem")!;
+            _itemList = this.FindControl<ItemsControl>("ItemList")!;
+
+            this.FindControl<TextBlock>("TxtTitle")!.Text = $"📝 {title}";
+            Title = Loc.GetF("title_manager", title);
+
+            // Convert to observable collection for binding
+            _items = new ObservableCollection<TextItem>(
+                data.Select(kvp => new TextItem { Text = kvp.Key, IsEnabled = kvp.Value })
+                    .OrderBy(x => x.Text)
+            );
+
+            foreach (var item in _items)
+                item.PropertyChanged += TextItem_Changed;
+
+            _itemList.ItemsSource = _items;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            _txtNewItem.KeyDown += (_, e) => { if (e.Key == Key.Enter) AddNewItem(); };
+            this.FindControl<Button>("BtnAdd")!.Click += (_, _) => AddNewItem();
+            this.FindControl<Button>("BtnSort")!.Click += (_, _) => BtnSort_Click();
+            this.FindControl<Button>("BtnToggleAll")!.Click += (_, _) => BtnToggleAll_Click();
+            this.FindControl<Button>("BtnRemoveSelected")!.Click += (_, _) => BtnRemoveSelected_Click();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => BtnCancel_Click();
+            this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
+
+            // One handler on the list instead of one inside the DataTemplate: template content has
+            // no name scope to FindControl through. PointerPressed bubbles, and the CheckBox marks
+            // it handled exactly as WPF's ButtonBase did, so ticking a box still does not select
+            // the row.
+            _itemList.AddHandler(InputElement.PointerPressedEvent, ItemList_PointerPressed);
+        }
+
+        private async void AddNewItem()
+        {
+            var text = (_txtNewItem.Text ?? "").Trim().ToUpperInvariant();
+
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            // Check for duplicates
+            if (_items.Any(x => x.Text.Equals(text, StringComparison.OrdinalIgnoreCase)))
+            {
+                await Ask(Loc.Get("title_duplicate"), Loc.Get("msg_this_item_already_exists"),
+                    (Loc.Get("btn_ok"), true));
+                return;
+            }
+
+            var added = new TextItem { Text = text, IsEnabled = true };
+            added.PropertyChanged += TextItem_Changed;
+            _items.Add(added);
+            _txtNewItem.Clear();
+            _txtNewItem.Focus();
+            _hasChanges = true;
+        }
+
+        private void BtnSort_Click()
+        {
+            var sorted = _items.OrderBy(x => x.Text).ToList();
+            _items.Clear();
+            foreach (var item in sorted)
+            {
+                _items.Add(item);
+            }
+        }
+
+        private void BtnToggleAll_Click()
+        {
+            // If all are enabled, disable all. Otherwise enable all.
+            bool allEnabled = _items.All(x => x.IsEnabled);
+            bool newState = !allEnabled;
+
+            foreach (var item in _items)
+            {
+                item.IsEnabled = newState;
+            }
+
+            _hasChanges = true;
+        }
+
+        private async void ItemList_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(_itemList).Properties.IsLeftButtonPressed)
+                return;
+
+            if ((e.Source as Control)?.DataContext is not TextItem item)
+                return;
+
+            if (e.Source is TextBlock { Name: "BtnRemove" })
+            {
+                e.Handled = true; // Prevent triggering the row click
+
+                var confirm = await Ask(Loc.Get("title_confirm"), Loc.GetF("msg_confirm_remove_item", item.Text),
+                    ("Yes", true), ("No", false));
+
+                if (confirm == true)
+                {
+                    _items.Remove(item);
+                    _hasChanges = true;
+                }
+                return;
+            }
+
+            // Toggle selection
+            item.IsSelected = !item.IsSelected;
+        }
+
+        /// <summary>
+        /// WPF's Checked/Unchecked handlers on the row CheckBox. Watching the item rather than the
+        /// widget is what keeps Sort clean: Sort re-materialises every container, so any handler
+        /// hung off ToggleButton.IsCheckedChanged would depend on whether the initial binding lands
+        /// before or after the CheckBox joins the visual tree. IsEnabled only changes when someone
+        /// actually edits, which is the thing WPF meant to track.
+        /// </summary>
+        private void TextItem_Changed(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(TextItem.IsEnabled))
+                _hasChanges = true;
+        }
+
+        private async void BtnRemoveSelected_Click()
+        {
+            var selected = _items.Where(x => x.IsSelected).ToList();
+
+            if (selected.Count == 0)
+            {
+                await Ask(Loc.Get("title_no_selection"),
+                    Loc.Get("msg_no_items_selected_n_nclick_on_items_to_select"),
+                    (Loc.Get("btn_ok"), true));
+                return;
+            }
+
+            var result = await Ask(Loc.Get("title_confirm"), Loc.GetF("msg_confirm_remove_selected", selected.Count),
+                ("Yes", true), ("No", false));
+
+            if (result == true)
+            {
+                foreach (var item in selected)
+                {
+                    _items.Remove(item);
+                }
+                _hasChanges = true;
+            }
+        }
+
+        private async void BtnCancel_Click()
+        {
+            if (_hasChanges)
+            {
+                var result = await Ask(Loc.Get("title_unsaved_changes"), Loc.Get("msg_discard_changes"),
+                    ("Yes", true), ("No", false));
+
+                if (result != true)
+                    return;
+            }
+
+            ResultData = null;
+            _dialogResult = false;
+            Close(false);
+        }
+
+        private void BtnSave_Click()
+        {
+            // Convert back to dictionary
+            ResultData = _items.ToDictionary(x => x.Text, x => x.IsEnabled);
+            _dialogResult = true;
+            Close(true);
+        }
+
+        protected override void OnClosing(WindowClosingEventArgs e)
+        {
+            // If closing via X button and there are changes
+            if (_dialogResult == null && _hasChanges)
+            {
+                // The prompt is async, so the close has to be cancelled and re-issued from it.
+                e.Cancel = true;
+                PromptSaveOnClose();
+            }
+
+            base.OnClosing(e);
+        }
+
+        private async void PromptSaveOnClose()
+        {
+            var result = await Ask(Loc.Get("title_unsaved_changes"), Loc.Get("msg_save_changes_before_closing"),
+                ("Yes", true), ("No", false), (Loc.Get("btn_cancel"), null));
+
+            if (result == true)
+            {
+                ResultData = _items.ToDictionary(x => x.Text, x => x.IsEnabled);
+                _dialogResult = true;
+                Close(true);
+            }
+            else if (result == false)
+            {
+                _dialogResult = false;
+                Close(false);
+            }
+            // Cancel, or dismissed with the X: stay open, as MessageBoxResult.Cancel did.
+        }
+
+        /// <summary>
+        /// Minimal stand-in for WPF's MessageBox, which Avalonia has no equivalent of. Each button
+        /// carries the value Close() hands back; dismissing the window yields null, matching the
+        /// Cancel button. Buttons hold a TextBlock, not Content, for the access-key reason above.
+        /// The app has no btn_yes/btn_no loc keys - WPF got those strings from the OS - so Yes and
+        /// No are English here. btn_ok and btn_cancel do exist and are used.
+        /// </summary>
+        private Task<bool?> Ask(string title, string message, params (string Label, bool? Value)[] buttons)
+        {
+            var row = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Margin = new Thickness(0, 16, 0, 0)
+            };
+
+            var dialog = new Window
+            {
+                Title = title,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                CanResize = false,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Background = Background,
+                Content = new StackPanel
+                {
+                    Margin = new Thickness(20),
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = message,
+                            Foreground = Brushes.White,
+                            FontSize = 13,
+                            TextWrapping = TextWrapping.Wrap,
+                            MaxWidth = 360
+                        },
+                        row
+                    }
+                }
+            };
+
+            foreach (var (label, value) in buttons)
+            {
+                var button = new Button
+                {
+                    Content = new TextBlock { Text = label },
+                    Padding = new Thickness(14, 6),
+                    Cursor = new Cursor(StandardCursorType.Hand)
+                };
+                button.Click += (_, _) => dialog.Close(value);
+                row.Children.Add(button);
+            }
+
+            return dialog.ShowDialog<bool?>(this);
+        }
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding.</summary>
+    public sealed class TextEditorViewModel
+    {
+        public string LocDialogTextManager => Loc.Get("dialog_text_manager");
+        public string LocBtnSortAZ => Loc.Get("btn_sort_a_z");
+        public string LocBtnToggleAll => Loc.Get("btn_toggle_all");
+        public string LocBtnAdd => Loc.Get("btn_add_2");
+        public string LocTooltipRemoveItem => Loc.Get("tooltip_remove_item");
+        public string LocBtnRemoveSelected => Loc.Get("btn_remove_selected_2");
+        public string LocBtnCancel => Loc.Get("btn_cancel");
+        public string LocBtnSave => Loc.Get("btn_save");
+    }
+
+    /// <summary>
+    /// Represents a text item in the list.
+    /// Copied from the WPF code-behind: the type lives there, not in CCP.Core, and neither the
+    /// WPF head nor Core may be touched by this port.
+    /// </summary>
+    public class TextItem : INotifyPropertyChanged
+    {
+        private string _text = "";
+        private bool _isEnabled = true;
+        private bool _isSelected = false;
+
+        public string Text
+        {
+            get => _text;
+            set { _text = value; OnPropertyChanged(nameof(Text)); }
+        }
+
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set { _isEnabled = value; OnPropertyChanged(nameof(IsEnabled)); }
+        }
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set { _isSelected = value; OnPropertyChanged(nameof(IsSelected)); }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged(string name)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}


### PR DESCRIPTION
Layer 13. Three more bucket-A views, structure and resource keys preserved from the WPF originals.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351