### PR TITLE
feat(avalonia): port OpenAiCompatibleSamplerSettingsDialog, WorkshopRosterCell, ProfilePrivacyPanel with ToggleStyle

### DIFF
--- a/CCP.Avalonia/Theme/Styles.xaml
+++ b/CCP.Avalonia/Theme/Styles.xaml
@@ -198,4 +198,133 @@
     </Style>
   </ControlTheme>
 
+  <!-- Controls.xaml:198. The animated on/off switch every settings and privacy row uses.
+       Deviations beyond the usual Style->ControlTheme / Trigger->pseudo-class mapping, all forced:
+
+         TranslateTransform x:Name="thumbTranslate"  ->  RenderTransform="translateX(...)"
+         ScaleTransform     x:Name="sparkScale"      ->  RenderTransform="scale(...)"
+             AVLN2000: Avalonia can only name a StyledElement, so neither transform could keep its
+             x:Name and neither can be an animation target. Animating RenderTransform with a
+             TransformOperations value is the Avalonia idiom and also sidesteps the runtime trap
+             that an animation setter targeting ScaleTransform.ScaleX compiles and then throws
+             InvalidCastException.
+
+         Storyboard EnterActions/ExitActions  ->  Transitions (the knob slide, the track fade and
+             the spark's growth) plus one keyframe Animation (the spark's opacity decay, which is
+             a one-shot and runs when :checked starts matching, exactly like the WPF
+             EnterActions storyboard). A Transition is inherently two-way, which is what the first
+             three want. RenderTransform HAS to be a transition rather than a keyframe: Avalonia
+             registers no keyframe animator for it - see the note on the spark below.
+
+         BackEase Amplitude="0.6" / "0.35"    ->  BackEaseOut. Avalonia's easings take no
+             amplitude, so the overshoot is whatever BackEaseOut gives. The 43.4-of-44 sum in the
+             comment below still holds for the resting position; only the overshoot peak differs.
+
+         Separate enter/exit durations        ->  one duration per property. WPF used 0.34 in /
+             0.30 out on the knob and 0.28 both ways on the track; a Transition has a single
+             duration, so the knob keeps the 0.34 enter value.
+
+         Spark exit (0.08s fade to 0)         ->  dropped. Unchecking stops the style matching, so
+             the spark snaps back to its parked Opacity="0" - the same "cut it dead" intent the
+             WPF comment states, minus the 80ms ramp. -->
+  <ControlTheme x:Key="ToggleStyle" TargetType="CheckBox">
+    <Setter Property="Template">
+      <ControlTemplate TargetType="CheckBox">
+        <Grid x:Name="toggleRoot">
+          <Border x:Name="track" Width="44" Height="22" CornerRadius="11" Cursor="Hand"
+                  Background="{DynamicResource PanelAccentBrush}"
+                  BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"/>
+          <!-- The ON skin, faded in over the OFF one. Same geometry as the track. -->
+          <Border x:Name="trackOn" Width="44" Height="22" CornerRadius="11" Cursor="Hand"
+                  Opacity="0"
+                  Background="{DynamicResource PinkBrush}"
+                  BorderBrush="{DynamicResource TransparentPink40Brush}" BorderThickness="1">
+            <Border.Transitions>
+              <Transitions>
+                <DoubleTransition Property="Opacity" Duration="0:0:0.28"/>
+              </Transitions>
+            </Border.Transitions>
+          </Border>
+          <!-- Knob: overshoot lands it just shy of the track's inner edge
+               (3 + 22 + ~2.4 + 16 = 43.4 of 44) - do not raise the amplitude
+               without re-checking that sum. -->
+          <Border x:Name="thumb" Width="16" Height="16" CornerRadius="8"
+                      Background="White" HorizontalAlignment="Left" Margin="3,0,0,0"
+                      RenderTransform="translateX(0px)">
+            <Border.Transitions>
+              <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.34">
+                  <TransformOperationsTransition.Easing>
+                    <BackEaseOut/>
+                  </TransformOperationsTransition.Easing>
+                </TransformOperationsTransition>
+              </Transitions>
+            </Border.Transitions>
+          </Border>
+          <!-- Spark: parked invisible at the ON edge (centre x = 33, where the knob
+               lands). Scales from its own centre, so it never moves anything. -->
+          <Ellipse x:Name="spark" Width="12" Height="12" Fill="White"
+                   HorizontalAlignment="Left" VerticalAlignment="Center"
+                   Margin="27,0,0,0" Opacity="0" IsHitTestVisible="False"
+                   RenderTransformOrigin="50%,50%"
+                   RenderTransform="scale(0.4)">
+            <Ellipse.Transitions>
+              <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.45">
+                  <TransformOperationsTransition.Easing>
+                    <QuadraticEaseOut/>
+                  </TransformOperationsTransition.Easing>
+                </TransformOperationsTransition>
+              </Transitions>
+            </Ellipse.Transitions>
+          </Ellipse>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:checked /template/ Border#trackOn">
+      <Setter Property="Opacity" Value="1"/>
+    </Style>
+    <Style Selector="^:checked /template/ Border#thumb">
+      <Setter Property="RenderTransform" Value="translateX(22px)"/>
+    </Style>
+    <Style Selector="^:checked /template/ Ellipse#spark">
+      <!-- The 0.4 -> 3 growth is a Setter + the transition above, NOT a keyframe: Avalonia ships
+           no keyframe animator for RenderTransform, and an <Animation> touching it dies at
+           TEMPLATE APPLY time with "No animator registered for the property RenderTransform" -
+           i.e. the toggle takes the whole window down before it ever draws. Found by rendering.
+           The opacity decay below is genuinely keyframed (three WPF LinearDoubleKeyFrames), and
+           Opacity does have a built-in animator. -->
+      <Setter Property="RenderTransform" Value="scale(3)"/>
+      <Style.Animations>
+        <Animation Duration="0:0:0.45" FillMode="Forward">
+          <KeyFrame Cue="0%">
+            <Setter Property="Opacity" Value="0"/>
+          </KeyFrame>
+          <KeyFrame Cue="13%">
+            <Setter Property="Opacity" Value="0.9"/>
+          </KeyFrame>
+          <KeyFrame Cue="100%">
+            <Setter Property="Opacity" Value="0"/>
+          </KeyFrame>
+        </Animation>
+      </Style.Animations>
+    </Style>
+
+    <!-- A locked toggle used to be pixel-identical to a live one (users read the two as "a bit
+         lost graphically"), because nothing here reacted to IsEnabled. Dim the whole template
+         root rather than the individual parts: trackOn's Opacity is driven by the :checked state
+         above, so a per-part setter would be fighting it on exactly the ON state that most needs
+         the cue. -->
+    <Style Selector="^:disabled /template/ Grid#toggleRoot">
+      <Setter Property="Opacity" Value="0.4"/>
+    </Style>
+    <Style Selector="^:disabled /template/ Border#track">
+      <Setter Property="Cursor" Value="Arrow"/>
+    </Style>
+    <Style Selector="^:disabled /template/ Border#trackOn">
+      <Setter Property="Cursor" Value="Arrow"/>
+    </Style>
+  </ControlTheme>
+
 </ResourceDictionary>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopRosterCell.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopRosterCell.axaml
@@ -1,0 +1,205 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopRosterCell.xaml.
+     Structure, order, spacing and every resource key are preserved so the two can be diffed.
+     Deviations, all forced:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       <Style x:Key TargetType>     ->  <ControlTheme x:Key TargetType>
+       {loc:Str key}                ->  {Binding LocX}               (LocExtension is a WPF
+                                        MarkupExtension and stays in the head; the strings still
+                                        come from CCP.Core's Loc, via the VM)
+       ToolTip="{loc:Str …}"        ->  ToolTip.Tip="{Binding …}"
+       Visibility="Collapsed"       ->  IsVisible="False"
+       MouseLeftButtonDown= /
+       PreviewMouseLeftButtonDown=  ->  wired in the constructor
+       x:FieldModifier="internal"   ->  dropped. It exists so the WPF MainWindow partials can poke
+                                        these TextBlocks by name; this head has no MainWindow API
+                                        surface, so the names stay as plain x:Name — the same
+                                        choice WorkshopCommunityCell made for its panel names.
+       the merged WorkshopCellTheme -> dropped. App.axaml merges that dictionary app-wide, so
+                                       CmpCellValueStyle already resolves here. pack:// URIs do not
+                                       exist on Avalonia. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime.WorkshopRosterCell"
+             x:DataType="vm:WorkshopRosterCellViewModel"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime"
+             mc:Ignorable="d" d:DesignWidth="312">
+
+    <!-- ================================================================
+         Z8 · ROSTER — the five companion cards, re-parented out of the
+         old hero's roster tray (design §6: "kept — Z8 Roster, opened by
+         the hero's Switch chip").
+
+         Every x:Name here is the one the MainWindow partials already
+         write to (UpdateCompanionCardsUI, UpdateCompanionPromptLabels)
+         and every handler forwards to the same MainWindow method the old
+         tab forwarded to. The tray's UniformGrid became a one-column list
+         because a Workshop pigeonhole is 340px wide — that is the only
+         thing about these cards that changed.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ControlTheme x:Key="RosterCardStyle" TargetType="Border">
+            <Setter Property="CornerRadius" Value="7"/>
+            <Setter Property="Padding" Value="9,7"/>
+            <Setter Property="Margin" Value="0,0,0,5"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="Background" Value="#FF1A1A32"/>
+        </ControlTheme>
+    </UserControl.Resources>
+
+    <StackPanel>
+        <!-- The roster's own help affordance rides beside the beta chip, as it did in the tray. -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+            <Border Background="#FF6B6B" CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
+                <TextBlock Text="{Binding LocBeta}" Foreground="White" FontSize="9" FontWeight="Bold"/>
+            </Border>
+            <Button x:Name="HelpBtnCompanions" Theme="{DynamicResource HelpButtonStyle}"
+                    VerticalAlignment="Center" Margin="7,0,0,0" Tag="Companions"/>
+        </StackPanel>
+
+        <Border x:Name="CompanionCard0" Theme="{StaticResource RosterCardStyle}"
+                Tag="0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="TxtCompanion0Name" Text="{Binding LocSyntheticBlowdoll}"
+                                   Foreground="{DynamicResource PinkBrush}" FontSize="11.5" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="TxtCompanion0Lock" Text=" [50]" Foreground="#FFD700"
+                                   FontSize="10" VerticalAlignment="Center" IsVisible="False"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                        <Button x:Name="BtnCompanion0Personality" Content="🎭" FontSize="10" Padding="4,0"
+                                Background="{DynamicResource DarkerBgBrush}" Foreground="#888" BorderThickness="0" Cursor="Hand"
+                                Tag="0"
+                                ToolTip.Tip="{Binding LocTooltipAssignAiPersonality}"/>
+                        <TextBlock x:Name="TxtCompanion0Prompt" Text="" Foreground="#666" FontSize="10"
+                                   VerticalAlignment="Center" Margin="4,0,0,0" TextTrimming="CharacterEllipsis" MaxWidth="150"/>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock x:Name="TxtCompanion0Level" Grid.Column="1" Text="{Binding LocLv1}"
+                           Theme="{StaticResource CmpCellValueStyle}" Foreground="#AAAAAA"/>
+            </Grid>
+        </Border>
+
+        <Border x:Name="CompanionCard1" Theme="{StaticResource RosterCardStyle}"
+                Tag="1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="TxtCompanion1Name" Text="{Binding LocPerfectFuckpuppet}"
+                                   Foreground="#9370DB" FontSize="11.5" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="TxtCompanion1Lock" Text=" [100]" Foreground="#FFD700"
+                                   FontSize="10" VerticalAlignment="Center" IsVisible="False"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                        <Button x:Name="BtnCompanion1Personality" Content="🎭" FontSize="10" Padding="4,0"
+                                Background="{DynamicResource DarkerBgBrush}" Foreground="#888" BorderThickness="0" Cursor="Hand"
+                                Tag="1"
+                                ToolTip.Tip="{Binding LocTooltipAssignAiPersonality}"/>
+                        <TextBlock x:Name="TxtCompanion1Prompt" Text="" Foreground="#666" FontSize="10"
+                                   VerticalAlignment="Center" Margin="4,0,0,0" TextTrimming="CharacterEllipsis" MaxWidth="150"/>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock x:Name="TxtCompanion1Level" Grid.Column="1" Text="{Binding LocLv1}"
+                           Theme="{StaticResource CmpCellValueStyle}" Foreground="#AAAAAA"/>
+            </Grid>
+        </Border>
+
+        <Border x:Name="CompanionCard2" Theme="{StaticResource RosterCardStyle}"
+                Tag="2">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="TxtCompanion2Name" Text="{Binding LocBrainwashedSlavedoll}"
+                                   Foreground="#50C878" FontSize="11.5" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="TxtCompanion2Lock" Text=" [125]" Foreground="#FFD700"
+                                   FontSize="10" VerticalAlignment="Center" IsVisible="False"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                        <Button x:Name="BtnCompanion2Personality" Content="🎭" FontSize="10" Padding="4,0"
+                                Background="{DynamicResource DarkerBgBrush}" Foreground="#888" BorderThickness="0" Cursor="Hand"
+                                Tag="2"
+                                ToolTip.Tip="{Binding LocTooltipAssignAiPersonality}"/>
+                        <TextBlock x:Name="TxtCompanion2Prompt" Text="" Foreground="#666" FontSize="10"
+                                   VerticalAlignment="Center" Margin="4,0,0,0" TextTrimming="CharacterEllipsis" MaxWidth="150"/>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock x:Name="TxtCompanion2Level" Grid.Column="1" Text="{Binding LocLv1}"
+                           Theme="{StaticResource CmpCellValueStyle}" Foreground="#AAAAAA"/>
+            </Grid>
+        </Border>
+
+        <Border x:Name="CompanionCard3" Theme="{StaticResource RosterCardStyle}"
+                Tag="3">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="TxtCompanion3Name" Text="{Binding LocPlatinumPuppet}"
+                                   Foreground="#FF6B6B" FontSize="11.5" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="TxtCompanion3Lock" Text=" [150]" Foreground="#FFD700"
+                                   FontSize="10" VerticalAlignment="Center" IsVisible="False"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                        <Button x:Name="BtnCompanion3Personality" Content="🎭" FontSize="10" Padding="4,0"
+                                Background="{DynamicResource DarkerBgBrush}" Foreground="#888" BorderThickness="0" Cursor="Hand"
+                                Tag="3"
+                                ToolTip.Tip="{Binding LocTooltipAssignAiPersonality}"/>
+                        <TextBlock x:Name="TxtCompanion3Prompt" Text="" Foreground="#666" FontSize="10"
+                                   VerticalAlignment="Center" Margin="4,0,0,0" TextTrimming="CharacterEllipsis" MaxWidth="150"/>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock x:Name="TxtCompanion3Level" Grid.Column="1" Text="{Binding LocLv1}"
+                           Theme="{StaticResource CmpCellValueStyle}" Foreground="#AAAAAA"/>
+            </Grid>
+        </Border>
+
+        <Border x:Name="CompanionCard4" Theme="{StaticResource RosterCardStyle}"
+                Tag="4">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="TxtCompanion4Name" Text="{Binding LocBambiCow}"
+                                   Foreground="#F5DEB3" FontSize="11.5" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="TxtCompanion4Lock" Text=" [75]" Foreground="#FFD700"
+                                   FontSize="10" VerticalAlignment="Center" IsVisible="False"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0">
+                        <Button x:Name="BtnCompanion4Personality" Content="🎭" FontSize="10" Padding="4,0"
+                                Background="{DynamicResource DarkerBgBrush}" Foreground="#888" BorderThickness="0" Cursor="Hand"
+                                Tag="4"
+                                ToolTip.Tip="{Binding LocTooltipAssignAiPersonality}"/>
+                        <TextBlock x:Name="TxtCompanion4Prompt" Text="" Foreground="#666" FontSize="10"
+                                   VerticalAlignment="Center" Margin="4,0,0,0" TextTrimming="CharacterEllipsis" MaxWidth="150"/>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock x:Name="TxtCompanion4Level" Grid.Column="1" Text="{Binding LocLv1}"
+                           Theme="{StaticResource CmpCellValueStyle}" Foreground="#AAAAAA"/>
+            </Grid>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopRosterCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopRosterCell.axaml.cs
@@ -1,0 +1,73 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>
+    /// Z8 · ROSTER. See the XAML header.
+    ///
+    /// <para>Like every re-parented cell, this control does no work of its own: it forwards to the
+    /// MainWindow handler the old tab forwarded to, so the roster's behaviour is byte-for-byte what
+    /// it was before the move.</para>
+    /// </summary>
+    public partial class WorkshopRosterCell : UserControl
+    {
+        // The WPF cell forwards both clicks to MainWindow (Window.GetWindow(this) is MainWindow).
+        // This head has no MainWindow API surface yet and the cell must not grow App. coupling, so
+        // the two actions leave the cell as events and the host wires them - the same contract, one
+        // indirection later. Unlike the sibling cells' bare EventHandler these carry the card index,
+        // which is what MainWindow.CompanionCard_Click / BtnCompanionPersonality_Click parse out of
+        // the sender's Tag; the Tag stays on the markup so the two files still diff.
+        public event EventHandler<int>? CompanionCardClicked;
+        public event EventHandler<int>? PersonalityAssignRequested;
+
+        public WorkshopRosterCell()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new WorkshopRosterCellViewModel();
+
+            for (int i = 0; i < 5; i++)
+            {
+                int index = i;
+
+                // WPF's MouseLeftButtonDown is left-button-only; Avalonia's PointerPressed fires for
+                // every button, so the guard below is what keeps a right-click from switching
+                // companions. That guard is the only new mechanic in this port.
+                this.FindControl<Border>($"CompanionCard{index}")!.PointerPressed += (s, e) =>
+                {
+                    if (e.GetCurrentPoint((Border)s!).Properties.IsLeftButtonPressed)
+                        CompanionCardClicked?.Invoke(this, index);
+                };
+
+                // WPF needed PreviewMouseLeftButtonDown here (plus a visual-tree walk in
+                // MainWindow.CompanionCard_Click that ignores clicks originating inside a
+                // "Personality" button) because the card's bubbling MouseLeftButtonDown would
+                // otherwise fire too. Neither is ported: Avalonia's Button marks PointerPressed
+                // handled, and a routed handler does not see handled events by default, so the
+                // card's handler never runs for a click on this button.
+                this.FindControl<Button>($"BtnCompanion{index}Personality")!.Click +=
+                    (_, _) => PersonalityAssignRequested?.Invoke(this, index);
+            }
+        }
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding.</summary>
+    public sealed class WorkshopRosterCellViewModel
+    {
+        public string LocBeta => Loc.Get("label_beta");
+        public string LocSyntheticBlowdoll => Loc.Get("label_synthetic_blowdoll");
+        public string LocPerfectFuckpuppet => Loc.Get("label_perfect_fuckpuppet");
+        public string LocBrainwashedSlavedoll => Loc.Get("label_brainwashed_slavedoll");
+        public string LocPlatinumPuppet => Loc.Get("label_platinum_puppet");
+        public string LocBambiCow => Loc.Get("label_bambi_cow");
+        public string LocTooltipAssignAiPersonality => Loc.Get("tooltip_assign_ai_personality");
+        // Placeholder only, exactly as in WPF: the host overwrites TxtCompanionNLevel.Text with
+        // "MAX" or $"Lv.{progress.Level}" (MainWindow.CompanionTab.cs:117). The five card names and
+        // the prompt labels are likewise re-written from there once mods and progress are known.
+        public string LocLv1 => Loc.Get("label_lv_1");
+    }
+}

--- a/CCP.Avalonia/Views/Controls/ProfilePrivacyPanel.axaml
+++ b/CCP.Avalonia/Views/Controls/ProfilePrivacyPanel.axaml
@@ -1,0 +1,216 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/ProfilePrivacyPanel.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Documented deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource ToggleStyle}" -> Theme="{StaticResource ToggleStyle}"
+                                        (a keyed style is a ControlTheme; ToggleStyle itself is
+                                        ported in Theme/Styles.xaml by this change)
+       {loc:Str key}                 ->  {Binding LocX}   (LocExtension is a WPF MarkupExtension
+                                        and stays in the head; the strings still come from
+                                        CCP.Core's Loc, via the view-model beside this view)
+       ToolTip="..."                 ->  ToolTip.Tip="..."
+       Content="{loc:Str btn_login}" ->  a <TextBlock> child (Avalonia parses "_" in Content as an
+                                        access key and every loc key here is snake_case)
+       x:FieldModifier="internal"    ->  dropped. On WPF those fields exist so MainWindow can poke
+                                        ~25 `DiscordTab.Chk*` writes at this panel; the Avalonia
+                                        head has no such host yet, so exposing the fields would
+                                        advertise a contract nothing implements. The x:Names are
+                                        kept, so re-adding the accessors later is mechanical.
+
+     Every Checked/Unchecked handler and the login Click are LEFT UNWIRED - see the code-behind. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.ProfilePrivacyPanel"
+             x:DataType="vm:ProfilePrivacyPanelViewModel"
+             xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls"
+             d:DesignHeight="700" d:DesignWidth="420"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+
+    <!-- ================================================================
+         PRIVACY & SHARING  (Profile redesign, Phase 1 "Reclaim")
+
+         This panel owns every toggle that used to live in the Profile
+         tab's right-hand column. It is a RELOCATION, not a behaviour
+         change: the x:Names, the Checked/Unchecked handlers and the
+         defaults are byte-for-byte what shipped on DiscordTabView.
+
+         Lifetime trap: the instance is created once by DiscordTabView
+         and handed to ProfilePrivacyDialog while the dialog is open, so
+         MainWindow's ~25 `DiscordTab.Chk*` writes keep landing whether
+         or not the dialog is on screen. Because it is therefore NOT in
+         MainWindow's visual tree, its handlers cannot use
+         Window.GetWindow(this) - see the code-behind's MainWindow lookup.
+
+         De-blurple rule: #5865F2 survives ONLY on the Discord connection
+         card at the top. Every group header is pink/purple.
+         ================================================================ -->
+
+    <StackPanel>
+
+        <!-- ==== Discord connection (blurple lives here, and only here) ==== -->
+        <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="10" Padding="15"
+                Margin="0,0,0,16" BorderBrush="#5865F2" BorderThickness="1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock x:Name="TxtDiscordTabStatus"
+                               Text="{Binding LocNotConnected}" Foreground="White"
+                               FontSize="14" FontWeight="Bold" TextTrimming="CharacterEllipsis"/>
+                    <TextBlock x:Name="TxtDiscordTabInfo"
+                               Text="{Binding LocLinkDiscordForCommunityFeatures}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               Margin="0,2,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+                <Button x:Name="BtnDiscordTabLogin" Grid.Column="1"
+                        Background="#5865F2" Foreground="White"
+                        BorderThickness="0" Padding="15,8" Margin="10,0,0,0" FontWeight="Bold"
+                        FontSize="11" Cursor="Hand">
+                    <TextBlock Text="{Binding LocLogin}"/>
+                </Button>
+            </Grid>
+        </Border>
+
+        <!-- ==== Presence ==== -->
+        <TextBlock Text="{Binding LocGroupPresence}"
+                   Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="Bold"
+                   Margin="0,0,0,10"/>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocDiscordRichPresence}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocShowYourActivityStatus}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabRichPresence" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocShowLevelInStatus}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocDisplayYourLevel}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabShowLevel" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center" IsChecked="True"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocShowOnlineStatus}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocAppearOfflineWhenDisabled}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabShowOnline" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center" IsChecked="True"/>
+            </Grid>
+        </Border>
+
+        <!-- ==== Community sharing ==== -->
+        <TextBlock Text="{Binding LocCommunitySharing}"
+                   Foreground="#B478FF" FontSize="13" FontWeight="Bold" Margin="0,14,0,10"/>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocShareAchievements}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocPostAchievementsToDiscord}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabShareAchievements" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocShareLevelMilestones}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocPostLevelUpsToDiscord}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabShareLevelUps" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocAllowDmsFromLeaderboard}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocLetOthersMessageYou}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabAllowDm" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocShareProfilePicture}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocShowYourAvatarToOthers}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkDiscordTabSharePfp" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <!-- Sibling of the toggle above, deliberately adjacent so the pair reads as
+             "signed in users" then "the whole internet". Separate consent: the one above
+             never covers the public web card. Bordered because the audience is unbounded. -->
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8"
+                BorderBrush="#B478FF" BorderThickness="1"
+                ToolTip.Tip="{Binding LocTooltipPublicShareRealAvatar}">
+            <Grid>
+                <StackPanel Margin="0,0,50,0">
+                    <TextBlock Text="{Binding LocPublicShareRealAvatar}" Foreground="White" FontSize="12" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                    <TextBlock Text="{Binding LocPublicShareRealAvatarDesc}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" TextWrapping="Wrap"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkPublicShareRealAvatar" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <!-- ==== Goon Game sharing (opt-in, sharer-only; all three default OFF).
+                 Separate audience from the community-sharing block above: these only
+                 affect the person you are currently duelling. ==== -->
+        <TextBlock Text="{Binding LocGoonGameSharing}"
+                   Foreground="#FFD700" FontSize="13" FontWeight="Bold" Margin="0,14,0,10"/>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8"
+                ToolTip.Tip="{Binding LocTooltipGoonShareAvatar}">
+            <Grid>
+                <TextBlock Text="{Binding LocGoonShareAvatar}" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                           VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,50,0"/>
+                <CheckBox x:Name="ChkGoonShareAvatar" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8"
+                ToolTip.Tip="{Binding LocTooltipGoonShareDiscordDm}">
+            <Grid>
+                <TextBlock Text="{Binding LocGoonShareDiscordDm}" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                           VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,50,0"/>
+                <CheckBox x:Name="ChkGoonShareDiscordDm" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+        <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,8"
+                ToolTip.Tip="{Binding LocTooltipGoonRichPresence}">
+            <Grid>
+                <TextBlock Text="{Binding LocGoonRichPresence}" Foreground="White" FontSize="12" FontWeight="SemiBold"
+                           VerticalAlignment="Center" TextWrapping="Wrap" Margin="0,0,50,0"/>
+                <CheckBox x:Name="ChkGoonRichPresence" Theme="{StaticResource ToggleStyle}"
+                          HorizontalAlignment="Right" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/ProfilePrivacyPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/ProfilePrivacyPanel.axaml.cs
@@ -1,0 +1,78 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// The Profile tab's "Privacy &amp; Sharing" body, ported from the WPF head.
+    ///
+    /// NOTHING HERE IS WIRED, deliberately. Every one of the WPF panel's twelve handlers is a
+    /// one-line forward to the identically-named <c>MainWindow</c> method
+    /// (<c>Host?.ChkShareAchievements_Changed(sender, e)</c>, ...), and that MainWindow is a
+    /// <c>System.Windows.Window</c> living in the WPF head - it cannot be reached from here, and
+    /// the Avalonia head has no equivalent host yet. A stub would silently pretend the settings
+    /// were being saved, which on a PRIVACY panel is the worst possible failure mode: the user
+    /// flips "share my real avatar" off, sees the knob move, and nothing is written.
+    ///
+    /// So the toggles render and animate but persist nothing. Wiring them needs the settings
+    /// surface that MainWindow provides today; that is a separate change from proving the view
+    /// draws. The x:Names are preserved, so each handler is a one-liner once a host exists.
+    /// </summary>
+    public partial class ProfilePrivacyPanel : UserControl
+    {
+        public ProfilePrivacyPanel()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new ProfilePrivacyPanelViewModel();
+        }
+    }
+
+    /// <summary>
+    /// Supplies the strings the view binds to, all from CCP.Core's <see cref="Loc"/> - the same
+    /// runtime and the same JSON the WPF head reads. This exists because WPF's {loc:Str key}
+    /// markup extension derives from System.Windows.Markup.MarkupExtension and stays in the head.
+    ///
+    /// Every key below is static in the original markup; none of them is formatted. The three
+    /// controls MainWindow.Browser.cs overwrites at runtime (TxtDiscordTabStatus,
+    /// TxtDiscordTabInfo, BtnDiscordTabLogin) take their markup default here, exactly as the WPF
+    /// panel does before a Discord connection exists - the "connected" strings
+    /// (label_connected_as_0, label_discord_account_linked, btn_logout, btn_link_discord_2) are
+    /// set by that host, which is not ported, so they are not modelled here.
+    /// </summary>
+    public sealed class ProfilePrivacyPanelViewModel
+    {
+        public string LocNotConnected => Loc.Get("label_not_connected");
+        public string LocLinkDiscordForCommunityFeatures => Loc.Get("label_link_discord_for_community_features");
+        public string LocLogin => Loc.Get("btn_login");
+
+        public string LocGroupPresence => Loc.Get("profile_privacy_group_presence");
+        public string LocDiscordRichPresence => Loc.Get("label_discord_rich_presence");
+        public string LocShowYourActivityStatus => Loc.Get("label_show_your_activity_status");
+        public string LocShowLevelInStatus => Loc.Get("label_show_level_in_status");
+        public string LocDisplayYourLevel => Loc.Get("label_display_your_level");
+        public string LocShowOnlineStatus => Loc.Get("label_show_online_status");
+        public string LocAppearOfflineWhenDisabled => Loc.Get("label_appear_offline_when_disabled");
+
+        public string LocCommunitySharing => Loc.Get("label_community_sharing");
+        public string LocShareAchievements => Loc.Get("label_share_achievements");
+        public string LocPostAchievementsToDiscord => Loc.Get("label_post_achievements_to_discord");
+        public string LocShareLevelMilestones => Loc.Get("label_share_level_milestones");
+        public string LocPostLevelUpsToDiscord => Loc.Get("label_post_level_ups_to_discord");
+        public string LocAllowDmsFromLeaderboard => Loc.Get("label_allow_dms_from_leaderboard");
+        public string LocLetOthersMessageYou => Loc.Get("label_let_others_message_you");
+        public string LocShareProfilePicture => Loc.Get("label_share_profile_picture");
+        public string LocShowYourAvatarToOthers => Loc.Get("label_show_your_avatar_to_others");
+        public string LocTooltipPublicShareRealAvatar => Loc.Get("tooltip_public_share_real_avatar");
+        public string LocPublicShareRealAvatar => Loc.Get("label_public_share_real_avatar");
+        public string LocPublicShareRealAvatarDesc => Loc.Get("label_public_share_real_avatar_desc");
+
+        public string LocGoonGameSharing => Loc.Get("label_goon_game_sharing");
+        public string LocTooltipGoonShareAvatar => Loc.Get("tooltip_goon_share_avatar");
+        public string LocGoonShareAvatar => Loc.Get("label_goon_share_avatar");
+        public string LocTooltipGoonShareDiscordDm => Loc.Get("tooltip_goon_share_discord_dm");
+        public string LocGoonShareDiscordDm => Loc.Get("label_goon_share_discord_dm");
+        public string LocTooltipGoonRichPresence => Loc.Get("tooltip_goon_rich_presence");
+        public string LocGoonRichPresence => Loc.Get("label_goon_rich_presence");
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml
@@ -1,0 +1,163 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/OpenAiCompatibleSamplerSettingsDialog.xaml.
+     Deviations, all forced:
+       ResizeMode="NoResize"            -> CanResize="False"
+       <Style x:Key TargetType>         -> <ControlTheme x:Key TargetType>
+       Style="{StaticResource X}"       -> Theme="{StaticResource X}"
+       Visibility="Collapsed"           -> IsVisible="False"
+       {loc:Str key}                    -> a binding
+       Content="{loc:Str …}" on Button
+         and on CheckBox                -> a TextBlock child (Avalonia parses "_" as an access key,
+                                           and every loc key here is snake_case)
+       BasedOn="{StaticResource {x:Type …}}" on the two templated-control themes.
+           WPF's keyed Style only overrides setters and keeps the default ControlTemplate; an
+           Avalonia ControlTheme REPLACES the control's theme wholesale, so without BasedOn the
+           TextBoxes and Buttons get a null template and render as nothing. Compiles clean, throws
+           nothing - only a render shows it. SamplerLabel needs no BasedOn: TextBlock is untemplated.
+       Checked/Unchecked -> one IsCheckedChanged handler, wired in the code-behind.
+     IsDefault/IsCancel exist in Avalonia and are kept, so Enter and Escape behave as before -
+     except that Avalonia's IsCancel only raises Click, it does not set a result, so Cancel's Click
+     closes with false explicitly. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.OpenAiCompatibleSamplerSettingsDialog"
+        x:DataType="d:OpenAiCompatibleSamplerSettingsViewModel"
+        xmlns:d="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Title="{Binding LocTitle}"
+        Width="420" Height="520"
+        Background="{DynamicResource DarkerBgBrush}"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False">
+
+    <Window.Resources>
+        <ControlTheme x:Key="SamplerLabel" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Margin" Value="0,0,0,4"/>
+        </ControlTheme>
+        <ControlTheme x:Key="SamplerInput" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#505050"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="6,4"/>
+            <Setter Property="FontSize" Value="13"/>
+        </ControlTheme>
+        <ControlTheme x:Key="SamplerButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="Padding" Value="14,6"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="20,16,20,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="{Binding LocTitle}"
+                   Foreground="White" FontSize="16" FontWeight="Bold" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="1" Text="{Binding LocHint}"
+                   Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                   TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <CheckBox x:Name="ChkUseCustomSamplers" Margin="0,0,0,12"
+                          Foreground="White" FontSize="13">
+                    <TextBlock Text="{Binding LocUseCustom}"/>
+                </CheckBox>
+
+                <Grid x:Name="InputsPanel" IsEnabled="False">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="12"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0" Grid.Column="0" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocTemperature}"/>
+                        <TextBox x:Name="TxtTemperature" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="0" Grid.Column="2" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocTopP}"/>
+                        <TextBox x:Name="TxtTopP" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocTopK}"/>
+                        <TextBox x:Name="TxtTopK" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="1" Grid.Column="2" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocMinP}"/>
+                        <TextBox x:Name="TxtMinP" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocFrequencyPenalty}"/>
+                        <TextBox x:Name="TxtFrequencyPenalty" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="2" Grid.Column="2" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocPresencePenalty}"/>
+                        <TextBox x:Name="TxtPresencePenalty" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="3" Grid.Column="0" Margin="0,0,0,10">
+                        <TextBlock Theme="{StaticResource SamplerLabel}" Text="{Binding LocRepetitionPenalty}"/>
+                        <TextBox x:Name="TxtRepetitionPenalty" Theme="{StaticResource SamplerInput}"/>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </ScrollViewer>
+
+        <TextBlock x:Name="TxtError" Grid.Row="3" Foreground="#FFFF6B6B" FontSize="11"
+                   TextWrapping="Wrap" Margin="0,8,0,0" IsVisible="False"/>
+
+        <Grid Grid.Row="4" Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <Button Grid.Column="0" x:Name="BtnReset" Theme="{StaticResource SamplerButton}"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderBrush="#505050" BorderThickness="1">
+                <TextBlock Text="{Binding LocResetDefaults}"/>
+            </Button>
+
+            <Button Grid.Column="2" x:Name="BtnCancel" Theme="{StaticResource SamplerButton}"
+                    IsCancel="True"
+                    Background="Transparent" Foreground="{DynamicResource TextLightBrush}"
+                    BorderBrush="#505050" BorderThickness="1" Margin="0,0,10,0">
+                <TextBlock Text="{Binding LocCancel}"/>
+            </Button>
+
+            <Button Grid.Column="3" x:Name="BtnOk" Theme="{StaticResource SamplerButton}"
+                    IsDefault="True"
+                    Background="{StaticResource PinkBrush}" Foreground="White"
+                    BorderThickness="0">
+                <TextBlock Text="{Binding LocOk}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Modal editor for the OpenAI-compatible provider's sampler parameters.
+    /// Only populated values are persisted; empty fields become null and are
+    /// omitted from the outbound request so strict OpenAI endpoints don't see
+    /// unsupported keys like top_k/repetition_penalty/min_p.
+    ///
+    /// Ported from the WPF head. WPF's <c>DialogResult</c> has no Avalonia equivalent, so the
+    /// dialog closes with <c>Close(bool)</c> and the caller awaits <c>ShowDialog&lt;bool&gt;</c>;
+    /// dismissing the window with the X yields <c>default(bool)</c> = false, which is what the
+    /// WPF caller's <c>ShowDialog() == true</c> did too.
+    /// </summary>
+    public partial class OpenAiCompatibleSamplerSettingsDialog : Window
+    {
+        private readonly CompanionPromptSettings _settings;
+
+        private readonly CheckBox _chkUseCustomSamplers;
+        private readonly Grid _inputsPanel;
+        private readonly TextBox _txtTemperature;
+        private readonly TextBox _txtTopP;
+        private readonly TextBox _txtTopK;
+        private readonly TextBox _txtMinP;
+        private readonly TextBox _txtFrequencyPenalty;
+        private readonly TextBox _txtPresencePenalty;
+        private readonly TextBox _txtRepetitionPenalty;
+        private readonly TextBlock _txtError;
+
+        public OpenAiCompatibleSamplerSettingsDialog(CompanionPromptSettings settings)
+        {
+            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new OpenAiCompatibleSamplerSettingsViewModel();
+
+            _chkUseCustomSamplers = this.FindControl<CheckBox>("ChkUseCustomSamplers")!;
+            _inputsPanel = this.FindControl<Grid>("InputsPanel")!;
+            _txtTemperature = this.FindControl<TextBox>("TxtTemperature")!;
+            _txtTopP = this.FindControl<TextBox>("TxtTopP")!;
+            _txtTopK = this.FindControl<TextBox>("TxtTopK")!;
+            _txtMinP = this.FindControl<TextBox>("TxtMinP")!;
+            _txtFrequencyPenalty = this.FindControl<TextBox>("TxtFrequencyPenalty")!;
+            _txtPresencePenalty = this.FindControl<TextBox>("TxtPresencePenalty")!;
+            _txtRepetitionPenalty = this.FindControl<TextBox>("TxtRepetitionPenalty")!;
+            _txtError = this.FindControl<TextBlock>("TxtError")!;
+
+            // WPF wired Checked and Unchecked to one handler; Avalonia raises both as
+            // IsCheckedChanged.
+            _chkUseCustomSamplers.IsCheckedChanged += (_, _) => UpdateInputState();
+            this.FindControl<Button>("BtnReset")!.Click += (_, _) => Reset();
+            // Avalonia's IsCancel only raises Click - unlike WPF it does not set a result - so
+            // the false is explicit here, as it was in BtnCancel_Click.
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnOk")!.Click += (_, _) => Accept();
+
+            Loaded += (_, _) => LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _chkUseCustomSamplers.IsChecked = _settings.OpenAiCompatibleUseCustomSamplerSettings;
+            UpdateInputState();
+
+            _txtTemperature.Text = FormatNullable(_settings.OpenAiCompatibleTemperature);
+            _txtTopP.Text = FormatNullable(_settings.OpenAiCompatibleTopP);
+            _txtTopK.Text = FormatNullable(_settings.OpenAiCompatibleTopK);
+            _txtFrequencyPenalty.Text = FormatNullable(_settings.OpenAiCompatibleFrequencyPenalty);
+            _txtPresencePenalty.Text = FormatNullable(_settings.OpenAiCompatiblePresencePenalty);
+            _txtRepetitionPenalty.Text = FormatNullable(_settings.OpenAiCompatibleRepetitionPenalty);
+            _txtMinP.Text = FormatNullable(_settings.OpenAiCompatibleMinP);
+        }
+
+        private static string FormatNullable(double? value)
+            => value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
+
+        private static string FormatNullable(int? value)
+            => value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
+
+        private void UpdateInputState()
+        {
+            _inputsPanel.IsEnabled = _chkUseCustomSamplers.IsChecked == true;
+        }
+
+        private void Reset()
+        {
+            _chkUseCustomSamplers.IsChecked = false;
+            _txtTemperature.Text = string.Empty;
+            _txtTopP.Text = string.Empty;
+            _txtTopK.Text = string.Empty;
+            _txtFrequencyPenalty.Text = string.Empty;
+            _txtPresencePenalty.Text = string.Empty;
+            _txtRepetitionPenalty.Text = string.Empty;
+            _txtMinP.Text = string.Empty;
+            UpdateInputState();
+            _txtError.IsVisible = false;
+        }
+
+        private void Accept()
+        {
+            _txtError.IsVisible = false;
+
+            var useCustom = _chkUseCustomSamplers.IsChecked == true;
+
+            if (!useCustom)
+            {
+                _settings.OpenAiCompatibleUseCustomSamplerSettings = false;
+                Close(true);
+                return;
+            }
+
+            // Permissive sane-guards: block only mathematically-impossible / clearly
+            // fat-fingered values, NOT cloud limits. This provider targets local
+            // backends (Ollama / vLLM / text-generation-webui) that allow far wider
+            // ranges than OpenAI cloud (e.g. temperature up to ~5+). top_p and min_p
+            // are cumulative probabilities so they are hard-bounded to 0..1; top_k
+            // accepts -1 as the "disabled" sentinel used by vLLM and others.
+            if (!TryParseDouble(_txtTemperature.Text, "temperature", 0d, 10d, out var temperature)
+                || !TryParseDouble(_txtTopP.Text, "top_p", 0d, 1d, out var topP)
+                || !TryParseInt(_txtTopK.Text, "top_k", -1, int.MaxValue, out var topK)
+                || !TryParseDouble(_txtFrequencyPenalty.Text, "frequency_penalty", -2d, 2d, out var frequencyPenalty)
+                || !TryParseDouble(_txtPresencePenalty.Text, "presence_penalty", -2d, 2d, out var presencePenalty)
+                || !TryParseDouble(_txtRepetitionPenalty.Text, "repetition_penalty", 0d, 10d, out var repetitionPenalty)
+                || !TryParseDouble(_txtMinP.Text, "min_p", 0d, 1d, out var minP))
+            {
+                return;
+            }
+
+            _settings.OpenAiCompatibleUseCustomSamplerSettings = true;
+            _settings.OpenAiCompatibleTemperature = temperature;
+            _settings.OpenAiCompatibleTopP = topP;
+            _settings.OpenAiCompatibleTopK = topK;
+            _settings.OpenAiCompatibleFrequencyPenalty = frequencyPenalty;
+            _settings.OpenAiCompatiblePresencePenalty = presencePenalty;
+            _settings.OpenAiCompatibleRepetitionPenalty = repetitionPenalty;
+            _settings.OpenAiCompatibleMinP = minP;
+
+            Close(true);
+        }
+
+        private bool TryParseDouble(string? text, string fieldName, double min, double max, out double? value)
+        {
+            value = null;
+            var trimmed = (text ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(trimmed)) return true;
+
+            if (!double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+            {
+                ShowError($"'{fieldName}' must be a number.");
+                return false;
+            }
+
+            if (parsed < min || parsed > max)
+            {
+                ShowError($"'{fieldName}' must be between {min.ToString(CultureInfo.InvariantCulture)} and {max.ToString(CultureInfo.InvariantCulture)}.");
+                return false;
+            }
+
+            value = parsed;
+            return true;
+        }
+
+        private bool TryParseInt(string? text, string fieldName, int min, int max, out int? value)
+        {
+            value = null;
+            var trimmed = (text ?? string.Empty).Trim();
+            if (string.IsNullOrEmpty(trimmed)) return true;
+
+            if (!int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                ShowError($"'{fieldName}' must be a whole number.");
+                return false;
+            }
+
+            if (parsed < min || parsed > max)
+            {
+                ShowError($"'{fieldName}' must be between {min} and {max}.");
+                return false;
+            }
+
+            value = parsed;
+            return true;
+        }
+
+        private void ShowError(string message)
+        {
+            _txtError.Text = message;
+            _txtError.IsVisible = true;
+        }
+    }
+
+    public sealed class OpenAiCompatibleSamplerSettingsViewModel
+    {
+        public string LocTitle => Loc.Get("dialog_openai_sampler_title");
+        public string LocHint => Loc.Get("hint_sampler_settings");
+        public string LocUseCustom => Loc.Get("label_sampler_use_custom_settings");
+        public string LocTemperature => Loc.Get("label_sampler_temperature");
+        public string LocTopP => Loc.Get("label_sampler_top_p");
+        public string LocTopK => Loc.Get("label_sampler_top_k");
+        public string LocMinP => Loc.Get("label_sampler_min_p");
+        public string LocFrequencyPenalty => Loc.Get("label_sampler_frequency_penalty");
+        public string LocPresencePenalty => Loc.Get("label_sampler_presence_penalty");
+        public string LocRepetitionPenalty => Loc.Get("label_sampler_repetition_penalty");
+        public string LocResetDefaults => Loc.Get("label_sampler_reset_defaults");
+        public string LocCancel => Loc.Get("btn_cancel");
+        public string LocOk => Loc.Get("btn_ok");
+    }
+}


### PR DESCRIPTION
Layer 14. Includes the ToggleStyle switch port; the PR body of the fork's original notes the ControlTheme-without-BasedOn trap it found.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351