### PR TITLE
feat(avalonia): port AwarenessAppPickerDialog and AttentionGaugeView

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml
@@ -1,0 +1,190 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/AttentionGaugeView.xaml.
+     Structure, ordering, spacing, comments and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"      ->  Theme="{StaticResource X}"
+       <Style x:Key TargetType>        ->  <ControlTheme x:Key TargetType>
+       Style.Triggers / DataTrigger    ->  a class binding + a nested <Style Selector="^.class">
+                                           Avalonia has no triggers; Classes.foo="{Binding Bool}"
+                                           is the supported way to drive one off viewmodel state.
+       ControlTemplate.Triggers        ->  <Style Selector="...:pointerover /template/ ...">
+                                           A ControlTemplate cannot carry a Style, so the upsell
+                                           button's hover rule moved to UserControl.Styles and
+                                           the button had to be named to keep the rule targeted.
+       <ContentPresenter/>             ->  Name="PART_ContentPresenter" + TemplateBindings
+       Visibility=/{CmpBoolToVis}      ->  IsVisible bound straight to the bool
+       ToolTip="..."                   ->  ToolTip.Tip="..."
+       {loc:Str key}                   ->  a binding (LocExtension is a WPF MarkupExtension and
+                                           stays in the head; the strings still come from
+                                           CCP.Core's LocalizationManager, via the viewmodel)
+       <Image {CmpEmojiToImage}>       ->  <TextBlock Text="💗"/>; Avalonia draws colour emoji
+                                           natively, so the Twemoji pipeline is not needed.
+
+     Verified rather than assumed: an Avalonia ColumnDefinition is NOT a StyledElement (its base
+     chain is DefinitionBase -> AvaloniaObject, no DataContext property), so the star-width
+     binding below looked like it could not resolve. It does - measured headless on 12.1.1, the
+     0.72/0.28 pair lands on 288px/112px of a 400px track. The Trainer Card recipe survives the
+     port unchanged; no ActualWidth arithmetic was introduced. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.AttentionGaugeView"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             x:DataType="local:AttentionGaugeViewModel"
+             mc:Ignorable="d"
+             d:DesignWidth="430" d:DesignHeight="170">
+
+    <!-- ================================================================
+         Z6 — HER ATTENTION (the daily budget meter).
+         Elegant, not scary. Copy rules, non-negotiable:
+           · never the word "tokens" — the ladder is in chats, in her voice
+           · the floor is not mute: barks keep playing, and the card says
+             so OUT LOUD — FloorNote is a resting line, never hover-gated
+           · the Patreon line appears below 40% only, once, quietly
+           · the numeric detail is on demand (hover or click), never resting
+
+         The bar is the Trainer Card recipe: a star-width fill column, no
+         ActualWidth arithmetic. At zero it keeps a 4% sliver so a spent
+         meter reads as empty rather than broken. This XAML knows no
+         numbers at all: the spent styling asks IsSpent and the floor note
+         asks ShowFloorNote, both computed in AttentionCopy where the
+         thresholds live and are unit-tested.
+
+         Thresholds live in AttentionCopy, not here, so they are
+         unit-tested and exist in exactly one place.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- the spent bar: same geometry, no heat. Keyed off IsSpent (intent), never off
+                 BarFraction == 0.04 — the sliver and a real 4% are the same double, and a user
+                 with 4 chats left was getting the "she'll be all yours tomorrow" treatment while
+                 the copy beside it said otherwise. -->
+            <ControlTheme x:Key="CmpZ6AttentionFillStyle" TargetType="Border"
+                          BasedOn="{StaticResource CmpGaugeFillAttentionStyle}">
+                <Style Selector="^.spent">
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Opacity" Value="0.70"/>
+                </Style>
+            </ControlTheme>
+
+            <!-- detail-on-demand: revealed by the toggle command OR by hovering the card.
+                 The WPF original was two DataTriggers on one style. Only the first survives as a
+                 class here; the second asked an ANCESTOR Button for IsMouseOver, which a nested
+                 style cannot reach, so it lives in UserControl.Styles below as a descendant
+                 selector. Both still resolve to "visible", and the un-hovered, un-toggled state
+                 still falls back to this theme's IsVisible="False". -->
+            <ControlTheme x:Key="CmpZ6DetailLineStyle" TargetType="TextBlock"
+                          BasedOn="{StaticResource CmpFaintTextStyle}">
+                <Setter Property="FontSize" Value="10"/>
+                <Setter Property="Margin" Value="0,4,0,0"/>
+                <Setter Property="IsVisible" Value="False"/>
+                <Style Selector="^.shown">
+                    <Setter Property="IsVisible" Value="True"/>
+                </Style>
+            </ControlTheme>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <!-- the second half of the detail line's trigger pair: hovering the gauge button.
+             A Style outranks a ControlTheme, so this wins over the theme's IsVisible="False"
+             while the pointer is over the card and releases it again on exit. -->
+        <Style Selector="Button:pointerover TextBlock#Z6DetailLine">
+            <Setter Property="IsVisible" Value="True"/>
+        </Style>
+        <!-- ControlTemplate.Triggers replacement for the upsell link's hover colour. -->
+        <Style Selector="Button#Z6UpsellButton:pointerover /template/ TextBlock#Txt">
+            <Setter Property="Foreground" Value="#FFFF9CCE"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Theme="{StaticResource CmpCardStyle}">
+        <StackPanel>
+
+            <!-- ========== header ========== -->
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="💗" FontSize="16" Margin="0,0,9,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding LocTitle}" Theme="{StaticResource CmpSectionTitleStyle}"/>
+                </StackPanel>
+                <Border Grid.Column="2" Theme="{StaticResource CmpTrainTagLiveStyle}">
+                    <TextBlock Text="{Binding LocTagTrain1}" Theme="{StaticResource CmpTrainTagLiveTextStyle}"/>
+                </Border>
+            </Grid>
+
+            <!-- ========== the gauge (the whole block hovers/clicks to reveal the numbers) ========== -->
+            <!-- HorizontalAlignment="Stretch" is NOT in the WPF original and is not decoration:
+                 Avalonia's Fluent Button theme defaults HorizontalAlignment to Left, where WPF's
+                 Button inherits Stretch. Without it the whole gauge collapsed to the natural
+                 width of the state-copy line - 194px inside a 388px card, measured headless. -->
+            <Button Command="{Binding ToggleDetailCommand}" HorizontalContentAlignment="Stretch"
+                    HorizontalAlignment="Stretch"
+                    ToolTip.Tip="{Binding LocDetailTip}" Margin="0,13,0,0">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="Transparent" Cursor="Hand">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                        </Border>
+                    </ControlTemplate>
+                </Button.Template>
+
+                <StackPanel>
+                    <Border Theme="{StaticResource CmpGaugeTrackThickStyle}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="{Binding BarFraction, Converter={StaticResource CmpFractionToStar}}"/>
+                                <ColumnDefinition Width="{Binding BarFraction, Converter={StaticResource CmpFractionToRemainderStar}}"/>
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Column="0" Theme="{StaticResource CmpZ6AttentionFillStyle}"
+                                    Classes.spent="{Binding IsSpent}"/>
+                        </Grid>
+                    </Border>
+
+                    <TextBlock Text="{Binding StateCopy}" Margin="0,8,0,0" FontSize="12.5"
+                               Foreground="#FFFFD9EC" TextWrapping="Wrap"/>
+
+                    <!-- the floor promise. ALWAYS visible once she is low — never behind hover.
+                         The numbers are detail-on-demand; "her voice never runs out" is the card
+                         answering the only question a shrinking meter actually raises, and a
+                         drained card that says nothing but "tomorrow~" reads as a ration. -->
+                    <TextBlock Text="{Binding FloorNote}" Margin="0,5,0,0" FontSize="11"
+                               FontStyle="Italic" Foreground="#FFCBA9C4" TextWrapping="Wrap"
+                               IsVisible="{Binding ShowFloorNote}"/>
+
+                    <!-- the numbers, for the curious only -->
+                    <TextBlock x:Name="Z6DetailLine" Text="{Binding DetailLine}"
+                               Theme="{StaticResource CmpZ6DetailLineStyle}"
+                               Classes.shown="{Binding IsDetailShown}"/>
+                </StackPanel>
+            </Button>
+
+            <!-- ========== the one quiet upsell, below 40% only ========== -->
+            <Button x:Name="Z6UpsellButton" Theme="{StaticResource CmpLinkButtonStyle}" Margin="0,8,0,0"
+                    Command="{Binding UpsellCommand}"
+                    IsVisible="{Binding ShowUpsell}">
+                <Button.Template>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="Transparent" Cursor="Hand" Padding="0,2,0,2">
+                            <TextBlock x:Name="Txt" Text="{Binding UpsellCopy}"
+                                       Theme="{StaticResource CmpFlavorTextStyle}" FontSize="11"/>
+                        </Border>
+                    </ControlTemplate>
+                </Button.Template>
+            </Button>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AttentionGaugeView.axaml.cs
@@ -1,0 +1,119 @@
+using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// Z6 — the attention meter. See the XAML header for the visual spec.
+    ///
+    /// <para>Code-free by design: the copy ladder is a pure function of the remaining fraction
+    /// (AttentionCopy), the bar is a star-width column, and detail-on-demand is a command on the
+    /// viewmodel. Nothing here animates.</para>
+    /// </summary>
+    public partial class AttentionGaugeView : UserControl
+    {
+        public AttentionGaugeView()
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new AttentionGaugeViewModel();
+        }
+
+        /// <summary>Convenience for hosts that hand in a viewmodel rather than setting DataContext.</summary>
+        public AttentionGaugeViewModel? ViewModel
+        {
+            get => DataContext as AttentionGaugeViewModel;
+            set => DataContext = value;
+        }
+    }
+
+    /// <summary>
+    /// Supplies everything the view binds to. The strings come from CCP.Core's <see cref="Loc"/> -
+    /// the same localization runtime and the same JSON files the WPF head reads.
+    ///
+    /// <para>This exists because WPF's <c>{loc:Str key}</c> markup extension (LocExtension)
+    /// cannot cross: it derives from System.Windows.Markup.MarkupExtension and stays in the head.
+    /// The strings do cross; only the binding mechanism differs.</para>
+    ///
+    /// <para><b>Not a port of IAttentionGaugeVm.</b> That interface, MockAttentionGaugeVm and
+    /// AttentionCopy all still live in the WPF head, so the thresholds cannot be reached from
+    /// here and are deliberately NOT re-implemented - a second copy of the ladder is exactly the
+    /// duplication the Core split exists to prevent. The numbers below are the WPF mock's
+    /// artboard state (72% left) hard-coded, and every derived flag is the value AttentionCopy
+    /// returns for it. Wiring the real viewmodel is a separate change from proving the view
+    /// renders.</para>
+    /// </summary>
+    public sealed class AttentionGaugeViewModel : INotifyPropertyChanged
+    {
+        private bool _isDetailShown;
+
+        public AttentionGaugeViewModel()
+        {
+            ToggleDetailCommand = new ToggleCommand(() => IsDetailShown = !IsDetailShown);
+        }
+
+        public string LocTitle => Loc.Get("companion_attention_title");
+        public string LocTagTrain1 => Loc.Get("companion_tag_train1");
+        public string LocDetailTip => Loc.Get("companion_attention_detail_tip");
+
+        /// <summary>The headline copy. AttentionCopy.CopyKeyFor(0.72) is the "plenty" rung.</summary>
+        public string StateCopy => Loc.Get("companion_attention_plenty");
+
+        /// <summary>
+        /// Numeric detail, on demand only. Note what it never says: "tokens".
+        ///
+        /// <para>This is the MOCK's static key. The shipped VM
+        /// (AttentionGaugeRuntimeVm, CompanionDepthRuntimeVms.cs:304-306) formats it instead -
+        /// <c>Loc.GetF("companion_attention_detail_fmt", remaining)</c>, or
+        /// <c>companion_attention_detail_unlimited</c> when she thinks on the user's machine.
+        /// Whoever wires the real chat budget in must switch to those two, not to this.</para>
+        /// </summary>
+        public string DetailLine => Loc.Get("companion_attention_detail_line");
+
+        /// <summary>The barks-only floor promise, at rest, in her voice.</summary>
+        public string FloorNote => Loc.Get("companion_attention_floor_note");
+
+        public string UpsellCopy => Loc.Get("companion_attention_upsell");
+
+        // Placeholder state: the WPF MockAttentionGaugeVm's default artboard, 72% remaining.
+        public double BarFraction => 0.72;
+        public bool IsSpent => false;
+        public bool ShowFloorNote => false;
+        public bool ShowUpsell => false;
+
+        public bool IsDetailShown
+        {
+            get => _isDetailShown;
+            set
+            {
+                if (_isDetailShown == value) return;
+                _isDetailShown = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsDetailShown)));
+            }
+        }
+
+        public ICommand ToggleDetailCommand { get; }
+
+        /// <summary>
+        /// LEFT UNWIRED. The WPF original hands this to the Companion tab, which deep-links to the
+        /// Patreon tab - head-owned navigation with no Avalonia counterpart yet. A null command
+        /// disables the link rather than pretending the click did something.
+        /// </summary>
+        public ICommand? UpsellCommand => null;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>The one command this view can honour on its own: it only flips local state.</summary>
+        private sealed class ToggleCommand : ICommand
+        {
+            private readonly Action _run;
+            public ToggleCommand(Action run) => _run = run;
+            public bool CanExecute(object? parameter) => true;
+            public void Execute(object? parameter) => _run();
+            public event EventHandler? CanExecuteChanged { add { } remove { } }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionConverters.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionConverters.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    // =====================================================================================
+    //  PORTED (PARTIAL) from ConditioningControlPanel/Views/Controls/Companion/CompanionConverters.cs.
+    //
+    //  Only the converters the ported zone controls still need cross. The WPF file also carries
+    //  CompanionBoolToVisibilityConverter, CompanionEmptyToVisibilityConverter and friends -
+    //  those exist to produce a System.Windows.Visibility and have no Avalonia counterpart,
+    //  because Avalonia binds IsVisible to a bool directly.
+    // =====================================================================================
+
+    /// <summary>
+    /// 0..1 fraction to a star <see cref="GridLength"/>. This is the Trainer Card bar recipe:
+    /// the filled part of a gauge is a star-width column, so it needs no ActualWidth maths,
+    /// causes no layout-thrash binding, and survives any resize.
+    /// </summary>
+    public sealed class FractionToStarConverter : IValueConverter
+    {
+        /// <summary>When true the converter returns the *remainder* (1 - fraction).</summary>
+        public bool Invert { get; set; }
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            double f = ToFraction(value);
+            if (Invert) f = 1.0 - f;
+            return new GridLength(f, GridUnitType.Star);
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => BindingOperations.DoNothing;
+
+        /// <summary>Clamps anything sane-looking into 0..1. Never throws, never returns NaN.</summary>
+        internal static double ToFraction(object? value)
+        {
+            double f;
+            switch (value)
+            {
+                case double d: f = d; break;
+                case float ff: f = ff; break;
+                case int i: f = i; break;
+                case long l: f = l; break;
+                case decimal m: f = (double)m; break;
+                default: return 0.0;
+            }
+            if (double.IsNaN(f) || double.IsInfinity(f)) return 0.0;
+            if (f < 0.0) return 0.0;
+            if (f > 1.0) return 1.0;
+            return f;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml
@@ -1,0 +1,212 @@
+<!-- PORTED (PARTIAL) from ConditioningControlPanel/Views/Controls/Companion/Themes/CompanionTheme.xaml.
+
+     PARTIAL ON PURPOSE. The WPF original is 1605 lines covering every zone of the Companion tab.
+     Only the keys the ported zone controls actually reach for live here, carrying their original
+     names, values, order and section headings so the two diff cleanly. Ported so far: everything
+     Z6 (AttentionGaugeView) needs. Adding a zone means copying its keys down in the same order,
+     never renaming or "tidying" one.
+
+     Deviations, all forced by real WPF/Avalonia differences:
+
+       <Style x:Key TargetType>          ->  <ControlTheme x:Key TargetType>
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"   (at the call site)
+       ControlTemplate.Triggers          ->  nested <Style Selector="^:pointerover">
+       <ContentPresenter/>               ->  Name="PART_ContentPresenter"
+       DropShadowEffect ShadowDepth="0"  ->  OffsetX="0" OffsetY="0"
+       SnapsToDevicePixels="True"        ->  dropped; Avalonia rounds layout by default
+                                             (UseLayoutRounding, on for every Control)
+       cmp:CompanionCapsule.IsCapsule    ->  CornerRadius="999"           (see the tag section)
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%"
+                                             Avalonia's StartPoint/EndPoint are RelativePoint and
+                                             BARE NUMBERS ARE ABSOLUTE PIXELS, so the WPF values
+                                             would paint a 1px-wide gradient in the top-left
+                                             corner and flat-fill everything after it.
+
+     Consumers merge this with
+       <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+     in place of the WPF pack:// URI. -->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:cmp="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion">
+
+    <!-- ============================ 0. converters ============================ -->
+    <cmp:FractionToStarConverter x:Key="CmpFractionToStar"/>
+    <cmp:FractionToStarConverter x:Key="CmpFractionToRemainderStar" Invert="True"/>
+    <!-- CmpBoolToVis and friends are NOT ported: Avalonia binds IsVisible to a bool directly.
+         CmpEmojiToImage is not ported either - Avalonia draws colour emoji natively, so an
+         <Image> through the Twemoji pipeline becomes a plain <TextBlock Text="💗"/>. -->
+
+    <!-- ============================ 1. spacing tokens ============================
+         The mockup's rhythm: 6/8/12/16/22. Cards sit 16 apart, card padding is 18x20,
+         the room breathes 22/26. Use these instead of typing margins by hand. -->
+    <Thickness x:Key="CmpCardPadding">20,18,20,18</Thickness>
+    <Thickness x:Key="CmpCardMargin">0,0,0,16</Thickness>
+
+    <CornerRadius x:Key="CmpRadiusCard">14</CornerRadius>
+
+    <!-- ============================ 2. palette ============================
+         :root of the mockup. Colours are exposed as both Color (for gradient stops and
+         animations) and Brush (for direct use). -->
+    <Color x:Key="CmpPinkColor">#FFFF69B4</Color>
+    <Color x:Key="CmpPinkLightColor">#FFFF8FCB</Color>
+    <Color x:Key="CmpPurpleColor">#FFB478FF</Color>
+    <Color x:Key="CmpLiveColor">#FF6EE7A7</Color>
+
+    <!-- .card background is #1A1A2Eee — 93% opaque over the room. -->
+    <SolidColorBrush x:Key="CmpCardBrush" Color="#EE1A1A2E"/>
+    <SolidColorBrush x:Key="CmpPurpleBrush" Color="{StaticResource CmpPurpleColor}"/>
+    <SolidColorBrush x:Key="CmpLiveBrush" Color="{StaticResource CmpLiveColor}"/>
+
+    <!-- text ramp: the mockup's txt / dim / muted / faint custom properties -->
+    <SolidColorBrush x:Key="CmpTextBrush" Color="#FFFFFFFF"/>
+    <SolidColorBrush x:Key="CmpDimBrush" Color="#FFB8B1CC"/>
+    <SolidColorBrush x:Key="CmpMutedBrush" Color="#FF9A93B8"/>
+    <SolidColorBrush x:Key="CmpFaintBrush" Color="#FF6C6689"/>
+
+    <!-- borders & hairlines -->
+    <SolidColorBrush x:Key="CmpCardBorderBrush" Color="#66FF69B4"/>
+    <SolidColorBrush x:Key="CmpTrackBrush" Color="#22FFFFFF"/>
+    <SolidColorBrush x:Key="CmpTrackSoftBrush" Color="#14FFFFFF"/>
+
+    <!-- gradients -->
+    <LinearGradientBrush x:Key="CmpPinkPurpleBrush" StartPoint="0%,0%" EndPoint="100%,0%">
+        <GradientStop Color="{StaticResource CmpPinkColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource CmpPurpleColor}" Offset="1"/>
+    </LinearGradientBrush>
+
+    <!-- Z6 attention bar: pink → light pink → purple. -->
+    <LinearGradientBrush x:Key="CmpAttentionBrush" StartPoint="0%,0%" EndPoint="100%,0%">
+        <GradientStop Color="{StaticResource CmpPinkColor}" Offset="0"/>
+        <GradientStop Color="{StaticResource CmpPinkLightColor}" Offset="0.5"/>
+        <GradientStop Color="{StaticResource CmpPurpleColor}" Offset="1"/>
+    </LinearGradientBrush>
+
+    <!-- ============================ 3. glows ============================
+         House glow = DropShadowEffect with zero offset. Budget (design §7.4): hero title,
+         portrait ring, active constellation node, section titles. Never on a scrolling item
+         container — fact cards get their emphasis from BorderBrush instead. -->
+    <DropShadowEffect x:Key="CmpSectionGlow" Color="{StaticResource CmpPinkColor}" BlurRadius="14"
+                      OffsetX="0" OffsetY="0" Opacity="0.70"/>
+
+    <!-- ============================ 4. text styles ============================ -->
+    <!-- .card h2 — the zone header. Glow is on the title only, not the whole row. -->
+    <ControlTheme x:Key="CmpSectionTitleStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="16.5"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Effect" Value="{StaticResource CmpSectionGlow}"/>
+        <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+    </ControlTheme>
+
+    <ControlTheme x:Key="CmpFaintTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="10.5"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpFaintBrush}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+    </ControlTheme>
+
+    <!-- in-character italic copy: dormant promises, flavor lines, veil sell copy -->
+    <ControlTheme x:Key="CmpFlavorTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontStyle" Value="Italic"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpDimBrush}"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="LineHeight" Value="18"/>
+    </ControlTheme>
+
+    <!-- quiet expert-door link.
+         NOTE: Text="{TemplateBinding Content}" is the WPF original verbatim. Z6 overrides this
+         template locally (as the WPF view does), so the object->string conversion is not
+         exercised by the ported view; the first zone that DOES use this template should check
+         it renders before trusting it. -->
+    <ControlTheme x:Key="CmpLinkButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpMutedBrush}"/>
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Padding" Value="0,2,10,2"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="Button">
+                <TextBlock x:Name="Txt" Text="{TemplateBinding Content}" Margin="{TemplateBinding Padding}"
+                           Foreground="{TemplateBinding Foreground}" FontSize="{TemplateBinding FontSize}"
+                           TextDecorations="Underline" Background="Transparent"/>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover /template/ TextBlock#Txt">
+            <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+        </Style>
+    </ControlTheme>
+
+    <!-- ============================ 5. cards ============================ -->
+    <ControlTheme x:Key="CmpCardStyle" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource CmpCardBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource CmpCardBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="{StaticResource CmpRadiusCard}"/>
+        <Setter Property="Padding" Value="{StaticResource CmpCardPadding}"/>
+        <Setter Property="Margin" Value="{StaticResource CmpCardMargin}"/>
+    </ControlTheme>
+
+    <!-- ============================ 6. train microtags ============================
+         WPF needed cmp:CompanionCapsule.IsCapsule="True" here because WPF's Border clamps the X
+         and Y corner radii INDEPENDENTLY, so border-radius:999px drew a full ellipse (78% fill,
+         i.e. pi/4, on a 110x26 box) instead of a stadium. Avalonia does not have that bug: it
+         scales the radii proportionally the way CSS does. Measured headless on the same 110x26
+         box, CornerRadius="999" and CornerRadius="13" (an exact half-height capsule) both fill
+         95.1% - so the attached property has no work left to do and is not ported. -->
+    <ControlTheme x:Key="CmpTrainTagStyle" TargetType="Border">
+        <Setter Property="Background" Value="#14B478FF"/>
+        <Setter Property="BorderBrush" Value="#55B478FF"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="999"/>
+        <Setter Property="Padding" Value="8,2,8,2"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </ControlTheme>
+    <ControlTheme x:Key="CmpTrainTagTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="9"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpPurpleBrush}"/>
+    </ControlTheme>
+    <!-- .ttag.live — green, "this is real right now" -->
+    <ControlTheme x:Key="CmpTrainTagLiveStyle" TargetType="Border" BasedOn="{StaticResource CmpTrainTagStyle}">
+        <Setter Property="Background" Value="#126EE7A7"/>
+        <Setter Property="BorderBrush" Value="#556EE7A7"/>
+    </ControlTheme>
+    <ControlTheme x:Key="CmpTrainTagLiveTextStyle" TargetType="TextBlock" BasedOn="{StaticResource CmpTrainTagTextStyle}">
+        <Setter Property="Foreground" Value="{StaticResource CmpLiveBrush}"/>
+    </ControlTheme>
+
+    <!-- ============================ 8. gauge primitives ============================
+         Every bar on this page is the Trainer Card recipe: a rounded track Border with a
+         two-column Grid inside, the fill column bound to a star GridLength. No ActualWidth
+         maths anywhere, so nothing thrashes layout while the page scrolls. -->
+    <ControlTheme x:Key="CmpGaugeTrackStyle" TargetType="Border">
+        <Setter Property="Height" Value="10"/>
+        <Setter Property="CornerRadius" Value="5"/>
+        <Setter Property="Background" Value="{StaticResource CmpTrackBrush}"/>
+        <Setter Property="ClipToBounds" Value="True"/>
+    </ControlTheme>
+    <!-- .att-track — the 12px attention gauge -->
+    <ControlTheme x:Key="CmpGaugeTrackThickStyle" TargetType="Border" BasedOn="{StaticResource CmpGaugeTrackStyle}">
+        <Setter Property="Height" Value="12"/>
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Background" Value="{StaticResource CmpTrackSoftBrush}"/>
+    </ControlTheme>
+
+    <!-- The heat used to be a DropShadowEffect on every fill. Gauges live inside PageScroll and
+         there are a dozen of them once the Workshop is open, so the glow is a brush now: a
+         lighter top edge inside the fill reads as "lit" without a bitmap effect. -->
+    <ControlTheme x:Key="CmpGaugeFillStyle" TargetType="Border">
+        <Setter Property="CornerRadius" Value="5"/>
+        <Setter Property="Background" Value="{StaticResource CmpPinkPurpleBrush}"/>
+        <Setter Property="BorderThickness" Value="0,1,0,0"/>
+        <Setter Property="BorderBrush" Value="#59FFB8DC"/>
+    </ControlTheme>
+    <ControlTheme x:Key="CmpGaugeFillAttentionStyle" TargetType="Border" BasedOn="{StaticResource CmpGaugeFillStyle}">
+        <Setter Property="CornerRadius" Value="6"/>
+        <Setter Property="Background" Value="{StaticResource CmpAttentionBrush}"/>
+        <Setter Property="BorderBrush" Value="#66FFD0E6"/>
+    </ControlTheme>
+</ResourceDictionary>

--- a/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml
@@ -1,0 +1,159 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/AwarenessAppPickerDialog.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       Style="{StaticResource X}"     -> Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       {loc:Str key}                  -> {Binding LocX}               (LocExtension is a WPF
+                                         MarkupExtension and stays in the head; the strings still
+                                         come from CCP.Core's Loc, via the VM)
+       Visibility="Collapsed"         -> IsVisible="False"
+       Converter={StaticResource BoolToVisibility}
+                                      -> IsVisible bound to the bool directly
+       ResizeMode="CanResizeWithGrip" -> CanResize="True"             (Avalonia has no resize grip;
+                                         the window still resizes)
+       ToolTip="..."                  -> ToolTip.Tip="..."
+       Checked/Unchecked              -> ToggleButton.IsCheckedChangedEvent, one bubbling handler
+                                         wired on the ItemsControl in the ctor (a DataTemplate has
+                                         no name scope). Mode=TwoWay is written out rather than
+                                         left to the property default.
+       KeyDown= / Click= attributes   -> wired in the ctor, per the porting convention; the two
+                                         unnamed Buttons gained x:Names so they can be found
+
+     The Add and Cancel buttons carry a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key and every loc key here is snake_case. See CLAUDE.md. BtnSave set its
+     text from code in the original and still does.
+
+     The one loc string inside the DataTemplate reaches the window's VM through $parent[Window],
+     because the template's x:DataType is the row, not the VM. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.AwarenessAppPickerDialog"
+        x:DataType="vm:AwarenessAppPickerViewModel"
+        xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        Height="560" Width="520"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="True">
+
+    <!-- ================================================================
+         The awareness app picker.
+
+         Both awareness lists used to open TextEditorDialog - the
+         subliminal PHRASE-POOL editor, complete with "Sort A-Z",
+         "Toggle All" and an uppercase-on-add rule. Two problems with
+         that, both reported from a real play-test:
+
+           1. It reads as a text pool, not as a privacy control, so
+              unticking a row does not look like deleting a guard. One
+              "Toggle All" silently disarmed the three seeded deny
+              groups, and because every editor path also sets
+              AwarenessDenySeeded, nothing ever put them back.
+           2. It opened EMPTY. Its candidate apps came from the keyword
+              trigger service's foreground ring, which only fills while
+              that service runs, and KeywordTriggersEnabled defaults to
+              false - so the normal user was handed a blank list and
+              asked to type process names from memory.
+
+         This dialog fixes both: candidates come from what awareness has
+         actually seen (see AwarenessAppCandidates), the copy states the
+         consequence of a tick in the list's own direction, and removing
+         a recommended guard asks first.
+         ================================================================ -->
+
+    <Grid Margin="18">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- header: title plus the sentence that says what a tick MEANS -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,14">
+            <TextBlock x:Name="TxtTitle" Foreground="{StaticResource PinkBrush}"
+                       FontSize="17" FontWeight="Bold" TextWrapping="Wrap"/>
+            <TextBlock x:Name="TxtSubtitle" Foreground="{DynamicResource TextMutedBrush}"
+                       FontSize="11.5" TextWrapping="Wrap" Margin="0,6,0,0"/>
+        </StackPanel>
+
+        <!-- the empty state. Never a blank box with an Add button and no explanation. -->
+        <Border Grid.Row="1" x:Name="EmptyHint" IsVisible="False"
+                Background="#1E1E32" BorderBrush="#3A3A5A" BorderThickness="1"
+                CornerRadius="7" Padding="11,9" Margin="0,0,0,10">
+            <TextBlock x:Name="TxtEmptyHint" Foreground="{DynamicResource TextMutedBrush}"
+                       FontSize="11" TextWrapping="Wrap"/>
+        </Border>
+
+        <Border Grid.Row="2" Background="{StaticResource PanelBgBrush}" CornerRadius="8">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="6">
+                <ItemsControl x:Name="ItemList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:AwarenessPickRow">
+                            <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="6"
+                                    Margin="3" Padding="11,8">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <CheckBox Grid.Column="0" IsChecked="{Binding IsListed, Mode=TwoWay}"
+                                              VerticalAlignment="Center" Margin="0,0,10,0"
+                                              Tag="{Binding}"/>
+
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding Label}" Foreground="White" FontSize="12.5"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="{Binding Detail}" Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0"
+                                                   IsVisible="{Binding HasDetail}"/>
+                                    </StackPanel>
+
+                                    <!-- a shipped guard is marked, so unticking one is a visibly
+                                         different act from unticking an app you added yourself -->
+                                    <Border Grid.Column="2" Background="#332A4A2A" BorderBrush="#4A7A4A"
+                                            BorderThickness="1" CornerRadius="4" Padding="6,2"
+                                            VerticalAlignment="Center"
+                                            IsVisible="{Binding IsRecommended}">
+                                        <TextBlock Text="{Binding $parent[Window].((vm:AwarenessAppPickerViewModel)DataContext).LocRecommended}"
+                                                   Foreground="#9FD79F" FontSize="9.5" FontWeight="Bold"/>
+                                    </Border>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <!-- typing an app is still possible, but it is now the fallback rather than the only path -->
+        <Grid Grid.Row="3" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="TxtNewItem" Grid.Column="0"
+                     Background="{DynamicResource SurfaceBgBrush}" Foreground="White"
+                     BorderBrush="{StaticResource PinkBrush}" BorderThickness="1"
+                     Padding="10,7" FontSize="12.5" VerticalContentAlignment="Center"
+                     ToolTip.Tip="{Binding LocAddTip}"/>
+            <Button x:Name="BtnAdd" Grid.Column="1" Theme="{StaticResource ActionButton}"
+                    Margin="8,0,0,0">
+                <TextBlock Text="{Binding LocBtnAdd}"/>
+            </Button>
+        </Grid>
+        <TextBlock Grid.Row="3" x:Name="TxtAddHint" Foreground="{DynamicResource TextMutedBrush}"
+                   FontSize="11" Margin="0,44,0,0" TextWrapping="Wrap"
+                   Text="{Binding LocAddHint}"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,24,0,0">
+            <Button x:Name="BtnCancel" Theme="{StaticResource SecondaryButton}"
+                    Margin="0,0,8,0">
+                <TextBlock Text="{Binding LocBtnCancel}"/>
+            </Button>
+            <Button x:Name="BtnSave" Theme="{StaticResource ActionButton}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services.Awareness;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>Which awareness list the picker is editing. The two have opposite meanings.</summary>
+    /// <remarks>
+    /// Copied from the WPF code-behind: the enum lives beside the WPF Window, and neither the WPF
+    /// head nor Core may be touched by this port. Same precedent as <c>TextItem</c> in
+    /// <see cref="TextEditorDialog"/>.
+    /// </remarks>
+    public enum AwarenessListKind
+    {
+        /// <summary>Apps she must never see at all.</summary>
+        Deny,
+
+        /// <summary>Apps whose page title may travel off this PC.</summary>
+        TitleAllow
+    }
+
+    /// <summary>
+    /// The picker for both awareness lists. See the AXAML header for why this replaced
+    /// <see cref="TextEditorDialog"/>.
+    ///
+    /// <para>Two rules this dialog exists to keep. First, a tick has to state its consequence in the
+    /// list's own direction: ticking in the deny list HIDES an app, ticking in the allow list SENDS
+    /// its titles, and one control that means both is how someone leaks a title while believing they
+    /// muted one. Second, the candidate rows are the point - a privacy list you can only fill by
+    /// typing process names from memory is one nobody fills.</para>
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Dialogs/AwarenessAppPickerDialog.xaml.cs.
+    /// Deviations:</para>
+    /// <list type="bullet">
+    ///   <item>WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>; the caller uses
+    ///   <c>ShowDialog&lt;bool?&gt;</c>. <see cref="Result"/> is unchanged.</item>
+    ///   <item><c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so
+    ///   <see cref="Ask"/> is the same minimal stand-in <see cref="TextEditorDialog"/> uses. It is
+    ///   async, so <c>Row_Unchecked</c> became one async handler over both tick directions.</item>
+    ///   <item><c>AwarenessPrivacyRules.IsGroupToken</c>/<c>ChipLabelKey</c> are pure string logic
+    ///   pinned to the WPF head (their class reads <c>App.Logger</c> and <c>AppSettings</c>), so
+    ///   <see cref="GroupTokens"/> below mirrors those two members verbatim. The real fix is moving
+    ///   them to Core, which this port may not touch.</item>
+    /// </list>
+    /// </summary>
+    public partial class AwarenessAppPickerDialog : Window
+    {
+        private readonly AwarenessListKind _kind;
+        private readonly ObservableCollection<AwarenessPickRow> _rows = new();
+        private readonly TextBox _txtNewItem;
+        private readonly Border _emptyHint;
+        private bool _suppressPrompt;
+
+        /// <summary>The chosen entries, or null when the dialog was cancelled.</summary>
+        public List<string>? Result { get; private set; }
+
+        /// <param name="kind">Which list is being edited. Drives every string on the dialog.</param>
+        /// <param name="listed">Entries currently in the list, raw (group tokens included).</param>
+        /// <param name="candidates">Apps to offer as rows, already sanitised, newest-interesting first.</param>
+        public AwarenessAppPickerDialog(AwarenessListKind kind,
+                                        IEnumerable<string> listed,
+                                        IEnumerable<string> candidates)
+        {
+            AvaloniaXamlLoader.Load(this);
+            DataContext = new AwarenessAppPickerViewModel();
+            _kind = kind;
+
+            _txtNewItem = this.FindControl<TextBox>("TxtNewItem")!;
+            _emptyHint = this.FindControl<Border>("EmptyHint")!;
+            var itemList = this.FindControl<ItemsControl>("ItemList")!;
+            var btnSave = this.FindControl<Button>("BtnSave")!;
+
+            bool deny = kind == AwarenessListKind.Deny;
+            Title = Loc.Get(deny ? "companion_awareness_deny_editor_title"
+                                 : "companion_awareness_allow_editor_title");
+            this.FindControl<TextBlock>("TxtTitle")!.Text = Title;
+            this.FindControl<TextBlock>("TxtSubtitle")!.Text =
+                Loc.Get(deny ? "companion_awareness_picker_deny_sub"
+                             : "companion_awareness_picker_allow_sub");
+            this.FindControl<TextBlock>("TxtEmptyHint")!.Text =
+                Loc.Get(deny ? "companion_awareness_picker_deny_empty"
+                             : "companion_awareness_picker_allow_empty");
+            btnSave.Content = new TextBlock { Text = Loc.Get("companion_awareness_picker_save") };
+
+            BuildRows(listed, candidates);
+            itemList.ItemsSource = _rows;
+
+            // The empty-state card explains the blank list instead of leaving an Add box to guess at.
+            _emptyHint.IsVisible = _rows.Count == 0;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            _txtNewItem.KeyDown += (_, e) => { if (e.Key == Key.Enter) AddTypedItem(); };
+            this.FindControl<Button>("BtnAdd")!.Click += (_, _) => AddTypedItem();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => BtnCancel_Click();
+            btnSave.Click += (_, _) => BtnSave_Click();
+
+            // One handler on the list instead of two inside the DataTemplate: template content has
+            // no name scope to FindControl through. IsCheckedChanged bubbles, so this stands in for
+            // WPF's Checked and Unchecked pair.
+            itemList.AddHandler(ToggleButton.IsCheckedChangedEvent, Row_IsCheckedChanged);
+        }
+
+        /// <summary>
+        /// Listed entries first (they are the answer to "what is on right now"), then the offered
+        /// candidates. A candidate already in the list is not repeated.
+        /// </summary>
+        private void BuildRows(IEnumerable<string> listed, IEnumerable<string> candidates)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var raw in listed ?? Enumerable.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(raw) || !seen.Add(raw)) continue;
+                _rows.Add(MakeRow(raw, isListed: true));
+            }
+
+            foreach (var raw in candidates ?? Enumerable.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(raw) || !seen.Add(raw)) continue;
+                _rows.Add(MakeRow(raw, isListed: false));
+            }
+        }
+
+        /// <summary>
+        /// A group token renders under its friendly label ("password managers") and carries the
+        /// recommended mark; an ordinary app renders as itself. The raw value is what gets saved either
+        /// way - a row that saved its LABEL would write "password managers" into the list and quietly
+        /// stop matching anything.
+        /// </summary>
+        private AwarenessPickRow MakeRow(string raw, bool isListed)
+        {
+            bool group = GroupTokens.IsGroupToken(raw);
+            var labelKey = GroupTokens.ChipLabelKey(raw);
+
+            return new AwarenessPickRow
+            {
+                Raw = raw,
+                Label = labelKey.Length > 0 ? Loc.Get(labelKey) : raw,
+                Detail = group ? Loc.Get("companion_awareness_picker_group_detail") : string.Empty,
+                IsRecommended = group && _kind == AwarenessListKind.Deny,
+                IsListed = isListed
+            };
+        }
+
+        // =====================================================================================
+        //  ticking
+        // =====================================================================================
+
+        /// <summary>
+        /// WPF's <c>Row_Checked</c> and <c>Row_Unchecked</c>, folded into the one event Avalonia
+        /// raises for both directions.
+        ///
+        /// <para>Unticking a shipped guard asks first. This is the exact click that emptied a live
+        /// user's deny list during play-testing: the row looked like a phrase in a pool, so removing
+        /// it did not read as disarming the password-manager, banking and email-title protections -
+        /// and every editor path also marks the seed as done, so nothing restores them afterwards.</para>
+        /// </summary>
+        private async void Row_IsCheckedChanged(object? sender, RoutedEventArgs e)
+        {
+            if (e.Source is not CheckBox { Tag: AwarenessPickRow row } box) return;
+
+            if (box.IsChecked == true)
+            {
+                row.IsListed = true;
+                return;
+            }
+
+            if (_suppressPrompt || !row.IsRecommended)
+            {
+                row.IsListed = false;
+                return;
+            }
+
+            var answer = await Ask(
+                Loc.Get("companion_awareness_picker_drop_guard_title"),
+                Loc.GetF("companion_awareness_picker_drop_guard", row.Label),
+                ("Yes", true), ("No", false));
+
+            if (answer == true)
+            {
+                row.IsListed = false;
+                return;
+            }
+
+            // Anything but an explicit Yes keeps the guard, matching MessageBoxResult.No as the
+            // WPF default - dismissing the prompt must never disarm one.
+            // Put the tick back without re-entering this handler.
+            _suppressPrompt = true;
+            try { box.IsChecked = true; row.IsListed = true; }
+            finally { _suppressPrompt = false; }
+        }
+
+        // =====================================================================================
+        //  typing an app in
+        // =====================================================================================
+
+        /// <summary>
+        /// Adds a hand-typed app, sanitised by the SAME helper the settings setters use - so what the
+        /// row shows is what will actually be stored. The old dialog uppercased on add and the setter
+        /// lowercased on save, so the list you approved was never the list you got.
+        /// </summary>
+        private async void AddTypedItem()
+        {
+            var clean = AwarenessText.SanitizeRuleEntry(_txtNewItem.Text);
+            if (clean == null)
+            {
+                await Ask(Loc.Get("title_confirm"),
+                    Loc.Get("companion_awareness_picker_bad_entry"),
+                    (Loc.Get("btn_ok"), true));
+                return;
+            }
+
+            var existing = _rows.FirstOrDefault(r =>
+                string.Equals(r.Raw, clean, StringComparison.OrdinalIgnoreCase));
+
+            if (existing != null)
+            {
+                existing.IsListed = true;   // already offered: tick it rather than duplicate it
+            }
+            else
+            {
+                _rows.Insert(0, new AwarenessPickRow
+                {
+                    Raw = clean,
+                    Label = clean,
+                    Detail = string.Empty,
+                    IsRecommended = false,
+                    IsListed = true
+                });
+            }
+
+            _txtNewItem.Clear();
+            _txtNewItem.Focus();
+            _emptyHint.IsVisible = false;
+        }
+
+        // =====================================================================================
+        //  close
+        // =====================================================================================
+
+        private void BtnSave_Click()
+        {
+            Result = _rows.Where(r => r.IsListed).Select(r => r.Raw).ToList();
+            Close(true);
+        }
+
+        private void BtnCancel_Click()
+        {
+            Result = null;
+            Close(false);
+        }
+
+        /// <summary>
+        /// Minimal stand-in for WPF's MessageBox, which Avalonia has no equivalent of. Copied from
+        /// <see cref="TextEditorDialog"/> rather than shared, because making it shared would mean
+        /// editing a sibling view another agent may be holding. Each button carries the value
+        /// Close() hands back; dismissing the window yields null. Buttons hold a TextBlock, not
+        /// Content, for the access-key reason in the AXAML header. The app has no btn_yes/btn_no loc
+        /// keys - WPF got those strings from the OS - so Yes and No are English here.
+        /// </summary>
+        private Task<bool?> Ask(string title, string message, params (string Label, bool? Value)[] buttons)
+        {
+            var row = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Spacing = 8,
+                Margin = new Thickness(0, 16, 0, 0)
+            };
+
+            var dialog = new Window
+            {
+                Title = title,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                CanResize = false,
+                ShowInTaskbar = false,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Background = Background,
+                Content = new StackPanel
+                {
+                    Margin = new Thickness(20),
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = message,
+                            Foreground = Brushes.White,
+                            FontSize = 13,
+                            TextWrapping = TextWrapping.Wrap,
+                            MaxWidth = 360
+                        },
+                        row
+                    }
+                }
+            };
+
+            foreach (var (label, value) in buttons)
+            {
+                var button = new Button
+                {
+                    Content = new TextBlock { Text = label },
+                    Padding = new Thickness(14, 6),
+                    Cursor = new Cursor(StandardCursorType.Hand)
+                };
+                button.Click += (_, _) => dialog.Close(value);
+                row.Children.Add(button);
+            }
+
+            return dialog.ShowDialog<bool?>(this);
+        }
+    }
+
+    /// <summary>
+    /// The two pure members of the head's <c>AwarenessPrivacyRules</c> that this dialog needs,
+    /// copied verbatim (constants included). That class cannot be referenced from here: it reads
+    /// <c>App.Logger</c> and <c>AppSettings</c>, so it is pinned to the WPF head, and this port may
+    /// touch neither the head nor Core. Deleting this mirror is the same change as moving
+    /// <c>IsGroupToken</c>/<c>ChipLabelKey</c> into CCP.Core.
+    /// </summary>
+    internal static class GroupTokens
+    {
+        private const string GroupPasswordManagers = "@passwords";
+        private const string GroupBanking = "@banking";
+        private const string GroupEmailTitles = "@email-titles";
+
+        private static bool TokenIs(string? entry, string token) =>
+            string.Equals(entry?.Trim(), token, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>True when this entry is one of the seeded group tokens rather than a typed substring.</summary>
+        public static bool IsGroupToken(string? entry) =>
+            !string.IsNullOrWhiteSpace(entry) && entry.TrimStart().StartsWith("@", StringComparison.Ordinal) &&
+            (TokenIs(entry, GroupPasswordManagers) || TokenIs(entry, GroupBanking) || TokenIs(entry, GroupEmailTitles));
+
+        /// <summary>The loc key naming a deny entry in the panel — a friendly label for a group token.</summary>
+        public static string ChipLabelKey(string? entry) => (entry ?? string.Empty).Trim().ToLowerInvariant() switch
+        {
+            GroupPasswordManagers => "companion_awareness_deny_passwords",
+            GroupBanking => "companion_awareness_deny_banking",
+            GroupEmailTitles => "companion_awareness_deny_email",
+            _ => string.Empty
+        };
+    }
+
+    /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
+    /// for why {loc:Str} becomes a binding. The four strings the code-behind sets directly are not
+    /// here, because they depend on which list is being edited.</summary>
+    public sealed class AwarenessAppPickerViewModel
+    {
+        public string LocRecommended => Loc.Get("companion_awareness_picker_recommended");
+        public string LocAddTip => Loc.Get("companion_awareness_picker_add_tip");
+        public string LocBtnAdd => Loc.Get("btn_add_2");
+        public string LocAddHint => Loc.Get("companion_awareness_picker_add_hint");
+        public string LocBtnCancel => Loc.Get("btn_cancel");
+    }
+
+    /// <summary>One offered app. <see cref="Raw"/> is stored; <see cref="Label"/> is only shown.</summary>
+    public sealed class AwarenessPickRow : INotifyPropertyChanged
+    {
+        private bool _isListed;
+
+        public string Raw { get; set; } = "";
+        public string Label { get; set; } = "";
+        public string Detail { get; set; } = "";
+        public bool IsRecommended { get; set; }
+
+        public bool HasDetail => !string.IsNullOrEmpty(Detail);
+
+        public bool IsListed
+        {
+            get => _isListed;
+            set
+            {
+                if (_isListed == value) return;
+                _isListed = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsListed)));
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}


### PR DESCRIPTION
Layer 15.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351