### PR TITLE
feat(avalonia): click-through and restacked overlay windows on X11

### DIFF
--- a/CCP.Avalonia/Platform/X11Overlay.cs
+++ b/CCP.Avalonia/Platform/X11Overlay.cs
@@ -43,6 +43,11 @@ internal static class X11Overlay
     // Values read from the system headers, not from memory - a wrong constant here compiles and
     // then silently addresses the wrong thing.
     private const int ShapeInput = 2;        // X11/extensions/shapeconst.h
+    private const int ClientMessage = 33;    // X11/X.h
+    private const int Above = 0;             // X11/X.h
+    private const long SubstructureMask = 1572864;  // SubstructureRedirect|SubstructureNotify
+    private const long SourcePager = 2;      // netwm_def.h RequestSource::FromTool
+    private const int XEventSize = 192;      // sizeof(XEvent), from the compiler
 
     private const string LibX11 = "libX11.so.6";
     private const string LibXfixes = "libXfixes.so.3";
@@ -52,6 +57,9 @@ internal static class X11Overlay
     [DllImport(LibX11)] private static extern IntPtr XOpenDisplay(IntPtr name);
     [DllImport(LibX11)] private static extern int XFlush(IntPtr display);
     [DllImport(LibX11)] private static extern IntPtr XSetErrorHandler(XErrorHandler handler);
+    [DllImport(LibX11)] private static extern IntPtr XDefaultRootWindow(IntPtr display);
+    [DllImport(LibX11)] private static extern IntPtr XInternAtom(IntPtr display, string name, bool onlyIfExists);
+    [DllImport(LibX11)] private static extern int XSendEvent(IntPtr display, IntPtr window, bool propagate, long mask, IntPtr sendEvent);
 
     [DllImport(LibXfixes)] private static extern int XFixesQueryExtension(IntPtr display, out int eventBase, out int errorBase);
     [DllImport(LibXfixes)] private static extern IntPtr XFixesCreateRegion(IntPtr display, IntPtr rectangles, int count);
@@ -107,23 +115,69 @@ internal static class X11Overlay
         }
     }
 
-    // NO RestackAbove HERE, DELIBERATELY - and this is a measured absence, not an oversight.
-    //
-    // The obvious implementation is XConfigureWindow(xid, CWSibling|CWStackMode, {sibling, Above}),
-    // which is the textbook analogue of SetWindowPos(hwnd, hwndInsertAfter, SWP_NOACTIVATE) and is
-    // what the porting research prescribed for the ~15-slot internal overlay order. It does not
-    // work on a window a compositing WM manages, and it fails SILENTLY: the request is valid, the
-    // server accepts it, and nothing moves.
-    //
-    // Measured with two real Avalonia windows under nested KWin - after the call the two windows
-    // held stacking indices 1 and 2 in exactly the order they started in. The reason is
-    // reparenting: KWin wraps each managed window in a frame, so the id Avalonia hands us is not a
-    // child of the root window, and restacking it only orders it inside its own frame where it is
-    // the only child.
-    //
-    // The real options are restacking the FRAME (fighting the WM, which re-asserts) or the EWMH
-    // _NET_RESTACK_WINDOW client message (asking the WM, which is the sanctioned route). Both need
-    // their own measurement, so they get their own change rather than an unverified method here.
+    /// <summary>Stacks <paramref name="window"/> immediately above <paramref name="sibling"/> -
+    /// the analogue of <c>SetWindowPos(hwnd, hwndInsertAfter, SWP_NOACTIVATE)</c>, and what holds
+    /// the ~15 Chaos overlay classes in their fixed internal order.
+    ///
+    /// <para>This is a separate concern from being above OTHER applications:
+    /// <c>Window.Topmost</c> puts the whole band in the keep-above layer, and this orders the band
+    /// within it.</para>
+    ///
+    /// <para><b>Why a client message and not <c>XConfigureWindow</c>.</b> Not because the direct
+    /// call fails - it works on these windows, measured side by side in the same probe. An earlier
+    /// version of this shim concluded it did not work, and that conclusion was wrong: the test read
+    /// the stacking order immediately after the call, and stacking is applied by the window
+    /// manager, which is a separate process. The call was fine; the test was too fast.
+    ///
+    /// <para>The client message is still the right choice, for reasons that outlive this machine.
+    /// Stacking is the WM's to arbitrate, so a raw <c>ConfigureWindow</c> is a request the WM may
+    /// apply its own policy to, and it addresses the id we hold - which stops being a child of the
+    /// root window as soon as anything reparents it into a decoration frame. KWin does not reparent
+    /// an undecorated XWayland window (measured: frame id == window id), but that is one compositor
+    /// on one backend, and the overlays have to hold their order on X11 proper and under other
+    /// window managers too. <c>_NET_RESTACK_WINDOW</c> asks the WM rather than going around it, so
+    /// it holds in every one of those cases, and KWin lists it in <c>_NET_SUPPORTED</c> and honours
+    /// it in both directions with either source indication.</para>
+    ///
+    /// <para><b>It is asynchronous.</b> The message goes to the WM, which is a separate process:
+    /// <c>XSync</c> only waits for the SERVER, so a caller that reads the stacking order straight
+    /// after this call can legitimately still see the old one.</para></summary>
+    internal static bool RestackAbove(TopLevel window, TopLevel sibling)
+    {
+        if (!TryGetXid(window, out var xid)) return false;
+        if (!TryGetXid(sibling, out var siblingXid)) return false;
+
+        lock (Gate)
+        {
+            if (!EnsureDisplay()) return false;
+
+            // XEvent is a union of 24 longs and XSendEvent reads the whole thing, so the buffer
+            // has to be full size even though only the client-message head is filled in. Every
+            // offset below was taken from offsetof() against the real headers, not from memory -
+            // a wrong one here sends a well-formed message that means something else.
+            var e = Marshal.AllocHGlobal(XEventSize);
+            try
+            {
+                for (var i = 0; i < XEventSize; i += IntPtr.Size) Marshal.WriteIntPtr(e, i, IntPtr.Zero);
+
+                Marshal.WriteInt32(e, 0, ClientMessage);
+                Marshal.WriteIntPtr(e, 24, _display);
+                Marshal.WriteIntPtr(e, 32, xid);                                          // window to restack
+                Marshal.WriteIntPtr(e, 40, XInternAtom(_display, "_NET_RESTACK_WINDOW", false));
+                Marshal.WriteInt32(e, 48, 32);                                            // format
+                Marshal.WriteIntPtr(e, 56, new IntPtr(SourcePager));                      // data.l[0] source
+                Marshal.WriteIntPtr(e, 64, siblingXid);                                   // data.l[1] sibling
+                Marshal.WriteIntPtr(e, 72, new IntPtr(Above));                            // data.l[2] detail
+
+                // Addressed to the ROOT window, not to ours: the WM holds SubstructureRedirect
+                // there, and that is how the request reaches it.
+                XSendEvent(_display, XDefaultRootWindow(_display), false, SubstructureMask, e);
+                XFlush(_display);
+                return true;
+            }
+            finally { Marshal.FreeHGlobal(e); }
+        }
+    }
 
     /// <summary>The window's X11 id, or false when there is not one to have.
     ///

--- a/CCP.Avalonia/Platform/X11Overlay.cs
+++ b/CCP.Avalonia/Platform/X11Overlay.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia.Platform;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Platform;
+
+/// <summary>
+/// The two window behaviours the Chaos overlays need that Avalonia does not expose: making a
+/// visible window transparent to the mouse, and pinning one overlay directly above another.
+///
+/// <para><b>Why this is a shim and not a port.</b> On Windows these are
+/// <c>WS_EX_TRANSPARENT</c> (39 files) and <c>SetWindowPos(HWND_TOPMOST)</c> (34 files), each
+/// P/Invoked at the call site. Both have exact X11 equivalents, so the overlays keep behaving
+/// as they do today rather than losing a feature — but Avalonia.X11 12.1.1 binds neither, which
+/// was verified by extracting the assembly's symbols rather than assumed.</para>
+///
+/// <para><b>Topmost is deliberately absent from this class.</b> Avalonia already maps
+/// <c>Window.Topmost</c> to <c>_NET_WM_STATE_ABOVE</c>, which is the correct X11 mechanism, so
+/// the 34 <c>HWND_TOPMOST</c> sites port to that property and need nothing here. Wrapping it
+/// would add an indirection that only obscures where the behaviour comes from. The one case it
+/// does NOT cover — sitting above ANOTHER app's focused fullscreen window, which KWin promotes
+/// above the keep-above layer — needs an override-redirect or KDE window-type flip applied
+/// before the window maps, so it belongs in its own change rather than bolted on here.</para>
+///
+/// <para><b>Everything in here fails silently if written carelessly</b>, which is why each guard
+/// below is explicit rather than defensive habit:</para>
+/// <list type="bullet">
+///   <item>X extensions are negotiated PER CONNECTION. Without <c>XFixesQueryExtension</c> on
+///         this class's own display, the shape requests are dropped by the server with no error
+///         and the window simply stays clickable.</item>
+///   <item>This class owns its display, so nothing else ever flushes it. Unflushed requests sit
+///         in the buffer indefinitely and the toggle appears to do nothing.</item>
+///   <item>Xlib's default error handler calls <c>exit()</c>. The overlays create and destroy
+///         windows constantly, so an XID that dies between the handle read and the call here
+///         would take the whole app down. The handler below logs and continues.</item>
+///   <item>Xlib is not thread-safe and the display is shared, so every entry point locks.</item>
+/// </list>
+/// </summary>
+internal static class X11Overlay
+{
+    // Values read from the system headers, not from memory - a wrong constant here compiles and
+    // then silently addresses the wrong thing.
+    private const int ShapeInput = 2;        // X11/extensions/shapeconst.h
+
+    private const string LibX11 = "libX11.so.6";
+    private const string LibXfixes = "libXfixes.so.3";
+
+    private delegate int XErrorHandler(IntPtr display, IntPtr errorEvent);
+
+    [DllImport(LibX11)] private static extern IntPtr XOpenDisplay(IntPtr name);
+    [DllImport(LibX11)] private static extern int XFlush(IntPtr display);
+    [DllImport(LibX11)] private static extern IntPtr XSetErrorHandler(XErrorHandler handler);
+
+    [DllImport(LibXfixes)] private static extern int XFixesQueryExtension(IntPtr display, out int eventBase, out int errorBase);
+    [DllImport(LibXfixes)] private static extern IntPtr XFixesCreateRegion(IntPtr display, IntPtr rectangles, int count);
+    [DllImport(LibXfixes)] private static extern void XFixesSetWindowShapeRegion(IntPtr display, IntPtr window, int shapeKind, int xOffset, int yOffset, IntPtr region);
+    [DllImport(LibXfixes)] private static extern void XFixesDestroyRegion(IntPtr display, IntPtr region);
+
+    private static readonly object Gate = new();
+
+    // Held in a static field on purpose: Xlib keeps the raw function pointer, so letting the
+    // delegate be collected turns the next X error into a jump into freed memory.
+    private static readonly XErrorHandler ErrorHandler = OnXError;
+
+    private static IntPtr _display;
+    private static bool _initialised;
+    private static bool _usable;
+
+    /// <summary>True when this process can actually drive the calls below - an X11 display is
+    /// open and the server offers XFixes. False on Windows, on headless CI and under a native
+    /// Wayland backend, where every method here is a no-op.</summary>
+    internal static bool IsAvailable
+    {
+        get { lock (Gate) { return EnsureDisplay(); } }
+    }
+
+    /// <summary>Makes <paramref name="window"/> transparent to the mouse while it keeps drawing,
+    /// or gives it back its input. The X11 equivalent of adding and clearing
+    /// <c>WS_EX_TRANSPARENT</c>, and reversible at runtime the same way.
+    ///
+    /// <para>An empty input region passes every event to whatever is underneath; region
+    /// <c>None</c> restores the default, which is the window's whole shape. Note this is
+    /// strictly more capable than the Win32 original: a NON-empty region would give partial
+    /// click-through, which <c>WS_EX_TRANSPARENT</c> cannot express at all.</para></summary>
+    /// <returns>False when the platform cannot do this, so callers can branch without catching.</returns>
+    internal static bool SetClickThrough(TopLevel window, bool clickThrough)
+    {
+        if (!TryGetXid(window, out var xid)) return false;
+
+        lock (Gate)
+        {
+            if (!EnsureDisplay()) return false;
+
+            var region = IntPtr.Zero;             // None
+            if (clickThrough)
+                region = XFixesCreateRegion(_display, IntPtr.Zero, 0);
+
+            XFixesSetWindowShapeRegion(_display, xid, ShapeInput, 0, 0, region);
+
+            if (region != IntPtr.Zero)
+                XFixesDestroyRegion(_display, region);
+
+            XFlush(_display);
+            return true;
+        }
+    }
+
+    // NO RestackAbove HERE, DELIBERATELY - and this is a measured absence, not an oversight.
+    //
+    // The obvious implementation is XConfigureWindow(xid, CWSibling|CWStackMode, {sibling, Above}),
+    // which is the textbook analogue of SetWindowPos(hwnd, hwndInsertAfter, SWP_NOACTIVATE) and is
+    // what the porting research prescribed for the ~15-slot internal overlay order. It does not
+    // work on a window a compositing WM manages, and it fails SILENTLY: the request is valid, the
+    // server accepts it, and nothing moves.
+    //
+    // Measured with two real Avalonia windows under nested KWin - after the call the two windows
+    // held stacking indices 1 and 2 in exactly the order they started in. The reason is
+    // reparenting: KWin wraps each managed window in a frame, so the id Avalonia hands us is not a
+    // child of the root window, and restacking it only orders it inside its own frame where it is
+    // the only child.
+    //
+    // The real options are restacking the FRAME (fighting the WM, which re-asserts) or the EWMH
+    // _NET_RESTACK_WINDOW client message (asking the WM, which is the sanctioned route). Both need
+    // their own measurement, so they get their own change rather than an unverified method here.
+
+    /// <summary>The window's X11 id, or false when there is not one to have.
+    ///
+    /// <para>Gating on the descriptor rather than on the OS is what lets the call sites stay
+    /// identical across heads: on Windows, under the headless backend used by the render proof,
+    /// and before the window has opened, this simply returns false.</para></summary>
+    private static bool TryGetXid(TopLevel window, out IntPtr xid)
+    {
+        xid = IntPtr.Zero;
+        var handle = window?.TryGetPlatformHandle();
+        if (handle is null || !string.Equals(handle.HandleDescriptor, "XID", StringComparison.Ordinal))
+            return false;
+        if (handle.Handle == IntPtr.Zero) return false;
+
+        xid = handle.Handle;
+        return true;
+    }
+
+    private static bool EnsureDisplay()
+    {
+        if (_initialised) return _usable;
+        _initialised = true;
+
+        try
+        {
+            _display = XOpenDisplay(IntPtr.Zero);
+            if (_display == IntPtr.Zero)
+            {
+                Log.Debug("X11Overlay: no X display; click-through and restacking are no-ops");
+                return _usable = false;
+            }
+
+            XSetErrorHandler(ErrorHandler);
+
+            // Per-connection negotiation. Skipping this is the silent failure: the server drops
+            // the shape requests and the overlay stays clickable with nothing logged anywhere.
+            if (XFixesQueryExtension(_display, out _, out _) == 0)
+            {
+                Log.Warning("X11Overlay: the X server has no XFixes; overlays cannot be click-through");
+                return _usable = false;
+            }
+
+            return _usable = true;
+        }
+        catch (DllNotFoundException e)
+        {
+            Log.Debug(e, "X11Overlay: libX11/libXfixes not present; overlay window control is a no-op");
+            return _usable = false;
+        }
+    }
+
+    private static int OnXError(IntPtr display, IntPtr errorEvent)
+    {
+        // Xlib's default handler exits the process. An overlay destroyed between reading its
+        // handle and the call above is normal churn, not a reason to take the app down.
+        Log.Debug("X11Overlay: X error on the overlay display, ignored");
+        return 0;
+    }
+}

--- a/CCP.Avalonia/Program.cs
+++ b/CCP.Avalonia/Program.cs
@@ -25,6 +25,13 @@ namespace ConditioningControlPanel.Avalonia
             if (rv >= 0 && rv + 1 < args.Length)
                 return RenderProof.Run(args[rv + 1], () => new Views.AppShell());
 
+            // --x11-probe drives the X11 overlay shim against a real window and asks the X
+            // server which window owns the pointer. Every way that shim can fail returns
+            // success and changes nothing, so only the server's answer proves it works.
+            // Run it inside a nested compositor - scripts/x11-overlay-probe.sh does that.
+            if (Array.IndexOf(args, "--x11-probe") >= 0)
+                return X11OverlayProbe.Run();
+
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
             return 0;
         }

--- a/CCP.Avalonia/X11OverlayProbe.cs
+++ b/CCP.Avalonia/X11OverlayProbe.cs
@@ -57,6 +57,15 @@ namespace ConditioningControlPanel.Avalonia
         [DllImport(LibX11)] private static extern IntPtr XDefaultRootWindow(IntPtr display);
         [DllImport(LibX11)] private static extern int XQueryTree(IntPtr display, IntPtr window,
             out IntPtr root, out IntPtr parent, out IntPtr children, out uint count);
+        [StructLayout(LayoutKind.Sequential)]
+        private struct XWindowChanges
+        {
+            public int X, Y, Width, Height, BorderWidth;
+            public IntPtr Sibling;
+            public int StackMode;
+        }
+
+        [DllImport(LibX11)] private static extern int XConfigureWindow(IntPtr display, IntPtr window, uint mask, ref XWindowChanges changes);
         [DllImport(LibXext)] private static extern IntPtr XShapeGetRectangles(IntPtr display, IntPtr window,
             int kind, out int count, out int ordering);
 
@@ -78,6 +87,17 @@ namespace ConditioningControlPanel.Avalonia
                 ShowInTaskbar = false
             };
 
+            // A second window, so restacking has something to be ordered against.
+            var other = new Window
+            {
+                Title = "probe-other",
+                Width = 300,
+                Height = 300,
+                Background = Brushes.DarkGreen,
+                Topmost = true,
+                ShowInTaskbar = false
+            };
+
             var exit = 1;
             overlay.Opened += (_, _) =>
             {
@@ -85,18 +105,19 @@ namespace ConditioningControlPanel.Avalonia
                 // unmapped window has no meaningful input shape to read back.
                 DispatcherTimer.RunOnce(() =>
                 {
-                    try { exit = Score(overlay); }
+                    try { exit = Score(overlay, other); }
                     catch (Exception e) { Console.Error.WriteLine("probe threw: " + e); exit = 1; }
                     finally { lifetime.Shutdown(); }
                 }, TimeSpan.FromMilliseconds(1200));
             };
 
+            other.Show();
             overlay.Show();
             lifetime.Start(Array.Empty<string>());
             return exit;
         }
 
-        private static int Score(Window overlay)
+        private static int Score(Window overlay, Window other)
         {
             if (!X11Overlay.IsAvailable)
             {
@@ -160,9 +181,63 @@ namespace ConditioningControlPanel.Avalonia
                 var stillDrawn = bounding.Length == 1 && bounding[0].Width == w && bounding[0].Height == h;
                 Console.WriteLine($"[4] bounding shape unchanged  -> {Describe(bounding)}   {(stillDrawn ? "<-- still drawn" : "<-- FAILED, the visible shape moved too")}");
 
-                var pass = controlOk && clickThrough && restored && stillDrawn;
+                // [5] RestackAbove. Deliberately structured as TWO FLIPS with no seeding step:
+                // whatever order the windows happen to start in, the call has to reverse it and
+                // then reverse it back. A no-op cannot pass that, which a "put A above B and
+                // check A is above B" test would if they already started that way.
+                //
+                // The settle sleeps are load-bearing. The message goes to KWin, a separate
+                // process; XSync waits for the SERVER only, so reading the order immediately
+                // after the call reads the OLD order and the check fails on working code.
+                var otherXid = Xid(other);
+                var restackOk = false;
+                if (otherXid == IntPtr.Zero)
+                {
+                    Console.WriteLine("[5] RestackAbove              -> skipped, second window has no XID");
+                }
+                else
+                {
+                    var (a0, b0) = (IndexOf(display, root, xid), IndexOf(display, root, otherXid));
+                    Console.WriteLine($"[5a] initial order            -> ours={a0} other={b0}   {(a0 > b0 ? "ours above" : "other above")}");
+
+                    // Flip 1: whichever is underneath goes on top.
+                    var (lower, upper) = a0 > b0 ? (other, overlay) : (overlay, other);
+                    X11Overlay.RestackAbove(lower, upper);
+                    System.Threading.Thread.Sleep(800);
+                    var (a1, b1) = (IndexOf(display, root, xid), IndexOf(display, root, otherXid));
+                    var flipped = (a1 > b1) != (a0 > b0);
+                    Console.WriteLine($"[5b] restacked the lower one  -> ours={a1} other={b1}   {(flipped ? "<-- order REVERSED" : "<-- FAILED, nothing moved")}");
+
+                    // Flip 2: and back, because the overlays reorder repeatedly at runtime.
+                    X11Overlay.RestackAbove(upper, lower);
+                    System.Threading.Thread.Sleep(800);
+                    var (a2, b2) = (IndexOf(display, root, xid), IndexOf(display, root, otherXid));
+                    var flippedBack = (a2 > b2) == (a0 > b0);
+                    Console.WriteLine($"[5c] restacked the other one  -> ours={a2} other={b2}   {(flippedBack ? "<-- order RESTORED" : "<-- FAILED, one-way")}");
+
+                    restackOk = a0 >= 0 && b0 >= 0 && flipped && flippedBack;
+                }
+
+                // [6] Informational, not a gate: does the DIRECT call work on these windows too?
+                // The shim uses the EWMH message because that is the WM-sanctioned route, but the
+                // comment justifying that choice should rest on a measurement rather than on
+                // repeating what the research assumed.
+                if (otherXid != IntPtr.Zero)
+                {
+                    var (c0, d0) = (IndexOf(display, root, xid), IndexOf(display, root, otherXid));
+                    var (lo, hi) = c0 > d0 ? (otherXid, xid) : (xid, otherXid);
+                    var changes = new XWindowChanges { Sibling = hi, StackMode = 0 /* Above */ };
+                    XConfigureWindow(display, lo, (1u << 5) | (1u << 6) /* CWSibling|CWStackMode */, ref changes);
+                    XSync(display, false);
+                    System.Threading.Thread.Sleep(800);
+                    var (c1, d1) = (IndexOf(display, root, xid), IndexOf(display, root, otherXid));
+                    var direct = (c1 > d1) != (c0 > d0);
+                    Console.WriteLine($"[6] XConfigureWindow direct   -> {c0},{d0} then {c1},{d1}   {(direct ? "(also works here)" : "(no effect - EWMH is required)")}");
+                }
+
+                var pass = controlOk && clickThrough && restored && stillDrawn && restackOk;
                 Console.WriteLine(pass
-                    ? "\nPASS - the input region empties and refills on a real Avalonia window"
+                    ? "\nPASS - click-through toggles and the overlay order flips, on real Avalonia windows"
                     : "\nFAIL - the round trip did not complete");
                 return pass ? 0 : 1;
             }
@@ -190,9 +265,9 @@ namespace ConditioningControlPanel.Avalonia
 
         /// <summary>Position of a window in the root's stacking order, bottom first, or -1.
         ///
-        /// <para>KWin reparents managed windows into a frame, so the id we hold is NOT a child of
-        /// root - its frame is. Walking up to the child-of-root first is what makes this compare
-        /// the right two things.</para></summary>
+        /// <para>Walks up to the child-of-root first. KWin does not reparent an undecorated
+        /// XWayland window - measured, the frame and the window are the same id - but it does
+        /// reparent a decorated one, and this has to compare the right two things either way.</para></summary>
         private static int IndexOf(IntPtr display, IntPtr root, IntPtr window)
         {
             var frame = window;

--- a/CCP.Avalonia/X11OverlayProbe.cs
+++ b/CCP.Avalonia/X11OverlayProbe.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Platform;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    /// <summary>
+    /// Proves <see cref="X11Overlay.SetClickThrough"/> works on a REAL Avalonia window, by reading
+    /// back from the X server what the window's input shape actually became.
+    ///
+    /// <para><b>Why a probe and not a unit test.</b> Every way that shim can fail - a missed
+    /// extension negotiation, an unflushed request, a wrong constant, bad struct marshalling -
+    /// produces a call that returns successfully and changes nothing. Only the server's own answer
+    /// separates "worked" from "silently did nothing", and no mock can supply that.</para>
+    ///
+    /// <para><b>Why it reads the input region instead of clicking.</b> The obvious test is to put
+    /// the pointer over the overlay and ask which window owns it - which is what the C probes
+    /// <c>ct2</c>/<c>ct3</c> did, passing 3/3 against KWin on a real session, so the MECHANISM is
+    /// already measured. That test cannot run here: <c>XWarpPointer</c> is silently ignored under
+    /// XWayland (Wayland owns pointer position), and inside a virtual compositor an internal
+    /// XWayland window sits above every client, so no client ever owns the pointer. Verified by
+    /// running the known-good <c>ct3</c> binary in this same sandbox, where it fails identically -
+    /// so that is the environment's limit, not the shim's. What is left to prove here is this
+    /// codebase's MARSHALLING of the mechanism, and <c>XFixesCreateRegionFromWindow</c> +
+    /// <c>XFixesFetchRegion</c> answers exactly that, straight from the server.</para>
+    ///
+    /// <para><b>Run it in a NESTED compositor, never a live session</b> - see
+    /// <c>scripts/x11-overlay-probe.sh</c>. During the research a probe called a Qt-internal D-Bus
+    /// interface with hand-marshalled arguments and aborted KWin, killing the user's mail client,
+    /// file sync and a browser helper with it.</para>
+    /// </summary>
+    internal static class X11OverlayProbe
+    {
+        private const string LibX11 = "libX11.so.6";
+        private const string LibXext = "libXext.so.6";
+        private const int ShapeBounding = 0;   // X11/extensions/shapeconst.h
+        private const int ShapeInput = 2;      // X11/extensions/shapeconst.h
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct XRectangle { public short X, Y; public ushort Width, Height; }
+
+        [DllImport(LibX11)] private static extern IntPtr XOpenDisplay(IntPtr name);
+        [DllImport(LibX11)] private static extern int XCloseDisplay(IntPtr display);
+        [DllImport(LibX11)] private static extern int XSync(IntPtr display, bool discard);
+        [DllImport(LibX11)] private static extern int XFree(IntPtr data);
+        [DllImport(LibX11)] private static extern int XGetGeometry(IntPtr display, IntPtr drawable,
+            out IntPtr root, out int x, out int y, out uint width, out uint height, out uint borderWidth, out uint depth);
+
+        // NOT XFixesCreateRegionFromWindow: that call only defines WindowRegionBounding(0) and
+        // WindowRegionClip(1), so asking it for the INPUT shape fails with BadValue. The Shape
+        // extension is where input-shape read-back lives. Verified by getting the BadValue.
+        [DllImport(LibX11)] private static extern IntPtr XDefaultRootWindow(IntPtr display);
+        [DllImport(LibX11)] private static extern int XQueryTree(IntPtr display, IntPtr window,
+            out IntPtr root, out IntPtr parent, out IntPtr children, out uint count);
+        [DllImport(LibXext)] private static extern IntPtr XShapeGetRectangles(IntPtr display, IntPtr window,
+            int kind, out int count, out int ordering);
+
+        public static int Run()
+        {
+            var lifetime = new ClassicDesktopStyleApplicationLifetime
+            {
+                ShutdownMode = ShutdownMode.OnExplicitShutdown
+            };
+            Program.BuildAvaloniaApp().SetupWithLifetime(lifetime);
+
+            var overlay = new Window
+            {
+                Title = "probe-overlay",
+                Width = 400,
+                Height = 400,
+                Background = Brushes.DarkRed,
+                Topmost = true,
+                ShowInTaskbar = false
+            };
+
+            var exit = 1;
+            overlay.Opened += (_, _) =>
+            {
+                // Opened fires before the compositor has necessarily mapped the window, and an
+                // unmapped window has no meaningful input shape to read back.
+                DispatcherTimer.RunOnce(() =>
+                {
+                    try { exit = Score(overlay); }
+                    catch (Exception e) { Console.Error.WriteLine("probe threw: " + e); exit = 1; }
+                    finally { lifetime.Shutdown(); }
+                }, TimeSpan.FromMilliseconds(1200));
+            };
+
+            overlay.Show();
+            lifetime.Start(Array.Empty<string>());
+            return exit;
+        }
+
+        private static int Score(Window overlay)
+        {
+            if (!X11Overlay.IsAvailable)
+            {
+                Console.Error.WriteLine("FAIL: X11Overlay reports unavailable - no display, or the server has no XFixes");
+                return 1;
+            }
+
+            var xid = Xid(overlay);
+            Console.WriteLine($"overlay XID = 0x{xid.ToInt64():x}");
+            if (xid == IntPtr.Zero) { Console.Error.WriteLine("FAIL: no XID - not an X11 backend"); return 1; }
+
+            var display = XOpenDisplay(IntPtr.Zero);
+            if (display == IntPtr.Zero) { Console.Error.WriteLine("FAIL: no display"); return 1; }
+
+            try
+            {
+                var root = XDefaultRootWindow(display);
+                XGetGeometry(display, xid, out _, out _, out _, out var w, out var h, out _, out _);
+                Console.WriteLine($"overlay geometry = {w}x{h}");
+
+                // [1] control. A window with no input shape set reports one rectangle covering
+                // itself. If that is not what comes back, nothing below means anything.
+                var before = InputRects(display, xid);
+                var controlOk = before.Length == 1 && before[0].Width == w && before[0].Height == h;
+                Console.WriteLine($"[1] no input shape set        -> {Describe(before)}   {(controlOk ? "(control OK)" : "(CONTROL FAILED)")}");
+                if (!controlOk)
+                {
+                    Console.Error.WriteLine("FAIL: control step - the server did not report the default full-window input shape");
+                    return 1;
+                }
+
+                // [2] the actual claim: an empty input region, which is what makes every event
+                // pass through to whatever is underneath.
+                if (!X11Overlay.SetClickThrough(overlay, true))
+                {
+                    Console.Error.WriteLine("FAIL: SetClickThrough(true) returned false");
+                    return 1;
+                }
+                XSync(display, false);
+                var during = InputRects(display, xid);
+                var clickThrough = during.Length == 0;
+                Console.WriteLine($"[2] SetClickThrough(true)     -> {Describe(during)}   {(clickThrough ? "<-- CLICK-THROUGH (empty input region)" : "<-- FAILED, window still takes input")}");
+
+                // [3] reversibility. The Chaos overlays toggle this at runtime - draft and result
+                // surfaces go interactive again - so a one-way door is a regression even if [2]
+                // passed.
+                if (!X11Overlay.SetClickThrough(overlay, false))
+                {
+                    Console.Error.WriteLine("FAIL: SetClickThrough(false) returned false");
+                    return 1;
+                }
+                XSync(display, false);
+                var after = InputRects(display, xid);
+                var restored = after.Length == 1 && after[0].Width == w && after[0].Height == h;
+                Console.WriteLine($"[3] SetClickThrough(false)    -> {Describe(after)}   {(restored ? "<-- interactive again" : "<-- FAILED, toggle is one-way")}");
+
+                // The visible shape must be untouched throughout. Click-through that also stopped
+                // the window DRAWING would pass every check above and be useless - the overlays
+                // have to stay visible while the mouse goes through them.
+                var bounding = Rects(display, xid, ShapeBounding);
+                var stillDrawn = bounding.Length == 1 && bounding[0].Width == w && bounding[0].Height == h;
+                Console.WriteLine($"[4] bounding shape unchanged  -> {Describe(bounding)}   {(stillDrawn ? "<-- still drawn" : "<-- FAILED, the visible shape moved too")}");
+
+                var pass = controlOk && clickThrough && restored && stillDrawn;
+                Console.WriteLine(pass
+                    ? "\nPASS - the input region empties and refills on a real Avalonia window"
+                    : "\nFAIL - the round trip did not complete");
+                return pass ? 0 : 1;
+            }
+            finally { XCloseDisplay(display); }
+        }
+
+        /// <summary>The window's CURRENT input shape as the server holds it - not as we believe we
+        /// set it. This is the whole point: it is a read-back, so a request that was dropped,
+        /// never flushed, or aimed at the wrong shape kind shows up as the wrong answer here.</summary>
+        private static XRectangle[] InputRects(IntPtr display, IntPtr window) => Rects(display, window, ShapeInput);
+
+        private static XRectangle[] Rects(IntPtr display, IntPtr window, int kind)
+        {
+            var ptr = XShapeGetRectangles(display, window, kind, out var count, out _);
+            if (ptr == IntPtr.Zero || count <= 0) return Array.Empty<XRectangle>();
+            try
+            {
+                var rects = new XRectangle[count];
+                for (var i = 0; i < count; i++)
+                    rects[i] = Marshal.PtrToStructure<XRectangle>(ptr + i * Marshal.SizeOf<XRectangle>());
+                return rects;
+            }
+            finally { XFree(ptr); }
+        }
+
+        /// <summary>Position of a window in the root's stacking order, bottom first, or -1.
+        ///
+        /// <para>KWin reparents managed windows into a frame, so the id we hold is NOT a child of
+        /// root - its frame is. Walking up to the child-of-root first is what makes this compare
+        /// the right two things.</para></summary>
+        private static int IndexOf(IntPtr display, IntPtr root, IntPtr window)
+        {
+            var frame = window;
+            for (var hop = 0; hop < 8; hop++)
+            {
+                if (XQueryTree(display, frame, out _, out var parent, out var kids, out _) == 0) return -1;
+                if (kids != IntPtr.Zero) XFree(kids);
+                if (parent == root) break;
+                if (parent == IntPtr.Zero) return -1;
+                frame = parent;
+            }
+
+            if (XQueryTree(display, root, out _, out _, out var children, out var count) == 0) return -1;
+            if (children == IntPtr.Zero) return -1;
+            try
+            {
+                for (var i = 0; i < count; i++)
+                    if (Marshal.ReadIntPtr(children, i * IntPtr.Size) == frame) return i;
+                return -1;
+            }
+            finally { XFree(children); }
+        }
+
+        private static string Describe(XRectangle[] rects) =>
+            rects.Length == 0
+                ? "input region: EMPTY (0 rectangles)"
+                : $"input region: {rects.Length} rect(s), first {rects[0].Width}x{rects[0].Height} at {rects[0].X},{rects[0].Y}";
+
+        private static IntPtr Xid(TopLevel window)
+        {
+            var handle = window.TryGetPlatformHandle();
+            return handle is not null && handle.HandleDescriptor == "XID" ? handle.Handle : IntPtr.Zero;
+        }
+    }
+}

--- a/scripts/x11-overlay-probe.sh
+++ b/scripts/x11-overlay-probe.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Runs the X11 overlay shim's probe inside a THROWAWAY compositor.
+#
+# Never run overlay/input probes against a live desktop session. During the research for this
+# work a probe called a Qt-internal D-Bus interface with hand-marshalled arguments and aborted
+# kwin_wayland, which killed the user's mail client, file sync and a browser helper along with
+# it. Nothing here is more trustworthy than that probe was.
+#
+# --virtual renders to an offscreen framebuffer, so this compositor has no window on the real
+# desktop at all: a crash costs a process, and nothing is visible while it runs.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KWIN_SOCKET="ccp-probe-$$"
+
+command -v kwin_wayland >/dev/null || { echo "kwin_wayland not installed"; exit 127; }
+
+before="$(ls /tmp/.X11-unix 2>/dev/null | sort)"
+
+# env -u is the safety interlock: with WAYLAND_DISPLAY or DISPLAY visible, kwin nests inside the
+# live session instead of taking the virtual backend, and a crash takes the real desktop down.
+env -u WAYLAND_DISPLAY -u DISPLAY \
+    kwin_wayland --virtual --width 1600 --height 1000 --xwayland --socket="$KWIN_SOCKET" \
+    >/tmp/ccp-kwin-probe.log 2>&1 &
+KWIN_PID=$!
+trap 'kill "$KWIN_PID" 2>/dev/null; wait "$KWIN_PID" 2>/dev/null' EXIT
+
+NESTED=""
+for _ in $(seq 1 40); do
+  sleep 0.5
+  kill -0 "$KWIN_PID" 2>/dev/null || { echo "nested kwin died:"; tail -20 /tmp/ccp-kwin-probe.log; exit 1; }
+  after="$(ls /tmp/.X11-unix 2>/dev/null | sort)"
+  new="$(comm -13 <(echo "$before") <(echo "$after") | head -1)"
+  [ -n "$new" ] && { NESTED=":${new#X}"; break; }
+done
+[ -n "$NESTED" ] || { echo "nested Xwayland never appeared:"; tail -20 /tmp/ccp-kwin-probe.log; exit 1; }
+
+echo "nested compositor pid $KWIN_PID, Xwayland display $NESTED"
+echo
+
+# With arguments, run those inside the nested compositor instead - useful for running a
+# known-good C probe next to the shim's own, to tell "the shim is wrong" apart from "this
+# sandbox cannot score it".
+if [ "$#" -gt 0 ]; then
+  DISPLAY="$NESTED" WAYLAND_DISPLAY="" "$@"
+  exit $?
+fi
+
+# Only the .NET 10 runtime is installed on some dev boxes while everything here targets
+# net8.0, so roll forward rather than pinning the machine to an extra runtime.
+DISPLAY="$NESTED" WAYLAND_DISPLAY="" DOTNET_ROLL_FORWARD=LatestMajor \
+  dotnet run --project "$ROOT/CCP.Avalonia/CCP.Avalonia.csproj" -c Release --no-build -- --x11-probe


### PR DESCRIPTION
Layer 19. XFixes input shapes and _NET_RESTACK_WINDOW behind `Platform/X11Overlay.cs`, with a probe meant for a nested compositor.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351