### PR TITLE
feat(avalonia): per-view render proof, {loc:Str}, and the twelve shared styles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,9 @@ jobs:
       # asserting it can produce every value it renders does not.
       - run: dotnet run --project CCP.VR/CCP.VR.csproj -c Release -- --smoke
       - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render $RUNNER_TEMP/render/MainWindow.png
-      # One PNG per ported view. This is the per-view proof: a view that throws on construction,
-      # binds a key that does not exist, or nulls its own template shows up here and nowhere else.
-      # Non-zero exit fails the job.
+      # One PNG per ported view. A view that throws on construction fails the job; one that nulls
+      # its own template or binds a missing property does NOT - Avalonia keeps bindings silent -
+      # so the run prints every binding error per view and the PNGs are the proof. Read them.
       - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render-all $RUNNER_TEMP/render
       # always(): the PNGs matter MOST when a view failed - a reviewer needs the 23 that drew.
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,15 @@ jobs:
       # targets Steam Frame (SteamOS/ARM64) and Quest standalone. Rendering needs a device;
       # asserting it can produce every value it renders does not.
       - run: dotnet run --project CCP.VR/CCP.VR.csproj -c Release -- --smoke
-      - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render $RUNNER_TEMP/ccp-avalonia-linux.png
+      - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render $RUNNER_TEMP/render/MainWindow.png
+      # One PNG per ported view. This is the per-view proof: a view that throws on construction,
+      # binds a key that does not exist, or nulls its own template shows up here and nowhere else.
+      # Non-zero exit fails the job.
+      - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render-all $RUNNER_TEMP/render
       - uses: actions/upload-artifact@v4
         with:
           name: linux-head-render
-          path: ${{ runner.temp }}/ccp-avalonia-linux.png
+          path: ${{ runner.temp }}/render/
 
   # The "behaves identically on Windows" gate.
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,9 @@ jobs:
       # binds a key that does not exist, or nulls its own template shows up here and nowhere else.
       # Non-zero exit fails the job.
       - run: dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render-all $RUNNER_TEMP/render
+      # always(): the PNGs matter MOST when a view failed - a reviewer needs the 23 that drew.
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: linux-head-render
           path: ${{ runner.temp }}/render/

--- a/CCP.Avalonia/Localization/StrExtension.cs
+++ b/CCP.Avalonia/Localization/StrExtension.cs
@@ -1,0 +1,43 @@
+using System;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Localization
+{
+    /// <summary>
+    /// Avalonia twin of the WPF head's {loc:Str key} markup extension
+    /// (ConditioningControlPanel/Localization/LocExtension.cs). Same usage:
+    ///
+    ///   xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+    ///   Content="{loc:Str btn_cancel}"
+    ///
+    /// Returns a binding on LocalizationManager's indexer, so a language change re-renders every
+    /// string - the manager raises PropertyChanged("Item[]") from SetLanguage. The manager lives in
+    /// CCP.Core; only this binding shim is per head.
+    ///
+    /// Why this exists: the first 21 ports each carried a hand-written "string bag" class of
+    /// `LocX => Loc.Get("key")` properties. Every key name was transcribed by hand, which is where
+    /// the raw-key bug in PR #81 came from. With this the WPF XAML copies nearly verbatim.
+    /// Formatted strings (Loc.GetF) stay in code-behind, exactly as in WPF.
+    /// </summary>
+    public sealed class StrExtension : MarkupExtension
+    {
+        public string Key { get; set; }
+
+        public StrExtension() { Key = string.Empty; }
+        public StrExtension(string key) { Key = key; }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            if (string.IsNullOrEmpty(Key))
+                return string.Empty;
+
+            return new Binding($"[{Key}]")
+            {
+                Source = LocalizationManager.Instance,
+                Mode = BindingMode.OneWay,
+            };
+        }
+    }
+}

--- a/CCP.Avalonia/Program.cs
+++ b/CCP.Avalonia/Program.cs
@@ -19,11 +19,20 @@ namespace ConditioningControlPanel.Avalonia
             if (r >= 0 && r + 1 < args.Length)
                 return RenderProof.Run(args[r + 1]);
 
-            // --render-view <path> renders a single ported view for side-by-side comparison
-            // against its WPF original.
+            // --render-view <TypeName> <path> renders ONE ported view by name, e.g.
+            //   --render-view AchievementsTabView out.png
+            // The name is matched against every Control under the Views namespace (simple name
+            // or full name). Until this existed the flag ignored its argument and always drew
+            // AppShell, so 20 of the first 21 ported views had never been rendered by anything.
             var rv = Array.IndexOf(args, "--render-view");
-            if (rv >= 0 && rv + 1 < args.Length)
-                return RenderProof.Run(args[rv + 1], () => new Views.AppShell());
+            if (rv >= 0 && rv + 2 < args.Length)
+                return RenderProof.RunView(args[rv + 1], args[rv + 2]);
+
+            // --render-all <dir> renders every view under Views/ to <dir>/<TypeName>.png and
+            // fails if any one throws. This is the per-view proof CI uploads.
+            var ra = Array.IndexOf(args, "--render-all");
+            if (ra >= 0 && ra + 1 < args.Length)
+                return RenderProof.RunAll(args[ra + 1]);
 
             // --x11-probe drives the X11 overlay shim against a real window and asks the X
             // server which window owns the pointer. Every way that shim can fail returns

--- a/CCP.Avalonia/Program.cs
+++ b/CCP.Avalonia/Program.cs
@@ -25,14 +25,28 @@ namespace ConditioningControlPanel.Avalonia
             // or full name). Until this existed the flag ignored its argument and always drew
             // AppShell, so 20 of the first 21 ported views had never been rendered by anything.
             var rv = Array.IndexOf(args, "--render-view");
-            if (rv >= 0 && rv + 2 < args.Length)
+            if (rv >= 0)
+            {
+                if (rv + 2 >= args.Length)
+                {
+                    Console.Error.WriteLine("usage: --render-view <TypeName> <out.png>");
+                    return 2;
+                }
                 return RenderProof.RunView(args[rv + 1], args[rv + 2]);
+            }
 
             // --render-all <dir> renders every view under Views/ to <dir>/<TypeName>.png and
             // fails if any one throws. This is the per-view proof CI uploads.
             var ra = Array.IndexOf(args, "--render-all");
-            if (ra >= 0 && ra + 1 < args.Length)
+            if (ra >= 0)
+            {
+                if (ra + 1 >= args.Length)
+                {
+                    Console.Error.WriteLine("usage: --render-all <dir>");
+                    return 2;
+                }
                 return RenderProof.RunAll(args[ra + 1]);
+            }
 
             // --x11-probe drives the X11 overlay shim against a real window and asks the X
             // server which window owns the pointer. Every way that shim can fail returns

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.Headless;
 using Avalonia.Media.Imaging;
@@ -8,7 +12,7 @@ using Avalonia.Media.Imaging;
 namespace ConditioningControlPanel.Avalonia
 {
     /// <summary>
-    /// Renders the real MainWindow offscreen and writes a PNG.
+    /// Renders the real MainWindow, or any ported view, offscreen and writes a PNG.
     ///
     /// This exists because "it compiles" and "it boots" are both weaker claims than "it draws".
     /// A desktop screenshot cannot run on a CI runner with no display server; headless Skia
@@ -17,6 +21,22 @@ namespace ConditioningControlPanel.Avalonia
     /// </summary>
     internal static class RenderProof
     {
+        private static bool _setUp;
+
+        /// <summary>
+        /// One headless platform per process. SetupWithoutStarting() throws if called twice,
+        /// which is what --render-all would otherwise do for every view.
+        /// </summary>
+        private static void EnsureSetUp()
+        {
+            if (_setUp) return;
+            AppBuilder.Configure<App>()
+                .UseSkia()
+                .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+                .SetupWithoutStarting();
+            _setUp = true;
+        }
+
         public static int Run(string outPath) => Run(outPath, null);
 
         /// <param name="viewFactory">Optional factory for a view to host instead of the default
@@ -28,19 +48,19 @@ namespace ConditioningControlPanel.Avalonia
         /// SetupWithoutStarting() has called App.Initialize(). The view then binds against an
         /// uninitialised app - which showed up as every localized string rendering as its raw key
         /// while the same lookup succeeded in --smoke. Construct after setup, not before.</param>
-        public static int Run(string outPath, global::System.Func<global::Avalonia.Controls.Control>? viewFactory)
+        public static int Run(string outPath, Func<Control>? viewFactory)
         {
             try
             {
-                AppBuilder.Configure<App>()
-                    .UseSkia()
-                    .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
-                    .SetupWithoutStarting();
+                EnsureSetUp();
 
                 var window = new MainWindow { Width = 880, Height = 620 };
                 if (viewFactory is not null)
                 {
-                    window.Content = viewFactory();
+                    var view = viewFactory();
+                    // A ported Window cannot be nested; host its content instead. The chrome is
+                    // Avalonia's, the content is the port - which is the part under test.
+                    window.Content = view is Window w ? DetachContent(w) : view;
                     // Wide enough that the shell's 196px rail plus content is not clipped.
                     window.Width = 1100;
                     window.Height = 780;
@@ -61,9 +81,10 @@ namespace ConditioningControlPanel.Avalonia
                 var dir = Path.GetDirectoryName(Path.GetFullPath(outPath));
                 if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
                 frame.Save(outPath);
+                window.Close();
 
                 var len = new FileInfo(outPath).Length;
-                Console.WriteLine($"rendered MainWindow -> {outPath} ({frame.PixelSize.Width}x{frame.PixelSize.Height}, {len} bytes)");
+                Console.WriteLine($"rendered -> {outPath} ({frame.PixelSize.Width}x{frame.PixelSize.Height}, {len} bytes)");
                 return len > 0 ? 0 : 1;
             }
             catch (Exception ex)
@@ -72,5 +93,62 @@ namespace ConditioningControlPanel.Avalonia
                 return 1;
             }
         }
+
+        /// <summary>
+        /// Lift a ported Window's content out so it can be hosted. The DataContext lives on the
+        /// Window and is inherited by the content, so it must travel too - without this every
+        /// bound string in a dialog rendered blank (found by the first --render-all).
+        /// </summary>
+        private static object? DetachContent(Window w)
+        {
+            var c = w.Content;
+            w.Content = null;
+            if (c is StyledElement se && se.DataContext is null)
+                se.DataContext = w.DataContext;
+            return c;
+        }
+
+        /// <summary>Render one view, found by simple or full type name.</summary>
+        public static int RunView(string typeName, string outPath)
+        {
+            var type = Views().FirstOrDefault(t =>
+                string.Equals(t.Name, typeName, StringComparison.Ordinal) ||
+                string.Equals(t.FullName, typeName, StringComparison.Ordinal));
+            if (type is null)
+            {
+                Console.Error.WriteLine($"no view named '{typeName}'. Known views:");
+                foreach (var t in Views()) Console.Error.WriteLine("  " + t.Name);
+                return 2;
+            }
+            return Run(outPath, () => (Control)Activator.CreateInstance(type)!);
+        }
+
+        /// <summary>Render every view to &lt;dir&gt;/&lt;TypeName&gt;.png. Non-zero if any fails.</summary>
+        public static int RunAll(string dir)
+        {
+            Directory.CreateDirectory(dir);
+            var failed = new List<string>();
+            var views = Views().ToList();
+            foreach (var t in views)
+            {
+                var rc = Run(Path.Combine(dir, t.Name + ".png"), () => (Control)Activator.CreateInstance(t)!);
+                if (rc != 0) failed.Add(t.Name);
+            }
+            Console.WriteLine($"{views.Count - failed.Count}/{views.Count} views rendered to {dir}");
+            foreach (var f in failed) Console.Error.WriteLine("  FAILED " + f);
+            return failed.Count == 0 ? 0 : 1;
+        }
+
+        /// <summary>
+        /// Every concrete Control with a parameterless constructor under the Views namespace.
+        /// Sorted so the --render-all output and the "known views" listing are stable.
+        /// </summary>
+        private static IEnumerable<Type> Views() =>
+            typeof(RenderProof).Assembly.GetTypes()
+                .Where(t => t.IsClass && !t.IsAbstract
+                            && typeof(Control).IsAssignableFrom(t)
+                            && (t.Namespace ?? "").StartsWith("ConditioningControlPanel.Avalonia.Views", StringComparison.Ordinal)
+                            && t.GetConstructor(Type.EmptyTypes) is not null)
+                .OrderBy(t => t.Name, StringComparer.Ordinal);
     }
 }

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -30,7 +30,11 @@ namespace ConditioningControlPanel.Avalonia
         private static void EnsureSetUp()
         {
             if (_setUp) return;
-            AppBuilder.Configure<App>()
+            // Start from the app's own builder so the render uses the same Inter font the user
+            // sees; a bare Configure<App>() drew every PNG in the platform fallback face, which
+            // hides exactly the text-metric overruns these renders exist to show. UseHeadless
+            // replaces the windowing subsystem UsePlatformDetect chose, so no display is needed.
+            Program.BuildAvaloniaApp()
                 .UseSkia()
                 .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
                 .SetupWithoutStarting();

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -7,6 +7,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.Headless;
+using Avalonia.Logging;
 using Avalonia.Media.Imaging;
 
 namespace ConditioningControlPanel.Avalonia
@@ -22,6 +23,28 @@ namespace ConditioningControlPanel.Avalonia
     internal static class RenderProof
     {
         private static bool _setUp;
+        private static readonly BindingErrorSink _bindingErrors = new();
+
+        /// <summary>
+        /// A failed binding is SILENT in Avalonia: the control keeps its default and the render
+        /// exits 0. That is how a view with every binding broken (EngineRoomDrawer's provider
+        /// bindings, on main) draws a header over 700px of nothing and passes. This sink counts
+        /// Binding-area warnings and errors per view and prints them, so the log names the
+        /// property and the path rather than leaving it to someone squinting at a PNG.
+        /// </summary>
+        private sealed class BindingErrorSink : ILogSink
+        {
+            public readonly List<string> Messages = new();
+            public bool IsEnabled(LogEventLevel level, string area) =>
+                area == LogArea.Binding && level >= LogEventLevel.Warning;
+            public void Log(LogEventLevel level, string area, object? source, string messageTemplate)
+                => Messages.Add($"{source?.GetType().Name}: {messageTemplate}");
+            public void Log(LogEventLevel level, string area, object? source, string messageTemplate, params object?[] propertyValues)
+            {
+                try { Messages.Add($"{source?.GetType().Name}: {string.Format(messageTemplate.Replace("{Property}", "{0}").Replace("{Path}", "{1}").Replace("{Error}", "{2}"), propertyValues)}"); }
+                catch { Messages.Add($"{source?.GetType().Name}: {messageTemplate}"); }
+            }
+        }
 
         /// <summary>
         /// One headless platform per process. SetupWithoutStarting() throws if called twice,
@@ -38,6 +61,7 @@ namespace ConditioningControlPanel.Avalonia
                 .UseSkia()
                 .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
                 .SetupWithoutStarting();
+            Logger.Sink = _bindingErrors;
             _setUp = true;
         }
 
@@ -58,6 +82,7 @@ namespace ConditioningControlPanel.Avalonia
             try
             {
                 EnsureSetUp();
+                _bindingErrors.Messages.Clear();
 
                 if (viewFactory is not null)
                 {
@@ -100,7 +125,10 @@ namespace ConditioningControlPanel.Avalonia
                 frame.Save(outPath);
 
                 var len = new FileInfo(outPath).Length;
-                Console.WriteLine($"rendered -> {outPath} ({frame.PixelSize.Width}x{frame.PixelSize.Height}, {len} bytes)");
+                var errs = _bindingErrors.Messages.Count;
+                Console.WriteLine($"rendered -> {outPath} ({frame.PixelSize.Width}x{frame.PixelSize.Height}, {len} bytes){(errs > 0 ? $"  [{errs} binding error(s)]" : "")}");
+                foreach (var m in _bindingErrors.Messages.Distinct().Take(20))
+                    Console.WriteLine("    binding: " + m);
                 return len > 0 ? 0 : 1;
             }
             catch (Exception ex)
@@ -128,7 +156,7 @@ namespace ConditioningControlPanel.Avalonia
                 foreach (var t in Views()) Console.Error.WriteLine("  " + t.Name);
                 return 2;
             }
-            return Run(outPath, () => (Control)Activator.CreateInstance(type)!);
+            return Run(outPath, () => Construct(type));
         }
 
         /// <summary>Render every view to &lt;dir&gt;/&lt;TypeName&gt;.png. Non-zero if any fails.</summary>
@@ -139,7 +167,7 @@ namespace ConditioningControlPanel.Avalonia
             var views = Views().ToList();
             foreach (var t in views)
             {
-                var rc = Run(Path.Combine(dir, t.Name + ".png"), () => (Control)Activator.CreateInstance(t)!);
+                var rc = Run(Path.Combine(dir, t.Name + ".png"), () => Construct(t));
                 if (rc != 0) failed.Add(t.Name);
             }
             Console.WriteLine($"{views.Count - failed.Count}/{views.Count} views rendered to {dir}");
@@ -148,15 +176,24 @@ namespace ConditioningControlPanel.Avalonia
         }
 
         /// <summary>
-        /// Every concrete Control with a parameterless constructor under the Views namespace.
+        /// Every concrete Control under the Views namespace - including ones with NO parameterless
+        /// constructor, which then fail in RunAll rather than silently shrinking the proof. A dialog
+        /// that needs arguments gets an `internal` render constructor with sample data (see
+        /// TextEditorDialog); internal, so no production caller can ship the sample.
         /// Sorted so the --render-all output and the "known views" listing are stable.
         /// </summary>
         private static IEnumerable<Type> Views() =>
             typeof(RenderProof).Assembly.GetTypes()
-                .Where(t => t.IsClass && !t.IsAbstract
+                .Where(t => t.IsClass && !t.IsAbstract && !t.IsNested
                             && typeof(Control).IsAssignableFrom(t)
-                            && (t.Namespace ?? "").StartsWith("ConditioningControlPanel.Avalonia.Views", StringComparison.Ordinal)
-                            && t.GetConstructor(Type.EmptyTypes) is not null)
+                            && (t.Namespace ?? "").StartsWith("ConditioningControlPanel.Avalonia.Views", StringComparison.Ordinal))
                 .OrderBy(t => t.Name, StringComparer.Ordinal);
+
+        private static Control Construct(Type t)
+        {
+            var ctor = t.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null)
+                ?? throw new InvalidOperationException($"{t.Name} has no parameterless constructor; add an internal render constructor with sample data.");
+            return (Control)ctor.Invoke(null);
+        }
     }
 }

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -50,20 +50,33 @@ namespace ConditioningControlPanel.Avalonia
         /// while the same lookup succeeded in --smoke. Construct after setup, not before.</param>
         public static int Run(string outPath, Func<Control>? viewFactory)
         {
+            Window? window = null;
             try
             {
                 EnsureSetUp();
 
-                var window = new MainWindow { Width = 880, Height = 620 };
                 if (viewFactory is not null)
                 {
                     var view = viewFactory();
-                    // A ported Window cannot be nested; host its content instead. The chrome is
-                    // Avalonia's, the content is the port - which is the part under test.
-                    window.Content = view is Window w ? DetachContent(w) : view;
-                    // Wide enough that the shell's 196px rail plus content is not clipped.
-                    window.Width = 1100;
-                    window.Height = 780;
+                    if (view is Window w)
+                    {
+                        // A ported dialog is a Window: show IT, not its content re-parented into a
+                        // host. Re-parenting breaks every `$parent[Window]` binding in the dialog
+                        // (they resolve to the host, whose DataContext is null) and rendered blank
+                        // labels with exit code 0 - the exact class of bug this flag exists to catch.
+                        window = w;
+                        if (double.IsNaN(w.Width) || w.Width < 200) w.Width = 1100;
+                        if (double.IsNaN(w.Height) || w.Height < 200) w.Height = 780;
+                    }
+                    else
+                    {
+                        // Wide enough that the shell's 196px rail plus content is not clipped.
+                        window = new MainWindow { Width = 1100, Height = 780, Content = view };
+                    }
+                }
+                else
+                {
+                    window = new MainWindow { Width = 880, Height = 620 };
                 }
                 window.Show();
 
@@ -81,7 +94,6 @@ namespace ConditioningControlPanel.Avalonia
                 var dir = Path.GetDirectoryName(Path.GetFullPath(outPath));
                 if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
                 frame.Save(outPath);
-                window.Close();
 
                 var len = new FileInfo(outPath).Length;
                 Console.WriteLine($"rendered -> {outPath} ({frame.PixelSize.Width}x{frame.PixelSize.Height}, {len} bytes)");
@@ -92,20 +104,12 @@ namespace ConditioningControlPanel.Avalonia
                 Console.Error.WriteLine("render failed: " + ex);
                 return 1;
             }
-        }
-
-        /// <summary>
-        /// Lift a ported Window's content out so it can be hosted. The DataContext lives on the
-        /// Window and is inherited by the content, so it must travel too - without this every
-        /// bound string in a dialog rendered blank (found by the first --render-all).
-        /// </summary>
-        private static object? DetachContent(Window w)
-        {
-            var c = w.Content;
-            w.Content = null;
-            if (c is StyledElement se && se.DataContext is null)
-                se.DataContext = w.DataContext;
-            return c;
+            finally
+            {
+                // --render-all runs many views in one process; a window left open by a failed
+                // view would otherwise stay in the headless platform's window list.
+                try { window?.Close(); } catch { /* already closed or never shown */ }
+            }
         }
 
         /// <summary>Render one view, found by simple or full type name.</summary>

--- a/CCP.Avalonia/Theme/Styles.xaml
+++ b/CCP.Avalonia/Theme/Styles.xaml
@@ -491,50 +491,99 @@
        theme of ours to alias, so BasedOn the Fluent default - the key exists for its call site. -->
   <ControlTheme x:Key="FocusGlowTextBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}"/>
 
-  <!-- MainWindow.xaml:280. WPF's Track/RepeatButton machinery is Avalonia's Track too, but the
-       stock Fluent slider template is a 60-line part contract (PART_Track, PART_DecreaseButton,
-       PART_IncreaseButton, thumb). Restyling those parts through selectors keeps the interaction
-       code and only repaints, which is what the WPF template does visually: 3px groove, pink
-       fill, 14px white thumb. -->
-  <ControlTheme x:Key="PinkSlider" TargetType="Slider" BasedOn="{StaticResource {x:Type Slider}}">
+  <!-- MainWindow.xaml:280. The WPF template replaced wholesale, and so does this one: a
+       ControlTheme's Resources are NOT in the DynamicResource lookup path of the templated parts,
+       and a `/template/ Thumb` setter loses to Fluent's own thumb theme (both measured: the thumb
+       stayed Fluent blue either way). So the template is our own - Track + two RepeatButtons +
+       Thumb, the same parts WPF's has. 3px groove, pink fill, 14px white thumb. -->
+  <!-- The two RepeatButtons are themed, not inline-templated: an inline template nested inside
+       the Slider's template painted nothing under headless Skia (measured), the theme form does. -->
+  <ControlTheme x:Key="SliderFillButton" TargetType="RepeatButton">
+    <Setter Property="Focusable" Value="False"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="RepeatButton">
+        <Border Background="{TemplateBinding Background}" Height="{TemplateBinding Height}"
+                CornerRadius="{TemplateBinding CornerRadius}" VerticalAlignment="Center"/>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="PinkSlider" TargetType="Slider">
     <Setter Property="Minimum" Value="0"/>
     <Setter Property="Maximum" Value="100"/>
     <Setter Property="Height" Value="18"/>
     <Setter Property="Margin" Value="0"/>
-    <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
     <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
-    <Style Selector="^ /template/ Thumb">
-      <Setter Property="Width" Value="14"/>
-      <Setter Property="Height" Value="14"/>
-      <Setter Property="Background" Value="White"/>
-      <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}"/>
-      <Setter Property="BorderThickness" Value="1"/>
-      <Setter Property="CornerRadius" Value="7"/>
-    </Style>
-    <Style Selector="^:disabled">
-      <Setter Property="Opacity" Value="0.35"/>
-    </Style>
+    <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Slider">
+        <Grid>
+          <Border x:Name="TrackGroove" Height="3" Background="{TemplateBinding Background}" CornerRadius="1.5" VerticalAlignment="Center"/>
+          <Track x:Name="PART_Track" Orientation="Horizontal" VerticalAlignment="Center"
+                 Minimum="{TemplateBinding Minimum}" Maximum="{TemplateBinding Maximum}"
+                 Value="{TemplateBinding Value, Mode=TwoWay}" IsDirectionReversed="{TemplateBinding IsDirectionReversed}">
+            <Track.DecreaseButton>
+              <RepeatButton x:Name="PART_DecreaseButton" Theme="{StaticResource SliderFillButton}"
+                            Background="{TemplateBinding Foreground}" Height="3" CornerRadius="1.5"/>
+            </Track.DecreaseButton>
+            <Track.IncreaseButton>
+              <RepeatButton x:Name="PART_IncreaseButton" Theme="{StaticResource SliderFillButton}"
+                            Background="Transparent" Height="3"/>
+            </Track.IncreaseButton>
+            <Thumb x:Name="SliderThumb" Width="14" Height="14" Cursor="Hand">
+              <Thumb.Template>
+                <ControlTemplate TargetType="Thumb">
+                  <Border x:Name="ThumbBody" Width="14" Height="14" CornerRadius="7" Background="White"
+                          BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"/>
+                </ControlTemplate>
+              </Thumb.Template>
+            </Thumb>
+          </Track>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+    <!-- A disabled slider must LOOK disabled (WPF comment kept): dim groove, fill and thumb. -->
+    <Style Selector="^:disabled /template/ Border#TrackGroove"><Setter Property="Opacity" Value="0.35"/></Style>
+    <Style Selector="^:disabled /template/ RepeatButton#PART_DecreaseButton"><Setter Property="Opacity" Value="0.28"/></Style>
+    <Style Selector="^:disabled /template/ Thumb#SliderThumb"><Setter Property="Opacity" Value="0.35"/></Style>
   </ControlTheme>
 
-  <!-- MainWindow.xaml:350. Same restyle approach as PinkSlider: 6px track, pink->purple fill,
-       16px pink thumb. The thumb's DropShadowEffect glow is dropped (no Effect on Avalonia). -->
-  <ControlTheme x:Key="BlinkTrainerGradientSlider" TargetType="Slider" BasedOn="{StaticResource {x:Type Slider}}">
+  <!-- MainWindow.xaml:350. Same parts, heavier: 6px track, pink->purple gradient fill, 16px pink
+       thumb with a white ring. The thumb's DropShadowEffect glow is dropped. -->
+  <ControlTheme x:Key="BlinkTrainerGradientSlider" TargetType="Slider">
     <Setter Property="MinHeight" Value="22"/>
-    <Setter Property="Background" Value="#22FFFFFF"/>
-    <Setter Property="Foreground">
-      <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
-        <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
-        <GradientStop Color="{DynamicResource NeonPurpleColor}" Offset="1"/>
-      </LinearGradientBrush>
+    <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Slider">
+        <Grid Height="22">
+          <Border Height="6" CornerRadius="3" Background="#22FFFFFF" VerticalAlignment="Center"/>
+          <Track x:Name="PART_Track" Orientation="Horizontal" VerticalAlignment="Center"
+                 Minimum="{TemplateBinding Minimum}" Maximum="{TemplateBinding Maximum}"
+                 Value="{TemplateBinding Value, Mode=TwoWay}" IsDirectionReversed="{TemplateBinding IsDirectionReversed}">
+            <Track.DecreaseButton>
+              <RepeatButton x:Name="PART_DecreaseButton" Theme="{StaticResource SliderFillButton}" Height="6" CornerRadius="3">
+                <RepeatButton.Background>
+                  <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                    <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+                    <GradientStop Color="{DynamicResource NeonPurpleColor}" Offset="1"/>
+                  </LinearGradientBrush>
+                </RepeatButton.Background>
+              </RepeatButton>
+            </Track.DecreaseButton>
+            <Track.IncreaseButton>
+              <RepeatButton x:Name="PART_IncreaseButton" Theme="{StaticResource SliderFillButton}" Background="Transparent" Height="6"/>
+            </Track.IncreaseButton>
+            <Thumb Width="16" Height="16" Cursor="Hand">
+              <Thumb.Template>
+                <ControlTemplate TargetType="Thumb">
+                  <Ellipse Fill="{DynamicResource PinkBrush}" Stroke="White" StrokeThickness="1.5"/>
+                </ControlTemplate>
+              </Thumb.Template>
+            </Thumb>
+          </Track>
+        </Grid>
+      </ControlTemplate>
     </Setter>
-    <Style Selector="^ /template/ Thumb">
-      <Setter Property="Width" Value="16"/>
-      <Setter Property="Height" Value="16"/>
-      <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
-      <Setter Property="BorderBrush" Value="White"/>
-      <Setter Property="BorderThickness" Value="1.5"/>
-      <Setter Property="CornerRadius" Value="8"/>
-    </Style>
   </ControlTheme>
 
   <!-- MainWindow.xaml:1234. Restyles the Fluent ComboBox parts rather than replacing the
@@ -549,11 +598,13 @@
     <Setter Property="Padding" Value="8,5"/>
     <Setter Property="CornerRadius" Value="6"/>
     <Setter Property="Cursor" Value="Hand"/>
-    <Style Selector="^:pointerover">
+    <!-- Fluent's item theme sets Background/Foreground on the presenter for these states, so a
+         control-level setter is overridden; target the presenter as Fluent does. -->
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Background" Value="{DynamicResource TransparentPink20Brush}"/>
       <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
     </Style>
-    <Style Selector="^:selected">
+    <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Background" Value="{DynamicResource TransparentPink40Brush}"/>
       <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
     </Style>
@@ -609,10 +660,18 @@
             </LinearGradientBrush>
           </Border.BorderBrush>
           <Grid RowDefinitions="Auto,Auto">
-            <ToggleButton Grid.Row="0" x:Name="PART_toggle" Cursor="Hand" Background="Transparent"
+            <ToggleButton Grid.Row="0" x:Name="PART_toggle" Cursor="Hand"
                           IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
-                          HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
-                          Padding="12,10" BorderThickness="0">
+                          HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+              <!-- Own template: Fluent's ToggleButton paints its :checked state accent-blue,
+                   and an expanded card is always :checked. WPF's header is a bare Border. -->
+              <ToggleButton.Template>
+                <ControlTemplate TargetType="ToggleButton">
+                  <Border Background="Transparent" Padding="12,10">
+                    <ContentPresenter Content="{TemplateBinding Content}"/>
+                  </Border>
+                </ControlTemplate>
+              </ToggleButton.Template>
               <Grid ColumnDefinitions="3,8,*,Auto">
                 <Rectangle Grid.Column="0" RadiusX="1.5" RadiusY="1.5">
                   <Rectangle.Fill>

--- a/CCP.Avalonia/Theme/Styles.xaml
+++ b/CCP.Avalonia/Theme/Styles.xaml
@@ -327,4 +327,320 @@
     </Style>
   </ControlTheme>
 
+  <!-- ============================================================================================
+       Shared keys the next batch of ported views bind to. Measured across AppSettings, Companion,
+       Dialogs and Features: these twelve were used there and missing here. Sources named per key.
+       Trigger machinery maps as elsewhere in this file: Trigger -> pseudo-class selector,
+       Storyboard scale -> RenderTransform setter, DropShadowEffect -> dropped (no Effect on
+       Avalonia Border; see ToggleStyle's note above).
+       Every templated-control theme here carries a Template. A property-only ControlTheme on a
+       templated control REPLACES its theme and leaves Template null - it draws nothing (trap 4).
+       ============================================================================================ -->
+
+  <!-- Inputs.xaml:32. Lives beside DarkComboBoxStyle, its only consumer here. -->
+  <SolidColorBrush x:Key="InputHoverBorderBrush" Color="{DynamicResource PinkColor}" Opacity="0.6"/>
+
+  <!-- Controls.xaml:429 -->
+  <ControlTheme x:Key="OutlineButton" TargetType="Button">
+    <Setter Property="Background" Value="Transparent"/>
+    <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="BorderThickness" Value="1.5"/>
+    <Setter Property="FontWeight" Value="Bold"/>
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="Padding" Value="15,8"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="border" Background="Transparent"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="8" Padding="{TemplateBinding Padding}"
+                RenderTransformOrigin="50%,50%">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource TransparentPinkBrush}"/>
+    </Style>
+    <Style Selector="^:pressed /template/ Border#border">
+      <Setter Property="RenderTransform" Value="scale(0.97)"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- Controls.xaml:342 -->
+  <ControlTheme x:Key="PinkButton" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="Foreground" Value="White"/>
+    <Setter Property="FontWeight" Value="Bold"/>
+    <Setter Property="FontSize" Value="14"/>
+    <Setter Property="Padding" Value="20,10"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="BorderBrush" Value="White"/>
+    <Setter Property="BorderThickness" Value="1.5"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="border" Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="8" Padding="{TemplateBinding Padding}">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource DarkPinkBrush}"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- MainWindow.xaml:122 -->
+  <ControlTheme x:Key="SmallPinkButton" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="Foreground" Value="White"/>
+    <Setter Property="BorderThickness" Value="0"/>
+    <Setter Property="FontWeight" Value="SemiBold"/>
+    <Setter Property="FontSize" Value="11"/>
+    <Setter Property="Padding" Value="12,6"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="border" CornerRadius="6" Padding="{TemplateBinding Padding}"
+                Background="{TemplateBinding Background}"
+                RenderTransformOrigin="50%,50%">
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource PinkButtonHoveredBrush}"/>
+    </Style>
+    <Style Selector="^:pressed /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
+      <Setter Property="RenderTransform" Value="scale(0.97)"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- Controls.xaml:153. Background is set per instance (it IS the colour swatch). -->
+  <ControlTheme x:Key="ColorButton" TargetType="Button">
+    <Setter Property="Width" Value="40"/>
+    <Setter Property="Height" Value="28"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="BorderThickness" Value="1.5"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource PanelAccentBrush}"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Button">
+        <Border x:Name="border" Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="6"/>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:pointerover /template/ Border#border">
+      <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- Controls.xaml:337. BasedOn is what keeps the Template (trap 4). -->
+  <ControlTheme x:Key="ColorButtonLarge" TargetType="Button" BasedOn="{StaticResource ColorButton}">
+    <Setter Property="Height" Value="40"/>
+  </ControlTheme>
+
+  <!-- Controls.xaml:310 -->
+  <ControlTheme x:Key="DotCheckBoxStyle" TargetType="CheckBox">
+    <Setter Property="Foreground" Value="White"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="CheckBox">
+        <StackPanel Orientation="Horizontal" Background="Transparent">
+          <Border x:Name="dot" Width="16" Height="16" CornerRadius="8" Margin="0,0,10,0"
+                  Background="#3A3A48" BorderBrush="#5A5A6A" BorderThickness="1"
+                  VerticalAlignment="Center"/>
+          <ContentPresenter Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            VerticalAlignment="Center"/>
+        </StackPanel>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:checked /template/ Border#dot">
+      <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+    </Style>
+    <Style Selector="^:pointerover /template/ Border#dot">
+      <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- MainWindow.xaml:557. TextBlock is not templated, so property-only is safe here. -->
+  <ControlTheme x:Key="ValueLabel" TargetType="TextBlock">
+    <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="FontSize" Value="13"/>
+    <Setter Property="FontWeight" Value="Bold"/>
+    <Setter Property="HorizontalAlignment" Value="Right"/>
+    <Setter Property="VerticalAlignment" Value="Center"/>
+  </ControlTheme>
+
+  <!-- Inputs.xaml:388. In WPF a thin alias over the implicit TextBox. Avalonia has no implicit
+       theme of ours to alias, so BasedOn the Fluent default - the key exists for its call site. -->
+  <ControlTheme x:Key="FocusGlowTextBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}"/>
+
+  <!-- MainWindow.xaml:280. WPF's Track/RepeatButton machinery is Avalonia's Track too, but the
+       stock Fluent slider template is a 60-line part contract (PART_Track, PART_DecreaseButton,
+       PART_IncreaseButton, thumb). Restyling those parts through selectors keeps the interaction
+       code and only repaints, which is what the WPF template does visually: 3px groove, pink
+       fill, 14px white thumb. -->
+  <ControlTheme x:Key="PinkSlider" TargetType="Slider" BasedOn="{StaticResource {x:Type Slider}}">
+    <Setter Property="Minimum" Value="0"/>
+    <Setter Property="Maximum" Value="100"/>
+    <Setter Property="Height" Value="18"/>
+    <Setter Property="Margin" Value="0"/>
+    <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
+    <Style Selector="^ /template/ Thumb">
+      <Setter Property="Width" Value="14"/>
+      <Setter Property="Height" Value="14"/>
+      <Setter Property="Background" Value="White"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="CornerRadius" Value="7"/>
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Opacity" Value="0.35"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- MainWindow.xaml:350. Same restyle approach as PinkSlider: 6px track, pink->purple fill,
+       16px pink thumb. The thumb's DropShadowEffect glow is dropped (no Effect on Avalonia). -->
+  <ControlTheme x:Key="BlinkTrainerGradientSlider" TargetType="Slider" BasedOn="{StaticResource {x:Type Slider}}">
+    <Setter Property="MinHeight" Value="22"/>
+    <Setter Property="Background" Value="#22FFFFFF"/>
+    <Setter Property="Foreground">
+      <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+        <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+        <GradientStop Color="{DynamicResource NeonPurpleColor}" Offset="1"/>
+      </LinearGradientBrush>
+    </Setter>
+    <Style Selector="^ /template/ Thumb">
+      <Setter Property="Width" Value="16"/>
+      <Setter Property="Height" Value="16"/>
+      <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+      <Setter Property="BorderBrush" Value="White"/>
+      <Setter Property="BorderThickness" Value="1.5"/>
+      <Setter Property="CornerRadius" Value="8"/>
+    </Style>
+  </ControlTheme>
+
+  <!-- MainWindow.xaml:1234. Restyles the Fluent ComboBox parts rather than replacing the
+       template: the popup, item presenter and toggle are a part contract worth keeping. Visual
+       contract kept: 8px radius, dark surface, pink border on hover/open, 24px min height. The
+       WPF ItemContainerStyle becomes a selector on the items. -->
+  <!-- The WPF ItemContainerStyle. A ControlTheme may not contain a descendant selector, so the
+       rows get their own theme, handed over through ItemContainerTheme. Declared first: a
+       same-dictionary StaticResource resolves at parse time. -->
+  <ControlTheme x:Key="DarkComboBoxItem" TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
+    <Setter Property="Foreground" Value="{DynamicResource TextSecondaryBrush}"/>
+    <Setter Property="Padding" Value="8,5"/>
+    <Setter Property="CornerRadius" Value="6"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="{DynamicResource TransparentPink20Brush}"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+    </Style>
+    <Style Selector="^:selected">
+      <Setter Property="Background" Value="{DynamicResource TransparentPink40Brush}"/>
+      <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="DarkComboBoxStyle" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+    <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+    <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+    <Setter Property="BorderBrush" Value="{DynamicResource PanelAccentHoverBrush}"/>
+    <Setter Property="BorderThickness" Value="1"/>
+    <Setter Property="FontSize" Value="11"/>
+    <Setter Property="MinHeight" Value="24"/>
+    <Setter Property="CornerRadius" Value="8"/>
+    <Setter Property="Cursor" Value="Hand"/>
+    <Setter Property="Padding" Value="8,2,2,2"/>
+    <Style Selector="^:pointerover /template/ Border#Background">
+      <Setter Property="BorderBrush" Value="{DynamicResource InputHoverBorderBrush}"/>
+    </Style>
+    <Style Selector="^:dropdownopen /template/ Border#Background">
+      <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Opacity" Value="0.45"/>
+    </Style>
+    <Style Selector="^ /template/ Border#PopupBorder">
+      <Setter Property="Background" Value="{DynamicResource ElevatedSurfaceBrush}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource TransparentPink20Brush}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="CornerRadius" Value="10"/>
+      <Setter Property="Padding" Value="4"/>
+    </Style>
+    <Setter Property="ItemContainerTheme" Value="{StaticResource DarkComboBoxItem}"/>
+  </ControlTheme>
+
+  <!-- MainWindow.xaml:1366. Gradient-border card with a left accent strip and a chevron that
+       rotates on expand. Expander's IsExpanded drives the content; the chevron rotation is a
+       :expanded selector rather than a Storyboard. DropShadowEffect dropped. -->
+  <ControlTheme x:Key="CollapsibleCard" TargetType="Expander">
+    <Setter Property="IsExpanded" Value="True"/>
+    <Setter Property="Template">
+      <ControlTemplate TargetType="Expander">
+        <Border CornerRadius="10" Margin="0,0,0,10" BorderThickness="1" ClipToBounds="True">
+          <Border.Background>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+              <GradientStop Color="{DynamicResource SurfaceBg}" Offset="0"/>
+              <GradientStop Color="#252548" Offset="1"/>
+            </LinearGradientBrush>
+          </Border.Background>
+          <Border.BorderBrush>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+              <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+              <GradientStop Color="{DynamicResource PatreonPurple}" Offset="1"/>
+            </LinearGradientBrush>
+          </Border.BorderBrush>
+          <Grid RowDefinitions="Auto,Auto">
+            <ToggleButton Grid.Row="0" x:Name="PART_toggle" Cursor="Hand" Background="Transparent"
+                          IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                          HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch"
+                          Padding="12,10" BorderThickness="0">
+              <Grid ColumnDefinitions="3,8,*,Auto">
+                <Rectangle Grid.Column="0" RadiusX="1.5" RadiusY="1.5">
+                  <Rectangle.Fill>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                      <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+                      <GradientStop Color="{DynamicResource PatreonPurple}" Offset="1"/>
+                    </LinearGradientBrush>
+                  </Rectangle.Fill>
+                </Rectangle>
+                <ContentPresenter Grid.Column="2" Content="{TemplateBinding Header}"
+                                  ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                  VerticalAlignment="Center"/>
+                <TextBlock x:Name="Chevron" Grid.Column="3" Text="&#x25B8;" Foreground="{DynamicResource PinkBrush}"
+                           FontSize="14" FontWeight="Bold" VerticalAlignment="Center" Margin="8,0,4,0"
+                           RenderTransformOrigin="50%,50%"/>
+              </Grid>
+            </ToggleButton>
+            <ContentPresenter x:Name="PART_ContentPresenter" Grid.Row="1" Margin="15,0,15,15"
+                              Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              IsVisible="{TemplateBinding IsExpanded}"/>
+          </Grid>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:expanded /template/ TextBlock#Chevron">
+      <Setter Property="RenderTransform" Value="rotate(90deg)"/>
+    </Style>
+  </ControlTheme>
+
 </ResourceDictionary>

--- a/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
@@ -71,7 +71,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// <param name="listed">Entries currently in the list, raw (group tokens included).</param>
         /// <param name="candidates">Apps to offer as rows, already sanitised, newest-interesting first.</param>
         /// <summary>Render/design constructor: sample rows so --render-view can draw the dialog.</summary>
-        public AwarenessAppPickerDialog()
+        internal AwarenessAppPickerDialog()
             : this(AwarenessListKind.Deny, new[] { "firefox" }, new[] { "firefox", "steam", "discord" }) { }
 
         public AwarenessAppPickerDialog(AwarenessListKind kind,

--- a/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
@@ -70,6 +70,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// <param name="kind">Which list is being edited. Drives every string on the dialog.</param>
         /// <param name="listed">Entries currently in the list, raw (group tokens included).</param>
         /// <param name="candidates">Apps to offer as rows, already sanitised, newest-interesting first.</param>
+        /// <summary>Render/design constructor: sample rows so --render-view can draw the dialog.</summary>
+        public AwarenessAppPickerDialog()
+            : this(AwarenessListKind.Deny, new[] { "firefox" }, new[] { "firefox", "steam", "discord" }) { }
+
         public AwarenessAppPickerDialog(AwarenessListKind kind,
                                         IEnumerable<string> listed,
                                         IEnumerable<string> candidates)

--- a/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
@@ -67,13 +67,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// <summary>The chosen entries, or null when the dialog was cancelled.</summary>
         public List<string>? Result { get; private set; }
 
-        /// <param name="kind">Which list is being edited. Drives every string on the dialog.</param>
-        /// <param name="listed">Entries currently in the list, raw (group tokens included).</param>
-        /// <param name="candidates">Apps to offer as rows, already sanitised, newest-interesting first.</param>
         /// <summary>Render/design constructor: sample rows so --render-view can draw the dialog.</summary>
         internal AwarenessAppPickerDialog()
             : this(AwarenessListKind.Deny, new[] { "firefox" }, new[] { "firefox", "steam", "discord" }) { }
 
+        /// <param name="kind">Which list is being edited. Drives every string on the dialog.</param>
+        /// <param name="listed">Entries currently in the list, raw (group tokens included).</param>
+        /// <param name="candidates">Apps to offer as rows, already sanitised, newest-interesting first.</param>
         public AwarenessAppPickerDialog(AwarenessListKind kind,
                                         IEnumerable<string> listed,
                                         IEnumerable<string> candidates)

--- a/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml.cs
@@ -33,6 +33,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private readonly TextBox _txtRepetitionPenalty;
         private readonly TextBlock _txtError;
 
+        /// <summary>Render/design constructor: default settings so --render-view can draw the dialog.</summary>
+        public OpenAiCompatibleSamplerSettingsDialog() : this(new CompanionPromptSettings()) { }
+
         public OpenAiCompatibleSamplerSettingsDialog(CompanionPromptSettings settings)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));

--- a/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/OpenAiCompatibleSamplerSettingsDialog.axaml.cs
@@ -34,7 +34,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private readonly TextBlock _txtError;
 
         /// <summary>Render/design constructor: default settings so --render-view can draw the dialog.</summary>
-        public OpenAiCompatibleSamplerSettingsDialog() : this(new CompanionPromptSettings()) { }
+        internal OpenAiCompatibleSamplerSettingsDialog() : this(new CompanionPromptSettings()) { }
 
         public OpenAiCompatibleSamplerSettingsDialog(CompanionPromptSettings settings)
         {

--- a/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
@@ -42,6 +42,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         public Dictionary<string, bool>? ResultData { get; private set; }
 
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        public TextEditorDialog() : this("Sample", new Dictionary<string, bool> { ["first item"] = true, ["second item"] = false }) { }
+
         public TextEditorDialog(string title, Dictionary<string, bool> data)
         {
             AvaloniaXamlLoader.Load(this);

--- a/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
@@ -43,7 +43,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         public Dictionary<string, bool>? ResultData { get; private set; }
 
         /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
-        public TextEditorDialog() : this("Sample", new Dictionary<string, bool> { ["first item"] = true, ["second item"] = false }) { }
+        internal TextEditorDialog() : this("Sample", new Dictionary<string, bool> { ["first item"] = true, ["second item"] = false }) { }
 
         public TextEditorDialog(string title, Dictionary<string, bool> data)
         {

--- a/CCP.Avalonia/Views/Tabs/AchievementsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/AchievementsTabView.axaml
@@ -3,9 +3,9 @@
      directly. Documented deviations, all forced by real WPF/Avalonia differences:
 
        Style="{StaticResource X}"  ->  Theme="{StaticResource X}"   (keyed styles are ControlThemes)
-       {loc:Str key}               ->  {Binding LocX}               (LocExtension is a WPF
-                                       MarkupExtension and stays in the head; the strings still
-                                       come from CCP.Core's LocalizationManager, via the VM)
+       {loc:Str key}               ->  {loc:Str key}                (Localization/StrExtension.cs,
+                                       the Avalonia twin; formatted strings still come from
+                                       Loc.GetF in the VM, keys read from the WPF code-behind)
        helpers:EmojiTextBlock      ->  TextBlock                    (custom control not ported yet)
        Visibility="Collapsed"      ->  IsVisible="False"
        Panel.ZIndex                ->  ZIndex
@@ -13,6 +13,7 @@
        WrapPanel                   ->  WrapPanel (identical) -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
              x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.AchievementsTabView"
              x:DataType="vm:AchievementsTabViewModel"
              xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Tabs">
@@ -20,11 +21,11 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
       <StackPanel>
         <Grid Margin="0,0,0,10">
-          <TextBlock Theme="{StaticResource SectionHeader}" Text="{Binding LocSectionAchievements}" Margin="0"/>
+          <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str section_achievements}" Margin="0"/>
           <Button x:Name="HelpBtnAchievements" Theme="{StaticResource HelpButtonStyle}"
                   HorizontalAlignment="Right" Tag="Achievements"/>
         </Grid>
-        <TextBlock Text="{Binding LocSubtitleRewards}"
+        <TextBlock Text="{loc:Str achv_subtitle_rewards}"
                    Foreground="{DynamicResource TextMutedBrush}" FontSize="12" Margin="0,0,0,10"/>
 
         <!-- Filter chips (populated in code-behind: All / Unlocked / Locked / Rewards) -->
@@ -48,8 +49,8 @@
              Free and patron counts are never summed. -->
         <Border Height="1" Background="#33FFFFFF" Margin="0,24,0,0"/>
         <TextBlock Theme="{StaticResource SectionHeader}"
-                   Text="{Binding LocSectionPatronAchievements}" Margin="0,18,0,0"/>
-        <TextBlock Text="{Binding LocPatronSubtitle}"
+                   Text="{loc:Str section_patron_achievements}" Margin="0,18,0,0"/>
+        <TextBlock Text="{loc:Str label_patron_achievements_subtitle}"
                    Foreground="{DynamicResource TextMutedBrush}" FontSize="12" Margin="0,0,0,12"/>
 
         <Grid Margin="0,5,0,0">
@@ -65,14 +66,14 @@
                   ZIndex="100" IsVisible="{Binding PatronLocked}">
             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="20">
               <TextBlock Text="🔒" FontSize="40" HorizontalAlignment="Center" Margin="0,0,0,15"/>
-              <TextBlock Text="{Binding LocSectionPatronAchievements}"
+              <TextBlock Text="{loc:Str section_patron_achievements}"
                          Foreground="{DynamicResource PinkBrush}"
                          FontSize="22" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,10">
                 <TextBlock.Effect>
                   <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
                 </TextBlock.Effect>
               </TextBlock>
-              <TextBlock Text="{Binding LocPatronLocked}" Foreground="{DynamicResource TextMutedBrush}"
+              <TextBlock Text="{loc:Str label_patron_achievements_locked}" Foreground="{DynamicResource TextMutedBrush}"
                          FontSize="14" HorizontalAlignment="Center" TextAlignment="Center"
                          TextWrapping="Wrap" MaxWidth="380"/>
               <!-- FIDELITY BUG, found by rendering this view: Avalonia's Button treats "_" in
@@ -84,7 +85,7 @@
               <Button Background="#FF424D" Foreground="White"
                       BorderThickness="0" Padding="18,8" Margin="0,15,0,0"
                       HorizontalAlignment="Center">
-                <TextBlock Text="{Binding LocVisitPatreon}"/>
+                <TextBlock Text="{loc:Str btn_visit_patreon}"/>
               </Button>
             </StackPanel>
           </Border>

--- a/CCP.Avalonia/Views/Tabs/AchievementsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AchievementsTabView.axaml.cs
@@ -14,30 +14,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     }
 
     /// <summary>
-    /// Supplies the strings the view binds to. Every one comes from CCP.Core's
-    /// <see cref="Loc"/> - the same localization runtime and the same JSON files the WPF head
-    /// reads, now that Localization has moved to Core.
-    ///
-    /// This exists because WPF's {loc:Str key} markup extension (LocExtension) cannot cross: it
-    /// derives from System.Windows.Markup.MarkupExtension and stays in the head. The strings do
-    /// cross; only the binding mechanism differs. A shared Loc markup extension for Avalonia is
-    /// the obvious follow-up and would remove this class entirely.
+    /// Supplies the FORMATTED strings the view binds to. Static strings now come straight from
+    /// {loc:Str key} in the XAML (Localization/StrExtension.cs); only the ones with numbers in
+    /// them need code, exactly as in the WPF head where they are set with Loc.GetF.
     /// </summary>
     public sealed class AchievementsTabViewModel
     {
-        public string LocSectionAchievements => Loc.Get("section_achievements");
-        public string LocSubtitleRewards => Loc.Get("achv_subtitle_rewards");
         // The three counters are FORMATTED, not static strings. Keys and arg order taken from
         // MainWindow.AchievementsTab.cs:153/160/196 - I had guessed key names on the first pass
         // and two of them did not exist, so they rendered raw. Read the code-behind that
         // populates a control before inventing its key.
         public string LocUnlockedCount => Loc.GetF("label_0_1_achievements_unlocked", Unlocked, Total);
         public string LocRewardCount => Loc.GetF("achv_reward_count", RewardsEarned, RewardsTotal);
-        public string LocSectionPatronAchievements => Loc.Get("section_patron_achievements");
-        public string LocPatronSubtitle => Loc.Get("label_patron_achievements_subtitle");
         public string LocPatronCount => Loc.GetF("label_0_1_achievements_unlocked", PatronUnlocked, PatronTotal);
-        public string LocPatronLocked => Loc.Get("label_patron_achievements_locked");
-        public string LocVisitPatreon => Loc.Get("btn_visit_patreon");
 
         // Placeholder counts. The real values come from AchievementService, which is still in
         // the WPF head; wiring them is a separate change from proving the view renders.

--- a/CCP.Core/Localization/LocalizationManager.cs
+++ b/CCP.Core/Localization/LocalizationManager.cs
@@ -116,7 +116,10 @@ namespace ConditioningControlPanel.Localization
             CurrentLanguage = languageCode;
             LanguageChanged?.Invoke(this, EventArgs.Empty);
             // Notify all bindings that use the indexer
+            // "Item[]" is what WPF's indexer bindings listen for; Avalonia's listen for "Item".
+            // Raise both so {loc:Str} re-renders on every head.
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item"));
         }
 
         /// <summary>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,32 @@ Three things that will bite, all found by rendering rather than by reading:
    verified on Linux with Noto Color Emoji. That collapses ~103 converter usages, the SharpVectors
    dependency and those `pack://` URIs to a plain `<TextBlock Text="🔒"/>` on that head.
    `BoolToVisibility` (~27 usages) likewise disappears: Avalonia binds `IsVisible` to a bool directly.
+   `helpers:EmojiTextBlock` (128 usages) is a `TextBlock` subclass for the same reason and becomes
+   a plain `TextBlock`.
+
+4. **A property-only `ControlTheme` on a templated control draws nothing.** A WPF keyed `<Style>`
+   overrides setters and keeps the control's default template. An Avalonia `ControlTheme` replaces
+   the theme wholesale, so a `ControlTheme` for `Button`, `CheckBox`, `Slider`, `ComboBox` etc. that
+   carries only setters leaves `Template` null. It compiles clean and throws nothing. Give it a
+   `Template`, or `BasedOn="{StaticResource {x:Type Button}}"`. `Border` and `TextBlock` are not
+   templated, so property-only is safe there.
+
+Static strings use `{loc:Str key}` with `xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"`
+- the Avalonia twin of the WPF extension, backed by the same `LocalizationManager` in Core.
+Formatted strings still come from `Loc.GetF` in code-behind, keys and argument order read from the
+WPF code-behind that populates the same control.
+
+**Definition of done for a ported view:** it renders headless on Linux with real strings and no
+blank templated controls. Prove it per view, not per app:
+
+```bash
+dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render-view <TypeName> out.png
+dotnet run --project CCP.Avalonia/CCP.Avalonia.csproj -c Release -- --render-all <dir>   # what CI uploads
+```
+
+Read the PNG. A raw `snake_case` key, an empty region where a button sits, or a swallowed
+underscore is a failed port, whatever the compiler said. There is no WPF render on Linux, so
+fidelity against the original is not what this proves; drawing, strings and templates are.
 
 ## What actually remains in the UI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Measured on the first ported view (`Views/Tabs/AchievementsTabView`). The mappin
 | `<Style x:Key TargetType>` | `<ControlTheme x:Key TargetType>` |
 | `Visibility="Collapsed"` | `IsVisible="False"` |
 | `Panel.ZIndex` | `ZIndex` |
-| `{loc:Str key}` | a binding - `LocExtension` is a WPF `MarkupExtension` and stays in the head |
+| `{loc:Str key}` | `{loc:Str key}` unchanged, with `xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"` (the Avalonia twin lives in the head; the strings come from Core) |
 
 Three things that will bite, all found by rendering rather than by reading:
 


### PR DESCRIPTION
Layer 20. `--render-view <Type>` and `--render-all`, which found two invisible defects on first run; the Avalonia `{loc:Str}` extension; twelve shared ControlThemes; CI uploads one PNG per view and the render prints silent binding errors. 19/19 views render.

Part of the Avalonia port stack: every layer builds on the one below it and is verified alone (solution build, Core guards, `--smoke`, `--render-all` where the head exists). Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351