### PR TITLE
feat(avalonia): port Settings sections I - General, Notifications, Updates

### DIFF
--- a/CCP.Avalonia/Views/Controls/AppSettings/GeneralSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/GeneralSettingsSection.axaml
@@ -1,0 +1,205 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/GeneralSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved. Deviations:
+
+       Style="{StaticResource X}"    -> Theme="{StaticResource X}"
+       ToolTip="..."                 -> ToolTip.Tip="..."
+       Image + EmojiToImageSource    -> <TextBlock Text="emoji"/>   (Avalonia renders colour emoji)
+       Style x:Key="SettingChip"     -> ControlTheme in UserControl.Resources, IsMouseOver -> :pointerover
+       Click=/Checked=/Unchecked=    -> wired in the constructor (IsCheckedChanged)
+       x:FieldModifier="internal"    -> dropped (no host reads the fields on this head yet) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.GeneralSettingsSection"
+             d:DesignWidth="620"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <!-- ponytail: local copy of GeneralSettingsSection.xaml:SettingChip, hoist when a second view needs it -->
+        <ControlTheme x:Key="SettingChip" TargetType="Border">
+            <Setter Property="CornerRadius" Value="10"/>
+            <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="12,8"/>
+            <Setter Property="Margin" Value="0,0,0,6"/>
+            <Style Selector="^:pointerover">
+                <Setter Property="BorderBrush" Value="{StaticResource SectionHueStartupBorderBrush}"/>
+            </Style>
+        </ControlTheme>
+    </UserControl.Resources>
+
+    <StackPanel>
+
+        <TextBlock Text="{loc:Str set2_section_general}" Theme="{StaticResource SectionHeader}"/>
+
+        <!-- ============================= language ============================= -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,10"
+                BorderBrush="{StaticResource SectionHueGeneralBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueGeneralWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueGeneralBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <TextBlock Text="🌍" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_general_language_title}"
+                                   Foreground="{StaticResource SectionHueGeneralBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+
+                    <Grid MinHeight="34" ColumnDefinitions="*,Auto" ToolTip.Tip="{loc:Str set2_general_language_hint}">
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}" Text="{loc:Str label_language}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <ComboBox Grid.Column="1" x:Name="CmbLanguageSetting"
+                                  Theme="{StaticResource DarkComboBoxStyle}" FontSize="11"
+                                  Width="190" MinHeight="28" VerticalAlignment="Center"
+                                  ToolTip.Tip="{loc:Str set2_general_language_hint}"/>
+                    </Grid>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ============================== startup ============================= -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,10"
+                BorderBrush="{StaticResource SectionHueStartupBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueStartupWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueStartupBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <TextBlock Text="🚀" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_general_startup_title}"
+                                   Foreground="{StaticResource SectionHueStartupBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+
+                    <!-- Four related switches = one 2-column chip grid. ChkWinStart keeps Click (NOT
+                         IsCheckedChanged) on purpose: the handler registers an OS shortcut and may
+                         revert the box, and a Click handler does not re-fire when it does. -->
+                    <Grid ColumnDefinitions="*,6,*" RowDefinitions="Auto,Auto">
+
+                        <Border Grid.Row="0" Grid.Column="0" Theme="{StaticResource SettingChip}"
+                                ToolTip.Tip="{loc:Str tooltip_launch_automatically_when_windows_starts}">
+                            <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_win_start}"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkWinStart"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
+
+                        <Border Grid.Row="0" Grid.Column="2" Theme="{StaticResource SettingChip}"
+                                ToolTip.Tip="{loc:Str tooltip_start_minimized_to_system_tray}">
+                            <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_start_hidden}"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkStartHidden"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="0" Theme="{StaticResource SettingChip}"
+                                ToolTip.Tip="{loc:Str tooltip_start_the_engine_automatically_on_launch}">
+                            <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_auto_run}"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkAutoRun"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="2" Theme="{StaticResource SettingChip}"
+                                ToolTip.Tip="{loc:Str tooltip_play_a_mandatory_video_when_app_opens}">
+                            <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_vid_launch}"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkVidLaunch"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
+                    </Grid>
+
+                    <!-- Startup video picker, one line. -->
+                    <Grid MinHeight="34" Margin="0,2,0,0" ColumnDefinitions="Auto,*,Auto,Auto"
+                          ToolTip.Tip="{loc:Str tooltip_select_a_specific_video_to_play_on_startup_wh}">
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Text="{loc:Str label_startup_video}" Margin="0,0,10,0"/>
+                        <TextBlock Grid.Column="1" x:Name="TxtStartupVideo"
+                                   Text="{loc:Str label_random}" TextTrimming="CharacterEllipsis"
+                                   Foreground="{DynamicResource PinkBrush}" FontSize="11"
+                                   VerticalAlignment="Center" Margin="0,0,10,0"/>
+                        <Button Grid.Column="2" x:Name="BtnSelectStartupVideo" Content="📁" Width="36"
+                                Theme="{StaticResource OutlineButton}" Padding="6,4" VerticalAlignment="Center"
+                                ToolTip.Tip="{loc:Str tooltip_browse_for_startup_video}"/>
+                        <Button Grid.Column="3" x:Name="BtnClearStartupVideo" Content="✕" Width="36"
+                                Theme="{StaticResource OutlineButton}" Padding="6,4" Margin="6,0,0,0"
+                                VerticalAlignment="Center"
+                                ToolTip.Tip="{loc:Str tooltip_clear_selection_use_random}"/>
+                    </Grid>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ========================== window & tray ========================== -->
+        <!-- Read-only by design: closing always minimises to the tray, there is no setting behind it. -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,10"
+                BorderBrush="{StaticResource SectionHueGeneralBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueGeneralWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueGeneralBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="🪟" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_general_tray_title}"
+                                   Foreground="{StaticResource SectionHueGeneralBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+                    <TextBlock Text="{loc:Str set2_general_tray_body}" TextWrapping="Wrap"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ============================== Deeper ============================= -->
+        <Border x:Name="DeeperGeneralCard" CornerRadius="12" Padding="0" Margin="0,0,0,10"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="{StaticResource SectionHueGeneralBorderBrush}" BorderThickness="1">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueGeneralWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueGeneralBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="🌊" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str section_deeper}"
+                                   Foreground="{DynamicResource DeeperAccentBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+                    <Grid MinHeight="34" ColumnDefinitions="*,Auto" ToolTip.Tip="{loc:Str tooltip_deeper_enable}">
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Text="{loc:Str setting_deeper_enable}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkEnableDeeper"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center" IsChecked="True"/>
+                    </Grid>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/GeneralSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/GeneralSettingsSection.axaml.cs
@@ -1,0 +1,89 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS ▸ GENERAL, ported from the WPF head. Language, startup, window/tray, Deeper switch.
+    ///
+    /// The language combo is populated for real from <see cref="LocalizationManager.AvailableLanguages"/>
+    /// (Core). Every handler on the WPF side forwards to MainWindow or writes <c>App.Settings</c>,
+    /// neither of which exists on this head yet, so they are stubs with the x:Names preserved.
+    /// <c>IAppSettingsSection</c> lives in the WPF head's AppSettingsTabView; <see cref="OnSectionShown"/>
+    /// keeps the shape so the host can pick it up when it is ported.
+    /// </summary>
+    public partial class GeneralSettingsSection : UserControl
+    {
+        public GeneralSettingsSection()
+        {
+            InitializeComponent();
+
+            var current = LocalizationManager.Instance.CurrentLanguage;
+            for (int i = 0; i < LocalizationManager.AvailableLanguages.Length; i++)
+            {
+                var (code, displayName, _) = LocalizationManager.AvailableLanguages[i];
+                var item = new ComboBoxItem { Content = displayName, Tag = code };
+                ToolTip.SetTip(item, displayName);
+                CmbLanguageSetting.Items.Add(item);
+                if (code == current) CmbLanguageSetting.SelectedIndex = i;
+            }
+            if (CmbLanguageSetting.SelectedIndex < 0) CmbLanguageSetting.SelectedIndex = 0; // WPF PopulateLanguageCombo falls back to the first entry
+
+            CmbLanguageSetting.SelectionChanged += CmbLanguageSetting_SelectionChanged;
+            ChkWinStart.Click += ChkWinStart_Click;
+            ChkStartHidden.Click += ChkStartHidden_Click;
+            ChkAutoRun.IsCheckedChanged += ChkAutoRun_Changed;
+            ChkVidLaunch.IsCheckedChanged += ChkVidLaunch_Changed;
+            ChkEnableDeeper.IsCheckedChanged += ChkEnableDeeper_Changed;
+            BtnSelectStartupVideo.Click += BtnSelectStartupVideo_Click;
+            BtnClearStartupVideo.Click += BtnClearStartupVideo_Click;
+        }
+
+        /// <summary>Re-reads the OS startup registration and the startup-video filename.</summary>
+        public void OnSectionShown()
+        {
+            // ponytail: needs App.Settings + StartupManager, wired when they move to Core
+        }
+
+        private void CmbLanguageSetting_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            // ponytail: needs MainWindow.ApplyLanguageSelection, wired when it moves to Core
+        }
+
+        private void ChkWinStart_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs StartupManager, wired when it moves to Core
+        }
+
+        private void ChkStartHidden_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.Settings (StartMinimized), wired when it moves to Core
+        }
+
+        private void BtnSelectStartupVideo_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs a file picker + App.Settings (StartupVideoPath), wired when it moves to Core
+        }
+
+        private void BtnClearStartupVideo_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.Settings (StartupVideoPath), wired when it moves to Core
+        }
+
+        private void ChkAutoRun_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.Settings (AutoStartEngine), wired when it moves to Core
+        }
+
+        private void ChkVidLaunch_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.Settings (ForceVideoOnLaunch), wired when it moves to Core
+        }
+
+        private void ChkEnableDeeper_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs MainWindow.ChkEnableDeeper_Changed (EnableDeeper + BtnDeeper visibility), wired when it moves to Core
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/AppSettings/NotificationsSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/NotificationsSettingsSection.axaml
@@ -1,0 +1,59 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/NotificationsSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved. Deviations:
+
+       Style="{StaticResource X}"    -> Theme="{StaticResource X}"
+       ToolTip="..."                 -> ToolTip.Tip="..."
+       Checked=/Unchecked=           -> IsCheckedChanged, wired in the constructor
+       x:FieldModifier="internal"    -> dropped -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.NotificationsSettingsSection"
+             d:DesignWidth="760"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+
+    <StackPanel>
+
+        <TextBlock Text="{loc:Str set2_section_notifications}" Theme="{StaticResource SectionHeader}"/>
+
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueNotificationsBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueNotificationsWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueNotificationsBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <Grid MinHeight="34" ColumnDefinitions="*,Auto" ToolTip.Tip="{loc:Str tooltip_intake_nudge_enabled}">
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueNotificationsBrush}"
+                                   Text="{loc:Str label_intake_nudge_enabled}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkIntakeNudge"
+                                  Theme="{StaticResource ToggleStyle}" IsChecked="True"
+                                  VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_intake_nudge_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <Grid MinHeight="34" Margin="0,10,0,0" ColumnDefinitions="*,Auto"
+                          ToolTip.Tip="{loc:Str tooltip_suppress_perk_notifications}">
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueNotificationsBrush}"
+                                   Text="{loc:Str label_suppress_perk_notifications}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkSuppressPerkNotifications"
+                                  Theme="{StaticResource ToggleStyle}" IsChecked="False"
+                                  VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_suppress_perk_notifications_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/NotificationsSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/NotificationsSettingsSection.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS · NOTIFICATIONS, ported from the WPF head. <c>ChkIntakeNudge</c> has no handler on
+    /// purpose (read at launch, round-trips through Load/SaveSettings). <c>ChkSuppressPerkNotifications</c>
+    /// is a live editor on WPF; here it is a stub until a settings surface exists on this head.
+    /// </summary>
+    public partial class NotificationsSettingsSection : UserControl
+    {
+        private bool _isLoading = true;
+
+        public NotificationsSettingsSection()
+        {
+            InitializeComponent();
+            ChkSuppressPerkNotifications.IsCheckedChanged += ChkSuppressPerkNotifications_Changed;
+            SyncFromSettings();
+        }
+
+        /// <summary>Paints the live row from settings without raising an edit.</summary>
+        internal void SyncFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                // ponytail: needs App.Settings (SuppressPerkNotifications), wired when it moves to Core
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void ChkSuppressPerkNotifications_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            // ponytail: needs App.Settings (SuppressPerkNotifications) + Save, wired when it moves to Core
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/AppSettings/UpdatesSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/UpdatesSettingsSection.axaml
@@ -1,0 +1,79 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/UpdatesSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved. Deviations:
+
+       Style="{DynamicResource X}"   -> Theme="{StaticResource X}"
+       Content="{loc:Str key}"       -> a <TextBlock> child (Avalonia parses "_" in Content as an access key)
+       Click=                        -> wired in the constructor
+       PreviewMouseWheel=            -> dropped (no Preview events; it forwarded to MainWindow anyway)
+       x:FieldModifier="internal"    -> dropped -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.UpdatesSettingsSection"
+             d:DesignWidth="760"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+
+    <StackPanel>
+
+        <TextBlock Text="{loc:Str set2_section_updates}" Theme="{StaticResource SectionHeader}"/>
+
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueUpdatesBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueUpdatesWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueUpdatesBrush}"/>
+                <Grid Margin="15,12,15,12" ColumnDefinitions="*,Auto">
+
+                    <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <TextBlock x:Name="TxtUpdatesVersion" Text=""
+                                   Foreground="{StaticResource SectionHueUpdatesBrush}"
+                                   FontSize="15" FontWeight="Bold"/>
+                        <TextBlock x:Name="TxtUpdatesProduct" Text=""
+                                   Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,2,0,0"/>
+                    </StackPanel>
+
+                    <Button x:Name="BtnCheckUpdates" Grid.Column="1"
+                            Theme="{StaticResource OutlineButton}"
+                            Padding="16,8" FontSize="13"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="{loc:Str btn_check_updates}"/>
+                    </Button>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <!-- Patch notes for the installed build, in a bounded scrollable box. -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueUpdatesBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueUpdatesWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueUpdatesBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <Grid Margin="0,0,0,8">
+                        <TextBlock x:Name="TxtPatchNotesHeader"
+                                   Text="{loc:Str set2_whats_new_header}"
+                                   Foreground="{StaticResource SectionHueUpdatesBrush}" FontSize="14" FontWeight="Bold"
+                                   VerticalAlignment="Center"/>
+                        <Button x:Name="BtnViewPatchNotes"
+                                Theme="{StaticResource OutlineButton}"
+                                Padding="12,6" FontSize="12"
+                                HorizontalAlignment="Right" VerticalAlignment="Center">
+                            <TextBlock Text="{loc:Str set2_btn_view_patch_notes}"/>
+                        </Button>
+                    </Grid>
+
+                    <ScrollViewer MaxHeight="180" VerticalScrollBarVisibility="Auto">
+                        <TextBlock x:Name="TxtPatchNotes" Text=""
+                                   Foreground="{DynamicResource TextSecondaryBrush}" FontSize="11"
+                                   TextWrapping="Wrap"/>
+                    </ScrollViewer>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/UpdatesSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/UpdatesSettingsSection.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS · UPDATES, ported from the WPF head. Version, manual update check, patch notes.
+    /// <c>UpdateService</c> (AppVersion, CurrentPatchNotes, the manual check) and
+    /// <c>WhatsNewDialog</c> are still in the WPF head, so the three text blocks carry placeholder
+    /// text and both buttons are stubs.
+    /// </summary>
+    public partial class UpdatesSettingsSection : UserControl
+    {
+        public UpdatesSettingsSection()
+        {
+            InitializeComponent();
+
+            // ponytail: needs UpdateService.AppVersion / CurrentPatchNotes, wired when it moves to Core
+            TxtUpdatesVersion.Text = "v0.0.0";
+            TxtUpdatesProduct.Text = "Conditioning Control Panel";
+            TxtPatchNotes.Text = "Placeholder patch notes. The installed build's notes come from UpdateService.CurrentPatchNotes.";
+
+            BtnCheckUpdates.Click += BtnCheckUpdates_Click;
+            BtnViewPatchNotes.Click += BtnViewPatchNotes_Click;
+        }
+
+        private void BtnCheckUpdates_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.CheckForUpdatesManuallyAsync, wired when UpdateService moves to Core
+        }
+
+        private void BtnViewPatchNotes_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs WhatsNewDialog (Loc.GetF("set2_whats_new_title_0", version)) + the upgrade tour, wired when they are ported
+        }
+    }
+}


### PR DESCRIPTION
508 lines, 6 files. Language combo is populated from Core's LocalizationManager; every handler that reaches MainWindow, App.Settings, StartupManager or UpdateService is a ponytail stub.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351