### PR TITLE
feat(avalonia): port Settings sections II - Account, Data, EmiDesk

### DIFF
--- a/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml
@@ -1,0 +1,286 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/AccountSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"
+       Visibility="Collapsed"        ->  IsVisible="False"
+       Content="{loc:Str btn_x}"     ->  a <TextBlock> child (Avalonia parses "_" in Content as an
+                                         access key and every loc key here is snake_case)
+       x:FieldModifier="internal"    ->  dropped; the MainWindow partials that poke these fields
+                                         are not ported. x:Names are kept.
+
+     The tier card is painted by RefreshTierBadge() in the code-behind; on this head it is a stub
+     that leaves the signed-out markup defaults, because App.Patreon / App.IsLoggedIn live in the
+     WPF head. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.AccountSettingsSection">
+
+    <StackPanel>
+
+        <TextBlock Text="{loc:Str set2_section_account}" Theme="{StaticResource SectionHeader}"/>
+
+        <!-- Net-new: who you are, and which bar you clear. Painted by RefreshTierBadge(). -->
+        <Border x:Name="AccountTierCard" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="{StaticResource SectionHueAccountBorderBrush}" BorderThickness="1">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueAccountWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueAccountBrush}"/>
+                <Grid Margin="15,12,15,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <TextBlock x:Name="TxtAccountSectionName"
+                                   Text="{loc:Str account_chip_sign_in}"
+                                   Foreground="{StaticResource SectionHueAccountBrush}"
+                                   FontSize="15" FontWeight="Bold"/>
+                        <TextBlock x:Name="TxtAccountSectionTier"
+                                   Text="{loc:Str label_login_to_unlock_exclusive_features}"
+                                   Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12" Margin="0,2,0,0"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+
+                    <Border x:Name="AccountTierBadge" Grid.Column="1"
+                            CornerRadius="10" Padding="10,4" IsVisible="False"
+                            Background="{DynamicResource DarkerBgBrush}"
+                            BorderBrush="{StaticResource SectionHueAccountBorderBrush}" BorderThickness="1"
+                            VerticalAlignment="Center">
+                        <TextBlock x:Name="TxtAccountTierBadge" Text="🔒"
+                                   Foreground="{DynamicResource TextLightBrush}" FontSize="14" FontWeight="Bold"/>
+                    </Border>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <!-- Brand card: keeps Patreon red, takes the shared edge-bar pattern in that colour. -->
+        <Border x:Name="PatreonLoginCard" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="#FF424D" BorderThickness="1">
+            <Grid>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="#FF424D"/>
+                <Grid Margin="15,12,15,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <TextBlock x:Name="TxtPatreonStatus" Text="{loc:Str label_not_connected}" Foreground="{DynamicResource TextLightBrush}" FontSize="14" FontWeight="Bold"/>
+                        <TextBlock x:Name="TxtPatreonTier" Text="{loc:Str label_login_to_unlock_exclusive_features}" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>
+                    </StackPanel>
+
+                    <Button x:Name="BtnPatreonLogin" Grid.Column="1"
+                            Background="#FF424D" Foreground="White"
+                            BorderThickness="0" Padding="15,8"
+                            FontWeight="Bold" FontSize="12"
+                            VerticalAlignment="Center"
+                            Cursor="Hand"
+                            Click="BtnPatreonLogin_Click">
+                        <TextBlock Text="{loc:Str btn_login}"/>
+                    </Button>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <Border x:Name="SubscribeStarLoginCard" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="#009E8F" BorderThickness="1">
+            <Grid>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="#009E8F"/>
+                <Grid Margin="15,12,15,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <TextBlock x:Name="TxtSubscribeStarStatus" Text="{loc:Str label_not_connected}" Foreground="{DynamicResource TextLightBrush}" FontSize="14" FontWeight="Bold"/>
+                        <TextBlock x:Name="TxtSubscribeStarTier" Text="{loc:Str label_login_to_unlock_exclusive_features}" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>
+                    </StackPanel>
+
+                    <Button x:Name="BtnSubscribeStarLogin" Grid.Column="1"
+                            Background="#009E8F" Foreground="White"
+                            BorderThickness="0" Padding="15,8"
+                            FontWeight="Bold" FontSize="12"
+                            VerticalAlignment="Center"
+                            Cursor="Hand"
+                            Click="BtnSubscribeStarLogin_Click">
+                        <TextBlock Text="{loc:Str btn_login}"/>
+                    </Button>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <Border x:Name="DiscordLoginCard" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="#5865F2" BorderThickness="1">
+            <Grid>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="#5865F2"/>
+                <Grid Margin="15,12,15,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <TextBlock x:Name="TxtDiscordStatus" Text="{loc:Str label_not_connected}" Foreground="{DynamicResource TextLightBrush}" FontSize="14" FontWeight="Bold"/>
+                        <TextBlock x:Name="TxtDiscordInfo" Text="{loc:Str label_link_discord_for_community_features}" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>
+                    </StackPanel>
+
+                    <Button x:Name="BtnDiscordLogin" Grid.Column="1"
+                            Background="#5865F2" Foreground="White"
+                            BorderThickness="0" Padding="15,8"
+                            FontWeight="Bold" FontSize="12"
+                            VerticalAlignment="Center"
+                            Cursor="Hand"
+                            Click="BtnDiscordLogin_Click">
+                        <TextBlock Text="{loc:Str btn_login}"/>
+                    </Button>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <!-- Starts hidden; MainWindow.Patreon.cs:UpdateAccountLinkingUI owns it on WPF. -->
+        <Border x:Name="AccountLinkingSection" Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueAccountBorderBrush}" BorderThickness="1" IsVisible="False">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueAccountWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueAccountBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <TextBlock Text="{loc:Str label_link_accounts}"
+                               Foreground="{StaticResource SectionHueAccountBrush}"
+                               FontSize="14" FontWeight="Bold" Margin="0,0,0,6"/>
+                    <TextBlock Text="{loc:Str label_link_both_providers_to_access_your_account_fr}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button x:Name="BtnLinkPatreon"
+                                Background="#FF424D" Foreground="White"
+                                BorderThickness="0" Padding="15,8" Margin="0,0,10,0"
+                                FontWeight="Bold" FontSize="12"
+                                Cursor="Hand" IsVisible="False"
+                                Click="BtnLinkPatreon_Click">
+                            <TextBlock Text="{loc:Str btn_link_patreon}"/>
+                        </Button>
+                        <Button x:Name="BtnLinkDiscord"
+                                Background="#5865F2" Foreground="White"
+                                BorderThickness="0" Padding="15,8"
+                                FontWeight="Bold" FontSize="12"
+                                Cursor="Hand" IsVisible="False"
+                                Click="BtnLinkDiscord_Click">
+                            <TextBlock Text="{loc:Str btn_link_discord}"/>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Starts hidden; shown only with a cloud identity. -->
+        <Border x:Name="CloudSettingsBackupSection" Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueAccountBorderBrush}" BorderThickness="1" IsVisible="False">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueAccountWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueAccountBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <TextBlock Text="{loc:Str label_cloud_settings_backup}"
+                               Foreground="{StaticResource SectionHueAccountBrush}"
+                               FontSize="14" FontWeight="Bold" Margin="0,0,0,6"/>
+                    <TextBlock x:Name="TxtCloudBackupStatus"
+                               Text="{loc:Str label_checking_backup_status}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button x:Name="BtnBackupSettingsNow"
+                                Background="{DynamicResource SecondaryBrush}" Foreground="White"
+                                BorderThickness="0" Padding="15,8" Margin="0,0,10,0"
+                                FontWeight="Bold" FontSize="12"
+                                Cursor="Hand"
+                                Click="BtnBackupSettingsNow_Click">
+                            <TextBlock Text="{loc:Str btn_backup_now}"/>
+                        </Button>
+                        <Button x:Name="BtnRestoreSettings"
+                                Background="Transparent" Foreground="{DynamicResource SecondaryBrush}"
+                                BorderBrush="{DynamicResource SecondaryBrush}" BorderThickness="1" Padding="15,8"
+                                FontWeight="Bold" FontSize="12"
+                                Cursor="Hand"
+                                Click="BtnRestoreSettings_Click">
+                            <TextBlock Text="{loc:Str btn_restore_from_cloud}"/>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Border x:Name="DataPrivacySection" Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueAccountBorderBrush}" BorderThickness="1" IsVisible="False">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueAccountWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueAccountBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <TextBlock Text="{loc:Str label_data_privacy}"
+                               Foreground="{StaticResource SectionHueAccountBrush}"
+                               FontSize="14" FontWeight="Bold" Margin="0,0,0,6"/>
+                    <TextBlock Text="{loc:Str label_export_your_cloud_data_or_view_our_privacy_po}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <Button x:Name="BtnExportData"
+                                Background="#555" Foreground="White"
+                                BorderThickness="0" Padding="15,8" Margin="0,0,10,0"
+                                FontWeight="Bold" FontSize="12"
+                                Cursor="Hand"
+                                Click="BtnExportData_Click">
+                            <TextBlock Text="{loc:Str btn_export_my_data}"/>
+                        </Button>
+                        <Button x:Name="BtnPrivacyPolicy"
+                                Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                                BorderBrush="#555" BorderThickness="1" Padding="15,8"
+                                FontWeight="Bold" FontSize="12"
+                                Cursor="Hand"
+                                Click="BtnPrivacyPolicy_Click">
+                            <TextBlock Text="{loc:Str btn_privacy_policy}"/>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Border x:Name="SupportDevelopmentCard" CornerRadius="12" Padding="0" Margin="0,0,0,12"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="{StaticResource SectionHueAccountBorderBrush}" BorderThickness="1">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueAccountWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueAccountBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <TextBlock Text="{loc:Str section_support_development}"
+                               Foreground="{StaticResource SectionHueAccountBrush}" FontSize="14" FontWeight="Bold"/>
+                    <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12" Margin="0,6,0,0">
+                        <Run Text="{loc:Str section_patreon_unlocks}"/> <Run x:Name="RunPatreonFeatures" Text="{loc:Str section_ai_chat_window_awareness_slut_mode_takeover}" Foreground="{DynamicResource TextLightBrush}"/>
+                    </TextBlock>
+                    <Button x:Name="BtnVisitPatreon"
+                            Background="{DynamicResource SecondaryBrush}" Foreground="White"
+                            BorderThickness="0" Padding="15,8" Margin="0,10,0,0"
+                            HorizontalAlignment="Left" FontSize="12"
+                            Cursor="Hand"
+                            Click="BtnVisitPatreon_Click">
+                        <TextBlock Text="{loc:Str btn_visit_patreon}"/>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS · ACCOUNT, ported from the WPF head.
+    ///
+    /// On WPF every Click is a one-line forward to the identically-named MainWindow handler and
+    /// <c>RefreshTierBadge</c> reads <c>App.IsLoggedIn</c> / <c>App.Patreon</c>. None of that is
+    /// reachable from this head, so the handlers are stubs and the tier card keeps its signed-out
+    /// markup defaults. The x:Names are preserved so wiring is mechanical once a host exists.
+    /// </summary>
+    public partial class AccountSettingsSection : UserControl
+    {
+        public AccountSettingsSection()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        // ponytail: needs App.Patreon / App.IsLoggedIn, wired when the account service moves to Core
+        internal void RefreshTierBadge() { }
+
+        // ponytail: needs the MainWindow.Patreon/SubscribeStar/CloudBackup partials, wired when they move to Core
+        private void BtnPatreonLogin_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnSubscribeStarLogin_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnDiscordLogin_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnLinkPatreon_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnLinkDiscord_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnBackupSettingsNow_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnRestoreSettings_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnExportData_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnPrivacyPolicy_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnVisitPatreon_Click(object? sender, RoutedEventArgs e) { }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/AppSettings/DataSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DataSettingsSection.axaml
@@ -1,0 +1,145 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/DataSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"
+       ToolTip="..."                 ->  ToolTip.Tip="..."
+       Image + EmojiToImageSource    ->  <TextBlock Text="emoji"/> (Avalonia renders colour emoji)
+       Content="{loc:Str btn_x}"     ->  a <TextBlock> child (access-key underscore trap)
+       x:FieldModifier="internal"    ->  dropped; x:Names kept. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.DataSettingsSection">
+
+    <StackPanel>
+
+        <TextBlock Text="{loc:Str set2_section_data}" Theme="{StaticResource SectionHeader}"/>
+
+        <!-- ============================ offline mode ========================== -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,10"
+                BorderBrush="{StaticResource SectionHueDataBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueDataWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueDataBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <TextBlock Text="📴" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_data_offline_title}"
+                                   Foreground="{StaticResource SectionHueDataBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+
+                    <Grid MinHeight="34" ToolTip.Tip="{loc:Str tooltip_disable_all_network_features_updates_ai_leade}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Text="{loc:Str setting_offline_mode}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkOfflineMode"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"
+                                  IsCheckedChanged="ChkOfflineMode_Changed"/>
+                    </Grid>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- =========================== phrase backup ========================== -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,10"
+                BorderBrush="{StaticResource SectionHueDataBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueDataWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueDataBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="📤" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_data_phrase_backup_title}"
+                                   Foreground="{StaticResource SectionHueDataBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+                    <TextBlock Text="{loc:Str set2_data_phrase_backup_hint}" TextWrapping="Wrap"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,0,0,8"/>
+                    <StackPanel Orientation="Horizontal">
+                        <Button x:Name="BtnExportPhrases"
+                                Theme="{StaticResource OutlineButton}" Padding="12,5" Margin="0,0,8,0"
+                                Click="BtnExportPhrases_Click"
+                                ToolTip.Tip="{loc:Str set2_tooltip_export_phrases}">
+                            <TextBlock Text="{loc:Str set2_btn_export_phrases}"/>
+                        </Button>
+                        <Button x:Name="BtnImportPhrases"
+                                Theme="{StaticResource OutlineButton}" Padding="12,5"
+                                Click="BtnImportPhrases_Click"
+                                ToolTip.Tip="{loc:Str set2_tooltip_import_phrases}">
+                            <TextBlock Text="{loc:Str set2_btn_import_phrases}"/>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ====================== cloud backup signpost ======================= -->
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,10"
+                BorderBrush="{StaticResource SectionHueDataBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueDataWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueDataBrush}"/>
+                <Grid Margin="15,12,15,12" MinHeight="34" ToolTip.Tip="{loc:Str set2_data_cloud_signpost}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                               Text="{loc:Str label_cloud_settings_backup}"
+                               Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                    <Button Grid.Column="1" x:Name="BtnGoToAccountBackup"
+                            Theme="{StaticResource OutlineButton}" Padding="12,5" VerticalAlignment="Center"
+                            Click="BtnGoToAccountBackup_Click">
+                        <TextBlock Text="{loc:Str set2_btn_open_account_section}"/>
+                    </Button>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <!-- ============================ danger zone =========================== -->
+        <!-- Crimson on purpose: the warning colour outranks the section hue, and both
+             descriptions stay visible (load-bearing consequence text). -->
+        <Border x:Name="DangerZoneSection"
+                CornerRadius="12" Padding="0" Margin="0,8,0,10"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="{DynamicResource DangerBrush}" BorderThickness="1">
+            <Grid>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{DynamicResource DangerBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                        <TextBlock Text="☠️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_data_danger_title}"
+                                   Foreground="{DynamicResource DangerBrush}"
+                                   FontSize="13" VerticalAlignment="Center" Margin="0"/>
+                    </StackPanel>
+
+                    <TextBlock Text="{loc:Str set2_data_factory_reset_body}" TextWrapping="Wrap"
+                               Foreground="{DynamicResource TextLightBrush}" FontSize="11" Margin="0,0,0,4"/>
+                    <TextBlock Text="{loc:Str set2_data_factory_reset_keeps}" TextWrapping="Wrap"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,0,0,10"/>
+
+                    <Button x:Name="BtnFactoryReset"
+                            Theme="{StaticResource OutlineButton}"
+                            Foreground="{DynamicResource DangerBrush}"
+                            BorderBrush="{DynamicResource DangerBrush}"
+                            Padding="14,6" HorizontalAlignment="Left"
+                            Click="BtnFactoryReset_Click"
+                            ToolTip.Tip="{loc:Str set2_tooltip_factory_reset}">
+                        <TextBlock Text="{loc:Str set2_btn_factory_reset}"/>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/DataSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DataSettingsSection.axaml.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS ▸ DATA, ported from the WPF head: offline mode, phrase backup, the cloud-backup
+    /// signpost and the Danger Zone.
+    ///
+    /// On WPF the first three rows forward to MainWindow partials, and the factory reset is a
+    /// double-confirmed (WarningDialog + typed keyword) settings-only wipe followed by a
+    /// <c>cmd.exe</c> relaunch. All of it reaches <c>App.*</c>, WPF dialogs or Win32, so every
+    /// handler here is a stub. A stub that silently pretended to reset would be worse than none,
+    /// so the button draws but does nothing until the reset lives in Core.
+    /// </summary>
+    public partial class DataSettingsSection : UserControl
+    {
+        public DataSettingsSection()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        // ponytail: needs MainWindow.ChkOfflineMode_Changed / PresetIO partials, wired when they move to Core
+        private void ChkOfflineMode_Changed(object? sender, RoutedEventArgs e) { }
+        private void BtnExportPhrases_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnImportPhrases_Click(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: needs the AppSettings host's FocusSection("account"), wired when the settings shell is ported
+        private void BtnGoToAccountBackup_Click(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: needs App.Settings.SealForReset, App.Lockdown, WarningDialog, InputDialog and a
+        // per-platform relaunch; wired when the factory reset moves to Core
+        private void BtnFactoryReset_Click(object? sender, RoutedEventArgs e) { }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/AppSettings/EmiDeskSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/EmiDeskSettingsSection.axaml
@@ -1,0 +1,170 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/EmiDeskSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"
+       ToolTip="..."                 ->  ToolTip.Tip="..."
+       Content="{loc:Str x}"         ->  a <TextBlock> child (access-key underscore trap)
+       ctl:EmiRingPicker             ->  an empty WrapPanel placeholder (bucket B; not ported yet) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.EmiDeskSettingsSection">
+
+    <StackPanel>
+
+        <TextBlock Text="{loc:Str set2_section_emidesk}" Theme="{StaticResource SectionHeader}"/>
+
+        <Border Theme="{StaticResource SectionPanel}" Padding="0" Margin="0,0,0,12"
+                BorderBrush="{StaticResource SectionHueEmiDeskBorderBrush}">
+            <Grid>
+                <Border CornerRadius="11" Background="{StaticResource SectionHueEmiDeskWashBrush}"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueEmiDeskBrush}"/>
+                <StackPanel Margin="15,12,15,12">
+
+                    <!-- 1. master switch -->
+                    <Grid MinHeight="34" ToolTip.Tip="{loc:Str tooltip_emi_desk_enabled}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_enabled}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkEnabled"
+                                  Theme="{StaticResource ToggleStyle}" IsChecked="True"
+                                  VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_emi_desk_enabled_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <!-- 2. the summon chord -->
+                    <Grid MinHeight="34" Margin="0,10,0,0" ToolTip.Tip="{loc:Str tooltip_emi_desk_hotkey}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_hotkey}"
+                                   Margin="0,0,12,0" TextTrimming="CharacterEllipsis"/>
+                        <Button Grid.Column="1" x:Name="BtnHotkey"
+                                Content="Ctrl+Alt+E" Theme="{StaticResource OutlineButton}"
+                                Padding="12,6" VerticalAlignment="Center" MinWidth="130"
+                                Click="BtnHotkey_Click"/>
+                    </Grid>
+                    <TextBlock x:Name="TxtHotkeyHint"
+                               Text="{loc:Str set2_emi_desk_hotkey_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <!-- 3. the mute offer -->
+                    <Grid MinHeight="34" Margin="0,10,0,0" ToolTip.Tip="{loc:Str tooltip_emi_desk_mute}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_mute}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkMuteAvatar"
+                                  Theme="{StaticResource ToggleStyle}" IsChecked="True"
+                                  VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_emi_desk_mute_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <!-- 4. spice -->
+                    <Grid MinHeight="34" Margin="0,10,0,0" ToolTip.Tip="{loc:Str tooltip_emi_desk_spice}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_spice}"
+                                   Margin="0,0,12,0" TextTrimming="CharacterEllipsis"/>
+                        <ComboBox Grid.Column="1" x:Name="CmbSpice" Width="170"
+                                  Theme="{StaticResource DarkComboBoxStyle}" FontSize="11"
+                                  VerticalAlignment="Center"
+                                  SelectionChanged="CmbSpice_SelectionChanged"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_emi_desk_spice_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <!-- 5. offers -->
+                    <Grid MinHeight="34" Margin="0,10,0,0" ToolTip.Tip="{loc:Str tooltip_emi_desk_offers}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_offers}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkOffers"
+                                  Theme="{StaticResource ToggleStyle}" IsChecked="True"
+                                  VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_emi_desk_offers_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <!-- 6. the glass -->
+                    <Grid MinHeight="34" Margin="0,10,0,0" ToolTip.Tip="{loc:Str tooltip_emi_desk_glass}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_glass}"
+                                   Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkGlass"
+                                  Theme="{StaticResource ToggleStyle}" IsChecked="True"
+                                  VerticalAlignment="Center"/>
+                    </Grid>
+                    <TextBlock Text="{loc:Str set2_emi_desk_glass_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+
+                    <!-- 7. her ring -->
+                    <Grid MinHeight="34" Margin="0,14,0,0" ToolTip.Tip="{loc:Str tooltip_emi_desk_ring}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                                   Foreground="{StaticResource SectionHueEmiDeskBrush}"
+                                   Text="{loc:Str label_emi_desk_ring}"
+                                   Margin="0,0,12,0" TextTrimming="CharacterEllipsis"/>
+                        <Button Grid.Column="1" x:Name="BtnRingReset"
+                                Theme="{StaticResource OutlineButton}"
+                                Padding="12,6" VerticalAlignment="Center"
+                                Click="BtnRingReset_Click">
+                            <TextBlock Text="{loc:Str emi_desk_ring_reset}"/>
+                        </Button>
+                    </Grid>
+                    <TextBlock x:Name="TxtRingHint"
+                               Text="{loc:Str set2_emi_desk_ring_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,2,0,6"/>
+                    <!-- ponytail: placeholder for ctl:EmiRingPicker (Views/Controls/EmiRingPicker, bucket B),
+                         swap in when that control is ported -->
+                    <WrapPanel x:Name="RingPicker" Margin="0,0,0,2"/>
+
+                    <TextBlock Text="{loc:Str set2_emi_desk_gestures_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,8,0,0"/>
+
+                </StackPanel>
+            </Grid>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/EmiDeskSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/EmiDeskSettingsSection.axaml.cs
@@ -1,0 +1,119 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS - EMI DESK, ported from the WPF head.
+    ///
+    /// On WPF this section is self-contained: it reads <c>App.Settings.Current</c> on Loaded,
+    /// writes it back on every change, re-arms the summon chord through <c>App.EmiDesk</c> and
+    /// validates chords with <c>EmiDeskService.ValidateChord</c>. None of that is reachable from
+    /// this head, so the toggles render but persist nothing, and the hotkey button only enters and
+    /// leaves capture. What IS ported: the spice combo's three localized rows, and the capture
+    /// state machine's shape (click to start, Escape or focus loss to cancel).
+    /// </summary>
+    public partial class EmiDeskSettingsSection : UserControl
+    {
+        private bool _loading;
+        private bool _capturing;
+
+        private readonly ComboBox _cmbSpice;
+        private readonly Button _btnHotkey;
+
+        public EmiDeskSettingsSection()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _cmbSpice = this.FindControl<ComboBox>("CmbSpice")!;
+            _btnHotkey = this.FindControl<Button>("BtnHotkey")!;
+
+            Loaded += OnLoaded;
+            Unloaded += (_, _) => CancelCapture();
+
+            _btnHotkey.AddHandler(KeyDownEvent, OnHotkeyPreviewKeyDown, RoutingStrategies.Tunnel);
+            _btnHotkey.LostFocus += (_, _) => CancelCapture();
+        }
+
+        private void OnLoaded(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                _loading = true;
+                if (_cmbSpice.Items.Count == 0)
+                {
+                    _cmbSpice.Items.Add(Loc.Get("emi_desk_spice_innocent"));
+                    _cmbSpice.Items.Add(Loc.Get("emi_desk_spice_suggestive"));
+                    _cmbSpice.Items.Add(Loc.Get("emi_desk_spice_anything"));
+                }
+                // ponytail: needs App.Settings.Current.EmiDesk*, wired when SettingsService moves to Core
+                _cmbSpice.SelectedIndex = 0;
+                RefreshHotkeyButton();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] settings section load failed");
+            }
+            finally
+            {
+                _loading = false;
+            }
+        }
+
+        // ponytail: needs App.Settings.Save, wired when SettingsService moves to Core
+        private void CmbSpice_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_loading) return;
+        }
+
+        // ------------------------------------------------------------------ hotkey capture
+
+        private void BtnHotkey_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_capturing) { CancelCapture(); return; }
+            _capturing = true;
+            _btnHotkey.Content = Loc.Get("emi_desk_hotkey_capturing");
+            _btnHotkey.Focus();
+        }
+
+        private void OnHotkeyPreviewKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (!_capturing) return;
+            e.Handled = true;
+            if (e.Key == Key.Escape) { CancelCapture(); return; }
+            // Wait for a real key: the modifiers alone are not a chord.
+            switch (e.Key)
+            {
+                case Key.LeftCtrl: case Key.RightCtrl:
+                case Key.LeftAlt: case Key.RightAlt:
+                case Key.LeftShift: case Key.RightShift:
+                case Key.LWin: case Key.RWin:
+                case Key.System: case Key.None:
+                    return;
+            }
+            // ponytail: needs EmiDeskService.ValidateChord/FormatChord + App.EmiDesk.ApplyHotkey; until
+            // then a completed chord ends capture without rebinding
+            CancelCapture();
+        }
+
+        private void CancelCapture()
+        {
+            if (!_capturing) return;
+            _capturing = false;
+            RefreshHotkeyButton();
+        }
+
+        private void RefreshHotkeyButton()
+        {
+            // ponytail: needs App.Settings.Current.EmiDeskHotkey; the markup default stands in
+            _btnHotkey.Content = "Ctrl+Alt+E";
+        }
+
+        // ponytail: needs EmiRingPicker.ResetPins, wired when that control is ported
+        private void BtnRingReset_Click(object? sender, RoutedEventArgs e) { }
+    }
+}


### PR DESCRIPTION
793 lines, 6 files. MainWindow-forwarding handlers, tier badge refresh, factory reset and EmiDesk persistence are ponytail stubs; EmiRingPicker placeholder until that control lands.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351