### PR TITLE
feat(avalonia): port Settings sections III - Performance, Audio

### DIFF
--- a/CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml
@@ -1,0 +1,224 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/AudioSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"    (keyed styles are ControlThemes)
+       helpers:EmojiTextBlock        ->  TextBlock  (Avalonia draws colour emoji natively)
+       ToolTip="..."                 ->  ToolTip.Tip="..."
+       Visibility="Collapsed"        ->  IsVisible="False"
+       Content="{loc:Str ...}"       ->  a <TextBlock> child (Avalonia's Button reads "_" in Content
+                                         as an access key and every loc key here is snake_case)
+       x:FieldModifier="internal"    ->  dropped; no host re-publishes these fields yet. x:Names kept.
+       CmbAudioOutputDevice          ->  Theme="{StaticResource DarkComboBoxStyle}" (WPF applies it
+                                         implicitly from Resources/Theme; Avalonia themes are keyed)
+       Sliders stay on the stock Fluent theme. WPF applies PinkSlider implicitly, but the ported
+       PinkSlider (Theme/Styles.xaml) clips the thumb at Height=18 and its /template/ Thumb setters
+       do not repaint it, so the stock slider is the one that renders correctly. Theme/ fix, not
+       this view's. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.AudioSettingsSection"
+             mc:Ignorable="d" d:DesignWidth="620">
+
+    <!-- ================================================================
+         SETTINGS · AUDIO (Phase 2)
+
+         Global audio only. Per-feature volumes (whisper, bubbles, mindwipe)
+         stay with their feature panels. The audio-sync delay/power tuning
+         pair at the foot is Collapsed until the Haptics routing matrix
+         turns that layer on; the enable switch is NOT here.
+
+         The x:Name AudioSection stays on the OUTER Border - TutorialService's
+         "set_audio" step spotlights it by name.
+         ================================================================ -->
+
+    <Border x:Name="AudioSection"
+            CornerRadius="12" Padding="0" Margin="0,0,0,12"
+            Background="{DynamicResource ElevatedSurfaceBrush}"
+            BorderBrush="{StaticResource SectionHueAudioBorderBrush}" BorderThickness="1">
+        <Grid>
+            <Border CornerRadius="11" Background="{StaticResource SectionHueAudioWashBrush}"/>
+            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                    Background="{StaticResource SectionHueAudioBrush}"/>
+            <StackPanel Margin="16,13,16,13">
+
+                <!-- Header -->
+                <Grid Margin="0,0,0,8">
+                    <TextBlock Theme="{StaticResource SectionHeader}"
+                               Foreground="{StaticResource SectionHueAudioBrush}"
+                               Text="{loc:Str section_audio}" FontSize="14" Margin="0"/>
+                    <Button x:Name="HelpBtnAudio"
+                            Theme="{StaticResource HelpButtonStyle}" Tag="Audio"
+                            HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- Master volume -->
+                <Grid MinHeight="34" Margin="0,0,0,6" ColumnDefinitions="150,*,46"
+                      ToolTip.Tip="{loc:Str tooltip_master_volume_for_all_audio}">
+                    <TextBlock Theme="{StaticResource SettingLabel}" Text="{loc:Str setting_master}" FontSize="12"
+                               VerticalAlignment="Center"
+                               ToolTip.Tip="{loc:Str tooltip_master_volume_for_all_audio}"/>
+                    <Slider Grid.Column="1" x:Name="SliderMaster"
+                            Minimum="0" Maximum="100" Value="50"
+                            Margin="6,0" VerticalAlignment="Center"
+                            ValueChanged="SliderMaster_Changed"
+                            ToolTip.Tip="{loc:Str tooltip_overall_audio_volume_level}"/>
+                    <TextBlock x:Name="TxtMaster" Grid.Column="2"
+                               Theme="{StaticResource ValueLabel}" Text="50%" FontSize="12"
+                               VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- Video volume -->
+                <Grid MinHeight="34" Margin="0,0,0,6" ColumnDefinitions="150,*,46"
+                      ToolTip.Tip="{loc:Str tooltip_volume_for_mandatory_videos}">
+                    <TextBlock Theme="{StaticResource SettingLabel}" Text="{loc:Str setting_video}" FontSize="12"
+                               VerticalAlignment="Center"
+                               ToolTip.Tip="{loc:Str tooltip_volume_for_mandatory_videos}"/>
+                    <Slider Grid.Column="1" x:Name="SliderVideoVolume"
+                            Minimum="0" Maximum="100" Value="50"
+                            Margin="6,0" VerticalAlignment="Center"
+                            ValueChanged="SliderVideoVolume_Changed"
+                            ToolTip.Tip="{loc:Str tooltip_separate_volume_control_for_videos}"/>
+                    <TextBlock x:Name="TxtVideoVolume" Grid.Column="2"
+                               Theme="{StaticResource ValueLabel}" Text="50%" FontSize="12"
+                               VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- Auto-duck master switch -->
+                <Grid MinHeight="34" Margin="0,0,0,6" ColumnDefinitions="*,Auto"
+                      ToolTip.Tip="{loc:Str tooltip_automatically_reduce_other_app_volumes_during}">
+                    <TextBlock Text="{loc:Str label_duck}" Theme="{StaticResource SettingLabel}" FontSize="12"
+                               VerticalAlignment="Center" Margin="0,0,14,0" TextTrimming="CharacterEllipsis"
+                               ToolTip.Tip="{loc:Str tooltip_automatically_reduce_other_app_volumes_during}"/>
+                    <CheckBox Grid.Column="1" x:Name="ChkAudioDuck"
+                              Theme="{StaticResource ToggleStyle}"
+                              IsChecked="True" VerticalAlignment="Center"
+                              IsCheckedChanged="ChkAudioDuck_Changed"
+                              ToolTip.Tip="{loc:Str tooltip_automatically_reduce_other_app_volumes_during}"/>
+                </Grid>
+
+                <!-- Duck amount -->
+                <Grid MinHeight="34" Margin="0,0,0,6" ColumnDefinitions="150,*,46"
+                      ToolTip.Tip="{loc:Str tooltip_how_much_to_reduce_other_audio}">
+                    <TextBlock Theme="{StaticResource SettingLabel}" Text="{loc:Str label_duck}" FontSize="12"
+                               VerticalAlignment="Center"
+                               ToolTip.Tip="{loc:Str tooltip_how_much_to_reduce_other_audio}"/>
+                    <Slider Grid.Column="1" x:Name="SliderDuck"
+                            Minimum="0" Maximum="100" Value="80"
+                            Margin="6,0" VerticalAlignment="Center"
+                            ValueChanged="SliderDuck_Changed"
+                            ToolTip.Tip="{loc:Str tooltip_ducking_percentage_80_reduce_other_audio_to_2}"/>
+                    <TextBlock x:Name="TxtDuck" Grid.Column="2"
+                               Theme="{StaticResource ValueLabel}" Text="80%" FontSize="12"
+                               VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- Don't-duck-the-browser exception -->
+                <Grid MinHeight="34" Margin="0,0,0,6" ColumnDefinitions="*,Auto"
+                      ToolTip.Tip="{loc:Str tooltip_when_enabled_audio_from_the_integrated_bambic}">
+                    <TextBlock Text="{loc:Str setting_don_t_duck_browser}" Theme="{StaticResource SettingLabel}"
+                               FontSize="12" Foreground="{DynamicResource PinkBrush}"
+                               VerticalAlignment="Center" Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                    <CheckBox Grid.Column="1" x:Name="ChkExcludeBambiCloudDucking"
+                              Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"
+                              IsChecked="True"
+                              IsCheckedChanged="ChkExcludeBambiCloudDucking_Changed"
+                              ToolTip.Tip="{loc:Str tooltip_when_enabled_audio_from_the_integrated_bambic}"/>
+                </Grid>
+
+                <!-- Audio output device picker - route CCP audio to a chosen device
+                     (e.g. private headset) so streamers can use the program without
+                     their viewers hearing the audio on the system default endpoint. -->
+                <Grid MinHeight="34" Margin="0,0,0,10" ColumnDefinitions="150,*,Auto"
+                      ToolTip.Tip="{loc:Str tooltip_audio_output_device}">
+                    <TextBlock Theme="{StaticResource SettingLabel}" Text="{loc:Str setting_output}" FontSize="12"
+                               VerticalAlignment="Center"
+                               ToolTip.Tip="{loc:Str tooltip_audio_output_device}"/>
+                    <ComboBox Grid.Column="1" x:Name="CmbAudioOutputDevice"
+                              Theme="{StaticResource DarkComboBoxStyle}"
+                              Margin="6,0" VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                              ToolTip.Tip="{loc:Str tooltip_audio_output_device}"
+                              SelectionChanged="CmbAudioOutputDevice_SelectionChanged"/>
+                    <Button Grid.Column="2" x:Name="BtnAudioOutputRefresh" Content="↻"
+                            Click="BtnAudioOutputRefresh_Click"
+                            ToolTip.Tip="{loc:Str set2_tooltip_audio_output_refresh}"
+                            Padding="10,3" Background="#33FF69B4" Foreground="White" FontSize="12"
+                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" Cursor="Hand"
+                            VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- Actions: diagnostics + the layered-audio mixer (#659) -->
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="BtnTestAudio"
+                            Click="BtnTestAudio_Click"
+                            ToolTip.Tip="{loc:Str set2_tooltip_test_audio}"
+                            Background="#33FF69B4" Foreground="White" FontSize="11" Padding="12,5"
+                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" Cursor="Hand"
+                            Margin="0,0,8,0">
+                        <TextBlock Text="{loc:Str set2_btn_test_audio}"/>
+                    </Button>
+                    <Button x:Name="BtnAudioLayers"
+                            Click="BtnAudioLayers_Click"
+                            ToolTip.Tip="{loc:Str tooltip_audio_layers}"
+                            Background="#33FF69B4" Foreground="White" FontSize="11" Padding="12,5"
+                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" Cursor="Hand">
+                        <TextBlock Text="{loc:Str btn_audio_layers}"/>
+                    </Button>
+                </StackPanel>
+
+                <!-- ============================================================
+                     AUDIO SYNC — the live haptic tuning pair (Phase 3).
+                     Collapsed until the Haptics "Media > Audio sync" layer is on;
+                     the host's RefreshAudioSyncCardVisibility owns visibility.
+                     These MIRROR the Haptics panel's own delay/power sliders.
+                     ============================================================ -->
+                <Border x:Name="AudioSyncLatencyPanel"
+                        IsVisible="False"
+                        Background="{DynamicResource PanelBgBrush}" CornerRadius="8"
+                        Padding="12,10" Margin="0,12,0,0">
+                    <StackPanel>
+                        <TextBlock Text="{loc:Str hm3_audio_sync_tuning}"
+                                   Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="12" FontWeight="Bold" Margin="0,0,0,6"/>
+
+                        <!-- Delay -->
+                        <Grid MinHeight="34" Margin="0,0,0,6" ColumnDefinitions="150,*,46"
+                              ToolTip.Tip="{loc:Str tooltip_adjust_haptic_timing_positive_earlier_negativ}">
+                            <TextBlock Theme="{StaticResource SettingLabel}" Text="{loc:Str label_delay}" FontSize="12"
+                                       VerticalAlignment="Center"
+                                       ToolTip.Tip="{loc:Str tooltip_adjust_haptic_timing_positive_earlier_negativ}"/>
+                            <Slider Grid.Column="1" x:Name="SliderAudioSyncLatency"
+                                    Minimum="-600" Maximum="600" Value="0"
+                                    Margin="6,0" VerticalAlignment="Center"
+                                    ValueChanged="SliderAudioSyncLatency_Changed"
+                                    ToolTip.Tip="{loc:Str tooltip_adjust_haptic_timing_positive_earlier_negativ}"/>
+                            <TextBlock x:Name="TxtAudioSyncLatency" Grid.Column="2"
+                                       Theme="{StaticResource ValueLabel}" Text="{loc:Str label_0ms}" FontSize="12"
+                                       VerticalAlignment="Center"/>
+                        </Grid>
+
+                        <!-- Power -->
+                        <Grid MinHeight="34" ColumnDefinitions="150,*,46"
+                              ToolTip.Tip="{loc:Str tooltip_live_intensity_control_reduce_if_vibration_is}">
+                            <TextBlock Theme="{StaticResource SettingLabel}" Text="{loc:Str label_power}" FontSize="12"
+                                       VerticalAlignment="Center"
+                                       ToolTip.Tip="{loc:Str tooltip_live_intensity_control_reduce_if_vibration_is}"/>
+                            <Slider Grid.Column="1" x:Name="SliderAudioSyncIntensity"
+                                    Minimum="0" Maximum="100" Value="100"
+                                    Margin="6,0" VerticalAlignment="Center"
+                                    ValueChanged="SliderAudioSyncIntensity_Changed"
+                                    ToolTip.Tip="{loc:Str tooltip_live_intensity_control_reduce_if_vibration_is}"/>
+                            <TextBlock x:Name="TxtAudioSyncIntensity" Grid.Column="2"
+                                       Theme="{StaticResource ValueLabel}" Text="100%" FontSize="12"
+                                       VerticalAlignment="Center"/>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml.cs
@@ -1,0 +1,43 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS · AUDIO, ported from the WPF head.
+    ///
+    /// On WPF every handler is a one-line hop to the identically named <c>MainWindow</c> method
+    /// (audio engine, NAudio device enumeration, ducking) and <see cref="BtnAudioLayers_Click"/>
+    /// opens <c>LayeredAudioWindow</c>. None of that is on this head, so the handlers are stubs.
+    /// The value labels beside each slider keep their markup defaults; on WPF the host repaints
+    /// them from settings.
+    /// </summary>
+    public partial class AudioSettingsSection : UserControl
+    {
+        public AudioSettingsSection()
+        {
+            AvaloniaXamlLoader.Load(this);
+            // ponytail: placeholder so the combo is not an empty pill; real list comes from the audio device service
+            var cmb = this.FindControl<ComboBox>("CmbAudioOutputDevice")!;
+            cmb.ItemsSource = new[] { "Default" };
+            cmb.SelectedIndex = 0;
+        }
+
+        // ponytail: needs MainWindow's audio handlers (AudioService, NAudio devices), wired when they move to Core
+        private void SliderMaster_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
+        private void SliderVideoVolume_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
+        private void SliderDuck_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
+        private void ChkAudioDuck_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkExcludeBambiCloudDucking_Changed(object? sender, RoutedEventArgs e) { }
+        private void CmbAudioOutputDevice_SelectionChanged(object? sender, SelectionChangedEventArgs e) { }
+        private void BtnAudioOutputRefresh_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnTestAudio_Click(object? sender, RoutedEventArgs e) { }
+        private void SliderAudioSyncLatency_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
+        private void SliderAudioSyncIntensity_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
+
+        // ponytail: needs LayeredAudioWindow, which is not ported
+        private void BtnAudioLayers_Click(object? sender, RoutedEventArgs e) { }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/AppSettings/PerformanceSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/PerformanceSettingsSection.axaml
@@ -1,0 +1,208 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AppSettings/PerformanceSettingsSection.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"    (keyed styles are ControlThemes)
+       <Style x:Key="SettingChip">   ->  a local ControlTheme with a ^:pointerover setter
+       Image + EmojiToImageSource    ->  <TextBlock Text="⚡"/>  (Avalonia draws colour emoji natively)
+       ToolTip="..."                 ->  ToolTip.Tip="..."
+       VerticalScrollBarVisibility   ->  ScrollViewer.VerticalScrollBarVisibility (attached here)
+       Content="{loc:Str ...}"       ->  a <TextBlock> child (Avalonia's Button reads "_" in Content
+                                         as an access key and every loc key here is snake_case)
+       x:FieldModifier="internal"    ->  dropped; no host re-publishes these fields yet. x:Names kept.
+       SelectedIndex on CmbMotionLevel is seeded to 0 here: WPF leaves it unset until
+       SyncFromSettings paints it from App.Settings, which does not exist on this head. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AppSettings.PerformanceSettingsSection"
+             mc:Ignorable="d" d:DesignWidth="620">
+
+    <!-- ================================================================
+         SETTINGS ▸ PERFORMANCE  (UX restructure, Phase 2)
+
+         CmbMotionLevel is the motion kill-switch. Item order IS the
+         MotionLevel enum ordinal (Full=0, Reduced=1, Off=2) - the WPF
+         host casts SelectedIndex straight to the enum. Never reorder
+         these three items.
+
+         Quiet surface: no animation, no ambient canvas, no hover
+         choreography beyond what the shared styles do.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <!-- ponytail: local copy of PerformanceSettingsSection.xaml:SettingChip, hoist when a second view needs it -->
+        <ControlTheme x:Key="SettingChip" TargetType="Border">
+            <Setter Property="CornerRadius" Value="10"/>
+            <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="12,8"/>
+            <Setter Property="Margin" Value="0,0,0,6"/>
+            <Style Selector="^:pointerover">
+                <Setter Property="BorderBrush" Value="{StaticResource SectionHuePerformanceBorderBrush}"/>
+            </Style>
+        </ControlTheme>
+    </UserControl.Resources>
+
+    <Border x:Name="PerformanceSectionCard" CornerRadius="12" Padding="0" Margin="0,0,0,10"
+            Background="{DynamicResource ElevatedSurfaceBrush}"
+            BorderBrush="{StaticResource SectionHuePerformanceBorderBrush}" BorderThickness="1">
+        <Grid>
+            <Border CornerRadius="11" Background="{StaticResource SectionHuePerformanceWashBrush}"/>
+            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                    Background="{StaticResource SectionHuePerformanceBrush}"/>
+            <StackPanel Margin="15,12,15,12">
+
+                <!-- header -->
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="⚡" FontSize="13" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                    <TextBlock Theme="{StaticResource SectionHeader}" Text="{loc:Str set2_section_performance}"
+                               Foreground="{StaticResource SectionHuePerformanceBrush}"
+                               FontSize="13" VerticalAlignment="Center"/>
+                </StackPanel>
+                <TextBlock Text="{loc:Str set2_section_performance_hint}" TextWrapping="Wrap"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,0,0,8"/>
+
+                <!-- Four related switches = one 2-column chip grid (contract). Every
+                     description became its chip's ToolTip; not one loc key changed. -->
+                <Grid ColumnDefinitions="*,6,*" RowDefinitions="Auto,Auto">
+
+                    <Border Grid.Row="0" Grid.Column="0" Theme="{StaticResource SettingChip}"
+                            ToolTip.Tip="{loc:Str set2_tooltip_performance_mode}">
+                        <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="{loc:Str set2_setting_performance_mode}"
+                                       Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkPerformanceMode"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"
+                                      IsCheckedChanged="ChkPerformanceMode_Changed"/>
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Row="0" Grid.Column="2" Theme="{StaticResource SettingChip}"
+                            ToolTip.Tip="{loc:Str set2_tooltip_auto_performance}">
+                        <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="{loc:Str set2_setting_auto_performance}"
+                                       Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkAutoPerformance"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center" IsChecked="True"
+                                      IsCheckedChanged="ChkAutoPerformance_Changed"/>
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="0" Theme="{StaticResource SettingChip}"
+                            ToolTip.Tip="{loc:Str set2_tooltip_unified_overlay}">
+                        <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="{loc:Str set2_setting_unified_overlay}"
+                                       Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkUnifiedOverlay"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center" IsChecked="True"
+                                      IsCheckedChanged="ChkUnifiedOverlay_Changed"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Force video GPU decode. -->
+                    <Border Grid.Row="1" Grid.Column="2" Theme="{StaticResource SettingChip}"
+                            ToolTip.Tip="{loc:Str set2_tooltip_video_hw_decode}">
+                        <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="{loc:Str set2_setting_video_hw_decode}"
+                                       Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkVideoHwDecode"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"
+                                      IsCheckedChanged="ChkVideoHwDecode_Changed"/>
+                        </Grid>
+                    </Border>
+                </Grid>
+
+                <!-- Motion (accessibility). The three items ARE the enum ordinals — never reorder. -->
+                <Grid MinHeight="34" Margin="0,2,0,0" ColumnDefinitions="*,Auto"
+                      ToolTip.Tip="{loc:Str tooltip_motion_level}">
+                    <TextBlock Grid.Column="0" Theme="{StaticResource SettingLabel}"
+                               Text="{loc:Str setting_motion_level}"
+                               Margin="0,0,14,0" TextTrimming="CharacterEllipsis"/>
+                    <ComboBox Grid.Column="1" x:Name="CmbMotionLevel"
+                              Theme="{StaticResource DarkComboBoxStyle}" FontSize="11"
+                              Width="110" MinHeight="28" VerticalAlignment="Center" SelectedIndex="0"
+                              SelectionChanged="CmbMotionLevel_SelectionChanged">
+                        <ComboBoxItem Content="{loc:Str label_motion_full}"/>
+                        <ComboBoxItem Content="{loc:Str label_motion_reduced}"/>
+                        <ComboBoxItem Content="{loc:Str label_motion_off}"/>
+                    </ComboBox>
+                </Grid>
+
+                <!-- ============================================================
+                     DO NOT DISTURB. The user lists the apps they watch things in;
+                     while one of those owns the FOREGROUND window the app stops
+                     scheduling its own media over the top of it. The list is
+                     stored NORMALISED (lower-case, no ".exe"); TxtDndProcesses
+                     is only ever a view of it. It starts EMPTY and is never
+                     auto-populated. Suppression is spawn-only.
+                     ============================================================ -->
+                <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Opacity="0.5"
+                        Margin="0,10,0,8"/>
+
+                <TextBlock Text="{loc:Str set2_dnd_header}" FontSize="12.5" FontWeight="SemiBold"
+                           Foreground="{DynamicResource TextLightBrush}"/>
+                <TextBlock Text="{loc:Str set2_dnd_hint}" TextWrapping="Wrap"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,2,0,6"/>
+
+                <TextBox x:Name="TxtDndProcesses"
+                         AcceptsReturn="True" TextWrapping="NoWrap" MinHeight="52" MaxHeight="110"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto" FontSize="11"
+                         Foreground="{DynamicResource TextLightBrush}" Background="{DynamicResource SurfaceBgBrush}"
+                         BorderBrush="{DynamicResource PanelAccentHoverBrush}" BorderThickness="1" Padding="6,4"
+                         LostFocus="TxtDndProcesses_LostFocus"
+                         ToolTip.Tip="{loc:Str set2_dnd_list_tooltip}"/>
+
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,2">
+                    <Button x:Name="BtnDndPickApp"
+                            Theme="{StaticResource OutlineButton}" Padding="12,5"
+                            Click="BtnDndPickApp_Click"
+                            ToolTip.Tip="{loc:Str set2_dnd_btn_pick_tooltip}">
+                        <TextBlock Text="{loc:Str set2_dnd_btn_pick}"/>
+                    </Button>
+                </StackPanel>
+
+                <Grid Margin="0,6,0,0" ColumnDefinitions="*,6,*">
+
+                    <Border Grid.Column="0" Theme="{StaticResource SettingChip}"
+                            ToolTip.Tip="{loc:Str set2_tooltip_dnd_videos}">
+                        <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="{loc:Str set2_setting_dnd_videos}"
+                                       Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkDndSuppressVideos"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center" IsChecked="True"
+                                      IsCheckedChanged="ChkDndSuppressVideos_Changed"/>
+                        </Grid>
+                    </Border>
+
+                    <Border Grid.Column="2" Theme="{StaticResource SettingChip}"
+                            ToolTip.Tip="{loc:Str set2_tooltip_dnd_flashes}">
+                        <Grid MinHeight="22" ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="{loc:Str set2_setting_dnd_flashes}"
+                                       Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12.5" FontWeight="SemiBold" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkDndSuppressFlashes"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"
+                                      IsCheckedChanged="ChkDndSuppressFlashes_Changed"/>
+                        </Grid>
+                    </Border>
+                </Grid>
+
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AppSettings/PerformanceSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/PerformanceSettingsSection.axaml.cs
@@ -1,0 +1,40 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// SETTINGS ▸ PERFORMANCE, ported from the WPF head.
+    ///
+    /// Every handler on the WPF control either forwards to <c>MainWindow</c> or writes
+    /// <c>App.Settings.Current</c> and saves; the DND picker enumerates windowed processes through
+    /// <c>Services/UI/DoNotDisturbGuard</c> (Win32). None of that exists on this head yet, so the
+    /// handlers are stubs and the view is a rendering proof. The WPF <c>_isLoading</c> seed guard
+    /// is omitted for the same reason: there is nothing to seed from and nothing to guard.
+    /// </summary>
+    public partial class PerformanceSettingsSection : UserControl
+    {
+        public PerformanceSettingsSection()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        // ponytail: needs App.Settings + MainWindow.Chk*_Changed forwards, wired when they move to Core
+        private void ChkPerformanceMode_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkAutoPerformance_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkUnifiedOverlay_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkVideoHwDecode_Changed(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: needs MainWindow.CmbMotionLevel_SelectionChanged (stops ambient loops), wired when it moves to Core
+        private void CmbMotionLevel_SelectionChanged(object? sender, SelectionChangedEventArgs e) { }
+
+        // ponytail: needs App.Settings + DoNotDisturbGuard.Parse/FormatProcessList, wired when they move to Core
+        private void TxtDndProcesses_LostFocus(object? sender, RoutedEventArgs e) { }
+        private void ChkDndSuppressVideos_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkDndSuppressFlashes_Changed(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: needs DoNotDisturbGuard.RunningWindowedProcesses (Win32 window enumeration); per-platform in the head
+        private void BtnDndPickApp_Click(object? sender, RoutedEventArgs e) { }
+    }
+}


### PR DESCRIPTION
515 lines, 4 files. Sliders use the stock Fluent theme here; PinkSlider is applied by a later theme fix.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351