### PR TITLE
feat(avalonia): port Companion I - AiPermissionsGrid, ChatThresholdView

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml
@@ -1,0 +1,227 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/AiPermissionsGrid.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"    (keyed styles are ControlThemes)
+       Visibility="Collapsed"       ->  IsVisible="False"
+       ToolTip="..."                ->  ToolTip.Tip="..."
+       Image + CmpEmojiToImage      ->  <TextBlock Text="🧠"/>: Avalonia renders colour emoji natively
+       Checked/Unchecked            ->  IsCheckedChanged (Avalonia's CheckBox raises one event)
+       Content="{loc:Str}" on Button->  a <TextBlock> child (Avalonia reads "_" in Content as an
+                                        access key, and every loc key here is snake_case)
+       x:FieldModifier="internal"   ->  dropped; no host in this head pokes the fields yet
+       pack:// merged dictionary    ->  avares:// ResourceInclude
+       hero ImageBrush              ->  dropped (see the comment at the header band) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.AiPermissionsGrid"
+             mc:Ignorable="d"
+             d:DesignWidth="1240" d:DesignHeight="560">
+
+    <!-- ================================================================
+         WHAT SHE'S ALLOWED TO DO — the one AI-permissions surface.
+
+         This card is the Lab tab's "AI Companion Effects & Memory" card,
+         moved (UX restructure, Phase 5) rather than rewritten: same
+         sixteen x:Names, same handlers, same bound
+         CompanionPromptSettings properties.
+
+         THE GATE. The Companion door is Free / Tier 1, so the card carries
+         its own bar - TierGate.RequiresLab, rendered as a violet lockband
+         over the effects half. The memory half is deliberately NOT gated:
+         chat memory works on cloud AI, which is Tier 1. The band is
+         presentation only; enforcement stays in AiCommandService and the
+         providers' prompt envelope.
+
+         MOTION BUDGET: zero.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border Theme="{StaticResource CmpVioletCardStyle}">
+        <StackPanel>
+
+            <!-- ========== hero header ==========
+                 The negative margin cancels the card's own 20,18 padding so the art reaches the
+                 card edges. ponytail: the lab_aimemory_hero.png ImageBrush is dropped - this head
+                 ships no Resources/ PNGs yet; only the scrim gradient is drawn. Re-add the brush
+                 as an avares:// ImageBrush when the art moves. -->
+            <Border CornerRadius="14,14,0,0" Height="138" Margin="-20,-18,-20,16" ClipToBounds="True">
+                <Grid>
+                    <Border CornerRadius="14,14,0,0" Background="{StaticResource CmpElevBrush}"/>
+                    <Border CornerRadius="14,14,0,0">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                                <GradientStop Color="{StaticResource CmpCardColor}" Offset="0"/>
+                                <GradientStop Color="Transparent" Offset="0.9"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <!-- ========== title row ========== -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                <Border Width="34" Height="34" CornerRadius="10" Margin="0,0,11,0"
+                        Background="{StaticResource CmpElevBrush}"
+                        BorderBrush="{StaticResource CmpHairlineBrush}" BorderThickness="1">
+                    <TextBlock Text="🧠" FontSize="18" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+                <TextBlock Text="{loc:Str lab_ai_effects_memory_title}" Theme="{StaticResource CmpSectionTitleStyle}"/>
+                <Border Theme="{StaticResource CmpTrainTagStyle}" Margin="9,0,0,0">
+                    <TextBlock Text="{loc:Str label_beta_2}" Theme="{StaticResource CmpTrainTagTextStyle}"/>
+                </Border>
+                <!-- The T2 plate: on a Free/T1 door it has to be said out loud, entitled or not. -->
+                <Border Theme="{StaticResource CmpTierPlateStyle}">
+                    <TextBlock Text="{loc:Str hm3_rail_lock_t2}" FontSize="10" FontWeight="Bold"
+                               Foreground="{StaticResource CmpTextBrush}"/>
+                </Border>
+            </StackPanel>
+
+            <TextBlock Text="{loc:Str lab_ai_effects_memory_subtitle}"
+                       Theme="{StaticResource CmpBodyTextStyle}" Margin="0,0,0,12"/>
+
+            <!-- ========== "needs a local model" notice ==========
+                 Cloud AI cannot drive effects, so the controls below do nothing without a local
+                 Ollama or a BYO endpoint. Written by UpdateAiBrainPills on the WPF host. -->
+            <Border x:Name="LabEffectsNeedsLocalNotice" IsVisible="False"
+                    Theme="{StaticResource CmpInsetPanelStyle}"
+                    BorderBrush="{StaticResource CmpPinkBrush}" Margin="0,0,0,12">
+                <Grid ColumnDefinitions="*,Auto">
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock Text="{loc:Str lab_ai_effects_needs_local_title}"
+                                   Foreground="{StaticResource CmpPinkBrush}" FontWeight="SemiBold" FontSize="13"/>
+                        <TextBlock Text="{loc:Str lab_ai_effects_needs_local_body}"
+                                   Theme="{StaticResource CmpDimTextStyle}" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" x:Name="BtnLabEffectsSetupLocal"
+                            Theme="{StaticResource CmpCtaPillStyle}"
+                            Margin="12,0,0,0" VerticalAlignment="Center"
+                            Click="BtnLabEffectsSetupLocal_Click">
+                        <TextBlock Text="{loc:Str btn_lab_effects_setup_local}"/>
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- ========== the two halves ==========
+                 Effects (Tier 2, gated) beside memory (Tier 1, not gated). -->
+            <Grid ColumnDefinitions="3*,16,2*">
+
+                <!-- ===== left: effect control + permissions ===== -->
+                <Grid Grid.Column="0">
+                    <StackPanel x:Name="EffectsGateHost">
+                        <!-- master toggle -->
+                        <Grid Margin="0,0,0,8">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center">
+                                <TextBlock Text="{loc:Str label_capability_effects}"
+                                           Foreground="{StaticResource CmpTextBrush}" FontSize="15" VerticalAlignment="Center"/>
+                                <Button Theme="{DynamicResource HelpButtonStyle}" ToolTip.Tip="{loc:Str tooltip_lab_ai_effects}"/>
+                            </StackPanel>
+                            <CheckBox x:Name="ChkCapEffects" Theme="{DynamicResource ToggleStyle}"
+                                      HorizontalAlignment="Right" VerticalAlignment="Center"
+                                      IsChecked="False"
+                                      IsCheckedChanged="ChkCapEffects_Changed"/>
+                        </Grid>
+
+                        <!-- effect permissions panel -->
+                        <Border x:Name="EffectPermsPanel" IsVisible="False"
+                                Theme="{StaticResource CmpInsetPanelStyle}"
+                                BorderBrush="{StaticResource CmpDangerBrush}" Margin="0,0,0,12">
+                            <StackPanel>
+                                <TextBlock Text="{loc:Str label_effect_permissions}"
+                                           Foreground="{StaticResource CmpDangerBrush}" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                <Grid Margin="0,0,0,8">
+                                    <TextBlock Text="{loc:Str label_max_haptic_intensity}"
+                                               Foreground="{StaticResource CmpTextBrush}" FontSize="13" VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="TxtMaxHapticIntensity" Text="60%"
+                                               Foreground="{StaticResource CmpPinkBrush}" FontSize="13" FontWeight="SemiBold"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                </Grid>
+                                <Slider x:Name="SliderMaxHapticIntensity" Theme="{DynamicResource PinkSlider}"
+                                        Minimum="0" Maximum="1" Value="0.6" Margin="0,0,0,10"
+                                        ValueChanged="SliderMaxHapticIntensity_ValueChanged"/>
+                                <!-- Ten switches, one handler: each names its own setting through Tag, so
+                                     re-ordering this grid can never remap a saved permission. -->
+                                <UniformGrid Columns="2" Rows="5">
+                                    <CheckBox x:Name="ChkAllowFlash" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_flash}" Foreground="White" FontSize="13" Margin="0,2,4,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Flash"/>
+                                    <CheckBox x:Name="ChkAllowVideo" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_video}" Foreground="White" FontSize="13" Margin="4,2,0,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Video"/>
+                                    <CheckBox x:Name="ChkAllowAudio" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_audio}" Foreground="White" FontSize="13" Margin="0,2,4,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Audio"/>
+                                    <CheckBox x:Name="ChkAllowBubbles" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_bubbles}" Foreground="White" FontSize="13" Margin="4,2,0,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Bubbles"/>
+                                    <CheckBox x:Name="ChkAllowSubliminal" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_subliminal}" Foreground="White" FontSize="13" Margin="0,2,4,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Subliminal"/>
+                                    <CheckBox x:Name="ChkAllowOverlay" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_overlay}" Foreground="White" FontSize="13" Margin="4,2,0,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Overlay"/>
+                                    <CheckBox x:Name="ChkAllowLockCard" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_lockcard}" Foreground="White" FontSize="13" Margin="0,2,4,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="LockCard"/>
+                                    <CheckBox x:Name="ChkAllowBounce" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_bounce}" Foreground="White" FontSize="13" Margin="4,2,0,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Bounce"/>
+                                    <CheckBox x:Name="ChkAllowHaptic" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_haptic}" Foreground="White" FontSize="13" Margin="0,2,4,2" IsCheckedChanged="ChkAllowEffect_Changed" Tag="Haptic"/>
+                                    <StackPanel Orientation="Horizontal" Margin="4,2,0,2">
+                                        <CheckBox x:Name="ChkAllowGetBackToMe" Theme="{DynamicResource DotCheckBoxStyle}" Content="{loc:Str label_allow_get_back_to_me}" Foreground="White" FontSize="13" IsCheckedChanged="ChkAllowEffect_Changed" Tag="GetBackToMe"/>
+                                        <!-- Named: MainWindow.Presets.cs hangs the help-registry popup on it. -->
+                                        <Button x:Name="HelpBtnGetBackToMe" Theme="{DynamicResource HelpButtonStyle}" Tag="GetBackToMe"/>
+                                    </StackPanel>
+                                </UniformGrid>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+
+                    <!-- ===== the Tier 2 lockband =====
+                         MinHeight so the band still has room to draw when the permissions panel
+                         underneath it is collapsed (a locked account's normal state). The veil
+                         itself takes no clicks (CmpVeilStyle); only the CTA does. -->
+                    <Grid x:Name="EffectsLockBand" IsVisible="False" MinHeight="164"
+                          AutomationProperties.AutomationId="CompanionPermissionsLockBand">
+                        <Border Theme="{StaticResource CmpVeilStyle}"/>
+                        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <TextBlock Text="🔒" Theme="{StaticResource CmpLockGlyphStyle}" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{loc:Str hm3_rail_lock_t2}" HorizontalAlignment="Center"
+                                       Margin="0,6,0,0" FontSize="13" FontWeight="Bold"
+                                       Foreground="{StaticResource CmpPurpleBrush}"/>
+                            <TextBlock x:Name="TxtEffectsLockCopy" Theme="{StaticResource CmpVeilCopyStyle}"/>
+                            <Button x:Name="BtnEffectsLockCta"
+                                    Theme="{StaticResource CmpCtaPillStyle}" HorizontalAlignment="Center"
+                                    Click="BtnEffectsLockCta_Click">
+                                <TextBlock Text="{loc:Str tiergate_see_tiers}"/>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+
+                <!-- ===== right: chat memory (Tier 1, NOT gated) ===== -->
+                <Border Grid.Column="2" Theme="{StaticResource CmpInsetPanelStyle}"
+                        BorderBrush="{StaticResource CmpVioletBrush}" VerticalAlignment="Top">
+                    <StackPanel>
+                        <Grid>
+                            <StackPanel VerticalAlignment="Center" Margin="0,0,12,0" HorizontalAlignment="Left">
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,2">
+                                    <TextBlock Text="{loc:Str label_chat_memory_title}"
+                                               Foreground="{StaticResource CmpVioletBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                    <Button Theme="{DynamicResource HelpButtonStyle}" ToolTip.Tip="{loc:Str tooltip_lab_ai_memory}"/>
+                                </StackPanel>
+                                <TextBlock Text="{loc:Str label_chat_memory_hint}"
+                                           Theme="{StaticResource CmpDimTextStyle}" TextWrapping="Wrap"/>
+                            </StackPanel>
+                            <CheckBox x:Name="ChkChatMemoryEnabled" Theme="{DynamicResource ToggleStyle}"
+                                      HorizontalAlignment="Right" VerticalAlignment="Center"
+                                      IsChecked="True"
+                                      IsCheckedChanged="ChkChatMemoryEnabled_Changed"/>
+                        </Grid>
+                        <Button x:Name="BtnClearChatMemory"
+                                Theme="{StaticResource CmpDangerButtonStyle}"
+                                HorizontalAlignment="Right" Margin="0,10,0,0"
+                                Click="BtnClearChatMemory_Click"
+                                ToolTip.Tip="{loc:Str tooltip_forget_everything}">
+                            <TextBlock Text="{loc:Str btn_forget_everything}"/>
+                        </Button>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs
@@ -1,0 +1,107 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using ConditioningControlPanel.Localization;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// "What she's allowed to do" — the single AI-permissions surface, ported from the WPF head.
+    ///
+    /// <para>On WPF every control here is a one-line shim to the identically named
+    /// <c>MainWindow.Patreon.cs</c> handler, which reads and writes
+    /// <c>App.Settings.Current.CompanionPrompt</c>. That host does not exist in this head, so each
+    /// handler keeps only the half that touches the view (showing the permissions panel, writing
+    /// the slider's percentage) and stubs the persistence. <see cref="ApplyTierGate"/> fails
+    /// closed, exactly as <c>TierGate.RequiresLab</c> does with no Patreon service alive.</para>
+    ///
+    /// <para>Motion budget: zero.</para>
+    /// </summary>
+    public partial class AiPermissionsGrid : UserControl
+    {
+        /// <summary>Opacity of the effects half while it is behind the lockband.</summary>
+        private const double LockedOpacity = 0.32;
+
+        public AiPermissionsGrid()
+        {
+            InitializeComponent();
+            Loaded += (_, _) => ApplyTierGate();
+        }
+
+        /// <summary>Whether this account clears the Tier 2 bar.</summary>
+        // ponytail: needs PatreonService.HasLabAccess, wired when it moves to Core. Fails closed.
+        internal bool IsLabEntitled => false;
+
+        /// <summary>
+        /// Paints the Tier 2 verdict onto the effects half: disabled and dimmed under a violet
+        /// lockband when the account does not clear the bar, untouched when it does. Deliberately
+        /// does NOT touch the memory half - chat memory is Tier 1.
+        /// </summary>
+        internal void ApplyTierGate()
+        {
+            try
+            {
+                var allowed = IsLabEntitled;
+                // Same sentence TierGate.RequiresLab formats, so this band and the toast agree.
+                var reason = allowed ? string.Empty
+                    : Loc.GetF("tiergate_denied_lab", Loc.Get("lab_ai_effects_memory_title"));
+
+                EffectsGateHost.IsEnabled = allowed;
+                EffectsGateHost.Opacity = allowed ? 1.0 : LockedOpacity;
+                EffectsLockBand.IsVisible = !allowed;
+                TxtEffectsLockCopy.Text = reason;
+            }
+            catch (Exception ex)
+            {
+                // A lockband that throws would take the whole Companion tab down with it.
+                Log.Debug("AiPermissionsGrid.ApplyTierGate failed: {E}", ex.Message);
+            }
+        }
+
+        private void BtnEffectsLockCta_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs MainWindow.ShowAppInfoPopup, wired when the shell has one
+        }
+
+        private void BtnClearChatMemory_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs CompanionBrain.ForgetConversation + a confirm dialog, wired when it moves to Core
+        }
+
+        private void BtnLabEffectsSetupLocal_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs the Engine Room deep link + LocalAiSetupWizard, wired when they are ported
+        }
+
+        private void ChkAllowEffect_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs CompanionPromptSettings.AllowAi<Tag>, wired when settings move to Core
+        }
+
+        private void ChkCapEffects_Changed(object? sender, RoutedEventArgs e)
+        {
+            var on = ChkCapEffects.IsChecked == true;
+            if (on && !IsLabEntitled)
+            {
+                // A refusal must not write: put the switch back and leave the panel closed.
+                ChkCapEffects.IsChecked = false;
+                return;
+            }
+            EffectPermsPanel.IsVisible = on;
+            // ponytail: needs CompanionPromptSettings.AllowAiToControlEffects, wired when settings move to Core
+        }
+
+        private void ChkChatMemoryEnabled_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs CompanionPromptSettings.ChatMemoryEnabled + the brain wipe, wired when they move to Core
+        }
+
+        private void SliderMaxHapticIntensity_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtMaxHapticIntensity.Text = $"{(int)(e.NewValue * 100)}%";
+            // ponytail: needs CompanionPromptSettings.MaxAiHapticIntensity, wired when settings move to Core
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/ChatThresholdView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/ChatThresholdView.axaml
@@ -1,0 +1,304 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/ChatThresholdView.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"    (keyed styles are ControlThemes)
+       Visibility + CmpEnumToVis    ->  IsVisible + CmpEnumToVis (it returns bool here)
+       CmpBoolToVis / Inverse       ->  IsVisible="{Binding X}" / "{Binding !X}"
+       CmpHasContentToVis           ->  StringConverters.IsNotNullOrEmpty
+       CmpEmptyToVis                ->  StringConverters.IsNullOrEmpty
+       Image + CmpEmojiToImage      ->  <TextBlock Text="💬"/>: Avalonia renders colour emoji natively
+       DataTemplate.Triggers        ->  Classes.you / Classes.echo on the row + selectors in
+                                        UserControl.Styles. The her defaults are set by the base
+                                        selectors too, because a local attribute would beat the
+                                        style setter and the you/echo overrides would never apply.
+       ToolTip="..."                ->  ToolTip.Tip="..."
+       UpdateSourceTrigger          ->  dropped (Avalonia's TextBox updates per keystroke)
+       Content="{...}" on a button  ->  a <TextBlock> child where the template has a
+                                        ContentPresenter; a string where it binds Text
+                                        (CmpLinkButtonStyle, CmpWatchChipStyle)
+       x:Name on a Transform        ->  dropped (illegal in Avalonia); reached through the group
+       Storyboards                  ->  see the code-behind
+       pack:// merged dictionary    ->  avares:// ResourceInclude -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.ChatThresholdView"
+             x:DataType="local:ChatThresholdViewModel"
+             mc:Ignorable="d"
+             d:DesignWidth="660" d:DesignHeight="420">
+
+    <!-- ================================================================
+         Z2 — TALK TO HER (the threshold surface).
+         Not a chat app on the tab: the last few turns, one input row, and
+         a hand-off to the tube chat.
+
+         States (mutually exclusive, all four ship copy):
+           Live      thread + enabled input
+           Dormant   pre-T1 honesty card, dashed violet outline plus a
+                     ONE-SHOT shimmer sweep on load, never a gray box
+           Disabled  provider Off — dimmed input + Engine Room jump link
+           Locked    free tier — a BLURRED STATIC mock thread under the
+                     Velvet-Vault veil. The veil takes no clicks; the CTA
+                     chip is the one hit-testable thing in it, and the
+                     input row stands down entirely.
+
+         The pink AI badge rides IsAiGenerated and nothing else.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- One bubble. Her / you / echo are picked by the row's classes so a single template
+                 serves the live thread and the staged teaser alike. The wrapper Grid carries the
+                 alignment and the width cap, NOT the bubble Border: the badge is positioned against
+                 the wrapper, so that is what keeps "✨ AI" pinned to the corner of her line. -->
+            <DataTemplate x:Key="CmpSurfChatBubbleTemplate" x:DataType="local:ChatBubble">
+                <Grid x:Name="Row" Classes="bubble" Classes.you="{Binding IsYou}" Classes.echo="{Binding IsEcho}"
+                      ToolTip.Tip="{Binding Timestamp}">
+                    <Border x:Name="Bubble" HorizontalAlignment="Stretch">
+                        <StackPanel>
+                            <TextBlock x:Name="BubbleText" Text="{Binding Text}"/>
+
+                            <!-- She names a title; the app owns the link. Hidden unless the title
+                                 she named resolves to something we can actually open. -->
+                            <Button x:Name="WatchChip" Theme="{StaticResource CmpWatchChipStyle}"
+                                    Command="{Binding OpenLinkCommand}"
+                                    Content="{Binding LinkTitle}"
+                                    IsVisible="{Binding LinkTitle, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- her signature rail: a faint outline PLUS a solid 3px pink left border;
+                         one BorderBrush cannot be both, so the rail is its own Rectangle. -->
+                    <Rectangle x:Name="HerRail" Theme="{StaticResource CmpBubbleHerRailStyle}"
+                               IsVisible="{Binding IsHer}"/>
+
+                    <!-- the echo's dashed outline: Border cannot dash. -->
+                    <Rectangle x:Name="EchoOutline" Theme="{StaticResource CmpBubbleEchoOutlineStyle}"
+                               IsVisible="{Binding IsEcho}"/>
+
+                    <!-- the AI badge floats on the bubble's top-right corner -->
+                    <Border x:Name="Badge" Theme="{StaticResource CmpAiBadgeStyle}" IsVisible="{Binding IsAiGenerated}">
+                        <TextBlock Text="{loc:Str companion_chat_ai_badge}" Theme="{StaticResource CmpAiBadgeTextStyle}"/>
+                    </Border>
+                </Grid>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <!-- the WPF DataTriggers: her is the base, you / echo override -->
+        <Style Selector="Grid.bubble">
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="MaxWidth" Value="420"/>
+        </Style>
+        <Style Selector="Grid.bubble Border#Bubble">
+            <Setter Property="Theme" Value="{StaticResource CmpBubbleHerStyle}"/>
+        </Style>
+        <Style Selector="Grid.bubble TextBlock#BubbleText">
+            <Setter Property="Theme" Value="{StaticResource CmpBubbleTextStyle}"/>
+        </Style>
+
+        <Style Selector="Grid.bubble.you">
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+        </Style>
+        <Style Selector="Grid.bubble.you Border#Bubble">
+            <Setter Property="Theme" Value="{StaticResource CmpBubbleYouStyle}"/>
+        </Style>
+        <Style Selector="Grid.bubble.you TextBlock#BubbleText">
+            <Setter Property="Foreground" Value="#FFDCD4F2"/>
+        </Style>
+
+        <Style Selector="Grid.bubble.echo">
+            <Setter Property="MaxWidth" Value="440"/>
+        </Style>
+        <Style Selector="Grid.bubble.echo Border#Bubble">
+            <Setter Property="Theme" Value="{StaticResource CmpBubbleEchoStyle}"/>
+        </Style>
+        <Style Selector="Grid.bubble.echo TextBlock#BubbleText">
+            <Setter Property="Theme" Value="{StaticResource CmpBubbleEchoTextStyle}"/>
+        </Style>
+
+        <!-- CmpThinkingDotsStoryboard: opacity 0.25 to 1.0, 0.45s each way, only while a send is
+             in flight - the .thinking class comes off with IsThinking, so nothing loops on an idle
+             page. ponytail: no per-dot 150ms stagger; add three keyed styles with Delay if it matters. -->
+        <Style Selector="StackPanel#ThinkingDots.thinking Ellipse">
+            <Style.Animations>
+                <Animation Duration="0:0:0.9" IterationCount="INFINITE">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.25"/></KeyFrame>
+                    <KeyFrame Cue="50%"><Setter Property="Opacity" Value="1.0"/></KeyFrame>
+                    <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0.25"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Theme="{StaticResource CmpCardStyle}">
+        <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
+
+            <!-- ========== header ========== -->
+            <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto">
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="💬" FontSize="16" Margin="0,0,9,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="{loc:Str companion_chat_title}" Theme="{StaticResource CmpSectionTitleStyle}"/>
+                </StackPanel>
+                <TextBlock Grid.Column="1" Text="{Binding LastHeardCopy}"
+                           Theme="{StaticResource CmpSectionHintStyle}"/>
+                <Border Grid.Column="2" Theme="{StaticResource CmpTrainTagLiveStyle}">
+                    <TextBlock Text="{loc:Str companion_tag_train1}" Theme="{StaticResource CmpTrainTagLiveTextStyle}"/>
+                </Border>
+            </Grid>
+
+            <!-- ========== the thread (live / dormant / disabled) ========== -->
+            <Grid Grid.Row="1" Margin="0,14,0,0">
+                <ItemsControl x:Name="ThreadList" ItemsSource="{Binding Turns}"
+                              ItemTemplate="{StaticResource CmpSurfChatBubbleTemplate}"
+                              Theme="{StaticResource CmpVirtualizedItemsControlStyle}"
+                              MaxHeight="260" Padding="0,9,0,0"
+                              IsVisible="{Binding State, Converter={StaticResource CmpEnumToVisInverse}, ConverterParameter=Locked}"/>
+
+                <!-- ===== the locked teaser ===== -->
+                <Grid IsVisible="{Binding State, Converter={StaticResource CmpEnumToVis}, ConverterParameter=Locked}"
+                      MinHeight="150">
+                    <Border CornerRadius="{StaticResource CmpRadiusInner}" ClipToBounds="True"
+                            Background="{StaticResource CmpCardBrush}" Padding="10">
+                        <!-- static mock bubbles only. Small, non-scrolling, cheap to blur. -->
+                        <ItemsControl ItemsSource="{Binding TeaserTurns}"
+                                      ItemTemplate="{StaticResource CmpSurfChatBubbleTemplate}"
+                                      IsHitTestVisible="False">
+                            <ItemsControl.Effect>
+                                <BlurEffect Radius="6"/>
+                            </ItemsControl.Effect>
+                        </ItemsControl>
+                    </Border>
+
+                    <!-- the veil: decoration, so it takes no clicks -->
+                    <Border Theme="{StaticResource CmpVeilStyle}"/>
+
+                    <!-- …and the one thing in it that does -->
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <TextBlock Text="🔒" Theme="{StaticResource CmpLockGlyphStyle}" HorizontalAlignment="Center"/>
+                        <TextBlock Text="{Binding LockCopy}" Theme="{StaticResource CmpVeilCopyStyle}"/>
+                        <Button Theme="{StaticResource CmpCtaPillStyle}"
+                                HorizontalAlignment="Center" Command="{Binding UnlockCommand}">
+                            <TextBlock Text="{Binding LockCtaLabel}"/>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Grid>
+
+            <!-- ========== the non-live states' copy ==========
+                 Its own row rather than an overlay, so a dormant thread and its promise cannot
+                 print on top of each other. -->
+            <Grid Grid.Row="2">
+                <!-- pre-Train 1: designed content — dashed outline + a one-shot shimmer -->
+                <Grid IsVisible="{Binding State, Converter={StaticResource CmpEnumToVis}, ConverterParameter=Dormant}"
+                      Margin="0,12,0,0">
+                    <Border x:Name="DormantHost" Theme="{StaticResource CmpDormantBlockStyle}">
+                        <Grid>
+                            <TextBlock Text="{Binding StateCopy}" Theme="{StaticResource CmpDormantCopyStyle}"/>
+                            <!-- the sweep band; its X is animated once by the code-behind -->
+                            <Border x:Name="DormantShimmer" Width="46" HorizontalAlignment="Left"
+                                    Background="{StaticResource CmpShimmerSoftBrush}"
+                                    IsHitTestVisible="False" Opacity="0">
+                                <Border.RenderTransform>
+                                    <TransformGroup>
+                                        <SkewTransform AngleX="-18"/>
+                                        <TranslateTransform X="-70"/>
+                                    </TransformGroup>
+                                </Border.RenderTransform>
+                            </Border>
+                        </Grid>
+                    </Border>
+                    <Rectangle Theme="{StaticResource CmpDashedOutlineStyle}"/>
+                </Grid>
+
+                <!-- provider Off: one honest line and the jump link into the Engine Room -->
+                <StackPanel Margin="0,12,0,0"
+                            IsVisible="{Binding State, Converter={StaticResource CmpEnumToVis}, ConverterParameter=Disabled}">
+                    <TextBlock Text="{Binding StateCopy}" Theme="{StaticResource CmpFlavorTextStyle}"/>
+                    <!-- string Content on purpose: CmpLinkButtonStyle's template binds Text to
+                         Content, so a TextBlock child would print its type name -->
+                    <Button HorizontalAlignment="Left" Margin="0,4,0,0"
+                            Content="{loc:Str companion_chat_open_engine}"
+                            Theme="{StaticResource CmpLinkButtonStyle}"
+                            Command="{Binding OpenEngineRoomCommand}"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- ========== input row ==========
+                 Stands down entirely behind the lock, and in Dormant: with the brain off there is
+                 no thread to add a line to. -->
+            <Grid Grid.Row="3" Margin="0,12,0,0" ColumnDefinitions="*,Auto"
+                  IsVisible="{Binding State, Converter={StaticResource CmpEnumToVisInverse}, ConverterParameter=Locked|Dormant}">
+
+                <Grid Grid.Column="0" Margin="0,0,9,0">
+                    <TextBox x:Name="DraftBox" Theme="{StaticResource CmpChatInputStyle}" MinHeight="41"
+                             Text="{Binding Draft, Mode=TwoWay}"
+                             IsEnabled="{Binding CanSend}"
+                             KeyDown="DraftBox_KeyDown"/>
+                    <!-- placeholder: shown only while the box is empty -->
+                    <TextBlock Text="{Binding InputPlaceholder}" IsHitTestVisible="False"
+                               Foreground="{StaticResource CmpFaintBrush}" FontSize="13"
+                               Margin="19,0,0,0" VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               Opacity="{Binding CanSend, Converter={StaticResource CmpBoolToOpacity}, ConverterParameter=1.0|0.45}"
+                               IsVisible="{Binding Draft, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
+                </Grid>
+
+                <Button Grid.Column="1" Theme="{StaticResource CmpSendButtonStyle}"
+                        Command="{Binding SendCommand}" IsEnabled="{Binding CanSend}"
+                        ToolTip.Tip="{loc:Str companion_chat_send_tip}">
+                    <TextBlock Text="♥" FontSize="16" Foreground="White"/>
+                </Button>
+            </Grid>
+
+            <!-- ========== footer ========== -->
+            <Grid Grid.Row="4" Margin="0,12,0,0" ColumnDefinitions="Auto,*">
+
+                <!-- both hand-offs lead somewhere a locked user cannot go, so behind the veil the
+                     CTA chip is the only thing left to press -->
+                <StackPanel Grid.Column="0" Orientation="Horizontal"
+                            IsVisible="{Binding State, Converter={StaticResource CmpEnumToVisInverse}, ConverterParameter=Locked}">
+                    <Button Theme="{StaticResource CmpChipButtonStyle}"
+                            Command="{Binding OpenFullChatCommand}">
+                        <TextBlock Text="{loc:Str companion_chat_open_full}"/>
+                    </Button>
+                    <!-- History: the read-only transcript viewer over the persisted session.json -->
+                    <Button Theme="{StaticResource CmpChipButtonStyle}"
+                            Command="{Binding HistoryCommand}">
+                        <TextBlock Text="{loc:Str companion_chat_history}"/>
+                    </Button>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right"
+                            VerticalAlignment="Center">
+                    <!-- "she's thinking" — a triggered pulse, never a Forever loop on the page -->
+                    <StackPanel x:Name="ThinkingDots" Orientation="Horizontal" Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                ToolTip.Tip="{loc:Str companion_chat_thinking}"
+                                Classes.thinking="{Binding IsThinking}"
+                                IsVisible="{Binding IsThinking}">
+                        <Ellipse x:Name="Dot1" Width="5" Height="5" Margin="2,0" Fill="{StaticResource CmpPinkBrush}"/>
+                        <Ellipse x:Name="Dot2" Width="5" Height="5" Margin="2,0" Fill="{StaticResource CmpPinkBrush}"/>
+                        <Ellipse x:Name="Dot3" Width="5" Height="5" Margin="2,0" Fill="{StaticResource CmpPinkBrush}"/>
+                    </StackPanel>
+                    <TextBlock Text="{loc:Str companion_chat_thinking}" FontSize="10.5" FontStyle="Italic"
+                               Foreground="{StaticResource CmpMutedBrush}" VerticalAlignment="Center"
+                               IsVisible="{Binding IsThinking}"/>
+                    <TextBlock Text="{Binding FooterCopy}" FontSize="10.5" FontStyle="Italic"
+                               Foreground="{StaticResource CmpFaintBrush}" VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               IsVisible="{Binding !IsThinking}"/>
+                </StackPanel>
+            </Grid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/ChatThresholdView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/ChatThresholdView.axaml.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// Z2 — the chat threshold surface, ported from the WPF head. See the XAML header for the spec.
+    ///
+    /// <para>The behaviour is deliberately thin: Enter-to-send, keeping the thread pinned to its
+    /// newest line, and the dormant state's one-shot shimmer. The "she's thinking" dot pulse is a
+    /// class-gated Style animation in the XAML, so the two Storyboards the WPF code-behind cloned
+    /// (<c>CmpThinkingDotsStoryboard</c>, <c>CmpShimmerSweepStoryboard</c>) have no counterpart
+    /// here; the shimmer is a <see cref="DoubleTransition"/> exactly as <see cref="MakeHerYoursView"/>
+    /// does it.</para>
+    ///
+    /// <para>Not done, and not stubbed: <c>CompanionWheelRelay.Attach(ThreadList)</c> - a WPF helper
+    /// on the routed MouseWheel event that has not been ported, so a wheel notch over the capped
+    /// thread may be eaten by it instead of reaching the page.</para>
+    ///
+    /// <para>Sending is the viewmodel's. The WPF <c>IChatThresholdVm</c> is routed through
+    /// <c>CompanionBrain.SendChatAsync</c>; here <see cref="ChatThresholdViewModel"/> is the mock's
+    /// artboard (append your line, raise IsThinking) with no transport behind it.</para>
+    /// </summary>
+    public partial class ChatThresholdView : UserControl
+    {
+        private INotifyCollectionChanged? _watchedTurns;
+        private bool _shimmerPlayed;
+
+        public ChatThresholdView()
+        {
+            InitializeComponent();
+            DataContext = new ChatThresholdViewModel();
+            DataContextChanged += (_, _) => WatchTurns((DataContext as ChatThresholdViewModel)?.Turns);
+            Loaded += OnLoaded;
+            Unloaded += (_, _) => WatchTurns(null);
+        }
+
+        /// <summary>Convenience for hosts that hand in a viewmodel rather than setting DataContext.</summary>
+        public ChatThresholdViewModel? ViewModel
+        {
+            get => DataContext as ChatThresholdViewModel;
+            set => DataContext = value;
+        }
+
+        private void OnLoaded(object? sender, RoutedEventArgs e)
+        {
+            WatchTurns(ViewModel?.Turns);
+            ScrollThreadToEnd();
+            PlayDormantShimmer();
+        }
+
+        /// <summary>Follows a live thread whose collection mutates in place.</summary>
+        private void WatchTurns(INotifyCollectionChanged? turns)
+        {
+            if (ReferenceEquals(_watchedTurns, turns)) return;
+            if (_watchedTurns != null) _watchedTurns.CollectionChanged -= OnTurnsChanged;
+            _watchedTurns = turns;
+            if (_watchedTurns != null) _watchedTurns.CollectionChanged += OnTurnsChanged;
+        }
+
+        private void OnTurnsChanged(object? sender, NotifyCollectionChangedEventArgs e) => ScrollThreadToEnd();
+
+        /// <summary>
+        /// Keeps the newest bubble visible. The ScrollViewer only exists once the ItemsControl's
+        /// template is applied - hence the deferred, tolerant lookup. Normal priority, never
+        /// Loaded: Loaded-priority work is starved in this app.
+        /// </summary>
+        public void ScrollThreadToEnd()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                try { ThreadList.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault()?.ScrollToEnd(); }
+                catch (InvalidOperationException) { /* layout torn down under us */ }
+            }, DispatcherPriority.Normal);
+        }
+
+        /// <summary>
+        /// The pre-Train-1 promise card's shimmer: one sweep, on load, and only in the dormant
+        /// state. Never a loop - the FX plan spends this tab's only ambient budget on the hero.
+        /// </summary>
+        public void PlayDormantShimmer()
+        {
+            if (_shimmerPlayed || !IsLoaded) return;
+            if (ViewModel is not { State: ChatThresholdViewModel.ZoneState.Dormant }) return;
+            if (DormantShimmer.RenderTransform is not TransformGroup group) return;
+            var shift = group.Children.OfType<TranslateTransform>().FirstOrDefault();
+            if (shift is null) return;
+
+            // One-time Bounds read at Loaded - a value, not a binding, so nothing thrashes.
+            double travel = DormantHost.Bounds.Width > 1 ? DormantHost.Bounds.Width + 90 : 480;
+            shift.Transitions = null;
+            shift.X = -90;
+            shift.Transitions = new Transitions
+            {
+                new DoubleTransition
+                {
+                    Property = TranslateTransform.XProperty,
+                    Duration = TimeSpan.FromSeconds(1.4),
+                    Easing = new CubicEaseInOut()
+                }
+            };
+            DormantShimmer.Opacity = 1;
+            shift.X = travel;
+            _shimmerPlayed = true;
+        }
+
+        /// <summary>Enter sends; Shift+Enter is left alone so a future multi-line box still works.</summary>
+        private void DraftBox_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Enter || e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;
+
+            var vm = ViewModel;
+            if (vm == null || !vm.CanSend) return;
+            if (string.IsNullOrWhiteSpace(vm.Draft)) return;
+            if (vm.SendCommand.CanExecute(null)) vm.SendCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// The view's viewmodel: the WPF <c>IChatThresholdVm</c> contract with <c>MockChatThresholdVm</c>'s
+    /// Live artboard as its default data, so the view renders a real her / you / echo thread with
+    /// an AI badge. <b>Not a port of the interface</b> - that, the mock and the zone-state enum live
+    /// in the WPF head beside the other zones' contracts, and a shared copy here would collide with
+    /// whichever sibling port lands its zone first. The enums are nested for the same reason.
+    /// </summary>
+    public sealed class ChatThresholdViewModel : INotifyPropertyChanged
+    {
+        public enum ZoneState { Live, Dormant, Locked, Empty, Disabled }
+
+        private readonly Relay _send;
+        private string _draft = string.Empty;
+        private bool _isThinking;
+
+        public ChatThresholdViewModel()
+        {
+            // WPF's CommandManager.RequerySuggested re-polled CanExecute for free; Avalonia only
+            // re-polls on CanExecuteChanged, so Draft and IsThinking raise it by hand.
+            SendCommand = _send = new Relay(Send, () => CanSend && !IsThinking && !string.IsNullOrWhiteSpace(Draft));
+            OpenFullChatCommand = new Relay(() => { });     // ponytail: needs the tube chat, wired when it is ported
+            HistoryCommand = new Relay(() => { });          // ponytail: needs the transcript viewer, wired when it is ported
+            UnlockCommand = new Relay(() => { });           // ponytail: needs the Patreon tab, wired when it is ported
+            OpenEngineRoomCommand = new Relay(() => { });   // ponytail: needs the room's RevealEngineRoom, wired when the page is composed
+        }
+
+        public ZoneState State { get; init; } = ZoneState.Live;
+
+        /// <summary>The last ~3 real turns, oldest first. Observable so the view follows a growing thread.</summary>
+        public ObservableCollection<ChatBubble> Turns { get; } = new(LiveThread());
+
+        /// <summary>Static fake bubbles rendered under the veil. Never live content.</summary>
+        public IReadOnlyList<ChatBubble> TeaserTurns { get; init; } = StagedTeaser();
+
+        public string Draft
+        {
+            get => _draft;
+            set { if (_draft != value) { _draft = value; Raise(); _send.RaiseCanExecuteChanged(); } }
+        }
+
+        public bool IsThinking
+        {
+            get => _isThinking;
+            set { if (_isThinking != value) { _isThinking = value; Raise(); _send.RaiseCanExecuteChanged(); } }
+        }
+
+        public bool CanSend { get; init; } = true;
+
+        public string LastHeardCopy { get; init; } = Loc.GetF("companion_chat_last_heard_fmt", "2h ago");
+        public string FooterCopy { get; init; } = Loc.Get("companion_chat_footer_remembers");
+        public string StateCopy { get; init; } = string.Empty;
+        public string LockCopy { get; init; } = Loc.Get("companion_chat_lock_copy");
+        public string LockCtaLabel { get; init; } = Loc.Get("companion_chat_lock_cta");
+        public string InputPlaceholder { get; init; } = Loc.Get("companion_chat_input_placeholder");
+
+        public ICommand SendCommand { get; }
+        public ICommand OpenFullChatCommand { get; }
+        public ICommand HistoryCommand { get; }
+        public ICommand UnlockCommand { get; }
+        public ICommand OpenEngineRoomCommand { get; }
+
+        /// <summary>Appends your line and puts her into "thinking". Nothing is sent anywhere.</summary>
+        // ponytail: needs CompanionBrain.SendChatAsync, wired when it moves to Core
+        public void Send()
+        {
+            if (!SendCommand.CanExecute(null)) return;
+            Turns.Add(new ChatBubble(ChatBubble.BubbleKind.You, Draft.Trim(), timestamp: "just now"));
+            Draft = string.Empty;
+            IsThinking = true;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void Raise([CallerMemberName] string? name = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        // The WPF mock's artboard, verbatim: AI badges on her model turns only, never on the echo.
+        private static IEnumerable<ChatBubble> LiveThread() => new[]
+        {
+            new ChatBubble(ChatBubble.BubbleKind.Echo, "said aloud: “the rabbit hole. every bubble's a little gift…”", timestamp: "3h ago"),
+            new ChatBubble(ChatBubble.BubbleKind.Her, "level 41 already?? remember when the spiral scared you, princess~", isAi: true, timestamp: "2h ago"),
+            new ChatBubble(ChatBubble.BubbleKind.You, "it still does a little", timestamp: "2h ago"),
+            new ChatBubble(ChatBubble.BubbleKind.Her, "good. it should~ 💕", isAi: true, timestamp: "2h ago")
+        };
+
+        private static IReadOnlyList<ChatBubble> StagedTeaser() => new[]
+        {
+            new ChatBubble(ChatBubble.BubbleKind.Her, "mmm I was just thinking about you~"),
+            new ChatBubble(ChatBubble.BubbleKind.You, "you were?"),
+            new ChatBubble(ChatBubble.BubbleKind.Her, "always, princess. now about that streak…")
+        };
+
+        private sealed class Relay : ICommand
+        {
+            private readonly Action _run;
+            private readonly Func<bool>? _can;
+            public Relay(Action run, Func<bool>? can = null) { _run = run; _can = can; }
+            public bool CanExecute(object? p) => _can?.Invoke() ?? true;
+            public void Execute(object? p) => _run();
+            public event EventHandler? CanExecuteChanged;
+            public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>One bubble in the thread - the WPF <c>IChatBubbleVm</c> shape, plus the three
+    /// kind flags the template's classes bind to.</summary>
+    public sealed class ChatBubble
+    {
+        public enum BubbleKind { Her, You, Echo }
+
+        public ChatBubble(BubbleKind kind, string text, bool isAi = false, string? timestamp = null,
+            string? linkTitle = null, ICommand? openLink = null)
+        {
+            Kind = kind; Text = text; IsAiGenerated = isAi; Timestamp = timestamp;
+            LinkTitle = linkTitle; OpenLinkCommand = openLink;
+        }
+
+        public BubbleKind Kind { get; }
+        public string Text { get; }
+        /// <summary>INVARIANT: true only for a genuine model completion. Never a bark, never an echo.</summary>
+        public bool IsAiGenerated { get; }
+        public string? Timestamp { get; }
+        public string? LinkTitle { get; }
+        public ICommand? OpenLinkCommand { get; }
+
+        public bool IsHer => Kind == BubbleKind.Her;
+        public bool IsYou => Kind == BubbleKind.You;
+        public bool IsEcho => Kind == BubbleKind.Echo;
+    }
+}


### PR DESCRIPTION
901 lines, 4 files. All 56 shared keys resolve on the theme below. Carries the CanExecute finding that became porting trap 5.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351