### PR TITLE
feat(avalonia): port Companion II, part 1/2 - AwarenessPrivacyView

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/AwarenessPrivacyView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/AwarenessPrivacyView.axaml
@@ -1,0 +1,520 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/AwarenessPrivacyView.xaml.
+     Structure, order, spacing, comments and every resource key are preserved so the two can be
+     diffed. Documented deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       <Style x:Key TargetType>          ->  <ControlTheme x:Key TargetType> (with Template)
+       Visibility + CmpBoolToVis         ->  IsVisible="{Binding X}"
+       Visibility + CmpBoolToVisInverse  ->  IsVisible="{Binding !X}"
+       Visibility + CmpHasContentToVis   ->  IsVisible="{Binding HasX}" (a bool on the view-model;
+                                             the lists are IReadOnlyList, not observable, so a
+                                             Count binding would not track a swap either)
+       DataTemplate.Triggers (hover ✕)   ->  <UserControl.Styles> Border.cmpChip:pointerover
+                                             Button.cmpChipClose (Avalonia has no template triggers;
+                                             a ControlTheme cannot carry a descendant selector, a
+                                             control-level Style can)
+       DataTrigger (page-title colour)   ->  Classes.allowed="{Binding AllowPageTitles}" + Style
+       DataTrigger (locked tooltip)      ->  ToolTip.Tip="{Binding EverythingLockedTip}", null when
+                                             the stop is selectable
+       <Image .. CmpEmojiToImage>        ->  <TextBlock Text="👁"/>
+       RelativeSource AncestorType       ->  $parent[local:AwarenessPrivacyView]
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       ToolTipService.ShowOnDisabled     ->  ToolTip.ShowOnDisabled
+       {loc:Str key}                     ->  {loc:Str key}  (the Avalonia twin in
+                                             CCP.Avalonia/Localization/StrExtension.cs)
+       CmpCursorBlinkStoryboard          ->  a DispatcherTimer in code-behind (not ported, see the
+                                             theme header)
+       CmpShimmerSweepStoryboard         ->  a DoubleTransition on the TranslateTransform, same as
+                                             MakeHerYoursView
+       x:Name on TranslateTransform      ->  dropped; reached through the TransformGroup
+       d:DataContext MockAwarenessPrivacyVm -> dropped; the view seeds AwarenessPrivacyViewModel
+                                             with the mock's Live() exhibit -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.AwarenessPrivacyView"
+             x:DataType="local:AwarenessPrivacyViewModel"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             mc:Ignorable="d"
+             d:DesignWidth="430" d:DesignHeight="620">
+
+    <!-- ================================================================
+         Z5 — WHAT SHE CAN SEE (awareness & privacy).
+         Design goal: capability visible, never a surprise.
+
+           · 3-stop intensity dial — three RadioButtons sharing one
+             templated pill strip. IsChecked binds two-way to the same
+             enum with a per-stop ConverterParameter, so the strip needs
+             no code-behind at all.
+           · The wire view is the trust element: a monospace chip showing
+             EXACTLY the projected ContextFrame, with the real cloud JSON
+             one click underneath. Off/paused shows it grayed saying
+             "[ her eyes are closed ]" rather than vanishing.
+           · Deny chips ship seeded (password managers, banking, email)
+             and each one can be lifted again — the ✕ is hover-revealed
+             and, until then, not hit-testable, because an invisible
+             control that removes a privacy guard is a trap.
+           · Seen-app chips are the zero-typing path INTO the deny list;
+             known-app chips are the zero-typing path OUT of the ledger.
+             Apps, never titles — a chip listing a page title would put
+             the thing this card keeps local into a screenshot.
+           · Incognito is a hard drop and says so in fixed copy.
+           · Page titles default OFF — the inverted default made visible,
+             and the label goes pink while they are hidden.
+           · The undo row is not settings: retention, pause and the wipe
+             are the answer to "what do you have on me", so they live on
+             the card rather than three screens away.
+
+         Pre-Train 2 (the mock gallery's dormant exhibit) keeps the third
+         stop unselectable and swaps the JSON block for the promise
+         block. Small TRAIN 2 microtag, never the word TODO.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- the hover-revealed ✕ on a deny chip -->
+            <ControlTheme x:Key="CmpZ5ChipCloseStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="FontSize" Value="9"/>
+                <Setter Property="FontWeight" Value="Bold"/>
+                <Setter Property="Foreground" Value="#FFFFB0BE"/>
+                <Setter Property="Margin" Value="7,0,0,0"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <!-- invisible AND inert until the chip is hovered -->
+                <Setter Property="Opacity" Value="0"/>
+                <Setter Property="IsHitTestVisible" Value="False"/>
+                <Setter Property="Template">
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="Transparent" Padding="2,0,2,0">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              VerticalAlignment="Center"
+                                              Foreground="{TemplateBinding Foreground}"
+                                              FontSize="{TemplateBinding FontSize}"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter>
+                <Style Selector="^:pointerover">
+                    <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+                </Style>
+            </ControlTheme>
+
+            <!-- a one-click app chip (seen apps, known apps): the whole chip IS the button.
+                 The WPF file inlines this template in the DataTemplate; a keyed ControlTheme is
+                 the same markup reachable by both app-chip lists. -->
+            <ControlTheme x:Key="CmpZ5AppChipStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="FontSize" Value="10.5"/>
+                <Setter Property="Padding" Value="11,4,11,4"/>
+                <Setter Property="Margin" Value="0,0,5,5"/>
+                <Setter Property="Foreground" Value="{StaticResource CmpMutedBrush}"/>
+                <Setter Property="Template">
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="#0EFFFFFF" local:CompanionCapsule.IsCapsule="True"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              VerticalAlignment="Center"
+                                              Foreground="{TemplateBinding Foreground}"
+                                              FontSize="{TemplateBinding FontSize}"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter>
+                <Style Selector="^:pointerover">
+                    <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+                </Style>
+                <Style Selector="^:pointerover /template/ Border#Bd">
+                    <Setter Property="Background" Value="#1AFFFFFF"/>
+                </Style>
+            </ControlTheme>
+
+            <!-- "+ add app…": chrome-free button laid over a dashed Rectangle -->
+            <ControlTheme x:Key="CmpZ5AddDenyStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="FontSize" Value="10.5"/>
+                <Setter Property="FontWeight" Value="Bold"/>
+                <Setter Property="Padding" Value="11,4,11,4"/>
+                <Setter Property="Foreground" Value="{StaticResource CmpMutedBrush}"/>
+                <Setter Property="Template">
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="#08FFFFFF" local:CompanionCapsule.IsCapsule="True"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter Name="PART_ContentPresenter"
+                                              Content="{TemplateBinding Content}"
+                                              VerticalAlignment="Center"
+                                              Foreground="{TemplateBinding Foreground}"
+                                              FontSize="{TemplateBinding FontSize}"
+                                              FontWeight="Bold"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter>
+                <Style Selector="^:pointerover">
+                    <Setter Property="Foreground" Value="{StaticResource CmpTextBrush}"/>
+                </Style>
+            </ControlTheme>
+
+            <DataTemplate x:Key="CmpDenyChipTemplate" x:DataType="local:AwarenessChip">
+                <Border Classes="cmpChip" Theme="{StaticResource CmpDenyChipStyle}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Label}" Theme="{StaticResource CmpDenyChipTextStyle}"
+                                   VerticalAlignment="Center"/>
+                        <Button Classes="cmpChipClose" Content="✕" Theme="{StaticResource CmpZ5ChipCloseStyle}"
+                                Command="{Binding RemoveCommand}"
+                                ToolTip.Tip="{loc:Str companion_awareness_deny_remove_tip}"/>
+                    </StackPanel>
+                </Border>
+            </DataTemplate>
+
+            <!-- the allow-list chip: same shape, its own remove tooltip, because "stop hiding this"
+                 and "stop sending this app's titles" are opposite promises -->
+            <DataTemplate x:Key="CmpAllowChipTemplate" x:DataType="local:AwarenessChip">
+                <Border Classes="cmpChip" Theme="{StaticResource CmpDenyChipStyle}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Label}" Theme="{StaticResource CmpDenyChipTextStyle}"
+                                   VerticalAlignment="Center"/>
+                        <Button Classes="cmpChipClose" Content="✕" Theme="{StaticResource CmpZ5ChipCloseStyle}"
+                                Command="{Binding RemoveCommand}"
+                                ToolTip.Tip="{loc:Str companion_awareness_allow_remove_tip}"/>
+                    </StackPanel>
+                </Border>
+            </DataTemplate>
+
+            <DataTemplate x:Key="CmpAppChipTemplate" x:DataType="local:AwarenessChip">
+                <Button Command="{Binding ActionCommand}" ToolTip.Tip="{Binding ActionTip}"
+                        Theme="{StaticResource CmpZ5AppChipStyle}">
+                    <TextBlock Text="{Binding Label}"/>
+                </Button>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.Styles>
+        <!-- WPF: DataTemplate.Triggers on ChipBd IsMouseOver -> RemoveBtn visible + hit-testable -->
+        <Style Selector="Border.cmpChip:pointerover Button.cmpChipClose">
+            <Setter Property="Opacity" Value="1"/>
+            <Setter Property="IsHitTestVisible" Value="True"/>
+        </Style>
+        <!-- WPF: DataTrigger AllowPageTitles=True -> dim; hidden is the protective state, so it
+             reads as the guard colour -->
+        <Style Selector="TextBlock.cmpPageTitles">
+            <Setter Property="Foreground" Value="#FFFFB0BE"/>
+        </Style>
+        <Style Selector="TextBlock.cmpPageTitles.allowed">
+            <Setter Property="Foreground" Value="{StaticResource CmpDimBrush}"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Theme="{StaticResource CmpVioletCardStyle}">
+        <StackPanel>
+
+            <!-- ========== header ========== -->
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="👁" FontSize="16" Margin="0,0,9,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="{loc:Str companion_awareness_title}" Theme="{StaticResource CmpSectionTitleStyle}"/>
+                </StackPanel>
+                <!-- live once Train 2 landed; the bridge exhibit still wears the train tag -->
+                <Border Grid.Column="2" Theme="{StaticResource CmpTrainTagLiveStyle}"
+                        IsVisible="{Binding !IsDormant}">
+                    <TextBlock Text="{loc:Str companion_tag_live}" Theme="{StaticResource CmpTrainTagLiveTextStyle}"/>
+                </Border>
+                <Border Grid.Column="2" Theme="{StaticResource CmpTrainTagStyle}"
+                        IsVisible="{Binding IsDormant}">
+                    <TextBlock Text="{loc:Str companion_tag_train2}" Theme="{StaticResource CmpTrainTagTextStyle}"/>
+                </Border>
+            </Grid>
+
+            <!-- ========== the legacy-pipeline warning ==========
+                 Everything below this band describes the v2 privacy layer. The legacy poll starts on
+                 two flags where the observer needs four, so declining the v2 consent dialog (or
+                 dropping the kill switch) leaves her watching with NONE of it: no incognito drop, no
+                 deny list, no title allow list. The card used to render those promises as fact in
+                 exactly that state. -->
+            <Border Margin="0,13,0,0" Padding="12,10,12,11" CornerRadius="9"
+                    Background="#332A1A1A" BorderBrush="#FF6B6B" BorderThickness="1"
+                    IsVisible="{Binding IsLegacyPipeline}">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                        <TextBlock Text="⚠️" FontSize="11" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding LegacyHead}" Foreground="#FF6B6B" FontSize="11.5"
+                                   FontWeight="Bold" VerticalAlignment="Center" Margin="5,0,0,0"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <TextBlock Text="{Binding LegacyBody}" Theme="{StaticResource CmpFaintTextStyle}"
+                               TextWrapping="Wrap" Margin="0,0,0,7"/>
+                    <Button Content="{Binding LegacyAction}" Command="{Binding ReviewConsentCommand}"
+                            Theme="{StaticResource CmpLinkButtonStyle}" HorizontalAlignment="Left"
+                            Padding="0,2,0,2"/>
+                </StackPanel>
+            </Border>
+
+            <!-- ========== intensity dial ==========
+                 The strip moves ONE thing: whether any app's page title may leave this PC. It used to
+                 sit here unlabelled, under a card headed "What she can see", with stops reading
+                 "Broad strokes" and "Everything" - so a play-tester read the third stop as "she sees
+                 everything", pressed it, and was handed an app-picking dialog that made no sense
+                 against that reading. The caption names the axis, the stop labels name their own
+                 content, and DialHint carries the consequence of whichever one is selected. -->
+            <TextBlock Text="{loc:Str companion_awareness_dial_head}" Theme="{StaticResource CmpFaintTextStyle}"
+                       Margin="2,13,0,5"/>
+            <Border Theme="{StaticResource CmpSegmentStripStyle}" Margin="0,0,0,6">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <RadioButton Grid.Column="0" GroupName="CmpAwarenessDial" Content="{loc:Str companion_awareness_dial_off}"
+                                 Theme="{StaticResource CmpSegmentStyle}"
+                                 IsChecked="{Binding Intensity, Mode=TwoWay,
+                                             Converter={StaticResource CmpEnumEquals}, ConverterParameter=Off}"/>
+                    <RadioButton Grid.Column="1" GroupName="CmpAwarenessDial" Content="{loc:Str companion_awareness_dial_broad}"
+                                 Theme="{StaticResource CmpSegmentStyle}"
+                                 IsChecked="{Binding Intensity, Mode=TwoWay,
+                                             Converter={StaticResource CmpEnumEquals}, ConverterParameter=BroadStrokes}"/>
+                    <!-- pre-Train 2 the third stop is present but not selectable, and says why.
+                         A disabled control swallows ToolTip unless told otherwise. -->
+                    <RadioButton Grid.Column="2" GroupName="CmpAwarenessDial" Content="{loc:Str companion_awareness_dial_everything}"
+                                 Theme="{StaticResource CmpSegmentStyle}"
+                                 IsEnabled="{Binding IsEverythingAvailable}"
+                                 ToolTip.Tip="{Binding EverythingLockedTip}"
+                                 ToolTip.ShowOnDisabled="True"
+                                 IsChecked="{Binding Intensity, Mode=TwoWay,
+                                             Converter={StaticResource CmpEnumEquals}, ConverterParameter=Everything}"/>
+                </Grid>
+            </Border>
+
+            <!-- what the SELECTED stop does. Tracks the dial, so it is never generic copy. -->
+            <TextBlock Text="{Binding DialHint}" Theme="{StaticResource CmpFaintTextStyle}"
+                       TextWrapping="Wrap" Margin="2,0,0,12"/>
+
+            <!-- ========== the wire view ========== -->
+            <Border Theme="{StaticResource CmpWireStyle}"
+                    Opacity="{Binding IsWireLive, Converter={StaticResource CmpBoolToOpacity},
+                                      ConverterParameter=1.0|0.55}">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{loc:Str companion_awareness_wire_prefix}" Theme="{StaticResource CmpWireTextStyle}"/>
+                    <TextBlock Text="{Binding WireLine}" Theme="{StaticResource CmpWireTextStyle}"/>
+                    <!-- blinking cursor: only alive while the frame is live. The blink itself is a
+                         timer in code-behind toggling Opacity, so IsVisible stays the VM's. -->
+                    <Rectangle x:Name="WireCursor" Width="7" Height="14" Margin="9,0,0,0"
+                               Fill="#FF8FE3B0" VerticalAlignment="Center"
+                               IsVisible="{Binding IsWireLive}"/>
+                </StackPanel>
+            </Border>
+
+            <!-- the caption belongs to a live frame; when dormant the promise block speaks instead -->
+            <TextBlock Text="{Binding WireCaption}" Theme="{StaticResource CmpWireCaptionStyle}"
+                       IsVisible="{Binding !IsDormant}"/>
+
+            <!-- ========== the exact bytes ========== -->
+            <StackPanel Margin="0,4,0,10"
+                        IsVisible="{Binding !IsDormant}">
+                <Button Content="{Binding JsonToggleLabel}" Command="{Binding ToggleJsonCommand}"
+                        Theme="{StaticResource CmpLinkButtonStyle}" HorizontalAlignment="Left"
+                        Padding="0,2,0,2"/>
+                <Border Margin="0,6,0,0" Padding="10,8,10,8" CornerRadius="7" Background="#14000000"
+                        IsVisible="{Binding IsJsonExpanded}">
+                    <StackPanel>
+                        <ScrollViewer MaxHeight="180" HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      IsVisible="{Binding HasWireJson}">
+                            <TextBlock Text="{Binding WireJson}" FontFamily="Consolas, Courier New, monospace" FontSize="10.5"
+                                       Foreground="{StaticResource CmpDimBrush}"/>
+                        </ScrollViewer>
+                        <TextBlock Text="{Binding WireJsonEmptyCopy}" Theme="{StaticResource CmpFaintTextStyle}"
+                                   IsVisible="{Binding !HasWireJson}"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+
+            <!-- ========== dormant promise (pre-Train 2 exhibit) ========== -->
+            <Grid Margin="0,6,0,12"
+                  IsVisible="{Binding IsDormant}">
+                <Border x:Name="DormantHost" Theme="{StaticResource CmpDormantBlockStyle}">
+                    <Grid>
+                        <TextBlock Text="{Binding DormantCopy}" Theme="{StaticResource CmpDormantCopyStyle}"/>
+                        <Border x:Name="DormantShimmer" Width="46" HorizontalAlignment="Left"
+                                Background="{StaticResource CmpShimmerSoftBrush}"
+                                IsHitTestVisible="False" Opacity="0">
+                            <Border.RenderTransform>
+                                <TransformGroup>
+                                    <SkewTransform AngleX="-18"/>
+                                    <TranslateTransform X="-70"/>
+                                </TransformGroup>
+                            </Border.RenderTransform>
+                        </Border>
+                    </Grid>
+                </Border>
+                <Rectangle Theme="{StaticResource CmpDashedOutlineStyle}"/>
+            </Grid>
+
+            <!-- ========== deny list ==========
+                 The heading is load-bearing: without it these chips sit under a card titled
+                 "What she can see" and read as the ONLY things she can see — the exact
+                 opposite of what they are. -->
+            <TextBlock Text="{loc:Str companion_awareness_deny_head}"
+                       Theme="{StaticResource CmpFaintTextStyle}" Margin="2,0,0,4"/>
+            <ItemsControl ItemsSource="{Binding DenyList}" ItemTemplate="{StaticResource CmpDenyChipTemplate}"
+                          Margin="0,0,0,4">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
+
+            <!-- "+ add app…" — dashed, per the mockup's .d.add. A Border cannot dash, so the
+                 outline is a Rectangle laid under a chrome-free button. -->
+            <Grid HorizontalAlignment="Left" Margin="0,0,0,4">
+                <!-- WPF clamps RadiusX/Y=999 to a stadium; Avalonia draws the 999px arcs, which
+                     scribbled dashed diagonals across the whole card in the headless render.
+                     12 = half the button's rendered height. -->
+                <Rectangle Theme="{StaticResource CmpDashedOutlineStyle}" Stroke="#2EFFFFFF"
+                           RadiusX="12" RadiusY="12"/>
+                <Button Content="{Binding AddDenyLabel}" Command="{Binding AddDenyCommand}"
+                        Theme="{StaticResource CmpZ5AddDenyStyle}"/>
+            </Grid>
+
+            <!-- seen apps: one click hides one of them, no typing -->
+            <StackPanel Margin="0,6,0,0"
+                        IsVisible="{Binding HasSeenApps}">
+                <TextBlock Text="{Binding SeenAppsLabel}" Theme="{StaticResource CmpFaintTextStyle}" Margin="2,0,0,4"/>
+                <ItemsControl ItemsSource="{Binding SeenApps}" ItemTemplate="{StaticResource CmpAppChipTemplate}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- Bound, not a fixed loc string: the incognito hard-drop is a v2 rule, so on the legacy
+                 pipeline "that one is not a setting" would be describing a guard that is not there. -->
+            <TextBlock Text="{Binding IncognitoCopy}" Theme="{StaticResource CmpFaintTextStyle}"
+                       TextWrapping="Wrap" Margin="2,4,0,11"/>
+
+            <!-- ========== page titles ========== -->
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                    <!-- Not a global switch: on asks WHICH app, off empties the list. The label
+                         reports the count, so a card showing "allowed" always says for how many. -->
+                    <ToggleButton Theme="{StaticResource CmpToggleSwitchStyle}" Margin="0,0,9,0"
+                                  ToolTip.Tip="{Binding PageTitlesLabel}"
+                                  ToolTip.ShowOnDisabled="True"
+                                  IsEnabled="{Binding IsEverythingAvailable}"
+                                  IsChecked="{Binding AllowPageTitles, Mode=TwoWay}"/>
+                    <TextBlock Text="{Binding PageTitlesLabel}" FontSize="11.5" VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               Classes="cmpPageTitles" Classes.allowed="{Binding AllowPageTitles}"/>
+                </StackPanel>
+                <Button Grid.Column="1" Content="{loc:Str companion_awareness_allow_per_app}" Theme="{StaticResource CmpLinkButtonStyle}"
+                        Margin="10,0,0,0" Command="{Binding AllowPerAppCommand}"/>
+                <Button Grid.Column="2" Content="{loc:Str companion_awareness_fine_tuning}" Theme="{StaticResource CmpLinkButtonStyle}"
+                        HorizontalAlignment="Right" Padding="0,2,0,2"
+                        Command="{Binding FineTuningCommand}"/>
+            </Grid>
+
+            <StackPanel Margin="0,7,0,0"
+                        IsVisible="{Binding HasTitleAllowList}">
+                <TextBlock Text="{Binding TitleAllowLabel}" Theme="{StaticResource CmpFaintTextStyle}" Margin="2,0,0,4"/>
+                <ItemsControl ItemsSource="{Binding TitleAllowList}" ItemTemplate="{StaticResource CmpAllowChipTemplate}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- ========== the undo ========== -->
+            <Border Margin="0,13,0,0" Padding="12,10,12,12" CornerRadius="9" Background="#12FFFFFF"
+                    IsVisible="{Binding !IsDormant}">
+                <StackPanel>
+                    <TextBlock Text="{loc:Str companion_awareness_undo_head}"
+                               Theme="{StaticResource CmpFaintTextStyle}" Margin="0,0,0,7"/>
+
+                    <!-- apps she is counting, each one a forget button -->
+                    <StackPanel IsVisible="{Binding HasKnownApps}"
+                                Margin="0,0,0,6">
+                        <TextBlock Text="{Binding KnownAppsLabel}" Theme="{StaticResource CmpFaintTextStyle}"
+                                   Margin="0,0,0,4"/>
+                        <ItemsControl ItemsSource="{Binding KnownApps}" ItemTemplate="{StaticResource CmpAppChipTemplate}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><WrapPanel Orientation="Horizontal"/></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <!-- retention: two stops, because a slider implies a precision nobody wants here -->
+                    <TextBlock Text="{Binding RetentionLabel}" Theme="{StaticResource CmpFaintTextStyle}"
+                               Margin="0,0,0,4"/>
+                    <Border Theme="{StaticResource CmpSegmentStripStyle}" HorizontalAlignment="Left"
+                            Margin="0,0,0,9">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <RadioButton Grid.Column="0" GroupName="CmpAwarenessRetention"
+                                         Content="{loc:Str companion_awareness_retention_7}"
+                                         Theme="{StaticResource CmpSegmentStyle}" MinWidth="86"
+                                         IsChecked="{Binding RetentionDays, Mode=TwoWay,
+                                                     Converter={StaticResource CmpIntEquals}, ConverterParameter=7}"/>
+                            <RadioButton Grid.Column="1" GroupName="CmpAwarenessRetention"
+                                         Content="{loc:Str companion_awareness_retention_30}"
+                                         Theme="{StaticResource CmpSegmentStyle}" MinWidth="86"
+                                         IsChecked="{Binding RetentionDays, Mode=TwoWay,
+                                                     Converter={StaticResource CmpIntEquals}, ConverterParameter=30}"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- pause + wipe. The wipe never fires from its own button: WipeConfirm is the
+                         same inline two-step the memory diary uses, so the tab is never blocked and
+                         the destructive command has exactly one path to it. -->
+                    <Grid IsVisible="{Binding !$parent[local:AwarenessPrivacyView].WipeConfirm.IsArmed}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0" Content="{Binding PauseLabel}" Command="{Binding PauseCommand}"
+                                Theme="{StaticResource CmpLinkButtonStyle}" Padding="0,2,0,2"/>
+                        <Button Grid.Column="1" Content="{Binding WipeLabel}"
+                                Command="{Binding $parent[local:AwarenessPrivacyView].WipeConfirm.ArmCommand}"
+                                Theme="{StaticResource CmpLinkButtonStyle}" Padding="0,2,0,2"
+                                HorizontalAlignment="Right" Foreground="{StaticResource CmpDangerBrush}"/>
+                    </Grid>
+
+                    <StackPanel IsVisible="{Binding $parent[local:AwarenessPrivacyView].WipeConfirm.IsArmed}">
+                        <TextBlock Text="{loc:Str companion_awareness_wipe_confirm}"
+                                   Theme="{StaticResource CmpFaintTextStyle}" TextWrapping="Wrap"
+                                   Margin="0,0,0,5"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Button Content="{loc:Str companion_awareness_wipe_yes}"
+                                    Command="{Binding $parent[local:AwarenessPrivacyView].WipeConfirm.ConfirmCommand}"
+                                    Theme="{StaticResource CmpLinkButtonStyle}" Padding="0,2,0,2"
+                                    Foreground="{StaticResource CmpDangerBrush}" Margin="0,0,14,0"/>
+                            <Button Content="{loc:Str companion_awareness_wipe_no}"
+                                    Command="{Binding $parent[local:AwarenessPrivacyView].WipeConfirm.CancelCommand}"
+                                    Theme="{StaticResource CmpLinkButtonStyle}" Padding="0,2,0,2"/>
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/AwarenessPrivacyView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AwarenessPrivacyView.axaml.cs
@@ -1,0 +1,488 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// Z5 — What she can see. See the XAML header for the visual spec.
+    ///
+    /// <para>Ported from the WPF code-behind. The dial itself is entirely declarative; this file
+    /// only runs the two decorative clocks - the wire cursor blink (alive only while the frame is
+    /// live) and the dormant block's one-shot shimmer - and both stop on unload so a hidden tab
+    /// is not still animating.</para>
+    ///
+    /// <para>Not ported: the 1.5 s refresh timer. It existed to call
+    /// <c>AwarenessPrivacyRuntimeVm.Sync()</c>, and that runtime viewmodel reads the awareness
+    /// service, which is still in the WPF head. The mock exhibits are static, so a timer here
+    /// would tick at nothing.</para>
+    /// </summary>
+    public partial class AwarenessPrivacyView : UserControl
+    {
+        /// <summary>The WPF storyboard's 1.2 s cycle: 0.6 s on, 0.6 s off.</summary>
+        private static readonly TimeSpan BlinkHalfPeriod = TimeSpan.FromMilliseconds(600);
+
+        private DispatcherTimer? _blink;
+        private bool _introPlayed;
+        private AwarenessPrivacyViewModel? _observed;
+
+        public AwarenessPrivacyView()
+        {
+            // Before Load: the $parent[...].WipeConfirm bindings read it once at parse time and
+            // WipeConfirm never raises a change, so a later assignment leaves them bound to null.
+            WipeConfirm = new MemoryForgetConfirm();
+            AvaloniaXamlLoader.Load(this);
+            DataContext = AwarenessPrivacyViewModel.Live(this);
+            Loaded += OnLoaded;
+            DataContextChanged += (_, _) =>
+            {
+                Observe(ViewModel);
+                WipeConfirm.Bind(ViewModel?.WipeCommand);
+            };
+            Unloaded += (_, _) =>
+            {
+                StopCursorBlink();
+                WipeConfirm.Disarm();
+                Observe(null);
+            };
+        }
+
+        /// <summary>
+        /// The wipe's two-step, in the same inline shape the memory diary uses: the destructive command
+        /// runs only from <c>ConfirmCommand</c>, only while armed, and re-binding always disarms. This
+        /// erases everything she has noticed, so it may never be one click.
+        /// </summary>
+        public MemoryForgetConfirm WipeConfirm { get; }
+
+        /// <summary>Convenience for hosts that hand in a viewmodel rather than setting DataContext.</summary>
+        public AwarenessPrivacyViewModel? ViewModel
+        {
+            get => DataContext as AwarenessPrivacyViewModel;
+            set => DataContext = value;
+        }
+
+        private void OnLoaded(object? sender, RoutedEventArgs e)
+        {
+            Observe(ViewModel);
+            WipeConfirm.Bind(ViewModel?.WipeCommand);
+            // Normal, never Loaded — DispatcherPriority.Loaded is starved in this app.
+            Dispatcher.UIThread.Post(() =>
+            {
+                SyncCursorBlink();
+                if (!_introPlayed) { _introPlayed = true; PlayIntro(); }
+            }, DispatcherPriority.Normal);
+        }
+
+        /// <summary>
+        /// Follows <see cref="AwarenessPrivacyViewModel.IsWireLive"/>. The dial is a live control:
+        /// turning her eyes on after the card has loaded has to start the cursor, and turning them
+        /// off has to stop it, or the blink is decided once at load and then lies.
+        /// </summary>
+        private void Observe(AwarenessPrivacyViewModel? vm)
+        {
+            if (ReferenceEquals(_observed, vm)) return;
+            if (_observed != null) _observed.PropertyChanged -= OnVmPropertyChanged;
+            _observed = vm;
+            if (_observed != null) _observed.PropertyChanged += OnVmPropertyChanged;
+        }
+
+        private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(AwarenessPrivacyViewModel.IsWireLive)) return;
+            Dispatcher.UIThread.Post(SyncCursorBlink, DispatcherPriority.Normal);
+        }
+
+        /// <summary>
+        /// Starts or stops the blink to match the viewmodel. Public because the room calls it when
+        /// the tab becomes visible again — this app hides tabs rather than unloading them.
+        /// </summary>
+        public void SyncCursorBlink()
+        {
+            if (ViewModel?.IsWireLive ?? false) StartCursorBlink();
+            else StopCursorBlink();
+        }
+
+        /// <summary>Starts the wire cursor blink. Idempotent; a no-op when the frame is not live.</summary>
+        public void StartCursorBlink()
+        {
+            if (!IsLoaded || _blink != null) return;
+            var cursor = this.FindControl<Rectangle>("WireCursor");
+            if (cursor is null) return;
+
+            // WPF flipped Visibility Visible/Hidden; Hidden keeps layout, which Opacity does here
+            // while IsVisible stays bound to the viewmodel.
+            _blink = new DispatcherTimer(BlinkHalfPeriod, DispatcherPriority.Normal,
+                (_, _) => cursor.Opacity = cursor.Opacity > 0.5 ? 0 : 1);
+            _blink.Start();
+        }
+
+        /// <summary>Stops the cursor blink and leaves the cursor visible.</summary>
+        public void StopCursorBlink()
+        {
+            _blink?.Stop();
+            _blink = null;
+            var cursor = this.FindControl<Rectangle>("WireCursor");
+            if (cursor is not null) cursor.Opacity = 1;
+        }
+
+        /// <summary>Sweeps the dormant block's shimmer once. No-op when Train 2 is live.</summary>
+        public void PlayIntro()
+        {
+            if (!IsLoaded) return;
+            if (!(ViewModel?.IsDormant ?? false)) return;
+            var host = this.FindControl<Border>("DormantHost");
+            var shimmer = this.FindControl<Border>("DormantShimmer");
+            if (host is null || shimmer is null) return;
+
+            // x:Name is illegal on a Transform in Avalonia, so the shift is reached through the group.
+            if (shimmer.RenderTransform is not TransformGroup group) return;
+            var shift = group.Children.OfType<TranslateTransform>().FirstOrDefault();
+            if (shift is null) return;
+
+            // Same sweep as MakeHerYoursView: park with no transition, then attach and set the end
+            // value so it runs once. One-time Bounds read at Loaded — a value, not a binding.
+            shift.Transitions = null;
+            shift.X = -90;
+            shift.Transitions = new Transitions
+            {
+                new DoubleTransition
+                {
+                    Property = TranslateTransform.XProperty,
+                    Duration = TimeSpan.FromSeconds(1.4),
+                    Delay = TimeSpan.FromSeconds(0.25),
+                    Easing = new CubicEaseInOut()
+                }
+            };
+            shimmer.Opacity = 1;
+            shift.X = host.Bounds.Width > 1 ? host.Bounds.Width + 90 : 420;
+        }
+
+        /// <summary>
+        /// The one command on this card that needs a window: the per-app title allow list opens the
+        /// already-ported picker. The list it hands back is applied to the viewmodel's exhibit
+        /// only; nothing here writes settings.
+        /// </summary>
+        internal async void OpenAllowPicker()
+        {
+            var vm = ViewModel;
+            if (vm is null || TopLevel.GetTopLevel(this) is not Window owner) return;
+            var listed = vm.TitleAllowList.Select(c => c.Label).ToList();
+            var candidates = vm.SeenApps.Select(c => c.Label).ToList();
+            var dialog = new AwarenessAppPickerDialog(AwarenessListKind.TitleAllow, listed, candidates);
+            await dialog.ShowDialog(owner);
+            if (dialog.Result is { } picked) vm.SetTitleAllowList(picked);
+        }
+    }
+
+    /// <summary>Mirror of the head's dial enum, <c>CompanionVmPrimitives.cs:AwarenessIntensity</c>.
+    /// NOT <c>Services/Awareness/AwarenessIntensity.cs</c>, which is a different enum
+    /// (Off/Subtle/Chatty/Unhinged) with the same name.</summary>
+    // ponytail: local twin; delete when CompanionVmPrimitives.cs moves to Core.
+    public enum AwarenessIntensity
+    {
+        Off,
+        BroadStrokes,
+        Everything
+    }
+
+    /// <summary>
+    /// One chip class for all three chip lists. The WPF file has <c>IDenyChipVm</c> (Label,
+    /// RemoveCommand) and <c>IAwarenessAppChipVm</c> (Label, ActionTip, ActionCommand); the
+    /// DataTemplates only ever read one side, so one type with both faces is the smaller port.
+    /// </summary>
+    public sealed class AwarenessChip
+    {
+        public AwarenessChip(string label, ICommand command, string actionTip = "")
+        {
+            Label = label;
+            RemoveCommand = command;
+            ActionCommand = command;
+            ActionTip = actionTip;
+        }
+
+        public string Label { get; }
+        public string ActionTip { get; }
+        public ICommand RemoveCommand { get; }
+        public ICommand ActionCommand { get; }
+    }
+
+    /// <summary>
+    /// Ported verbatim from the WPF head's <c>MemoryForgetConfirm</c>: a two-step arm/confirm gate
+    /// in front of a destructive command.
+    /// </summary>
+    public sealed class MemoryForgetConfirm : INotifyPropertyChanged
+    {
+        private ICommand? _target;
+        private bool _isArmed;
+        private readonly RelayCommand _arm;
+        private readonly RelayCommand _confirm;
+
+        public MemoryForgetConfirm()
+        {
+            _arm = new RelayCommand(Arm, () => CanArm);
+            _confirm = new RelayCommand(Confirm, () => IsArmed);
+            CancelCommand = new RelayCommand(Disarm);
+        }
+
+        public bool IsArmed
+        {
+            get => _isArmed;
+            private set
+            {
+                if (_isArmed == value) return;
+                _isArmed = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsArmed)));
+                _confirm.RaiseCanExecuteChanged();
+            }
+        }
+
+        public bool CanArm => _target != null && _target.CanExecute(null);
+        public int ConfirmedCount { get; private set; }
+
+        public ICommand ArmCommand => _arm;
+        public ICommand ConfirmCommand => _confirm;
+        public ICommand CancelCommand { get; }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void Bind(ICommand? forgetEverything)
+        {
+            _target = forgetEverything;
+            IsArmed = false;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanArm)));
+            _arm.RaiseCanExecuteChanged();
+        }
+
+        public void Disarm() => IsArmed = false;
+
+        private void Arm()
+        {
+            if (!CanArm) return;
+            IsArmed = true;
+        }
+
+        private void Confirm()
+        {
+            if (!IsArmed) return;
+            var target = _target;
+
+            // Disarm before executing: the strip disappears on the first click, so a second one
+            // lands on the restored footer instead of running the wipe again.
+            IsArmed = false;
+            if (target == null || !target.CanExecute(null)) return;
+
+            ConfirmedCount++;
+            target.Execute(null);
+        }
+    }
+
+    /// <summary>
+    /// The view's data contract, as a concrete type for compiled bindings. The WPF view binds to
+    /// <c>IAwarenessPrivacyVm</c>, whose mock and runtime implementations both live in the head
+    /// (the runtime one reads the awareness service). This is that interface's shape seeded with
+    /// the mock's exhibits; <see cref="Live"/> is what the view shows by default.
+    /// </summary>
+    public sealed class AwarenessPrivacyViewModel : INotifyPropertyChanged
+    {
+        private AwarenessIntensity _intensity = AwarenessIntensity.BroadStrokes;
+        private bool _allowPageTitles;
+        private bool _isJsonExpanded;
+        private int _retentionDays = 30;
+        private IReadOnlyList<AwarenessChip> _titleAllowList = Array.Empty<AwarenessChip>();
+
+        public AwarenessPrivacyViewModel(AwarenessPrivacyView? view = null)
+        {
+            // ponytail: chips are static exhibits; the remove/hide/forget commands are no-ops until
+            // the awareness ledger moves to Core.
+            var noop = new RelayCommand(() => { });
+            DenyList = new[]
+            {
+                new AwarenessChip(Loc.Get("companion_awareness_deny_passwords"), noop),
+                new AwarenessChip(Loc.Get("companion_awareness_deny_banking"), noop),
+                new AwarenessChip(Loc.Get("companion_awareness_deny_email"), noop)
+            };
+            SeenApps = new[]
+            {
+                new AwarenessChip("Chrome", noop, Loc.Get("companion_awareness_seen_tip")),
+                new AwarenessChip("Discord", noop, Loc.Get("companion_awareness_seen_tip")),
+                new AwarenessChip("Steam", noop, Loc.Get("companion_awareness_seen_tip"))
+            };
+            KnownApps = new[]
+            {
+                new AwarenessChip("YouTube", noop, Loc.Get("companion_awareness_forget_tip")),
+                new AwarenessChip("Discord", noop, Loc.Get("companion_awareness_forget_tip"))
+            };
+
+            AddDenyCommand = noop;            // ponytail: needs the deny-list editor, wired when awareness moves to Core
+            AllowPerAppCommand = new RelayCommand(() => view?.OpenAllowPicker());
+            ToggleJsonCommand = new RelayCommand(() => IsJsonExpanded = !IsJsonExpanded);
+            PauseCommand = noop;              // ponytail: needs the awareness service
+            WipeCommand = noop;               // ponytail: needs the awareness ledger
+            FineTuningCommand = noop;         // ponytail: needs ICompanionRoomNavigator (workshop deep link)
+            ReviewConsentCommand = noop;      // ponytail: needs the v2 consent dialog
+        }
+
+        public AwarenessIntensity Intensity
+        {
+            get => _intensity;
+            set { if (Set(ref _intensity, value)) Raise(nameof(DialHint)); }
+        }
+
+        public string DialHint => _intensity switch
+        {
+            AwarenessIntensity.Off => Loc.Get("companion_awareness_dial_hint_off"),
+            AwarenessIntensity.BroadStrokes => Loc.Get("companion_awareness_dial_hint_broad"),
+            _ => Loc.Get("companion_awareness_dial_hint_everything")
+        };
+
+        public bool IsLegacyPipeline { get; init; }
+
+        public string IncognitoCopy => Loc.Get(IsLegacyPipeline
+            ? "companion_awareness_incognito_legacy"
+            : "companion_awareness_incognito");
+
+        public string LegacyHead => Loc.Get("companion_awareness_legacy_head");
+        public string LegacyBody => Loc.Get("companion_awareness_legacy_body");
+        public string LegacyAction => Loc.Get("companion_awareness_legacy_action");
+        public ICommand ReviewConsentCommand { get; }
+
+        public bool IsEverythingAvailable { get; init; }
+
+        /// <summary>WPF: a DataTrigger sets the tooltip only while the stop is locked.</summary>
+        public string? EverythingLockedTip => IsEverythingAvailable
+            ? null
+            : Loc.Get("companion_awareness_everything_locked_tip");
+
+        public string WireLine { get; init; } = "[ fun · Chrome · 22m ]";
+        public bool IsWireLive { get; init; } = true;
+        public string WireCaption { get; init; } = Loc.Get("companion_awareness_wire_caption");
+        public string DormantCopy { get; init; } = Loc.Get("companion_awareness_dormant_copy");
+        public bool IsDormant { get; init; }
+
+        public string WireJson { get; init; } =
+            "{\n  \"v\": 1,\n  \"cluster\": \"site_video\",\n  \"app\": \"YouTube\",\n" +
+            "  \"visits_today\": 4,\n  \"minutes_today\": 45,\n  \"dwell\": \"15-30m\"\n}";
+        public bool HasWireJson => !string.IsNullOrWhiteSpace(WireJson);
+        public string WireJsonEmptyCopy { get; init; } = Loc.Get("companion_awareness_wire_json_empty");
+
+        public bool IsJsonExpanded
+        {
+            get => _isJsonExpanded;
+            set { if (Set(ref _isJsonExpanded, value)) Raise(nameof(JsonToggleLabel)); }
+        }
+
+        public string JsonToggleLabel => Loc.Get(IsJsonExpanded
+            ? "companion_awareness_wire_json_hide"
+            : "companion_awareness_wire_json_show");
+
+        public IReadOnlyList<AwarenessChip> DenyList { get; }
+        public string AddDenyLabel { get; init; } = Loc.Get("companion_awareness_add_deny");
+
+        public IReadOnlyList<AwarenessChip> TitleAllowList
+        {
+            get => _titleAllowList;
+            private set { if (Set(ref _titleAllowList, value)) Raise(nameof(HasTitleAllowList)); }
+        }
+        public bool HasTitleAllowList => TitleAllowList.Count > 0;
+        public string TitleAllowLabel { get; init; } = Loc.Get("companion_awareness_allow_label");
+
+        public IReadOnlyList<AwarenessChip> SeenApps { get; }
+        public bool HasSeenApps => SeenApps.Count > 0;
+        public string SeenAppsLabel { get; init; } = Loc.Get("companion_awareness_seen_label");
+
+        public IReadOnlyList<AwarenessChip> KnownApps { get; }
+        public bool HasKnownApps => KnownApps.Count > 0;
+        public string KnownAppsLabel { get; init; } = Loc.Get("companion_awareness_known_label");
+
+        public bool AllowPageTitles
+        {
+            get => _allowPageTitles;
+            set => Set(ref _allowPageTitles, value);
+        }
+
+        public string PageTitlesLabel { get; init; } = Loc.Get("companion_awareness_page_titles_hidden");
+
+        public int RetentionDays
+        {
+            get => _retentionDays;
+            set { if (Set(ref _retentionDays, value)) Raise(nameof(RetentionLabel)); }
+        }
+
+        public string RetentionLabel => Loc.GetF("companion_awareness_retention_fmt", RetentionDays);
+
+        public bool IsPaused { get; init; }
+        public string PauseLabel => Loc.Get(IsPaused
+            ? "companion_awareness_pause_resume"
+            : "companion_awareness_pause");
+
+        public string WipeLabel { get; init; } = Loc.Get("companion_awareness_wipe");
+
+        public ICommand AddDenyCommand { get; }
+        public ICommand AllowPerAppCommand { get; }
+        public ICommand FineTuningCommand { get; }
+        public ICommand ToggleJsonCommand { get; }
+        public ICommand PauseCommand { get; }
+        public ICommand WipeCommand { get; }
+
+        /// <summary>What the picker handed back becomes the allow chips, each removable (no-op).</summary>
+        public void SetTitleAllowList(IEnumerable<string> apps)
+        {
+            var noop = new RelayCommand(() => { });
+            TitleAllowList = apps.Select(a => new AwarenessChip(a, noop)).ToList();
+        }
+
+        // ------------------------------- state exhibits -------------------------------
+
+        public static AwarenessPrivacyViewModel Live(AwarenessPrivacyView? view = null) => new(view)
+        {
+            IsEverythingAvailable = true
+        };
+
+        public static AwarenessPrivacyViewModel Dormant(AwarenessPrivacyView? view = null) => new(view)
+        {
+            IsEverythingAvailable = false,
+            IsDormant = true,
+            IsWireLive = false,
+            WireLine = "[ her eyes are closed ]",
+            WireJson = string.Empty
+        };
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void Raise([CallerMemberName] string? name = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        private bool Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+            field = value;
+            Raise(name);
+            return true;
+        }
+    }
+
+    /// <summary>The smallest ICommand: runs a delegate, with an optional CanExecute predicate.</summary>
+    internal sealed class RelayCommand : ICommand
+    {
+        private readonly Action _run;
+        private readonly Func<bool>? _can;
+        public RelayCommand(Action run, Func<bool>? can = null) { _run = run; _can = can; }
+        public bool CanExecute(object? parameter) => _can?.Invoke() ?? true;
+        public void Execute(object? parameter) { if (CanExecute(parameter)) _run(); }
+        public event EventHandler? CanExecuteChanged;
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}


### PR DESCRIPTION
1,008 lines, 2 files (a view pair never splits). Declares the namespace's RelayCommand and MemoryForgetConfirm that later layers reuse.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351