### PR TITLE
feat(avalonia): port Companion II, part 2/2 - KeywordTriggersPanel

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml
@@ -1,0 +1,229 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/KeywordTriggersPanel.xaml.
+     Structure, order, spacing, comments and every loc key are preserved so the two can be diffed.
+     Documented deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"   ->  Theme="{StaticResource X}"
+       Visibility="Collapsed"       ->  IsVisible="False"
+       Panel.ZIndex                 ->  ZIndex
+       ToolTip="..."                ->  ToolTip.Tip="..."
+       ValueChanged= / Click= etc.  ->  handlers attached in code-behind (porting convention)
+       PreviewMouseWheel            ->  dropped; Avalonia's ScrollViewer already hands an
+                                        exhausted wheel to its ancestor
+       Button Content="{loc:Str}"   ->  a TextBlock child (Trap 1: '_' is an access key)
+       Slider Style (none in WPF)   ->  Theme="{StaticResource PinkSlider}"; the WPF head styles
+                                        Slider implicitly, this head has no implicit Slider theme
+       IsExpanded="False"           ->  "True"  (ponytail: the WPF drawer ships shut and the
+                                        Awareness tab opens it on demand; expanded here so
+                                        the render-all proof shows the interior. The host that
+                                        mounts it sets IsExpanded=false.) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.KeywordTriggersPanel"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             mc:Ignorable="d"
+             d:DesignHeight="520" d:DesignWidth="900">
+    <!--
+      PHASE 5 (G3) — the custom keyword-trigger + Screen OCR editors rescued from the
+      permanently-Collapsed PatreonTabView (Views/Tabs/PatreonTabView.xaml:83-251).
+      That corpse is NOT deleted here (Phase 8 owns demolition); this panel is the live
+      surface and MainWindow's handlers now read these controls.
+
+      Deliberately NOT re-hosted, because the Awareness page above already owns them and
+      PLAN.md's Phase-2 exit rule is one editor per property:
+        * master start/stop      -> ChkAwarenessMaster
+        * premium lock label     -> AwarenessGate (whole-tab overlay, same T1 gate)
+        * Screen OCR on/off      -> ChkAwarenessOcr           (SIGNAL SOURCES)
+        * global cooldown        -> SliderAwarenessGlobalCooldown (TIMING)
+        * highlight on/off       -> ChkAwarenessHighlight     (SAFETY)
+        * highlight in capture   -> ChkAwarenessHighlightVisibleInCapture
+        * app scoping            -> CmbAwarenessAppScope + list + seen-app chips
+      The two detail blocks below therefore *follow* those masters instead of duplicating
+      them, and say so when the master is off.
+
+      FX: this panel is deliberately quiet. No storyboards, no Forever loops - the
+      Companion door's one-Forever budget belongs to the portrait breathe
+      (CompanionTheme.xaml:22), and the Awareness status dot keeps its existing
+      SetStatusPulse mechanism untouched.
+    -->
+    <Expander x:Name="KeywordTriggersExpander"
+              Theme="{StaticResource CollapsibleCard}" IsExpanded="True">
+        <Expander.Header>
+            <TextBlock Text="{loc:Str cp5_awareness_custom_triggers_header}"
+                       Foreground="White" FontSize="14" FontWeight="Bold"/>
+        </Expander.Header>
+
+        <!-- CollapsibleCard's ContentPresenter already insets 15,0,15,15 - do not double it. -->
+        <StackPanel Margin="0,2,0,0">
+
+            <!-- ==================== INTRO ==================== -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                <TextBlock Text="{loc:Str label_keyword_triggers_2}" Foreground="{DynamicResource PinkBrush}"
+                           FontSize="13" FontWeight="Bold" VerticalAlignment="Center"/>
+                <Button x:Name="HelpBtnKeywordTriggers"
+                        Theme="{StaticResource HelpButtonStyle}" VerticalAlignment="Center"
+                        Margin="8,0,0,0" Tag="KeywordTriggers" ZIndex="1"/>
+            </StackPanel>
+            <TextBlock Text="{loc:Str cp5_awareness_custom_triggers_note}"
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                       TextWrapping="Wrap" Margin="0,0,0,2"/>
+            <TextBlock Text="{loc:Str label_your_everyday_typing_becomes_part_of_your_con}"
+                       Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                       TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+            <!-- ==================== DETECTION TIMING ==================== -->
+            <Border CornerRadius="8" Padding="12,10" Margin="0,0,0,10"
+                    Background="{DynamicResource DarkerBgBrush}" BorderBrush="#2E2E48" BorderThickness="1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="14"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Buffer timeout -->
+                    <StackPanel Grid.Column="0"
+                                ToolTip.Tip="{loc:Str tooltip_how_long_to_wait_after_a_keystroke_before_che}">
+                        <TextBlock Text="{loc:Str label_buffer_timeout}" Foreground="#A0A0A0" FontSize="10"/>
+                        <Grid>
+                            <Slider x:Name="SliderKeywordBufferTimeout" Theme="{StaticResource PinkSlider}"
+                                    Minimum="1000" Maximum="10000" Value="3000"
+                                    TickFrequency="500" IsSnapToTickEnabled="True"/>
+                            <TextBlock x:Name="TxtKeywordBufferTimeout"
+                                       Text="{loc:Str label_3_0s}" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top"
+                                       IsHitTestVisible="False"/>
+                        </Grid>
+                    </StackPanel>
+
+                    <!-- Session XP boost -->
+                    <StackPanel Grid.Column="2"
+                                ToolTip.Tip="{loc:Str tooltip_xp_multiplier_bonus_when_triggers_fire_during}">
+                        <TextBlock Text="{loc:Str label_session_xp_boost}" Foreground="#A0A0A0" FontSize="10"/>
+                        <Grid>
+                            <Slider x:Name="SliderKeywordSessionMultiplier" Theme="{StaticResource PinkSlider}"
+                                    Minimum="1.0" Maximum="3.0" Value="1.5"
+                                    TickFrequency="0.1" IsSnapToTickEnabled="True"/>
+                            <TextBlock x:Name="TxtKeywordSessionMultiplier"
+                                       Text="1.5x" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top"
+                                       IsHitTestVisible="False"/>
+                        </Grid>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- ==================== SCREEN OCR DETAIL ==================== -->
+            <Border CornerRadius="8" Padding="12,10" Margin="0,0,0,10"
+                    Background="{DynamicResource DarkerBgBrush}" BorderBrush="#353550" BorderThickness="1">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,2">
+                        <TextBlock Text="{loc:Str label_screen_text_detection_ocr}" Foreground="#C0C0C0"
+                                   FontSize="12" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <Button x:Name="HelpBtnScreenOcr"
+                                Theme="{StaticResource HelpButtonStyle}" VerticalAlignment="Center"
+                                Margin="6,0,0,0" Tag="ScreenOcr" ZIndex="1"/>
+                    </StackPanel>
+                    <TextBlock Text="{loc:Str label_scans_your_screen_for_trigger_keywords_using}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="10"
+                               TextWrapping="Wrap" Margin="0,0,0,4"/>
+
+                    <!-- Shown instead of the detail rows while the SIGNAL SOURCES master is off.
+                         The master itself deliberately lives above, not here. -->
+                    <TextBlock x:Name="TxtScreenOcrOffHint"
+                               Text="{loc:Str cp5_ocr_detail_needs_source}"
+                               Foreground="{DynamicResource TextDimBrush}" FontSize="10" FontStyle="Italic"
+                               TextWrapping="Wrap" IsVisible="False"/>
+
+                    <StackPanel x:Name="ScreenOcrIntervalPanel" IsVisible="False">
+                        <TextBlock Text="{loc:Str label_scan_interval}" Foreground="#A0A0A0" FontSize="10"/>
+                        <Grid ToolTip.Tip="{loc:Str tooltip_how_often_to_scan_your_screen_for_trigger_key}">
+                            <Slider x:Name="SliderScreenOcrInterval" Theme="{StaticResource PinkSlider}"
+                                    Minimum="2" Maximum="10" Value="3"
+                                    TickFrequency="1" IsSnapToTickEnabled="True"/>
+                            <TextBlock x:Name="TxtScreenOcrInterval"
+                                       Text="{loc:Str label_3s}" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top"
+                                       IsHitTestVisible="False"/>
+                        </Grid>
+                        <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                            <TextBlock Text="{loc:Str cp5_ocr_confirm_label}" Foreground="#A0A0A0" FontSize="10"
+                                       VerticalAlignment="Center"/>
+                            <ComboBox x:Name="CmbOcrConfirmation" Margin="6,0,0,0" MinWidth="150"
+                                      Theme="{StaticResource DarkComboBoxStyle}" FontSize="10"
+                                      SelectedIndex="0"
+                                      ToolTip.Tip="{loc:Str cp5_ocr_confirm_tip}">
+                                <ComboBoxItem Content="{loc:Str cp5_ocr_confirm_first}"/>
+                                <ComboBoxItem Content="{loc:Str cp5_ocr_confirm_double}"/>
+                                <ComboBoxItem Content="{loc:Str cp5_ocr_confirm_triple}"/>
+                            </ComboBox>
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ==================== HIGHLIGHT DETAIL ==================== -->
+            <Border CornerRadius="8" Padding="12,10" Margin="0,0,0,10"
+                    Background="{DynamicResource DarkerBgBrush}" BorderBrush="#353550" BorderThickness="1">
+                <StackPanel>
+                    <TextBlock Text="{loc:Str setting_highlight_matched_keywords_on_screen}"
+                               Foreground="#C0C0C0" FontSize="12" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+                    <TextBlock x:Name="TxtHighlightOffHint"
+                               Text="{loc:Str cp5_highlight_detail_needs_source}"
+                               Foreground="{DynamicResource TextDimBrush}" FontSize="10" FontStyle="Italic"
+                               TextWrapping="Wrap" IsVisible="False"/>
+
+                    <StackPanel x:Name="HighlightDurationPanel" IsVisible="False">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <TextBlock Text="{loc:Str label_highlight_mode}" Foreground="#A0A0A0" FontSize="10"
+                                       VerticalAlignment="Center"/>
+                            <ComboBox x:Name="CmbOcrHighlightMode" Margin="6,0,0,0" MinWidth="110"
+                                      Theme="{StaticResource DarkComboBoxStyle}" FontSize="10"
+                                      SelectedIndex="0"
+                                      ToolTip.Tip="{loc:Str tooltip_all_matches_highlights_every_keyword_immediat}">
+                                <ComboBoxItem Content="{loc:Str btn_all_matches}"/>
+                                <ComboBoxItem Content="{loc:Str btn_random_subset}"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <TextBlock Text="{loc:Str label_highlight_duration}" Foreground="#A0A0A0" FontSize="10"/>
+                        <Grid ToolTip.Tip="{loc:Str tooltip_how_long_the_pink_highlight_stays_on_screen_0}">
+                            <Slider x:Name="SliderKeywordHighlightDuration" Theme="{StaticResource PinkSlider}"
+                                    Minimum="0.3" Maximum="5.0" Value="0.6"
+                                    TickFrequency="0.1" IsSnapToTickEnabled="True"/>
+                            <TextBlock x:Name="TxtKeywordHighlightDuration"
+                                       Text="{loc:Str label_0_6s}" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top"
+                                       IsHitTestVisible="False"/>
+                        </Grid>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- ==================== TRIGGER LIST ====================
+                 Rows are built imperatively by MainWindow.CreateKeywordTriggerRow; preset
+                 clones (Id prefix "preset:") are filtered out and stay owned by the preset
+                 detail dialogs on the PRESETS row above. -->
+            <TextBlock Text="{loc:Str label_keyword_triggers}" Foreground="#8A8AA0" FontSize="10"
+                       FontWeight="Bold" Margin="0,2,0,6"/>
+            <ScrollViewer MaxHeight="300" VerticalScrollBarVisibility="Auto">
+                <StackPanel x:Name="KeywordTriggerListPanel"/>
+            </ScrollViewer>
+
+            <!-- ==================== ACTIONS ==================== -->
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <Button x:Name="BtnAddKeywordTrigger" Background="{DynamicResource PinkBrush}"
+                        Foreground="White" FontWeight="Bold" FontSize="11" Padding="12,6"
+                        BorderThickness="0" Cursor="Hand">
+                    <TextBlock Text="{loc:Str btn_add_trigger}"/>
+                </Button>
+                <Button x:Name="BtnImportFromCustomTriggers" Background="#353550"
+                        Foreground="#A0A0A0" FontSize="11" Padding="12,6" Margin="8,0,0,0"
+                        BorderThickness="0" Cursor="Hand">
+                    <TextBlock Text="{loc:Str btn_import_from_trigger_mode}"/>
+                </Button>
+            </StackPanel>
+        </StackPanel>
+    </Expander>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs
@@ -1,0 +1,99 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// PHASE 5 (G3): the custom keyword-trigger + Screen OCR editors, rescued from the
+    /// permanently-Collapsed <c>PatreonTabView</c> and mounted on the Awareness tab.
+    ///
+    /// <para>Ported from the WPF code-behind. The WPF version is pure re-hosting: every handler
+    /// forwards to a <c>MainWindow</c> method that reads <c>App.Settings</c>,
+    /// <c>KeywordTriggerService</c>, <c>App.ScreenOcr</c> and <c>App.KeywordHighlight</c>. None of
+    /// those are in Core, so here the sliders keep their own value labels (the same format strings
+    /// MainWindow uses) and everything else is a stub.</para>
+    /// </summary>
+    public partial class KeywordTriggersPanel : UserControl
+    {
+        private readonly Expander _expander;
+        private readonly TextBlock _txtScreenOcrOffHint;
+        private readonly StackPanel _screenOcrIntervalPanel;
+        private readonly TextBlock _txtHighlightOffHint;
+        private readonly StackPanel _highlightDurationPanel;
+
+        public KeywordTriggersPanel()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _expander = this.FindControl<Expander>("KeywordTriggersExpander")!;
+            _txtScreenOcrOffHint = this.FindControl<TextBlock>("TxtScreenOcrOffHint")!;
+            _screenOcrIntervalPanel = this.FindControl<StackPanel>("ScreenOcrIntervalPanel")!;
+            _txtHighlightOffHint = this.FindControl<TextBlock>("TxtHighlightOffHint")!;
+            _highlightDurationPanel = this.FindControl<StackPanel>("HighlightDurationPanel")!;
+
+            // Value labels: formats copied from MainWindow.KeywordTriggers.cs, which owns them on WPF.
+            Track("SliderKeywordBufferTimeout", "TxtKeywordBufferTimeout", v => $"{v / 1000.0:F1}s");
+            Track("SliderKeywordSessionMultiplier", "TxtKeywordSessionMultiplier", v => $"{v:F1}x");
+            Track("SliderScreenOcrInterval", "TxtScreenOcrInterval", v => $"{v}s");
+            Track("SliderKeywordHighlightDuration", "TxtKeywordHighlightDuration", v => $"{v:0.0}s");
+
+            // ponytail: needs MainWindow.BtnAddKeywordTrigger_Click / BtnImportFromCustomTriggers_Click
+            // (KeywordTriggerService + the trigger row builder), wired when they move to Core.
+            this.FindControl<Button>("BtnAddKeywordTrigger")!.Click += (_, _) => { };
+            this.FindControl<Button>("BtnImportFromCustomTriggers")!.Click += (_, _) => { };
+            // ponytail: needs App.ScreenOcr / App.KeywordHighlight for the two ComboBoxes.
+            this.FindControl<ComboBox>("CmbOcrConfirmation")!.SelectionChanged += (_, _) => { };
+            this.FindControl<ComboBox>("CmbOcrHighlightMode")!.SelectionChanged += (_, _) => { };
+
+            // ponytail: on WPF the SIGNAL SOURCES / SAFETY masters on the Awareness tab drive these
+            // from settings at load. Placeholder: both masters on, so the detail rows render.
+            SetScreenOcrDetail(true);
+            SetHighlightDetail(true);
+        }
+
+        /// <summary>Follows the Screen OCR master: detail rows when on, the "needs source" hint when off.</summary>
+        internal void SetScreenOcrDetail(bool masterOn)
+        {
+            _screenOcrIntervalPanel.IsVisible = masterOn;
+            _txtScreenOcrOffHint.IsVisible = !masterOn;
+        }
+
+        /// <summary>Follows the highlight master: detail rows when on, the "needs source" hint when off.</summary>
+        internal void SetHighlightDetail(bool masterOn)
+        {
+            _highlightDurationPanel.IsVisible = masterOn;
+            _txtHighlightOffHint.IsVisible = !masterOn;
+        }
+
+        /// <summary>
+        /// Opens the drawer and scrolls it into view. Used by the Awareness tab's "advanced editor"
+        /// hyperlink. The WPF version also drives the ancestor ScrollViewer by hand and pulses a
+        /// DropShadowEffect; Avalonia's <see cref="Control.BringIntoView"/> resolves against the
+        /// post-layout geometry, and the pulse is dropped (decorative; no bitmap-effect animation
+        /// budget on this head yet).
+        /// </summary>
+        internal void RevealTriggerEditor()
+        {
+            try
+            {
+                _expander.IsExpanded = true;
+                UpdateLayout();
+                this.BringIntoView();
+            }
+            catch (InvalidOperationException)
+            {
+                // Layout torn down mid-navigation - the drawer is still expanded, which is the
+                // part that matters.
+            }
+        }
+
+        private void Track(string slider, string label, Func<double, string> format)
+        {
+            var s = this.FindControl<Slider>(slider)!;
+            var t = this.FindControl<TextBlock>(label)!;
+            s.ValueChanged += (_, e) => t.Text = format(e.NewValue);
+        }
+    }
+}


### PR DESCRIPTION
328 lines, 2 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351