### PR TITLE
feat(avalonia): port Companion IV, part 1/2 - CompanionVmPrimitives, MemoryDiaryView

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/CompanionVmPrimitives.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionVmPrimitives.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    // PORTED (the used slice) from ConditioningControlPanel/Views/Controls/Companion/CompanionVmPrimitives.cs.
+    // The WPF version leans on CommandManager.RequerySuggested; Avalonia has none, so
+    // RaiseCanExecuteChanged is explicit. Plain net8.0 - folding into CCP.Core deletes this copy.
+
+    /// <summary>Minimal ICommand. Port of CompanionRelayCommand's used surface.</summary>
+    public sealed class CompanionRelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool>? _canExecute;
+
+        public CompanionRelayCommand(Action execute, Func<bool>? canExecute = null)
+        {
+            _execute = execute;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+        public void Execute(object? parameter) => _execute();
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>No CommandManager on Avalonia: whoever changes the answer says so.</summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public abstract class CompanionObservable : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected bool Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+            field = value;
+            Raise(name);
+            return true;
+        }
+
+        protected void Raise([CallerMemberName] string? name = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml
@@ -1,0 +1,327 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/MemoryDiaryView.xaml.
+     Structure, order, spacing and every resource key are preserved so the two can be diffed.
+     Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"       ->  Theme="{StaticResource X}"
+       {loc:Str key}                    ->  {loc:Str key} (the Avalonia twin in CCP.Avalonia/Localization)
+       DataTemplate.Triggers            ->  Classes.boundary/.dormant/.editing bound on the card's
+                                            root Grid + selectors in <UserControl.Styles>. A Style
+                                            setter outranks a ControlTheme setter, so the WPF
+                                            "swap the Style" triggers become the swapped style's
+                                            setters written directly on the same Border.
+       Trigger IsMouseOver              ->  :pointerover
+       Visibility + CmpBoolToVis        ->  IsVisible="{Binding X}" / "{Binding !X}"
+       <Image .. CmpEmojiToImage>       ->  <TextBlock Text="📌"/> (colour emoji render natively)
+       RelativeSource AncestorType      ->  #Root (x:Name on the UserControl)
+       ToolTip="..."                    ->  ToolTip.Tip="..."
+       IsVisibleChanged                 ->  PropertyChanged (filtered on IsVisibleProperty in code)
+       d:DataContext MockMemoryDiaryVm  ->  dropped; MemoryDiaryViewModel (code-behind) carries the
+                                            same artboard data
+       CompanionWheelRelay              ->  dropped; Avalonia's ScrollViewer chains an unusable
+                                            wheel notch to its parent by itself (IsScrollChainingEnabled) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.MemoryDiaryView"
+             x:Name="Root"
+             x:DataType="local:MemoryDiaryViewModel"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             mc:Ignorable="d"
+             d:DesignWidth="660" d:DesignHeight="560">
+
+    <!-- ================================================================
+         Z3 — WHAT SHE KNOWS ABOUT YOU (her diary).
+         The trust surface, and deliberately NOT paywalled: everything
+         here is local and deterministic, so a free user sees all of it.
+
+         Layout: gold profile strip ▸ kind filter chips ▸ the fact wall
+         ▸ footer (storage note + "Forget everything…").
+
+         Ordering and filtering are done by the viewmodel
+         (boundary ▸ pinned ▸ salience ▸ dormant). The view never sorts.
+
+         Kind is legible before a word is read: every card carries a thin
+         kind-coloured rail and a kind-coloured tag. Boundary cards keep
+         the theme's steel border instead so the consent record reads
+         differently from a running joke at a glance.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!-- kind → accent. Local to this control (the assembler promotes shared candidates). -->
+            <local:CompanionFactKindBrushConverter x:Key="CmpSurfFactKindBrush"/>
+            <local:CompanionFactKindBrushConverter x:Key="CmpSurfFactKindRailBrush" Soft="True"/>
+
+            <!-- gold read-only stat chip -->
+            <DataTemplate x:Key="CmpSurfProfileStatTemplate" x:DataType="x:String">
+                <Border Theme="{StaticResource CmpStatChipStyle}">
+                    <TextBlock Text="{Binding}" Theme="{StaticResource CmpStatChipTextStyle}"/>
+                </Border>
+            </DataTemplate>
+
+            <!-- kind filter chip -->
+            <DataTemplate x:Key="CmpSurfFactFilterTemplate" x:DataType="local:FactFilter">
+                <ToggleButton Theme="{StaticResource CmpToggleChipStyle}"
+                              IsChecked="{Binding IsSelected, Mode=TwoWay}">
+                    <TextBlock Text="{Binding Label}"/>
+                </ToggleButton>
+            </DataTemplate>
+
+            <!-- one fact card: kind rail + tag, text (or inline edit box), meta, hover action row -->
+            <DataTemplate x:Key="CmpSurfFactCardTemplate" x:DataType="local:MemoryFact">
+                <Grid Classes="fact"
+                      Classes.boundary="{Binding IsBoundary}"
+                      Classes.dormant="{Binding IsDormant}"
+                      Classes.editing="{Binding IsEditing}">
+                    <Border Name="Card" Theme="{StaticResource CmpFactCardStyle}">
+                        <Grid RowDefinitions="Auto,Auto,Auto">
+
+                            <Grid Grid.Row="0">
+                                <TextBlock Name="KindTag" Text="{Binding KindLabel}"
+                                           Theme="{StaticResource CmpFactKindTagStyle}"
+                                           Foreground="{Binding KindKey, Converter={StaticResource CmpSurfFactKindBrush}}"
+                                           TextTrimming="CharacterEllipsis" Margin="0,0,20,0"/>
+                                <!-- the gold pin, on pinned cards only -->
+                                <TextBlock Name="Pin" Text="📌" FontSize="11" HorizontalAlignment="Right"
+                                           VerticalAlignment="Top" IsVisible="{Binding IsPinned}"
+                                           ToolTip.Tip="{loc:Str companion_memory_pin_tip}"/>
+                            </Grid>
+
+                            <TextBlock Name="FactText" Grid.Row="1" Text="{Binding Text}"
+                                       Theme="{StaticResource CmpFactTextStyle}"/>
+
+                            <!-- inline edit: the text becomes a box in place, Enter saves, Esc backs out -->
+                            <Grid Name="FactEditRow" Grid.Row="1" IsVisible="{Binding IsEditing}" Margin="0,4,0,0"
+                                  ColumnDefinitions="*,Auto,Auto">
+                                <!-- IsVisible on the box itself too: Avalonia's IsVisible does not propagate,
+                                     so the focus handler below would otherwise never see a change. -->
+                                <TextBox Name="FactEdit" Grid.Column="0" IsVisible="{Binding IsEditing}"
+                                         Theme="{StaticResource CmpFieldBoxStyle}"
+                                         Text="{Binding EditText, Mode=TwoWay}"
+                                         PropertyChanged="FactEdit_PropertyChanged"
+                                         KeyDown="FactEdit_KeyDown"/>
+                                <Button Grid.Column="1" Margin="6,0,0,0" FontSize="10.5"
+                                        Foreground="{StaticResource CmpDimBrush}"
+                                        Theme="{StaticResource CmpFactActionStyle}"
+                                        Command="{Binding CommitEditCommand}">
+                                    <TextBlock Text="{loc:Str companion_memory_edit_save}"/>
+                                </Button>
+                                <Button Grid.Column="2" FontSize="10.5"
+                                        Foreground="{StaticResource CmpFaintBrush}"
+                                        Theme="{StaticResource CmpFactActionStyle}"
+                                        Click="FactEditCancel_Click">
+                                    <TextBlock Text="{loc:Str companion_memory_edit_cancel}"/>
+                                </Button>
+                            </Grid>
+
+                            <Grid Grid.Row="2">
+                                <TextBlock Text="{Binding MetaLabel}" Theme="{StaticResource CmpFactMetaStyle}"
+                                           Margin="0,6,96,0"/>
+                                <!-- hover-reveal action row: pure selector, no code-behind. Opacity=0 lives
+                                     in UserControl.Styles, not here: a local value would outrank the
+                                     :pointerover setter and the row could never appear. -->
+                                <StackPanel Name="Actions" Orientation="Horizontal"
+                                            HorizontalAlignment="Right" VerticalAlignment="Bottom">
+                                    <Button Name="PinAction" Theme="{StaticResource CmpFactActionStyle}"
+                                            Command="{Binding PinCommand}"
+                                            ToolTip.Tip="{loc:Str companion_memory_pin_tip}">
+                                        <TextBlock Text="📌" FontSize="11"/>
+                                    </Button>
+                                    <Button Theme="{StaticResource CmpFactActionStyle}" Command="{Binding EditCommand}"
+                                            ToolTip.Tip="{loc:Str companion_memory_edit_tip}">
+                                        <TextBlock Text="✏" FontSize="11" Foreground="{StaticResource CmpDimBrush}"/>
+                                    </Button>
+                                    <Button Theme="{StaticResource CmpFactActionStyle}" Command="{Binding ForgetCommand}"
+                                            ToolTip.Tip="{loc:Str companion_memory_forget_tip}">
+                                        <TextBlock Text="🗑" FontSize="11"/>
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
+                        </Grid>
+                    </Border>
+
+                    <!-- the kind rail. A separate Rectangle rather than the card's own BorderBrush,
+                         because a bound BorderBrush would be a local value and the hover style
+                         could no longer light the card. -->
+                    <Rectangle Name="KindRail" Width="3" HorizontalAlignment="Left"
+                               Margin="0,0,0,9" RadiusX="1.5" RadiusY="1.5" IsHitTestVisible="False"
+                               Fill="{Binding KindKey, Converter={StaticResource CmpSurfFactKindRailBrush}}"/>
+
+                    <!-- dashed outline for the dormant promise card -->
+                    <Rectangle Name="DormantOutline" Theme="{StaticResource CmpDashedOutlineStyle}"
+                               Margin="0,0,0,9" IsVisible="{Binding IsDormant}"/>
+                </Grid>
+            </DataTemplate>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <!-- The WPF DataTemplate.Triggers, as selectors. Each block is one trigger, in the same order. -->
+    <UserControl.Styles>
+        <!-- IsBoundary: CmpFactBoundaryCardStyle's setters; the steel rail IS the border, the kind
+             rail stands down; a boundary is never "pinned" like a joke. -->
+        <Style Selector="Grid.fact.boundary Border#Card">
+            <Setter Property="Background" Value="#A61D2735"/>
+            <Setter Property="BorderBrush" Value="{StaticResource CmpSteelBrush}"/>
+            <Setter Property="BorderThickness" Value="3,1,1,1"/>
+        </Style>
+        <Style Selector="Grid.fact.boundary Rectangle#KindRail">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <Style Selector="Grid.fact.boundary Button#PinAction">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <!-- IsDormant: CmpDormantBlockStyle on the card, CmpDormantCopyStyle on the text -->
+        <Style Selector="Grid.fact.dormant Border#Card">
+            <Setter Property="Background" Value="#0AB478FF"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="14"/>
+        </Style>
+        <Style Selector="Grid.fact.dormant TextBlock#FactText">
+            <Setter Property="FontSize" Value="11.5"/>
+            <Setter Property="FontStyle" Value="Italic"/>
+            <Setter Property="Foreground" Value="#FFC9B8EC"/>
+            <Setter Property="LineHeight" Value="18"/>
+        </Style>
+        <Style Selector="Grid.fact.dormant Rectangle#KindRail">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <Style Selector="Grid.fact.dormant StackPanel#Actions">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <!-- IsEditing: the box replaces the text; the hover row would fight the save/cancel pair -->
+        <Style Selector="Grid.fact.editing TextBlock#FactText">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <Style Selector="Grid.fact.editing StackPanel#Actions">
+            <Setter Property="IsVisible" Value="False"/>
+        </Style>
+        <!-- Hover reveals the action row on every card. The BORDER is split: a boundary card
+             brightens its steel instead of going pink, so the rail survives the moment you aim. -->
+        <Style Selector="Grid.fact StackPanel#Actions">
+            <Setter Property="Opacity" Value="0"/>
+        </Style>
+        <Style Selector="Grid.fact Border#Card:pointerover">
+            <Setter Property="BorderBrush" Value="#66FF69B4"/>
+        </Style>
+        <Style Selector="Grid.fact.boundary Border#Card:pointerover">
+            <Setter Property="BorderBrush" Value="#FF9FCFEE"/>
+        </Style>
+        <Style Selector="Grid.fact Border#Card:pointerover StackPanel#Actions">
+            <Setter Property="Opacity" Value="1"/>
+        </Style>
+    </UserControl.Styles>
+
+    <Border Theme="{StaticResource CmpCardStyle}">
+        <Grid RowDefinitions="Auto,Auto,Auto,*,Auto">
+
+            <!-- ========== header ========== -->
+            <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto">
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="📖" FontSize="16" Margin="0,0,9,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="{loc:Str companion_memory_title}" Theme="{StaticResource CmpSectionTitleStyle}"/>
+                </StackPanel>
+                <TextBlock Grid.Column="1" Text="{loc:Str companion_memory_hint}"
+                           Theme="{StaticResource CmpSectionHintStyle}"/>
+                <Border Grid.Column="2" Theme="{StaticResource CmpTrainTagLiveStyle}">
+                    <TextBlock Text="{loc:Str companion_tag_train1}" Theme="{StaticResource CmpTrainTagLiveTextStyle}"/>
+                </Border>
+            </Grid>
+
+            <!-- ========== profile strip (deterministic, free, always populated) ==========
+                 DockPanel, not a StackPanel: the label docks left and the chip WrapPanel gets a
+                 constrained width, so a long German strip wraps to a second line. -->
+            <Border Grid.Row="1" Margin="0,13,0,12" CornerRadius="{StaticResource CmpRadiusInner}"
+                    Background="#B312101F" BorderBrush="#26FFD700" BorderThickness="1"
+                    Padding="12,10,12,10">
+                <DockPanel LastChildFill="True">
+                    <TextBlock DockPanel.Dock="Left" Text="{Binding ProfileStripLabel}"
+                               FontSize="11" FontWeight="Bold" VerticalAlignment="Center"
+                               Foreground="{StaticResource CmpMutedBrush}" Margin="0,0,8,0"/>
+                    <ItemsControl ItemsSource="{Binding ProfileStats}"
+                                  ItemTemplate="{StaticResource CmpSurfProfileStatTemplate}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </DockPanel>
+            </Border>
+
+            <!-- ========== kind filter chips ========== -->
+            <ItemsControl Grid.Row="2" ItemsSource="{Binding Filters}"
+                          ItemTemplate="{StaticResource CmpSurfFactFilterTemplate}" Margin="0,0,0,10">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
+
+            <!-- ========== the fact wall ========== -->
+            <Grid Grid.Row="3" MinHeight="90">
+                <ItemsControl Name="FactWall" ItemsSource="{Binding Facts}"
+                              ItemTemplate="{StaticResource CmpSurfFactCardTemplate}"
+                              Theme="{StaticResource CmpVirtualizedItemsControlStyle}"
+                              MaxHeight="420"/>
+
+                <!-- fresh user: the wall is not blank, it is a ghost card -->
+                <Grid VerticalAlignment="Top" IsVisible="{Binding IsEmpty}">
+                    <Border Theme="{StaticResource CmpEmptyBlockStyle}">
+                        <TextBlock Text="{Binding EmptyCopy}" Theme="{StaticResource CmpEmptyCopyStyle}"/>
+                    </Border>
+                    <Rectangle Theme="{StaticResource CmpEmptyOutlineStyle}"/>
+                </Grid>
+            </Grid>
+
+            <!-- ========== footer ==========
+                 Two faces in one row: the usual storage note, and — once armed — the wipe's
+                 confirm strip, asked in her voice. Inline rather than a modal, so the card never
+                 blocks the tab (the Vault rule). ForgetConfirm is the little state machine that
+                 owns which one shows; see MemoryForgetConfirm. -->
+            <Grid Grid.Row="4" Margin="0,13,0,0">
+
+                <Grid IsVisible="{Binding !#Root.ForgetConfirm.IsArmed}"
+                      ColumnDefinitions="Auto,Auto,*">
+                    <TextBlock Grid.Column="0" Text="{Binding StorageNote}" FontSize="11"
+                               Foreground="{StaticResource CmpFaintBrush}" VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"/>
+                    <!-- string Content on purpose: CmpLinkButtonStyle's template is a TextBlock bound
+                         to Content, which does no access-key parsing and cannot host a child. -->
+                    <Button Grid.Column="1" Content="{Binding StorageLinkLabel}"
+                            Theme="{StaticResource CmpLinkButtonStyle}" Margin="6,0,0,0"
+                            Command="{Binding OpenStorageFolderCommand}"/>
+                    <Button Grid.Column="2" Theme="{StaticResource CmpDangerButtonStyle}" HorizontalAlignment="Right"
+                            Command="{Binding #Root.ForgetConfirm.ArmCommand}">
+                        <TextBlock Text="{Binding ForgetEverythingLabel}"/>
+                    </Button>
+                </Grid>
+
+                <Border Background="#12FF5C7A" BorderBrush="#59FF5C7A" BorderThickness="1"
+                        CornerRadius="{StaticResource CmpRadiusInner}" Padding="12,9,12,9"
+                        IsVisible="{Binding #Root.ForgetConfirm.IsArmed}">
+                    <Grid ColumnDefinitions="*,Auto,Auto">
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center" TextWrapping="Wrap"
+                                   Margin="0,0,10,0" FontSize="11.5" FontStyle="Italic"
+                                   Foreground="#FFF2DEED"
+                                   Text="{loc:Str companion_memory_forget_confirm}"/>
+                        <Button Grid.Column="1" Theme="{StaticResource CmpDangerButtonStyle}"
+                                Command="{Binding #Root.ForgetConfirm.ConfirmCommand}">
+                            <TextBlock Text="{loc:Str companion_memory_forget_yes}"/>
+                        </Button>
+                        <Button Grid.Column="2" Margin="8,0,0,0" Theme="{StaticResource CmpGrayButtonStyle}"
+                                Command="{Binding #Root.ForgetConfirm.CancelCommand}">
+                            <TextBlock Text="{loc:Str companion_memory_forget_no}"/>
+                        </Button>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml
@@ -284,7 +284,7 @@
                  Two faces in one row: the usual storage note, and — once armed — the wipe's
                  confirm strip, asked in her voice. Inline rather than a modal, so the card never
                  blocks the tab (the Vault rule). ForgetConfirm is the little state machine that
-                 owns which one shows; see MemoryForgetConfirm. -->
+                 owns which one shows; see DiaryForgetConfirm. -->
             <Grid Grid.Row="4" Margin="0,13,0,0">
 
                 <Grid IsVisible="{Binding !#Root.ForgetConfirm.IsArmed}"

--- a/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// Z3 — the memory diary. See the XAML header for the visual spec.
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Views/Controls/Companion/MemoryDiaryView.xaml.cs.
+    /// Almost code-free by design: filtering, sorting, the kind rails and the hover-reveal action
+    /// row are all declarative. What is left is the wipe's inline confirm flow and the inline-edit
+    /// ergonomics (the box takes focus when it appears, Enter saves, Esc backs out).</para>
+    ///
+    /// <para>Deviations: <c>CompanionWheelRelay.Attach(FactWall)</c> is gone — Avalonia's
+    /// ScrollViewer chains a wheel notch it cannot use to its parent by itself. The WPF
+    /// <c>IMemoryDiaryVm</c>, <c>MockMemoryDiaryVm</c>, <c>MemoryFactCard</c>, <c>FactOrdering</c>
+    /// and <c>MemoryForgetConfirm</c> live in the head; their shape is carried below as concrete
+    /// classes seeded with the mock's artboard, the same way MakeHerYoursView does it.</para>
+    /// </summary>
+    public partial class MemoryDiaryView : UserControl
+    {
+        public MemoryDiaryView()
+        {
+            // ForgetConfirm is initialised inline, BEFORE InitializeComponent: the footer binds
+            // #Root.ForgetConfirm.* and a CLR property assigned afterwards never re-notifies.
+            InitializeComponent();
+            DataContextChanged += (_, _) => ForgetConfirm.Bind(ViewModel?.ForgetEverythingCommand);
+            // Leaving the tab backs the question out; the binding itself survives so the button
+            // still works when the user comes back.
+            Unloaded += (_, _) => ForgetConfirm.Disarm();
+            DataContext = new MemoryDiaryViewModel();
+        }
+
+        /// <summary>Convenience for hosts that hand in a viewmodel rather than setting DataContext.</summary>
+        public MemoryDiaryViewModel? ViewModel
+        {
+            get => DataContext as MemoryDiaryViewModel;
+            set => DataContext = value;
+        }
+
+        /// <summary>
+        /// The "Forget everything…" two-step. Bound from the footer by name through the
+        /// UserControl, so the destructive command has exactly one path to being executed.
+        /// </summary>
+        public MemoryForgetConfirm ForgetConfirm { get; } = new();
+
+        // =====================================================================================
+        //  inline edit
+        // =====================================================================================
+
+        /// <summary>Enter saves, Esc backs out. Esc leaves the fact exactly as it was.</summary>
+        private void FactEdit_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (sender is not Control { DataContext: MemoryFact fact }) return;
+
+            if (e.Key == Key.Enter && (e.KeyModifiers & KeyModifiers.Shift) == 0)
+            {
+                if (fact.CommitEditCommand.CanExecute(null)) fact.CommitEditCommand.Execute(null);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Escape)
+            {
+                fact.IsEditing = false;
+                e.Handled = true;
+            }
+        }
+
+        private void FactEditCancel_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is Control { DataContext: MemoryFact fact }) fact.IsEditing = false;
+        }
+
+        /// <summary>
+        /// Puts the caret where the user is already looking. Deferred at Normal priority — the box
+        /// is only laid out once the class selector has run, and Loaded priority is starved here.
+        /// </summary>
+        private void FactEdit_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (sender is not TextBox box || e.Property != IsVisibleProperty) return;
+            if (e.NewValue is not true) return;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (!box.IsVisible) return;
+                box.Focus();
+                box.SelectAll();
+            }, DispatcherPriority.Normal);
+        }
+    }
+
+    /// <summary>
+    /// Fact kind → its accent colour, for the wall's kind-coloured card edge and kind tag. Port of
+    /// the head's CompanionSurfaceConverters.cs. Unknown kinds fall back to violet — a new memory
+    /// kind shipping from the Brain must render as a normal card, never as a blank or a crash.
+    /// </summary>
+    public sealed class CompanionFactKindBrushConverter : IValueConverter
+    {
+        /// <summary>Rail mode: the same hue at reduced alpha, so the edge whispers.</summary>
+        public bool Soft { get; set; }
+
+        private static readonly Dictionary<string, Color> Palette =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["boundary"] = Color.FromRgb(0x7F, 0xB2, 0xD9),   // steel — consent hygiene
+                ["joke"] = Color.FromRgb(0xFF, 0x69, 0xB4),       // pink
+                ["preference"] = Color.FromRgb(0xB4, 0x78, 0xFF), // purple
+                ["goal"] = Color.FromRgb(0xFF, 0xD7, 0x00),       // gold
+                ["moment"] = Color.FromRgb(0x93, 0x70, 0xDB),     // violet
+                ["identity"] = Color.FromRgb(0x6E, 0xE7, 0xA7)    // live-green
+            };
+
+        private static readonly Color Fallback = Color.FromRgb(0xB4, 0x78, 0xFF);
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            Color c = Palette.TryGetValue(value as string ?? string.Empty, out var hue) ? hue : Fallback;
+            return new SolidColorBrush(Soft ? Color.FromArgb(0x99, c.R, c.G, c.B) : c);
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => BindingOperations.DoNothing;
+    }
+
+    /// <summary>
+    /// The two-step "Forget everything…" flow for Z3, in her voice. Port of the head's
+    /// MemoryForgetConfirm.cs. Invariants: the destructive command runs only from
+    /// <see cref="ConfirmCommand"/> and only while armed; confirming disarms first so a double-click
+    /// cannot fire the wipe twice; re-binding always disarms.
+    /// </summary>
+    public sealed class MemoryForgetConfirm : CompanionObservable
+    {
+        private ICommand? _target;
+        private bool _isArmed;
+        private readonly CompanionRelayCommand _arm, _confirm;
+
+        public MemoryForgetConfirm()
+        {
+            ArmCommand = _arm = new CompanionRelayCommand(Arm, () => CanArm);
+            ConfirmCommand = _confirm = new CompanionRelayCommand(Confirm, () => IsArmed);
+            CancelCommand = new CompanionRelayCommand(Cancel);
+        }
+
+        /// <summary>True while the in-voice confirm strip is showing instead of the footer.</summary>
+        public bool IsArmed
+        {
+            get => _isArmed;
+            private set { if (Set(ref _isArmed, value)) _confirm.RaiseCanExecuteChanged(); }
+        }
+
+        /// <summary>There is something to wipe and it is willing to run.</summary>
+        public bool CanArm => _target != null && _target.CanExecute(null);
+
+        /// <summary>How many times the wipe actually ran. Diagnostics for the tests.</summary>
+        public int ConfirmedCount { get; private set; }
+
+        public ICommand ArmCommand { get; }
+        public ICommand ConfirmCommand { get; }
+        public ICommand CancelCommand { get; }
+
+        /// <summary>Points the flow at a viewmodel's ForgetEverythingCommand (null unbinds). Always disarms.</summary>
+        public void Bind(ICommand? forgetEverything)
+        {
+            _target = forgetEverything;
+            IsArmed = false;
+            Raise(nameof(CanArm));
+            _arm.RaiseCanExecuteChanged();
+        }
+
+        public void Disarm() => IsArmed = false;
+
+        private void Arm() { if (CanArm) IsArmed = true; }
+
+        private void Cancel() => Disarm();
+
+        private void Confirm()
+        {
+            if (!IsArmed) return;
+            var target = _target;
+            // Disarm before executing: the strip disappears on the first click, so a second one
+            // lands on the restored footer instead of running the wipe again.
+            IsArmed = false;
+            if (target == null || !target.CanExecute(null)) return;
+            ConfirmedCount++;
+            target.Execute(null);
+        }
+    }
+
+    /// <summary>One kind chip. Port of CompanionFactFilter / IFactFilterVm.</summary>
+    public sealed class FactFilter : CompanionObservable
+    {
+        private bool _isSelected;
+
+        public FactFilter(string key, string label, bool selected = false)
+        {
+            Key = key;
+            Label = label;
+            _isSelected = selected;
+        }
+
+        public string Key { get; }
+        public string Label { get; }
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set => Set(ref _isSelected, value);
+        }
+    }
+
+    /// <summary>One card on the wall. Port of MemoryFactCard / IMemoryFactVm.</summary>
+    public sealed class MemoryFact : CompanionObservable
+    {
+        private string _text;
+        private string _metaLabel;
+        private bool _isPinned;
+        private bool _isEditing;
+        private string _editText = string.Empty;
+
+        public MemoryFact(string text, string kindKey, string kindLabel, string metaLabel = "",
+                          bool isBoundary = false, bool isPinned = false, bool isDormant = false)
+        {
+            _text = text;
+            _metaLabel = metaLabel;
+            _isPinned = isPinned;
+            KindKey = string.IsNullOrWhiteSpace(kindKey) ? "moment" : kindKey;
+            KindLabel = kindLabel;
+            IsBoundary = isBoundary;
+            IsDormant = isDormant;
+
+            PinCommand = new CompanionRelayCommand(() => { if (CanPin) IsPinned = !IsPinned; }, () => CanPin);
+            EditCommand = new CompanionRelayCommand(() => IsEditing = true, () => CanEdit);
+            ForgetCommand = new CompanionRelayCommand(Forget, () => CanForget);
+            CommitEditCommand = new CompanionRelayCommand(CommitEdit);
+        }
+
+        public string KindKey { get; }
+        public string KindLabel { get; }
+        public bool IsBoundary { get; }
+        public bool IsDormant { get; }
+
+        /// <summary>The meta line once the user has rewritten the fact.</summary>
+        public string? UserEditedMetaLabel { get; init; }
+
+        /// <summary>Set by the wall: a forget takes the card out of the list.</summary>
+        public Action<MemoryFact>? Forgotten { get; set; }
+
+        public string Text { get => _text; private set => Set(ref _text, value); }
+        public string MetaLabel { get => _metaLabel; private set => Set(ref _metaLabel, value); }
+        public bool IsPinned { get => _isPinned; private set => Set(ref _isPinned, value); }
+
+        public bool IsEditing
+        {
+            get => _isEditing;
+            set
+            {
+                if (value && !CanEdit) return;             // dormant copy is never editable
+                if (!Set(ref _isEditing, value)) return;
+                if (value) EditText = Text;                // opening the box seeds it with the fact
+            }
+        }
+
+        public string EditText { get => _editText; set => Set(ref _editText, value); }
+
+        public ICommand PinCommand { get; }
+        public ICommand EditCommand { get; }
+        public ICommand ForgetCommand { get; }
+        public ICommand CommitEditCommand { get; }
+
+        /// <summary>A boundary already sorts first and can never sink; offering the pin would promise the wrong thing.</summary>
+        public bool CanPin => !IsBoundary && !IsDormant;
+        public bool CanEdit => !IsDormant;
+        public bool CanForget => !IsDormant;
+
+        private void CommitEdit()
+        {
+            if (!_isEditing) return;
+            string trimmed = (EditText ?? string.Empty).Trim();
+            if (trimmed.Length > 0)
+            {
+                bool changed = !string.Equals(trimmed, Text, StringComparison.Ordinal);
+                Text = trimmed;
+                if (changed && !string.IsNullOrWhiteSpace(UserEditedMetaLabel)) MetaLabel = UserEditedMetaLabel!;
+            }
+            _isEditing = false;
+            Raise(nameof(IsEditing));
+        }
+
+        private void Forget()
+        {
+            if (!CanForget) return;
+            _isEditing = false;
+            Raise(nameof(IsEditing));
+            Forgotten?.Invoke(this);
+        }
+    }
+
+    /// <summary>
+    /// The view's data contract, seeded with the WPF mock's artboard (five real facts plus the
+    /// Train 4 promise card). Port of MockMemoryDiaryVm's used surface: selecting a chip
+    /// re-projects the wall, pinning re-projects so the card visibly climbs, forgetting removes
+    /// the card and can tip the wall back into its empty state.
+    /// </summary>
+    public sealed class MemoryDiaryViewModel : CompanionObservable
+    {
+        // ponytail: copy of the head's FactOrdering.FilterKeys; delete when CompanionVmPrimitives moves to Core
+        private static readonly string[] FilterKeys = { "all", "boundary", "joke", "preference", "goal", "moment" };
+
+        private readonly List<MemoryFact> _all;
+        private string _selectedFilterKey = "all";
+        private IReadOnlyList<MemoryFact> _facts = Array.Empty<MemoryFact>();
+
+        public MemoryDiaryViewModel() : this(ArtboardFacts(), ArtboardStats()) { }
+
+        public MemoryDiaryViewModel(List<MemoryFact> facts, IReadOnlyList<string> stats)
+        {
+            _all = facts;
+            ProfileStats = stats;
+            Filters = FilterKeys.Select(k => new FactFilter(k, Loc.Get($"companion_memory_filter_{k}"), k == "all")).ToArray();
+            foreach (var fact in _all) Attach(fact);
+            Reproject();
+            ForgetEverythingCommand = new CompanionRelayCommand(ForgetEverything);
+
+            // The chips are radio-like: selecting one clears the rest and re-projects the wall.
+            // A ToggleButton also UNchecks on a second click; the chips are strictly single-select,
+            // so clicking the active one is a no-op and we put it straight back.
+            foreach (var f in Filters)
+            {
+                f.PropertyChanged += (_, e) =>
+                {
+                    if (e.PropertyName != nameof(FactFilter.IsSelected)) return;
+                    if (f.IsSelected) { SelectedFilterKey = f.Key; return; }
+                    if (string.Equals(f.Key, _selectedFilterKey, StringComparison.OrdinalIgnoreCase))
+                        f.IsSelected = true;
+                };
+            }
+        }
+
+        public string ProfileStripLabel { get; init; } = Loc.Get("companion_memory_profile_strip");
+        public IReadOnlyList<string> ProfileStats { get; }
+        public IReadOnlyList<FactFilter> Filters { get; }
+
+        public IReadOnlyList<MemoryFact> Facts
+        {
+            get => _facts;
+            private set => Set(ref _facts, value);
+        }
+
+        public string SelectedFilterKey
+        {
+            get => _selectedFilterKey;
+            set
+            {
+                if (!Set(ref _selectedFilterKey, value)) return;
+                foreach (var f in Filters) f.IsSelected = string.Equals(f.Key, value, StringComparison.OrdinalIgnoreCase);
+                Reproject();
+            }
+        }
+
+        /// <summary>Only the dormant/ghost card left standing means the wall is empty.</summary>
+        public bool IsEmpty => _all.All(f => f.IsDormant);
+
+        public string EmptyCopy { get; init; } = Loc.Get("companion_memory_empty_copy");
+        public string StorageNote { get; init; } = Loc.Get("companion_memory_storage_note");
+        public string StorageLinkLabel { get; init; } = Loc.Get("companion_memory_storage_link");
+        public string ForgetEverythingLabel { get; init; } = Loc.Get("companion_memory_forget_everything");
+
+        // ponytail: needs a shell "open folder" on CorePaths' companion dir, wired when the diary moves to Core
+        public ICommand? OpenStorageFolderCommand => null;
+        public ICommand ForgetEverythingCommand { get; }
+
+        private void Attach(MemoryFact fact)
+        {
+            fact.Forgotten = Forget;
+            fact.PropertyChanged += OnFactPropertyChanged;
+        }
+
+        private void Detach(MemoryFact fact)
+        {
+            fact.Forgotten = null;
+            fact.PropertyChanged -= OnFactPropertyChanged;
+        }
+
+        private void OnFactPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(MemoryFact.IsPinned)) Reproject();
+        }
+
+        public void Forget(MemoryFact fact)
+        {
+            if (!_all.Remove(fact)) return;
+            Detach(fact);
+            Reproject();
+            Raise(nameof(IsEmpty));
+        }
+
+        /// <summary>Every real fact goes; the dormant promise card is copy, not a memory, so it stays.</summary>
+        public void ForgetEverything()
+        {
+            foreach (var fact in _all.Where(f => !f.IsDormant).ToList())
+            {
+                _all.Remove(fact);
+                Detach(fact);
+            }
+            Reproject();
+            Raise(nameof(IsEmpty));
+        }
+
+        /// <summary>filter ▸ boundary ▸ pinned ▸ salience ▸ dormant. OrderBy is stable, so insertion order is the tiebreak.</summary>
+        private void Reproject()
+        {
+            bool all = _selectedFilterKey == "all";
+            Facts = _all
+                .Where(f => f.IsDormant || all || string.Equals(f.KindKey, _selectedFilterKey, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(f => f.IsDormant ? 3 : f.IsBoundary ? 0 : f.IsPinned ? 1 : 2)
+                .ToArray();
+        }
+
+        // ------------------------------- sample data (the WPF mock's artboard) -------------------------------
+
+        private static IReadOnlyList<string> ArtboardStats() => new[]
+        {
+            "Level 41", "Streak 12 days", "87 sessions", "Archetype: Dreamer", "Favorite: Flash"
+        };
+
+        private static List<MemoryFact> ArtboardFacts() => new()
+        {
+            new MemoryFact("Never tease about chastity.",
+                "boundary", Loc.Get("companion_memory_card_boundary"), "set by you · 2026-07-30", isBoundary: true)
+                { UserEditedMetaLabel = "set by you · edited just now" },
+            new MemoryFact("First trance: 2026-03-02 — “the day we met.”",
+                "moment", Loc.Get("companion_memory_card_moment"), "pinned · she brings this up on anniversaries", isPinned: true)
+                { UserEditedMetaLabel = "pinned · edited by you" },
+            new MemoryFact("Calls his cat “Prime Minister Beans.”",
+                "joke", Loc.Get("companion_memory_card_joke"), "used 4× · last: yesterday")
+                { UserEditedMetaLabel = "edited by you · she'll use your wording" },
+            new MemoryFact("Melts fastest to spiral + whisper combos.",
+                "preference", Loc.Get("companion_memory_card_preference"), "from chat · salience high")
+                { UserEditedMetaLabel = "edited by you · she'll use your wording" },
+            new MemoryFact("Wants to hit Level 50 before September.",
+                "goal", Loc.Get("companion_memory_card_goal"), "she checks in on this")
+                { UserEditedMetaLabel = "edited by you · she checks in on this" },
+            new MemoryFact(Loc.Get("companion_memory_dormant_promise"),
+                "all", Loc.Get("companion_memory_card_dormant"), string.Empty, isDormant: true)
+        };
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs
@@ -28,7 +28,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// <para>Deviations: <c>CompanionWheelRelay.Attach(FactWall)</c> is gone — Avalonia's
     /// ScrollViewer chains a wheel notch it cannot use to its parent by itself. The WPF
     /// <c>IMemoryDiaryVm</c>, <c>MockMemoryDiaryVm</c>, <c>MemoryFactCard</c>, <c>FactOrdering</c>
-    /// and <c>MemoryForgetConfirm</c> live in the head; their shape is carried below as concrete
+    /// and <c>DiaryForgetConfirm</c> live in the head; their shape is carried below as concrete
     /// classes seeded with the mock's artboard, the same way MakeHerYoursView does it.</para>
     /// </summary>
     public partial class MemoryDiaryView : UserControl
@@ -56,7 +56,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         /// The "Forget everything…" two-step. Bound from the footer by name through the
         /// UserControl, so the destructive command has exactly one path to being executed.
         /// </summary>
-        public MemoryForgetConfirm ForgetConfirm { get; } = new();
+        public DiaryForgetConfirm ForgetConfirm { get; } = new();
 
         // =====================================================================================
         //  inline edit
@@ -137,17 +137,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 
     /// <summary>
     /// The two-step "Forget everything…" flow for Z3, in her voice. Port of the head's
-    /// MemoryForgetConfirm.cs. Invariants: the destructive command runs only from
+    /// DiaryForgetConfirm.cs. Invariants: the destructive command runs only from
     /// <see cref="ConfirmCommand"/> and only while armed; confirming disarms first so a double-click
     /// cannot fire the wipe twice; re-binding always disarms.
     /// </summary>
-    public sealed class MemoryForgetConfirm : CompanionObservable
+    public sealed class DiaryForgetConfirm : CompanionObservable
     {
         private ICommand? _target;
         private bool _isArmed;
         private readonly CompanionRelayCommand _arm, _confirm;
 
-        public MemoryForgetConfirm()
+        public DiaryForgetConfirm()
         {
             ArmCommand = _arm = new CompanionRelayCommand(Arm, () => CanArm);
             ConfirmCommand = _confirm = new CompanionRelayCommand(Confirm, () => IsArmed);


### PR DESCRIPTION
835 lines, 3 files. The VM primitives feed the next layer's views. The forget-confirm helper is named DiaryForgetConfirm to avoid the namespace clash with Companion II's.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351