### PR TITLE
feat(avalonia): port Companion IV, part 2/2 - CompanionRoomView, CompanionRoomPreviewWindow

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/CompanionRoomPreviewWindow.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionRoomPreviewWindow.axaml
@@ -1,0 +1,74 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/CompanionRoomPreviewWindow.xaml.
+     Deviations: Style -> Theme, pack:// -> avares://, ToolTip -> ToolTip.Tip, and the strip's
+     buttons are built from a static key list rather than MockCompanionRoomVm.Variants (the mock
+     lives in the WPF head — see the code-behind). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.CompanionRoomPreviewWindow"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+        mc:Ignorable="d"
+        Title="Her Room — preview harness"
+        Width="1240" Height="1400"
+        MinWidth="820" MinHeight="600"
+        Background="#FF080711"
+        UseLayoutRounding="True"
+        WindowStartupLocation="CenterScreen"
+        AutomationProperties.AutomationId="CtabPreviewWindow">
+
+    <!-- ================================================================
+         DEBUG PREVIEW HARNESS for the composed Companion tab.
+
+         Nothing in the app opens this window. It exists so the redesign can
+         be looked at, screenshotted and driven before the wiring pass
+         connects the real services — the whole page, every state, no login,
+         no provider, no train.
+
+         Opened by CompanionRoomPreviewWindow.Launch() (optionally with a
+         variant key) from a driver, or constructed directly by a test and
+         driven with ShowVariant(key). The state strip is built in code and
+         every button carries an AutomationId of the form CtabPreview_<key>.
+         ================================================================ -->
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- ========== the state strip ========== -->
+        <Border Grid.Row="0" Background="#FF12101F" BorderBrush="#33B478FF"
+                BorderThickness="0,0,0,1" Padding="14,10,14,10">
+            <Grid ColumnDefinitions="Auto,*,Auto">
+
+                <TextBlock Grid.Column="0" Text="page state" VerticalAlignment="Center"
+                           Margin="0,0,12,0" Theme="{StaticResource CmpFaintTextStyle}"/>
+
+                <!-- Filled by BuildStateStrip(). -->
+                <WrapPanel x:Name="StateStrip" Grid.Column="1" Orientation="Horizontal"
+                           AutomationProperties.AutomationId="CtabPreview_Strip"/>
+
+                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock x:Name="CurrentLabel" VerticalAlignment="Center" Margin="0,0,12,0"
+                               Theme="{StaticResource CmpDimTextStyle}"
+                               AutomationProperties.AutomationId="CtabPreview_Current"/>
+                    <Button x:Name="WidthToggle" Click="WidthToggle_Click"
+                            Theme="{StaticResource CmpChipButtonStyle}"
+                            ToolTip.Tip="flips the window across the shelf's 1100px collapse threshold"
+                            AutomationProperties.AutomationId="CtabPreview_ToggleWidth">
+                        <TextBlock Text="narrow ⇄ wide"/>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ========== the page under test ========== -->
+        <local:CompanionRoomView x:Name="Room" Grid.Row="1" Margin="10"
+                                 AutomationProperties.AutomationId="CtabPreview_Room"/>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionRoomPreviewWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionRoomPreviewWindow.axaml.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Styling;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// Debug preview harness for <see cref="CompanionRoomView"/>. See the XAML header for how it is
+    /// opened and why nothing in the app opens it by itself.
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Views/Controls/Companion/CompanionRoomPreviewWindow.xaml.cs.
+    /// The strip, the current-state label and the width toggle cross as they are. What does not:
+    /// <c>MockCompanionRoomVm</c> and <c>ICompanionRoomVm</c> live in the WPF head, so
+    /// <see cref="ShowVariant"/> re-labels the strip but cannot yet swap the page's state.</para>
+    /// </summary>
+    public partial class CompanionRoomPreviewWindow : Window
+    {
+        /// <summary>Window width used by the strip's narrow toggle — under the shelf's threshold.</summary>
+        private const double NarrowWidth = 1000;
+
+        /// <summary>…and the width it goes back to. Both sit clear of the hysteresis band.</summary>
+        private const double WideWidth = 1240;
+
+        // ponytail: mirrors MockCompanionRoomVm.Variants' keys; read the dictionary once the mock moves
+        private static readonly string[] Variants = { "default", "freeTier", "dormant", "empty", "drained", "disabled" };
+
+        private readonly Dictionary<string, Button> _stateButtons = new(StringComparer.OrdinalIgnoreCase);
+
+        public CompanionRoomPreviewWindow()
+        {
+            InitializeComponent();
+            BuildStateStrip();
+            ShowVariant(DefaultVariantKey);
+        }
+
+        /// <summary>The page state the harness opens on.</summary>
+        public const string DefaultVariantKey = "default";
+
+        /// <summary>The key currently on screen. Also rendered into the strip for the driver.</summary>
+        public string CurrentVariantKey { get; private set; } = DefaultVariantKey;
+
+        /// <summary>The composed page, for a driver that wants to poke it directly.</summary>
+        public CompanionRoomView RoomView => Room;
+
+        /// <summary>Builds, shows and returns the harness. Must be called on the UI thread.</summary>
+        public static CompanionRoomPreviewWindow Launch(string? variantKey = null)
+        {
+            var window = new CompanionRoomPreviewWindow();
+            if (!string.IsNullOrWhiteSpace(variantKey)) window.ShowVariant(variantKey!);
+            window.Show();
+            return window;
+        }
+
+        /// <summary>
+        /// Swaps the page state. No-op on an unknown key — the current page stays exactly as it is
+        /// rather than blanking, so a mistyped key in a driver script is visible but harmless.
+        /// </summary>
+        public bool ShowVariant(string? variantKey)
+        {
+            if (variantKey == null || !_stateButtons.ContainsKey(variantKey)) return false;
+
+            // ponytail: Room.ViewModel = MockCompanionRoomVm.Get(key) once the mock moves off the head
+            CurrentVariantKey = variantKey;
+            CurrentLabel.Text = variantKey;
+
+            foreach (var pair in _stateButtons)
+            {
+                bool active = string.Equals(pair.Key, variantKey, StringComparison.OrdinalIgnoreCase);
+                pair.Value.Opacity = active ? 1.0 : 0.55;
+                pair.Value.FontWeight = active ? FontWeight.Bold : FontWeight.Normal;
+            }
+            return true;
+        }
+
+        /// <summary>One button per page state, built from the variant table rather than typed out.</summary>
+        private void BuildStateStrip()
+        {
+            this.TryFindResource("CmpChipButtonStyle", out var chip);
+            foreach (var key in Variants)
+            {
+                var button = new Button
+                {
+                    // A TextBlock, not a string: "freeTier" is safe but a Button parses "_" as an access key.
+                    Content = new TextBlock { Text = Humanize(key) },
+                    Tag = key,
+                    Margin = new Thickness(0, 2, 8, 2),
+                    Theme = chip as ControlTheme
+                };
+                AutomationProperties.SetAutomationId(button, "CtabPreview_" + key);
+                AutomationProperties.SetName(button, key);
+                button.Click += StateButton_Click;
+
+                _stateButtons[key] = button;
+                StateStrip.Children.Add(button);
+            }
+        }
+
+        /// <summary>"freeTier" → "free tier". Display only; the key is what automation uses.</summary>
+        private static string Humanize(string key)
+        {
+            var chars = new List<char>(key.Length + 2);
+            foreach (char c in key)
+            {
+                if (char.IsUpper(c)) { chars.Add(' '); chars.Add(char.ToLowerInvariant(c)); }
+                else chars.Add(c);
+            }
+            return new string(chars.ToArray());
+        }
+
+        private void StateButton_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is Button { Tag: string key }) ShowVariant(key);
+        }
+
+        /// <summary>Flips the window across the shelf's collapse threshold.</summary>
+        private void WidthToggle_Click(object? sender, RoutedEventArgs e)
+            => Width = Width > NarrowWidth + 1 ? NarrowWidth : WideWidth;
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionRoomView.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionRoomView.axaml
@@ -1,0 +1,160 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Companion/CompanionRoomView.xaml.
+     Arrangement is preserved zone for zone. Deviations, all forced by what exists on this head:
+
+       Style="{StaticResource X}"    ->  Theme="{StaticResource X}"
+       pack:// merged dictionary     ->  avares:// ResourceInclude
+       DataContext="{Binding Zone}"  ->  dropped. ICompanionRoomVm and its eight zone interfaces
+                                         live in the WPF head; every ported zone seeds its own
+                                         viewmodel, exactly as it does when rendered alone.
+       x:Name on ColumnDefinition    ->  dropped (not a StyledElement); the code-behind indexes
+                                         Shelf.ColumnDefinitions instead.
+       CompanionHeroCard, ChatThresholdView, AwarenessPrivacyView, AiPermissionsGrid
+                                     ->  NOT PORTED YET. Each sits as a labelled placeholder card
+                                         carrying the zone's x:Name, so the shelf, the navigator
+                                         and the deep links keep their real targets and the swap
+                                         is one element each. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Companion.CompanionRoomView"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             mc:Ignorable="d"
+             d:DesignWidth="1240" d:DesignHeight="1400">
+
+    <!-- ================================================================
+         "HER ROOM" — the composed Companion tab.
+
+         Nine controls, one page. Arrangement only: every zone owns its own
+         card, its own states and its own copy, and nothing here reaches
+         inside one. What the page adds is the three things a zone cannot
+         have on its own — the room it sits in, the shelf that puts the
+         columns beside each other, and the navigator that lets a link in
+         one zone land in another.
+
+         Strata, outside in:
+           1. THE ROOM   — CmpRoomShellStyle: the linear backdrop, clipped
+                           and cornered, with the mockup's three radial
+                           washes riding above it as sibling Borders.
+           2. THE SCROLL — one column, the whole page, MaxWidth 1460.
+           3. THE SHELF  — Z2/Z3 at 60% beside Z4/Z5/Z6 at 40%, stacking
+                           to one column on a narrow window.
+
+         ZONE ORDER (design §2's zone map, top to bottom):
+           Z0+Z1  CompanionHeroCard      header band + Companion Card
+           Z2     ChatThresholdView      talk to her          (left column)
+           Z3     MemoryDiaryView        what she knows       (left column)
+           Z4     MakeHerYoursView       make her yours       (right column)
+           Z5     AwarenessPrivacyView   what she can see     (right column)
+           Z6     AttentionGaugeView     her attention        (right column)
+           Z7     EngineRoomDrawer       the Engine Room      (full width)
+           Z7b    AiPermissionsGrid      what she's allowed   (full width)
+           Z8     WorkshopAccordion      the Workshop         (full width)
+
+         MOTION BUDGET (ONE ambient loop per tab). The page adds none.
+         RoomAmbientHost is the seam the mockup's dust motes would go in.
+
+         Nothing here binds to Bounds. The shelf's one-column collapse is a
+         threshold flip with hysteresis in code-behind.
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="avares://CCP.Avalonia/Views/Controls/Companion/Themes/CompanionTheme.axaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border Theme="{StaticResource CmpRoomShellStyle}">
+        <Grid>
+            <!-- ========== 1. the room's washes ==========
+                 .room's four stacked CSS backgrounds: the linear base is the shell's own
+                 Background, these three are the radials. Order matters — purple top-left,
+                 pink top-right, then the cool pool the floor sits in. -->
+            <Border Theme="{StaticResource CmpRoomWashStyle}"
+                    Background="{StaticResource CmpRoomGlowPurpleBrush}"/>
+            <Border Theme="{StaticResource CmpRoomWashStyle}"
+                    Background="{StaticResource CmpRoomGlowPinkBrush}"/>
+            <Border Theme="{StaticResource CmpRoomWashStyle}"
+                    Background="{StaticResource CmpRoomFloorGlowBrush}"/>
+
+            <!-- The seam for the room's ambient layer. Empty on purpose — see the motion
+                 budget note above. -->
+            <Grid x:Name="RoomAmbientHost" IsHitTestVisible="False"/>
+
+            <!-- ========== 2. the scroll ========== -->
+            <ScrollViewer x:Name="PageScroll" Focusable="False"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Padding="{StaticResource CmpRoomPadding}"
+                          AutomationProperties.AutomationId="CompanionRoomScroll">
+
+                <!-- The body is centred and capped, like the other redesigned tabs, so the
+                     cards do not stretch to absurd widths on an ultrawide. -->
+                <StackPanel MaxWidth="1460" HorizontalAlignment="Stretch">
+
+                    <!-- ========== Z0 + Z1 ==========
+                         ponytail: CompanionHeroCard placeholder, swap for the port when it lands -->
+                    <Border x:Name="HeroZone" Theme="{StaticResource CmpCardStyle}" Margin="0,0,0,16"
+                            AutomationProperties.AutomationId="CompanionRoomHero">
+                        <TextBlock Text="Z0+Z1 · CompanionHeroCard (not ported yet)" Theme="{StaticResource CmpFaintTextStyle}"/>
+                    </Border>
+
+                    <!-- ========== 3. the shelf ==========
+                         Three columns: left 3*, a 16px gutter, right 2*. The gutter is a column
+                         rather than a margin, so the collapse can close it to zero without
+                         touching either card's own spacing. Stacked, the right panel moves to
+                         row 1 and both panels span all three columns. The flip lives in
+                         ApplyShelfLayout(); the widths and spans below are the WIDE state. -->
+                    <Grid x:Name="Shelf" ColumnDefinitions="3*,16,2*" RowDefinitions="Auto,Auto">
+
+                        <StackPanel x:Name="ShelfLeft" Grid.Row="0" Grid.Column="0">
+                            <!-- ponytail: ChatThresholdView placeholder, swap for the port when it lands -->
+                            <Border x:Name="ChatZone" Theme="{StaticResource CmpCardStyle}" Margin="{StaticResource CmpCardMargin}"
+                                    AutomationProperties.AutomationId="CompanionRoomChat">
+                                <TextBlock Text="Z2 · ChatThresholdView (not ported yet)" Theme="{StaticResource CmpFaintTextStyle}"/>
+                            </Border>
+                            <local:MemoryDiaryView x:Name="MemoryZone"
+                                                   AutomationProperties.AutomationId="CompanionRoomMemory"/>
+                        </StackPanel>
+
+                        <StackPanel x:Name="ShelfRight" Grid.Row="0" Grid.Column="2">
+                            <local:MakeHerYoursView x:Name="PersonalityZone"
+                                                    AutomationProperties.AutomationId="CompanionRoomPersonality"/>
+                            <!-- Focusable so the hero's awareness pill has somewhere to put the
+                                 keyboard when it deep-links here; the card itself takes no input.
+                                 ponytail: AwarenessPrivacyView placeholder, swap for the port when it lands -->
+                            <Border x:Name="AwarenessZone" Focusable="True" Theme="{StaticResource CmpCardStyle}"
+                                    Margin="{StaticResource CmpCardMargin}"
+                                    AutomationProperties.AutomationId="CompanionRoomAwareness">
+                                <TextBlock Text="Z5 · AwarenessPrivacyView (not ported yet)" Theme="{StaticResource CmpFaintTextStyle}"/>
+                            </Border>
+                            <local:AttentionGaugeView x:Name="AttentionZone"
+                                                      AutomationProperties.AutomationId="CompanionRoomAttention"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- ========== Z7 / Z8 ==========
+                         Both drawers carry their own top margin from CmpDrawerStyle, so the
+                         shelf needs no trailing gap of its own. -->
+                    <local:EngineRoomDrawer x:Name="EngineZone"
+                                            AutomationProperties.AutomationId="CompanionRoomEngine"/>
+
+                    <!-- ========== Z7b · WHAT SHE'S ALLOWED TO DO ==========
+                         The AI-effects permissions grid. It sits HERE, between the provider
+                         plumbing it depends on and the Workshop, because "may she fire a flash"
+                         is meaningless until "which brain is she running on" is answered.
+                         ponytail: AiPermissionsGrid placeholder, swap for the port when it lands -->
+                    <Border x:Name="PermissionsZone" Theme="{StaticResource CmpCardStyle}" Margin="0,16,0,0"
+                            AutomationProperties.AutomationId="CompanionRoomPermissions">
+                        <TextBlock Text="Z7b · AiPermissionsGrid (not ported yet)" Theme="{StaticResource CmpFaintTextStyle}"/>
+                    </Border>
+
+                    <local:WorkshopAccordion x:Name="WorkshopZone"
+                                             AutomationProperties.AutomationId="CompanionRoomWorkshop"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionRoomView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionRoomView.axaml.cs
@@ -1,0 +1,157 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// "Her Room" — the composed Companion tab. See the XAML header for the zone map.
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Views/Controls/Companion/CompanionRoomView.xaml.cs.
+    /// Of the three page-level behaviours the WPF view owns, two cross: the navigator and the
+    /// shelf collapse. The third, clock parking, and the compat-seam passthroughs
+    /// (TxtDetachStatusCompanion, the sixteen AiPermissionsGrid names, ...) reach into zones
+    /// that are not on this head yet — see the stub comments below.</para>
+    /// </summary>
+    public partial class CompanionRoomView : UserControl, ICompanionRoomNavigator
+    {
+        private bool _isShelfStacked;
+        private bool _shelfApplied;
+
+        public CompanionRoomView()
+        {
+            InitializeComponent();
+            // A one-time Bounds read at Loaded — a value, not a binding. SizeChanged owns it from here.
+            Loaded += (_, _) => ApplyShelfLayout(Bounds.Width);
+            SizeChanged += (_, e) => { if (e.WidthChanged) ApplyShelfLayout(e.NewSize.Width); };
+        }
+
+        // ponytail: ICompanionRoomVm (Hero/Chat/Memory/... zone interfaces + Navigator) lives in the
+        // WPF head; each ported zone seeds its own viewmodel. ViewModel/Claim return when it moves.
+
+        // ponytail: ParkClocks/ResumeClocks on IsVisible need CompanionHeroCard, AwarenessPrivacyView
+        // and ChatThresholdView; wired when those zones port.
+
+        /// <summary>
+        /// True while the shelf is one column. Exposed for the tests and the preview harness — the
+        /// collapse is the only piece of layout on this page that a screenshot cannot prove.
+        /// </summary>
+        internal bool IsShelfStacked => _isShelfStacked;
+
+        // =====================================================================================
+        //  the shelf's one-column collapse
+        // =====================================================================================
+
+        /// <summary>
+        /// Moves the right-hand column below the left one under
+        /// <see cref="CompanionShelfLayout.StackBelow"/> and back up above
+        /// <see cref="CompanionShelfLayout.UnstackAbove"/>. Only writes on a real threshold
+        /// crossing, and the hysteresis gap means the width the new layout produces can never push
+        /// it straight back over the line it just crossed.
+        /// </summary>
+        internal void ApplyShelfLayout(double width)
+        {
+            bool stack = CompanionShelfLayout.ShouldStack(_isShelfStacked, width);
+            if (_shelfApplied && stack == _isShelfStacked) return;
+
+            _isShelfStacked = stack;
+            _shelfApplied = true;
+
+            var gutter = Shelf.ColumnDefinitions[1];
+            var right = Shelf.ColumnDefinitions[2];
+            if (stack)
+            {
+                gutter.Width = new GridLength(0);
+                right.Width = new GridLength(0);
+                Grid.SetColumnSpan(ShelfLeft, 3);
+                Grid.SetRow(ShelfRight, 1);
+                Grid.SetColumn(ShelfRight, 0);
+                Grid.SetColumnSpan(ShelfRight, 3);
+            }
+            else
+            {
+                gutter.Width = new GridLength(CompanionShelfLayout.GutterWidth);
+                right.Width = new GridLength(2, GridUnitType.Star);
+                Grid.SetColumnSpan(ShelfLeft, 1);
+                Grid.SetRow(ShelfRight, 0);
+                Grid.SetColumn(ShelfRight, 2);
+                Grid.SetColumnSpan(ShelfRight, 1);
+            }
+        }
+
+        // =====================================================================================
+        //  ICompanionRoomNavigator — the cross-zone links
+        // =====================================================================================
+
+        /// <inheritdoc/>
+        public void RevealEngineRoom() => EngineZone.ExpandAndReveal();
+
+        /// <inheritdoc/>
+        public void RevealWorkshop(string? cellTitle = null) => WorkshopZone.ExpandAndReveal(cellTitle);
+
+        /// <inheritdoc/>
+        /// <remarks>Scroll first, focus second, both deferred one turn at Normal priority — Loaded
+        /// priority is starved in this app, and the card may not have been arranged yet.</remarks>
+        public void FocusAwareness()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                try
+                {
+                    AwarenessZone.BringIntoView();
+                    AwarenessZone.Focus();
+                }
+                catch (InvalidOperationException)
+                {
+                    // Torn down mid-scroll. A deep link that arrives late is not worth a crash.
+                }
+            }, DispatcherPriority.Normal);
+        }
+    }
+
+    /// <summary>
+    /// What a zone may ask the page to do. Implemented by <see cref="CompanionRoomView"/>. Port of
+    /// the head's ICompanionRoomVm.cs (the navigator half; the viewmodel half stays until its eight
+    /// zone interfaces exist here).
+    /// </summary>
+    public interface ICompanionRoomNavigator
+    {
+        /// <summary>Expands the Engine Room drawer and scrolls it into view.</summary>
+        void RevealEngineRoom();
+
+        /// <summary>Scrolls "What she can see" into view and gives it the keyboard focus.</summary>
+        void FocusAwareness();
+
+        /// <summary>Expands the Workshop and, when <paramref name="cellTitle"/> names one of its
+        /// pigeonholes, brings that cell into view.</summary>
+        void RevealWorkshop(string? cellTitle = null);
+    }
+
+    /// <summary>
+    /// When the shelf is one column instead of two ("two-column shelf collapses to one below
+    /// ~1100px"). Its own type because it is the page's only real decision and must be
+    /// unit-testable: a collapse that oscillates is a hang. Verbatim from the WPF head.
+    /// </summary>
+    public static class CompanionShelfLayout
+    {
+        /// <summary>Below this width the right column moves under the left one.</summary>
+        public const double StackBelow = 1100;
+
+        /// <summary>And it only comes back up above this one. The 60px gap is the hysteresis.</summary>
+        public const double UnstackAbove = 1160;
+
+        /// <summary>The gutter column's width while the shelf is two columns.</summary>
+        public const double GutterWidth = 16;
+
+        /// <summary>
+        /// The next stacked-ness given the current one and a width. A non-positive or non-finite
+        /// width changes nothing — the caller keeps whatever it had rather than snapping to a
+        /// column count on a number that means "unknown".
+        /// </summary>
+        public static bool ShouldStack(bool isStacked, double width)
+        {
+            if (double.IsNaN(width) || double.IsInfinity(width) || width <= 0) return isStacked;
+            return isStacked ? width < UnstackAbove : width < StackBelow;
+        }
+    }
+}


### PR DESCRIPTION
515 lines, 4 files. Room shell with placeholder cards for the four zones not yet ported.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351