### PR TITLE
feat(avalonia): port consent dialogs, part 1/2 - Awareness, ContentPolicy, ExplicitContent, Mic

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/AwarenessConsentDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessConsentDialog.axaml
@@ -1,0 +1,136 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/AwarenessConsentDialog.xaml.
+     Structure, order, spacing and every x:Name preserved. Deviations, all forced:
+       Style="{StaticResource X}"  -> Theme="{StaticResource X}"   (keyed styles are ControlThemes,
+                                      local copies of the WPF Window.Resources block)
+       ResizeMode="NoResize"       -> CanResize="False"
+       Click="Handler"             -> wired in the constructor
+       Content="{loc:Str …}"       -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                      access key and every loc key here is snake_case) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.AwarenessConsentDialog"
+        Title="{loc:Str awareness_consent_title}"
+        Width="580"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+    <!-- ================================================================
+         First-enable consent for Awareness (doc 02 §6.3).
+
+         COPY RULE: every sentence in here is checked against the merged
+         code path (see the WPF AwarenessConsentDialog.xaml.cs for the map).
+         ================================================================ -->
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/AwarenessConsentDialog.xaml:DlgHeader…DlgSecondaryButton, hoist when a second view needs it -->
+        <ControlTheme x:Key="DlgHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgBody" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="13.5"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="LineHeight" Value="21"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSectionHead" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Margin" Value="0,14,0,3"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgFaint" TargetType="TextBlock" BasedOn="{StaticResource DlgBody}">
+            <Setter Property="Foreground" Value="#9A9AB8"/>
+            <Setter Property="FontSize" Value="12"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgButton" TargetType="Button">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="22,10"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinWidth" Value="150"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgPrimaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSecondaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="#3A3A52"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="30,26,30,22">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0">
+            <TextBlock Theme="{StaticResource DlgHeader}" Text="{loc:Str awareness_consent_title}"/>
+            <TextBlock Theme="{StaticResource DlgBody}" Margin="0,14,0,0" Text="{loc:Str awareness_consent_intro}"/>
+        </StackPanel>
+
+        <Border Grid.Row="1" Margin="0,16,0,0" Padding="16,10,16,14" CornerRadius="6"
+                Background="#1F1F38"
+                BorderBrush="{StaticResource PinkBrush}"
+                BorderThickness="0,0,0,3">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgSectionHead}" Margin="0,4,0,3"
+                           Text="{loc:Str awareness_consent_watch_head}"/>
+                <TextBlock Theme="{StaticResource DlgBody}" Text="{loc:Str awareness_consent_watch_body}"/>
+
+                <TextBlock Theme="{StaticResource DlgSectionHead}" Text="{loc:Str awareness_consent_leaves_head}"/>
+                <!-- Set in code-behind: the sentence differs when the v2 kill switch is down. -->
+                <TextBlock x:Name="TxtLeavesBody" Theme="{StaticResource DlgBody}"/>
+
+                <TextBlock Theme="{StaticResource DlgSectionHead}" Text="{loc:Str awareness_consent_never_head}"/>
+                <TextBlock Theme="{StaticResource DlgBody}" Text="{loc:Str awareness_consent_never_body}"/>
+                <TextBlock Theme="{StaticResource DlgFaint}" Margin="0,4,0,0"
+                           Text="{loc:Str awareness_consent_never_note}"/>
+
+                <TextBlock Theme="{StaticResource DlgSectionHead}" Text="{loc:Str awareness_consent_control_head}"/>
+                <TextBlock Theme="{StaticResource DlgBody}" Text="{loc:Str awareness_consent_control_body}"/>
+                <TextBlock x:Name="TxtRetention" Theme="{StaticResource DlgFaint}" Margin="0,4,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <Grid Grid.Row="2" Margin="0,18,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0" Theme="{StaticResource DlgFaint}" VerticalAlignment="Center"
+                       Margin="0,0,14,0" Text="{loc:Str awareness_consent_footer}"/>
+
+            <Button x:Name="BtnDecline" Grid.Column="1"
+                    Theme="{StaticResource DlgSecondaryButton}"
+                    Margin="0,0,10,0">
+                <TextBlock Text="{loc:Str awareness_consent_decline}"/>
+            </Button>
+
+            <Button x:Name="BtnAccept" Grid.Column="2"
+                    Theme="{StaticResource DlgPrimaryButton}">
+                <TextBlock Text="{loc:Str awareness_consent_accept}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/AwarenessConsentDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessConsentDialog.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// First-enable consent for Awareness (doc 02 §6.3). Ported from the WPF dialog of the same
+    /// name; the copy map lives in that file's doc comment. ShowDialog&lt;bool&gt; yields true on
+    /// accept, false on decline or dismiss.
+    /// </summary>
+    public partial class AwarenessConsentDialog : Window
+    {
+        /// <summary>Matches <c>AppSettings.AwarenessRetentionDays</c>'s default; used only headlessly.</summary>
+        private const int AppSettingsRetentionFallback = 30;
+
+        public AwarenessConsentDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // ponytail: needs AppSettings (UseAwarenessV2, AwarenessRetentionDays), wired when it moves to Core.
+            // Until then the WPF null-settings fallbacks apply: v2 on, 30 days.
+            const bool v2 = true;
+            this.FindControl<TextBlock>("TxtLeavesBody")!.Text = Loc.Get(v2
+                ? "awareness_consent_leaves_body"
+                : "awareness_consent_leaves_body_legacy");
+            this.FindControl<TextBlock>("TxtRetention")!.Text =
+                Loc.GetF("awareness_consent_retention_fmt", AppSettingsRetentionFallback);
+
+            this.FindControl<Button>("BtnAccept")!.Click += (_, _) => Close(true);
+            this.FindControl<Button>("BtnDecline")!.Click += (_, _) => Close(false);
+        }
+
+        // ponytail: IsRequired/EnsureConsent need AppSettings, AwarenessPrivacyRules and
+        // AwarenessIntensityMigration (all head-only); ported when they move to Core.
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/ContentPolicyWarningDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/ContentPolicyWarningDialog.axaml
@@ -1,0 +1,94 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/ContentPolicyWarningDialog.xaml.
+     Structure, order, spacing and every x:Name preserved. Deviations, all forced:
+       Style="{StaticResource X}"  -> Theme="{StaticResource X}"   (local ControlThemes below)
+       ResizeMode="NoResize"       -> CanResize="False"
+       Hyperlink                   -> HyperlinkButton NavigateUri (native; replaces Process.Start)
+       Click="Handler"             -> wired in the constructor
+       Content="{loc:Str …}"       -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                      access key and every loc key here is snake_case) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.ContentPolicyWarningDialog"
+        Title="{loc:Str policy_warning_title}"
+        Width="540"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/ContentPolicyWarningDialog.xaml:DlgHeader…DlgButton, hoist when a second view needs it -->
+        <ControlTheme x:Key="DlgHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E5C76B"/>
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgBody" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="LineHeight" Value="22"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgButton" TargetType="Button">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="22,10"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinWidth" Value="120"/>
+            <Setter Property="Background" Value="#A98E3A"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="32,28,32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0">
+            <TextBlock Theme="{StaticResource DlgHeader}" Text="{loc:Str policy_warning_title}"/>
+
+            <TextBlock x:Name="TxtBodyCount"
+                       Theme="{StaticResource DlgBody}"
+                       Margin="0,18,0,0"/>
+
+            <TextBlock Theme="{StaticResource DlgBody}" Margin="0,14,0,0"
+                       Text="{loc:Str policy_warning_body_explain}"/>
+
+            <TextBlock Theme="{StaticResource DlgBody}" Margin="0,14,0,0"
+                       Text="{loc:Str policy_warning_body_link}"/>
+
+            <HyperlinkButton x:Name="LnkPolicy" Margin="0,8,0,0" Padding="0"
+                             Foreground="#E5C76B"
+                             NavigateUri="https://app.cclabs.app/policies/prohibited-content">
+                <TextBlock Text="{loc:Str moderation_policy_link}" FontSize="14"/>
+            </HyperlinkButton>
+        </StackPanel>
+
+        <Grid Grid.Row="1" Margin="0,24,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="BtnOk" Grid.Column="1"
+                    Theme="{StaticResource DlgButton}"
+                    IsDefault="True">
+                <TextBlock Text="{loc:Str policy_warning_ok}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/ContentPolicyWarningDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ContentPolicyWarningDialog.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// CCBill compliance — moderation escalation warning modal. Shown once per threshold-cross
+    /// by the moderation counter; ShowDialog&lt;bool&gt; yields true on OK.
+    /// </summary>
+    public partial class ContentPolicyWarningDialog : Window
+    {
+        /// <summary>Render/design constructor: sample count so --render-view can draw the dialog.</summary>
+        public ContentPolicyWarningDialog() : this(3) { }
+
+        public ContentPolicyWarningDialog(int hitCount)
+        {
+            AvaloniaXamlLoader.Load(this);
+            this.FindControl<TextBlock>("TxtBodyCount")!.Text = Loc.GetF("policy_warning_body_count", hitCount);
+            this.FindControl<Button>("BtnOk")!.Click += (_, _) => Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/ExplicitContentAcknowledgementDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/ExplicitContentAcknowledgementDialog.axaml
@@ -1,0 +1,164 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/ExplicitContentAcknowledgementDialog.xaml.
+     Structure, order, spacing and every x:Name preserved. Deviations, all forced:
+       Style="{StaticResource X}"  -> Theme="{StaticResource X}"   (local ControlThemes below)
+       ChkAgeConfirm (implicit WPF CheckBox = dark dot)
+                                   -> local DlgCheckbox, a copy of Theme/Styles.xaml:DotCheckBoxStyle
+                                      with a Grid so the long label wraps
+       ResizeMode="NoResize"       -> CanResize="False"
+       Hyperlink                   -> HyperlinkButton NavigateUri (native; replaces Process.Start)
+       Click/Checked/Unchecked     -> wired in the constructor
+       Content="{loc:Str …}"       -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                      access key and every loc key here is snake_case) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.ExplicitContentAcknowledgementDialog"
+        Title="{loc:Str explicit_ack_title}"
+        Width="560"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/ExplicitContentAcknowledgementDialog.xaml:DlgHeader…DlgSecondaryButton, hoist when a second view needs it -->
+        <ControlTheme x:Key="DlgHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgBody" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="LineHeight" Value="22"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgBullet" TargetType="TextBlock" BasedOn="{StaticResource DlgBody}">
+            <Setter Property="Margin" Value="0,8,0,0"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgButton" TargetType="Button">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="22,10"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinWidth" Value="140"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <!-- WPF had no disabled trigger here; a disabled Accept looked identical to enabled.
+                 Keeping that would hide the gate on screen, so the fade is added deliberately. -->
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.35"/>
+            </Style>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgPrimaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSecondaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="#3A3A52"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgCheckbox" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid ColumnDefinitions="Auto,*" Background="Transparent">
+                        <Border x:Name="dot" Width="16" Height="16" CornerRadius="8" Margin="0,0,10,0"
+                                Background="#3A3A48" BorderBrush="#5A5A6A" BorderThickness="1"
+                                VerticalAlignment="Center"/>
+                        <ContentPresenter Grid.Column="1" Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          VerticalAlignment="Center"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ Border#dot">
+                <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#dot">
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="32,28,32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0">
+            <TextBlock Theme="{StaticResource DlgHeader}" Text="{loc:Str explicit_ack_title}"/>
+
+            <TextBlock Theme="{StaticResource DlgBody}" Margin="0,18,0,0"
+                       Text="{loc:Str explicit_ack_body_intro}"/>
+
+            <Border Margin="0,18,0,0" Padding="16" CornerRadius="6"
+                    Background="#1F1F38"
+                    BorderBrush="{StaticResource PinkBrush}"
+                    BorderThickness="0,0,0,3">
+                <StackPanel>
+                    <TextBlock Theme="{StaticResource DlgBullet}" Margin="0,0,0,0">
+                        <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                        <Run Text="{loc:Str explicit_ack_body_age}"/>
+                    </TextBlock>
+                    <TextBlock Theme="{StaticResource DlgBullet}">
+                        <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                        <Run Text="{loc:Str explicit_ack_body_policy}"/>
+                    </TextBlock>
+                    <TextBlock Theme="{StaticResource DlgBullet}">
+                        <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                        <Run Text="{loc:Str explicit_ack_body_ai}"/>
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+
+            <HyperlinkButton x:Name="LnkPolicy" Margin="0,16,0,0" Padding="0"
+                             Foreground="{StaticResource PinkBrush}"
+                             NavigateUri="https://app.cclabs.app/policies/prohibited-content">
+                <TextBlock Text="{loc:Str explicit_ack_policy_link}" FontSize="14"/>
+            </HyperlinkButton>
+        </StackPanel>
+
+        <!-- Required age-confirmation checkbox (C3 hardening) -->
+        <CheckBox x:Name="ChkAgeConfirm" Grid.Row="2"
+                  Theme="{StaticResource DlgCheckbox}"
+                  Margin="0,20,0,0">
+            <TextBlock TextWrapping="Wrap" Text="{loc:Str explicit_ack_checkbox}"/>
+        </CheckBox>
+
+        <!-- Button row -->
+        <Grid Grid.Row="3" Margin="0,20,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="BtnCancel" Grid.Column="1"
+                    Theme="{StaticResource DlgSecondaryButton}"
+                    Margin="0,0,10,0">
+                <TextBlock Text="{loc:Str explicit_ack_cancel}"/>
+            </Button>
+
+            <Button x:Name="BtnAccept" Grid.Column="2"
+                    Theme="{StaticResource DlgPrimaryButton}"
+                    IsEnabled="False">
+                <TextBlock Text="{loc:Str explicit_ack_accept}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/ExplicitContentAcknowledgementDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ExplicitContentAcknowledgementDialog.axaml.cs
@@ -1,0 +1,33 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// CCBill AI Content Merchant Addendum — 18+ and content-policy acknowledgement gate.
+    /// Accept stays disabled until the age checkbox is ticked. ShowDialog&lt;bool&gt; yields true on
+    /// accept; the caller records the acknowledgement, exactly as on WPF.
+    /// </summary>
+    public partial class ExplicitContentAcknowledgementDialog : Window
+    {
+        public ExplicitContentAcknowledgementDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            var chk = this.FindControl<CheckBox>("ChkAgeConfirm")!;
+            var accept = this.FindControl<Button>("BtnAccept")!;
+
+            chk.IsCheckedChanged += (_, _) => accept.IsEnabled = chk.IsChecked == true;
+            accept.Click += (_, _) =>
+            {
+                // Defense-in-depth: IsEnabled already prevents this, but a harness may invoke it.
+                if (chk.IsChecked != true) return;
+
+                // ponytail: needs AppSettings.CompanionPrompt (ExplicitAcknowledgedAt/Locale audit stamp),
+                // wired when AppSettings moves to Core.
+                Close(true);
+            };
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/MicConsentDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/MicConsentDialog.axaml
@@ -1,0 +1,252 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/MicConsentDialog.xaml.
+     Structure, order, spacing and every x:Name preserved. The WPF original has no loc keys -
+     every string is English in the XAML - so the English is copied verbatim, not keyed.
+     Deviations, all forced:
+       Style="{StaticResource X}"    -> Theme="{StaticResource X}"  (local ControlThemes below)
+       ControlTemplate.Triggers      -> ^:pointerover / ^:disabled styles inside the theme
+       DlgCheckbox BasedOn implicit  -> local copy of Theme/Styles.xaml:DotCheckBoxStyle with a
+                                        Grid instead of a StackPanel, so long labels wrap
+       ResizeMode="NoResize"         -> CanResize="False"
+       Visibility="Collapsed"        -> IsVisible="False"
+       Hyperlink                     -> HyperlinkButton NavigateUri (native; replaces Process.Start)
+       Click/Checked/TextChanged     -> wired in the constructor
+       whitespace between <Run>s     -> moved inside the Run text (Avalonia drops it) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.MicConsentDialog"
+        Title="Microphone — Privacy and Consent"
+        Width="640" Height="620"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/MicConsentDialog.xaml:DlgHeader…DlgCheckbox, hoist when a second view needs it -->
+        <ControlTheme x:Key="DlgHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="22"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSub" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#B0B0B0"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Margin" Value="0,4,0,0"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgBody" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="LineHeight" Value="22"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgPromise" TargetType="TextBlock" BasedOn="{StaticResource DlgBody}">
+            <Setter Property="Margin" Value="0,0,0,12"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="22,10"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinWidth" Value="120"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chrome" Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Chrome">
+                <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.35"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgPrimaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSecondaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="#3A3A52"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgCheckbox" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Margin" Value="0,8,0,0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid ColumnDefinitions="Auto,*" Background="Transparent">
+                        <Border x:Name="dot" Width="16" Height="16" CornerRadius="8" Margin="0,0,10,0"
+                                Background="#3A3A48" BorderBrush="#5A5A6A" BorderThickness="1"
+                                VerticalAlignment="Center"/>
+                        <ContentPresenter Grid.Column="1" Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          VerticalAlignment="Center"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ Border#dot">
+                <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#dot">
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="32,28,32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Step indicator -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
+            <Ellipse x:Name="DotStep1" Width="10" Height="10" Margin="4,0" Fill="{StaticResource PinkBrush}"/>
+            <Ellipse x:Name="DotStep2" Width="10" Height="10" Margin="4,0" Fill="#3A3A52"/>
+            <Ellipse x:Name="DotStep3" Width="10" Height="10" Margin="4,0" Fill="#3A3A52"/>
+        </StackPanel>
+
+        <!-- ─── STEP 1 — What this enables ─── -->
+        <ScrollViewer x:Name="PanelStep1" Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Voice — &quot;say it for me&quot;"/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Optional. Off by default. Lets her hear you say things back."/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,24,0,0"
+                           Text="With this on, during Takeover she can ask you to repeat a phrase out loud — and actually listen for it. She knows the phrase already, so all the app checks is whether you said it, and loudly enough. Recognition runs entirely on your computer using a small offline model bundled with the app — no internet is used."/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,16,0,0" FontWeight="SemiBold" Foreground="{StaticResource PinkBrush}"
+                           Text="How the mic is used:"/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="14,8,0,0">
+                    <Run FontWeight="Bold">• Only when she asks (default)</Run>
+                    <LineBreak/>
+                    <Run>The mic opens for a few seconds right after she prompts you, then closes again. It is not listening the rest of the time.</Run>
+                </TextBlock>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="14,12,0,0">
+                    <Run FontWeight="Bold">• Always-on wake word (separate opt-in)</Run>
+                    <LineBreak/>
+                    <Run>A &quot;Hey Bambi&quot;-style trigger that keeps the mic open is available later as its own setting — it is NOT enabled by this consent.</Run>
+                </TextBlock>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,28,0,0" Foreground="#9090A8" FontStyle="Italic"
+                           Text="The next screen explains exactly what happens to the audio — and what never does. Read it carefully."/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ─── STEP 2 — Privacy contract ─── -->
+        <ScrollViewer x:Name="PanelStep2" Grid.Row="1" VerticalScrollBarVisibility="Auto" IsVisible="False">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Your voice stays on this computer."/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Always. Read each line."/>
+
+                <Border Margin="0,24,0,0" Padding="20" CornerRadius="6" Background="#1F1F38" BorderBrush="{StaticResource PinkBrush}" BorderThickness="0,0,0,3">
+                    <StackPanel>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Audio is </Run>
+                            <Run FontWeight="Bold">never transmitted</Run>
+                            <Run> — not to our server, not to Patreon, not to any third party.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Audio is processed in memory and </Run>
+                            <Run FontWeight="Bold">immediately discarded. </Run>
+                            <Run>No recording, no clip, no file is ever written to disk.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Only a </Run>
+                            <Run FontWeight="Bold">match score </Run>
+                            <Run>(did you say the phrase, and how loud) is used — never the raw audio.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Recognition runs </Run>
+                            <Run FontWeight="Bold">offline </Run>
+                            <Run>with a model bundled in the app. </Run>
+                            <Run FontWeight="Bold">No internet connection is used or required.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>By default the mic opens </Run>
+                            <Run FontWeight="Bold">only during a prompt</Run>
+                            <Run>, for a few seconds — not continuously.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>You can disable this </Run>
+                            <Run FontWeight="Bold">instantly </Run>
+                            <Run>with the panic key, the in-app toggle, or by closing the app.</Run>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,18,0,0" Foreground="#B8B8C8"
+                           Text="Want to verify? The source code for this feature is public."/>
+                <HyperlinkButton x:Name="LnkSource" Padding="0" Foreground="{StaticResource PinkBrush}"
+                                 NavigateUri="https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/blob/main/ConditioningControlPanel/Services/Speech/SpeechService.cs">
+                    <TextBlock Text="View on GitHub →" FontSize="14"/>
+                </HyperlinkButton>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ─── STEP 3 — Explicit consent ─── -->
+        <ScrollViewer x:Name="PanelStep3" Grid.Row="1" VerticalScrollBarVisibility="Auto" IsVisible="False">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Confirm consent"/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Each box must be checked. None are pre-checked."/>
+
+                <CheckBox x:Name="ChkConsent1" Theme="{StaticResource DlgCheckbox}" Margin="0,24,0,0">
+                    <TextBlock TextWrapping="Wrap" Text="I understand my voice stays on this device and is never transmitted."/>
+                </CheckBox>
+                <CheckBox x:Name="ChkConsent2" Theme="{StaticResource DlgCheckbox}">
+                    <TextBlock TextWrapping="Wrap" Text="I understand audio is processed in memory and never saved to disk."/>
+                </CheckBox>
+                <CheckBox x:Name="ChkConsent3" Theme="{StaticResource DlgCheckbox}">
+                    <TextBlock TextWrapping="Wrap" Text="I consent to the microphone opening while Takeover is running and prompting me to speak."/>
+                </CheckBox>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,28,0,8" FontWeight="SemiBold"
+                           Text="Type ENABLE in capitals to confirm:"/>
+                <TextBox x:Name="TxtConfirm" FontSize="14" Padding="10,8" Background="#1F1F38" Foreground="White"
+                         BorderBrush="#3A3A52" BorderThickness="1" CaretBrush="White"/>
+
+                <TextBlock x:Name="TxtConfirmHint" Theme="{StaticResource DlgBody}" Margin="0,8,0,0" Foreground="#8888A0" FontStyle="Italic"
+                           Text="Waiting for: 3 checkboxes + ENABLE typed."/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- Button row -->
+        <Grid Grid.Row="2" Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="BtnCancel" Grid.Column="0" Theme="{StaticResource DlgSecondaryButton}" HorizontalAlignment="Left"
+                    Content="Cancel"/>
+
+            <Button x:Name="BtnBack" Grid.Column="1" Theme="{StaticResource DlgSecondaryButton}" Margin="0,0,8,0"
+                    Content="← Back" IsVisible="False"/>
+
+            <Button x:Name="BtnNext" Grid.Column="2" Theme="{StaticResource DlgPrimaryButton}"
+                    Content="I want to know more →"/>
+
+            <Button x:Name="BtnEnable" Grid.Column="2" Theme="{StaticResource DlgPrimaryButton}"
+                    Content="Enable Voice" IsEnabled="False" IsVisible="False"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/MicConsentDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/MicConsentDialog.axaml.cs
@@ -1,0 +1,141 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Multi-step privacy/consent flow for the offline microphone ("repeat after me").
+    /// Steps: 1) what it enables, 2) privacy contract, 3) explicit consent.
+    /// Mirrors WebcamConsentDialog so the two consent flows feel identical.
+    /// ShowDialog&lt;bool&gt; yields true only when every gate passed and Enable was clicked.
+    /// </summary>
+    public partial class MicConsentDialog : Window
+    {
+        private enum Step { Intro = 1, Privacy = 2, Consent = 3 }
+        private Step _step = Step.Intro;
+
+        /// <summary>True when the user completed all consent gates and clicked Enable.</summary>
+        public bool ConsentGiven { get; private set; }
+
+        private readonly ScrollViewer _panel1, _panel2, _panel3;
+        private readonly Ellipse _dot1, _dot2, _dot3;
+        private readonly Button _btnBack, _btnNext, _btnEnable;
+        private readonly CheckBox _chk1, _chk2, _chk3;
+        private readonly TextBox _txtConfirm;
+        private readonly TextBlock _txtConfirmHint;
+
+        public MicConsentDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _panel1 = this.FindControl<ScrollViewer>("PanelStep1")!;
+            _panel2 = this.FindControl<ScrollViewer>("PanelStep2")!;
+            _panel3 = this.FindControl<ScrollViewer>("PanelStep3")!;
+            _dot1 = this.FindControl<Ellipse>("DotStep1")!;
+            _dot2 = this.FindControl<Ellipse>("DotStep2")!;
+            _dot3 = this.FindControl<Ellipse>("DotStep3")!;
+            _btnBack = this.FindControl<Button>("BtnBack")!;
+            _btnNext = this.FindControl<Button>("BtnNext")!;
+            _btnEnable = this.FindControl<Button>("BtnEnable")!;
+            _chk1 = this.FindControl<CheckBox>("ChkConsent1")!;
+            _chk2 = this.FindControl<CheckBox>("ChkConsent2")!;
+            _chk3 = this.FindControl<CheckBox>("ChkConsent3")!;
+            _txtConfirm = this.FindControl<TextBox>("TxtConfirm")!;
+            _txtConfirmHint = this.FindControl<TextBlock>("TxtConfirmHint")!;
+
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => { ConsentGiven = false; Close(false); };
+            _btnBack.Click += (_, _) =>
+            {
+                if (_step == Step.Privacy) _step = Step.Intro;
+                else if (_step == Step.Consent) _step = Step.Privacy;
+                UpdateUiForStep();
+            };
+            _btnNext.Click += (_, _) =>
+            {
+                _step = _step == Step.Intro ? Step.Privacy : Step.Consent;
+                UpdateUiForStep();
+            };
+            _btnEnable.Click += (_, _) => Enable();
+            _chk1.IsCheckedChanged += (_, _) => UpdateEnableButtonState();
+            _chk2.IsCheckedChanged += (_, _) => UpdateEnableButtonState();
+            _chk3.IsCheckedChanged += (_, _) => UpdateEnableButtonState();
+            _txtConfirm.TextChanged += (_, _) => UpdateEnableButtonState();
+
+            UpdateUiForStep();
+        }
+
+        private void UpdateUiForStep()
+        {
+            _panel1.IsVisible = _step == Step.Intro;
+            _panel2.IsVisible = _step == Step.Privacy;
+            _panel3.IsVisible = _step == Step.Consent;
+
+            _dot1.Fill = StepDotBrush(Step.Intro);
+            _dot2.Fill = StepDotBrush(Step.Privacy);
+            _dot3.Fill = StepDotBrush(Step.Consent);
+
+            _btnBack.IsVisible = _step != Step.Intro;
+
+            switch (_step)
+            {
+                case Step.Intro:
+                    _btnNext.IsVisible = true;
+                    _btnEnable.IsVisible = false;
+                    _btnNext.Content = "I want to know more →";
+                    break;
+                case Step.Privacy:
+                    _btnNext.IsVisible = true;
+                    _btnEnable.IsVisible = false;
+                    _btnNext.Content = "Continue →";
+                    break;
+                case Step.Consent:
+                    _btnNext.IsVisible = false;
+                    _btnEnable.IsVisible = true;
+                    UpdateEnableButtonState();
+                    break;
+            }
+        }
+
+        private IBrush StepDotBrush(Step s)
+        {
+            if (_step == s) return (IBrush)this.FindResource("PinkBrush")!;
+            return (int)_step > (int)s ? new SolidColorBrush(Color.FromRgb(0x8A, 0x4A, 0x6F))
+                                       : new SolidColorBrush(Color.FromRgb(0x3A, 0x3A, 0x52));
+        }
+
+        private void UpdateEnableButtonState()
+        {
+            var allChecked = _chk1.IsChecked == true && _chk2.IsChecked == true && _chk3.IsChecked == true;
+            var typed = _txtConfirm.Text?.Trim() == "ENABLE";
+            _btnEnable.IsEnabled = allChecked && typed;
+
+            if (allChecked && typed)
+            {
+                _txtConfirmHint.Text = "All gates passed. You can enable now.";
+                _txtConfirmHint.Foreground = new SolidColorBrush(Color.FromRgb(0xA0, 0xE0, 0xA0));
+            }
+            else
+            {
+                var missing = "";
+                if (!allChecked) missing += "all 3 checkboxes";
+                if (!allChecked && !typed) missing += " + ";
+                if (!typed) missing += "ENABLE typed";
+                _txtConfirmHint.Text = "Waiting for: " + missing + ".";
+                _txtConfirmHint.Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0xA0));
+            }
+        }
+
+        private void Enable()
+        {
+            // ponytail: needs AppSettings (MicConsentGiven) + SettingsService.Save, wired when they move to Core.
+            // The mic stays closed - it only opens during an explicit listen window while Takeover runs.
+            Log.Information("Mic consent granted at {Time}", System.DateTime.UtcNow);
+
+            ConsentGiven = true;
+            Close(true);
+        }
+    }
+}


### PR DESCRIPTION
880 lines, 8 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351