### PR TITLE
feat(avalonia): port consent dialogs, part 2/2 - WebcamConsentDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/WebcamConsentDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/WebcamConsentDialog.axaml
@@ -1,0 +1,295 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/WebcamConsentDialog.xaml.
+     Structure, order, spacing and every x:Name preserved. The WPF original has no loc keys -
+     every string is English in the XAML - so the English is copied verbatim, not keyed.
+     Deviations, all forced:
+       Style="{StaticResource X}"    -> Theme="{StaticResource X}"  (local ControlThemes below)
+       ControlTemplate.Triggers      -> ^:pointerover / ^:disabled styles inside the theme
+       DlgCheckbox BasedOn implicit  -> local copy of Theme/Styles.xaml:DotCheckBoxStyle with a
+                                        Grid instead of a StackPanel, so long labels wrap
+       ResizeMode="NoResize"         -> CanResize="False"
+       Visibility="Collapsed"        -> IsVisible="False"
+       Hyperlink                     -> HyperlinkButton NavigateUri (native; replaces Process.Start)
+       Click/Checked/TextChanged     -> wired in the constructor
+       whitespace between <Run>s     -> moved inside the Run text (Avalonia drops it) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.WebcamConsentDialog"
+        Title="Webcam Tracking — Privacy and Consent"
+        Width="640" Height="640"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/WebcamConsentDialog.xaml:DlgHeader…DlgCheckbox, hoist when a second view needs it -->
+        <ControlTheme x:Key="DlgHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="22"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSub" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#B0B0B0"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Margin" Value="0,4,0,0"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgBody" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="LineHeight" Value="22"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgPromise" TargetType="TextBlock" BasedOn="{StaticResource DlgBody}">
+            <Setter Property="Margin" Value="0,0,0,12"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="22,10"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinWidth" Value="120"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chrome" Background="{TemplateBinding Background}" CornerRadius="4" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Chrome">
+                <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.35"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgPrimaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgSecondaryButton" TargetType="Button" BasedOn="{StaticResource DlgButton}">
+            <Setter Property="Background" Value="#3A3A52"/>
+        </ControlTheme>
+        <ControlTheme x:Key="DlgCheckbox" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="#E8E8E8"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Margin" Value="0,8,0,0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid ColumnDefinitions="Auto,*" Background="Transparent">
+                        <Border x:Name="dot" Width="16" Height="16" CornerRadius="8" Margin="0,0,10,0"
+                                Background="#3A3A48" BorderBrush="#5A5A6A" BorderThickness="1"
+                                VerticalAlignment="Center"/>
+                        <ContentPresenter Grid.Column="1" Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          VerticalAlignment="Center"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ Border#dot">
+                <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#dot">
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="32,28,32,24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Step indicator -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,20">
+            <Ellipse x:Name="DotStep1" Width="10" Height="10" Margin="4,0" Fill="{StaticResource PinkBrush}"/>
+            <Ellipse x:Name="DotStep2" Width="10" Height="10" Margin="4,0" Fill="#3A3A52"/>
+            <Ellipse x:Name="DotStep3" Width="10" Height="10" Margin="4,0" Fill="#3A3A52"/>
+            <Ellipse x:Name="DotStep4" Width="10" Height="10" Margin="4,0" Fill="#3A3A52"/>
+        </StackPanel>
+
+        <!-- ─── STEP 1 — What this enables ─── -->
+        <ScrollViewer x:Name="PanelStep1" Grid.Row="1" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Webcam Tracking — Lab Feature"/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Optional. Off by default. Powers two new Lab features."/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,24,0,0"
+                           Text="This optional feature uses your webcam to detect when you blink, open your mouth, or look at parts of the screen. Detection runs entirely on your computer using AI models bundled with the app — no internet connection is used."/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,16,0,0" FontWeight="SemiBold" Foreground="{StaticResource PinkBrush}"
+                           Text="What you get:"/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="14,8,0,0">
+                    <Run FontWeight="Bold">• Webcam Triggers</Run>
+                    <LineBreak/>
+                    <Run>Blink, look at a spot for a while, or open your mouth — each can drive a flash, subliminal, or other effect.</Run>
+                </TextBlock>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="14,12,0,0">
+                    <Run FontWeight="Bold">• Focus Training</Run>
+                    <LineBreak/>
+                    <Run>A split-screen video game. Look at the "correct" side, get rewarded with XP and reinforcement.</Run>
+                </TextBlock>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,28,0,0" Foreground="#9090A8" FontStyle="Italic"
+                           Text="Before turning this on, the next screen explains exactly what we do with the camera — and what we never do. Read it carefully."/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ─── STEP 2 — Privacy contract ─── -->
+        <ScrollViewer x:Name="PanelStep2" Grid.Row="1" VerticalScrollBarVisibility="Auto" IsVisible="False">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Your camera frames stay on this computer."/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Always. Read each line."/>
+
+                <Border Margin="0,24,0,0" Padding="20" CornerRadius="6" Background="#1F1F38" BorderBrush="{StaticResource PinkBrush}" BorderThickness="0,0,0,3">
+                    <StackPanel>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Frames are </Run>
+                            <Run FontWeight="Bold">never transmitted</Run>
+                            <Run> — not to our server, not to Patreon, not to any third party.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Frames are processed in memory and </Run>
+                            <Run FontWeight="Bold">immediately discarded. </Run>
+                            <Run>No video, no images, no snapshots are ever written to disk.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>Only </Run>
+                            <Run FontWeight="Bold">numbers </Run>
+                            <Run>(eye-open ratio, gaze coordinates, mouth-open ratio) flow between components — never pictures.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>All AI tracking runs </Run>
+                            <Run FontWeight="Bold">offline </Run>
+                            <Run>with models bundled in the app. </Run>
+                            <Run FontWeight="Bold">No internet connection is used or required.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run FontWeight="Bold">Audio is never captured. </Run>
+                            <Run>The webcam microphone is not accessed.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>The webcam light is </Run>
+                            <Run FontWeight="Bold">on whenever this feature is active</Run>
+                            <Run>, controlled by Windows itself — we cannot hide it.</Run>
+                        </TextBlock>
+                        <TextBlock Theme="{StaticResource DlgPromise}">
+                            <Run FontWeight="Bold" Foreground="{StaticResource PinkBrush}">• </Run>
+                            <Run>You can disable this </Run>
+                            <Run FontWeight="Bold">instantly </Run>
+                            <Run>with the panic key, the in-app toggle, or by closing the app.</Run>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,18,0,0" Foreground="#B8B8C8"
+                           Text="Want to verify? The source code for this feature is public."/>
+                <HyperlinkButton x:Name="LnkSource" Padding="0" Foreground="{StaticResource PinkBrush}"
+                                 NavigateUri="https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/blob/main/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs">
+                    <TextBlock Text="View on GitHub →" FontSize="14"/>
+                </HyperlinkButton>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ─── STEP 3 — Explicit consent ─── -->
+        <ScrollViewer x:Name="PanelStep3" Grid.Row="1" VerticalScrollBarVisibility="Auto" IsVisible="False">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Confirm consent"/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Each box must be checked. None are pre-checked."/>
+
+                <CheckBox x:Name="ChkConsent1" Theme="{StaticResource DlgCheckbox}" Margin="0,24,0,0">
+                    <TextBlock TextWrapping="Wrap" Text="I understand camera frames stay on this device and are never transmitted."/>
+                </CheckBox>
+                <CheckBox x:Name="ChkConsent2" Theme="{StaticResource DlgCheckbox}">
+                    <TextBlock TextWrapping="Wrap" Text="I understand frames are processed in memory and never saved to disk."/>
+                </CheckBox>
+                <CheckBox x:Name="ChkConsent3" Theme="{StaticResource DlgCheckbox}">
+                    <TextBlock TextWrapping="Wrap" Text="I am the only person in front of this camera, or others present have given consent."/>
+                </CheckBox>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,28,0,8" FontWeight="SemiBold"
+                           Text="Type ENABLE in capitals to confirm:"/>
+                <TextBox x:Name="TxtConfirm" FontSize="14" Padding="10,8" Background="#1F1F38" Foreground="White"
+                         BorderBrush="#3A3A52" BorderThickness="1" CaretBrush="White"/>
+
+                <TextBlock x:Name="TxtConfirmHint" Theme="{StaticResource DlgBody}" Margin="0,8,0,0" Foreground="#8888A0" FontStyle="Italic"
+                           Text="Waiting for: 3 checkboxes + ENABLE typed."/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- ─── STEP 4 — Calibration prompt ─── -->
+        <ScrollViewer x:Name="PanelStep4" Grid.Row="1" VerticalScrollBarVisibility="Auto" IsVisible="False">
+            <StackPanel>
+                <TextBlock Theme="{StaticResource DlgHeader}" Text="Calibration"/>
+                <TextBlock Theme="{StaticResource DlgSub}" Text="Quick one-time setup so the camera knows where you're looking."/>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,24,0,0"
+                           Text="Two options. You can switch later from the Lab card."/>
+
+                <Border Margin="0,16,0,0" Padding="18" CornerRadius="6" Background="#1F1F38">
+                    <StackPanel>
+                        <TextBlock Theme="{StaticResource DlgBody}" FontWeight="Bold" Foreground="{StaticResource PinkBrush}" Text="Fast (about 10 seconds)"/>
+                        <TextBlock Theme="{StaticResource DlgBody}" Margin="0,4,0,0"
+                                   Text="Just left vs right gaze. Enough for the Focus Training game."/>
+                    </StackPanel>
+                </Border>
+
+                <Border Margin="0,12,0,0" Padding="18" CornerRadius="6" Background="#1F1F38">
+                    <StackPanel>
+                        <TextBlock Theme="{StaticResource DlgBody}" FontWeight="Bold" Foreground="{StaticResource PinkBrush}" Text="Full (about 45 seconds)"/>
+                        <TextBlock Theme="{StaticResource DlgBody}" Margin="0,4,0,0"
+                                   Text="Twenty-five-point precision (5×5 grid). Needed for &quot;long stare&quot; triggers and stare-to-pop bubbles."/>
+                    </StackPanel>
+                </Border>
+
+                <TextBlock Theme="{StaticResource DlgBody}" Margin="0,20,0,0" Foreground="#9090A8" FontStyle="Italic"
+                           Text="You can also skip and calibrate later. The Lab cards will be visible but features that need calibration will show a &quot;Calibrate to enable&quot; hint until you do."/>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- Button row -->
+        <Grid Grid.Row="2" Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="BtnCancel" Grid.Column="0" Theme="{StaticResource DlgSecondaryButton}" HorizontalAlignment="Left"
+                    Content="Cancel"/>
+
+            <Button x:Name="BtnBack" Grid.Column="1" Theme="{StaticResource DlgSecondaryButton}" Margin="0,0,8,0"
+                    Content="← Back" IsVisible="False"/>
+
+            <Button x:Name="BtnNext" Grid.Column="2" Theme="{StaticResource DlgPrimaryButton}"
+                    Content="I want to know more →"/>
+
+            <Button x:Name="BtnEnable" Grid.Column="2" Theme="{StaticResource DlgPrimaryButton}"
+                    Content="Enable Webcam Tracking" IsEnabled="False" IsVisible="False"/>
+
+            <Button x:Name="BtnSkipCal" Grid.Column="2" Theme="{StaticResource DlgSecondaryButton}" Margin="0,0,8,0"
+                    Content="Calibrate later" IsVisible="False"/>
+
+            <Button x:Name="BtnCalNow" Grid.Column="3" Theme="{StaticResource DlgPrimaryButton}"
+                    Content="Calibrate now" IsVisible="False"/>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/WebcamConsentDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WebcamConsentDialog.axaml.cs
@@ -1,0 +1,167 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Multi-step privacy/consent flow for the webcam tracking feature.
+    /// Steps: 1) what it does, 2) privacy contract, 3) explicit consent, 4) calibration prompt.
+    /// Does NOT start the camera. ShowDialog&lt;bool&gt; yields true only after step 4.
+    /// </summary>
+    public partial class WebcamConsentDialog : Window
+    {
+        private enum Step { Intro = 1, Privacy = 2, Consent = 3, Calibrate = 4 }
+        private Step _step = Step.Intro;
+
+        /// <summary>True when the user completed all consent gates and clicked Enable.</summary>
+        public bool ConsentGiven { get; private set; }
+
+        /// <summary>True when the user clicked "Calibrate now" on step 4. Caller opens calibration window.</summary>
+        public bool WantsCalibrationNow { get; private set; }
+
+        private readonly ScrollViewer _panel1, _panel2, _panel3, _panel4;
+        private readonly Ellipse _dot1, _dot2, _dot3, _dot4;
+        private readonly Button _btnCancel, _btnBack, _btnNext, _btnEnable, _btnSkipCal, _btnCalNow;
+        private readonly CheckBox _chk1, _chk2, _chk3;
+        private readonly TextBox _txtConfirm;
+        private readonly TextBlock _txtConfirmHint;
+
+        public WebcamConsentDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _panel1 = this.FindControl<ScrollViewer>("PanelStep1")!;
+            _panel2 = this.FindControl<ScrollViewer>("PanelStep2")!;
+            _panel3 = this.FindControl<ScrollViewer>("PanelStep3")!;
+            _panel4 = this.FindControl<ScrollViewer>("PanelStep4")!;
+            _dot1 = this.FindControl<Ellipse>("DotStep1")!;
+            _dot2 = this.FindControl<Ellipse>("DotStep2")!;
+            _dot3 = this.FindControl<Ellipse>("DotStep3")!;
+            _dot4 = this.FindControl<Ellipse>("DotStep4")!;
+            _btnCancel = this.FindControl<Button>("BtnCancel")!;
+            _btnBack = this.FindControl<Button>("BtnBack")!;
+            _btnNext = this.FindControl<Button>("BtnNext")!;
+            _btnEnable = this.FindControl<Button>("BtnEnable")!;
+            _btnSkipCal = this.FindControl<Button>("BtnSkipCal")!;
+            _btnCalNow = this.FindControl<Button>("BtnCalNow")!;
+            _chk1 = this.FindControl<CheckBox>("ChkConsent1")!;
+            _chk2 = this.FindControl<CheckBox>("ChkConsent2")!;
+            _chk3 = this.FindControl<CheckBox>("ChkConsent3")!;
+            _txtConfirm = this.FindControl<TextBox>("TxtConfirm")!;
+            _txtConfirmHint = this.FindControl<TextBlock>("TxtConfirmHint")!;
+
+            _btnCancel.Click += (_, _) => { ConsentGiven = false; Close(false); };
+            _btnBack.Click += (_, _) =>
+            {
+                if (_step == Step.Privacy) _step = Step.Intro;
+                else if (_step == Step.Consent) _step = Step.Privacy;
+                UpdateUiForStep();
+            };
+            _btnNext.Click += (_, _) =>
+            {
+                _step = _step == Step.Intro ? Step.Privacy : Step.Consent;
+                UpdateUiForStep();
+            };
+            _btnEnable.Click += (_, _) => Enable();
+            _btnSkipCal.Click += (_, _) => { WantsCalibrationNow = false; Close(true); };
+            _btnCalNow.Click += (_, _) => { WantsCalibrationNow = true; Close(true); };
+            _chk1.IsCheckedChanged += (_, _) => UpdateEnableButtonState();
+            _chk2.IsCheckedChanged += (_, _) => UpdateEnableButtonState();
+            _chk3.IsCheckedChanged += (_, _) => UpdateEnableButtonState();
+            _txtConfirm.TextChanged += (_, _) => UpdateEnableButtonState();
+
+            UpdateUiForStep();
+        }
+
+        private void UpdateUiForStep()
+        {
+            _panel1.IsVisible = _step == Step.Intro;
+            _panel2.IsVisible = _step == Step.Privacy;
+            _panel3.IsVisible = _step == Step.Consent;
+            _panel4.IsVisible = _step == Step.Calibrate;
+
+            _dot1.Fill = StepDotBrush(Step.Intro);
+            _dot2.Fill = StepDotBrush(Step.Privacy);
+            _dot3.Fill = StepDotBrush(Step.Consent);
+            _dot4.Fill = StepDotBrush(Step.Calibrate);
+
+            _btnBack.IsVisible = _step != Step.Intro;
+            _btnCancel.IsVisible = _step != Step.Calibrate;
+
+            switch (_step)
+            {
+                case Step.Intro:
+                    _btnNext.IsVisible = true;
+                    _btnEnable.IsVisible = false;
+                    _btnSkipCal.IsVisible = false;
+                    _btnCalNow.IsVisible = false;
+                    _btnNext.Content = "I want to know more →";
+                    break;
+                case Step.Privacy:
+                    _btnNext.IsVisible = true;
+                    _btnEnable.IsVisible = false;
+                    _btnSkipCal.IsVisible = false;
+                    _btnCalNow.IsVisible = false;
+                    _btnNext.Content = "Continue →";
+                    break;
+                case Step.Consent:
+                    _btnNext.IsVisible = false;
+                    _btnEnable.IsVisible = true;
+                    _btnSkipCal.IsVisible = false;
+                    _btnCalNow.IsVisible = false;
+                    UpdateEnableButtonState();
+                    break;
+                case Step.Calibrate:
+                    _btnNext.IsVisible = false;
+                    _btnEnable.IsVisible = false;
+                    _btnBack.IsVisible = false;
+                    _btnSkipCal.IsVisible = true;
+                    _btnCalNow.IsVisible = true;
+                    break;
+            }
+        }
+
+        private IBrush StepDotBrush(Step s)
+        {
+            if (_step == s) return (IBrush)this.FindResource("PinkBrush")!;
+            return (int)_step > (int)s ? new SolidColorBrush(Color.FromRgb(0x8A, 0x4A, 0x6F))
+                                       : new SolidColorBrush(Color.FromRgb(0x3A, 0x3A, 0x52));
+        }
+
+        private void UpdateEnableButtonState()
+        {
+            var allChecked = _chk1.IsChecked == true && _chk2.IsChecked == true && _chk3.IsChecked == true;
+            var typed = _txtConfirm.Text?.Trim() == "ENABLE";
+            _btnEnable.IsEnabled = allChecked && typed;
+
+            if (allChecked && typed)
+            {
+                _txtConfirmHint.Text = "All gates passed. You can enable now.";
+                _txtConfirmHint.Foreground = new SolidColorBrush(Color.FromRgb(0xA0, 0xE0, 0xA0));
+            }
+            else
+            {
+                var missing = "";
+                if (!allChecked) missing += "all 3 checkboxes";
+                if (!allChecked && !typed) missing += " + ";
+                if (!typed) missing += "ENABLE typed";
+                _txtConfirmHint.Text = "Waiting for: " + missing + ".";
+                _txtConfirmHint.Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0xA0));
+            }
+        }
+
+        private void Enable()
+        {
+            // ponytail: needs AppSettings (WebcamConsentGiven/Version/Date), SettingsService.Save and
+            // WebcamTrackingService.ConsentVersion, wired when they move to Core. Camera stays closed.
+            Log.Information("Webcam consent granted at {Time}", System.DateTime.UtcNow);
+
+            ConsentGiven = true;
+            _step = Step.Calibrate;
+            UpdateUiForStep();
+        }
+    }
+}


### PR DESCRIPTION
462 lines, 2 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351