### PR TITLE
feat(avalonia): port small input dialogs, part 1/2 - Input, ProfilePrivacy, OfflineUsername, DisplayName, RoadmapDiary

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml
@@ -1,0 +1,88 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/DisplayNameDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None" -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="False"                 -> dropped (Avalonia default)
+       Height="240"                               -> 260: the star row holding the 0/20 counter
+                                                     collapsed to nothing under Linux font metrics
+       KeyDown="..." / Click="..."                -> wired in the constructor
+       Window.Resources PinkBrush/DarkPinkBrush   -> dropped. PinkBrush re-declared the global
+                                                     brush with the same colour; DarkPinkBrush was
+                                                     never referenced. WarningBrush is kept.
+     The warning label, warning text and prompt gained x:Names: the WPF delete-mode constructor
+     reached them by walking Children[n], which Avalonia can do too but a name is honest.
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.DisplayNameDialog"
+        Title="{loc:Str dialog_choose_your_display_name}"
+        Height="260" Width="450"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False"
+        SystemDecorations="None">
+
+    <Window.Resources>
+        <SolidColorBrush x:Key="WarningBrush" Color="#FFB347"/>
+    </Window.Resources>
+
+    <Border BorderBrush="{StaticResource PinkBrush}" BorderThickness="1" CornerRadius="0">
+        <Grid Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <TextBlock x:Name="TxtTitle" Grid.Row="0" Text="{loc:Str label_welcome_choose_your_display_name}"
+                       Foreground="{StaticResource PinkBrush}"
+                       FontSize="18" FontWeight="Bold" Margin="0,0,0,10"
+                       HorizontalAlignment="Center"/>
+
+            <!-- Warning -->
+            <Border x:Name="WarningPanel" Grid.Row="1" Background="#2A2A3E" CornerRadius="4" Padding="12,8" Margin="0,0,0,15">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock x:Name="TxtWarningLabel" Text="{loc:Str label_warning}" Foreground="{StaticResource WarningBrush}"
+                               FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
+                    <TextBlock x:Name="TxtWarningText" Text="{loc:Str label_this_name_cannot_be_changed_later}"
+                               Foreground="{StaticResource WarningBrush}"
+                               FontSize="12" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Prompt -->
+            <TextBlock x:Name="TxtPrompt" Grid.Row="2" Text="{loc:Str label_enter_the_name_you_d_like_to_be_called}"
+                       Foreground="White" FontSize="13" Margin="0,0,0,8"/>
+
+            <!-- Input -->
+            <TextBox x:Name="TxtDisplayName" Grid.Row="3"
+                     Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                     BorderBrush="{StaticResource PinkBrush}"
+                     Padding="12,10" FontSize="15"
+                     MaxLength="20"/>
+
+            <!-- Character count -->
+            <TextBlock x:Name="TxtCharCount" Grid.Row="4" Text="{loc:Str label_0_20_characters}"
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,5,0,0"
+                       HorizontalAlignment="Right" VerticalAlignment="Top"/>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+                <Button x:Name="BtnCancel" Width="90" Padding="10,10" Margin="0,0,10,0"
+                        Background="{DynamicResource PanelAccentBrush}" Foreground="White" BorderThickness="0"
+                        Cursor="Hand" FontSize="13">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnConfirm" Width="90" Padding="10,10"
+                        Background="{StaticResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="13"
+                        Cursor="Hand" IsEnabled="False">
+                    <TextBlock x:Name="TxtConfirm" Text="{loc:Str btn_confirm}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml.cs
@@ -1,0 +1,131 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/DisplayNameDialog.xaml.cs. Deviations:
+    ///  - DialogResult becomes Close(bool).
+    ///  - Delete mode addresses the warning label/text and prompt by x:Name instead of walking
+    ///    Children[n]; the ordering it relied on is unchanged in the markup.
+    ///  - The MessageBox in Accept() guarded a path the UI already blocks (Confirm disabled and
+    ///    Enter ignored outside 2-20 characters), so it is a plain return here.
+    /// The parameterless constructor is the real "welcome" mode and doubles as the render ctor.
+    /// </summary>
+    public partial class DisplayNameDialog : Window
+    {
+        private static readonly IBrush DeleteRed = Brush.Parse("#FF4444");
+
+        private readonly TextBox _txtDisplayName;
+        private readonly Button _btnConfirm;
+        private readonly TextBlock _txtCharCount;
+        private bool _isDeleteMode;
+
+        public string DisplayName { get; private set; } = "";
+
+        public DisplayNameDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtDisplayName = this.FindControl<TextBox>("TxtDisplayName")!;
+            _btnConfirm = this.FindControl<Button>("BtnConfirm")!;
+            _txtCharCount = this.FindControl<TextBlock>("TxtCharCount")!;
+
+            _txtDisplayName.TextChanged += (_, _) => OnTextChanged();
+            _txtDisplayName.KeyDown += TxtDisplayName_KeyDown;
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            _btnConfirm.Click += (_, _) => Accept();
+
+            Loaded += (_, _) => _txtDisplayName.Focus();
+        }
+
+        public DisplayNameDialog(bool isChangeName, string? currentName) : this()
+        {
+            if (isChangeName)
+            {
+                this.FindControl<TextBlock>("TxtTitle")!.Text = Loc.Get("label_change_your_display_name");
+                this.FindControl<Border>("WarningPanel")!.IsVisible = false;
+
+                if (!string.IsNullOrEmpty(currentName))
+                {
+                    _txtDisplayName.Text = currentName;
+                    _txtDisplayName.SelectAll();
+                }
+            }
+        }
+
+        public DisplayNameDialog(string confirmationMode) : this()
+        {
+            if (confirmationMode == "delete")
+            {
+                _isDeleteMode = true;
+                var title = this.FindControl<TextBlock>("TxtTitle")!;
+                title.Text = Loc.Get("label_delete_your_profile");
+                title.Foreground = DeleteRed;
+
+                // Red-tinted warning
+                this.FindControl<Border>("WarningPanel")!.IsVisible = true;
+                var warningLabel = this.FindControl<TextBlock>("TxtWarningLabel")!;
+                var warningText = this.FindControl<TextBlock>("TxtWarningText")!;
+                warningLabel.Text = Loc.Get("label_warning_2");
+                warningLabel.Foreground = DeleteRed;
+                warningText.Text = Loc.Get("label_this_will_permanently_delete_all_your_data_an");
+                warningText.Foreground = DeleteRed;
+
+                // Update prompt and button
+                this.FindControl<TextBlock>("TxtPrompt")!.Text = Loc.Get("label_type_delete_to_confirm");
+                this.FindControl<TextBlock>("TxtConfirm")!.Text = Loc.Get("btn_delete");
+                _btnConfirm.Background = DeleteRed;
+
+                _txtDisplayName.MaxLength = 6;
+                _txtDisplayName.Text = "";
+                _txtCharCount.IsVisible = false;
+            }
+        }
+
+        private void OnTextChanged()
+        {
+            var text = (_txtDisplayName.Text ?? "").Trim();
+            if (_isDeleteMode)
+            {
+                _btnConfirm.IsEnabled = text == "DELETE";
+            }
+            else
+            {
+                var length = text.Length;
+                _txtCharCount.Text = Loc.GetF("label_char_count_of_max", length, 20);
+                _btnConfirm.IsEnabled = length >= 2 && length <= 20;
+            }
+        }
+
+        private void TxtDisplayName_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && _btnConfirm.IsEnabled)
+                Accept();
+            else if (e.Key == Key.Escape)
+                Close(false);
+        }
+
+        private void Accept()
+        {
+            var name = (_txtDisplayName.Text ?? "").Trim();
+
+            if (_isDeleteMode)
+            {
+                if (name != "DELETE") return;
+                DisplayName = name;
+                Close(true);
+                return;
+            }
+
+            if (name.Length < 2 || name.Length > 20)
+                return;
+
+            DisplayName = name;
+            Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/InputDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/InputDialog.axaml
@@ -1,0 +1,59 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/InputDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None" -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="False"                 -> dropped (Avalonia default)
+       KeyDown="..." / Click="..."                -> wired in the constructor
+       <Window.Resources/>                        -> dropped, it was empty
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key and the loc keys are snake_case (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.InputDialog"
+        Title="{loc:Str dialog_input}"
+        Height="180" Width="400"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False"
+        SystemDecorations="None"
+        Topmost="True">
+
+    <Border BorderBrush="{StaticResource PinkBrush}" BorderThickness="1" CornerRadius="0">
+        <Grid Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <TextBlock x:Name="TxtTitle" Grid.Row="0" Text="{loc:Str label_title}"
+                       Foreground="{StaticResource PinkBrush}"
+                       FontSize="16" FontWeight="Bold" Margin="0,0,0,10"/>
+
+            <!-- Prompt -->
+            <TextBlock x:Name="TxtPrompt" Grid.Row="1" Text="{loc:Str label_enter_value}"
+                       Foreground="White" FontSize="12" Margin="0,0,0,8"/>
+
+            <!-- Input -->
+            <TextBox x:Name="TxtInput" Grid.Row="2"
+                     Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                     BorderBrush="{StaticResource PinkBrush}"
+                     Padding="10,8" FontSize="14"/>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+                <Button x:Name="BtnCancel" Width="80" Padding="10,8" Margin="0,0,10,0"
+                        Background="{DynamicResource PanelAccentBrush}" Foreground="White" BorderThickness="0"
+                        Cursor="Hand">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnOK" Content="OK" Width="80" Padding="10,8"
+                        Background="{StaticResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold"
+                        Cursor="Hand"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/InputDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/InputDialog.axaml.cs
@@ -1,0 +1,54 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/InputDialog.xaml.cs. WPF's DialogResult
+    /// becomes Close(bool): Avalonia hands the result back through ShowDialog&lt;bool?&gt;.
+    /// </summary>
+    public partial class InputDialog : Window
+    {
+        private readonly TextBox _txtInput;
+
+        public string ResultText { get; private set; } = "";
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        public InputDialog() : this("Sample title", "Enter a sample value:", "default") { }
+
+        public InputDialog(string title, string prompt, string defaultValue = "")
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtInput = this.FindControl<TextBox>("TxtInput")!;
+            this.FindControl<TextBlock>("TxtTitle")!.Text = title;
+            this.FindControl<TextBlock>("TxtPrompt")!.Text = prompt;
+            _txtInput.Text = defaultValue;
+
+            _txtInput.KeyDown += TxtInput_KeyDown;
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnOK")!.Click += (_, _) => Accept();
+
+            Loaded += (_, _) =>
+            {
+                _txtInput.Focus();
+                _txtInput.SelectAll();
+            };
+        }
+
+        private void TxtInput_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+                Accept();
+            else if (e.Key == Key.Escape)
+                Close(false);
+        }
+
+        private void Accept()
+        {
+            ResultText = _txtInput.Text ?? "";
+            Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/OfflineUsernameDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/OfflineUsernameDialog.axaml
@@ -1,0 +1,82 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/OfflineUsernameDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None" -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="False"                 -> dropped (Avalonia default)
+       KeyDown="..." / Click="..."                -> wired in the constructor
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.OfflineUsernameDialog"
+        Title="{loc:Str dialog_choose_your_offline_username}"
+        Height="300" Width="450"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False"
+        SystemDecorations="None">
+
+    <Window.Resources>
+        <SolidColorBrush x:Key="InfoBrush" Color="#88AAFF"/>
+    </Window.Resources>
+
+    <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" CornerRadius="0">
+        <Grid Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <TextBlock Grid.Row="0" Text="{loc:Str dialog_choose_your_offline_username}"
+                       Foreground="{DynamicResource PinkBrush}"
+                       FontSize="18" FontWeight="Bold" Margin="0,0,0,10"
+                       HorizontalAlignment="Center"/>
+
+            <!-- Info Box -->
+            <Border Grid.Row="1" Background="#2A2A3E" CornerRadius="4" Padding="12,8" Margin="0,0,0,15">
+                <StackPanel>
+                    <TextBlock Text="{loc:Str label_offline_progress_is_stored_locally_only_and_c}"
+                               Foreground="{StaticResource InfoBrush}"
+                               FontSize="12" TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock Text="{loc:Str label_you_can_change_this_name_later_in_settings}"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11" Margin="0,5,0,0" TextAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Prompt -->
+            <TextBlock Grid.Row="2" Text="{loc:Str label_enter_the_name_you_d_like_to_use}"
+                       Foreground="White" FontSize="13" Margin="0,0,0,8"/>
+
+            <!-- Input -->
+            <TextBox x:Name="TxtUsername" Grid.Row="3"
+                     Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                     BorderBrush="{DynamicResource PinkBrush}"
+                     Padding="12,10" FontSize="15"
+                     MaxLength="30"/>
+
+            <!-- Character count -->
+            <TextBlock x:Name="TxtCharCount" Grid.Row="4" Text="{loc:Str label_0_30_characters}"
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,5,0,0"
+                       HorizontalAlignment="Right" VerticalAlignment="Top"/>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+                <Button x:Name="BtnCancel" Width="90" Padding="10,10" Margin="0,0,10,0"
+                        Background="#555577" Foreground="White" BorderThickness="0"
+                        Cursor="Hand" FontSize="13" FontWeight="SemiBold">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnConfirm" Width="90" Padding="10,10"
+                        Background="{DynamicResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="13"
+                        Cursor="Hand" IsEnabled="False">
+                    <TextBlock Text="{loc:Str btn_confirm}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/OfflineUsernameDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/OfflineUsernameDialog.axaml.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/OfflineUsernameDialog.xaml.cs. DialogResult
+    /// becomes Close(bool). The WPF MessageBox in Accept() guarded a path the UI already blocks
+    /// (Confirm is disabled and Enter ignored below two characters), so here it is a plain return.
+    /// </summary>
+    public partial class OfflineUsernameDialog : Window
+    {
+        private readonly TextBox _txtUsername;
+        private readonly Button _btnConfirm;
+
+        public string Username { get; private set; } = "";
+
+        public OfflineUsernameDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtUsername = this.FindControl<TextBox>("TxtUsername")!;
+            _btnConfirm = this.FindControl<Button>("BtnConfirm")!;
+            var txtCharCount = this.FindControl<TextBlock>("TxtCharCount")!;
+
+            _txtUsername.TextChanged += (_, _) =>
+            {
+                var length = (_txtUsername.Text ?? "").Trim().Length;
+                txtCharCount.Text = Loc.GetF("label_char_count_of_max", length, 30);
+                _btnConfirm.IsEnabled = length >= 2;
+            };
+
+            _txtUsername.KeyDown += TxtUsername_KeyDown;
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            _btnConfirm.Click += (_, _) => Accept();
+
+            Loaded += (_, _) => _txtUsername.Focus();
+        }
+
+        private void TxtUsername_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && _btnConfirm.IsEnabled)
+                Accept();
+            else if (e.Key == Key.Escape)
+                Close(false);
+        }
+
+        private void Accept()
+        {
+            var name = (_txtUsername.Text ?? "").Trim();
+            if (name.Length < 2)
+                return;
+
+            Username = name;
+            Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/ProfilePrivacyDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/ProfilePrivacyDialog.axaml
@@ -1,0 +1,69 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/ProfilePrivacyDialog.xaml. Deviations, all forced:
+       ResizeMode="CanResize"              -> CanResize="True"
+       FontFamily="/Fonts/#Fredoka, ..."   -> FontFamily="Fredoka, Segoe UI" (font asset not
+                                              shipped by this head yet; renders where installed)
+       DropShadowEffect ShadowDepth="0"    -> OffsetX/OffsetY="0" (Avalonia's property names)
+       Click="..."                         -> wired in the constructor
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.ProfilePrivacyDialog"
+        Title="Privacy &amp; Sharing"
+        Width="500" Height="700" MinWidth="420" MinHeight="420"
+        Background="{DynamicResource DarkerBgBrush}"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        ShowInTaskbar="False">
+
+    <!-- Host for the single long-lived ProfilePrivacyPanel instance owned by the Discord tab.
+         The panel is attached in the constructor and detached on Closed so the next open can
+         re-parent the same instance (an element may have only one parent at a time). -->
+    <Grid Margin="18,16,18,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,14">
+            <TextBlock Text="{loc:Str profile_privacy_title}"
+                       FontFamily="Fredoka, Segoe UI" FontWeight="SemiBold"
+                       FontSize="22" Foreground="White">
+                <TextBlock.Effect>
+                    <DropShadowEffect Color="#FF69B4" BlurRadius="16" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                </TextBlock.Effect>
+            </TextBlock>
+            <TextBlock Text="{loc:Str profile_privacy_sub}" Foreground="#9A93B8" FontSize="12"
+                       TextWrapping="Wrap" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                      Padding="0,0,8,0">
+            <Border x:Name="PanelHost"/>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="2" Margin="0,14,0,0">
+            <TextBlock Text="{loc:Str label_all_sharing_is_opt_in}" Foreground="#B478FF"
+                       FontSize="11" FontStyle="Italic" Margin="0,0,0,10"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <!-- Discord-specific CTA: blurple is allowed here. -->
+                <Button x:Name="BtnJoinDiscord" Grid.Column="0"
+                        Background="#5865F2" Foreground="White" BorderThickness="0"
+                        Padding="15,10" FontWeight="Bold" FontSize="12" Cursor="Hand"
+                        HorizontalAlignment="Left">
+                    <TextBlock Text="{loc:Str btn_join_discord_server}"/>
+                </Button>
+                <Button x:Name="BtnClose" Grid.Column="1"
+                        Background="#FF69B4" Foreground="Black" BorderThickness="0"
+                        Padding="24,10" FontWeight="Bold" FontSize="12" Cursor="Hand">
+                    <TextBlock Text="{loc:Str btn_close}"/>
+                </Button>
+            </Grid>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/ProfilePrivacyDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ProfilePrivacyDialog.axaml.cs
@@ -1,0 +1,42 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Avalonia.Views.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/ProfilePrivacyDialog.xaml.cs. Holds the
+    /// Profile tab's relocated sharing controls. The dialog owns no state of its own: it borrows
+    /// the long-lived <see cref="ProfilePrivacyPanel"/> instance for as long as it is open, then
+    /// hands it back on close so the host keeps writing into the same controls.
+    /// </summary>
+    public partial class ProfilePrivacyDialog : Window
+    {
+        private readonly Border _panelHost;
+
+        /// <summary>Render/design constructor: a fresh panel so --render-view can draw the dialog.</summary>
+        public ProfilePrivacyDialog() : this(new ProfilePrivacyPanel()) { }
+
+        public ProfilePrivacyDialog(ProfilePrivacyPanel panel)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _panelHost = this.FindControl<Border>("PanelHost")!;
+
+            // An element has exactly one parent: if a previous dialog was torn down without its
+            // Closed handler running, detach before re-parenting rather than throwing.
+            if (panel.Parent is Border previous)
+                previous.Child = null;
+            _panelHost.Child = panel;
+
+            Closed += (_, _) => _panelHost.Child = null;
+            this.FindControl<Button>("BtnJoinDiscord")!.Click += (_, _) => BtnJoinDiscord_Click();
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+        }
+
+        private void BtnJoinDiscord_Click()
+        {
+            // ponytail: needs MainWindow.BtnDiscord_Click (opens the invite URL), wired when it moves to Core
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/RoadmapDiaryDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapDiaryDialog.axaml
@@ -1,0 +1,151 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/RoadmapDiaryDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None"   -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="False"                   -> dropped; Background="Transparent" kept and
+                                                       TransparencyLevelHint added so the rounded
+                                                       border shows against the desktop
+       Visibility="Collapsed"                       -> IsVisible="False"
+       RenderOptions.BitmapScalingMode="HighQuality"-> RenderOptions.BitmapInterpolationMode
+       Button.Style IsMouseOver triggers            -> Window.Styles :pointerover selectors on
+                                                       the .close / .save / .cancel classes
+       Click="..."                                  -> wired in the constructor
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.RoadmapDiaryDialog"
+        Title="{loc:Str dialog_transformation_diary}"
+        Width="500" Height="700"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="False"
+        Topmost="True">
+
+    <Window.Styles>
+        <Style Selector="Button.close:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+        </Style>
+        <Style Selector="Button.save:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#FF1493"/>
+        </Style>
+        <Style Selector="Button.cancel:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{StaticResource PinkBrush}" BorderThickness="2" CornerRadius="15">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>  <!-- Header -->
+                <RowDefinition Height="Auto"/>  <!-- Photo -->
+                <RowDefinition Height="Auto"/>  <!-- Step Info -->
+                <RowDefinition Height="Auto"/>  <!-- Stats -->
+                <RowDefinition Height="*"/>     <!-- Note -->
+                <RowDefinition Height="Auto"/>  <!-- Buttons -->
+            </Grid.RowDefinitions>
+
+            <!-- Header with Close Button -->
+            <Grid Grid.Row="0" Margin="0,0,0,15">
+                <StackPanel>
+                    <TextBlock x:Name="TxtStepNumber" Text="{loc:Str label_step_1_2}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="12"/>
+                    <TextBlock x:Name="TxtStepTitle" Text="{loc:Str label_the_blank_slate}"
+                               Foreground="{StaticResource PinkBrush}" FontSize="20" FontWeight="Bold"/>
+                </StackPanel>
+                <Button x:Name="BtnCloseX" Classes="close" Content="X" HorizontalAlignment="Right" VerticalAlignment="Top"
+                        Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                        BorderThickness="0" FontSize="16" FontWeight="Bold"
+                        Cursor="Hand" Padding="5"/>
+            </Grid>
+
+            <!-- Full Resolution Photo -->
+            <Border Grid.Row="1" CornerRadius="12" Background="{DynamicResource PanelBgBrush}"
+                    Margin="0,0,0,15" Height="280" ClipToBounds="True">
+                <Grid>
+                    <Image x:Name="ImgFullPhoto" Stretch="Uniform"
+                           RenderOptions.BitmapInterpolationMode="HighQuality"/>
+                    <TextBlock x:Name="TxtNoPhoto" Text="{loc:Str label_no_photo_available}"
+                               Foreground="{DynamicResource TextDimBrush}" FontSize="14"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               IsVisible="False"/>
+                </Grid>
+            </Border>
+
+            <!-- Objective/Requirement -->
+            <Border Grid.Row="2" Background="{DynamicResource PanelBgBrush}" CornerRadius="10"
+                    Padding="15" Margin="0,0,0,15">
+                <StackPanel>
+                    <TextBlock Text="{loc:Str label_objective}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,0,0,4"/>
+                    <TextBlock x:Name="TxtObjective" Text="" Foreground="White"
+                               FontSize="13" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Completion Stats -->
+            <Border Grid.Row="3" Background="{DynamicResource PanelBgBrush}" CornerRadius="10"
+                    Padding="15" Margin="0,0,0,15">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" HorizontalAlignment="Center">
+                        <TextBlock Text="{loc:Str label_completed}" Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="TxtCompletedDate" Text="{loc:Str label_jan_15_2024}"
+                                   Foreground="White" FontSize="14" FontWeight="Bold"
+                                   HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                        <TextBlock x:Name="TxtCompletedTime" Text="{loc:Str label_3_45_pm}"
+                                   Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                                   HorizontalAlignment="Center"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+                        <TextBlock Text="{loc:Str label_time_taken}" Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="11" HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="TxtTimeTaken" Text="{loc:Str label_45_minutes}"
+                                   Foreground="White" FontSize="14" FontWeight="Bold"
+                                   HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- User Note -->
+            <Border Grid.Row="4" Background="{DynamicResource PanelBgBrush}" CornerRadius="10" Padding="15">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Text="{loc:Str label_personal_note}" Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11" Margin="0,0,0,8"/>
+                    <TextBox x:Name="TxtUserNote" Grid.Row="1"
+                             Background="Transparent" Foreground="White"
+                             BorderThickness="0" TextWrapping="Wrap"
+                             AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             FontSize="13" Padding="0"
+                             CaretBrush="{StaticResource PinkBrush}"/>
+                </Grid>
+            </Border>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="5" Orientation="Horizontal"
+                        HorizontalAlignment="Center" Margin="0,15,0,0">
+                <Button x:Name="BtnSaveNote" Classes="save" Background="{StaticResource PinkBrush}"
+                        Foreground="White" Padding="20,10"
+                        BorderThickness="0" Cursor="Hand" Margin="0,0,10,0"
+                        FontWeight="Bold">
+                    <TextBlock x:Name="TxtSaveNote" Text="{loc:Str btn_save_note}"/>
+                </Button>
+                <Button x:Name="BtnClose" Classes="cancel" Background="{DynamicResource PanelAccentBrush}"
+                        Foreground="White" Padding="20,10"
+                        BorderThickness="0" Cursor="Hand">
+                    <TextBlock Text="{loc:Str btn_close}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/RoadmapDiaryDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapDiaryDialog.axaml.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/RoadmapDiaryDialog.xaml.cs. Deviations:
+    ///  - BitmapImage -> Avalonia.Media.Imaging.Bitmap(path).
+    ///  - The "Saved!" flash swaps the button's TextBlock text (the button holds a TextBlock, not
+    ///    Content) and uses DispatcherTimer.RunOnce instead of a hand-rolled timer.
+    ///  - App.Roadmap (photo path resolution, note persistence) is a head service: see the
+    ///    ponytail stubs. A PhotoPath that is already absolute still loads.
+    /// </summary>
+    public partial class RoadmapDiaryDialog : Window
+    {
+        private readonly string _stepId;
+        private readonly RoadmapStepProgress _progress;
+        private readonly Image _imgFullPhoto;
+        private readonly TextBlock _txtNoPhoto;
+        private readonly TextBox _txtUserNote;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        public RoadmapDiaryDialog() : this("t1_step1",
+            new RoadmapStepDefinition("t1_step1", RoadmapTrack.EmptyDoll, 1, "The Blank Slate",
+                "Sit still for five minutes and let every thought drain away.", "A photo of your empty desk"),
+            new RoadmapStepProgress("t1_step1")
+            {
+                IsCompleted = true,
+                CompletedAt = new DateTime(2024, 1, 15, 15, 45, 0),
+                TimeToCompleteMinutes = 45,
+                UserNote = "It was easier than I expected."
+            })
+        { }
+
+        public RoadmapDiaryDialog(string stepId, RoadmapStepDefinition stepDef, RoadmapStepProgress progress)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _stepId = stepId;
+            _progress = progress;
+
+            _imgFullPhoto = this.FindControl<Image>("ImgFullPhoto")!;
+            _txtNoPhoto = this.FindControl<TextBlock>("TxtNoPhoto")!;
+            _txtUserNote = this.FindControl<TextBox>("TxtUserNote")!;
+
+            // Set step info
+            this.FindControl<TextBlock>("TxtStepNumber")!.Text = stepDef.StepType == RoadmapStepType.Boss
+                ? $"BOSS - Step {stepDef.StepNumber}"
+                : $"Step {stepDef.StepNumber}";
+            this.FindControl<TextBlock>("TxtStepTitle")!.Text = stepDef.Title;
+            this.FindControl<TextBlock>("TxtObjective")!.Text = stepDef.Objective;
+
+            // Load photo
+            LoadPhoto();
+
+            // Populate stats
+            var completedDate = this.FindControl<TextBlock>("TxtCompletedDate")!;
+            var completedTime = this.FindControl<TextBlock>("TxtCompletedTime")!;
+            if (progress.CompletedAt.HasValue)
+            {
+                completedDate.Text = progress.CompletedAt.Value.ToString("MMM d, yyyy");
+                completedTime.Text = progress.CompletedAt.Value.ToString("h:mm tt");
+            }
+            else
+            {
+                completedDate.Text = "N/A";
+                completedTime.Text = "";
+            }
+
+            this.FindControl<TextBlock>("TxtTimeTaken")!.Text = progress.TimeToCompleteMinutes > 0
+                ? $"{progress.TimeToCompleteMinutes} min"
+                : "N/A";
+
+            _txtUserNote.Text = progress.UserNote ?? "";
+
+            this.FindControl<Button>("BtnSaveNote")!.Click += (_, _) => BtnSaveNote_Click();
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            this.FindControl<Button>("BtnCloseX")!.Click += (_, _) => Close();
+        }
+
+        private void LoadPhoto()
+        {
+            try
+            {
+                // ponytail: needs RoadmapService.GetFullPhotoPath for a diary-relative path, wired when it moves to Core
+                var fullPath = _progress.PhotoPath;
+                if (!string.IsNullOrEmpty(fullPath) && Path.IsPathRooted(fullPath) && File.Exists(fullPath))
+                {
+                    _imgFullPhoto.Source = new Bitmap(fullPath);
+                    _txtNoPhoto.IsVisible = false;
+                    return;
+                }
+
+                // No photo available
+                _imgFullPhoto.Source = null;
+                _txtNoPhoto.IsVisible = true;
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Error(ex, "Failed to load diary photo");
+                _imgFullPhoto.Source = null;
+                _txtNoPhoto.IsVisible = true;
+            }
+        }
+
+        private void BtnSaveNote_Click()
+        {
+            var newNote = _txtUserNote.Text?.Trim();
+            // ponytail: needs RoadmapService.UpdateStepNote(_stepId, newNote), wired when it moves to Core
+            _progress.UserNote = newNote;
+
+            // Visual feedback
+            var btn = this.FindControl<Button>("BtnSaveNote")!;
+            var label = this.FindControl<TextBlock>("TxtSaveNote")!;
+            var originalText = label.Text;
+            label.Text = Loc.Get("btn_saved");
+            btn.IsEnabled = false;
+
+            DispatcherTimer.RunOnce(() =>
+            {
+                label.Text = originalText;
+                btn.IsEnabled = true;
+            }, TimeSpan.FromSeconds(1));
+        }
+    }
+}


### PR DESCRIPTION
867 lines, 10 files. DisplayNameDialog height 240 to 260 so the character counter is not clipped under Linux font metrics; noted in the file header.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351