### PR TITLE
feat(avalonia): port small input dialogs, part 2/2 - ColorEditor, LockCardColor

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/ColorEditorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/ColorEditorDialog.axaml
@@ -1,0 +1,125 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize"            -> CanResize="False"
+       Style="{StaticResource X}"       -> Theme="{StaticResource X}"
+       ToolTip="..."                    -> ToolTip.Tip="..."
+       Visibility="Collapsed"           -> IsVisible="False"
+       Click="..."                      -> wired in the constructor
+       <Window.Resources/>              -> dropped, it held only a comment
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.ColorEditorDialog"
+        Title="{loc:Str dialog_subliminal_colors}"
+        Height="480" Width="450"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0" Text="{loc:Str label_subliminal_colors}"
+                   Foreground="{StaticResource PinkBrush}"
+                   FontSize="18" FontWeight="Bold" Margin="0,0,0,20"/>
+
+        <!-- Color Settings -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,20">
+
+            <!-- Background Color -->
+            <Grid Margin="0,0,0,15">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_background}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnBgColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change}"/>
+                <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="15,0,0,0" VerticalAlignment="Center">
+                    <TextBlock Text="{loc:Str label_transparent}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <CheckBox x:Name="ChkBgTransparent" Theme="{StaticResource ToggleStyle}"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Text Color -->
+            <Grid Margin="0,0,0,15">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_text_5}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnTextColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change}"/>
+                <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="15,0,0,0" VerticalAlignment="Center"
+                            IsVisible="False">
+                    <TextBlock Text="{loc:Str label_transparent}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <CheckBox x:Name="ChkTextTransparent" Theme="{StaticResource ToggleStyle}"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Border Color -->
+            <Grid Margin="0,0,0,15">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_border_outline}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnBorderColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change}"/>
+            </Grid>
+
+            <!-- Steal Focus Toggle -->
+            <Grid Margin="0,10,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock Text="{loc:Str label_steal_keyboard_focus}" Foreground="{StaticResource TextLightBrush}"
+                               FontSize="14"/>
+                    <TextBlock Text="{loc:Str label_forces_attention_by_stealing_keyboard_focus_w}"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,2,0,0"/>
+                </StackPanel>
+                <CheckBox x:Name="ChkStealsFocus" Grid.Column="1" Theme="{StaticResource ToggleStyle}"
+                          VerticalAlignment="Center"/>
+            </Grid>
+        </StackPanel>
+
+        <!-- Preview -->
+        <Border Grid.Row="2" x:Name="PreviewBorder" Background="Black" CornerRadius="8"
+                Height="80" Margin="0,0,0,20">
+            <TextBlock x:Name="PreviewText" Text="{loc:Str label_good_girl}"
+                       FontSize="28" FontWeight="Bold" FontFamily="Arial, Segoe UI"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        </Border>
+
+        <!-- Buttons -->
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="BtnCancel" Grid.Column="1" Theme="{StaticResource SecondaryButton}"
+                    Margin="0,0,10,0">
+                <TextBlock Text="{loc:Str btn_cancel}"/>
+            </Button>
+            <Button x:Name="BtnSave" Grid.Column="2" Theme="{StaticResource ActionButton}">
+                <TextBlock Text="{loc:Str btn_save}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/ColorEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ColorEditorDialog.axaml.cs
@@ -1,0 +1,139 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Dialog for editing subliminal text colors.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml.cs. Deviations:
+    ///  - DialogResult becomes Close(bool).
+    ///  - App.Settings (AppSettings lives in the WPF head) is stubbed: the dialog opens on the
+    ///    WPF defaults and Save writes nowhere. FontPickerHelper is likewise a head helper, so the
+    ///    preview keeps the markup's Arial.
+    ///  - System.Windows.Forms.ColorDialog has no Avalonia twin in the referenced packages, so
+    ///    ShowColorPicker is a stub that returns null (no change).
+    ///  - The text outline stays a DropShadowEffect - Avalonia.Media has the same type.
+    /// </summary>
+    public partial class ColorEditorDialog : Window
+    {
+        private Color _bgColor;
+        private Color _textColor;
+        private Color _borderColor;
+
+        private readonly Button _btnBgColor;
+        private readonly Button _btnTextColor;
+        private readonly Button _btnBorderColor;
+        private readonly CheckBox _chkBgTransparent;
+        private readonly CheckBox _chkTextTransparent;
+        private readonly CheckBox _chkStealsFocus;
+        private readonly Border _previewBorder;
+        private readonly TextBlock _previewText;
+
+        public ColorEditorDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _btnBgColor = this.FindControl<Button>("BtnBgColor")!;
+            _btnTextColor = this.FindControl<Button>("BtnTextColor")!;
+            _btnBorderColor = this.FindControl<Button>("BtnBorderColor")!;
+            _chkBgTransparent = this.FindControl<CheckBox>("ChkBgTransparent")!;
+            _chkTextTransparent = this.FindControl<CheckBox>("ChkTextTransparent")!;
+            _chkStealsFocus = this.FindControl<CheckBox>("ChkStealsFocus")!;
+            _previewBorder = this.FindControl<Border>("PreviewBorder")!;
+            _previewText = this.FindControl<TextBlock>("PreviewText")!;
+
+            LoadCurrentSettings();
+            UpdatePreview();
+
+            _btnBgColor.Click += (_, _) => Pick(ref _bgColor);
+            _btnTextColor.Click += (_, _) => Pick(ref _textColor);
+            _btnBorderColor.Click += (_, _) => Pick(ref _borderColor);
+            _chkBgTransparent.IsCheckedChanged += (_, _) => UpdatePreview();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
+        }
+
+        private void LoadCurrentSettings()
+        {
+            // ponytail: needs SettingsManager (App.Settings.Current.Sub*), wired when it moves to Core.
+            // Values below are the WPF fallbacks for an unset setting.
+            _bgColor = ParseColor("", Colors.Black);
+            _textColor = ParseColor("", Color.FromRgb(255, 0, 255));
+            _borderColor = ParseColor("", Colors.White);
+
+            _chkBgTransparent.IsChecked = false;
+            _chkTextTransparent.IsChecked = false;
+            _chkStealsFocus.IsChecked = false;
+
+            UpdateColorButtons();
+        }
+
+        private void UpdateColorButtons()
+        {
+            _btnBgColor.Background = new SolidColorBrush(_bgColor);
+            _btnTextColor.Background = new SolidColorBrush(_textColor);
+            _btnBorderColor.Background = new SolidColorBrush(_borderColor);
+        }
+
+        private void UpdatePreview()
+        {
+            if (_chkBgTransparent.IsChecked == true)
+            {
+                _previewBorder.Background = this.TryFindResource("DarkerBgBrush", out var brush) && brush is IBrush b
+                    ? b
+                    : new SolidColorBrush(Color.FromRgb(26, 26, 46));
+            }
+            else
+            {
+                _previewBorder.Background = new SolidColorBrush(_bgColor);
+            }
+
+            // Create text with outline effect in preview
+            _previewText.Foreground = new SolidColorBrush(_textColor);
+
+            // Add stroke effect using TextBlock's effect
+            _previewText.Effect = new DropShadowEffect
+            {
+                Color = _borderColor,
+                OffsetX = 0,
+                OffsetY = 0,
+                BlurRadius = 3,
+                Opacity = 1
+            };
+        }
+
+        private void Pick(ref Color target)
+        {
+            var color = ShowColorPicker(target);
+            if (color.HasValue)
+            {
+                target = color.Value;
+                UpdateColorButtons();
+                UpdatePreview();
+            }
+        }
+
+        private Color? ShowColorPicker(Color currentColor)
+        {
+            // ponytail: needs a colour picker (WPF used System.Windows.Forms.ColorDialog); Avalonia's
+            // ColorPicker lives in a package this head does not reference yet. Returns "no change".
+            return null;
+        }
+
+        private void BtnSave_Click()
+        {
+            // ponytail: needs SettingsManager to persist Sub* colours and the two toggles, wired when it moves to Core
+            Serilog.Log.Information("Subliminal settings updated");
+            Close(true);
+        }
+
+        private static Color ParseColor(string hex, Color fallback)
+        {
+            if (string.IsNullOrEmpty(hex)) return fallback;
+            if (!hex.StartsWith("#")) hex = "#" + hex;
+            return Color.TryParse(hex, out var color) ? color : fallback;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/LockCardColorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/LockCardColorDialog.axaml
@@ -1,0 +1,142 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/LockCardColorDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize"            -> CanResize="False"
+       Style="{StaticResource X}"       -> Theme="{StaticResource X}"
+       ToolTip="..."                    -> ToolTip.Tip="..."
+       Click="..."                      -> wired in the constructor
+       <Window.Resources/>              -> dropped, it was empty
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.LockCardColorDialog"
+        Title="{loc:Str dialog_lock_card_colors}"
+        Height="700" Width="600"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0" Text="{loc:Str label_lock_card_colors}"
+                   Foreground="{StaticResource PinkBrush}"
+                   FontSize="18" FontWeight="Bold" Margin="0,0,0,20"/>
+
+        <!-- Color Settings -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,20">
+
+            <!-- Background Color -->
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_background}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnBgColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change_background_color}"/>
+            </Grid>
+
+            <!-- Text Color (Phrase) -->
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_phrase_text}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnTextColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change_phrase_text_color}"/>
+            </Grid>
+
+            <!-- Input Background Color -->
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_input_background}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnInputBgColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change_input_field_background}"/>
+            </Grid>
+
+            <!-- Input Text Color -->
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_input_text}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnInputTextColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change_input_text_color}"/>
+            </Grid>
+
+            <!-- Accent Color -->
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="150"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{loc:Str label_accent_progress}" Foreground="{StaticResource TextLightBrush}"
+                           FontSize="14" VerticalAlignment="Center"/>
+                <Button x:Name="BtnAccentColor" Grid.Column="1" Theme="{StaticResource ColorButtonLarge}"
+                        ToolTip.Tip="{loc:Str tooltip_click_to_change_accent_color_progress_bar_bor}"/>
+            </Grid>
+        </StackPanel>
+
+        <!-- Preview -->
+        <Border Grid.Row="2" x:Name="PreviewBorder" Background="{DynamicResource DarkerBgBrush}" CornerRadius="8"
+                Padding="20" Margin="0,0,0,20">
+            <StackPanel VerticalAlignment="Center">
+                <!-- Title -->
+                <TextBlock Text="{loc:Str label_type_to_unlock}" Foreground="{DynamicResource PinkBrush}" FontSize="14"
+                           HorizontalAlignment="Center" Margin="0,0,0,15"/>
+
+                <!-- Phrase to type -->
+                <TextBlock x:Name="PreviewPhrase" Text="{loc:Str label_good_girls_obey}"
+                           FontSize="22" FontWeight="Bold"
+                           HorizontalAlignment="Center" Margin="0,0,0,15"/>
+
+                <!-- Input field preview -->
+                <Border x:Name="PreviewInputBorder" Background="{DynamicResource PanelBgBrush}" CornerRadius="6"
+                        Padding="15,10" Margin="0,0,0,15" BorderThickness="2">
+                    <TextBlock x:Name="PreviewInputText" Text="{loc:Str label_good_girls_ob}"
+                               FontSize="16" HorizontalAlignment="Center"/>
+                </Border>
+
+                <!-- Progress indicator -->
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock x:Name="PreviewProgress" Text="1 / 3" FontSize="12" Margin="0,0,10,0"/>
+                    <Border Background="{DynamicResource PanelAccentBrush}" CornerRadius="3" Width="100" Height="6">
+                        <Border x:Name="PreviewProgressBar" Background="{DynamicResource PinkBrush}" CornerRadius="3"
+                                Width="33" HorizontalAlignment="Left"/>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Buttons -->
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="BtnCancel" Grid.Column="1" Theme="{StaticResource SecondaryButton}"
+                    Margin="0,0,10,0">
+                <TextBlock Text="{loc:Str btn_cancel}"/>
+            </Button>
+            <Button x:Name="BtnSave" Grid.Column="2" Theme="{StaticResource ActionButton}">
+                <TextBlock Text="{loc:Str btn_save}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/LockCardColorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LockCardColorDialog.axaml.cs
@@ -1,0 +1,127 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Dialog for editing lock card colors.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/LockCardColorDialog.xaml.cs. Deviations:
+    ///  - DialogResult becomes Close(bool).
+    ///  - App.Settings and App.Mods (both WPF-head services) are stubbed: the dialog opens on the
+    ///    WPF defaults with the stock #FF69B4 accent, and Save writes nowhere.
+    ///  - System.Windows.Forms.ColorDialog has no Avalonia twin in the referenced packages, so
+    ///    ShowColorPicker is a stub that returns null (no change).
+    /// </summary>
+    public partial class LockCardColorDialog : Window
+    {
+        private Color _bgColor;
+        private Color _textColor;
+        private Color _inputBgColor;
+        private Color _inputTextColor;
+        private Color _accentColor;
+
+        private readonly Button _btnBgColor;
+        private readonly Button _btnTextColor;
+        private readonly Button _btnInputBgColor;
+        private readonly Button _btnInputTextColor;
+        private readonly Button _btnAccentColor;
+
+        public LockCardColorDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _btnBgColor = this.FindControl<Button>("BtnBgColor")!;
+            _btnTextColor = this.FindControl<Button>("BtnTextColor")!;
+            _btnInputBgColor = this.FindControl<Button>("BtnInputBgColor")!;
+            _btnInputTextColor = this.FindControl<Button>("BtnInputTextColor")!;
+            _btnAccentColor = this.FindControl<Button>("BtnAccentColor")!;
+
+            LoadCurrentSettings();
+            UpdatePreview();
+
+            _btnBgColor.Click += (_, _) => Pick(ref _bgColor);
+            _btnTextColor.Click += (_, _) => Pick(ref _textColor);
+            _btnInputBgColor.Click += (_, _) => Pick(ref _inputBgColor);
+            _btnInputTextColor.Click += (_, _) => Pick(ref _inputTextColor);
+            _btnAccentColor.Click += (_, _) => Pick(ref _accentColor);
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
+        }
+
+        private void LoadCurrentSettings()
+        {
+            // ponytail: needs SettingsManager (App.Settings.Current.LockCard*) and Mods.GetAccentColorHex,
+            // wired when they move to Core. Values below are the WPF fallbacks for an unset setting.
+            var accent = Color.Parse("#FF69B4");
+            _bgColor = ParseColor("", Color.FromRgb(26, 26, 46));
+            _textColor = ParseColor("", accent);
+            _inputBgColor = ParseColor("", Color.FromRgb(37, 37, 66));
+            _inputTextColor = ParseColor("", Colors.White);
+            _accentColor = ParseColor("", accent);
+
+            UpdateColorButtons();
+        }
+
+        private void UpdateColorButtons()
+        {
+            _btnBgColor.Background = new SolidColorBrush(_bgColor);
+            _btnTextColor.Background = new SolidColorBrush(_textColor);
+            _btnInputBgColor.Background = new SolidColorBrush(_inputBgColor);
+            _btnInputTextColor.Background = new SolidColorBrush(_inputTextColor);
+            _btnAccentColor.Background = new SolidColorBrush(_accentColor);
+        }
+
+        private void UpdatePreview()
+        {
+            // Background
+            this.FindControl<Border>("PreviewBorder")!.Background = new SolidColorBrush(_bgColor);
+
+            // Phrase text
+            this.FindControl<TextBlock>("PreviewPhrase")!.Foreground = new SolidColorBrush(_textColor);
+
+            // Input field
+            var inputBorder = this.FindControl<Border>("PreviewInputBorder")!;
+            inputBorder.Background = new SolidColorBrush(_inputBgColor);
+            inputBorder.BorderBrush = new SolidColorBrush(_accentColor);
+            this.FindControl<TextBlock>("PreviewInputText")!.Foreground = new SolidColorBrush(_inputTextColor);
+
+            // Progress
+            this.FindControl<TextBlock>("PreviewProgress")!.Foreground = new SolidColorBrush(_accentColor);
+            this.FindControl<Border>("PreviewProgressBar")!.Background = new SolidColorBrush(_accentColor);
+        }
+
+        private void Pick(ref Color target)
+        {
+            var color = ShowColorPicker(target);
+            if (color.HasValue)
+            {
+                target = color.Value;
+                UpdateColorButtons();
+                UpdatePreview();
+            }
+        }
+
+        private Color? ShowColorPicker(Color currentColor)
+        {
+            // ponytail: needs a colour picker (WPF used System.Windows.Forms.ColorDialog); Avalonia's
+            // ColorPicker lives in a package this head does not reference yet. Returns "no change".
+            return null;
+        }
+
+        private void BtnSave_Click()
+        {
+            // ponytail: needs SettingsManager to persist the five LockCard* colours, wired when it moves to Core
+            Serilog.Log.Information("Lock card colors updated");
+            Close(true);
+        }
+
+        private static Color ParseColor(string hex, Color fallback)
+        {
+            if (string.IsNullOrEmpty(hex)) return fallback;
+            if (!hex.StartsWith("#")) hex = "#" + hex;
+            return Color.TryParse(hex, out var color) ? color : fallback;
+        }
+    }
+}


### PR DESCRIPTION
533 lines, 4 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351