### PR TITLE
feat(avalonia): port editor dialogs, part 1/2 - AttentionTargetEditor, WardrobeEditor

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/AttentionTargetEditorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/AttentionTargetEditorDialog.axaml
@@ -1,0 +1,185 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/AttentionTargetEditorDialog.xaml.
+     Deviations, all forced:
+       ResizeMode="NoResize"          -> CanResize="False"
+       Style="{StaticResource X}"     -> Theme="{StaticResource X}"
+       Visibility="Collapsed"         -> IsVisible="False"
+       ToolTip="…"                    -> ToolTip.Tip="…"
+       Click="…" / Checked / Unchecked / SelectionChanged -> wired in the constructor by x:Name
+       Content="{loc:Str …}" on Button -> a TextBlock child (trap 1: "_" is an access key)
+       DropShadowEffect (x2)          -> dropped; Avalonia has no DropShadowEffect on a Border/TextBlock.
+                                         PreviewTextShadow's colour math is kept out of the code-behind
+                                         with it. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.AttentionTargetEditorDialog"
+        Title="{loc:Str dialog_attention_target_style}"
+        Height="520" Width="480"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False">
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <TextBlock Grid.Row="0" Text="{loc:Str dialog_attention_target_style}"
+                   Foreground="{StaticResource PinkBrush}"
+                   FontSize="18" FontWeight="Bold" Margin="0,0,0,15"/>
+
+        <!-- Preview Section -->
+        <Border Grid.Row="1" Background="{DynamicResource PreviewBgBrush}" CornerRadius="8" Padding="20" Margin="0,0,0,15">
+            <StackPanel>
+                <TextBlock Text="{loc:Str section_preview}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,0,0,10"/>
+                <Border x:Name="PreviewBorder" HorizontalAlignment="Center"
+                        CornerRadius="20" Padding="20,10,20,10" Cursor="Hand">
+                    <TextBlock x:Name="PreviewText" Text="{loc:Str label_good_girl}"
+                               FontSize="40" FontWeight="Bold"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Settings -->
+        <Border Grid.Row="2" Background="{StaticResource PanelBgBrush}" CornerRadius="8" Padding="15">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <!-- Preset Buttons -->
+                    <TextBlock Text="{loc:Str label_quick_presets}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,0,0,8"/>
+                    <WrapPanel Margin="0,0,0,15">
+                        <Button x:Name="PresetPurple" Theme="{StaticResource SecondaryButton}" Margin="0,0,8,8">
+                            <TextBlock Text="{loc:Str btn_purple_classic}"/>
+                        </Button>
+                        <Button x:Name="PresetPink" Theme="{StaticResource SecondaryButton}" Margin="0,0,8,8">
+                            <TextBlock Text="{loc:Str btn_pink_bubbly}"/>
+                        </Button>
+                        <Button x:Name="PresetGreen" Theme="{StaticResource SecondaryButton}" Margin="0,0,8,8">
+                            <TextBlock Text="{loc:Str btn_neon_green}"/>
+                        </Button>
+                        <Button x:Name="PresetBlue" Theme="{StaticResource SecondaryButton}" Margin="0,0,8,8">
+                            <TextBlock Text="{loc:Str btn_ocean_blue}"/>
+                        </Button>
+                    </WrapPanel>
+
+                    <!-- Color 1 -->
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_primary_color}" Foreground="White" VerticalAlignment="Center"/>
+                        <Button x:Name="BtnColor1" Grid.Column="1" Theme="{StaticResource ColorButton}"/>
+                        <TextBlock x:Name="TxtColor1" Grid.Column="2" Foreground="{DynamicResource TextMutedBrush}"
+                                   VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
+                    </Grid>
+
+                    <!-- Color 2 -->
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_secondary_color}" Foreground="White" VerticalAlignment="Center"/>
+                        <Button x:Name="BtnColor2" Grid.Column="1" Theme="{StaticResource ColorButton}"/>
+                        <TextBlock x:Name="TxtColor2" Grid.Column="2" Foreground="{DynamicResource TextMutedBrush}"
+                                   VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
+                    </Grid>
+
+                    <!-- Text Color -->
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_text_color}" Foreground="White" VerticalAlignment="Center"/>
+                        <Button x:Name="BtnTextColor" Grid.Column="1" Theme="{StaticResource ColorButton}"/>
+                        <TextBlock x:Name="TxtTextColor" Grid.Column="2" Foreground="{DynamicResource TextMutedBrush}"
+                                   VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
+                    </Grid>
+
+                    <!-- Floating Text Toggle -->
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_floating_text}" Foreground="White" VerticalAlignment="Center"
+                                   ToolTip.Tip="{loc:Str tooltip_remove_background_just_show_text_transparent}"/>
+                        <CheckBox x:Name="ChkFloatingText" Grid.Column="1" VerticalAlignment="Center"/>
+                    </Grid>
+
+                    <!-- Border Toggle -->
+                    <Grid x:Name="BorderToggleRow" Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_show_border}" Foreground="White" VerticalAlignment="Center"/>
+                        <CheckBox x:Name="ChkShowBorder" Grid.Column="1" VerticalAlignment="Center"/>
+                    </Grid>
+
+                    <!-- Border Color (only visible when border enabled) -->
+                    <Grid x:Name="BorderColorRow" Margin="0,0,0,12" IsVisible="False">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_border_color}" Foreground="White" VerticalAlignment="Center"/>
+                        <Button x:Name="BtnBorderColor" Grid.Column="1" Theme="{StaticResource ColorButton}"/>
+                        <TextBlock x:Name="TxtBorderColor" Grid.Column="2" Foreground="{DynamicResource TextMutedBrush}"
+                                   VerticalAlignment="Center" Margin="10,0,0,0" FontSize="11"/>
+                    </Grid>
+
+                    <!-- Font -->
+                    <Grid Margin="0,0,0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="120"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{loc:Str label_font}" Foreground="White" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="CmbFont" Grid.Column="1" Background="{DynamicResource SurfaceBgBrush}"
+                                  Foreground="White" Padding="8,6" HorizontalAlignment="Stretch">
+                            <ComboBoxItem Content="{loc:Str btn_segoe_ui}" Tag="Segoe UI"/>
+                            <ComboBoxItem Content="{loc:Str btn_comic_sans_ms}" Tag="Comic Sans MS"/>
+                            <ComboBoxItem Content="{loc:Str btn_impact}" Tag="Impact"/>
+                            <ComboBoxItem Content="{loc:Str btn_arial_black}" Tag="Arial Black"/>
+                            <ComboBoxItem Content="{loc:Str btn_verdana}" Tag="Verdana"/>
+                        </ComboBox>
+                    </Grid>
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Footer Buttons -->
+        <Grid Grid.Row="3" Margin="0,15,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="BtnTest" Grid.Column="0" Theme="{StaticResource SecondaryButton}"
+                    ToolTip.Tip="{loc:Str tooltip_spawn_a_test_target_to_see_how_it_looks}">
+                <TextBlock Text="{loc:Str btn_test_target}"/>
+            </Button>
+            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                <Button x:Name="BtnCancel" Theme="{StaticResource SecondaryButton}" Margin="0,0,8,0">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnSave" Theme="{StaticResource ActionButton}">
+                    <TextBlock Text="{loc:Str btn_save}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/AttentionTargetEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AttentionTargetEditorDialog.axaml.cs
@@ -1,0 +1,276 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Dialog for customizing attention target appearance.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/AttentionTargetEditorDialog.xaml.cs. Deviations:
+    ///  - Settings load/save, the colour picker (WinForms ColorDialog) and the test target
+    ///    (Services.FloatingText on a Win32 screen) are stubs - see the ponytail comments.
+    ///  - <c>PreviewTextShadow</c> is gone with the DropShadowEffect it coloured.
+    ///  - <c>DialogResult = x; Close()</c> becomes <c>Close(x)</c>.
+    /// </summary>
+    public partial class AttentionTargetEditorDialog : Window
+    {
+        private string _color1;
+        private string _color2;
+        private string _textColor;
+        private string _borderColor;
+        private bool _showBorder;
+        private bool _floatingText;
+        private string _font;
+
+        private readonly Border _previewBorder;
+        private readonly TextBlock _previewText;
+        private readonly CheckBox _chkFloatingText;
+        private readonly CheckBox _chkShowBorder;
+        private readonly ComboBox _cmbFont;
+        private readonly Grid _borderToggleRow;
+        private readonly Grid _borderColorRow;
+
+        public AttentionTargetEditorDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _previewBorder = this.FindControl<Border>("PreviewBorder")!;
+            _previewText = this.FindControl<TextBlock>("PreviewText")!;
+            _chkFloatingText = this.FindControl<CheckBox>("ChkFloatingText")!;
+            _chkShowBorder = this.FindControl<CheckBox>("ChkShowBorder")!;
+            _cmbFont = this.FindControl<ComboBox>("CmbFont")!;
+            _borderToggleRow = this.FindControl<Grid>("BorderToggleRow")!;
+            _borderColorRow = this.FindControl<Grid>("BorderColorRow")!;
+
+            // Load current settings
+            // ponytail: needs App.Settings.Current.Attention*, wired when settings move to Core.
+            // These are the "purple classic" preset values.
+            _color1 = "#9B59B6";
+            _color2 = "#8E44AD";
+            _textColor = "#FFFFFF";
+            _borderColor = "#FFFFFF";
+            _showBorder = false;
+            _floatingText = false;
+            _font = "Segoe UI";
+
+            this.FindControl<Button>("PresetPurple")!.Click += (_, _) => PresetPurple_Click();
+            this.FindControl<Button>("PresetPink")!.Click += (_, _) => PresetPink_Click();
+            this.FindControl<Button>("PresetGreen")!.Click += (_, _) => PresetGreen_Click();
+            this.FindControl<Button>("PresetBlue")!.Click += (_, _) => PresetBlue_Click();
+            this.FindControl<Button>("BtnColor1")!.Click += (_, _) => PickInto(ref _color1);
+            this.FindControl<Button>("BtnColor2")!.Click += (_, _) => PickInto(ref _color2);
+            this.FindControl<Button>("BtnTextColor")!.Click += (_, _) => PickInto(ref _textColor);
+            this.FindControl<Button>("BtnBorderColor")!.Click += (_, _) => PickInto(ref _borderColor);
+            this.FindControl<Button>("BtnTest")!.Click += (_, _) => BtnTest_Click();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
+            _chkFloatingText.IsCheckedChanged += (_, _) => ChkFloatingText_Changed();
+            _chkShowBorder.IsCheckedChanged += (_, _) => ChkShowBorder_Changed();
+            _cmbFont.SelectionChanged += (_, _) => CmbFont_SelectionChanged();
+
+            // Initialize UI
+            UpdateColorButtons();
+            _chkFloatingText.IsChecked = _floatingText;
+            _chkShowBorder.IsChecked = _showBorder;
+            UpdateRowVisibility();
+            SelectFontInCombo(_font);
+            UpdatePreview();
+        }
+
+        private void SelectFontInCombo(string fontName)
+        {
+            foreach (var item in _cmbFont.Items)
+            {
+                if (item is ComboBoxItem cbi && cbi.Tag?.ToString() == fontName)
+                {
+                    _cmbFont.SelectedItem = item;
+                    return;
+                }
+            }
+            _cmbFont.SelectedIndex = 0; // Default to first
+        }
+
+        private void UpdateColorButtons()
+        {
+            try
+            {
+                Paint("BtnColor1", "TxtColor1", _color1);
+                Paint("BtnColor2", "TxtColor2", _color2);
+                Paint("BtnTextColor", "TxtTextColor", _textColor);
+                Paint("BtnBorderColor", "TxtBorderColor", _borderColor);
+            }
+            catch { }
+        }
+
+        private void Paint(string button, string label, string hex)
+        {
+            this.FindControl<Button>(button)!.Background = new SolidColorBrush(Color.Parse(hex));
+            this.FindControl<TextBlock>(label)!.Text = hex;
+        }
+
+        private void UpdateRowVisibility()
+        {
+            // When floating text is enabled, hide background/border options
+            _borderToggleRow.IsVisible = !_floatingText;
+            _borderColorRow.IsVisible = _showBorder && !_floatingText;
+        }
+
+        private void UpdatePreview()
+        {
+            try
+            {
+                var color1 = Color.Parse(_color1);
+                var color2 = Color.Parse(_color2);
+                var textColor = Color.Parse(_textColor);
+                var borderColor = Color.Parse(_borderColor);
+
+                // Background - transparent for floating text mode
+                if (_floatingText)
+                {
+                    _previewBorder.Background = Brushes.Transparent;
+                    _previewBorder.BorderBrush = Brushes.Transparent;
+                    _previewBorder.BorderThickness = new Thickness(0);
+                }
+                else
+                {
+                    // Gradient background - WPF's (color1, color2, 90°) is top-to-bottom.
+                    _previewBorder.Background = new LinearGradientBrush
+                    {
+                        StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+                        EndPoint = new RelativePoint(0, 1, RelativeUnit.Relative),
+                        GradientStops = { new GradientStop(color1, 0), new GradientStop(color2, 1) }
+                    };
+
+                    // Border
+                    if (_showBorder)
+                    {
+                        _previewBorder.BorderBrush = new SolidColorBrush(borderColor);
+                        _previewBorder.BorderThickness = new Thickness(3);
+                    }
+                    else
+                    {
+                        _previewBorder.BorderBrush = Brushes.Transparent;
+                        _previewBorder.BorderThickness = new Thickness(0);
+                    }
+                }
+
+                // Text
+                _previewText.Foreground = new SolidColorBrush(textColor);
+                _previewText.FontFamily = new FontFamily(_font);
+            }
+            catch { }
+        }
+
+        private void PickInto(ref string field)
+        {
+            // ponytail: needs a colour picker; WPF used WinForms ColorDialog. Avalonia's ColorPicker
+            // is a separate package and no dependency may be added here. Wired when one is chosen.
+            string? color = null;
+            if (color != null)
+            {
+                field = color;
+                UpdateColorButtons();
+                UpdatePreview();
+            }
+        }
+
+        private void ChkFloatingText_Changed()
+        {
+            _floatingText = _chkFloatingText.IsChecked == true;
+            UpdateRowVisibility();
+            UpdatePreview();
+        }
+
+        private void ChkShowBorder_Changed()
+        {
+            _showBorder = _chkShowBorder.IsChecked == true;
+            UpdateRowVisibility();
+            UpdatePreview();
+        }
+
+        private void CmbFont_SelectionChanged()
+        {
+            if (_cmbFont.SelectedItem is ComboBoxItem item && item.Tag is string font)
+            {
+                _font = font;
+                UpdatePreview();
+            }
+        }
+
+        #region Presets
+
+        private void PresetPurple_Click()
+        {
+            // ponytail: App.Mods?.GetSecondaryColorHex() fallback kept; wired when Mods moves to Core.
+            _color1 = "#9B59B6";
+            _color2 = "#8E44AD";
+            _textColor = "#FFFFFF";
+            _showBorder = false;
+            _floatingText = false;
+            _font = "Segoe UI";
+            ApplyPreset();
+        }
+
+        private void PresetPink_Click()
+        {
+            _color1 = "#FF64C8";
+            _color2 = "#FF3296";
+            _textColor = "#FFFFFF";
+            _showBorder = true;
+            _floatingText = false;
+            _borderColor = "#FFFFFF";
+            _font = "Comic Sans MS";
+            ApplyPreset();
+        }
+
+        private void PresetGreen_Click()
+        {
+            _color1 = "#2ECC71";
+            _color2 = "#27AE60";
+            _textColor = "#FFFFFF";
+            _showBorder = false;
+            _floatingText = false;
+            _font = "Impact";
+            ApplyPreset();
+        }
+
+        private void PresetBlue_Click()
+        {
+            _color1 = "#3498DB";
+            _color2 = "#2980B9";
+            _textColor = "#FFFFFF";
+            _showBorder = false;
+            _floatingText = false;
+            _font = "Arial Black";
+            ApplyPreset();
+        }
+
+        private void ApplyPreset()
+        {
+            _chkFloatingText.IsChecked = _floatingText;
+            _chkShowBorder.IsChecked = _showBorder;
+            UpdateRowVisibility();
+            SelectFontInCombo(_font);
+            UpdateColorButtons();
+            UpdatePreview();
+        }
+
+        #endregion
+
+        private void BtnTest_Click()
+        {
+            // ponytail: needs Services.FloatingText (a Win32 layered window, bucket E) and
+            // App.Settings; wired when the overlay has a per-platform implementation.
+        }
+
+        private void BtnSave_Click()
+        {
+            // ponytail: needs App.Settings.Current.Attention* to persist; wired when settings move
+            // to Core. The chosen values live in the fields above until then.
+            Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/WardrobeEditorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/WardrobeEditorDialog.axaml
@@ -1,0 +1,148 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/WardrobeEditorDialog.xaml.
+     Deviations, all forced:
+       ResizeMode="CanResize"         -> CanResize="True"
+       Visibility="Collapsed"         -> IsVisible="False"
+       MouseMove / MouseLeftButtonUp / MouseWheel / Click / Checked / ValueChanged
+                                      -> wired in the constructor by x:Name
+       Content="{loc:Str …}" on Button and CheckBox -> a TextBlock child (trap 1)
+       FontFamily="/Fonts/#Fredoka, Segoe UI" -> dropped; the font is a WPF-head resource
+       DropShadowEffect on the title  -> dropped; Avalonia has no DropShadowEffect on a TextBlock
+       LinearGradientBrush StartPoint/EndPoint -> RelativePoint syntax "0%,0%" / "100%,100%" -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.WardrobeEditorDialog"
+        Title="{loc:Str wardrobe_editor_title}"
+        Width="760" Height="560" MinWidth="680" MinHeight="500"
+        Background="{DynamicResource DarkerBgBrush}"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        ShowInTaskbar="False">
+
+    <!-- =====================================================================
+         The Wardrobe editor (Profile redesign, owner feedback round 1).
+
+         Edits ONLY the transform fields of the ProfileCosmetics draft handed in
+         by the Customize dialog: which items are worn stays the Customize
+         dialog's job; where and how they sit on the card is decided here.
+
+         The stage is a to-scale mock of the hero card: its size is the LIVE
+         card's own width/height scaled down to fit, and every sprite is placed
+         by the same fractions the live renderer uses.
+
+         All sprites are built in code - same converter-free rule as the
+         Customize dialog's tiles.
+         ===================================================================== -->
+
+    <Grid Margin="18,16,18,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="{loc:Str wardrobe_editor_title}"
+                       FontWeight="SemiBold"
+                       FontSize="22" Foreground="White"/>
+            <TextBlock Text="{loc:Str wardrobe_editor_sub}" Foreground="#9A93B8" FontSize="12"
+                       TextWrapping="Wrap" Margin="0,4,0,0"/>
+        </StackPanel>
+
+        <!-- ================= stage ================= -->
+        <Border Grid.Row="1" CornerRadius="10" Padding="12"
+                Background="#B3252542" BorderBrush="#335EC8F2" BorderThickness="1">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <!-- item chips: click to select without pixel-hunting -->
+                <WrapPanel x:Name="ItemChips" Grid.Row="0" Margin="0,0,0,10"/>
+
+                <TextBlock x:Name="TxtNothingEquipped" Grid.Row="1"
+                           Text="{loc:Str wardrobe_editor_nothing}"
+                           Foreground="#8079A3" FontSize="12" FontStyle="Italic"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           IsVisible="False" TextWrapping="Wrap"/>
+
+                <!-- The card mock. Width/Height are set in code to the LIVE hero card's aspect
+                     ratio. The values here are only the design-time placeholder. -->
+                <Border x:Name="StageFrame" Grid.Row="1" Width="640" Height="240"
+                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                        CornerRadius="14" ClipToBounds="True"
+                        Background="#EE1A1A2E" BorderBrush="#66FF69B4" BorderThickness="1">
+                    <Grid>
+                        <!-- default gradient exactly like the hero -->
+                        <Border>
+                            <Border.Background>
+                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                    <GradientStop Color="#2A1E4D" Offset="0"/>
+                                    <GradientStop Color="#3B2159" Offset="0.5"/>
+                                    <GradientStop Color="#1E1E3F" Offset="1"/>
+                                </LinearGradientBrush>
+                            </Border.Background>
+                        </Border>
+                        <Border x:Name="StageBanner" Opacity="0.85"/>
+                        <Canvas x:Name="Stage" Background="Transparent"/>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+
+        <!-- ================= controls for the selected item ================= -->
+        <Border Grid.Row="2" CornerRadius="10" Padding="14,10" Margin="0,10,0,0"
+                Background="#B3252542" BorderBrush="#33B478FF" BorderThickness="1">
+            <Grid x:Name="ControlsRow" IsEnabled="False">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" Text="{loc:Str wardrobe_editor_scale}" Foreground="#B8B1CC"
+                           FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <Slider x:Name="ScaleSlider" Grid.Column="1" Minimum="0.3" Maximum="3" Value="1"
+                        TickFrequency="0.05" IsSnapToTickEnabled="True" VerticalAlignment="Center"
+                        Margin="0,0,16,0"/>
+
+                <TextBlock Grid.Column="2" Text="{loc:Str wardrobe_editor_rotation}" Foreground="#B8B1CC"
+                           FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <Slider x:Name="RotationSlider" Grid.Column="3" Minimum="-180" Maximum="180" Value="0"
+                        TickFrequency="1" IsSnapToTickEnabled="True" VerticalAlignment="Center"
+                        Margin="0,0,16,0"/>
+
+                <CheckBox x:Name="ChkFlip" Grid.Column="4"
+                          Foreground="#B8B1CC" FontSize="11" VerticalAlignment="Center"
+                          Margin="0,0,16,0">
+                    <TextBlock Text="{loc:Str wardrobe_editor_flip}"/>
+                </CheckBox>
+
+                <Button x:Name="BtnResetItem" Grid.Column="5"
+                        Background="#33FFFFFF" Foreground="#E7DEFF" BorderThickness="0"
+                        Padding="12,5" FontSize="11" Cursor="Hand">
+                    <TextBlock Text="{loc:Str wardrobe_editor_reset}"/>
+                </Button>
+            </Grid>
+        </Border>
+
+        <!-- ================= footer ================= -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,14,0,0">
+            <Button x:Name="BtnCancel"
+                    Background="#33FFFFFF" Foreground="White" BorderThickness="0"
+                    Padding="18,8" Margin="0,0,10,0" FontSize="12" Cursor="Hand">
+                <TextBlock Text="{loc:Str btn_cancel}"/>
+            </Button>
+            <Button x:Name="BtnSave"
+                    Background="#5EC8F2" Foreground="#1A1A2E" FontWeight="Bold" BorderThickness="0"
+                    Padding="18,8" FontSize="12" Cursor="Hand">
+                <TextBlock Text="{loc:Str btn_save}"/>
+            </Button>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/WardrobeEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WardrobeEditorDialog.axaml.cs
@@ -1,0 +1,486 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// The Wardrobe editor: drag / resize / rotate / flip the equipped decoration and charms on a
+    /// to-scale mock of the hero card. Edits ONLY the transform fields of the draft the Customize
+    /// dialog handed in (same instance), snapshotting them on open so Cancel really cancels.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/WardrobeEditorDialog.xaml.cs. Deviations:
+    ///  - <c>WardrobeStageGeometry</c> and the <c>WardrobeCatalog</c> constants live in the WPF
+    ///    head; the handful of numbers and the three rect functions are inlined below (ponytail).
+    ///  - Sprite art comes from <c>WardrobeCatalog.GetImage</c> (pack:// URIs, WPF ImageSource).
+    ///    Sprites here are placeholder Borders until the catalogue is portable; the transform
+    ///    maths is identical and applies to whatever control stands in.
+    ///  - The selection glow (DropShadowEffect) is a cyan border on the sprite instead.
+    ///  - Mouse events -> Pointer events; CaptureMouse -> e.Pointer.Capture(Stage).
+    ///  - <c>DialogResult = x; Close()</c> -> <c>Close(x)</c>.
+    /// </summary>
+    public partial class WardrobeEditorDialog : Window
+    {
+        /// <summary>The stage box the card mock is fitted into, at the card's own aspect ratio.</summary>
+        private const double StageMaxWidth = 660;
+        private const double StageMaxHeight = 250;
+
+        // ponytail: WardrobeStageGeometry + WardrobeCatalog constants, inlined. Delete this block and
+        // call the originals when Services/Profile/WardrobeStageGeometry.cs moves to Core.
+        private const double CardAvatarSize = 104d, CardAvatarLeft = 24d, CardAvatarTop = 22d;
+        private const double FallbackCardWidth = 1200d, FallbackCardHeight = 250d;
+        private const double AvatarCircleRatio = 0.70, CharmBaseHeightFraction = 0.35;
+        private static readonly (double X, double Y)[] DefaultCharmAnchors = { (0.90, 0.76), (0.965, 0.90) };
+
+        private readonly struct StageBox
+        {
+            public StageBox(double w, double h, double s) { Width = w; Height = h; Scale = s; }
+            public double Width { get; }
+            public double Height { get; }
+            public double Scale { get; }
+            public double AvatarSize => CardAvatarSize * Scale;
+            public double AvatarLeft => CardAvatarLeft * Scale;
+            public double AvatarTop => CardAvatarTop * Scale;
+        }
+
+        private static bool IsUsable(double v) => !double.IsNaN(v) && !double.IsInfinity(v) && v > 0d;
+
+        private static StageBox ForCard(double cardWidth, double cardHeight, double maxWidth, double maxHeight)
+        {
+            if (!IsUsable(cardWidth) || !IsUsable(cardHeight)) { cardWidth = FallbackCardWidth; cardHeight = FallbackCardHeight; }
+            var scale = Math.Min(maxWidth / cardWidth, maxHeight / cardHeight);
+            if (!IsUsable(scale)) scale = 1d;
+            return new StageBox(cardWidth * scale, cardHeight * scale, scale);
+        }
+
+        private static (double Left, double Top, double Size) CharmRect(double w, double h, double x, double y, double scale)
+        {
+            var size = Math.Max(1d, CharmBaseHeightFraction * h * (IsUsable(scale) ? scale : 1d));
+            return (x * w - size / 2d, y * h - size / 2d, size);
+        }
+
+        private static (double Left, double Top, double Canvas) DecorationRect(double avatarSize, double avatarLeft, double avatarTop)
+        {
+            var canvas = avatarSize / AvatarCircleRatio;
+            return (avatarLeft + avatarSize / 2d - canvas / 2d, avatarTop + avatarSize / 2d - canvas / 2d, canvas);
+        }
+
+        /// <summary>The live card, scaled down. Every number on the stage comes from this.</summary>
+        private readonly StageBox _stage;
+
+        private double DecoCanvas => _stage.AvatarSize / AvatarCircleRatio;
+
+        private sealed class Sprite
+        {
+            public string Key = string.Empty;          // "deco" or the charm id
+            public bool IsDeco;
+            public int CharmSlot;                      // default-anchor index for charms
+            public string Name = string.Empty;
+            public Border Image = null!;
+            public Border Chip = null!;
+        }
+
+        private readonly ProfileCosmetics _draft;
+        private readonly CosmeticTransform? _snapshotDeco;
+        private readonly Dictionary<string, CosmeticTransform>? _snapshotCharms;
+
+        private readonly List<Sprite> _sprites = new();
+        private Sprite? _selected;
+        private bool _dragging;
+        private Point _dragStartMouse;
+        private (double X, double Y) _dragStartValue;
+        private bool _updatingUi;
+
+        private static readonly IBrush ChipIdle = Brush.Parse("#26FFFFFF");
+        private static readonly IBrush ChipIdleBorder = Brush.Parse("#33FFFFFF");
+        private static readonly IBrush ChipOn = Brush.Parse("#335EC8F2");
+        private static readonly IBrush ChipOnBorder = Brush.Parse("#5EC8F2");
+
+        private readonly Canvas _stageCanvas;
+        private readonly Border _stageFrame;
+        private readonly WrapPanel _itemChips;
+        private readonly Grid _controlsRow;
+        private readonly Slider _scaleSlider;
+        private readonly Slider _rotationSlider;
+        private readonly CheckBox _chkFlip;
+
+        /// <summary>Render/design constructor: a decoration and two charms so --render-view has
+        /// something to lay out.</summary>
+        public WardrobeEditorDialog() : this(new ProfileCosmetics
+        {
+            AvatarDeco = "sample-deco",
+            Charms = { "sample-charm-1", "sample-charm-2" },
+            CharmTransforms = new Dictionary<string, CosmeticTransform>(StringComparer.Ordinal)
+            {
+                ["sample-charm-2"] = new CosmeticTransform { X = 0.75, Y = 0.5, Scale = 1.2, Rotation = 20, Flip = true }
+            }
+        }, null) { }
+
+        /// <param name="cardWidth">The live hero card's width, or 0 when it has not been
+        /// measured yet - the stage falls back to a typical windowed hero in that case.</param>
+        /// <param name="cardHeight">The live hero card's height, same rule.</param>
+        public WardrobeEditorDialog(ProfileCosmetics draft, IImageBrushSource? avatar,
+                                    double cardWidth = 0, double cardHeight = 0)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _stageCanvas = this.FindControl<Canvas>("Stage")!;
+            _stageFrame = this.FindControl<Border>("StageFrame")!;
+            _itemChips = this.FindControl<WrapPanel>("ItemChips")!;
+            _controlsRow = this.FindControl<Grid>("ControlsRow")!;
+            _scaleSlider = this.FindControl<Slider>("ScaleSlider")!;
+            _rotationSlider = this.FindControl<Slider>("RotationSlider")!;
+            _chkFlip = this.FindControl<CheckBox>("ChkFlip")!;
+
+            _stageCanvas.PointerMoved += Stage_PointerMoved;
+            _stageCanvas.PointerReleased += Stage_PointerReleased;
+            _stageCanvas.PointerWheelChanged += Stage_PointerWheelChanged;
+            _scaleSlider.ValueChanged += ScaleSlider_ValueChanged;
+            _rotationSlider.ValueChanged += RotationSlider_ValueChanged;
+            _chkFlip.IsCheckedChanged += (_, _) => ChkFlip_Changed();
+            this.FindControl<Button>("BtnResetItem")!.Click += (_, _) => BtnResetItem_Click();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => BtnCancel_Click();
+            this.FindControl<Button>("BtnSave")!.Click += (_, _) => Close(true);
+
+            _stage = ForCard(cardWidth, cardHeight, StageMaxWidth, StageMaxHeight);
+            _stageFrame.Width = _stage.Width;
+            _stageFrame.Height = _stage.Height;
+
+            _draft = draft ?? new ProfileCosmetics();
+            _snapshotDeco = _draft.DecoTransform?.Clone();
+            _snapshotCharms = _draft.CharmTransforms?.ToDictionary(
+                kv => kv.Key, kv => kv.Value.Clone(), StringComparer.Ordinal);
+
+            BuildStageBackdrop(avatar);
+            BuildSprites();
+
+            if (_sprites.Count == 0)
+            {
+                this.FindControl<TextBlock>("TxtNothingEquipped")!.IsVisible = true;
+                _stageFrame.IsVisible = false;
+            }
+            else
+            {
+                SelectSprite(_sprites[0]);
+            }
+
+            LayoutSprites();
+        }
+
+        // ============================== build ==============================
+
+        private void BuildStageBackdrop(IImageBrushSource? avatar)
+        {
+            // ponytail: needs CosmeticsCatalog.GetBannerImage (WPF head) for the banner; wired when
+            // the catalogue moves to Core. The default gradient in the XAML shows through meanwhile.
+
+            // The avatar bubble: the hero's 104px circle + pink ring, at stage scale.
+            IBrush avatarBrush = avatar != null
+                ? new ImageBrush(avatar) { Stretch = Stretch.UniformToFill }
+                : new LinearGradientBrush
+                {
+                    StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+                    EndPoint = new RelativePoint(1, 1, RelativeUnit.Relative),
+                    GradientStops = { new GradientStop(Color.Parse("#FF69B4"), 0), new GradientStop(Color.Parse("#B478FF"), 1) }
+                };
+
+            var bubble = new Border
+            {
+                Width = _stage.AvatarSize,
+                Height = _stage.AvatarSize,
+                CornerRadius = new CornerRadius(_stage.AvatarSize / 2),
+                BorderBrush = Brush.Parse("#FF69B4"),
+                BorderThickness = new Thickness(Math.Max(1, 3 * _stage.Scale)),
+                Background = avatarBrush,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(bubble, _stage.AvatarLeft);
+            Canvas.SetTop(bubble, _stage.AvatarTop);
+            _stageCanvas.Children.Add(bubble);
+        }
+
+        private void BuildSprites()
+        {
+            // ponytail: needs WardrobeCatalog.GetImage/Find (WPF head) for real art and names;
+            // wired when the catalogue moves to Core. Every equipped id gets a placeholder sprite.
+            if (!string.IsNullOrWhiteSpace(_draft.AvatarDeco))
+                AddSprite("deco", isDeco: true, 0,
+                    $"{Loc.Get("wardrobe_editor_decoration")} · {_draft.AvatarDeco}");
+
+            for (var i = 0; i < _draft.Charms.Count && i < ProfileCosmetics.MaxCharms; i++)
+                AddSprite(_draft.Charms[i], isDeco: false, i, _draft.Charms[i]);
+        }
+
+        private void AddSprite(string key, bool isDeco, int charmSlot, string name)
+        {
+            // Placeholder art: a soft disc with the first letter. Replaced by an Image when the
+            // catalogue is portable; the drag/transform code does not care which.
+            var image = new Border
+            {
+                Background = Brush.Parse(isDeco ? "#66B478FF" : "#66FFD166"),
+                BorderBrush = Brushes.Transparent,
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(999),
+                Cursor = new Cursor(StandardCursorType.SizeAll),
+                RenderTransformOrigin = RelativePoint.Center,
+                Child = new TextBlock
+                {
+                    Text = name.Substring(0, 1).ToUpperInvariant(),
+                    Foreground = Brushes.White,
+                    FontWeight = FontWeight.Bold,
+                    HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Center,
+                    VerticalAlignment = global::Avalonia.Layout.VerticalAlignment.Center
+                }
+            };
+
+            var sprite = new Sprite { Key = key, IsDeco = isDeco, CharmSlot = charmSlot, Name = name, Image = image };
+            image.PointerPressed += (_, e) => BeginDrag(sprite, e);
+            _stageCanvas.Children.Add(image);
+
+            var chip = new Border
+            {
+                Margin = new Thickness(0, 0, 6, 6),
+                Padding = new Thickness(10, 4, 10, 4),
+                CornerRadius = new CornerRadius(11),
+                Background = ChipIdle,
+                BorderBrush = ChipIdleBorder,
+                BorderThickness = new Thickness(1),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Child = new TextBlock
+                {
+                    Text = name,                     // registry names are English proper nouns
+                    Foreground = Brushes.White,
+                    FontSize = 11,
+                    FontWeight = FontWeight.SemiBold
+                }
+            };
+            chip.PointerReleased += (_, _) => SelectSprite(sprite);
+            sprite.Chip = chip;
+            _itemChips.Children.Add(chip);
+
+            _sprites.Add(sprite);
+        }
+
+        // ============================== transforms ==============================
+
+        private CosmeticTransform EnsureTransform(Sprite sprite)
+        {
+            if (sprite.IsDeco)
+                return _draft.DecoTransform ??= new CosmeticTransform();
+
+            _draft.CharmTransforms ??= new Dictionary<string, CosmeticTransform>(StringComparer.Ordinal);
+            if (!_draft.CharmTransforms.TryGetValue(sprite.Key, out var t))
+            {
+                var anchor = sprite.CharmSlot < DefaultCharmAnchors.Length ? DefaultCharmAnchors[sprite.CharmSlot] : DefaultCharmAnchors[0];
+                t = new CosmeticTransform { X = anchor.X, Y = anchor.Y, Scale = 0.8 };
+                _draft.CharmTransforms[sprite.Key] = t;
+            }
+            return t;
+        }
+
+        private CosmeticTransform? PeekTransform(Sprite sprite)
+        {
+            if (sprite.IsDeco) return _draft.DecoTransform;
+            return _draft.CharmTransforms != null && _draft.CharmTransforms.TryGetValue(sprite.Key, out var t)
+                ? t : null;
+        }
+
+        /// <summary>
+        /// Places every sprite from its transform - the same math the live renderer runs.
+        /// </summary>
+        private void LayoutSprites()
+        {
+            var stageW = _stage.Width;
+            var stageH = _stage.Height;
+
+            foreach (var sprite in _sprites)
+            {
+                var t = PeekTransform(sprite);
+
+                if (sprite.IsDeco)
+                {
+                    var (left, top, canvas) = DecorationRect(_stage.AvatarSize, _stage.AvatarLeft, _stage.AvatarTop);
+                    sprite.Image.Width = canvas;
+                    sprite.Image.Height = canvas;
+                    Canvas.SetLeft(sprite.Image, left);
+                    Canvas.SetTop(sprite.Image, top);
+
+                    // Mirrors AdornedAvatar.ApplyDecorationTransform exactly.
+                    if (t != null)
+                    {
+                        var group = new TransformGroup();
+                        group.Children.Add(new ScaleTransform(t.Flip ? -t.Scale : t.Scale, t.Scale));
+                        group.Children.Add(new RotateTransform(t.Rotation));
+                        group.Children.Add(new TranslateTransform(t.X * canvas, t.Y * canvas));
+                        sprite.Image.RenderTransform = group;
+                    }
+                    else
+                    {
+                        sprite.Image.RenderTransform = null;
+                    }
+                }
+                else
+                {
+                    var anchor = sprite.CharmSlot < DefaultCharmAnchors.Length ? DefaultCharmAnchors[sprite.CharmSlot] : DefaultCharmAnchors[0];
+                    var (left, top, size) = CharmRect(stageW, stageH, t?.X ?? anchor.X, t?.Y ?? anchor.Y, t?.Scale ?? 0.8);
+
+                    sprite.Image.Width = size;
+                    sprite.Image.Height = size;
+                    Canvas.SetLeft(sprite.Image, left);
+                    Canvas.SetTop(sprite.Image, top);
+
+                    if (t != null && (t.Flip || Math.Abs(t.Rotation) > 0.05))
+                    {
+                        var group = new TransformGroup();
+                        group.Children.Add(new ScaleTransform(t.Flip ? -1 : 1, 1));
+                        group.Children.Add(new RotateTransform(t.Rotation));
+                        sprite.Image.RenderTransform = group;
+                    }
+                    else
+                    {
+                        sprite.Image.RenderTransform = null;
+                    }
+                }
+            }
+        }
+
+        // ============================== selection ==============================
+
+        private void SelectSprite(Sprite sprite)
+        {
+            _selected = sprite;
+
+            foreach (var s in _sprites)
+            {
+                var on = ReferenceEquals(s, sprite);
+                s.Image.BorderBrush = on ? ChipOnBorder : Brushes.Transparent;
+                s.Chip.Background = on ? ChipOn : ChipIdle;
+                s.Chip.BorderBrush = on ? ChipOnBorder : ChipIdleBorder;
+            }
+
+            RefreshControls();
+        }
+
+        private void RefreshControls()
+        {
+            _updatingUi = true;
+            try
+            {
+                _controlsRow.IsEnabled = _selected != null;
+                var t = _selected != null ? PeekTransform(_selected) : null;
+                _scaleSlider.Value = t?.Scale ?? (_selected?.IsDeco == true ? 1.0 : 0.8);
+                _rotationSlider.Value = t?.Rotation ?? 0;
+                _chkFlip.IsChecked = t?.Flip ?? false;
+            }
+            finally { _updatingUi = false; }
+        }
+
+        // ============================== dragging ==============================
+
+        private void BeginDrag(Sprite sprite, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(_stageCanvas).Properties.IsLeftButtonPressed) return;
+            SelectSprite(sprite);
+
+            var t = EnsureTransform(sprite);
+            _dragging = true;
+            _dragStartMouse = e.GetPosition(_stageCanvas);
+            _dragStartValue = (t.X, t.Y);
+            e.Pointer.Capture(_stageCanvas);
+            e.Handled = true;
+        }
+
+        private void Stage_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (!_dragging || _selected == null || !e.GetCurrentPoint(_stageCanvas).Properties.IsLeftButtonPressed) return;
+
+            var t = EnsureTransform(_selected);
+            var pos = e.GetPosition(_stageCanvas);
+            var dx = pos.X - _dragStartMouse.X;
+            var dy = pos.Y - _dragStartMouse.Y;
+
+            if (_selected.IsDeco)
+            {
+                t.X = Math.Clamp(_dragStartValue.X + dx / DecoCanvas, -0.75, 0.75);
+                t.Y = Math.Clamp(_dragStartValue.Y + dy / DecoCanvas, -0.75, 0.75);
+            }
+            else
+            {
+                t.X = Math.Clamp(_dragStartValue.X + dx / _stage.Width, 0, 1);
+                t.Y = Math.Clamp(_dragStartValue.Y + dy / _stage.Height, 0, 1);
+            }
+
+            LayoutSprites();
+        }
+
+        private void Stage_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (!_dragging) return;
+            _dragging = false;
+            e.Pointer.Capture(null);
+        }
+
+        private void Stage_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
+        {
+            if (_selected == null) return;
+            var t = EnsureTransform(_selected);
+            t.Scale = Math.Clamp(t.Scale + (e.Delta.Y > 0 ? 0.05 : -0.05), 0.3, 3.0);
+            LayoutSprites();
+            RefreshControls();
+            e.Handled = true;
+        }
+
+        // ============================== control row ==============================
+
+        private void ScaleSlider_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_updatingUi || _selected == null) return;
+            EnsureTransform(_selected).Scale = Math.Clamp(e.NewValue, 0.3, 3.0);
+            LayoutSprites();
+        }
+
+        private void RotationSlider_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_updatingUi || _selected == null) return;
+            EnsureTransform(_selected).Rotation = Math.Clamp(e.NewValue, -180, 180);
+            LayoutSprites();
+        }
+
+        private void ChkFlip_Changed()
+        {
+            if (_updatingUi || _selected == null) return;
+            EnsureTransform(_selected).Flip = _chkFlip.IsChecked == true;
+            LayoutSprites();
+        }
+
+        private void BtnResetItem_Click()
+        {
+            if (_selected == null) return;
+
+            if (_selected.IsDeco) _draft.DecoTransform = null;
+            else _draft.CharmTransforms?.Remove(_selected.Key);
+
+            LayoutSprites();
+            RefreshControls();
+        }
+
+        // ============================== footer ==============================
+
+        private void BtnCancel_Click()
+        {
+            // Same draft instance the Customize dialog holds - put the transforms back the way
+            // they were when this editor opened. Item choices were never ours to touch.
+            _draft.DecoTransform = _snapshotDeco;
+            _draft.CharmTransforms = _snapshotCharms;
+            Close(false);
+        }
+    }
+}


### PR DESCRIPTION
1,095 lines, 4 files; the only two-file pairing under the ceiling.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351