### PR TITLE
feat(avalonia): port large dialogs, part 2/2 - LocalAiSetupWizard

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/LocalAiSetupWizard.axaml
+++ b/CCP.Avalonia/Views/Dialogs/LocalAiSetupWizard.axaml
@@ -1,0 +1,269 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/LocalAiSetupWizard.xaml.
+     Structure, ordering, spacing and every resource key preserved. Deviations, all forced:
+
+       Style="{StaticResource X}"  -> Theme="{StaticResource X}"   (keyed styles are ControlThemes,
+                                      local copies below - Theme/ has no wizard styles)
+       Visibility="Collapsed"      -> IsVisible="False"
+       ResizeMode="NoResize"       -> CanResize="False"
+       <Hyperlink> in a TextBlock  -> an underlined TextBlock with PointerPressed wired in the ctor
+                                      (Avalonia has no inline Hyperlink)
+       Checked/Unchecked           -> IsCheckedChanged, wired in the ctor
+       ProgressBar Foreground      -> same property; Avalonia's ProgressBar honours it
+
+     Buttons and the CheckBox carry a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key and every loc key here is snake_case. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.LocalAiSetupWizard"
+        Title="{loc:Str dialog_local_ai_setup_title}"
+        Width="560" Height="540"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of LocalAiSetupWizard.xaml:WizardHeader/WizardSub/WizardBody/
+             WizardButton/WizardPrimaryButton, hoist when a second view needs them. -->
+        <ControlTheme x:Key="WizardHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+        </ControlTheme>
+        <ControlTheme x:Key="WizardSub" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Margin" Value="0,4,0,0"/>
+        </ControlTheme>
+        <ControlTheme x:Key="WizardBody" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E0E0E0"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </ControlTheme>
+        <ControlTheme x:Key="WizardButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="18,8"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="MinWidth" Value="100"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="4"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.4"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+        <ControlTheme x:Key="WizardPrimaryButton" TargetType="Button" BasedOn="{StaticResource WizardButton}">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <Border Grid.Row="0" Background="{DynamicResource PanelBgBrush}" Padding="24,18">
+            <StackPanel>
+                <TextBlock x:Name="TxtStepTitle" Theme="{StaticResource WizardHeader}"
+                           Text="{loc:Str dialog_local_ai_setup_title}"/>
+                <TextBlock x:Name="TxtStepSubtitle" Theme="{StaticResource WizardSub}"
+                           Text="{loc:Str label_local_ai_setup_subtitle}"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Body -->
+        <Grid Grid.Row="1" Margin="24,18,24,0">
+
+            <!-- Step: Detecting -->
+            <StackPanel x:Name="PanelDetecting" IsVisible="True" VerticalAlignment="Center">
+                <TextBlock Theme="{StaticResource WizardBody}"
+                           HorizontalAlignment="Center"
+                           Text="{loc:Str label_local_ai_detecting}"/>
+                <ProgressBar IsIndeterminate="True" Height="6" Margin="0,16,0,0"
+                             Background="{DynamicResource PanelBgBrush}"
+                             Foreground="{StaticResource PinkBrush}"/>
+            </StackPanel>
+
+            <!-- Step: Consent -->
+            <StackPanel x:Name="PanelConsent" IsVisible="False">
+                <TextBlock Theme="{StaticResource WizardBody}"
+                           Text="{loc:Str label_local_ai_consent_intro}"/>
+
+                <Border Margin="0,14,0,0" Padding="14,10"
+                        Background="{DynamicResource PanelBgBrush}" CornerRadius="6">
+                    <StackPanel>
+                        <TextBlock Theme="{StaticResource WizardBody}"
+                                   FontWeight="SemiBold"
+                                   Text="{loc:Str label_local_ai_consent_will_do}"/>
+
+                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                            <TextBlock Text="•" Foreground="{StaticResource PinkBrush}" FontSize="13" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="TxtConsentLine1" Theme="{StaticResource WizardBody}"
+                                       Text="{loc:Str label_local_ai_consent_install_ollama}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="•" Foreground="{StaticResource PinkBrush}" FontSize="13" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="TxtConsentLine2" Theme="{StaticResource WizardBody}"
+                                       Text="{loc:Str label_local_ai_consent_pull_model}"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                            <TextBlock Text="•" Foreground="{StaticResource PinkBrush}" FontSize="13" Margin="0,0,8,0"/>
+                            <TextBlock Theme="{StaticResource WizardBody}"
+                                       Text="{loc:Str label_local_ai_consent_runs_local}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <TextBlock Margin="0,14,0,0" Theme="{StaticResource WizardSub}"
+                           Text="{loc:Str label_local_ai_consent_disk_note}"/>
+
+                <CheckBox x:Name="ChkAdvanced" Margin="0,14,0,0"
+                          Foreground="{DynamicResource TextMutedBrush}">
+                    <TextBlock Text="{loc:Str label_local_ai_advanced_use_different_model}"/>
+                </CheckBox>
+                <Grid x:Name="AdvancedPanel" IsVisible="False" Margin="0,8,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Theme="{StaticResource WizardBody}"
+                               VerticalAlignment="Center" Margin="0,0,8,0"
+                               Text="{loc:Str label_local_ai_advanced_model_label}"/>
+                    <TextBox Grid.Column="1" x:Name="TxtAdvancedModel"
+                             Background="{DynamicResource PanelBgBrush}" Foreground="#E0E0E0"
+                             BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
+                             Padding="6,4" FontSize="13"/>
+                </Grid>
+
+                <TextBlock x:Name="LinkManualInstall" Margin="0,14,0,0" Cursor="Hand"
+                           Foreground="#B084DC" TextDecorations="Underline"
+                           Text="{loc:Str link_local_ai_manual_install}"/>
+            </StackPanel>
+
+            <!-- Step: Downloading installer -->
+            <StackPanel x:Name="PanelDownloadInstaller" IsVisible="False">
+                <TextBlock Theme="{StaticResource WizardBody}"
+                           Text="{loc:Str label_local_ai_downloading_installer}"/>
+                <Border x:Name="DownloadProgressTrack" Margin="0,12,0,0" Background="{DynamicResource PanelBgBrush}"
+                        CornerRadius="4" Height="20" Padding="2">
+                    <Grid>
+                        <Border x:Name="DownloadProgressFill"
+                                Background="{StaticResource PinkBrush}"
+                                CornerRadius="3" HorizontalAlignment="Left" Width="0"/>
+                    </Grid>
+                </Border>
+                <TextBlock x:Name="TxtDownloadProgress" Theme="{StaticResource WizardBody}"
+                           Margin="0,8,0,0" HorizontalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Step: Installing -->
+            <StackPanel x:Name="PanelInstalling" IsVisible="False" VerticalAlignment="Center">
+                <TextBlock Theme="{StaticResource WizardBody}" HorizontalAlignment="Center"
+                           Text="{loc:Str label_local_ai_installing}"/>
+                <ProgressBar IsIndeterminate="True" Height="6" Margin="0,16,0,0"
+                             Background="{DynamicResource PanelBgBrush}"
+                             Foreground="{StaticResource PinkBrush}"/>
+                <TextBlock Theme="{StaticResource WizardSub}" HorizontalAlignment="Center"
+                           Margin="0,12,0,0"
+                           Text="{loc:Str label_local_ai_installing_hint}"/>
+            </StackPanel>
+
+            <!-- Step: Pulling model -->
+            <StackPanel x:Name="PanelPullModel" IsVisible="False">
+                <TextBlock x:Name="TxtPullHeader" Theme="{StaticResource WizardBody}"
+                           Text="{loc:Str label_local_ai_pulling_model}"/>
+                <Border x:Name="PullProgressTrack" Margin="0,12,0,0" Background="{DynamicResource PanelBgBrush}"
+                        CornerRadius="4" Height="20" Padding="2">
+                    <Grid>
+                        <Border x:Name="PullProgressFill"
+                                Background="{StaticResource PinkBrush}"
+                                CornerRadius="3" HorizontalAlignment="Left" Width="0"/>
+                    </Grid>
+                </Border>
+                <TextBlock x:Name="TxtPullStatus" Theme="{StaticResource WizardBody}"
+                           Margin="0,8,0,0" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtPullDetail" Theme="{StaticResource WizardSub}"
+                           Margin="0,4,0,0" HorizontalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Step: Smoke test -->
+            <StackPanel x:Name="PanelSmokeTest" IsVisible="False" VerticalAlignment="Center">
+                <TextBlock Theme="{StaticResource WizardBody}" HorizontalAlignment="Center"
+                           Text="{loc:Str label_local_ai_smoke_test}"/>
+                <ProgressBar IsIndeterminate="True" Height="6" Margin="0,16,0,0"
+                             Background="{DynamicResource PanelBgBrush}"
+                             Foreground="{StaticResource PinkBrush}"/>
+                <TextBlock Theme="{StaticResource WizardSub}" HorizontalAlignment="Center"
+                           Margin="0,12,0,0"
+                           Text="{loc:Str label_local_ai_smoke_test_hint}"/>
+            </StackPanel>
+
+            <!-- Step: Done -->
+            <StackPanel x:Name="PanelDone" IsVisible="False" VerticalAlignment="Center">
+                <TextBlock Foreground="{StaticResource PinkBrush}" FontSize="36"
+                           HorizontalAlignment="Center" Text="✓" FontWeight="Bold"/>
+                <TextBlock Theme="{StaticResource WizardBody}" HorizontalAlignment="Center"
+                           Margin="0,12,0,0" FontSize="15" FontWeight="SemiBold"
+                           Text="{loc:Str label_local_ai_done}"/>
+                <TextBlock x:Name="TxtDoneDetail" Theme="{StaticResource WizardSub}"
+                           Margin="0,8,0,0" HorizontalAlignment="Center"
+                           TextAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Step: Error -->
+            <StackPanel x:Name="PanelError" IsVisible="False">
+                <TextBlock Foreground="#FF6B6B" FontSize="32" HorizontalAlignment="Center"
+                           Text="!" FontWeight="Bold"/>
+                <TextBlock Theme="{StaticResource WizardBody}" HorizontalAlignment="Center"
+                           Margin="0,8,0,0" FontWeight="SemiBold"
+                           Text="{loc:Str label_local_ai_error_heading}"/>
+                <TextBox x:Name="TxtErrorDetail" Margin="0,12,0,0" MaxHeight="180"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="#E0E0E0"
+                         BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
+                         Padding="8" FontFamily="Consolas, Courier New, monospace" FontSize="11"
+                         IsReadOnly="True" TextWrapping="Wrap"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                <TextBlock x:Name="LinkManualInstallError" Margin="0,12,0,0" Cursor="Hand"
+                           Foreground="#B084DC" TextDecorations="Underline"
+                           Text="{loc:Str link_local_ai_manual_install}"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Footer -->
+        <Border Grid.Row="2" Background="{DynamicResource PanelBgBrush}" Padding="20,14">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button Grid.Column="1" x:Name="BtnSecondary" Theme="{StaticResource WizardButton}"
+                        Margin="0,0,10,0">
+                    <TextBlock x:Name="TxtSecondary" Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button Grid.Column="2" x:Name="BtnPrimary" Theme="{StaticResource WizardPrimaryButton}">
+                    <TextBlock x:Name="TxtPrimary" Text="{loc:Str btn_continue}"/>
+                </Button>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/LocalAiSetupWizard.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LocalAiSetupWizard.axaml.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Onboarding wizard for the local-AI (Ollama) provider. Drives users through
+    /// detect → consent → install Ollama → pull model → smoke test → done.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/LocalAiSetupWizard.xaml.cs. The page switching,
+    /// footer wording, advanced-model toggle and progress-bar maths are the original's. Everything
+    /// that reached OllamaSetupService, App.Settings or App.Logger is a stub that lands on the page
+    /// the real call would have shown and stops there - the service is Windows-head code and has
+    /// not moved to Core yet. WPF's DialogResult becomes Close(bool).
+    /// </summary>
+    public partial class LocalAiSetupWizard : Window
+    {
+        private const string DefaultModel = "qwen3.5:latest";
+        private const string ManualInstallUrl = "https://ollama.com/download";
+
+        private enum Step
+        {
+            Detecting,
+            Consent,
+            DownloadInstaller,
+            Installing,
+            PullModel,
+            SmokeTest,
+            Done,
+            Error
+        }
+
+        private Step _step = Step.Detecting;
+        private string _targetModel = DefaultModel;
+        private bool _wizardComplete;
+
+        public bool LocalAiReady { get; private set; }
+        public string SelectedModel => _targetModel;
+
+        private readonly StackPanel _panelDetecting, _panelConsent, _panelDownloadInstaller, _panelInstalling,
+            _panelPullModel, _panelSmokeTest, _panelDone, _panelError;
+        private readonly TextBlock _txtStepTitle, _txtStepSubtitle, _txtConsentLine2, _txtDownloadProgress,
+            _txtPullHeader, _txtPullStatus, _txtPullDetail, _txtDoneDetail, _txtPrimary, _txtSecondary;
+        private readonly Button _btnPrimary, _btnSecondary;
+        private readonly CheckBox _chkAdvanced;
+        private readonly Grid _advancedPanel;
+        private readonly TextBox _txtAdvancedModel, _txtErrorDetail;
+        private readonly Border _downloadProgressTrack, _downloadProgressFill, _pullProgressTrack, _pullProgressFill;
+
+        public LocalAiSetupWizard()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            T C<T>(string name) where T : Control => this.FindControl<T>(name)!;
+            _panelDetecting = C<StackPanel>("PanelDetecting");
+            _panelConsent = C<StackPanel>("PanelConsent");
+            _panelDownloadInstaller = C<StackPanel>("PanelDownloadInstaller");
+            _panelInstalling = C<StackPanel>("PanelInstalling");
+            _panelPullModel = C<StackPanel>("PanelPullModel");
+            _panelSmokeTest = C<StackPanel>("PanelSmokeTest");
+            _panelDone = C<StackPanel>("PanelDone");
+            _panelError = C<StackPanel>("PanelError");
+            _txtStepTitle = C<TextBlock>("TxtStepTitle");
+            _txtStepSubtitle = C<TextBlock>("TxtStepSubtitle");
+            _txtConsentLine2 = C<TextBlock>("TxtConsentLine2");
+            _txtDownloadProgress = C<TextBlock>("TxtDownloadProgress");
+            _txtPullHeader = C<TextBlock>("TxtPullHeader");
+            _txtPullStatus = C<TextBlock>("TxtPullStatus");
+            _txtPullDetail = C<TextBlock>("TxtPullDetail");
+            _txtDoneDetail = C<TextBlock>("TxtDoneDetail");
+            _txtPrimary = C<TextBlock>("TxtPrimary");
+            _txtSecondary = C<TextBlock>("TxtSecondary");
+            _btnPrimary = C<Button>("BtnPrimary");
+            _btnSecondary = C<Button>("BtnSecondary");
+            _chkAdvanced = C<CheckBox>("ChkAdvanced");
+            _advancedPanel = C<Grid>("AdvancedPanel");
+            _txtAdvancedModel = C<TextBox>("TxtAdvancedModel");
+            _txtErrorDetail = C<TextBox>("TxtErrorDetail");
+            _downloadProgressTrack = C<Border>("DownloadProgressTrack");
+            _downloadProgressFill = C<Border>("DownloadProgressFill");
+            _pullProgressTrack = C<Border>("PullProgressTrack");
+            _pullProgressFill = C<Border>("PullProgressFill");
+
+            _btnPrimary.Click += (_, _) => BtnPrimary_Click();
+            _btnSecondary.Click += (_, _) => BtnSecondary_Click();
+            _chkAdvanced.IsCheckedChanged += (_, _) => ChkAdvanced_Changed();
+            C<TextBlock>("LinkManualInstall").PointerPressed += (_, _) => LinkManualInstall_Click();
+            C<TextBlock>("LinkManualInstallError").PointerPressed += (_, _) => LinkManualInstall_Click();
+
+            _targetModel = ResolveStartingModel();
+            _txtAdvancedModel.Text = _targetModel;
+            UpdateConsentDiskNote();
+
+            // WPF ran this from Loaded; here it is synchronous because the stub cannot await
+            // anything, and running it now is what puts the Consent page in the render PNG.
+            StartDetect();
+        }
+
+        private static string ResolveStartingModel()
+        {
+            // ponytail: needs App.Settings.Current.CompanionPrompt.AiModel, wired when settings move to Core
+            return DefaultModel;
+        }
+
+        private void UpdateConsentDiskNote()
+        {
+            // The default model is ~6.6 GB; for unknown custom models we just say "varies."
+            // Both lines stay readable in any locale.
+            _txtConsentLine2.Text = string.Equals(_targetModel, DefaultModel, StringComparison.OrdinalIgnoreCase)
+                ? Loc.GetF("label_local_ai_consent_pull_model_known", _targetModel, "~6.6 GB")
+                : Loc.GetF("label_local_ai_consent_pull_model_custom", _targetModel);
+        }
+
+        // -------- Step transitions --------
+
+        private void Show(Step s)
+        {
+            _step = s;
+            _panelDetecting.IsVisible = s == Step.Detecting;
+            _panelConsent.IsVisible = s == Step.Consent;
+            _panelDownloadInstaller.IsVisible = s == Step.DownloadInstaller;
+            _panelInstalling.IsVisible = s == Step.Installing;
+            _panelPullModel.IsVisible = s == Step.PullModel;
+            _panelSmokeTest.IsVisible = s == Step.SmokeTest;
+            _panelDone.IsVisible = s == Step.Done;
+            _panelError.IsVisible = s == Step.Error;
+
+            switch (s)
+            {
+                case Step.Detecting:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_detecting");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_detecting_sub");
+                    _btnPrimary.IsVisible = false;
+                    _txtSecondary.Text = Loc.Get("btn_cancel");
+                    _btnSecondary.IsEnabled = true;
+                    break;
+                case Step.Consent:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_consent");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_consent_sub");
+                    _btnPrimary.IsVisible = true;
+                    _txtPrimary.Text = Loc.Get("btn_continue");
+                    _txtSecondary.Text = Loc.Get("btn_cancel");
+                    _btnPrimary.IsEnabled = true;
+                    _btnSecondary.IsEnabled = true;
+                    break;
+                case Step.DownloadInstaller:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_download");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_download_sub");
+                    _btnPrimary.IsVisible = false;
+                    _txtSecondary.Text = Loc.Get("btn_cancel");
+                    _btnSecondary.IsEnabled = true;
+                    break;
+                case Step.Installing:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_install");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_install_sub");
+                    _btnPrimary.IsVisible = false;
+                    // Don't allow cancel during silent install — Ollama's NSIS installer
+                    // doesn't roll back gracefully and a half-finished install is worse
+                    // than a finished one the user can uninstall.
+                    _btnSecondary.IsEnabled = false;
+                    break;
+                case Step.PullModel:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_pull");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_pull_sub");
+                    _btnPrimary.IsVisible = false;
+                    _txtSecondary.Text = Loc.Get("btn_cancel");
+                    _btnSecondary.IsEnabled = true;
+                    break;
+                case Step.SmokeTest:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_smoke");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_smoke_sub");
+                    _btnPrimary.IsVisible = false;
+                    _btnSecondary.IsEnabled = false;
+                    break;
+                case Step.Done:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_done");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_done_sub");
+                    _btnPrimary.IsVisible = true;
+                    _txtPrimary.Text = Loc.Get("btn_close");
+                    _btnPrimary.IsEnabled = true;
+                    _btnSecondary.IsVisible = false;
+                    break;
+                case Step.Error:
+                    _txtStepTitle.Text = Loc.Get("label_local_ai_step_error");
+                    _txtStepSubtitle.Text = Loc.Get("label_local_ai_step_error_sub");
+                    _btnPrimary.IsVisible = true;
+                    _txtPrimary.Text = Loc.Get("btn_retry");
+                    _txtSecondary.Text = Loc.Get("btn_close");
+                    _btnPrimary.IsEnabled = true;
+                    _btnSecondary.IsEnabled = true;
+                    break;
+            }
+        }
+
+        // -------- Step 1: Detect --------
+
+        private void StartDetect()
+        {
+            Show(Step.Detecting);
+            // ponytail: needs OllamaSetupService.DetectAsync, wired when it moves to Core.
+            // The WPF original lands on Consent when detection throws; the stub takes that branch.
+            Show(Step.Consent);
+        }
+
+        // -------- Step 2: Consent → Download --------
+
+        private void StartDownloadInstaller()
+        {
+            Show(Step.DownloadInstaller);
+            SetDownloadProgressBar(0);
+            _txtDownloadProgress.Text = "";
+            // ponytail: needs OllamaSetupService.DownloadInstallerAsync + StartInstall/StartPull/
+            // StartSmokeTest chain, wired when it moves to Core. The page shows; nothing drives it.
+        }
+
+        private void SetDownloadProgressBar(double percent)
+        {
+            percent = Math.Clamp(percent, 0, 100);
+            double max = _downloadProgressTrack.Bounds.Width - 6;
+            if (max > 0) _downloadProgressFill.Width = max * percent / 100.0;
+        }
+
+        private void SetPullProgressBar(double percent)
+        {
+            percent = Math.Clamp(percent, 0, 100);
+            double max = _pullProgressTrack.Bounds.Width - 6;
+            if (max > 0) _pullProgressFill.Width = max * percent / 100.0;
+        }
+
+        // -------- Step 6: Done --------
+
+        private void Finish(TimeSpan smokeElapsed)
+        {
+            // ponytail: needs App.Settings (AiProvider/AiModel + Save), wired when settings move to Core
+            LocalAiReady = true;
+            _wizardComplete = true;
+
+            var seconds = Math.Max(0, (int)Math.Round(smokeElapsed.TotalSeconds));
+            _txtDoneDetail.Text = Loc.GetF("label_local_ai_done_detail", _targetModel, seconds);
+            Show(Step.Done);
+        }
+
+        private void ShowError(string detail)
+        {
+            _txtErrorDetail.Text = detail;
+            Show(Step.Error);
+        }
+
+        // -------- Footer button handlers --------
+
+        private void BtnPrimary_Click()
+        {
+            switch (_step)
+            {
+                case Step.Consent:
+                    if (_chkAdvanced.IsChecked == true)
+                    {
+                        var typed = (_txtAdvancedModel.Text ?? "").Trim();
+                        if (!string.IsNullOrEmpty(typed)) _targetModel = typed;
+                    }
+                    StartDownloadInstaller();
+                    break;
+                case Step.Done:
+                    Close(true);
+                    break;
+                case Step.Error:
+                    // Retry from detect — the right next step depends on what's now true.
+                    StartDetect();
+                    break;
+            }
+        }
+
+        private void BtnSecondary_Click()
+        {
+            // Cancel current step and bail out. The Done state hides this button entirely.
+            Close(_wizardComplete);
+        }
+
+        private void ChkAdvanced_Changed()
+        {
+            _advancedPanel.IsVisible = _chkAdvanced.IsChecked == true;
+        }
+
+        private void LinkManualInstall_Click()
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = ManualInstallUrl,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Warning(ex, "LocalAiSetupWizard: failed to open manual install URL");
+            }
+        }
+    }
+}


### PR DESCRIPTION
572 lines, 2 files. Page switching and validation are real; downloads and the Ollama setup chain are ponytail stubs.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351