### PR TITLE
feat(avalonia): port feature cards, part 1/2 - FeatureCard, SplitFeatureCard

### DIFF
--- a/CCP.Avalonia/Views/Features/FeatureCard.axaml
+++ b/CCP.Avalonia/Views/Features/FeatureCard.axaml
@@ -1,0 +1,164 @@
+<!-- PORTED from ConditioningControlPanel/Features/FeatureCard.xaml.
+     Structure, order, spacing, every x:Name and every resource key preserved. Deviations, all forced:
+
+       Visibility="Collapsed"          -> IsVisible="False"
+       Panel.ZIndex                    -> ZIndex
+       RenderTransformOrigin="0.5,0.5" -> "50%,50%" (Avalonia reads a bare number as pixels)
+       ShadowDepth="0"                 -> OffsetX="0" OffsetY="0"
+       RenderOptions.BitmapScalingMode -> RenderOptions.BitmapInterpolationMode
+       LinearGradientBrush points      -> percentages
+       Style="{DynamicResource X}"     -> Theme="{StaticResource X}"
+       Image of an emoji via EmojiToImageSource -> a plain TextBlock (Avalonia draws colour emoji)
+       MouseLeftButtonUp / MouseRightButtonUp / SizeChanged -> wired in the constructor
+       Hover rim-light DoubleAnimation -> a DoubleTransition on RimLight.Opacity (below) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.FeatureCard"
+             Cursor="Hand">
+
+    <Border x:Name="RootBorder"
+            Background="{DynamicResource ElevatedSurfaceBrush}"
+            BorderBrush="{DynamicResource GlassBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="12"
+            ClipToBounds="True"
+            Margin="6"
+            RenderTransformOrigin="50%,50%">
+        <!-- RootScale (hover lift) is built in the code-behind: a transform's x:Name is not
+             reachable through FindControl. -->
+        <!-- The card's glow. Colour comes from FxTheme (FxGlowColor is rewritten on every mod
+             switch) rather than PinkColor, so an active tile is the mod's colour, not Bambi's.
+             Opacity is driven entirely from code (ApplyActiveState / StartActiveBreath). -->
+        <Border.Effect>
+            <DropShadowEffect
+                              Color="{DynamicResource FxGlowColor}"
+                              BlurRadius="18"
+                              OffsetX="0" OffsetY="0"
+                              Opacity="0"/>
+        </Border.Effect>
+
+        <Grid x:Name="ContentRoot">
+            <!-- Full-bleed background image via ImageBrush (respects parent CornerRadius) -->
+            <Border x:Name="ImgIconHost" CornerRadius="11"
+                    RenderOptions.BitmapInterpolationMode="HighQuality"/>
+
+            <!-- Glyph fallback (for cards without an image) -->
+            <Border x:Name="GlyphHost"
+                    Width="68" Height="68"
+                    CornerRadius="34"
+                    Background="{DynamicResource TransparentPinkBrush}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsVisible="False">
+                <TextBlock x:Name="TxtGlyph"
+                           FontSize="32"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource PinkBrush}"/>
+            </Border>
+
+            <!-- TEASE VEIL. Shown only when TeaseTier > 0 (see ApplyTeaseState): the art below
+                 is blurred out and this scrim + "?" is what the card actually says. Static. -->
+            <Grid x:Name="TeaseHost" IsVisible="False" IsHitTestVisible="False">
+                <Border CornerRadius="11" Background="#59000000"/>
+                <TextBlock x:Name="TxtTeaseGlyph"
+                           Text="?"
+                           FontSize="46" FontWeight="Bold"
+                           Margin="0,0,0,16"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Foreground="White" Opacity="0.9"/>
+            </Grid>
+
+            <!-- Bottom gradient + title overlay -->
+            <Border CornerRadius="0,0,11,11"
+                    VerticalAlignment="Bottom"
+                    IsHitTestVisible="False">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                        <GradientStop Color="Transparent" Offset="0"/>
+                        <GradientStop Color="#60000000" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+                <TextBlock x:Name="TxtTitle"
+                           Text="Feature"
+                           Margin="8,14,8,8"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Foreground="White"
+                           FontSize="12"
+                           FontWeight="SemiBold"/>
+            </Border>
+
+            <!-- Hover rim-light. A separate 1.5px ring rather than a brush swap on RootBorder.
+                 Opacity-only, 150ms. -->
+            <Border x:Name="RimLight"
+                    BorderBrush="{DynamicResource FxGlowBrush}"
+                    BorderThickness="1.5"
+                    CornerRadius="12"
+                    IsHitTestVisible="False"
+                    Opacity="0">
+                <Border.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.15" Easing="QuadraticEaseOut"/>
+                    </Transitions>
+                </Border.Transitions>
+            </Border>
+
+            <!-- Active overlay: mod-tinted ring when the underlying feature is enabled.
+                 Right-click a card to toggle the feature on/off. Breathes with the glow. -->
+            <Border x:Name="ActiveBorder"
+                    BorderBrush="{DynamicResource FxGlowBrush}"
+                    BorderThickness="3.5"
+                    CornerRadius="12"
+                    IsHitTestVisible="False"
+                    IsVisible="False"/>
+
+            <!-- Locked overlay -->
+            <Border x:Name="LockedOverlay"
+                    Background="#C0000000"
+                    CornerRadius="12"
+                    IsVisible="False">
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <TextBlock Text="🔒" FontSize="26" HorizontalAlignment="Center"/>
+                    <TextBlock x:Name="TxtLockLabel"
+                               Text="Lvl 10"
+                               Margin="0,4,0,0"
+                               HorizontalAlignment="Center"
+                               Foreground="White"
+                               FontSize="11"
+                               FontWeight="SemiBold"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Tier badge (top-left). A price tag, NOT the LockedOverlay veil above: the art
+                 stays bright and the badge names the price. IsHitTestVisible=False on purpose,
+                 so a locked click still lands on the real handler. -->
+            <Border x:Name="TierBadgeHost"
+                    HorizontalAlignment="Left" VerticalAlignment="Top"
+                    Margin="8,8,0,0" Padding="6,2,7,3"
+                    CornerRadius="7"
+                    Background="#D91A1A2E"
+                    BorderBrush="{DynamicResource PinkBrush}"
+                    BorderThickness="1"
+                    IsHitTestVisible="False"
+                    ZIndex="11"
+                    IsVisible="False">
+                <TextBlock x:Name="TxtTierBadge"
+                           Text="TIER 1"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontSize="9"
+                           FontWeight="Bold"/>
+            </Border>
+
+            <!-- Help icon overlay (top-right corner) -->
+            <Button x:Name="BtnHelp"
+                    Theme="{StaticResource HelpButtonStyle}"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="0,8,8,0"
+                    ZIndex="10"
+                    IsVisible="False"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/FeatureCard.axaml.cs
+++ b/CCP.Avalonia/Views/Features/FeatureCard.axaml.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Threading;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+using ConditioningControlPanel.Services;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Click-to-open tile for a feature on the dashboard grid. Shows an icon + title; when
+    /// locked, desaturates the content and overlays a padlock + required level. Ported from the
+    /// WPF head; the property surface (Title, Icon, Glyph, LockLevel, IsLocked, IsActive,
+    /// HelpSectionId, TierBadge, TeaseTier) and the Click / ToggleRequested events are the same,
+    /// so a dashboard can be written against either.
+    ///
+    /// FX: hover = a 1.02 lift + 150ms rim-light, active = the glow and the ring breathing on one
+    /// 3.5s clock. The WPF gates (MotionFx, PerformanceProfile, window focus, tab visibility)
+    /// live in the head, so this card always animates.
+    /// ponytail: needs MotionFx/PerformanceProfile, gate the breath when they move to Core
+    /// </summary>
+    public partial class FeatureCard : UserControl
+    {
+        private const double ActiveGlowMinOpacity = 0.50;
+        private const double ActiveGlowMaxOpacity = 0.90;
+        private const double ActiveRingMinOpacity = 0.55;
+        private const double ActiveRingMaxOpacity = 1.00;
+        private const double ActiveBreathSeconds = 3.5;
+        private const double RimLightOpacity = 0.85;
+        private const double HoverLiftScale = 1.02;
+        private const double HoverPopScale = 1.06;
+        private const int HoverMs = 150;
+        private const double TeaseBlurRadius = 26;
+        private const double TeaseBorderThickness = 2;
+        private const double ContentClipRadius = 11;
+
+        public static readonly StyledProperty<string> TitleProperty =
+            AvaloniaProperty.Register<FeatureCard, string>(nameof(Title), "Feature");
+        public static readonly StyledProperty<IImageBrushSource?> IconProperty =
+            AvaloniaProperty.Register<FeatureCard, IImageBrushSource?>(nameof(Icon));
+        public static readonly StyledProperty<string?> GlyphProperty =
+            AvaloniaProperty.Register<FeatureCard, string?>(nameof(Glyph));
+        public static readonly StyledProperty<int> LockLevelProperty =
+            AvaloniaProperty.Register<FeatureCard, int>(nameof(LockLevel));
+        public static readonly StyledProperty<bool> IsLockedProperty =
+            AvaloniaProperty.Register<FeatureCard, bool>(nameof(IsLocked));
+        public static readonly StyledProperty<bool> IsActiveProperty =
+            AvaloniaProperty.Register<FeatureCard, bool>(nameof(IsActive));
+        public static readonly StyledProperty<string?> HelpSectionIdProperty =
+            AvaloniaProperty.Register<FeatureCard, string?>(nameof(HelpSectionId));
+        public static readonly StyledProperty<string?> TierBadgeProperty =
+            AvaloniaProperty.Register<FeatureCard, string?>(nameof(TierBadge));
+        public static readonly StyledProperty<int> TeaseTierProperty =
+            AvaloniaProperty.Register<FeatureCard, int>(nameof(TeaseTier));
+
+        public static readonly RoutedEvent<RoutedEventArgs> ClickEvent =
+            RoutedEvent.Register<FeatureCard, RoutedEventArgs>(nameof(Click), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<RoutedEventArgs> ToggleRequestedEvent =
+            RoutedEvent.Register<FeatureCard, RoutedEventArgs>(nameof(ToggleRequested), RoutingStrategies.Bubble);
+
+        public string Title { get => GetValue(TitleProperty); set => SetValue(TitleProperty, value); }
+        public IImageBrushSource? Icon { get => GetValue(IconProperty); set => SetValue(IconProperty, value); }
+        public string? Glyph { get => GetValue(GlyphProperty); set => SetValue(GlyphProperty, value); }
+        /// <summary>Required level for this feature. 0 means always unlocked.</summary>
+        public int LockLevel { get => GetValue(LockLevelProperty); set => SetValue(LockLevelProperty, value); }
+        public bool IsLocked { get => GetValue(IsLockedProperty); set => SetValue(IsLockedProperty, value); }
+        /// <summary>Highlights the card with a glow + ring when the underlying feature is enabled.</summary>
+        public bool IsActive { get => GetValue(IsActiveProperty); set => SetValue(IsActiveProperty, value); }
+        /// <summary>ID of the HelpContentService entry behind the "?" icon. Null/unknown hides it.</summary>
+        public string? HelpSectionId { get => GetValue(HelpSectionIdProperty); set => SetValue(HelpSectionIdProperty, value); }
+        /// <summary>Short price tag pill, top-left ("TIER 1", "LAB", "SOON"). Null/blank hides it.</summary>
+        public string? TierBadge { get => GetValue(TierBadgeProperty); set => SetValue(TierBadgeProperty, value); }
+        /// <summary>0 = normal card, 1 = gold tease livery, 2+ = diamond. Blurs the art, veils it, wears a "?".</summary>
+        public int TeaseTier { get => GetValue(TeaseTierProperty); set => SetValue(TeaseTierProperty, value); }
+
+        public event EventHandler<RoutedEventArgs> Click { add => AddHandler(ClickEvent, value); remove => RemoveHandler(ClickEvent, value); }
+        /// <summary>Raised on right-click so the dashboard can quick-toggle the feature without opening its popup.</summary>
+        public event EventHandler<RoutedEventArgs> ToggleRequested { add => AddHandler(ToggleRequestedEvent, value); remove => RemoveHandler(ToggleRequestedEvent, value); }
+
+        private readonly Border _rootBorder, _imgIconHost, _glyphHost, _rimLight, _activeBorder, _lockedOverlay, _tierBadgeHost;
+        private readonly Grid _contentRoot, _teaseHost;
+        private readonly TextBlock _txtTitle, _txtGlyph, _txtTeaseGlyph, _txtLockLabel, _txtTierBadge;
+        private readonly Button _btnHelp;
+        private readonly DropShadowEffect _activeGlow;
+        private readonly ScaleTransform _rootScale = new(1, 1), _artScale = new(1, 1);
+        private CancellationTokenSource? _breath;
+        private bool _hovered;
+
+        public FeatureCard()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _rootBorder = this.FindControl<Border>("RootBorder")!;
+            _imgIconHost = this.FindControl<Border>("ImgIconHost")!;
+            _glyphHost = this.FindControl<Border>("GlyphHost")!;
+            _rimLight = this.FindControl<Border>("RimLight")!;
+            _activeBorder = this.FindControl<Border>("ActiveBorder")!;
+            _lockedOverlay = this.FindControl<Border>("LockedOverlay")!;
+            _tierBadgeHost = this.FindControl<Border>("TierBadgeHost")!;
+            _contentRoot = this.FindControl<Grid>("ContentRoot")!;
+            _teaseHost = this.FindControl<Grid>("TeaseHost")!;
+            _txtTitle = this.FindControl<TextBlock>("TxtTitle")!;
+            _txtGlyph = this.FindControl<TextBlock>("TxtGlyph")!;
+            _txtTeaseGlyph = this.FindControl<TextBlock>("TxtTeaseGlyph")!;
+            _txtLockLabel = this.FindControl<TextBlock>("TxtLockLabel")!;
+            _txtTierBadge = this.FindControl<TextBlock>("TxtTierBadge")!;
+            _btnHelp = this.FindControl<Button>("BtnHelp")!;
+            _activeGlow = (DropShadowEffect)_rootBorder.Effect!;
+
+            // Hover lift (WPF: MotionFx.HoverLift) and art pop (WPF: HoverPop) as transitions on
+            // two scale transforms; the 6px margin on RootBorder is the headroom the lift paints into.
+            var hoverTransitions = new Transitions
+            {
+                new DoubleTransition { Property = ScaleTransform.ScaleXProperty, Duration = TimeSpan.FromMilliseconds(HoverMs), Easing = new QuadraticEaseOut() },
+                new DoubleTransition { Property = ScaleTransform.ScaleYProperty, Duration = TimeSpan.FromMilliseconds(HoverMs), Easing = new QuadraticEaseOut() },
+            };
+            _rootScale.Transitions = hoverTransitions;
+            _artScale.Transitions = hoverTransitions;
+            _rootBorder.RenderTransform = _rootScale;
+            _imgIconHost.RenderTransform = _artScale;
+
+            _contentRoot.SizeChanged += (_, _) => UpdateRoundedClip();
+            PointerEntered += (_, _) => ApplyHover(true);
+            PointerExited += (_, _) => ApplyHover(false);
+            PointerReleased += OnPointerReleased;
+            Unloaded += (_, _) => ApplyActiveBreath(false);
+            Loaded += (_, _) => ApplyActiveState(); // re-arm the breath after a detach/re-attach (tab switch)
+
+            ApplyLockState();
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (_rootBorder is null) return; // fired before the XAML loaded
+            if (change.Property == TitleProperty) _txtTitle.Text = Title ?? "";
+            else if (change.Property == IconProperty || change.Property == GlyphProperty) ApplyArt();
+            else if (change.Property == LockLevelProperty || change.Property == IsLockedProperty) ApplyLockState();
+            else if (change.Property == IsActiveProperty) ApplyActiveState();
+            else if (change.Property == HelpSectionIdProperty) RefreshHelpTooltip();
+            else if (change.Property == TierBadgeProperty) ApplyTierBadge();
+            else if (change.Property == TeaseTierProperty) ApplyTeaseState();
+        }
+
+        private void ApplyArt()
+        {
+            var src = Icon;
+            _txtGlyph.Text = Glyph ?? "";
+            _imgIconHost.Background = src is null
+                ? null
+                : new ImageBrush(src) { Stretch = Stretch.UniformToFill, AlignmentY = AlignmentY.Center };
+            _imgIconHost.IsVisible = src is not null;
+            _glyphHost.IsVisible = src is null && !string.IsNullOrEmpty(Glyph);
+        }
+
+        private void ApplyTierBadge()
+        {
+            var text = TierBadge;
+            if (string.IsNullOrWhiteSpace(text)) { _tierBadgeHost.IsVisible = false; return; }
+            _txtTierBadge.Text = text;
+            _tierBadgeHost.IsVisible = true;
+            // A teased card's badge is worn in the livery metal, not in pink; the two properties
+            // are written in whichever order the caller happens to use.
+            if (TeaseTier > 0) ApplyTeaseState();
+        }
+
+        /// <summary>
+        /// Puts on (or takes off) the tease costume. Reversible: TeaseTier = 0 rebinds the border
+        /// and badge brushes to the theme resources instead of freezing them.
+        /// ponytail: TierFxBorder's living-metal rim stays in the head; the tease rim is static here
+        /// </summary>
+        private void ApplyTeaseState()
+        {
+            if (TeaseTier <= 0)
+            {
+                _teaseHost.IsVisible = false;
+                _imgIconHost.Effect = null;
+                _glyphHost.Effect = null;
+                _rootBorder[!Border.BorderBrushProperty] = this.GetResourceObservable("GlassBorderBrush").ToBinding();
+                _rootBorder.BorderThickness = new Thickness(1);
+                _tierBadgeHost[!Border.BorderBrushProperty] = this.GetResourceObservable("PinkBrush").ToBinding();
+                _txtTierBadge[!TextBlock.ForegroundProperty] = this.GetResourceObservable("PinkBrush").ToBinding();
+                return;
+            }
+
+            // Bound to the resource, not copied: a local value would be overwritten by the XAML
+            // DynamicResource re-emitting on every attach, and misses before the card is attached.
+            var liveryKey = TeaseTier >= 2 ? "Tier2DiamondBorderBrush" : "Tier1GoldBorderBrush";
+            var livery = this.GetResourceObservable(liveryKey).ToBinding();
+
+            // ONE BlurEffect shared by both art hosts: only one is ever visible (icon XOR glyph).
+            var blur = new BlurEffect { Radius = TeaseBlurRadius };
+            _imgIconHost.Effect = blur;
+            _glyphHost.Effect = blur;
+
+            _txtTeaseGlyph[!TextBlock.ForegroundProperty] = livery;
+            _teaseHost.IsVisible = true;
+
+            _rootBorder[!Border.BorderBrushProperty] = livery;
+            _rootBorder.BorderThickness = new Thickness(TeaseBorderThickness);
+            _tierBadgeHost[!Border.BorderBrushProperty] = livery;
+            _txtTierBadge[!TextBlock.ForegroundProperty] = livery;
+        }
+
+        private void RefreshHelpTooltip()
+        {
+            var id = HelpSectionId;
+            if (string.IsNullOrWhiteSpace(id) || !HelpContentService.HasContent(id))
+            {
+                _btnHelp.IsVisible = false;
+                ToolTip.SetTip(_btnHelp, null);
+                return;
+            }
+            // ponytail: needs HelpPopover (head-only interactive popover); a plain tooltip with the
+            // section title until it is ported
+            ToolTip.SetTip(_btnHelp, HelpContentService.GetContent(id).Title);
+            _btnHelp.IsVisible = true;
+        }
+
+        private void ApplyLockState()
+        {
+            if (IsLocked)
+            {
+                _lockedOverlay.IsVisible = true;
+                _txtLockLabel.Text = LockLevel > 0 ? $"Lvl {LockLevel}" : "Locked";
+                _contentRoot.Opacity = 0.35;
+            }
+            else
+            {
+                _lockedOverlay.IsVisible = false;
+                _contentRoot.Opacity = 1.0;
+            }
+            ApplyActiveState();
+        }
+
+        private void ApplyActiveState()
+        {
+            // A locked feature can't really be "on" even if the underlying setting is true.
+            var showActive = IsActive && !IsLocked;
+            _activeBorder.IsVisible = showActive;
+            ApplyActiveBreath(showActive);
+        }
+
+        /// <summary>The glow and the ring share one 3.5s clock so the tile pulses as one object.</summary>
+        private void ApplyActiveBreath(bool active)
+        {
+            _breath?.Cancel();
+            _breath = null;
+            if (!active)
+            {
+                _activeGlow.Opacity = 0;
+                _activeBorder.Opacity = 1;
+                return;
+            }
+            _breath = new CancellationTokenSource();
+            _ = Breathe(_activeGlow, ActiveGlowMinOpacity, ActiveGlowMaxOpacity).RunAsync(_activeGlow, _breath.Token);
+            _ = Breathe(_activeBorder, ActiveRingMinOpacity, ActiveRingMaxOpacity).RunAsync(_activeBorder, _breath.Token);
+        }
+
+        private static Animation Breathe(Animatable target, double min, double max)
+        {
+            var prop = target is Visual ? Visual.OpacityProperty : DropShadowEffect.OpacityProperty;
+            return new Animation
+            {
+                Duration = TimeSpan.FromSeconds(ActiveBreathSeconds),
+                IterationCount = IterationCount.Infinite,
+                PlaybackDirection = PlaybackDirection.Alternate,
+                Easing = new SineEaseInOut(),
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(prop, min) } },
+                    new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(prop, max) } },
+                },
+            };
+        }
+
+        /// <summary>Rounded clip matching RootBorder's inner arc: a Border never clips its
+        /// CHILDREN to its CornerRadius, so the full-bleed art would poke square corners past the frame.</summary>
+        private void UpdateRoundedClip()
+        {
+            var b = _contentRoot.Bounds;
+            _contentRoot.Clip = b.Width <= 0 || b.Height <= 0
+                ? null
+                : new RectangleGeometry(new Rect(0, 0, b.Width, b.Height)) { RadiusX = ContentClipRadius, RadiusY = ContentClipRadius };
+        }
+
+        private void ApplyHover(bool on)
+        {
+            if (_hovered == on) return;
+            _hovered = on;
+            // A locked tile is not an affordance; lighting it up promises a click that does nothing.
+            if (IsLocked) on = false;
+            _rootScale.ScaleX = _rootScale.ScaleY = on ? HoverLiftScale : 1;
+            _artScale.ScaleX = _artScale.ScaleY = on ? HoverPopScale : 1;
+            _rimLight.Opacity = on ? RimLightOpacity : 0;
+        }
+
+        private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            // Swallow clicks that originate inside the help button so the user can hover/click
+            // the "?" without also opening the feature popup.
+            if (e.Source is Visual src && (src == _btnHelp || _btnHelp.IsVisualAncestorOf(src))) return;
+
+            if (e.InitialPressMouseButton == MouseButton.Left)
+            {
+                RaiseEvent(new RoutedEventArgs(ClickEvent, this));
+            }
+            else if (e.InitialPressMouseButton == MouseButton.Right)
+            {
+                // Right-click is a quick on/off shortcut. A locked feature can't be toggled on.
+                if (IsLocked) return;
+                e.Handled = true;
+                RaiseEvent(new RoutedEventArgs(ToggleRequestedEvent, this));
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/SplitFeatureCard.axaml
+++ b/CCP.Avalonia/Views/Features/SplitFeatureCard.axaml
@@ -1,0 +1,114 @@
+<!-- PORTED from ConditioningControlPanel/Features/SplitFeatureCard.xaml.
+     Structure, order, spacing, every x:Name and every resource key preserved. Deviations, all forced:
+
+       Visibility="Collapsed"          -> IsVisible="False"
+       RenderTransformOrigin           -> percentages (Avalonia reads a bare number as pixels)
+       ShadowDepth="0"                 -> OffsetX="0" OffsetY="0"
+       RenderOptions.BitmapScalingMode -> RenderOptions.BitmapInterpolationMode
+       ScaleTransform x:Name           -> built in the code-behind (not reachable via FindControl)
+       MouseLeftButtonUp / MouseRightButtonUp / MouseMove / SizeChanged -> wired in the constructor
+       Hover rim-light DoubleAnimation -> a DoubleTransition on RimLight.Opacity
+
+     DIAGONAL SPLIT TILE: one mosaic cell, TWO features. Half A owns the TOP-LEFT triangle,
+     half B the BOTTOM-RIGHT, split on the "/" diagonal. Hovering a half sweeps the seam across
+     the card until that half fills the square bar a corner peek for the other one. Every
+     size-dependent geometry (clips, washes, scrims, seam, rings, hit test) is a function of
+     SplitProgress in the code-behind, rebuilt on SizeChanged and on every frame of the sweep. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.SplitFeatureCard"
+             Cursor="Hand">
+
+    <Border x:Name="RootBorder"
+            Background="{DynamicResource ElevatedSurfaceBrush}"
+            BorderBrush="{DynamicResource GlassBorderBrush}"
+            BorderThickness="1"
+            CornerRadius="12"
+            ClipToBounds="True"
+            Margin="6"
+            RenderTransformOrigin="50%,50%">
+        <Border.Effect>
+            <DropShadowEffect Color="{DynamicResource FxGlowColor}"
+                              BlurRadius="18"
+                              OffsetX="0" OffsetY="0"
+                              Opacity="0"/>
+        </Border.Effect>
+
+        <Grid x:Name="ContentRoot">
+            <!-- The two art halves. Full-bleed brushes, polygon-clipped in code. -->
+            <Border x:Name="HalfHostA" CornerRadius="11"
+                    RenderOptions.BitmapInterpolationMode="HighQuality"/>
+            <Border x:Name="HalfHostB" CornerRadius="11"
+                    RenderOptions.BitmapInterpolationMode="HighQuality"/>
+
+            <!-- Per-half hover wash: opacity flips on pointer move, geometry rides the seam. -->
+            <Path x:Name="HoverWashA" Fill="#14FFFFFF" Opacity="0" IsHitTestVisible="False"/>
+            <Path x:Name="HoverWashB" Fill="#14FFFFFF" Opacity="0" IsHitTestVisible="False"/>
+
+            <!-- Peek scrim: the receding half's surviving corner wedge is darkened as the fill
+                 runs, so the filled half reads as a card laid ON TOP. -->
+            <Path x:Name="PeekScrimA" Fill="Black" Opacity="0" IsHitTestVisible="False"/>
+            <Path x:Name="PeekScrimB" Fill="Black" Opacity="0" IsHitTestVisible="False"/>
+
+            <!-- The seam. Stroke is the FULL-fill white; the code-behind parks its Opacity at
+                 SeamRestOpacity so the resting seam renders as the ~#66 hair line. -->
+            <Path x:Name="SeamLine" Stroke="#B3FFFFFF" StrokeThickness="1.2"
+                  Opacity="0.6" IsHitTestVisible="False"/>
+
+            <!-- Per-half active rings: polygon outlines in the mod glow colour. -->
+            <Path x:Name="ActiveRingA" Stroke="{DynamicResource FxGlowBrush}"
+                  StrokeThickness="3" Fill="#12FF69B4"
+                  IsVisible="False" IsHitTestVisible="False"/>
+            <Path x:Name="ActiveRingB" Stroke="{DynamicResource FxGlowBrush}"
+                  StrokeThickness="3" Fill="#12FF69B4"
+                  IsVisible="False" IsHitTestVisible="False"/>
+
+            <!-- Half titles: A pinned to its top-left corner, B to its bottom-right, each on a
+                 dark pill. TextTrimming, not wrapping: a pill in a triangle's corner has one
+                 line of room. Each pill render-scales up when its half fills the card, anchored
+                 to its own corner. -->
+            <Border x:Name="TitlePillA"
+                    HorizontalAlignment="Left" VerticalAlignment="Top"
+                    Margin="8,8,0,0" CornerRadius="7" Background="#B01A1A2E"
+                    Padding="7,2,8,3" IsHitTestVisible="False"
+                    RenderTransformOrigin="0%,0%">
+                <Border.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.26" Easing="QuadraticEaseOut"/>
+                    </Transitions>
+                </Border.Transitions>
+                <TextBlock x:Name="TxtTitleA" Text="A" Foreground="White"
+                           TextTrimming="CharacterEllipsis"
+                           FontSize="11" FontWeight="SemiBold"/>
+            </Border>
+            <Border x:Name="TitlePillB"
+                    HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                    Margin="0,0,8,8" CornerRadius="7" Background="#B01A1A2E"
+                    Padding="7,2,8,3" IsHitTestVisible="False"
+                    RenderTransformOrigin="100%,100%">
+                <Border.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.26" Easing="QuadraticEaseOut"/>
+                    </Transitions>
+                </Border.Transitions>
+                <TextBlock x:Name="TxtTitleB" Text="B" Foreground="White"
+                           TextTrimming="CharacterEllipsis"
+                           FontSize="11" FontWeight="SemiBold"/>
+            </Border>
+
+            <!-- Hover rim-light, same register as FeatureCard's. -->
+            <Border x:Name="RimLight"
+                    BorderBrush="{DynamicResource FxGlowBrush}"
+                    BorderThickness="1.5"
+                    CornerRadius="12"
+                    IsHitTestVisible="False"
+                    Opacity="0">
+                <Border.Transitions>
+                    <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.15" Easing="QuadraticEaseOut"/>
+                    </Transitions>
+                </Border.Transitions>
+            </Border>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/SplitFeatureCard.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SplitFeatureCard.axaml.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// A mosaic tile carrying TWO features on one diagonal ("/") split: half A is the top-left
+    /// triangle, half B the bottom-right. Left-click on a half opens it (ClickA/ClickB),
+    /// right-click toggles it (ToggleA/ToggleB). Hovering a half sweeps the seam across the card
+    /// until that half fills the square bar a corner peek, so the other half stays clickable.
+    /// Ported from the WPF head; the geometry maths is verbatim.
+    ///
+    /// FX plumbing is deliberately copied from <see cref="FeatureCard"/> rather than shared
+    /// through a base class, as in WPF. The WPF gates (MotionFx, PerformanceProfile, window
+    /// focus, tab visibility) live in the head, so this card always animates.
+    /// ponytail: needs MotionFx/PerformanceProfile, gate the breath and sweep when they move to Core
+    /// </summary>
+    public partial class SplitFeatureCard : UserControl
+    {
+        private const double ActiveGlowMinOpacity = 0.50;
+        private const double ActiveGlowMaxOpacity = 0.90;
+        private const double ActiveRingMinOpacity = 0.55;
+        private const double ActiveRingMaxOpacity = 1.00;
+        private const double ActiveBreathSeconds = 3.5;
+        private const double RimLightOpacity = 0.85;
+        private const double HoverLiftScale = 1.02;
+        private const int HoverMs = 150;
+
+        // ---- hover fill (the seam sweep) ----
+        /// <summary>Seam parameter at rest: the 50/50 "/" diagonal.</summary>
+        private const double SplitRest = 1.0;
+        /// <summary>How much of the card the RECEDING half keeps: the corner peek, as a fraction of each edge.</summary>
+        private const double SplitPeekFraction = 0.26;
+        private const double SplitFillA = 2.0 - SplitPeekFraction;
+        private const double SplitFillB = SplitPeekFraction;
+        private const double SeamRestOpacity = 0.60;
+        private const double SeamRestThickness = 1.2;
+        private const double SeamFilledThickness = 2.4;
+        private const double PeekScrimOpacity = 0.20;
+        private const double TitleExpandedScale = 1.35;
+        private const double RingInset = 2.0;
+        /// <summary>Pill margin + padding, taken off before capping the grown title's width.</summary>
+        private const double TitlePillChrome = 34;
+        private const int SplitExpandMs = 260;
+        private const int SplitCollapseMs = 210;
+
+        private static readonly Geometry EmptyGeometry = new PolylineGeometry(Array.Empty<Point>(), true);
+
+        public static readonly StyledProperty<string> TitleAProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, string>(nameof(TitleA), "A");
+        public static readonly StyledProperty<string> TitleBProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, string>(nameof(TitleB), "B");
+        public static readonly StyledProperty<IImageBrushSource?> IconAProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, IImageBrushSource?>(nameof(IconA));
+        public static readonly StyledProperty<IImageBrushSource?> IconBProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, IImageBrushSource?>(nameof(IconB));
+        public static readonly StyledProperty<bool> IsActiveAProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, bool>(nameof(IsActiveA));
+        public static readonly StyledProperty<bool> IsActiveBProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, bool>(nameof(IsActiveB));
+
+        /// <summary>
+        /// Where the seam sits, normalised: the seam is the line x/W + y/H = SplitProgress. 1 is
+        /// the resting diagonal, SplitFillA pushes it towards the bottom-right corner, SplitFillB
+        /// towards the top-left. A styled property purely so a DoubleTransition can drive it.
+        /// </summary>
+        private static readonly StyledProperty<double> SplitProgressProperty =
+            AvaloniaProperty.Register<SplitFeatureCard, double>(nameof(SplitProgress), SplitRest);
+
+        public static readonly RoutedEvent<RoutedEventArgs> ClickAEvent =
+            RoutedEvent.Register<SplitFeatureCard, RoutedEventArgs>(nameof(ClickA), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<RoutedEventArgs> ClickBEvent =
+            RoutedEvent.Register<SplitFeatureCard, RoutedEventArgs>(nameof(ClickB), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<RoutedEventArgs> ToggleAEvent =
+            RoutedEvent.Register<SplitFeatureCard, RoutedEventArgs>(nameof(ToggleA), RoutingStrategies.Bubble);
+        public static readonly RoutedEvent<RoutedEventArgs> ToggleBEvent =
+            RoutedEvent.Register<SplitFeatureCard, RoutedEventArgs>(nameof(ToggleB), RoutingStrategies.Bubble);
+
+        public string TitleA { get => GetValue(TitleAProperty); set => SetValue(TitleAProperty, value); }
+        public string TitleB { get => GetValue(TitleBProperty); set => SetValue(TitleBProperty, value); }
+        public IImageBrushSource? IconA { get => GetValue(IconAProperty); set => SetValue(IconAProperty, value); }
+        public IImageBrushSource? IconB { get => GetValue(IconBProperty); set => SetValue(IconBProperty, value); }
+        public bool IsActiveA { get => GetValue(IsActiveAProperty); set => SetValue(IsActiveAProperty, value); }
+        public bool IsActiveB { get => GetValue(IsActiveBProperty); set => SetValue(IsActiveBProperty, value); }
+        private double SplitProgress { get => GetValue(SplitProgressProperty); set => SetValue(SplitProgressProperty, value); }
+
+        public event EventHandler<RoutedEventArgs> ClickA { add => AddHandler(ClickAEvent, value); remove => RemoveHandler(ClickAEvent, value); }
+        public event EventHandler<RoutedEventArgs> ClickB { add => AddHandler(ClickBEvent, value); remove => RemoveHandler(ClickBEvent, value); }
+        public event EventHandler<RoutedEventArgs> ToggleA { add => AddHandler(ToggleAEvent, value); remove => RemoveHandler(ToggleAEvent, value); }
+        public event EventHandler<RoutedEventArgs> ToggleB { add => AddHandler(ToggleBEvent, value); remove => RemoveHandler(ToggleBEvent, value); }
+
+        private readonly Border _rootBorder, _halfHostA, _halfHostB, _titlePillA, _titlePillB, _rimLight;
+        private readonly Grid _contentRoot;
+        private readonly Path _hoverWashA, _hoverWashB, _peekScrimA, _peekScrimB, _seamLine, _activeRingA, _activeRingB;
+        private readonly TextBlock _txtTitleA, _txtTitleB;
+        private readonly DropShadowEffect _activeGlow;
+        private readonly ScaleTransform _rootScale = new(1, 1), _titleScaleA = new(1, 1), _titleScaleB = new(1, 1);
+        /// <summary>Drives SplitProgress. ONE instance, mutated per sweep: replacing it mid-flight
+        /// drops the animated value and the seam snaps to the old target before the new sweep.</summary>
+        private readonly DoubleTransition _splitTransition = new() { Property = SplitProgressProperty };
+        private CancellationTokenSource? _breath;
+        private bool _hovered;
+        /// <summary>Which half the pointer has committed the card to: true = A, false = B, null = neither.</summary>
+        private bool? _halfHover;
+
+        public SplitFeatureCard()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _rootBorder = this.FindControl<Border>("RootBorder")!;
+            _halfHostA = this.FindControl<Border>("HalfHostA")!;
+            _halfHostB = this.FindControl<Border>("HalfHostB")!;
+            _titlePillA = this.FindControl<Border>("TitlePillA")!;
+            _titlePillB = this.FindControl<Border>("TitlePillB")!;
+            _rimLight = this.FindControl<Border>("RimLight")!;
+            _contentRoot = this.FindControl<Grid>("ContentRoot")!;
+            _hoverWashA = this.FindControl<Path>("HoverWashA")!;
+            _hoverWashB = this.FindControl<Path>("HoverWashB")!;
+            _peekScrimA = this.FindControl<Path>("PeekScrimA")!;
+            _peekScrimB = this.FindControl<Path>("PeekScrimB")!;
+            _seamLine = this.FindControl<Path>("SeamLine")!;
+            _activeRingA = this.FindControl<Path>("ActiveRingA")!;
+            _activeRingB = this.FindControl<Path>("ActiveRingB")!;
+            _txtTitleA = this.FindControl<TextBlock>("TxtTitleA")!;
+            _txtTitleB = this.FindControl<TextBlock>("TxtTitleB")!;
+            _activeGlow = (DropShadowEffect)_rootBorder.Effect!;
+
+            _rootScale.Transitions = ScaleTransitions(HoverMs, new QuadraticEaseOut());
+            _titleScaleA.Transitions = ScaleTransitions(SplitExpandMs, new QuadraticEaseOut());
+            _titleScaleB.Transitions = ScaleTransitions(SplitExpandMs, new QuadraticEaseOut());
+            _rootBorder.RenderTransform = _rootScale;
+            _titlePillA.RenderTransform = _titleScaleA;
+            _titlePillB.RenderTransform = _titleScaleB;
+
+            _contentRoot.SizeChanged += (_, _) => { UpdateRoundedClip(); RebuildGeometry(); };
+            PointerEntered += (_, _) => ApplyHover(true);
+            PointerExited += (_, _) => { ApplyHover(false); SetHalfHover(null); };
+            PointerMoved += (_, e) => SetHalfHover(IsInHalfA(e.GetPosition(_contentRoot)));
+            PointerReleased += OnPointerReleased;
+            Unloaded += (_, _) => { ApplyActiveBreath(false); ResetSplit(); };
+            Loaded += (_, _) => ApplyActiveState(); // re-arm the breath after a detach/re-attach (tab switch)
+            Transitions = new Transitions { _splitTransition };
+        }
+
+        private static Transitions ScaleTransitions(int ms, Easing easing) => new()
+        {
+            new DoubleTransition { Property = ScaleTransform.ScaleXProperty, Duration = TimeSpan.FromMilliseconds(ms), Easing = easing },
+            new DoubleTransition { Property = ScaleTransform.ScaleYProperty, Duration = TimeSpan.FromMilliseconds(ms), Easing = easing },
+        };
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (_rootBorder is null) return; // fired before the XAML loaded
+            if (change.Property == TitleAProperty) _txtTitleA.Text = TitleA ?? "";
+            else if (change.Property == TitleBProperty) _txtTitleB.Text = TitleB ?? "";
+            else if (change.Property == IconAProperty) ApplyIcon(_halfHostA, IconA);
+            else if (change.Property == IconBProperty) ApplyIcon(_halfHostB, IconB);
+            else if (change.Property == IsActiveAProperty || change.Property == IsActiveBProperty) ApplyActiveState();
+            else if (change.Property == SplitProgressProperty) RebuildGeometry();
+            else if (change.Property == IsVisibleProperty && !IsVisible) ResetSplit();
+        }
+
+        private static void ApplyIcon(Border host, IImageBrushSource? src)
+        {
+            host.Background = src == null
+                ? null
+                : new ImageBrush(src) { Stretch = Stretch.UniformToFill, AlignmentY = AlignmentY.Center };
+        }
+
+        // ============================== geometry ==============================
+
+        /// <summary>True when the point sits on half A's side of the seam AT THE SEAM'S CURRENT
+        /// POSITION, so the test follows the fill right down to the corner wedge.</summary>
+        private bool IsInHalfA(Point p)
+        {
+            double w = _contentRoot.Bounds.Width, h = _contentRoot.Bounds.Height;
+            if (w <= 0 || h <= 0) return true;
+            return p.X / w + p.Y / h <= SplitProgress;
+        }
+
+        /// <summary>Rounded clip for the whole content stack: the polygon clips have square outer
+        /// corners, so without this the art pokes past the rounded frame at every card corner.</summary>
+        private void UpdateRoundedClip()
+        {
+            var b = _contentRoot.Bounds;
+            _contentRoot.Clip = b.Width <= 0 || b.Height <= 0
+                ? null
+                : new RectangleGeometry(new Rect(0, 0, b.Width, b.Height)) { RadiusX = 11, RadiusY = 11 };
+        }
+
+        /// <summary>Rebuilds every seam-dependent geometry. Runs on resize AND on every frame of the sweep.</summary>
+        private void RebuildGeometry()
+        {
+            double w = _contentRoot.Bounds.Width, h = _contentRoot.Bounds.Height;
+            if (w <= 0 || h <= 0) return;
+            double k = SplitProgress;
+
+            var regionA = RegionGeometry(true, k, w, h, 0);
+            var regionB = RegionGeometry(false, k, w, h, 0);
+
+            _halfHostA.Clip = regionA;
+            _halfHostB.Clip = regionB;
+            _hoverWashA.Data = regionA;
+            _hoverWashB.Data = regionB;
+
+            // Rings inset by their stroke so the outline hugs the region instead of being clipped.
+            if (_activeRingA.IsVisible) _activeRingA.Data = RegionGeometry(true, k, w, h, RingInset);
+            if (_activeRingB.IsVisible) _activeRingB.Data = RegionGeometry(false, k, w, h, RingInset);
+
+            var (s1, s2) = SeamPoints(k, w, h);
+            _seamLine.Data = new LineGeometry(s1, s2);
+
+            ApplyPeekChrome(k, regionA, regionB);
+        }
+
+        /// <summary>The corner-peek chrome, a function of how far the fill has run: 0 at rest, 1 filled.
+        /// The scrim goes on the RECEDING half; the seam brightens and thickens for both.</summary>
+        private void ApplyPeekChrome(double k, Geometry regionA, Geometry regionB)
+        {
+            double fill = Math.Min(1.0, Math.Abs(k - SplitRest) / (SplitRest - SplitPeekFraction));
+            bool aFilling = k > SplitRest;
+
+            _peekScrimA.Data = regionA;
+            _peekScrimB.Data = regionB;
+            _peekScrimA.Opacity = aFilling ? 0 : fill * PeekScrimOpacity;
+            _peekScrimB.Opacity = aFilling ? fill * PeekScrimOpacity : 0;
+
+            _seamLine.Opacity = SeamRestOpacity + (1 - SeamRestOpacity) * fill;
+            _seamLine.StrokeThickness = SeamRestThickness + (SeamFilledThickness - SeamRestThickness) * fill;
+        }
+
+        /// <summary>The seam's two endpoints on the card's edge for a given seam parameter.</summary>
+        private static (Point A, Point B) SeamPoints(double k, double w, double h)
+            => k <= SplitRest
+                ? (new Point(k * w, 0), new Point(0, k * h))
+                : (new Point(w, (k - SplitRest) * h), new Point((k - SplitRest) * w, h));
+
+        /// <summary>One half's region: the card rectangle (optionally inset) clipped against the
+        /// seam's half-plane. A real polygon clip, because the shape passes through triangle,
+        /// pentagon, square and nothing as the seam sweeps.</summary>
+        private static Geometry RegionGeometry(bool halfA, double k, double w, double h, double inset)
+        {
+            double l = inset, t = inset, r = w - inset, b = h - inset;
+            if (r <= l || b <= t) return EmptyGeometry;
+
+            // Insetting the diagonal means moving the line along its own normal, and the seam's
+            // gradient is (1/w, 1/h) - so `inset` pixels are worth that much of k.
+            double seamK = k + (halfA ? -1 : 1) * inset * Math.Sqrt(1.0 / (w * w) + 1.0 / (h * h));
+            double sign = halfA ? 1.0 : -1.0;
+
+            var rect = new[] { new Point(l, t), new Point(r, t), new Point(r, b), new Point(l, b) };
+            var kept = new List<Point>(6);
+            for (int i = 0; i < rect.Length; i++)
+            {
+                Point p1 = rect[i], p2 = rect[(i + 1) % rect.Length];
+                double d1 = sign * (p1.X / w + p1.Y / h - seamK);
+                double d2 = sign * (p2.X / w + p2.Y / h - seamK);
+                if (d1 <= 0) AddVertex(kept, p1);
+                if ((d1 <= 0) != (d2 <= 0))
+                {
+                    double f = d1 / (d1 - d2);
+                    AddVertex(kept, new Point(p1.X + (p2.X - p1.X) * f, p1.Y + (p2.Y - p1.Y) * f));
+                }
+            }
+            // The ends of the sweep put a corner exactly on the seam, which the clip walks into twice.
+            if (kept.Count > 1 && Near(kept[0], kept[^1])) kept.RemoveAt(kept.Count - 1);
+            if (kept.Count < 3) return EmptyGeometry;
+
+            return new PolylineGeometry(kept, true);
+        }
+
+        private static void AddVertex(List<Point> poly, Point p)
+        {
+            if (poly.Count > 0 && Near(poly[^1], p)) return;
+            poly.Add(p);
+        }
+
+        private static bool Near(Point a, Point b) => Math.Abs(a.X - b.X) < 0.01 && Math.Abs(a.Y - b.Y) < 0.01;
+
+        // ============================== input ==============================
+
+        private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            // Purely positional, against the seam where it is DRAWN at that instant - the corner
+            // wedge is on screen precisely so it can be clicked.
+            bool halfA = IsInHalfA(e.GetPosition(_contentRoot));
+            if (e.InitialPressMouseButton == MouseButton.Left)
+            {
+                RaiseEvent(new RoutedEventArgs(halfA ? ClickAEvent : ClickBEvent, this));
+            }
+            else if (e.InitialPressMouseButton == MouseButton.Right)
+            {
+                e.Handled = true;
+                RaiseEvent(new RoutedEventArgs(halfA ? ToggleAEvent : ToggleBEvent, this));
+            }
+        }
+
+        /// <summary>Commits the card to a half: the wash flips, the seam sweeps, its title grows.
+        /// Null hands the card back to the 50/50 split. Idempotent: PointerMoved calls this on every pixel.</summary>
+        private void SetHalfHover(bool? halfA)
+        {
+            if (_halfHover == halfA) return;
+            _halfHover = halfA;
+
+            _hoverWashA.Opacity = halfA == true ? 1 : 0;
+            _hoverWashB.Opacity = halfA == false ? 1 : 0;
+
+            double target = halfA switch { true => SplitFillA, false => SplitFillB, _ => SplitRest };
+            bool expanding = halfA != null;
+            // WPF: a to-only DoubleAnimation; here the one transition, retuned so expand and
+            // collapse keep their own durations and easings.
+            _splitTransition.Duration = TimeSpan.FromMilliseconds(expanding ? SplitExpandMs : SplitCollapseMs);
+            _splitTransition.Easing = expanding ? new CubicEaseOut() : new CubicEaseIn();
+            SplitProgress = target;
+            ApplyTitleEmphasis(halfA);
+        }
+
+        /// <summary>The filled half's title grows into the card; the other one gets out of the way.</summary>
+        private void ApplyTitleEmphasis(bool? halfA)
+        {
+            CapGrownTitle(_txtTitleA, halfA == true);
+            CapGrownTitle(_txtTitleB, halfA == false);
+            EmphasiseTitle(_titlePillA, _titleScaleA, grown: halfA == true, hidden: halfA == false);
+            EmphasiseTitle(_titlePillB, _titleScaleB, grown: halfA == false, hidden: halfA == true);
+        }
+
+        private static void EmphasiseTitle(Border pill, ScaleTransform scale, bool grown, bool hidden)
+        {
+            scale.ScaleX = scale.ScaleY = grown ? TitleExpandedScale : 1.0;
+            pill.Opacity = hidden ? 0.0 : 1.0;
+        }
+
+        /// <summary>A render scale is applied after measure, so a grown pill would run its longer
+        /// localised titles under ClipToBounds with no ellipsis. Cap the width the scale leaves it.</summary>
+        private void CapGrownTitle(TextBlock text, bool grown)
+        {
+            double w = _contentRoot.Bounds.Width;
+            text.MaxWidth = grown && w > 0
+                ? Math.Max(40, (w - TitlePillChrome) / TitleExpandedScale)
+                : double.PositiveInfinity;
+        }
+
+        /// <summary>Drops any in-flight fill back to the resting split, without motion.</summary>
+        private void ResetSplit()
+        {
+            _halfHover = null;
+            Transitions = null; // no motion on the way back
+            SplitProgress = SplitRest;
+            Transitions = new Transitions { _splitTransition };
+            // Assigning a value it already holds raises no change, so rebuild explicitly.
+            RebuildGeometry();
+            _hoverWashA.Opacity = 0;
+            _hoverWashB.Opacity = 0;
+            CapGrownTitle(_txtTitleA, false);
+            CapGrownTitle(_txtTitleB, false);
+            EmphasiseTitle(_titlePillA, _titleScaleA, grown: false, hidden: false);
+            EmphasiseTitle(_titlePillB, _titleScaleB, grown: false, hidden: false);
+        }
+
+        // ============================== FX (kept in step with FeatureCard) ==============================
+
+        private void ApplyActiveState()
+        {
+            _activeRingA.IsVisible = IsActiveA;
+            _activeRingB.IsVisible = IsActiveB;
+            // RebuildGeometry only draws the rings that are on screen, so a ring that just came on
+            // needs this to get its geometry.
+            RebuildGeometry();
+            ApplyActiveBreath(IsActiveA || IsActiveB);
+        }
+
+        /// <summary>The card-level glow breathes when EITHER half is on (the drop shadow cannot be
+        /// halved); the per-half rings breathe with it.</summary>
+        private void ApplyActiveBreath(bool active)
+        {
+            _breath?.Cancel();
+            _breath = null;
+            _activeRingA.Opacity = 1;
+            _activeRingB.Opacity = 1;
+            if (!active) { _activeGlow.Opacity = 0; return; }
+
+            _breath = new CancellationTokenSource();
+            _ = Breathe(DropShadowEffect.OpacityProperty, ActiveGlowMinOpacity, ActiveGlowMaxOpacity).RunAsync(_activeGlow, _breath.Token);
+            if (IsActiveA) _ = Breathe(OpacityProperty, ActiveRingMinOpacity, ActiveRingMaxOpacity).RunAsync(_activeRingA, _breath.Token);
+            if (IsActiveB) _ = Breathe(OpacityProperty, ActiveRingMinOpacity, ActiveRingMaxOpacity).RunAsync(_activeRingB, _breath.Token);
+        }
+
+        private static Animation Breathe(AvaloniaProperty prop, double min, double max) => new()
+        {
+            Duration = TimeSpan.FromSeconds(ActiveBreathSeconds),
+            IterationCount = IterationCount.Infinite,
+            PlaybackDirection = PlaybackDirection.Alternate,
+            Easing = new SineEaseInOut(),
+            Children =
+            {
+                new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(prop, min) } },
+                new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(prop, max) } },
+            },
+        };
+
+        private void ApplyHover(bool on)
+        {
+            if (_hovered == on) return;
+            _hovered = on;
+            _rootScale.ScaleX = _rootScale.ScaleY = on ? HoverLiftScale : 1;
+            _rimLight.Opacity = on ? RimLightOpacity : 0;
+        }
+    }
+}


### PR DESCRIPTION
1,021 lines, 4 files. Hosts with the full WPF property surface as StyledProperties; the seam transition and hover/breath as Transitions and Animations.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351