### PR TITLE
feat(avalonia): port feature cards, part 2/2 - FeaturePopupWindow, AppInfoFeatureControl

### DIFF
--- a/CCP.Avalonia/Views/Features/AppInfoFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/AppInfoFeatureControl.axaml
@@ -1,0 +1,61 @@
+<!-- PORTED from ConditioningControlPanel/Features/AppInfoFeatureControl.xaml.
+     Structure, order, spacing and every resource key preserved. Deviations, all forced:
+
+       Style="{StaticResource OutlineButton}" -> Theme="{StaticResource OutlineButton}"
+       Content="{loc:Str key}"                -> a <TextBlock> child (Avalonia parses "_" in
+                                                 Content as an access key; keys are snake_case)
+       Click="X"                              -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.AppInfoFeatureControl">
+
+    <StackPanel>
+        <!-- Version header -->
+        <Border Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{DynamicResource GlassBorderBrush}"
+                BorderThickness="1" CornerRadius="10" Padding="20,20" Margin="0,0,0,12">
+            <StackPanel HorizontalAlignment="Center">
+                <TextBlock Text="{loc:Str label_app_info}"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontSize="20" FontWeight="Bold"
+                           HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                <TextBlock x:Name="TxtVersion" Text=""
+                           Foreground="White"
+                           FontSize="14"
+                           HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                <TextBlock x:Name="TxtProduct" Text=""
+                           Foreground="{DynamicResource TextMutedBrush}"
+                           FontSize="11"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Phase 2: this control is About + support only.
+             · The reparented account sections host (ExternalSectionsHost) is gone — the login /
+               linking / cloud-backup / privacy cards live permanently in Settings · Account.
+             · BtnCheckUpdates moved to Settings · Updates, which also shows the patch notes.
+             Everything below is unchanged and still self-contained. -->
+
+        <Button x:Name="BtnReportBug"
+                Theme="{StaticResource OutlineButton}"
+                Padding="14,12" FontSize="14"
+                Margin="0,0,0,8">
+            <TextBlock Text="{loc:Str btn_report_bug}"/>
+        </Button>
+
+        <Button x:Name="BtnSuggestion"
+                Theme="{StaticResource OutlineButton}"
+                Padding="14,12" FontSize="14"
+                Margin="0,0,0,8">
+            <TextBlock Text="{loc:Str btn_suggestion}"/>
+        </Button>
+
+        <!-- #769: report numbers persist, so they can be looked up long after the success panel. -->
+        <Button x:Name="BtnMyReports"
+                Theme="{StaticResource OutlineButton}"
+                Padding="14,12" FontSize="14">
+            <TextBlock Text="{loc:Str btn_my_reports}"/>
+        </Button>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/AppInfoFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/AppInfoFeatureControl.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// About + the three support-form buttons, ported from the WPF head.
+    ///
+    /// The three Click handlers each open a head-only dialog (BugReportWindow, MyReportsWindow)
+    /// and are stubs here; the buttons render and do nothing. The version string comes from
+    /// UpdateService.AppVersion in the WPF head, a const that has not moved to Core.
+    /// </summary>
+    public partial class AppInfoFeatureControl : UserControl
+    {
+        public AppInfoFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+            // Both literals in WPF too (OnLoaded), not loc keys.
+            // ponytail: needs UpdateService.AppVersion, wired when it moves to Core
+            this.FindControl<TextBlock>("TxtVersion")!.Text = "v0.0.0";
+            this.FindControl<TextBlock>("TxtProduct")!.Text = "Conditioning Control Panel";
+
+            // ponytail: needs BugReportWindow / MyReportsWindow, wired when those dialogs are ported
+            this.FindControl<Button>("BtnReportBug")!.Click += (_, _) => { };
+            this.FindControl<Button>("BtnSuggestion")!.Click += (_, _) => { };
+            this.FindControl<Button>("BtnMyReports")!.Click += (_, _) => { };
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/FeaturePopupWindow.axaml
+++ b/CCP.Avalonia/Views/Features/FeaturePopupWindow.axaml
@@ -1,0 +1,119 @@
+<!-- PORTED from ConditioningControlPanel/Features/FeaturePopupWindow.xaml.
+     Structure, order, spacing and every resource key preserved. Deviations, all forced:
+
+       WindowStyle="None"          -> WindowDecorations="None"
+       ResizeMode="NoResize"       -> CanResize="False"
+       AllowsTransparency="False"  -> dropped (Avalonia default)
+       Visibility="Collapsed"      -> IsVisible="False"
+       RenderOptions.BitmapScalingMode -> RenderOptions.BitmapInterpolationMode
+       ToolTip="..."               -> ToolTip.Tip="..."
+       Button.Template + IsMouseOver trigger -> the CloseButton ControlTheme below with a
+                                      :pointerover /template/ style (Avalonia has no triggers)
+       MouseLeftButtonDown / Click / PreviewKeyDown -> wired in the constructor -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Features.FeaturePopupWindow"
+        Title="Feature"
+        Width="520" Height="640"
+        MinWidth="420" MinHeight="360"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False"
+        WindowDecorations="None"
+        ShowInTaskbar="False">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of FeaturePopupWindow.xaml:BtnClose inline template, hoist when a second view needs it -->
+        <ControlTheme x:Key="CloseButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="0">
+                        <TextBlock Text="✕"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontSize="14"
+                                   Foreground="{TemplateBinding Foreground}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="{DynamicResource DangerBrush}"/>
+            </Style>
+            <Style Selector="^:pointerover">
+                <Setter Property="Foreground" Value="White"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Titlebar -->
+            <Border Grid.Row="0" x:Name="Titlebar"
+                    Background="{DynamicResource ElevatedSurfaceBrush}"
+                    BorderBrush="{DynamicResource GlassBorderBrush}"
+                    BorderThickness="0,0,0,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Icon -->
+                    <Border Grid.Column="0"
+                            Width="28" Height="28"
+                            Margin="14,10,10,10"
+                            CornerRadius="6"
+                            Background="{DynamicResource TransparentPinkBrush}">
+                        <Grid>
+                            <Image x:Name="ImgIcon" Width="20" Height="20"
+                                   Stretch="Uniform"
+                                   RenderOptions.BitmapInterpolationMode="HighQuality"/>
+                            <TextBlock x:Name="TxtGlyph"
+                                       FontSize="16"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       Foreground="{DynamicResource PinkBrush}"
+                                       IsVisible="False"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Title -->
+                    <TextBlock Grid.Column="1"
+                               x:Name="TxtTitle"
+                               Text="Feature"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="15"
+                               FontWeight="SemiBold"/>
+
+                    <!-- Close button -->
+                    <Button Grid.Column="2"
+                            x:Name="BtnClose"
+                            Theme="{StaticResource CloseButton}"
+                            Cursor="Hand"
+                            Width="38" Height="38"
+                            ToolTip.Tip="Close (Esc)"/>
+                </Grid>
+            </Border>
+
+            <!-- Content host -->
+            <ScrollViewer Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Padding="16">
+                <ContentControl x:Name="ContentHost"/>
+            </ScrollViewer>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Features/FeaturePopupWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Features/FeaturePopupWindow.axaml.cs
@@ -1,0 +1,85 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Generic modeless popup window that hosts a feature control. Borderless, pink-themed
+    /// titlebar, drag-to-move, Escape-to-close, centered on owner. Ported from the WPF head;
+    /// see the original for the Phase 4 single-parent rule, which the constructor still enforces.
+    /// </summary>
+    public partial class FeaturePopupWindow : Window
+    {
+        /// <summary>Render/design constructor: sample content so --render-view can draw the window.</summary>
+        public FeaturePopupWindow() : this(new AppInfoFeatureControl(), "App Info", null, "ℹ") { }
+
+        public FeaturePopupWindow(Control content, string title, IImage? icon = null, string? glyph = null)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            var txtTitle = this.FindControl<TextBlock>("TxtTitle")!;
+            var imgIcon = this.FindControl<Image>("ImgIcon")!;
+            var txtGlyph = this.FindControl<TextBlock>("TxtGlyph")!;
+            var contentHost = this.FindControl<ContentControl>("ContentHost")!;
+
+            txtTitle.Text = title;
+            Title = title; // also set Window.Title for accessibility
+
+            if (icon != null)
+            {
+                imgIcon.Source = icon;
+                imgIcon.IsVisible = true;
+                txtGlyph.IsVisible = false;
+            }
+            else if (!string.IsNullOrEmpty(glyph))
+            {
+                txtGlyph.Text = glyph;
+                txtGlyph.IsVisible = true;
+                imgIcon.IsVisible = false;
+            }
+            else
+            {
+                imgIcon.IsVisible = false;
+                txtGlyph.IsVisible = false;
+            }
+
+            // Single-parent guard (Phase 4): refuse an already-parented control instead of
+            // throwing out of a plain card click. The popup opens empty and the log names the type.
+            if (content.Parent != null || content.GetVisualParent() != null)
+            {
+                Log.Error(
+                    "[FeaturePopup] Refused to host '{Type}' - it is already parented (the Studio " +
+                    "rack owns a permanent instance of every feature panel). ShowFeaturePopup must " +
+                    "construct a NEW control for the popup; never re-parent the rack's.",
+                    content.GetType().Name);
+            }
+            else
+            {
+                contentHost.Content = content;
+            }
+
+            this.FindControl<Border>("Titlebar")!.PointerPressed += (_, e) =>
+            {
+                if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                {
+                    try { BeginMoveDrag(e); } catch { /* dragging can throw if not pressed */ }
+                }
+            };
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+
+            // Escape closes the popup.
+            // ponytail: needs MainWindow.IsCapturingPanicKey (don't eat Esc while the panic-key
+            // picker waits for a key), wired when that host exists on this head
+            KeyDown += (_, e) =>
+            {
+                if (e.Key != Key.Escape) return;
+                Close();
+                e.Handled = true;
+            };
+        }
+    }
+}


### PR DESCRIPTION
294 lines, 4 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351