### PR TITLE
feat(avalonia): port Features II, part 1/2 - Visuals, BubbleCount, PinkFilter

### DIFF
--- a/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml
@@ -1,0 +1,136 @@
+<!-- PORTED from ConditioningControlPanel/Features/BubbleCountFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"
+       ToolTip="..."                     -> ToolTip.Tip="..."
+       helpers:EmojiTextBlock            -> TextBlock
+       Content="{loc:Str btn_test_now}"  -> a TextBlock child (Avalonia parses "_" as an access key)
+       ImageBrush + BitmapImage pack://  -> dropped (ponytail: Resources/features/*.png does not ship
+                                            in CCP.Avalonia; the hero plate and side card keep the
+                                            section wash so the layout survives. Restore with an
+                                            avares:// ImageBrush when the art crosses.)
+       Border.OpacityMask gradient       -> dropped with the art it masked
+       feat:SessionLock.Owned            -> dropped (ponytail: WPF-head attached prop)
+       feat:AdaptiveSideArt.CollapseBelow-> dropped (ponytail: same)
+       LinearGradientBrush "0,1"/"0,0"   -> "0%,100%"/"0%,0%" (bare numbers are pixels here)
+       <Slider> (unstyled)               -> Theme="{StaticResource PinkSlider}" (the WPF theme applies
+                                            PinkSlider implicitly to every Slider: Resources/Theme/MainWindow.xaml:341)
+       Checked/Unchecked/Click/...       -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.BubbleCountFeatureControl">
+
+    <StackPanel>
+
+        <!-- HERO. No subtitle line: this module's only description string is three lines long and
+             would overflow the 72px strip, so it rides the enable pill as a ToolTip instead. -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}"/>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str label_bubble_count}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5"
+                        ToolTip.Tip="{loc:Str tooltip_count_the_bubbles_challenge_memory_and_attent}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_challenges_per_hour_1_10}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_per_hour}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderFreq" Minimum="1" Maximum="10" Value="2"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtFreq" Text="2" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <Grid Height="36">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_difficulty}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <ComboBox Grid.Column="1" x:Name="CmbDifficulty" Width="130"
+                                          VerticalAlignment="Center"
+                                          Theme="{DynamicResource DarkComboBoxStyle}">
+                                    <ComboBoxItem Content="{loc:Str btn_easy}" Tag="0"/>
+                                    <ComboBoxItem Content="{loc:Str btn_medium}" Tag="1"/>
+                                    <ComboBoxItem Content="{loc:Str btn_hard}" Tag="2"/>
+                                </ComboBox>
+                            </Grid>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_prevent_closing_until_correctly_answered}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_strict_lock}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkStrict"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <Button x:Name="BtnTest" Theme="{DynamicResource OutlineButton}">
+                    <TextBlock Text="{loc:Str btn_test_now}"/>
+                </Button>
+            </StackPanel>
+
+            <!-- SIDE ART. Plate dropped (see header); the wash and the scrim keep the card's shape. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <!-- Scrim so the plate sits under the page instead of fighting it. -->
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs
@@ -1,0 +1,73 @@
+using Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Bubble Count settings panel, ported from the WPF head. <see cref="BubbleCountSettings"/>
+    /// stands in for <c>App.Settings.Current</c>. Save, SettingsHook, the mod-art repaint and the
+    /// BubbleCountService calls are stubbed; the strict-lock double warning writes through.
+    /// </summary>
+    public partial class BubbleCountFeatureControl : UserControl
+    {
+        private bool _isLoading = true;
+        private readonly BubbleCountSettings _s = new();
+
+        public BubbleCountFeatureControl()
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            // ponytail: needs App.BubbleCount Start/Stop/RefreshSchedule/TriggerGame, wired when it moves to Core
+            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.BubbleCountEnabled = ChkEnable.IsChecked ?? false; Save(); };
+            SliderFreq.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFreq.Text = v.ToString(); _s.BubbleCountFrequency = v; Save(); };
+            CmbDifficulty.SelectionChanged += (_, _) =>
+            {
+                if (_isLoading) return;
+                if (CmbDifficulty.SelectedItem is ComboBoxItem item && item.Tag is string tag && int.TryParse(tag, out var difficulty))
+                {
+                    _s.BubbleCountDifficulty = difficulty;
+                    Save();
+                }
+            };
+            // ponytail: needs WarningDialog.ShowDoubleWarning (WPF head); writes through without the confirm
+            ChkStrict.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.BubbleCountStrictLock = ChkStrict.IsChecked ?? false; Save(); };
+            BtnTest.Click += (_, _) => { };
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = _s.BubbleCountEnabled;
+                SliderFreq.Value = _s.BubbleCountFrequency;
+                TxtFreq.Text = _s.BubbleCountFrequency.ToString();
+                // Select matching ComboBoxItem by Tag
+                foreach (var obj in CmbDifficulty.Items)
+                {
+                    if (obj is ComboBoxItem item && item.Tag is string tag && int.TryParse(tag, out var val) && val == _s.BubbleCountDifficulty)
+                    {
+                        CmbDifficulty.SelectedItem = item;
+                        break;
+                    }
+                }
+                ChkStrict.IsChecked = _s.BubbleCountStrictLock;
+            }
+            finally { _isLoading = false; }
+        }
+
+        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
+        private static void Save() { }
+    }
+
+    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
+    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
+    public sealed class BubbleCountSettings
+    {
+        public bool BubbleCountEnabled { get; set; }
+        public int BubbleCountFrequency { get; set; } = 2;
+        public int BubbleCountDifficulty { get; set; } = 1;
+        public bool BubbleCountStrictLock { get; set; }
+    }
+}

--- a/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml
@@ -1,0 +1,135 @@
+<!-- PORTED from ConditioningControlPanel/Features/PinkFilterFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"
+       ToolTip="..."                     -> ToolTip.Tip="..."
+       helpers:EmojiTextBlock            -> TextBlock
+       Content="{loc:Str btn_x}"         -> a TextBlock child (Avalonia parses "_" as an access key)
+       ImageBrush + BitmapImage pack://  -> dropped (ponytail: Resources/features/*.png does not ship
+                                            in CCP.Avalonia; hero plate and side card keep the wash)
+       Border.OpacityMask gradient       -> dropped with the art it masked
+       feat:SessionLock.Owned            -> dropped (ponytail: WPF-head attached prop)
+       feat:AdaptiveSideArt.CollapseBelow-> dropped (ponytail: same)
+       LinearGradientBrush "0,1"/"0,0"   -> "0%,100%"/"0%,0%"
+       <Slider> (unstyled)               -> Theme="{StaticResource PinkSlider}" (the WPF theme applies
+                                            PinkSlider implicitly to every Slider: Resources/Theme/MainWindow.xaml:341)
+       Checked/Unchecked/Click/...       -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.PinkFilterFeatureControl">
+
+    <StackPanel>
+
+        <!-- HERO -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}"/>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str label_pink_filter}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str tooltip_apply_pink_color_filter_to_all_monitors}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}" Margin="0,1,0,0"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card: opacity, colour, and the monitor picker (#639). -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_filter_opacity_5_50}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_opacity}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderOpacity" Minimum="5" Maximum="50" Value="10"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtOpacity" Text="10%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <Grid Height="40" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_pink_filter_color}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_filter_color}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <Border x:Name="ColorSwatch" Width="26" Height="26" CornerRadius="8"
+                                            BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"
+                                            Background="#FF69B4" Margin="0,0,8,0"/>
+                                    <Button x:Name="BtnChooseColor" Theme="{StaticResource SmallPinkButton}">
+                                        <TextBlock Text="{loc:Str btn_choose_color}"/>
+                                    </Button>
+                                    <Button x:Name="BtnResetColor" Theme="{StaticResource SmallPinkButton}"
+                                            Margin="6,0,0,0">
+                                        <TextBlock Text="{loc:Str btn_reset}"/>
+                                    </Button>
+                                </StackPanel>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_effect_monitor}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_effect_monitor}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <ComboBox Grid.Column="1" x:Name="CmbMonitor"
+                                          Width="180" VerticalAlignment="Center"
+                                          Theme="{DynamicResource DarkComboBoxStyle}"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </StackPanel>
+
+            <!-- SIDE ART. Plate dropped (see header); the wash and the scrim keep the card's shape. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
@@ -1,0 +1,136 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Pink Filter settings panel, ported from the WPF head. <see cref="PinkFilterSettings"/>
+    /// stands in for <c>App.Settings.Current</c>. Save, the overlay refresh, the mod colour/art
+    /// repaint, the WinForms ColorDialog and the screen enumeration are stubbed: the monitor combo
+    /// carries the two fixed entries plus one placeholder monitor line built with the same loc keys
+    /// and format the WPF code-behind uses.
+    /// </summary>
+    public partial class PinkFilterFeatureControl : UserControl
+    {
+        // ponytail: local copy of App.ScreenResolver's sentinels, reuse when they move to Core
+        private const int MonitorTargetFollowGlobal = -1;
+        private const int MonitorTargetAll = -2;
+
+        private bool _isLoading = true;
+        private bool _monitorPopulating;
+        private readonly PinkFilterSettings _s = new();
+
+        public PinkFilterFeatureControl()
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            // ponytail: needs App.Overlay.RefreshOverlays / RefreshFilterColor, wired when it moves to Core
+            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.PinkFilterEnabled = ChkEnable.IsChecked ?? false; Save(); };
+            SliderOpacity.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtOpacity.Text = $"{v}%"; _s.PinkFilterOpacity = v; Save(); };
+            CmbMonitor.DropDownOpened += (_, _) => PopulateMonitors();
+            CmbMonitor.SelectionChanged += (_, _) =>
+            {
+                if (_monitorPopulating || _isLoading) return;
+                if (CmbMonitor.SelectedItem is not ComboBoxItem item || item.Tag is not int target) return;
+                if (_s.PinkFilterTargetMonitor == target) return;
+                _s.PinkFilterTargetMonitor = target;
+                Save();
+            };
+            // ponytail: needs a colour picker (WinForms ColorDialog on WPF); no cross-platform picker yet
+            BtnChooseColor.Click += (_, _) => { };
+            BtnResetColor.Click += (_, _) =>
+            {
+                _s.PinkFilterColor = ""; // empty = default (mod / hot pink)
+                Save();
+                UpdateSwatch();
+            };
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = _s.PinkFilterEnabled;
+                SliderOpacity.Value = _s.PinkFilterOpacity;
+                TxtOpacity.Text = $"{_s.PinkFilterOpacity}%";
+                UpdateSwatch();
+                PopulateMonitors();
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void PopulateMonitors()
+        {
+            int saved = _s.PinkFilterTargetMonitor;
+            _monitorPopulating = true;
+            try
+            {
+                CmbMonitor.Items.Clear();
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = MonitorTargetFollowGlobal });
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = MonitorTargetAll });
+
+                // ponytail: needs the screen list (App.GetAllScreensCached on WPF); one placeholder
+                // monitor in the exact WPF format so the row renders with a real string.
+                string monitorLabel = Loc.Get("monitor_label");
+                string primaryMarker = Loc.Get("monitor_primary_marker");
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = $"{monitorLabel} 1 ({primaryMarker}, 1920x1080)", Tag = 0 });
+
+                ComboBoxItem? match = null;
+                foreach (var obj in CmbMonitor.Items)
+                    if (obj is ComboBoxItem it && it.Tag is int t && t == saved) { match = it; break; }
+                CmbMonitor.SelectedItem = match ?? (CmbMonitor.Items.Count > 0 ? CmbMonitor.Items[0] : null);
+            }
+            finally { _monitorPopulating = false; }
+        }
+
+        private void UpdateSwatch()
+        {
+            var (r, g, b) = EffectiveColor();
+            ColorSwatch.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
+        }
+
+        // The colour the tint renders: the user's pick if set, else hot pink.
+        // ponytail: the mod fallback (App.Mods.GetFilterColorRgb) is skipped until ModService moves to Core.
+        private (byte R, byte G, byte B) EffectiveColor()
+        {
+            if (TryParseHex(_s.PinkFilterColor, out var rgb)) return rgb;
+            return (255, 105, 180);
+        }
+
+        // ponytail: third copy of the hex->RGB parse (WPF PinkFilterFeatureControl, ModService.ParseHexColor);
+        // hoist to CCP.Core and call it from both heads when AppSettings crosses. Not done here: this PR adds no shared files.
+        private static bool TryParseHex(string? hex, out (byte R, byte G, byte B) rgb)
+        {
+            rgb = (255, 105, 180);
+            if (string.IsNullOrWhiteSpace(hex)) return false;
+            hex = hex.Trim().TrimStart('#');
+            if (hex.Length != 6) return false;
+            try
+            {
+                rgb = (Convert.ToByte(hex.Substring(0, 2), 16),
+                       Convert.ToByte(hex.Substring(2, 2), 16),
+                       Convert.ToByte(hex.Substring(4, 2), 16));
+                return true;
+            }
+            catch { return false; }
+        }
+
+        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
+        private static void Save() { }
+    }
+
+    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
+    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
+    public sealed class PinkFilterSettings
+    {
+        public bool PinkFilterEnabled { get; set; }
+        public int PinkFilterOpacity { get; set; } = 10;
+        public string PinkFilterColor { get; set; } = "";
+        public int PinkFilterTargetMonitor { get; set; } = -1;
+    }
+}

--- a/CCP.Avalonia/Views/Features/VisualsFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/VisualsFeatureControl.axaml
@@ -1,0 +1,141 @@
+<!-- PORTED from ConditioningControlPanel/Features/VisualsFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"
+       ToolTip="..."                     -> ToolTip.Tip="..."
+       helpers:EmojiTextBlock            -> TextBlock (Avalonia renders colour emoji natively)
+       Image + EmojiToImageSource        -> TextBlock with the emoji
+       feat:SessionLock.Owned            -> dropped (ponytail: session-lock attached prop lives in
+                                            the WPF head; restore when the banner is ported)
+       feat:AdaptiveSideArt.CollapseBelow-> dropped (ponytail: same, the art column stays)
+       <Slider> (unstyled)               -> Theme="{StaticResource PinkSlider}" (the WPF theme applies
+                                            PinkSlider implicitly to every Slider: Resources/Theme/MainWindow.xaml:341)
+       ValueChanged= / Checked= / ...    -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.VisualsFeatureControl">
+
+    <!-- Velvet Kit 2 density pass. The root stays a StackPanel: MainWindow.SessionFeatureLock.cs
+         inserts the session-lock banner at index 0 of this panel. -->
+    <StackPanel>
+
+        <!-- HERO. No art (Resources/features has no visuals plate) and no enable pill: Visuals is
+             the one module with no master toggle at all. Title only. -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str section_visuals}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_scale_of_flash_images_100_original_size_200_d}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_size}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderSize" Minimum="50" Maximum="250" Value="100"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtSize" Text="100%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_transparency_of_flash_images_lower_more_see_t}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_opacity}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderOpacity" Minimum="10" Maximum="100" Value="100"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtOpacity" Text="100%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_fade_in_out_animation_speed_0_instant_appear}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_fade}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderFade" Minimum="0" Maximum="100" Value="50"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtFade" Text="50%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_how_long_images_stay_on_screen_only_used_when}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_duration}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderDuration" Minimum="1" Maximum="30" Value="5"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtDuration" Text="5s" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <!-- Link to Audio. Deliberately NOT SessionLock.Owned: killing sound is the one
+                                 change a user most often needs to make RIGHT NOW. -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_when_enabled_flash_duration_matches_audio_len}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_link_to_audio_trigger}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkAudio"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </StackPanel>
+
+            <!-- SIDE CARD, no art: the page's own glyph, huge and nearly transparent, on the section wash. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <TextBlock Text="👁" FontSize="120" Opacity="0.18"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/VisualsFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/VisualsFeatureControl.axaml.cs
@@ -1,0 +1,60 @@
+using Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Visuals settings panel, ported from the WPF head. Same load/handler shape as the original;
+    /// <see cref="VisualsSettings"/> stands in for <c>App.Settings.Current</c> until AppSettings
+    /// reaches Core. Save, SettingsHook and ISettingsRebindable are stubbed.
+    /// </summary>
+    public partial class VisualsFeatureControl : UserControl
+    {
+        private bool _isLoading = true;
+        private readonly VisualsSettings _s = new();
+
+        public VisualsFeatureControl()
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            SliderSize.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtSize.Text = $"{v}%"; _s.ImageScale = v; Save(); };
+            SliderOpacity.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtOpacity.Text = $"{v}%"; _s.FlashOpacity = v; Save(); };
+            SliderFade.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFade.Text = $"{v}%"; _s.FadeDuration = v; Save(); };
+            SliderDuration.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtDuration.Text = $"{v}s"; _s.FlashDuration = v; Save(); };
+            ChkAudio.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.FlashAudioEnabled = ChkAudio.IsChecked ?? false; Save(); };
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                SliderSize.Value = _s.ImageScale;
+                TxtSize.Text = $"{_s.ImageScale}%";
+                SliderOpacity.Value = _s.FlashOpacity;
+                TxtOpacity.Text = $"{_s.FlashOpacity}%";
+                SliderFade.Value = _s.FadeDuration;
+                TxtFade.Text = $"{_s.FadeDuration}%";
+                SliderDuration.Value = _s.FlashDuration;
+                TxtDuration.Text = $"{_s.FlashDuration}s";
+                ChkAudio.IsChecked = _s.FlashAudioEnabled;
+            }
+            finally { _isLoading = false; }
+        }
+
+        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
+        private static void Save() { }
+    }
+
+    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
+    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
+    public sealed class VisualsSettings
+    {
+        public int ImageScale { get; set; } = 100;
+        public int FlashOpacity { get; set; } = 100;
+        public int FadeDuration { get; set; } = 50;
+        public int FlashDuration { get; set; } = 5;
+        public bool FlashAudioEnabled { get; set; }
+    }
+}


### PR DESCRIPTION
681 lines, 6 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351