### PR TITLE
feat(avalonia): port Features II, part 2/2 - LockCard, MindWipe, Subliminal

### DIFF
--- a/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml
@@ -1,0 +1,176 @@
+<!-- PORTED from ConditioningControlPanel/Features/LockCardFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"
+       ToolTip="..."                     -> ToolTip.Tip="..."
+       helpers:EmojiTextBlock            -> TextBlock
+       Content="{loc:Str btn_x}"         -> a TextBlock child (Avalonia parses "_" as an access key)
+       ImageBrush + BitmapImage pack://  -> dropped (ponytail: Resources/features/*.png does not ship
+                                            in CCP.Avalonia; hero plate and side card keep the wash)
+       Border.OpacityMask gradient       -> dropped with the art it masked
+       feat:SessionLock.Owned            -> dropped (ponytail: WPF-head attached prop)
+       feat:AdaptiveSideArt.CollapseBelow-> dropped (ponytail: same)
+       LinearGradientBrush "0,1"/"0,0"   -> "0%,100%"/"0%,0%"
+       <Slider> (unstyled)               -> Theme="{StaticResource PinkSlider}" (the WPF theme applies
+                                            PinkSlider implicitly to every Slider: Resources/Theme/MainWindow.xaml:341)
+       Checked/Unchecked/Click/...       -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.LockCardFeatureControl">
+
+    <Grid>
+        <StackPanel>
+            <!-- HERO. The enable checkbox lives in the pill on the right and the description is
+                 the subtitle. -->
+            <Border Height="72" CornerRadius="16" Margin="0,0,0,10"
+                    Background="{DynamicResource SurfaceBgBrush}"
+                    BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2">
+                <Grid ClipToBounds="True">
+                    <Border Width="240" HorizontalAlignment="Right" CornerRadius="0,16,16,0"
+                            Background="{StaticResource SectionHueStudioWashBrush}"/>
+
+                    <StackPanel VerticalAlignment="Center" Margin="16,0,0,0">
+                        <TextBlock Text="{loc:Str label_lock_card}" FontSize="17" FontWeight="Bold"
+                                   Foreground="{StaticResource TextLightBrush}"/>
+                        <TextBlock Text="{loc:Str tooltip_show_lock_cards_that_require_typing_to_dismis}"
+                                   FontSize="11.5" Foreground="{StaticResource TextMutedBrush}"
+                                   TextTrimming="CharacterEllipsis" Margin="0,2,0,0"/>
+                    </StackPanel>
+
+                    <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,14,0"
+                            CornerRadius="9999" Padding="12,6"
+                            Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <CheckBox x:Name="ChkEnable"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*" MaxWidth="780"/>
+                    <ColumnDefinition Width="2*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0">
+                    <!-- ONE dense controls card: two dials, then the two switches. -->
+                    <Border Theme="{StaticResource SettingCardStyle}">
+                        <Grid>
+                            <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                    Background="{StaticResource SectionHueStudioBrush}"/>
+                            <StackPanel Margin="16,8,16,8">
+
+                                <!-- Per hour -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_lock_card_frequency_1_10_per_hour}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_per_hour}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderFreq" Minimum="1" Maximum="10" Value="2"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtFreq" Text="2" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <!-- Repeats -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_number_of_times_to_type_the_phrase_1_10}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_repeats}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderRepeats" Minimum="1" Maximum="10" Value="3"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtRepeats" Text="3x" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                                <!-- Strict lock -->
+                                <Grid Height="34" ToolTip.Tip="{loc:Str tooltip_cannot_escape_must_complete_typing}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_strict_lock}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <CheckBox Grid.Column="1" x:Name="ChkStrict"
+                                              Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                                </Grid>
+
+                                <!-- Solve by voice. TxtVoiceHint stays VISIBLE, not a ToolTip: code-behind
+                                     repaints it with the mic / speech-model status. -->
+                                <Grid Height="34">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="🎤 Solve by voice" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <CheckBox Grid.Column="1" x:Name="ChkVoiceMode"
+                                              Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                                </Grid>
+                                <TextBlock x:Name="TxtVoiceHint"
+                                           Text="Say the phrase out loud instead of typing it (offline mic). Falls back to typing if no mic."
+                                           Foreground="{StaticResource TextMutedBrush}" FontSize="10.5" FontStyle="Italic"
+                                           TextWrapping="Wrap" Margin="0,0,0,4"/>
+
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <!-- Actions -->
+                    <Grid Margin="0,0,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="8"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0" x:Name="BtnManagePhrases" Theme="{DynamicResource OutlineButton}">
+                            <TextBlock Text="{loc:Str btn_manage_phrases}"/>
+                        </Button>
+                        <Button Grid.Column="2" x:Name="BtnTest" Theme="{DynamicResource OutlineButton}">
+                            <TextBlock Text="{loc:Str btn_test_2}"/>
+                        </Button>
+                        <Button Grid.Column="4" x:Name="BtnColorSettings" Content="⚙" Width="44"
+                                Theme="{DynamicResource OutlineButton}"/>
+                    </Grid>
+                </StackPanel>
+
+                <!-- SIDE ART. Plate dropped (see header); the wash and the scrim keep the card's shape. -->
+                <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                        BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                        Background="{StaticResource SectionHueStudioWashBrush}"
+                        VerticalAlignment="Stretch" MinHeight="200">
+                    <Border CornerRadius="12">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                                <GradientStop Color="#66000000" Offset="0"/>
+                                <GradientStop Color="#00000000" Offset="0.45"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                </Border>
+            </Grid>
+
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
@@ -1,0 +1,83 @@
+using Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Lock Card settings panel, ported from the WPF head. <see cref="LockCardSettings"/> stands
+    /// in for <c>App.Settings.Current</c>. Save, the LockCardService calls, the strict-lock double
+    /// warning, MicConsentDialog, the phrase editor write-back, LockCardColorDialog, MessageBox and
+    /// the mod-art repaint are stubbed. The voice hint keeps the WPF literals; with no speech
+    /// service the "on" branch lands on "No microphone detected", which is the honest answer here.
+    /// </summary>
+    public partial class LockCardFeatureControl : UserControl
+    {
+        private bool _isLoading = true;
+        private readonly LockCardSettings _s = new();
+
+        public LockCardFeatureControl()
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            // ponytail: needs App.LockCard Start/Stop/TestLockCard, wired when it moves to Core
+            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.LockCardEnabled = ChkEnable.IsChecked ?? false; Save(); };
+            SliderFreq.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFreq.Text = v.ToString(); _s.LockCardFrequency = v; Save(); };
+            SliderRepeats.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtRepeats.Text = $"{v}x"; _s.LockCardRepeats = v; Save(); };
+            // ponytail: needs WarningDialog.ShowDoubleWarning (WPF head); writes through without the confirm
+            ChkStrict.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.LockCardStrict = ChkStrict.IsChecked ?? false; Save(); };
+            // ponytail: needs MicConsentDialog (WPF head); writes through without the consent gate
+            ChkVoiceMode.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.LockCardVoiceMode = ChkVoiceMode.IsChecked ?? false; Save(); UpdateVoiceHint(); };
+            // ponytail: Views/Dialogs/TextEditorDialog is ported, but the write-back is App.Settings; wired with it
+            BtnManagePhrases.Click += (_, _) => { };
+            BtnTest.Click += (_, _) => { };
+            // ponytail: needs LockCardColorDialog, ported separately
+            BtnColorSettings.Click += (_, _) => { };
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = _s.LockCardEnabled;
+                SliderFreq.Value = _s.LockCardFrequency;
+                TxtFreq.Text = _s.LockCardFrequency.ToString();
+                SliderRepeats.Value = _s.LockCardRepeats;
+                TxtRepeats.Text = $"{_s.LockCardRepeats}x";
+                ChkStrict.IsChecked = _s.LockCardStrict;
+                ChkVoiceMode.IsChecked = _s.LockCardVoiceMode && _s.MicConsentGiven;
+                UpdateVoiceHint();
+            }
+            finally { _isLoading = false; }
+        }
+
+        /// <summary>Refresh the grey hint under the voice toggle to reflect mic availability.</summary>
+        private void UpdateVoiceHint()
+        {
+            var on = ChkVoiceMode.IsChecked ?? false;
+            if (!on)
+            {
+                TxtVoiceHint.Text = "Say the phrase out loud instead of typing it (offline mic). Falls back to typing if no mic.";
+                return;
+            }
+            // ponytail: needs App.Speech (IsAvailable / HasCaptureDevice / ModelStatus); no service means no mic
+            TxtVoiceHint.Text = "No microphone detected — lock cards will use typing until one is connected.";
+        }
+
+        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
+        private static void Save() { }
+    }
+
+    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
+    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
+    public sealed class LockCardSettings
+    {
+        public bool LockCardEnabled { get; set; }
+        public int LockCardFrequency { get; set; } = 2;
+        public int LockCardRepeats { get; set; } = 3;
+        public bool LockCardStrict { get; set; }
+        public bool LockCardVoiceMode { get; set; }
+        public bool MicConsentGiven { get; set; }
+    }
+}

--- a/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml
@@ -1,0 +1,178 @@
+<!-- PORTED from ConditioningControlPanel/Features/MindWipeFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"
+       ToolTip="..."                     -> ToolTip.Tip="..."
+       helpers:EmojiTextBlock            -> TextBlock
+       Content="{loc:Str btn_x}"         -> a TextBlock child (Avalonia parses "_" as an access key)
+       ImageBrush + BitmapImage pack://  -> dropped (ponytail: Resources/features/*.png does not ship
+                                            in CCP.Avalonia; hero plate and side card keep the wash)
+       Border.OpacityMask gradient       -> dropped with the art it masked
+       feat:SessionLock.Owned            -> dropped (ponytail: WPF-head attached prop)
+       feat:AdaptiveSideArt.CollapseBelow-> dropped (ponytail: same)
+       LinearGradientBrush "0,1"/"0,0"   -> "0%,100%"/"0%,0%"
+       <Slider> (unstyled)               -> Theme="{StaticResource PinkSlider}" (the WPF theme applies
+                                            PinkSlider implicitly to every Slider: Resources/Theme/MainWindow.xaml:341)
+       Checked/Unchecked/Click/...       -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.MindWipeFeatureControl">
+
+    <Grid>
+        <StackPanel>
+            <!-- HERO. The feature's blurb is the hero ToolTip; the enable checkbox lives in the pill. -->
+            <Border Height="72" CornerRadius="16" Margin="0,0,0,10"
+                    Background="{DynamicResource SurfaceBgBrush}"
+                    BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2"
+                    ToolTip.Tip="{loc:Str tooltip_random_mind_wipe_audio_effects_escalates_in_f}">
+                <Grid ClipToBounds="True">
+                    <Border Width="240" HorizontalAlignment="Right" CornerRadius="0,16,16,0"
+                            Background="{StaticResource SectionHueStudioWashBrush}"/>
+
+                    <StackPanel VerticalAlignment="Center" Margin="16,0,0,0">
+                        <TextBlock Text="{loc:Str label_mind_wipe}" FontSize="17" FontWeight="Bold"
+                                   Foreground="{StaticResource TextLightBrush}"/>
+                    </StackPanel>
+
+                    <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,14,0"
+                            CornerRadius="9999" Padding="12,6"
+                            Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <CheckBox x:Name="ChkEnable"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*" MaxWidth="780"/>
+                    <ColumnDefinition Width="2*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0">
+                    <!-- ONE dense controls card: the two dials, then the loop switch. -->
+                    <Border Theme="{StaticResource SettingCardStyle}">
+                        <Grid>
+                            <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                    Background="{StaticResource SectionHueStudioBrush}"/>
+                            <StackPanel Margin="16,8,16,8">
+
+                                <!-- Frequency -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_mind_wipe_frequency_1_180_per_hour}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_frequency}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderFreq" Minimum="1" Maximum="180" Value="6"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtFreq" Text="6/h" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <!-- Volume -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_volume_level_0_100}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_volume}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderVolume" Minimum="0" Maximum="100" Value="50"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtVolume" Text="50%" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                                <!-- Loop in background -->
+                                <Grid Height="34" ToolTip.Tip="{loc:Str tooltip_continuously_loop_a_single_track_instead_of_r}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_loop_in_background}"
+                                               FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <CheckBox Grid.Column="1" x:Name="ChkLoop"
+                                              Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                                </Grid>
+
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <!-- Custom audio clip: its own card, same grammar. TxtAudioFile stays visible because
+                         code-behind writes the current filename into it. -->
+                    <Border Theme="{StaticResource SettingCardStyle}"
+                            ToolTip.Tip="Pick your own mind-wipe sound. Keep it short — about 2 seconds works best. Leave it on Default to use the built-in clips.">
+                        <Grid>
+                            <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                    Background="{StaticResource SectionHueStudioBrush}"/>
+                            <StackPanel Margin="16,8,16,8">
+                                <Grid Height="34">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="CUSTOM AUDIO" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <TextBlock Grid.Column="1" x:Name="TxtAudioFile" Text="Default (built-in clips)"
+                                               Foreground="{DynamicResource PinkBrush}" FontSize="12"
+                                               HorizontalAlignment="Right" VerticalAlignment="Center"
+                                               TextTrimming="CharacterEllipsis" Margin="10,0,0,0"/>
+                                </Grid>
+                                <Grid Height="36">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Button Grid.Column="0" x:Name="BtnSelectAudio" Content="Select audio…"
+                                            Theme="{DynamicResource OutlineButton}" Padding="12,6"
+                                            Margin="0,0,6,0"/>
+                                    <Button Grid.Column="1" x:Name="BtnClearAudio" Content="Reset"
+                                            Theme="{DynamicResource OutlineButton}" Padding="12,6"/>
+                                </Grid>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <Button x:Name="BtnTest" Theme="{DynamicResource OutlineButton}">
+                        <TextBlock Text="{loc:Str btn_test_now_2}"/>
+                    </Button>
+                </StackPanel>
+
+                <!-- SIDE ART. Plate dropped (see header); the wash and the scrim keep the card's shape. -->
+                <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                        BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                        Background="{StaticResource SectionHueStudioWashBrush}"
+                        VerticalAlignment="Stretch" MinHeight="200">
+                    <Border CornerRadius="12">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                                <GradientStop Color="#66000000" Offset="0"/>
+                                <GradientStop Color="#00000000" Offset="0.45"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                </Border>
+            </Grid>
+
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml.cs
@@ -1,0 +1,77 @@
+using System.IO;
+using Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Mind Wipe settings panel, ported from the WPF head. <see cref="MindWipeSettings"/> stands
+    /// in for <c>App.Settings.Current</c>. Save, the MindWipeService calls, the Win32
+    /// OpenFileDialog and the mod-art repaint are stubbed.
+    /// </summary>
+    public partial class MindWipeFeatureControl : UserControl
+    {
+        private bool _isLoading = true;
+        private readonly MindWipeSettings _s = new();
+
+        public MindWipeFeatureControl()
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            // ponytail: needs App.MindWipe UpdateSettings/StartLoop/StopLoop/TriggerOnce/ReloadAudioFiles, wired when it moves to Core
+            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.MindWipeEnabled = ChkEnable.IsChecked ?? false; Save(); };
+            SliderFreq.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFreq.Text = $"{v}/h"; _s.MindWipeFrequency = v; Save(); };
+            SliderVolume.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtVolume.Text = $"{v}%"; _s.MindWipeVolume = v; Save(); };
+            ChkLoop.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.MindWipeLoop = ChkLoop.IsChecked ?? false; Save(); };
+            BtnTest.Click += (_, _) => { };
+            // ponytail: needs a file picker (Win32 OpenFileDialog on WPF); StorageProvider needs a TopLevel, wired with the host
+            BtnSelectAudio.Click += (_, _) => { };
+            BtnClearAudio.Click += (_, _) =>
+            {
+                if (string.IsNullOrEmpty(_s.MindWipeAudioPath)) return;
+                _s.MindWipeAudioPath = "";
+                Save();
+                UpdateAudioFileLabel();
+            };
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = _s.MindWipeEnabled;
+                SliderFreq.Value = _s.MindWipeFrequency;
+                TxtFreq.Text = $"{_s.MindWipeFrequency}/h";
+                SliderVolume.Value = _s.MindWipeVolume;
+                TxtVolume.Text = $"{_s.MindWipeVolume}%";
+                ChkLoop.IsChecked = _s.MindWipeLoop;
+                UpdateAudioFileLabel();
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void UpdateAudioFileLabel()
+        {
+            var path = _s.MindWipeAudioPath;
+            TxtAudioFile.Text = !string.IsNullOrWhiteSpace(path) && File.Exists(path)
+                ? Path.GetFileName(path)
+                : "Default (built-in clips)";
+        }
+
+        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
+        private static void Save() { }
+    }
+
+    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
+    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
+    public sealed class MindWipeSettings
+    {
+        public bool MindWipeEnabled { get; set; }
+        public int MindWipeFrequency { get; set; } = 6;
+        public int MindWipeVolume { get; set; } = 50;
+        public bool MindWipeLoop { get; set; }
+        public string MindWipeAudioPath { get; set; } = "";
+    }
+}

--- a/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml
@@ -1,0 +1,198 @@
+<!-- PORTED from ConditioningControlPanel/Features/SubliminalFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"
+       ToolTip="..."                     -> ToolTip.Tip="..."
+       helpers:EmojiTextBlock            -> TextBlock
+       ImageBrush + BitmapImage pack://  -> dropped (ponytail: Resources/features/*.png does not ship
+                                            in CCP.Avalonia; hero plate and side card keep the wash)
+       Border.OpacityMask gradient       -> dropped with the art it masked
+       feat:SessionLock.Owned            -> dropped (ponytail: WPF-head attached prop)
+       feat:AdaptiveSideArt.CollapseBelow-> dropped (ponytail: same)
+       LinearGradientBrush "0,1"/"0,0"   -> "0%,100%"/"0%,0%"
+       <Slider> (unstyled)               -> Theme="{StaticResource PinkSlider}" (the WPF theme applies
+                                            PinkSlider implicitly to every Slider: Resources/Theme/MainWindow.xaml:341)
+       Checked/Unchecked/Click/...       -> wired in the constructor -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.SubliminalFeatureControl">
+
+    <StackPanel>
+
+        <!-- HERO -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}"/>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str section_subliminals_2}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str tooltip_enable_disable_subliminal_messages}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}" Margin="0,1,0,0"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_messages_shown_per_minute}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_per_min}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderPerMin" Minimum="1" Maximum="30" Value="5"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtPerMin" Text="5" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_display_duration_in_frames_lower_faster_flash}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_frames}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderFrames" Minimum="1" Maximum="10" Value="2"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtFrames" Text="2" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_text_visibility_lower_more_subtle}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_opacity}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderOpacity" Minimum="10" Maximum="100" Value="80"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtOpacity" Text="80%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_play_whispered_audio_when_subliminal_messages}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_volume}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" Theme="{StaticResource PinkSlider}" x:Name="SliderWhisperVol" Minimum="0" Maximum="100" Value="50"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtWhisperVol" Text="50%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_play_whispered_audio_when_subliminal_messages}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_audio_whispers}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkWhispers"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Solid mode: shared-host renderer, mirrors the Flashes/Bubble Pop toggle -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Draws subliminal text on one shared overlay instead of a dedicated window per screen - lighter on the renderer and friendlier to fullscreen games. Ignored while 'steal focus' is on. Applies to the next flash.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Solid mode (game friendly)" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkSolidMode"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Font: any family installed on the system, plus the bundled Fredoka. -->
+                            <Grid Height="34" Background="Transparent"
+                                  ToolTip.Tip="Any font installed on Windows. Applies to the next subliminal.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_font}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <ComboBox Grid.Column="1" x:Name="CmbFont" Height="26" MaxWidth="220"
+                                          HorizontalAlignment="Right" VerticalAlignment="Center"
+                                          Theme="{DynamicResource DarkComboBoxStyle}"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Actions -->
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0" x:Name="BtnManageMessages" Content="📝 Messages"
+                            Theme="{DynamicResource OutlineButton}"
+                            ToolTip.Tip="{loc:Str tooltip_edit_subliminal_messages}"/>
+                    <Button Grid.Column="2" x:Name="BtnAdvanced" Content="⚙ Advanced"
+                            Theme="{DynamicResource OutlineButton}"
+                            ToolTip.Tip="{loc:Str tooltip_advanced_subliminal_visual_settings}"/>
+                </Grid>
+            </StackPanel>
+
+            <!-- SIDE ART. Plate dropped (see header); the wash and the scrim keep the card's shape. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
@@ -1,0 +1,85 @@
+using Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Subliminal settings panel, ported from the WPF head. <see cref="SubliminalSettings"/>
+    /// stands in for <c>App.Settings.Current</c>. Save, SubliminalService.SetEnabled, the pool
+    /// editor write-back (with its user-added / removed-default bookkeeping), ColorEditorDialog,
+    /// FontPickerHelper and the mod-art repaint are stubbed; the font combo carries two
+    /// placeholder families.
+    /// </summary>
+    public partial class SubliminalFeatureControl : UserControl
+    {
+        private bool _isLoading = true;
+        private readonly SubliminalSettings _s = new();
+
+        public SubliminalFeatureControl()
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            // ponytail: needs App.Subliminal.SetEnabled (the single authority on WPF), wired when it moves to Core
+            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.SubliminalEnabled = ChkEnable.IsChecked ?? false; Save(); };
+            SliderPerMin.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtPerMin.Text = v.ToString(); _s.SubliminalFrequency = v; Save(); };
+            SliderFrames.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFrames.Text = v.ToString(); _s.SubliminalDuration = v; Save(); };
+            SliderOpacity.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtOpacity.Text = $"{v}%"; _s.SubliminalOpacity = v; Save(); };
+            ChkWhispers.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.SubAudioEnabled = ChkWhispers.IsChecked ?? false; Save(); };
+            SliderWhisperVol.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtWhisperVol.Text = $"{v}%"; _s.SubAudioVolume = v; Save(); };
+            ChkSolidMode.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.SubliminalSolidMode = ChkSolidMode.IsChecked ?? false; Save(); };
+            CmbFont.SelectionChanged += (_, _) =>
+            {
+                if (_isLoading) return;
+                var name = CmbFont.SelectedItem as string;
+                if (string.IsNullOrWhiteSpace(name) || _s.SubliminalFont == name) return;
+                _s.SubliminalFont = name;
+                Save();
+            };
+            // ponytail: Views/Dialogs/TextEditorDialog is ported, but the pool bookkeeping is App.Settings/App.Mods; wired with them
+            BtnManageMessages.Click += (_, _) => { };
+            // ponytail: needs ColorEditorDialog, ported separately
+            BtnAdvanced.Click += (_, _) => { };
+
+            LoadFromSettings();
+        }
+
+        private void LoadFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = _s.SubliminalEnabled;
+                SliderPerMin.Value = _s.SubliminalFrequency;
+                TxtPerMin.Text = _s.SubliminalFrequency.ToString();
+                SliderFrames.Value = _s.SubliminalDuration;
+                TxtFrames.Text = _s.SubliminalDuration.ToString();
+                SliderOpacity.Value = _s.SubliminalOpacity;
+                TxtOpacity.Text = $"{_s.SubliminalOpacity}%";
+                ChkWhispers.IsChecked = _s.SubAudioEnabled;
+                SliderWhisperVol.Value = _s.SubAudioVolume;
+                TxtWhisperVol.Text = $"{_s.SubAudioVolume}%";
+                ChkSolidMode.IsChecked = _s.SubliminalSolidMode;
+                // ponytail: needs Helpers.FontPickerHelper (system font enumeration); two placeholders, selection by name as on WPF
+                CmbFont.ItemsSource = new[] { "Arial", "Fredoka" };
+                CmbFont.SelectedItem = _s.SubliminalFont;
+            }
+            finally { _isLoading = false; }
+        }
+
+        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
+        private static void Save() { }
+    }
+
+    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
+    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
+    public sealed class SubliminalSettings
+    {
+        public bool SubliminalEnabled { get; set; }
+        public int SubliminalFrequency { get; set; } = 5;
+        public int SubliminalDuration { get; set; } = 2;
+        public int SubliminalOpacity { get; set; } = 80;
+        public bool SubAudioEnabled { get; set; }
+        public int SubAudioVolume { get; set; } = 50;
+        public bool SubliminalSolidMode { get; set; }
+        public string SubliminalFont { get; set; } = "Arial";
+    }
+}


### PR DESCRIPTION
797 lines, 6 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351