### PR TITLE
feat(avalonia): port Features III, part 1/3 - SliderLabel helper, System, Spiral, BubblePop

### DIFF
--- a/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml
@@ -1,0 +1,232 @@
+<!-- PORTED from ConditioningControlPanel/Features/BubblePopFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock
+       Visibility="Collapsed"            ->  IsVisible="False"
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%"
+       ImageBrush HeroArtBrush/SideArtBrush -> dropped (feature art not an AvaloniaResource here
+                                            yet; x:Name on a brush is AVLN2000); wash stands in
+       feat:AdaptiveSideArt.CollapseBelow, feat:SessionLock.Owned -> dropped
+       all event handlers                ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.BubblePopFeatureControl">
+
+    <!-- Velvet Kit 2 density pass. The root IS the StackPanel (the old Grid wrapper is gone):
+         MainWindow.SessionFeatureLock.cs inserts the session-lock banner at index 0 of
+         content.Content, and into a Grid that banner would have overlapped the settings. -->
+    <StackPanel>
+
+        <!-- HERO -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}">
+                    <Border.OpacityMask>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#00000000" Offset="0"/>
+                            <GradientStop Color="#E6000000" Offset="0.55"/>
+                        </LinearGradientBrush>
+                    </Border.OpacityMask>
+                </Border>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str label_bubble_pop}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str tooltip_pop_bubbles_to_earn_xp}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}" Margin="0,1,0,0"/>
+                    <!-- #1019/#1026: ambient-pop XP has a 300/day ceiling. Text is set in code
+                         (LoadFromSettings + the service's budget event). -->
+                    <TextBlock x:Name="TxtAmbientXpBudget" FontSize="11"
+                               Foreground="{StaticResource TextMutedBrush}" Opacity="0.85" Margin="0,2,0,0"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY: settings column capped, art card takes the rest. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_bubble_spawn_rate}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_per_min}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderFreq" Minimum="1" Maximum="60" Value="5"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtFreq" Text="5" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="How fast bubbles travel across the screen">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Speed" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderSpeed" Minimum="0" Maximum="500" Value="0"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtSpeed" Text="+0%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <!-- Size. Sits with Per Min / Speed: "these are too big" is a first-minute reaction. -->
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_bubble_size}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_size}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderSize" Minimum="50" Maximum="150" Value="100"
+                                        SmallChange="5" LargeChange="10" TickFrequency="5" IsSnapToTickEnabled="True"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtSize" Text="100%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_bubble_pop_sound_volume}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_volume}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderVolume" Minimum="0" Maximum="100" Value="50"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtVolume" Text="50%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <!-- Solid mode: render all bubbles on one shared host (the DTRH/Chaos path). -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Uses the Rabbit Hole's optimized renderer so the field stays smooth with lots of bubbles. Lifts the on-screen cap. Turn off to use the classic one-window-per-bubble mode. Takes effect when bubbles restart.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Solid mode (many bubbles)" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkSolidMode"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Trigger Bubbles: a share of bubbles fire a Chaos effect when popped. The egg
+                                 hint stays VISIBLE (code-behind rewrites it with the active persona's name). -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Some bubbles fire an effect when popped (flash, video, overlays…)">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock Text="Trigger Bubbles" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="TxtTriggerEggHint"
+                                               Text="careful — Bambi loves these…"
+                                               Foreground="{DynamicResource PinkBrush}" FontSize="10.5" FontStyle="Italic"
+                                               VerticalAlignment="Center" Margin="8,1,0,0"/>
+                                </StackPanel>
+                                <CheckBox Grid.Column="1" x:Name="ChkTriggers"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Trigger options: own card, revealed by the switch above. -->
+                <StackPanel x:Name="TriggerOptionsPanel" IsVisible="False">
+                    <Border Theme="{StaticResource SettingCardStyle}">
+                        <Grid>
+                            <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                    Background="{StaticResource SectionHueStudioBrush}"/>
+                            <StackPanel Margin="16,8,16,10">
+
+                                <Grid Height="36" Background="Transparent" ToolTip.Tip="How often a spawned bubble carries an effect">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="Trigger chance" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" x:Name="SliderTriggerChance" Minimum="0" Maximum="50" Value="10"
+                                            VerticalAlignment="Center" Margin="14,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtTriggerChance" Text="10%" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                               FontSize="13" FontWeight="Bold"/>
+                                </Grid>
+
+                                <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                                <TextBlock Text="Effect types" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" Margin="0,2,0,8"/>
+                                <WrapPanel Background="Transparent" ToolTip.Tip="Each ticked effect has an equal chance">
+                                    <CheckBox x:Name="ChkTypeFlash"      Tag="flash"      Content="Flash"       Foreground="White" Margin="0,0,16,8"/>
+                                    <CheckBox x:Name="ChkTypeSubliminal" Tag="subliminal" Content="Subliminal"  Foreground="White" Margin="0,0,16,8"/>
+                                    <CheckBox x:Name="ChkTypePink"       Tag="pink"       Content="Pink Filter" Foreground="White" Margin="0,0,16,8"/>
+                                    <CheckBox x:Name="ChkTypeSpiral"     Tag="spiral"     Content="Spiral"      Foreground="White" Margin="0,0,16,8"/>
+                                    <CheckBox x:Name="ChkTypeGlitch"     Tag="glitch"     Content="Glitch"      Foreground="White" Margin="0,0,16,8"/>
+                                    <CheckBox x:Name="ChkTypeCascade"    Tag="htlink"     Content="Cascade"     Foreground="White" Margin="0,0,16,8"/>
+                                    <CheckBox x:Name="ChkTypeVideo"      Tag="video"      Content="Video"       Foreground="White" Margin="0,0,16,8"/>
+                                </WrapPanel>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- SIDE ART. On WPF an ImageBrush background; the wash stands in. Scrim kept verbatim. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Bubble Pop panel, ported from the WPF head. The slider read-outs, the trigger-options
+    /// reveal and the two formatted lines are real; the settings writes, the BubbleService
+    /// start/stop and the persona lookup (App.Mods.ActiveModId) are WPF-head services.
+    /// </summary>
+    public partial class BubblePopFeatureControl : UserControl
+    {
+        public BubblePopFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            SliderLabel.Wire(this, "SliderFreq", "TxtFreq", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderVolume", "TxtVolume", v => $"{(int)v}%");
+            SliderLabel.Wire(this, "SliderSize", "TxtSize", v => $"{(int)v}%");
+            SliderLabel.Wire(this, "SliderSpeed", "TxtSpeed", v => $"+{(int)v}%");
+            SliderLabel.Wire(this, "SliderTriggerChance", "TxtTriggerChance", v => $"{(int)v}%");
+
+            var triggers = this.FindControl<CheckBox>("ChkTriggers")!;
+            var options = this.FindControl<StackPanel>("TriggerOptionsPanel")!;
+            triggers.IsCheckedChanged += (_, _) => options.IsVisible = triggers.IsChecked ?? false;
+
+            // WPF: persona from App.Mods.ActiveModId; "your companion" is its fallback arm.
+            this.FindControl<TextBlock>("TxtTriggerEggHint")!.Text = "careful — your companion loves these…";
+            // WPF: BubbleService.AmbientBubbleXpPaidToday() / AmbientBubbleDailyXpCap (300).
+            this.FindControl<TextBlock>("TxtAmbientXpBudget")!.Text = Loc.GetF("label_ambient_bubble_xp_budget", 0, 300);
+
+            // ponytail: needs App.Settings / App.Bubbles / App.Mods, wired when they move to Core.
+            // ChkEnable, ChkSolidMode and the ChkType* effect checkboxes are settings writes only.
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/SliderLabel.cs
+++ b/CCP.Avalonia/Views/Features/SliderLabel.cs
@@ -1,0 +1,23 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// The one view-side thing every feature panel's slider handler does: repaint the value
+    /// TextBlock beside it. On WPF each handler also writes App.Settings; that half is not
+    /// portable yet, so this is what remains of ~40 near-identical handlers across the panels.
+    /// </summary>
+    internal static class SliderLabel
+    {
+        public static Slider Wire(Control host, string slider, string label, Func<double, string> format)
+        {
+            var s = host.FindControl<Slider>(slider)!;
+            var t = host.FindControl<TextBlock>(label)!;
+            t.Text = format(s.Value);
+            s.ValueChanged += (_, e) => t.Text = format(e.NewValue);
+            return s;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml
@@ -1,0 +1,237 @@
+<!-- PORTED from ConditioningControlPanel/Features/SpiralFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock
+       Visibility="Collapsed"            ->  IsVisible="False"
+       Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1)
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%" (Avalonia points are absolute
+                                            unless given as %)
+       ImageBrush HeroArtBrush/SideArtBrush -> dropped: Resources/features/*.png is not an
+                                            AvaloniaResource in this head yet, and x:Name on a
+                                            brush is AVLN2000. The wash stands in on both plates.
+       feat:AdaptiveSideArt.CollapseBelow, feat:SessionLock.Owned -> dropped (WPF-head attached
+                                            behaviours)
+       all event handlers                ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.SpiralFeatureControl">
+
+    <!-- Velvet Kit 2 density pass. The root IS the StackPanel (the old Grid wrapper is gone):
+         MainWindow.SessionFeatureLock.cs inserts the session-lock banner at index 0 of
+         content.Content, and into a Grid that banner would have overlapped the settings
+         instead of sitting above them. -->
+    <StackPanel>
+
+        <!-- HERO -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}">
+                    <Border.OpacityMask>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#00000000" Offset="0"/>
+                            <GradientStop Color="#E6000000" Offset="0.55"/>
+                        </LinearGradientBrush>
+                    </Border.OpacityMask>
+                </Border>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str label_spiral_overlay}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str tooltip_show_hypnotic_spiral_overlay}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}" Margin="0,1,0,0"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY. The settings column is capped (3*, MaxWidth 780) so a
+             slider stops being a ~1200px runway in the wide Studio detail pane, and the width that
+             buys back becomes ONE big art card instead of dead margin. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card: opacity, the randomize switch (#641), the monitor picker (#639). -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_spiral_opacity_5_100}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_opacity}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderOpacity"
+                                        Minimum="5" Maximum="100" Value="15"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtOpacity" Text="15%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_spiral_randomize}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_spiral_randomize}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkRandomize"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- User master for the SESSION corner GIF. -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_session_corner_gif_allowed}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_session_corner_gif_allowed}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis" Margin="0,0,12,0"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkSessionCornerGif"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_effect_monitor}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_effect_monitor}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <ComboBox Grid.Column="1" x:Name="CmbMonitor"
+                                          Width="180" VerticalAlignment="Center"
+                                          Theme="{DynamicResource DarkComboBoxStyle}"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Actions (kept above the library so they're reachable without scrolling) -->
+                <!-- THE LOOM: weave your own spiral (also craftable inside DtRH) -->
+                <Button x:Name="BtnOpenLoom"
+                        Content="🌀 THE LOOM — weave your own spiral"
+                        Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch"
+                        Padding="12,10"
+                        Margin="0,0,0,10"/>
+
+                <!-- Standalone corner-GIF overlays (independent of sessions) -->
+                <Button x:Name="BtnCornerGifs"
+                        Content="🖼 CORNER GIFs — pin a GIF to a screen corner"
+                        Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch"
+                        Padding="12,10"
+                        Margin="0,0,0,10"/>
+
+                <!-- Select GIF (browse anywhere) -->
+                <Button x:Name="BtnSelectGif"
+                        Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch"
+                        Padding="12,10"
+                        Margin="0,0,0,10">
+                    <TextBlock Text="{loc:Str btn_select_gif}"/>
+                </Button>
+
+                <!-- Spiral library: its own card - it is a picker, not a dial. -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,10,16,12">
+                            <Grid Margin="0,0,0,10" Background="Transparent"
+                                  ToolTip.Tip="Pick the spiral used everywhere. Drop your own .gif / image files in the folder, then Refresh.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           Text="SPIRAL LIBRARY"
+                                           Foreground="{StaticResource TextLightBrush}"
+                                           FontSize="13"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"/>
+                                <Button Grid.Column="1"
+                                        x:Name="BtnOpenSpiralFolder"
+                                        Content="Open folder"
+                                        Theme="{DynamicResource OutlineButton}"
+                                        Padding="10,5"
+                                        Margin="0,0,6,0"
+                                        FontSize="11"/>
+                                <Button Grid.Column="2"
+                                        x:Name="BtnRefreshSpirals"
+                                        Content="⟳ Refresh"
+                                        Theme="{DynamicResource OutlineButton}"
+                                        Padding="10,5"
+                                        FontSize="11"/>
+                            </Grid>
+
+                            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled"
+                                          MaxHeight="280">
+                                <WrapPanel x:Name="SpiralLibraryPanel" Orientation="Horizontal"/>
+                            </ScrollViewer>
+
+                            <TextBlock x:Name="SpiralEmptyState"
+                                       IsVisible="False"
+                                       Text="No spirals in your folder yet — only the built-in spiral is available. Click &quot;Open folder&quot; to add your own."
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,8,0,0"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <TextBlock Text="{loc:Str label_if_you_have_display_problems_try_setting_your}"
+                           Foreground="#FFA500"
+                           FontSize="11"
+                           FontStyle="Italic"
+                           TextWrapping="Wrap"
+                           Opacity="0.8"
+                           Margin="0,2,0,0"/>
+            </StackPanel>
+
+            <!-- SIDE ART. On WPF the art is the Border's BACKGROUND (an ImageBrush); the wash stands
+                 in until feature art ships in this head. The scrim is kept verbatim. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <!-- Scrim so the plate sits under the page instead of fighting it. -->
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
@@ -1,0 +1,120 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Spiral Overlay panel, ported from the WPF head.
+    ///
+    /// What is real here: the opacity read-out, the monitor picker's two fixed entries, and the
+    /// library's "Default" card. What is not: everything that reads App.Settings (SpiralEnabled,
+    /// SpiralOpacity, SpiralPath, SpiralTargetMonitor...), the screen enumeration
+    /// (App.GetAllScreensCached), the Spirals folder scan (App.UserDataPath), the Loom and
+    /// Corner-GIF windows, the file picker and the overlay refresh. Each is a WPF-head service.
+    /// </summary>
+    public partial class SpiralFeatureControl : UserControl
+    {
+        private static readonly Color SelectedAccent = Color.FromRgb(0xFF, 0x69, 0xB4);
+        private static readonly Color IdleAccent = Color.FromRgb(0x33, 0x33, 0x3A);
+
+        public SpiralFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            SliderLabel.Wire(this, "SliderOpacity", "TxtOpacity", v => $"{(int)v}%");
+            PopulateMonitors();
+            RefreshLibrary();
+
+            // ponytail: needs App.Settings / App.Overlay / App.GetAllScreensCached / LoomHostService /
+            // CornerGifWindow / a file picker, wired when they move to Core. ChkEnable, ChkRandomize,
+            // ChkSessionCornerGif, CmbMonitor, BtnOpenLoom, BtnCornerGifs, BtnSelectGif,
+            // BtnOpenSpiralFolder are inert until then.
+            this.FindControl<Button>("BtnRefreshSpirals")!.Click += (_, _) => RefreshLibrary();
+        }
+
+        /// <summary>
+        /// The two fixed entries come from the same keys WPF uses; the per-screen lines need the
+        /// display topology, so one placeholder line in WPF's exact format stands in for them.
+        /// </summary>
+        private void PopulateMonitors()
+        {
+            var cmb = this.FindControl<ComboBox>("CmbMonitor")!;
+            cmb.Items.Clear();
+            cmb.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = -1 });
+            cmb.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = -2 });
+            // WPF: $"{monitorLabel} {i + 1} ({prefix}{b.Width}x{b.Height})" per screen.
+            cmb.Items.Add(new ComboBoxItem
+            {
+                Content = $"{Loc.Get("monitor_label")} 1 ({Loc.Get("monitor_primary_marker")}, 1920x1080)",
+                Tag = 0,
+            });
+            cmb.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// Rebuilds the gallery: the "Default" card only, since the user folder lives under
+        /// App.UserDataPath. Empty-state text shows, as it does on WPF with an empty folder.
+        /// </summary>
+        private void RefreshLibrary()
+        {
+            var panel = this.FindControl<WrapPanel>("SpiralLibraryPanel")!;
+            panel.Children.Clear();
+            panel.Children.Add(BuildSpiralCard("", "Default", selected: true));
+            this.FindControl<TextBlock>("SpiralEmptyState")!.IsVisible = true;
+        }
+
+        /// <summary>
+        /// WPF's BuildSpiralCard minus the bitmap branch: no file to thumbnail here, so every card
+        /// gets the glyph. Selection highlight is the same 2px accent swap.
+        /// </summary>
+        private static Border BuildSpiralCard(string path, string display, bool selected)
+        {
+            var card = new Border
+            {
+                Width = 120,
+                Background = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)),
+                BorderBrush = new SolidColorBrush(selected ? SelectedAccent : IdleAccent),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8),
+                Margin = new Thickness(0, 0, 8, 8),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Tag = path,
+            };
+            ToolTip.SetTip(card, string.IsNullOrEmpty(path) ? "Built-in spiral" : path);
+
+            var stack = new StackPanel();
+            stack.Children.Add(new Border
+            {
+                Height = 80,
+                Background = new SolidColorBrush(Color.FromRgb(0x0A, 0x0A, 0x14)),
+                CornerRadius = new CornerRadius(6, 6, 0, 0),
+                ClipToBounds = true,
+                Child = new TextBlock
+                {
+                    Text = "🌀",
+                    FontSize = 32,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88)),
+                },
+            });
+            stack.Children.Add(new TextBlock
+            {
+                Text = display,
+                Foreground = Brushes.White,
+                FontWeight = FontWeight.SemiBold,
+                FontSize = 11,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(6, 6, 6, 8),
+            });
+            card.Child = stack;
+            return card;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml
@@ -1,0 +1,231 @@
+<!-- PORTED from ConditioningControlPanel/Features/SystemFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock (Avalonia renders colour emoji natively)
+       Image of an emoji (EmojiToImageSource) -> TextBlock with the emoji
+       Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1: "_" is an access key)
+       feat:AdaptiveSideArt.CollapseBelow -> dropped (attached behaviour lives in the WPF head)
+       Click/Checked handlers            ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.SystemFeatureControl">
+
+    <!-- This control hangs off the Settings door, not the Studio rack, so it gets NO hero
+         strip - just the dense row grammar. Every description that used to sit under a
+         control is now that row's ToolTip; the read-out rows (startup group, no-panic,
+         offline mode, startup video, panic key) keep their state TextBlocks VISIBLE because
+         code-behind writes the current value into them - that text IS the row's value. -->
+    <StackPanel>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY. The settings column is capped (3*, MaxWidth 780) so a
+             slider stops being a ~1200px runway in the wide Studio detail pane, and the width that
+             buys back becomes ONE big art card instead of dead margin. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <!-- Multi-monitor -->
+                            <Grid Height="34" ToolTip.Tip="{loc:Str tooltip_show_content_on_all_connected_monitors_2_3_or}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_multi_mon}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkMultiMon"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Depends on the row above, so it stays indented. -->
+                            <Grid Height="34" Margin="16,0,0,0" ToolTip.Tip="{loc:Str tooltip_fill_all_monitors_video}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_fill_all_monitors_video}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkFillAllMon"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- GPU decode -->
+                            <Grid Height="34" ToolTip.Tip="Play mandatory videos on the GPU. Off by default (software decode) to dodge a white-screen bug on some PCs. Turn ON if a video only plays on one of your screens, keeps swapping screens, or freezes when it starts.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Force video GPU decode" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkVideoGpuDecode"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Blurred video background -->
+                            <Grid Height="34" ToolTip.Tip="Fill the empty bars around a video that doesn't fit the screen (e.g. a vertical clip on a widescreen monitor) with a blurred, zoomed copy of the video, like TikTok. Turn OFF for plain black bars.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Blurred video background" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkVideoBlurBg"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Browser video engine -->
+                            <Grid Height="34" ToolTip.Tip="{loc:Str tooltip_browser_video_engine}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_browser_video_engine}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkBrowserVideoEngine"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                            <!-- Read-only since Phase 2 of the UX restructure: Settings → General owns the
+                                 startup group; this is a read-out that LoadFromSettings keeps painted. -->
+                            <Grid Height="38">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str set2_general_startup_title}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" x:Name="TxtStartupGroupState" Text=""
+                                           Foreground="{StaticResource TextMutedBrush}" FontSize="11"
+                                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                           HorizontalAlignment="Right" Margin="10,0,10,0"/>
+                                <Button Grid.Column="2" x:Name="BtnOpenGeneralSettings"
+                                        Theme="{DynamicResource OutlineButton}" Padding="10,4" FontSize="11"
+                                        VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str set2_configure_in_settings}"/>
+                                </Button>
+                            </Grid>
+
+                            <!-- Read-only since Phase 2. Settings → Devices owns the panic key. -->
+                            <Grid Height="38">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_no_panic}" Foreground="#FF6B6B"
+                                           FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" x:Name="TxtNoPanicState" Text="{loc:Str set2_chip_off}"
+                                           Foreground="{StaticResource TextMutedBrush}" FontSize="11"
+                                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                           HorizontalAlignment="Right" Margin="10,0,10,0"/>
+                                <Button Grid.Column="2" x:Name="BtnOpenDeviceSettingsNoPanic"
+                                        Theme="{DynamicResource OutlineButton}" Padding="10,4" FontSize="11"
+                                        VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str set2_configure_in_settings}"/>
+                                </Button>
+                            </Grid>
+
+                            <!-- Read-only since Phase 2. Settings → Data owns OfflineMode. -->
+                            <Grid Height="38">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_offline_mode}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" x:Name="TxtOfflineModeState" Text="{loc:Str set2_chip_off}"
+                                           Foreground="{StaticResource TextMutedBrush}" FontSize="11"
+                                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                           HorizontalAlignment="Right" Margin="10,0,10,0"/>
+                                <Button Grid.Column="2" x:Name="BtnOpenDataSettings"
+                                        Theme="{DynamicResource OutlineButton}" Padding="10,4" FontSize="11"
+                                        VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str set2_configure_in_settings}"/>
+                                </Button>
+                            </Grid>
+
+                            <!-- Startup video: read-only since Phase 2, picker lives in Settings → General. -->
+                            <Grid Height="38">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_startup_video}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" x:Name="TxtStartupVideo" Text="{loc:Str label_random}"
+                                           Foreground="{DynamicResource PinkBrush}" FontSize="12"
+                                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                           HorizontalAlignment="Right" Margin="10,0,10,0"/>
+                                <Button Grid.Column="2" x:Name="BtnOpenGeneralSettingsVideo"
+                                        Theme="{DynamicResource OutlineButton}" Padding="10,4" FontSize="11"
+                                        VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str set2_configure_in_settings}"/>
+                                </Button>
+                            </Grid>
+
+                            <!-- Panic key. Read-only: the rebind lives in Settings → Devices (Phase 2). -->
+                            <Grid Height="34" ToolTip.Tip="{loc:Str set2_panic_change_in_settings}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str btn_escape}"
+                                           Foreground="{StaticResource TextLightBrush}"
+                                           FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" x:Name="TxtPanicKeyState" Text="🔑 —"
+                                           Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="Bold"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            </Grid>
+
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Assets folder: buttons live below the card, as everywhere else in this kit. -->
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0" x:Name="BtnPickAssets" Content="📁 Pick Folder"
+                            Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch"
+                            ToolTip.Tip="{loc:Str tooltip_set_custom_assets_folder}"/>
+                    <Button Grid.Column="2" x:Name="BtnOpenAssets"
+                            Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch"
+                            ToolTip.Tip="{loc:Str tooltip_open_assets_folder_images_videos_sounds}">
+                        <TextBlock Text="{loc:Str btn_assets}"/>
+                    </Button>
+                </Grid>
+            </StackPanel>
+
+            <!-- SIDE CARD, no art: this feature has no plate in Resources/features and round 3 invents
+                 no assets. The page's own glyph, huge and nearly transparent, on the section wash. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <TextBlock Text="⚙" FontSize="100" Opacity="0.18"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// System panel, ported from the WPF head. Five live toggles plus five read-out rows that
+    /// LoadFromSettings paints from App.Settings. AppSettings, StartupManager and MainWindow's
+    /// navigation (OpenAppSettingsSection / OpenDeviceSettings / RequestPickAssetsFolder) are all
+    /// still in the WPF head, so the read-outs show the "nothing set" defaults and the buttons
+    /// are inert.
+    /// </summary>
+    public partial class SystemFeatureControl : UserControl
+    {
+        public SystemFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+            LoadFromSettings();
+            // ponytail: needs App.Settings + MainWindow navigation, wired when they move to Core.
+            // ChkMultiMon / ChkFillAllMon / ChkVideoGpuDecode / ChkVideoBlurBg / ChkBrowserVideoEngine
+            // are pure settings writes; BtnOpen* / BtnPickAssets / BtnOpenAssets call MainWindow.
+        }
+
+        /// <summary>
+        /// Placeholder mirror of the WPF LoadFromSettings: same keys, "nothing configured" values.
+        /// TxtNoPanicState / TxtOfflineModeState / TxtStartupVideo keep their markup defaults
+        /// (set2_chip_off / label_random), exactly what WPF paints for a fresh settings file.
+        /// </summary>
+        private void LoadFromSettings()
+        {
+            this.FindControl<TextBlock>("TxtStartupGroupState")!.Text = Loc.Get("set2_startup_group_none");
+            this.FindControl<TextBlock>("TxtPanicKeyState")!.Text = "🔑 —"; // WPF: $"🔑 {s.PanicKey}"
+        }
+    }
+}


### PR DESCRIPTION
916 lines, 7 files. One 15-line SliderLabel helper replaces the per-slider label handlers.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351