### PR TITLE
feat(avalonia): port Features III, part 2/3 - IntensityRamp, Video, Flash

### DIFF
--- a/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml
@@ -1,0 +1,274 @@
+<!-- PORTED from ConditioningControlPanel/Features/FlashFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock
+       {Binding IsChecked, ElementName=X} -> {Binding #X.IsChecked}
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%"
+       ImageBrush HeroArtBrush/SideArtBrush -> dropped (feature art not an AvaloniaResource here
+                                            yet; x:Name on a brush is AVLN2000); wash stands in
+       feat:AdaptiveSideArt.CollapseBelow, feat:SessionLock.Owned -> dropped
+       all event handlers                ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.FlashFeatureControl">
+
+    <!-- Velvet Kit 2 density pass. The root stays a StackPanel: MainWindow.SessionFeatureLock.cs
+         inserts the session-lock banner at index 0 of this panel. -->
+    <StackPanel>
+
+        <!-- HERO: title, one-line pitch, and the master enable as a pill. -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}">
+                    <Border.OpacityMask>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#00000000" Offset="0"/>
+                            <GradientStop Color="#E6000000" Offset="0.55"/>
+                        </LinearGradientBrush>
+                    </Border.OpacityMask>
+                </Border>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str section_flash_images}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str tooltip_flash_enable}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}" Margin="0,1,0,0"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY: settings column capped, art card takes the rest. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card: the dials, then the switches. -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_per_hour}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderFrequency" Minimum="1" Maximum="180" Value="10"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtFrequency" Text="10" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_images}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderImages" Minimum="1" Maximum="20" Value="5"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtImages" Text="5" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_max_on_screen}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderMaxOnScreen" Minimum="2" Maximum="20" Value="20"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtMaxOnScreen" Text="20" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_when_enabled_clicking_an_image_dismisses_it_w}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_click}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkClickable"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_hydra_mode_clicking_an_image_spawns_two_more}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_hydra}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkCorruption"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_linked_hydra_spawns_share_the_parent_flash_ti}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_linked}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkHydraLinked"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_toggle_the_pink_sparkle_glow_effect_on_flash}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_glow}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkGlow"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Solid mode: shared-host renderer, mirrors the Bubble Pop toggle -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Draws flashes on one shared overlay instead of a new window per image, so fullscreen games stop reacting to the window churn. Flashes become click-through (no mouse pop or hydra clicks) — gaze pop and stare-to-keep still work. Applies to the next flash.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Solid mode (game friendly)" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkSolidMode"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <!-- Avoid Screen Center (#770, re-homed for #859). Range stays 5-60 to match
+                                 AppSettings.FlashCenterExclusionPercent's own clamp. -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_keep_flash_images_out_of_a_square_in_the_midd}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_avoid_screen_center}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkFlashAvoidCenter"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_keep_flash_images_out_of_a_square_in_the_midd}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_size}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderCenterExclusion" Minimum="5" Maximum="60" Value="25"
+                                        IsEnabled="{Binding #ChkFlashAvoidCenter.IsChecked}"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtCenterExclusion" Text="25%" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Gaze interaction (Phase 3). Its own card: a distinct capability with its own
+                     hardware prerequisite. Placeholder copy; voice-pass at ship. -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+                            <TextBlock Text="Gaze interaction" FontSize="13" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextLightBrush}" Margin="0,2,0,4"/>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Look at a flash for ~1s to dismiss it (same effect as clicking, including hydra).">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Stare to pop" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkFlashGazePop"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Keep a flash alive by looking at it. Stops boosting when you look away.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Stare to keep" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkFlashGazeLinger"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Height="36">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Linger boost" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderFlashLingerMs" Minimum="500" Maximum="5000" Value="1500"
+                                        TickFrequency="250" IsSnapToTickEnabled="True"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtFlashLingerMs" Text="1500 ms" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </StackPanel>
+
+            <!-- SIDE ART. On WPF an ImageBrush background; the wash stands in. Scrim kept verbatim. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml.cs
@@ -1,0 +1,27 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Flash Images panel, ported from the WPF head. Slider read-outs are real; every toggle and
+    /// slider also writes App.Settings on WPF (and ChkEnable / SliderFrequency poke FlashService),
+    /// which is not portable yet.
+    /// </summary>
+    public partial class FlashFeatureControl : UserControl
+    {
+        public FlashFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            SliderLabel.Wire(this, "SliderFrequency", "TxtFrequency", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderImages", "TxtImages", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderMaxOnScreen", "TxtMaxOnScreen", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderCenterExclusion", "TxtCenterExclusion", v => $"{(int)v}%");
+            SliderLabel.Wire(this, "SliderFlashLingerMs", "TxtFlashLingerMs", v => $"{(int)v} ms");
+
+            // ponytail: needs App.Settings / App.Flash, wired when they move to Core. The ten Chk*
+            // toggles are settings writes only.
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/IntensityRampFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/IntensityRampFeatureControl.axaml
@@ -1,0 +1,242 @@
+<!-- PORTED from ConditioningControlPanel/Features/IntensityRampFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock
+       Visibility="Collapsed"            ->  IsVisible="False"
+       Polyline StrokeLineJoin/Start+EndLineCap -> StrokeJoin / StrokeLineCap (one cap property)
+       feat:SessionLock.Owned            ->  dropped (WPF-head attached behaviour)
+       all event handlers                ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.IntensityRampFeatureControl">
+
+    <!-- ONE dense controls card plus the links card. The hero for this feature lives on
+         Views/Controls/Studio/RampRackPanel.xaml, but the ENABLE SWITCH stays here: this
+         control is also hosted bare in the feature popup, and a hero-mounted pill would exist
+         on the rack only. So the standalone Enable card becomes this card's first row. -->
+    <StackPanel>
+
+        <Border Theme="{StaticResource SettingCardStyle}">
+            <Grid>
+                <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueStudioBrush}"/>
+                <StackPanel Margin="16,8,16,8">
+
+                    <!-- Enable -->
+                    <Grid Height="34">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str btn_enable}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkEnabled"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </Grid>
+
+                    <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                    <!-- Duration -->
+                    <Grid Height="36">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto" MinWidth="56"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str setting_duration}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <Slider Grid.Column="1" x:Name="SliderDuration" Minimum="10" Maximum="180" Value="60"
+                                VerticalAlignment="Center" Margin="10,0"/>
+                        <TextBlock Grid.Column="2" x:Name="TxtDuration" Text="60 min" HorizontalAlignment="Right"
+                                   VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                   Foreground="{DynamicResource PinkBrush}"/>
+                    </Grid>
+
+                    <!-- Ramp mode. Multiplier is the legacy behaviour and the default; Range swaps the
+                         single "up to Nx" dial for a start to end pair expressed as a PERCENT OF EACH
+                         LINKED FEATURE'S OWN SETTING. -->
+                    <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_ramp_mode}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str label_ramp_mode}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <ComboBox Grid.Column="1" x:Name="CmbRampMode"
+                                  Height="26" MaxWidth="220" HorizontalAlignment="Right" VerticalAlignment="Center">
+                            <ComboBoxItem Content="{loc:Str ramp_mode_multiplier}" Tag="Multiplier"/>
+                            <ComboBoxItem Content="{loc:Str ramp_mode_range}" Tag="Range"/>
+                        </ComboBox>
+                    </Grid>
+
+                    <!-- Multiplier (Multiplier mode only) -->
+                    <Grid x:Name="RowMultiplier" Height="36">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto" MinWidth="56"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str setting_multiplier}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <Slider Grid.Column="1" x:Name="SliderMultiplier" Minimum="1" Maximum="3" Value="1.5"
+                                SmallChange="0.1" LargeChange="0.5"
+                                VerticalAlignment="Center" Margin="10,0"/>
+                        <TextBlock Grid.Column="2" x:Name="TxtMultiplier" Text="1.5x" HorizontalAlignment="Right"
+                                   VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                   Foreground="{DynamicResource PinkBrush}"/>
+                    </Grid>
+
+                    <!-- Range start/end (Range mode only). 0..300% of the feature's own value;
+                         100 to 100 is the default and a deliberate no-op. -->
+                    <Grid x:Name="RowRangeStart" Height="36" IsVisible="False"
+                          ToolTip.Tip="{loc:Str tooltip_ramp_range}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto" MinWidth="56"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str label_ramp_start}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <Slider Grid.Column="1" x:Name="SliderRangeStart" Minimum="0" Maximum="300" Value="100"
+                                SmallChange="5" LargeChange="25" TickFrequency="5" IsSnapToTickEnabled="True"
+                                VerticalAlignment="Center" Margin="10,0"/>
+                        <TextBlock Grid.Column="2" x:Name="TxtRangeStart" Text="100%" HorizontalAlignment="Right"
+                                   VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                   Foreground="{DynamicResource PinkBrush}"/>
+                    </Grid>
+
+                    <Grid x:Name="RowRangeEnd" Height="36" IsVisible="False"
+                          ToolTip.Tip="{loc:Str tooltip_ramp_range}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto" MinWidth="56"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str label_ramp_end}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <Slider Grid.Column="1" x:Name="SliderRangeEnd" Minimum="0" Maximum="300" Value="100"
+                                SmallChange="5" LargeChange="25" TickFrequency="5" IsSnapToTickEnabled="True"
+                                VerticalAlignment="Center" Margin="10,0"/>
+                        <TextBlock Grid.Column="2" x:Name="TxtRangeEnd" Text="100%" HorizontalAlignment="Right"
+                                   VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                   Foreground="{DynamicResource PinkBrush}"/>
+                    </Grid>
+
+                    <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                    <!-- Ramp curve. THE ONLY OWNED CONTROL IN THIS POPUP: SessionEngine resolves
+                         `settings.RampCurve ?? App.Settings.Current.RampCurve` on EVERY tick, so for
+                         most sessions this dropdown reshapes the running session's own ramp. -->
+                    <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_ramp_curve}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str label_ramp_curve}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <ComboBox Grid.Column="1" x:Name="CmbRampCurve"
+                                  Height="26" MaxWidth="220" HorizontalAlignment="Right" VerticalAlignment="Center">
+                            <ComboBoxItem Content="{loc:Str ramp_curve_linear}" Tag="Linear"/>
+                            <ComboBoxItem Content="{loc:Str ramp_curve_ease_in}" Tag="EaseIn"/>
+                            <ComboBoxItem Content="{loc:Str ramp_curve_ease_out}" Tag="EaseOut"/>
+                            <ComboBoxItem Content="{loc:Str ramp_curve_scurve}" Tag="SCurve"/>
+                            <ComboBoxItem Content="{loc:Str ramp_curve_exponential}" Tag="Exponential"/>
+                        </ComboBox>
+                    </Grid>
+
+                    <!-- Live curve preview. Drawn in code-behind off the same curve math the runtime
+                         uses (CCP.Core RampCurves), so it cannot drift from what the ramp does. -->
+                    <Grid Height="52" Margin="0,4,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str label_ramp_preview}" FontSize="12"
+                                   Foreground="{StaticResource TextMutedBrush}" VerticalAlignment="Center"/>
+                        <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="8" MinWidth="120"
+                                Background="{StaticResource SectionHueStudioWashBrush}"
+                                BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}">
+                            <Canvas x:Name="CurvePreviewCanvas" ClipToBounds="True" Margin="6,5,6,5"
+                                    Background="Transparent">
+                                <Polyline x:Name="CurvePreviewLine" StrokeThickness="2"
+                                          Stroke="{DynamicResource PinkBrush}"
+                                          StrokeJoin="Round" StrokeLineCap="Round"/>
+                            </Canvas>
+                        </Border>
+                    </Grid>
+
+                    <!-- Stays VISIBLE, not a ToolTip: it is the reason the dials above look inert
+                         mid-session. -->
+                    <TextBlock Text="{loc:Str st4_ramp_session_note}"
+                               Foreground="{StaticResource TextMutedBrush}" FontSize="10.5" FontStyle="Italic"
+                               TextWrapping="Wrap" Margin="0,2,0,4"/>
+
+                    <!-- End at ramp -->
+                    <Grid Height="34">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str setting_end_at_complete}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkEndAt"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </Grid>
+
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Ramp links: its own card, six peer switches on one wrapped row. -->
+        <Border Theme="{StaticResource SettingCardStyle}">
+            <Grid>
+                <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueStudioBrush}"/>
+                <StackPanel Margin="16,8,16,8">
+                    <TextBlock Text="{loc:Str label_link_to_ramp}"
+                               Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"
+                               Margin="0,0,0,6"/>
+                    <WrapPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,14,6">
+                            <CheckBox x:Name="ChkLinkFlash" Theme="{StaticResource ToggleStyle}"/>
+                            <TextBlock Text="{loc:Str label_flash}" Foreground="{StaticResource TextLightBrush}"
+                                       FontSize="12" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,14,6">
+                            <CheckBox x:Name="ChkLinkSpiral" Theme="{StaticResource ToggleStyle}"/>
+                            <TextBlock Text="{loc:Str label_spiral}" Foreground="{StaticResource TextLightBrush}"
+                                       FontSize="12" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,14,6">
+                            <CheckBox x:Name="ChkLinkPink" Theme="{StaticResource ToggleStyle}"/>
+                            <TextBlock Text="{loc:Str label_pink}" Foreground="{StaticResource TextLightBrush}"
+                                       FontSize="12" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,14,6">
+                            <CheckBox x:Name="ChkLinkMaster" Theme="{StaticResource ToggleStyle}"/>
+                            <TextBlock Text="{loc:Str setting_master}" Foreground="{StaticResource TextLightBrush}"
+                                       FontSize="12" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,14,6">
+                            <CheckBox x:Name="ChkLinkSub" Theme="{StaticResource ToggleStyle}"/>
+                            <TextBlock Text="{loc:Str label_sub}" Foreground="{StaticResource TextLightBrush}"
+                                       FontSize="12" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <!-- Brain Drain rides the ramp like the spiral does: the BLUR strength. -->
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                            <CheckBox x:Name="ChkLinkBrainDrain" Theme="{StaticResource ToggleStyle}"/>
+                            <TextBlock Text="{loc:Str label_braindrain}" Foreground="{StaticResource TextLightBrush}"
+                                       FontSize="12" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </WrapPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/IntensityRampFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/IntensityRampFeatureControl.axaml.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Helpers;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Intensity Ramp panel, ported from the WPF head. The mode/row visibility, the slider
+    /// read-outs and the live curve preview are real and driven by the controls themselves;
+    /// on WPF they are driven by App.Settings, which is what the preview reads there.
+    /// </summary>
+    public partial class IntensityRampFeatureControl : UserControl
+    {
+        private readonly ComboBox _mode;
+        private readonly ComboBox _curve;
+        private readonly Slider _multiplier;
+        private readonly Slider _rangeStart;
+        private readonly Slider _rangeEnd;
+        private readonly Canvas _canvas;
+        private readonly Polyline _line;
+
+        public IntensityRampFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            SliderLabel.Wire(this, "SliderDuration", "TxtDuration", v => $"{(int)v} min");
+            _multiplier = SliderLabel.Wire(this, "SliderMultiplier", "TxtMultiplier", v => $"{v:F1}x");
+            _rangeStart = SliderLabel.Wire(this, "SliderRangeStart", "TxtRangeStart", v => $"{(int)v}%");
+            _rangeEnd = SliderLabel.Wire(this, "SliderRangeEnd", "TxtRangeEnd", v => $"{(int)v}%");
+            _mode = this.FindControl<ComboBox>("CmbRampMode")!;
+            _curve = this.FindControl<ComboBox>("CmbRampCurve")!;
+            _canvas = this.FindControl<Canvas>("CurvePreviewCanvas")!;
+            _line = this.FindControl<Polyline>("CurvePreviewLine")!;
+
+            // Placeholder defaults = a fresh AppSettings: Multiplier mode, Linear curve.
+            _mode.SelectedIndex = 0;
+            _curve.SelectedIndex = 0;
+
+            _mode.SelectionChanged += (_, _) => { ApplyModeVisibility(); RedrawPreview(); };
+            _curve.SelectionChanged += (_, _) => RedrawPreview();
+            _multiplier.ValueChanged += (_, _) => RedrawPreview();
+            _rangeStart.ValueChanged += (_, _) => RedrawPreview();
+            _rangeEnd.ValueChanged += (_, _) => RedrawPreview();
+            _canvas.SizeChanged += (_, _) => RedrawPreview();
+
+            ApplyModeVisibility();
+            // ponytail: needs App.Settings, wired when it moves to Core. ChkEnabled, ChkEndAt and the
+            // six ChkLink* toggles are settings writes only.
+        }
+
+        /// <summary>
+        /// Multiplier mode shows the single "up to Nx" dial; Range mode shows the start/end pair
+        /// instead. Never both.
+        /// </summary>
+        private void ApplyModeVisibility()
+        {
+            var isRange = _mode.SelectedIndex == 1;
+            this.FindControl<Grid>("RowMultiplier")!.IsVisible = !isRange;
+            this.FindControl<Grid>("RowRangeStart")!.IsVisible = isRange;
+            this.FindControl<Grid>("RowRangeEnd")!.IsVisible = isRange;
+        }
+
+        private RampCurve SelectedCurve => _curve.SelectedIndex switch
+        {
+            1 => RampCurve.EaseIn,
+            2 => RampCurve.EaseOut,
+            3 => RampCurve.SCurve,
+            4 => RampCurve.Exponential,
+            _ => RampCurve.Linear,
+        };
+
+        /// <summary>
+        /// Repaints the factor-over-time polyline. The vertical axis is normalised to whatever
+        /// span the curve covers (a flat 100 -> 100 draws a centred straight line rather than
+        /// dividing by zero), because the shape is the point here, not absolute values.
+        /// </summary>
+        private void RedrawPreview()
+        {
+            var w = _canvas.Bounds.Width;
+            var h = _canvas.Bounds.Height;
+            if (w <= 1 || h <= 1) return; // not laid out yet - SizeChanged calls back
+
+            var isRange = _mode.SelectedIndex == 1;
+            var curve = SelectedCurve;
+            var mult = _multiplier.Value;
+            var start = Math.Clamp(_rangeStart.Value, 0, 300);
+            var end = Math.Clamp(_rangeEnd.Value, 0, 300);
+
+            const int steps = 48;
+            var values = new double[steps + 1];
+            double min = double.MaxValue, max = double.MinValue;
+            for (var i = 0; i <= steps; i++)
+            {
+                // ponytail: mirrors Helpers/RampMath.ResolveFactor (WPF head, RampMode lives there);
+                // delete when RampMath moves to Core.
+                var eased = RampCurves.ApplyCurve((double)i / steps, curve);
+                var f = isRange ? (start + (end - start) * eased) / 100.0 : 1.0 + (mult - 1.0) * eased;
+                values[i] = f;
+                if (f < min) min = f;
+                if (f > max) max = f;
+            }
+
+            var span = max - min;
+            if (span < 0.0001) { min -= 0.5; span = 1.0; }
+
+            var points = new List<Point>(steps + 1);
+            for (var i = 0; i <= steps; i++)
+                points.Add(new Point(w * i / steps, h - (values[i] - min) / span * h));
+            _line.Points = points;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml
@@ -1,0 +1,261 @@
+<!-- PORTED from ConditioningControlPanel/Features/VideoFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock
+       Image of 🎲 (EmojiToImageSource)  ->  TextBlock "🎲"
+       Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1)
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%"
+       ImageBrush HeroArtBrush/SideArtBrush -> dropped (feature art not an AvaloniaResource here
+                                            yet; x:Name on a brush is AVLN2000); wash stands in
+       feat:AdaptiveSideArt.CollapseBelow, feat:SessionLock.Owned -> dropped
+       all event handlers                ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.VideoFeatureControl">
+
+    <!-- Velvet Kit 2 density pass. The root stays a StackPanel: MainWindow.SessionFeatureLock.cs
+         inserts the session-lock banner at index 0 of this panel. -->
+    <StackPanel>
+
+        <!-- HERO -->
+        <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
+            <Grid>
+                <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        Background="{StaticResource SectionHueStudioWashBrush}">
+                    <Border.OpacityMask>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#00000000" Offset="0"/>
+                            <GradientStop Color="#E6000000" Offset="0.55"/>
+                        </LinearGradientBrush>
+                    </Border.OpacityMask>
+                </Border>
+                <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                    <TextBlock Text="{loc:Str section_mandatory_video}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str tooltip_turn_mandatory_videos_on_or_off}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}" Margin="0,1,0,0"/>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0" CornerRadius="99"
+                        Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" Padding="12,5,8,5">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        <CheckBox x:Name="ChkEnable"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY: settings column capped, art card takes the rest. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- ONE dense card: rate, the duration filter, then the strict switch. -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_videos_per_hour}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_per_hour}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderPerHour" Minimum="1" Maximum="20" Value="2"
+                                        VerticalAlignment="Center" Margin="14,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtPerHour" Text="2" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <!-- Duration filter: min -> max on one row. -->
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="Duration filter: min length &#x2192; max length. Filter videos by length. 0 = no limit.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="130"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="24"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Duration filter" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderVideoMinDur" Minimum="0" Maximum="600" Value="0"
+                                        VerticalAlignment="Center" Margin="14,0,8,0"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtVideoMinDur" Text="off" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                                <TextBlock Grid.Column="3" Text="&#x2192;" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Foreground="{StaticResource TextDimBrush}" FontSize="11"/>
+                                <Slider Grid.Column="4" x:Name="SliderVideoMaxDur" Minimum="0" Maximum="1800" Value="0"
+                                        VerticalAlignment="Center" Margin="8,0,8,0"/>
+                                <TextBlock Grid.Column="5" x:Name="TxtVideoMaxDur" Text="off" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_strict_mode_videos_cannot_be_skipped_must_wat}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_strict}" Foreground="#FFB347"
+                                           FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkStrict"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Mini game: its own card, same row recipes, header line kept. -->
+                <Border Theme="{StaticResource SettingCardStyle}">
+                    <Grid>
+                        <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                        <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                Background="{StaticResource SectionHueStudioBrush}"/>
+                        <StackPanel Margin="16,8,16,8">
+
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_enable_attention_check_targets}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_mini_game}" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="14" FontWeight="Bold" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkMiniGame" Theme="{StaticResource ToggleStyle}"
+                                          HorizontalAlignment="Right" VerticalAlignment="Center"
+                                          ToolTip.Tip="{loc:Str tooltip_enable_attention_check_targets}"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <!-- Targets (the dice toggle randomises the count, so it rides the label) -->
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_number_of_targets_to_click_per_video}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str label_targets}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <CheckBox x:Name="ChkRandomize" Margin="8,0,0,0" VerticalAlignment="Center"
+                                              ToolTip.Tip="{loc:Str tooltip_randomize_target_count_1_to_max}">
+                                        <TextBlock Text="🎲" FontSize="12"/>
+                                    </CheckBox>
+                                </StackPanel>
+                                <Slider Grid.Column="1" x:Name="SliderTargets" Minimum="1" Maximum="10" Value="3"
+                                        VerticalAlignment="Center" Margin="14,0"
+                                        ToolTip.Tip="{loc:Str tooltip_number_of_targets_to_click_per_video}"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtTargets" Text="3" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_seconds_each_target_stays_visible}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_duration}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderDuration" Minimum="1" Maximum="30" Value="12"
+                                        VerticalAlignment="Center" Margin="14,0"
+                                        ToolTip.Tip="{loc:Str tooltip_seconds_each_target_stays_visible}"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtDuration" Text="12" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Grid Height="36" Background="Transparent" ToolTip.Tip="{loc:Str tooltip_target_button_size_in_pixels}">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str setting_size}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <Slider Grid.Column="1" x:Name="SliderTargetSize" Minimum="30" Maximum="150" Value="70"
+                                        VerticalAlignment="Center" Margin="14,0"
+                                        ToolTip.Tip="{loc:Str tooltip_target_button_size_in_pixels}"/>
+                                <TextBlock Grid.Column="2" x:Name="TxtTargetSize" Text="70" HorizontalAlignment="Right"
+                                           VerticalAlignment="Center" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                            </Grid>
+
+                            <Border Height="1" Background="{DynamicResource GlassBorderBrush}" Margin="0,6"/>
+
+                            <!-- Phase 3 placeholder copy — voice-pass at ship. -->
+                            <Grid Height="34" Background="Transparent" ToolTip.Tip="Look at a target for ~1s instead of clicking. Same hit, same reward.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="Stare to click" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="1" x:Name="ChkVideoGazeClick"
+                                          Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                            </Grid>
+
+                            <Grid Margin="0,8,0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="8"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Grid.Column="0" x:Name="BtnManageAttention"
+                                        ToolTip.Tip="{loc:Str tooltip_edit_attention_check_phrases}"
+                                        Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch">
+                                    <TextBlock Text="{loc:Str btn_phrases}"/>
+                                </Button>
+                                <Button Grid.Column="2" x:Name="BtnAttentionStyle"
+                                        ToolTip.Tip="{loc:Str tooltip_customize_target_appearance_colors_border_fon}"
+                                        Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch">
+                                    <TextBlock Text="{loc:Str btn_style}"/>
+                                </Button>
+                            </Grid>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <Button x:Name="BtnTestVideo" Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch">
+                    <TextBlock Text="{loc:Str btn_test_2}"/>
+                </Button>
+            </StackPanel>
+
+            <!-- SIDE ART. On WPF an ImageBrush background; the wash stands in. Scrim kept verbatim. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <Border CornerRadius="12">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                            <GradientStop Color="#66000000" Offset="0"/>
+                            <GradientStop Color="#00000000" Offset="0.45"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Mandatory Video panel, ported from the WPF head. The read-outs and the min/max duration
+    /// clamp are real; the settings writes, VideoService start/stop/test, the strict-lock
+    /// double-confirm (WarningDialog) and the two editor dialogs (TextEditorDialog over
+    /// s.AttentionPool, AttentionTargetEditorDialog) are WPF-head services or need App.Settings.
+    /// </summary>
+    public partial class VideoFeatureControl : UserControl
+    {
+        public VideoFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            SliderLabel.Wire(this, "SliderPerHour", "TxtPerHour", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderTargets", "TxtTargets", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderDuration", "TxtDuration", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderTargetSize", "TxtTargetSize", v => ((int)v).ToString());
+            var min = SliderLabel.Wire(this, "SliderVideoMinDur", "TxtVideoMinDur", v => FormatDuration((int)v));
+            var max = SliderLabel.Wire(this, "SliderVideoMaxDur", "TxtVideoMaxDur", v => FormatDuration((int)v));
+
+            // Keep max >= min (and min <= max) when both are non-zero, so the user can't trap the
+            // queue empty. Same rule as WPF; the paired slider's own ValueChanged repaints its label.
+            min.ValueChanged += (_, e) => { if (max.Value > 0 && e.NewValue > 0 && max.Value < e.NewValue) max.Value = e.NewValue; };
+            max.ValueChanged += (_, e) => { if (min.Value > 0 && e.NewValue > 0 && min.Value > e.NewValue) min.Value = e.NewValue; };
+
+            // ponytail: needs App.Settings / App.Video / WarningDialog / AttentionTargetEditorDialog,
+            // wired when they move to Core. ChkEnable, ChkStrict, ChkMiniGame, ChkRandomize,
+            // ChkVideoGazeClick, BtnManageAttention, BtnAttentionStyle, BtnTestVideo are inert.
+        }
+
+        private static string FormatDuration(int seconds)
+        {
+            if (seconds <= 0) return "off";
+            if (seconds < 60) return $"{seconds}s";
+            var m = seconds / 60;
+            var rem = seconds % 60;
+            return rem == 0 ? $"{m}m" : $"{m}m {rem}s";
+        }
+    }
+}


### PR DESCRIPTION
965 lines, 6 files. Ramp preview uses Core's RampCurves.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351