### PR TITLE
feat(avalonia): port Features III, part 3/3 - BouncingText, Scheduler

### DIFF
--- a/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml
@@ -1,0 +1,325 @@
+<!-- PORTED from ConditioningControlPanel/Features/BouncingTextFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       helpers:EmojiTextBlock            ->  TextBlock
+       Visibility="Collapsed"            ->  IsVisible="False"
+       Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1)
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%"
+       ImageBrush HeroArtBrush/SideArtBrush -> dropped (feature art not an AvaloniaResource here
+                                            yet; x:Name on a brush is AVLN2000); wash stands in
+       feat:AdaptiveSideArt.CollapseBelow, feat:SessionLock.Owned -> dropped
+       all event handlers                ->  wired in code-behind (porting convention) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.BouncingTextFeatureControl">
+
+    <Grid>
+        <StackPanel>
+            <!-- HERO. Replaces the standalone Enable card: the checkbox moved into the pill
+                 verbatim; the subtitle reuses this page's own XP line and the feature's long
+                 blurb becomes the hero ToolTip - no new loc strings. -->
+            <Border Height="72" CornerRadius="16" Margin="0,0,0,10"
+                    Background="{DynamicResource SurfaceBgBrush}"
+                    BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2"
+                    ToolTip.Tip="{loc:Str tooltip_dvd_screensaver_style_bouncing_text_customiza}">
+                <Grid ClipToBounds="True">
+                    <Border Width="240" HorizontalAlignment="Right" CornerRadius="0,16,16,0"
+                            Background="{StaticResource SectionHueStudioWashBrush}">
+                        <Border.OpacityMask>
+                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                <GradientStop Color="Transparent" Offset="0"/>
+                                <GradientStop Color="#E6000000" Offset="0.55"/>
+                            </LinearGradientBrush>
+                        </Border.OpacityMask>
+                    </Border>
+
+                    <StackPanel VerticalAlignment="Center" Margin="16,0,0,0">
+                        <TextBlock Text="{loc:Str label_bouncing_text}" FontSize="17" FontWeight="Bold"
+                                   Foreground="{StaticResource TextLightBrush}"/>
+                        <TextBlock Text="{loc:Str label_10_xp_per_bounce}" FontSize="11.5"
+                                   Foreground="{StaticResource TextMutedBrush}"
+                                   TextTrimming="CharacterEllipsis" Margin="0,2,0,0"/>
+                    </StackPanel>
+
+                    <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,14,0"
+                            CornerRadius="9999" Padding="12,6"
+                            Background="#8C131320" BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{loc:Str btn_enable}" FontSize="11.5" FontWeight="SemiBold"
+                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                            <CheckBox x:Name="ChkEnable"
+                                      Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <!-- VELVET KIT 2 · ROUND 3 · DENSITY: settings column capped, art card takes the rest. -->
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*" MaxWidth="780"/>
+                    <ColumnDefinition Width="2*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0">
+                    <!-- ONE dense controls card: the three dials, the colour mode, then the switches. -->
+                    <Border Theme="{StaticResource SettingCardStyle}">
+                        <Grid>
+                            <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                    Background="{StaticResource SectionHueStudioBrush}"/>
+                            <StackPanel Margin="16,8,16,8">
+
+                                <!-- Speed -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_bounce_speed_1_slow_10_fast}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_speed}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" x:Name="SliderSpeed" Minimum="1" Maximum="10" Value="5"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtSpeed" Text="5" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <!-- Size -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_text_size_50_small_100_normal_300_huge}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_size}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" x:Name="SliderSize" Minimum="50" Maximum="300" Value="100"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtSize" Text="100%" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <!-- Opacity -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_bouncing_text_opacity_10_ghostly_100_solid}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto" MinWidth="56"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_opacity}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <Slider Grid.Column="1" x:Name="SliderOpacity" Minimum="10" Maximum="100" Value="100"
+                                            VerticalAlignment="Center" Margin="10,0"/>
+                                    <TextBlock Grid.Column="2" x:Name="TxtOpacity" Text="100%" HorizontalAlignment="Right"
+                                               VerticalAlignment="Center" FontSize="13" FontWeight="Bold"
+                                               Foreground="{DynamicResource PinkBrush}"/>
+                                </Grid>
+
+                                <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                                <!-- Colour mode -->
+                                <Grid Height="36" ToolTip.Tip="{loc:Str tooltip_random_rerolls_every_bounce_fixed_keeps_one_c}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_color_mode}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <ComboBox Grid.Column="1" x:Name="CmbColorMode" Height="26" MaxWidth="220"
+                                              HorizontalAlignment="Right" VerticalAlignment="Center"
+                                              Theme="{DynamicResource DarkComboBoxStyle}">
+                                        <ComboBoxItem Content="{loc:Str option_color_random}"/>
+                                        <ComboBoxItem Content="{loc:Str option_color_fixed}"/>
+                                        <ComboBoxItem Content="{loc:Str option_color_rainbow}"/>
+                                    </ComboBox>
+                                </Grid>
+
+                                <!-- Shown by code-behind only while "fixed" is the colour mode. -->
+                                <Grid x:Name="PanelFixedColor" Height="36" IsVisible="False">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_text_color}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                        <Border x:Name="ColorSwatch" Width="24" Height="24" CornerRadius="6"
+                                                BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"
+                                                Background="#FF69B4" Margin="0,0,8,0"/>
+                                        <Button x:Name="BtnChooseColor" Theme="{StaticResource SmallPinkButton}">
+                                            <TextBlock Text="{loc:Str btn_choose_color}"/>
+                                        </Button>
+                                        <Button x:Name="BtnResetColor" Theme="{StaticResource SmallPinkButton}"
+                                                Margin="6,0,0,0">
+                                            <TextBlock Text="{loc:Str btn_reset}"/>
+                                        </Button>
+                                    </StackPanel>
+                                </Grid>
+
+                                <!-- Font: any family installed on the system, plus the bundled Fredoka. -->
+                                <Grid Height="36" ToolTip.Tip="Any font installed on Windows. Applies live - no restart.">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str label_font}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <ComboBox Grid.Column="1" x:Name="CmbFont" Height="26" MaxWidth="220"
+                                              HorizontalAlignment="Right" VerticalAlignment="Center"
+                                              Theme="{DynamicResource DarkComboBoxStyle}"/>
+                                </Grid>
+
+                                <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                                <!-- Second text -->
+                                <Grid Height="34" ToolTip.Tip="{loc:Str tooltip_second_independent_bouncing_text}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_second_text}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <CheckBox Grid.Column="1" x:Name="ChkSecondText"
+                                              Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                                </Grid>
+
+                                <!-- Show over videos -->
+                                <Grid Height="34" ToolTip.Tip="{loc:Str tooltip_keep_bouncing_text_visible_on_top_of_fullscre}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str setting_show_over_videos}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <CheckBox Grid.Column="1" x:Name="ChkAlwaysOnTop"
+                                              Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                                </Grid>
+
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <!-- Effects: its own card, two columns because the seven switches are peers. -->
+                    <Border Theme="{StaticResource SettingCardStyle}"
+                            ToolTip.Tip="{loc:Str tooltip_bouncing_text_effects_combine_freely}">
+                        <Grid>
+                            <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                            <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                                    Background="{StaticResource SectionHueStudioBrush}"/>
+                            <StackPanel Margin="16,8,16,8">
+                                <TextBlock Text="{loc:Str label_effects}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" Margin="0,0,0,2"/>
+                                <UniformGrid Columns="2">
+                                    <Grid Height="30" Margin="0,0,10,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_breathing}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkFxBreathing" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                    <Grid Height="30">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_wobble}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkFxWobble" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                    <Grid Height="30" Margin="0,0,10,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_spin}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkFxSpin" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                    <Grid Height="30">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_velocity_tilt}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkFxVelocityTilt" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                    <Grid Height="30" Margin="0,0,10,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_squash}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkFxSquash" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                    <Grid Height="30">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_corner_burst}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkFxCornerBurst" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                    <Grid Height="30" Margin="0,0,10,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str setting_fx_outline}"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   FontSize="12" VerticalAlignment="Center"/>
+                                        <CheckBox Grid.Column="1" x:Name="ChkOutline" Theme="{StaticResource ToggleStyle}"
+                                                  VerticalAlignment="Center"/>
+                                    </Grid>
+                                </UniformGrid>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <Button x:Name="BtnEditPhrases" Theme="{DynamicResource OutlineButton}" HorizontalAlignment="Stretch">
+                        <TextBlock Text="{loc:Str btn_edit_phrases}"/>
+                    </Button>
+                </StackPanel>
+
+                <!-- SIDE ART. On WPF an ImageBrush background; the wash stands in. Scrim kept verbatim. -->
+                <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                        BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                        Background="{StaticResource SectionHueStudioWashBrush}"
+                        VerticalAlignment="Stretch" MinHeight="200">
+                    <Border CornerRadius="12">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                                <GradientStop Color="#66000000" Offset="0"/>
+                                <GradientStop Color="#00000000" Offset="0.45"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                </Border>
+            </Grid>
+
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Bouncing Text panel, ported from the WPF head. Slider read-outs, the fixed-colour row
+    /// reveal and the font list are real; settings writes, BouncingTextService refresh/restart,
+    /// the WinForms ColorDialog and the phrase editor over s.BouncingTextPool are not portable yet.
+    /// </summary>
+    public partial class BouncingTextFeatureControl : UserControl
+    {
+        public BouncingTextFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            SliderLabel.Wire(this, "SliderSpeed", "TxtSpeed", v => ((int)v).ToString());
+            SliderLabel.Wire(this, "SliderSize", "TxtSize", v => $"{(int)v}%");
+            SliderLabel.Wire(this, "SliderOpacity", "TxtOpacity", v => $"{(int)v}%");
+
+            var mode = this.FindControl<ComboBox>("CmbColorMode")!;
+            var fixedRow = this.FindControl<Grid>("PanelFixedColor")!;
+            mode.SelectedIndex = 0; // placeholder: AppSettings.BouncingTextColorMode default
+            mode.SelectionChanged += (_, _) => fixedRow.IsVisible = mode.SelectedIndex == 1;
+
+            PopulateFonts();
+
+            // ponytail: needs App.Settings / App.BouncingText / a colour picker / TextEditorDialog over
+            // the pool, wired when they move to Core. ChkEnable, ChkSecondText, ChkAlwaysOnTop, the
+            // ChkFx* toggles, BtnChooseColor, BtnResetColor, BtnEditPhrases are inert.
+        }
+
+        /// <summary>
+        /// WPF: Helpers.FontPickerHelper.Populate(CmbFont, s.BouncingTextFont, "Segoe UI") - installed
+        /// families plus the bundled Fredoka. FontManager is cross-platform, so the installed half
+        /// is real here; a headless run may enumerate nothing, hence the fallback.
+        /// </summary>
+        private void PopulateFonts()
+        {
+            var cmb = this.FindControl<ComboBox>("CmbFont")!;
+            string[] names;
+            try { names = FontManager.Current.SystemFonts.Select(f => f.Name).OrderBy(n => n).ToArray(); }
+            catch { names = System.Array.Empty<string>(); }
+            if (names.Length == 0) names = new[] { "Segoe UI" };
+            foreach (var n in names) cmb.Items.Add(new ComboBoxItem { Content = n });
+            cmb.SelectedIndex = 0;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Features/SchedulerFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/SchedulerFeatureControl.axaml
@@ -1,0 +1,88 @@
+<!-- PORTED from ConditioningControlPanel/Features/SchedulerFeatureControl.xaml.
+     Structure, order, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+       Style="{StaticResource X}"  ->  Theme="{StaticResource X}"
+       Checked/Unchecked/LostFocus ->  wired in code-behind (porting convention)
+     Every handler writes to App.Settings on WPF; here the values are placeholders - see the
+     code-behind. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Features.SchedulerFeatureControl">
+
+    <!-- ONE dense controls card for all nine scheduler settings. The hero for this feature
+         lives on Views/Controls/Studio/SchedulerRackPanel.xaml, but the ENABLE SWITCH stays
+         here: this control is also hosted bare in the feature popup (the "Scheduler + Ramp"
+         button on the Presets surface), and a hero-mounted pill would exist on the rack only,
+         leaving that path with no way to arm the feature. So the standalone Enable card
+         becomes the card's first row instead. -->
+    <StackPanel>
+        <Border Theme="{StaticResource SettingCardStyle}">
+            <Grid>
+                <Border Background="{StaticResource SectionHueStudioWashBrush}" CornerRadius="11"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,10" CornerRadius="0,2,2,0"
+                        Background="{StaticResource SectionHueStudioBrush}"/>
+                <StackPanel Margin="16,8,16,8">
+
+                    <!-- Enable -->
+                    <Grid Height="34">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str btn_enable}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <CheckBox Grid.Column="1" x:Name="ChkEnabled"
+                                  Theme="{StaticResource ToggleStyle}" VerticalAlignment="Center"/>
+                    </Grid>
+
+                    <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
+
+                    <!-- Time range -->
+                    <Grid Height="36">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str st4_scheduler_time_range}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right"
+                                    VerticalAlignment="Center">
+                            <TextBox x:Name="TxtStart" Text="16:00" Width="74"
+                                     Background="{DynamicResource SurfaceBgBrush}"
+                                     Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                                     Padding="6,3" FontSize="13" TextAlignment="Center"/>
+                            <TextBlock Text="→" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="15" Margin="10,0" VerticalAlignment="Center"/>
+                            <TextBox x:Name="TxtEnd" Text="22:00" Width="74"
+                                     Background="{DynamicResource SurfaceBgBrush}"
+                                     Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                                     Padding="6,3" FontSize="13" TextAlignment="Center"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Active days -->
+                    <Grid Height="36">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="120"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{loc:Str st4_scheduler_active_days}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right"
+                                    VerticalAlignment="Center">
+                            <CheckBox x:Name="DayMon" Content="M" Foreground="White" Margin="0,0,10,0" IsChecked="True" FontSize="13"/>
+                            <CheckBox x:Name="DayTue" Content="T" Foreground="White" Margin="0,0,10,0" IsChecked="True" FontSize="13"/>
+                            <CheckBox x:Name="DayWed" Content="W" Foreground="White" Margin="0,0,10,0" IsChecked="True" FontSize="13"/>
+                            <CheckBox x:Name="DayThu" Content="T" Foreground="White" Margin="0,0,10,0" IsChecked="True" FontSize="13"/>
+                            <CheckBox x:Name="DayFri" Content="F" Foreground="White" Margin="0,0,10,0" IsChecked="True" FontSize="13"/>
+                            <CheckBox x:Name="DaySat" Content="S" Foreground="White" Margin="0,0,10,0" IsChecked="True" FontSize="13"/>
+                            <CheckBox x:Name="DaySun" Content="S" Foreground="White" IsChecked="True" FontSize="13"/>
+                        </StackPanel>
+                    </Grid>
+
+                </StackPanel>
+            </Grid>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Features/SchedulerFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SchedulerFeatureControl.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Features
+{
+    /// <summary>
+    /// Scheduler panel, ported from the WPF head. On WPF every handler round-trips
+    /// App.Settings.Current.Scheduler* and the SettingsHook/ISettingsRebindable pair keeps the
+    /// panel following a cloud-restored settings instance. AppSettings still lives in the WPF
+    /// head, so this port renders the markup defaults and persists nothing.
+    /// </summary>
+    public partial class SchedulerFeatureControl : UserControl
+    {
+        public SchedulerFeatureControl()
+        {
+            AvaloniaXamlLoader.Load(this);
+            // ponytail: needs App.Settings (Scheduler* fields) + SettingsHook, wired when they move to Core.
+            // The ChkEnabled / TxtStart / TxtEnd / Day* handlers are pure settings writes; nothing
+            // view-side is left for them to do, so they are not stubbed one by one.
+        }
+    }
+}


### PR DESCRIPTION
486 lines, 4 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351