### PR TITLE
feat(avalonia): port controls, part 1/2 - EmiDock, EmiRingPicker, AdornedAvatar

### DIFF
--- a/CCP.Avalonia/Views/Controls/AdornedAvatar.axaml
+++ b/CCP.Avalonia/Views/Controls/AdornedAvatar.axaml
@@ -1,0 +1,50 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/AdornedAvatar.xaml.
+     Structure, x:Names and every literal preserved. Deviations, all forced:
+
+       x:Name on the ImageBrush     -> dropped (AVLN2000: only a StyledElement can be named);
+                                       the code-behind casts AvatarRing.Background instead
+       Visibility="Collapsed"       -> IsVisible="False"
+       SnapsToDevicePixels          -> dropped (no Avalonia equivalent; UseLayoutRounding kept) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.AdornedAvatar"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignHeight="104" d:DesignWidth="104"
+             UseLayoutRounding="True">
+
+    <!-- ================================================================
+         ADORNED AVATAR — the wardrobe render surface (redesign Phase 3)
+
+         A circular avatar with an optional decoration stacked 1:1 over it.
+         The decoration is a 512 canvas PNG whose avatar circle sits centred
+         at 70% of the canvas width, so the ONLY layout maths in the whole
+         wardrobe is "draw the canvas at diameter / 0.70, centred" — there is
+         no per-item anchor data and no per-item code.
+
+         Nothing here clips: a hat has to overflow the avatar box, and layout
+         must NOT reserve room for it (the avatar still measures as its own
+         diameter, so the hero's columns do not move when a hat is equipped).
+         ================================================================ -->
+
+    <Grid x:Name="Root" Width="104" Height="104">
+        <!-- The avatar itself. Ring colour/thickness are properties: the profile
+             hero wants the pink ring, a leaderboard row will want none. -->
+        <Border x:Name="AvatarRing" CornerRadius="52" BorderBrush="#FF69B4" BorderThickness="3">
+            <Border.Background>
+                <ImageBrush Stretch="UniformToFill"/>
+            </Border.Background>
+        </Border>
+
+        <!-- Decoration layer. Sized/centred in code from AvatarSize; Fill because
+             the canvas is square and must map onto the avatar exactly. -->
+        <Image x:Name="DecoLayer" Stretch="Fill" IsVisible="False"
+               IsHitTestVisible="False"
+               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+
+        <!-- Presence dot, above the decoration so a choker can never hide it. -->
+        <Ellipse x:Name="PresenceDotShape" Width="20" Height="20"
+                 HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                 Margin="0,0,4,4" Stroke="#1E1E3F" StrokeThickness="3" Fill="#43B581"/>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/AdornedAvatar.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AdornedAvatar.axaml.cs
@@ -1,0 +1,242 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Models;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// A circular avatar with an optional wardrobe decoration stacked over it.
+    ///
+    /// PORTED from ConditioningControlPanel/Views/Controls/AdornedAvatar.xaml.cs. Every
+    /// DependencyProperty is a StyledProperty with the same name and default; the six change
+    /// callbacks collapse into one <see cref="OnPropertyChanged"/> override. The placement model is
+    /// unchanged: the art is drawn at <c>AvatarSize / 0.70</c>, centred, and the offset lives in
+    /// the pixels.
+    ///
+    /// Avalonia does not apply WPF's ArrangeCore layout clip, but the symmetric negative margin is
+    /// kept verbatim: it is also what makes the 148px canvas contribute only <c>size</c> to layout.
+    /// </summary>
+    public partial class AdornedAvatar : UserControl
+    {
+        // ponytail: WardrobeCatalog stays in the WPF head (pack:// art). Ratio copied; GetImage
+        // returns null until the catalogue moves to Core, so the plain avatar draws - the same
+        // quiet failure the WPF control documents for a missing PNG.
+        private const double AvatarCircleRatio = 0.70;
+        private static IImage? GetImage(string? decorationId) => null;
+
+        private readonly Grid _root;
+        private readonly Border _avatarRing;
+        private readonly Image _decoLayer;
+        private readonly Ellipse _presenceDot;
+
+        public AdornedAvatar()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _root = this.FindControl<Grid>("Root")!;
+            _avatarRing = this.FindControl<Border>("AvatarRing")!;
+            _decoLayer = this.FindControl<Image>("DecoLayer")!;
+            _presenceDot = this.FindControl<Ellipse>("PresenceDotShape")!;
+            ApplySize();
+            ApplyDecoration();
+        }
+
+        // ---- the avatar picture ---------------------------------------------------------
+
+        /// <summary>The brush the avatar picture is painted with, for callers that write
+        /// <c>AvatarBrush.Source</c> directly as MainWindow's profile code does.</summary>
+        internal ImageBrush AvatarBrush => (ImageBrush)_avatarRing.Background!;
+
+        /// <summary>The presence dot, for callers that set its Fill/IsVisible directly.</summary>
+        internal Ellipse PresenceDot => _presenceDot;
+
+        public static readonly StyledProperty<IImageBrushSource?> AvatarImageProperty =
+            AvaloniaProperty.Register<AdornedAvatar, IImageBrushSource?>(nameof(AvatarImage));
+
+        /// <summary>The avatar picture. Equivalent to setting <c>AvatarBrush.Source</c>.</summary>
+        public IImageBrushSource? AvatarImage
+        {
+            get => GetValue(AvatarImageProperty);
+            set => SetValue(AvatarImageProperty, value);
+        }
+
+        // ---- the decoration -------------------------------------------------------------
+
+        public static readonly StyledProperty<string?> DecorationIdProperty =
+            AvaloniaProperty.Register<AdornedAvatar, string?>(nameof(DecorationId));
+
+        /// <summary>Registry id of the equipped decoration, or null for none. Unknown ids and ids
+        /// whose art is missing are treated exactly like null.</summary>
+        public string? DecorationId
+        {
+            get => GetValue(DecorationIdProperty);
+            set => SetValue(DecorationIdProperty, value);
+        }
+
+        public static readonly StyledProperty<CosmeticTransform?> DecorationTransformProperty =
+            AvaloniaProperty.Register<AdornedAvatar, CosmeticTransform?>(nameof(DecorationTransform));
+
+        /// <summary>The wearer's saved placement, or null for the classic centred render. Offsets
+        /// are fractions of the decoration canvas, so the same transform reproduces the same
+        /// composition at 104px or 28px.</summary>
+        public CosmeticTransform? DecorationTransform
+        {
+            get => GetValue(DecorationTransformProperty);
+            set => SetValue(DecorationTransformProperty, value);
+        }
+
+        // ---- geometry -------------------------------------------------------------------
+
+        public static readonly StyledProperty<double> AvatarSizeProperty =
+            AvaloniaProperty.Register<AdornedAvatar, double>(nameof(AvatarSize), 104d);
+
+        /// <summary>Avatar diameter in DIPs. Everything else scales off it.</summary>
+        public double AvatarSize
+        {
+            get => GetValue(AvatarSizeProperty);
+            set => SetValue(AvatarSizeProperty, value);
+        }
+
+        public static readonly StyledProperty<IBrush?> RingBrushProperty =
+            AvaloniaProperty.Register<AdornedAvatar, IBrush?>(nameof(RingBrush));
+
+        /// <summary>Avatar ring colour. Null keeps the XAML default (profile pink).</summary>
+        public IBrush? RingBrush
+        {
+            get => GetValue(RingBrushProperty);
+            set => SetValue(RingBrushProperty, value);
+        }
+
+        public static readonly StyledProperty<double> RingThicknessProperty =
+            AvaloniaProperty.Register<AdornedAvatar, double>(nameof(RingThickness), 3d);
+
+        public double RingThickness
+        {
+            get => GetValue(RingThicknessProperty);
+            set => SetValue(RingThicknessProperty, value);
+        }
+
+        public static readonly StyledProperty<bool> ShowPresenceProperty =
+            AvaloniaProperty.Register<AdornedAvatar, bool>(nameof(ShowPresence), true);
+
+        /// <summary>Presence dot on/off. Surfaces that have no presence signal turn it off.</summary>
+        public bool ShowPresence
+        {
+            get => GetValue(ShowPresenceProperty);
+            set => SetValue(ShowPresenceProperty, value);
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (_root == null) return; // still loading XAML
+            if (change.Property == AvatarImageProperty) AvatarBrush.Source = change.GetNewValue<IImageBrushSource?>();
+            else if (change.Property == DecorationIdProperty) ApplyDecoration();
+            else if (change.Property == DecorationTransformProperty) ApplyDecorationTransform();
+            else if (change.Property == AvatarSizeProperty || change.Property == RingBrushProperty
+                     || change.Property == RingThicknessProperty || change.Property == ShowPresenceProperty)
+                ApplySize();
+        }
+
+        private void ApplyDecorationTransform()
+        {
+            try
+            {
+                var t = DecorationTransform;
+                if (t == null)
+                {
+                    _decoLayer.RenderTransform = null;
+                    return;
+                }
+
+                var canvas = AvatarSize / AvatarCircleRatio;
+                if (double.IsNaN(canvas) || double.IsInfinity(canvas) || canvas <= 0) canvas = 148d;
+
+                var group = new TransformGroup();
+                group.Children.Add(new ScaleTransform(t.Flip ? -t.Scale : t.Scale, t.Scale));
+                group.Children.Add(new RotateTransform(t.Rotation));
+                group.Children.Add(new TranslateTransform(t.X * canvas, t.Y * canvas));
+
+                _decoLayer.RenderTransformOrigin = RelativePoint.Center;
+                _decoLayer.RenderTransform = group;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("AdornedAvatar: transform failed: {E}", ex.Message);
+                _decoLayer.RenderTransform = null;
+            }
+        }
+
+        private void ApplyDecoration()
+        {
+            try
+            {
+                var art = GetImage(DecorationId);
+                if (art == null)
+                {
+                    // Also clears the Source, so switching from a good id to a broken one does not
+                    // leave the previous decoration painted on the card.
+                    _decoLayer.Source = null;
+                    _decoLayer.IsVisible = false;
+                    return;
+                }
+
+                _decoLayer.Source = art;
+                _decoLayer.IsVisible = true;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("AdornedAvatar: decoration {Id} failed: {E}", DecorationId ?? "none", ex.Message);
+                _decoLayer.Source = null;
+                _decoLayer.IsVisible = false;
+            }
+        }
+
+        /// <summary>
+        /// Lays the three layers out from a single number. The presence dot's proportions are the
+        /// 104px hero values (20 / 3 / 4) expressed as ratios, so a 28px leaderboard avatar gets a
+        /// dot that still reads instead of one that swallows it.
+        /// </summary>
+        private void ApplySize()
+        {
+            try
+            {
+                var size = AvatarSize;
+                if (double.IsNaN(size) || double.IsInfinity(size) || size <= 0) size = 104d;
+
+                _root.Width = size;
+                _root.Height = size;
+
+                _avatarRing.CornerRadius = new CornerRadius(size / 2d);
+                _avatarRing.BorderThickness = new Thickness(RingThickness);
+                if (RingBrush != null) _avatarRing.BorderBrush = RingBrush;
+
+                // The one piece of wardrobe geometry in the app.
+                var canvas = size / AvatarCircleRatio;
+                _decoLayer.Width = canvas;
+                _decoLayer.Height = canvas;
+                // A symmetric negative margin makes the total desired size (canvas + margin) equal
+                // the slot, so the art centres on the avatar and contributes only `size` to layout.
+                _decoLayer.Margin = new Thickness(-(canvas - size) / 2d);
+                // Translate offsets are canvas-relative, so a size change re-derives them.
+                ApplyDecorationTransform();
+
+                var dot = Math.Max(6d, size * 0.1923d);
+                _presenceDot.Width = dot;
+                _presenceDot.Height = dot;
+                _presenceDot.StrokeThickness = Math.Max(1d, size * 0.0288d);
+                var inset = size * 0.0385d;
+                _presenceDot.Margin = new Thickness(0, 0, inset, inset);
+                _presenceDot.IsVisible = ShowPresence;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("AdornedAvatar: layout failed: {E}", ex.Message);
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/EmiDock.axaml
+++ b/CCP.Avalonia/Views/Controls/EmiDock.axaml
@@ -1,0 +1,88 @@
+<!-- PORTED from ConditioningControlPanel/Controls/EmiDock.xaml.
+     Structure, x:Names and literals preserved. Deviations, all forced:
+
+       ControlTemplate <ContentPresenter/>  -> ContentPresenter Content="{TemplateBinding Content}"
+                                               (a bare presenter draws nothing on Avalonia)
+       x:Name on SolidColorBrush / DropShadowEffect -> dropped (AVLN2000: only a StyledElement can
+                                               be named); the knock reaches them through Ring.Stroke
+       emi:EmiFace                          -> TextBlock stub (see the code-behind)
+       Text set from code (Loc.Get)         -> {loc:Str key}, same keys
+       ToolTip set from code                -> ToolTip.Tip="{loc:Str ...}"
+       Visibility="Collapsed"               -> IsVisible="False" -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.EmiDock"
+             Margin="0,2,0,4">
+
+    <!--
+        THE DOCK CHIP. EMI's way in and out when she is not already out, pinned under the nav rail's
+        doors. Deliberately NOT a door medallion: no NavDoorMap row, no "you are here" ring.
+
+        The face and the ring are the button's CONTENT, not its template, so they are real fields on
+        this class: the live face binding needs an element it can address without a
+        FindName-through-the-template dance every time the rail rebuilds.
+    -->
+    <Grid ColumnDefinitions="56,*">
+
+        <Button x:Name="BtnChip"
+                Grid.Column="0"
+                Width="40" Height="40"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                Background="Transparent" BorderThickness="0" Padding="0"
+                Cursor="Hand" Focusable="False"
+                ToolTip.Tip="{loc:Str emi_desk_dock_tooltip}">
+            <Button.Template>
+                <ControlTemplate TargetType="Button">
+                    <Grid Background="Transparent">
+                        <ContentPresenter Content="{TemplateBinding Content}"/>
+                    </Grid>
+                </ControlTemplate>
+            </Button.Template>
+            <Grid>
+                <!--
+                    THE KNOCK'S RING. The knock animates the stroke colour, the thickness and the
+                    glow. The face is NEVER animated: a live kaomoji pulsing reads as a glitch,
+                    not a knock. See EmiDock.axaml.cs.
+                -->
+                <Ellipse x:Name="Ring"
+                         Fill="#0E0E1C"
+                         StrokeThickness="2">
+                    <Ellipse.Stroke>
+                        <SolidColorBrush Color="#FF69B4"/>
+                    </Ellipse.Stroke>
+                    <Ellipse.Effect>
+                        <DropShadowEffect Color="#FF69B4"
+                                          BlurRadius="0"
+                                          OffsetX="0" OffsetY="0"
+                                          Opacity="0"/>
+                    </Ellipse.Effect>
+                </Ellipse>
+                <!-- Her live face, inset so the kaomoji never touches the ring.
+                     ponytail: EmiFace is a WPF FrameworkElement with its own OnRender; until it is
+                     ported this is the resting kaomoji as plain text in her pink. -->
+                <TextBlock x:Name="MiniFace" Margin="7,8,7,8"
+                           Text="0_0" Foreground="#FF69B4"
+                           FontSize="11" FontWeight="Bold"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+        </Button>
+
+        <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="0,0,10,0">
+            <TextBlock x:Name="TxtName"
+                       Text="{loc:Str emi_desk_dock_name}"
+                       Foreground="#FF69B4"
+                       FontSize="11" FontWeight="SemiBold"/>
+            <!-- The muted pill. Press Start 2P is bundled as woff2 for the web layers; this asks
+                 for the installed family and falls through to a mono stack. 7px chrome either way. -->
+            <TextBlock x:Name="TxtMuted"
+                       Text="{loc:Str emi_desk_dock_muted_pill}"
+                       IsVisible="False"
+                       Foreground="#9A8FB5"
+                       FontFamily="Press Start 2P, Consolas, monospace"
+                       FontSize="7"
+                       TextWrapping="Wrap"
+                       Margin="0,3,0,0"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/EmiDock.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/EmiDock.axaml.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Threading;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// THE DOCK CHIP: a 40 px pink ring at the bottom of the nav rail with EMI's live face in it.
+    /// Click summons her, click again sends her away.
+    ///
+    /// PORTED from ConditioningControlPanel/Controls/EmiDock.xaml.cs. Deviations:
+    ///  - <c>App.EmiDesk</c> (OutChanged, KnockRequested, Toggle, the live face binding and the
+    ///    muted flag) is a WPF-head service. <see cref="Refresh"/> and <see cref="StartKnock"/> are
+    ///    public so a host can drive the chip until the service moves to Core.
+    ///  - The four WPF keyframe timelines become one Avalonia <see cref="Animation"/> on the ring
+    ///    (stroke colour, thickness) plus one on its glow. Both run three times and stop.
+    ///  - The frozen-brush guard is gone: Avalonia brushes do not freeze.
+    /// </summary>
+    public partial class EmiDock : UserControl
+    {
+        private readonly Button _btnChip;
+        private readonly Ellipse _ring;
+        private readonly TextBlock _txtMuted;
+
+        /// <summary>True only while the six seconds of pulses are running.</summary>
+        private bool _knocking;
+        private CancellationTokenSource? _knock;
+
+        public EmiDock()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _btnChip = this.FindControl<Button>("BtnChip")!;
+            _ring = this.FindControl<Ellipse>("Ring")!;
+            _txtMuted = this.FindControl<TextBlock>("TxtMuted")!;
+
+            _btnChip.Click += OnChipClick;
+            Unloaded += (_, _) => StopKnock();
+        }
+
+        /// <summary>Show or hide the muted pill. The pill states a FACT about right now, so the
+        /// host asks the same gate the tube asks: it is never shown just because the setting is on.
+        /// ANY route out answers the knock, so the pulses stop here too.</summary>
+        public void Refresh(bool isOut, bool avatarMuted = false)
+        {
+            if (isOut) StopKnock();
+            // ponytail: needs EmiDeskService for the live face binding; the stub face rests.
+            _txtMuted.IsVisible = avatarMuted;
+        }
+
+        private void OnChipClick(object? sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+            StopKnock();
+            // ponytail: needs EmiDeskService.Toggle(), wired when it moves to Core
+            Log.Debug("[EmiDesk] dock chip clicked with no service");
+        }
+
+        // ============================================================================================
+        //  THE KNOCK
+        // ============================================================================================
+
+        /// <summary>One pulse: a fast swell and a slow fall. Three of these is the whole knock.</summary>
+        private const int PulseMs = 2000;
+
+        /// <summary>Pulses. Three reads as deliberate; more reads as a notification badge.</summary>
+        private const int PulseCount = 3;
+
+        /// <summary>Her pink at rest.</summary>
+        private static readonly Color RestPink = Color.FromRgb(0xFF, 0x69, 0xB4);
+
+        /// <summary>...and the brighter pink each swell reaches.</summary>
+        private static readonly Color HotPink = Color.FromRgb(0xFF, 0xC4, 0xE8);
+
+        /// <summary>The ring's resting stroke, restored by hand when the pulses are taken off.</summary>
+        private const double RestThickness = 2.0;
+
+        /// <summary>
+        /// Three pink pulses over about six seconds, and then quiet forever. The ring, never the
+        /// face. Nothing starts unless the chip is really loaded into a window.
+        /// </summary>
+        public void StartKnock()
+        {
+            try
+            {
+                if (_knocking) return;
+                if (!IsLoaded) return;
+                if (_ring.Effect is not DropShadowEffect glow) return;
+
+                _knocking = true;
+                _knock = new CancellationTokenSource();
+                var span = TimeSpan.FromMilliseconds(PulseMs);
+                var repeat = new IterationCount(PulseCount);
+
+                // The swell is fast and the fall is slow: a pulse that decays reads as a knock, a
+                // pulse that is symmetrical reads as a warning light.
+                var ring = new Animation { Duration = span, IterationCount = repeat };
+                ring.Children.Add(Frame(0.00, new Setter(Shape.StrokeProperty, new SolidColorBrush(RestPink)), new Setter(Shape.StrokeThicknessProperty, RestThickness)));
+                ring.Children.Add(Frame(0.18, new Setter(Shape.StrokeProperty, new SolidColorBrush(HotPink)), new Setter(Shape.StrokeThicknessProperty, 3.2)));
+                ring.Children.Add(Frame(0.55, new Setter(Shape.StrokeProperty, new SolidColorBrush(RestPink)), new Setter(Shape.StrokeThicknessProperty, RestThickness)));
+                ring.Children.Add(Frame(1.00, new Setter(Shape.StrokeProperty, new SolidColorBrush(RestPink)), new Setter(Shape.StrokeThicknessProperty, RestThickness)));
+
+                var glowAnim = new Animation { Duration = span, IterationCount = repeat };
+                glowAnim.Children.Add(Frame(0.00, new Setter(DropShadowEffect.OpacityProperty, 0.0), new Setter(DropShadowEffect.BlurRadiusProperty, 0.0)));
+                glowAnim.Children.Add(Frame(0.18, new Setter(DropShadowEffect.OpacityProperty, 0.95), new Setter(DropShadowEffect.BlurRadiusProperty, 16.0)));
+                glowAnim.Children.Add(Frame(0.55, new Setter(DropShadowEffect.OpacityProperty, 0.0), new Setter(DropShadowEffect.BlurRadiusProperty, 0.0)));
+                glowAnim.Children.Add(Frame(1.00, new Setter(DropShadowEffect.OpacityProperty, 0.0), new Setter(DropShadowEffect.BlurRadiusProperty, 0.0)));
+
+                // ONE of the two carries the tidy-up: its task completes once the whole repeat
+                // count is spent, and StopKnock is idempotent, so a click landing mid-pulse and
+                // the natural end both arrive at the same place.
+                var token = _knock.Token;
+                _ = glowAnim.RunAsync(glow, token);
+                ring.RunAsync(_ring, token).ContinueWith(_ => global::Avalonia.Threading.Dispatcher.UIThread.Post(StopKnock));
+
+                Log.Information("[EmiDesk] the dock chip is knocking");
+            }
+            catch (Exception ex)
+            {
+                _knocking = false;
+                Log.Warning(ex, "[EmiDesk] dock chip knock failed to start");
+            }
+        }
+
+        private static KeyFrame Frame(double cue, params Setter[] setters)
+        {
+            var f = new KeyFrame { Cue = new Cue(cue) };
+            foreach (var s in setters) f.Setters.Add(s);
+            return f;
+        }
+
+        /// <summary>Put the ring back exactly as it was, and never knock again. Idempotent.</summary>
+        private void StopKnock()
+        {
+            try
+            {
+                if (!_knocking) return;
+                _knocking = false;
+
+                _knock?.Cancel();
+                _knock?.Dispose();
+                _knock = null;
+
+                _ring.Stroke = new SolidColorBrush(RestPink);
+                _ring.StrokeThickness = RestThickness;
+                if (_ring.Effect is DropShadowEffect glow)
+                {
+                    glow.Opacity = 0;
+                    glow.BlurRadius = 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] dock chip knock stop failed");
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml
+++ b/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml
@@ -1,0 +1,117 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/EmiRingPicker.xaml.
+     Structure, x:Names and every literal brush preserved. Deviations, all forced:
+
+       <Style x:Key TargetType>            -> <ControlTheme x:Key TargetType> (keyed styles are
+                                              ControlThemes; every brush stays a literal, for the
+                                              same two-hosts reason the WPF file documents)
+       ControlTemplate.Triggers           -> ^:pointerover / ^:checked / ^:disabled selectors with
+                                              /template/ part selectors, hover-then-checked order kept
+       <ContentPresenter/>                -> ContentPresenter Content="{TemplateBinding Content}"
+       Visibility="Collapsed"             -> IsVisible="False"
+       Content="Let her choose" (code-set) -> a TextBlock child with {loc:Str emi_desk_ring_reset}
+                                              (Avalonia parses "_" in Content as an access key) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.EmiRingPicker"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="380">
+
+    <!-- ================================================================
+         HER RING, THE PIN PICKER.
+
+         One control for her options panel and the settings tab, so there is
+         exactly one front end onto the one pin store (EmiState.Pins, written
+         through EmiSuggester). The header row is optional: the settings tab
+         draws its own and sets ShowHeader="False".
+         ================================================================ -->
+
+    <UserControl.Resources>
+        <!-- One target in the picker: the card art, its name on a dark strip, and a pink frame
+             plus a dot when it is pinned. The selectors are ordered hover-then-checked on purpose:
+             the other way round, moving the pointer over a pinned tile would take its pink frame off. -->
+        <ControlTheme x:Key="EmiRingTile" TargetType="ToggleButton">
+            <Setter Property="Width" Value="92"/>
+            <Setter Property="Height" Value="66"/>
+            <Setter Property="Margin" Value="0,0,6,6"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="Shell" CornerRadius="6" BorderThickness="2"
+                            BorderBrush="#33FFFFFF" Background="#FF1A1A2E"
+                            ClipToBounds="True">
+                        <Grid>
+                            <ContentPresenter Content="{TemplateBinding Content}"/>
+                            <Ellipse x:Name="Dot" Width="9" Height="9" Margin="0,4,4,0"
+                                     HorizontalAlignment="Right" VerticalAlignment="Top"
+                                     Fill="#FFFF69B4" Stroke="#FF0E0E1C" StrokeThickness="1.5"
+                                     IsVisible="False"/>
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Shell">
+                <Setter Property="BorderBrush" Value="#8CFF69B4"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#Shell">
+                <Setter Property="BorderBrush" Value="#FFFF69B4"/>
+            </Style>
+            <Style Selector="^:checked /template/ Ellipse#Dot">
+                <Setter Property="IsVisible" Value="True"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.42"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="EmiPickerButton" TargetType="Button">
+            <Setter Property="Foreground" Value="#FFF2FA"/>
+            <Setter Property="Background" Value="#252542"/>
+            <Setter Property="BorderBrush" Value="#4A3A63"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Chrome">
+                <Setter Property="Background" Value="#33294F"/>
+                <Setter Property="BorderBrush" Value="#FF69B4"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.42"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+    </UserControl.Resources>
+
+    <StackPanel>
+        <Grid x:Name="HeaderRow" Margin="0,0,0,6" ColumnDefinitions="*,Auto">
+            <TextBlock x:Name="TxtHint" Grid.Column="0"
+                       Foreground="#9C93B8" FontSize="11"
+                       TextWrapping="Wrap" VerticalAlignment="Center"
+                       Margin="0,0,10,0"/>
+            <Button x:Name="BtnReset" Grid.Column="1"
+                    Theme="{StaticResource EmiPickerButton}"
+                    VerticalAlignment="Center">
+                <TextBlock Text="{loc:Str emi_desk_ring_reset}"/>
+            </Button>
+        </Grid>
+        <WrapPanel x:Name="PnlRing" Orientation="Horizontal"/>
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using ConditioningControlPanel.Localization;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// HER RING, AS A WALL OF TILES. Check a target to pin it; six is the whole ring.
+    ///
+    /// PORTED from ConditioningControlPanel/Views/Controls/EmiRingPicker.xaml.cs. The WPF control
+    /// keeps no list of its own: the tiles ARE <c>EmiState.Pins</c>, written through
+    /// <c>EmiSuggester</c>. Those, <c>EmiTargets</c> and <c>ModResourceResolver</c> are all in the
+    /// WPF head, so this port carries a PLACEHOLDER catalogue and pin set (see the ponytail note)
+    /// that must be deleted, not kept, when the store moves to Core.
+    /// </summary>
+    public partial class EmiRingPicker : UserControl
+    {
+        // ponytail: placeholder catalogue + pin set. EmiSuggester/EmiState are the ONLY pin store;
+        // replace both with EmiTargets.All / EmiSuggester.IsPinned / TogglePin / ClearPins when
+        // they move to Core. Ids are real so emi_desk_target_<id> resolves to real labels.
+        private sealed record Target(string Id, Color Hue, bool Locked)
+        {
+            public string Label { get { try { return Loc.Get("emi_desk_target_" + Id); } catch { return Id; } } }
+        }
+        private static readonly Target[] Catalogue =
+        {
+            new("sessions", Color.Parse("#FF69B4"), false),
+            new("flashes", Color.Parse("#FFB84E"), false),
+            new("videos", Color.Parse("#5EA8FF"), false),
+            new("subliminals", Color.Parse("#B47BFF"), false),
+            new("bubbles", Color.Parse("#5CE0A5"), false),
+            new("spiral", Color.Parse("#E85CE0"), false),
+            new("loom", Color.Parse("#FF7E6B"), true),
+            new("arcademy", Color.Parse("#5ED4E8"), true),
+        };
+        private const int MaxPins = 6;
+        private readonly HashSet<string> _pins = new(StringComparer.Ordinal) { "sessions", "spiral" };
+
+        /// <summary>Suppresses the toggle handler while the code is setting boxes.</summary>
+        private bool _loading;
+
+        /// <summary>Every tile in the picker, by target id, so a refresh does not rebuild the wall.</summary>
+        private readonly Dictionary<string, ToggleButton> _ringTiles = new(StringComparer.Ordinal);
+
+        /// <summary>The tiles that are gated, kept beside the wall rather than re-probed.</summary>
+        private readonly HashSet<string> _ringLocked = new(StringComparer.Ordinal);
+
+        private readonly Grid _headerRow;
+        private readonly TextBlock _txtHint;
+        private readonly Button _btnReset;
+        private readonly WrapPanel _pnlRing;
+
+        public EmiRingPicker()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _headerRow = this.FindControl<Grid>("HeaderRow")!;
+            _txtHint = this.FindControl<TextBlock>("TxtHint")!;
+            _btnReset = this.FindControl<Button>("BtnReset")!;
+            _pnlRing = this.FindControl<WrapPanel>("PnlRing")!;
+
+            _btnReset.Click += (_, _) => ResetPins();
+            // Built in the constructor rather than on Loaded so a headless render sees the wall;
+            // Loaded rebuilds it too, exactly as WPF does, because a host can be reopened.
+            Rebuild();
+            Loaded += (_, _) => Rebuild();
+        }
+
+        /// <summary>Something changed the pin set. The settings host listens so its own count line
+        /// and its own "let her choose" button follow the wall it is not drawing.</summary>
+        public event EventHandler? StateChanged;
+
+        /// <summary>Draw the built-in count line and reset button. False for the settings tab.</summary>
+        public bool ShowHeader
+        {
+            get => _headerRow.IsVisible;
+            set => _headerRow.IsVisible = value;
+        }
+
+        /// <summary>The count line as it stands: "n of 6 pinned", or the full-ring line at six.</summary>
+        public string HintText { get; private set; } = string.Empty;
+
+        /// <summary>False when there is nothing to hand back to her.</summary>
+        public bool CanReset { get; private set; }
+
+        // ------------------------------------------------------------------ the wall
+
+        /// <summary>Build the wall from the catalogue. Locked targets are shown and disabled,
+        /// because "this exists and you have not got it yet" is information and an empty space is not.</summary>
+        public void Rebuild()
+        {
+            try
+            {
+                _pnlRing.Children.Clear();
+                _ringTiles.Clear();
+                _ringLocked.Clear();
+
+                foreach (var t in Catalogue)
+                {
+                    bool locked = t.Locked;
+                    var tile = new ToggleButton
+                    {
+                        Theme = (ControlTheme)this.FindResource("EmiRingTile")!,
+                        Content = BuildTileFace(t, locked),
+                        IsChecked = _pins.Contains(t.Id),
+                        IsEnabled = !locked,
+                        Tag = t.Id,
+                    };
+                    ToolTip.SetTip(tile, locked ? Loc.Get("emi_desk_ring_tile_locked") : t.Label);
+                    // A locked tile is disabled, and a disabled control eats its own tooltip
+                    // unless told not to. The reason IS the point of showing it at all.
+                    ToolTip.SetShowOnDisabled(tile, true);
+
+                    tile.IsCheckedChanged += OnRingTileToggled;
+
+                    _pnlRing.Children.Add(tile);
+                    _ringTiles[t.Id] = tile;
+                    if (locked) _ringLocked.Add(t.Id);
+                }
+
+                Refresh();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] ring picker build failed");
+            }
+        }
+
+        /// <summary>The target's flat hue with its name on a strip.
+        /// ponytail: card art comes through ModResourceResolver (WPF head); the flat-hue branch
+        /// is the one the WPF control takes when there is no art, so it is the only one here.</summary>
+        private static Control BuildTileFace(Target t, bool locked)
+        {
+            var grid = new Grid();
+
+            grid.Children.Add(new Rectangle
+            {
+                Fill = new SolidColorBrush(t.Hue) { Opacity = locked ? 0.28 : 0.62 },
+                IsHitTestVisible = false,
+            });
+
+            var strip = new Border
+            {
+                VerticalAlignment = VerticalAlignment.Bottom,
+                Background = new SolidColorBrush(Color.FromArgb(0xD9, 0x0E, 0x0E, 0x1C)),
+                Padding = new Thickness(3, 2, 3, 2),
+                IsHitTestVisible = false,
+                Child = new TextBlock
+                {
+                    Text = (locked ? "\U0001F512 " : "") + t.Label,
+                    FontSize = 9.5,
+                    Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0xF0, 0xE1)),
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                    TextAlignment = TextAlignment.Center,
+                },
+            };
+            grid.Children.Add(strip);
+
+            return grid;
+        }
+
+        /// <summary>A tile flipped. The pin store is the arbiter, not the checkbox: a seventh pin is
+        /// refused, so the tile is put back to whatever the store ended up saying.</summary>
+        private void OnRingTileToggled(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (_loading) return;
+            try
+            {
+                if (sender is not ToggleButton tb || tb.Tag is not string id) return;
+
+                bool nowPinned = TogglePin(id);
+                if (tb.IsChecked != nowPinned)
+                {
+                    _loading = true;
+                    try { tb.IsChecked = nowPinned; }
+                    finally { _loading = false; }
+                }
+
+                // ponytail: EmiState.SaveNow() and App.EmiDesk.RefreshRing() go here when wired.
+                Refresh();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] ring pin toggle failed");
+            }
+        }
+
+        /// <summary>Placeholder for EmiSuggester.TogglePin: refuses a seventh pin, returns the
+        /// pinned state the store ended up in.</summary>
+        private bool TogglePin(string id)
+        {
+            if (_pins.Remove(id)) return false;
+            if (_pins.Count >= MaxPins) return false;
+            _pins.Add(id);
+            return true;
+        }
+
+        /// <summary>"Let her choose": drop every pin and hand the six slots back to the scores.</summary>
+        public void ResetPins()
+        {
+            try
+            {
+                _pins.Clear(); // ponytail: EmiSuggester.ClearPins() + EmiState.SaveNow() when wired
+
+                _loading = true;
+                try
+                {
+                    foreach (var tb in _ringTiles.Values) tb.IsChecked = false;
+                }
+                finally { _loading = false; }
+
+                Refresh();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] ring reset failed");
+            }
+        }
+
+        /// <summary>The count line and the "full" state. At six pins every UNCHECKED unlocked tile
+        /// goes disabled, so the refusal is something the user sees coming.</summary>
+        public void Refresh()
+        {
+            try
+            {
+                int pins = _pins.Count;
+                bool full = pins >= MaxPins;
+
+                HintText = full
+                    ? Loc.Get("emi_desk_ring_full")
+                    : Loc.GetF("emi_desk_ring_count", pins, MaxPins);
+                CanReset = pins > 0;
+
+                _txtHint.Text = HintText;
+                _btnReset.IsEnabled = CanReset;
+
+                foreach (var kv in _ringTiles)
+                {
+                    var tb = kv.Value;
+                    bool checkedNow = tb.IsChecked == true;
+                    tb.IsEnabled = !_ringLocked.Contains(kv.Key) && (checkedNow || !full);
+                }
+
+                try { StateChanged?.Invoke(this, EventArgs.Empty); }
+                catch (Exception ex) { Log.Debug(ex, "[EmiDesk] ring picker StateChanged threw"); }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] ring picker refresh failed");
+            }
+        }
+    }
+}


### PR DESCRIPTION
922 lines, 6 files. EmiFace becomes a TextBlock kaomoji; EmiDesk services are ponytail stubs.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351