### PR TITLE
feat(avalonia): port controls, part 2/2 - SeasonRecapCard, SeasonRecapWindow

### DIFF
--- a/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml
+++ b/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml
@@ -1,0 +1,376 @@
+<!-- PORTED from ConditioningControlPanel/Controls/SeasonRecapCard.xaml.
+     Structure, order, spacing and every resource key preserved. Deviations, all forced:
+
+       Resources/Theme/SeasonRecapCard.xaml    -> the same keys as view-local resources below
+                                                  (ponytail: local copy, hoist when a second view
+                                                  needs them). StaticResource, not DynamicResource:
+                                                  the RecapTheme per-mod recolor is WPF-head
+                                                  runtime machinery and is not ported.
+       Gradient points "1,1"                   -> "100%,100%" (bare numbers are absolute pixels here)
+       x:Name on GradientStop / transforms     -> dropped (AVLN2000); the code-behind casts
+                                                  SpiralCanvas.RenderTransform / Holo.RenderTransform
+       Visibility="{Binding XVisibility}"      -> IsVisible="{Binding IsX}"
+       Image Source="{Binding path}"           -> Source="{Binding image}" (IImage; a string does not
+                                                  convert, and pack:// is WPF-only). Null placeholders.
+       RenderOptions.BitmapScalingMode         -> RenderOptions.BitmapInterpolationMode
+       SnapsToDevicePixels                     -> dropped
+       FontFamily="Segoe UI"                   -> "Segoe UI, Liberation Sans, sans-serif"
+                                                  (ponytail: under Inter the right column overran
+                                                  585px by ~80px; Arial metrics fit. Without
+                                                  Liberation Sans the generic fallback overflows
+                                                  again - hoist a bundled font when that bites) -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.SeasonRecapCard"
+             x:DataType="local:SeasonRecapCardViewModel"
+             xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls"
+             Width="1040" Height="585"
+             FontFamily="Segoe UI, Liberation Sans, sans-serif"
+             UseLayoutRounding="True">
+    <!-- 16:9 landscape, shareable. Wide two-column layout; the personalized verdict is enlarged
+         and sits above the right-column stats; supporter/OG status pills under the hero; the
+         seasonal neon art is a faded backdrop. Badges use the real dashboard feature icons. -->
+
+    <UserControl.Resources>
+        <!-- ponytail: local copy of Resources/Theme/SeasonRecapCard.xaml, hoist when a second view needs it -->
+        <!-- Structural darks / constants -->
+        <Color x:Key="RecapVoid">#FF0A0414</Color>
+        <Color x:Key="RecapPanel">#FF150A26</Color>
+        <Color x:Key="RecapPanelMid">#FF2A103F</Color>
+        <Color x:Key="RecapFoilCyan">#FF34E0E8</Color>
+        <Color x:Key="RecapGold">#FFFFD166</Color>
+        <Color x:Key="RecapInk">#FFF3ECFF</Color>
+        <Color x:Key="RecapInkDim">#FFA78FD6</Color>
+
+        <!-- Mod-driven accents (overridden per active mod by RecapTheme on WPF) -->
+        <Color x:Key="RecapViolet">#FF7C3AED</Color>
+        <Color x:Key="RecapVioletLite">#FFB18CFF</Color>
+        <Color x:Key="RecapMagenta">#FFE84CF2</Color>
+        <Color x:Key="RecapLine">#2EB18CFF</Color>
+        <Color x:Key="RecapAvatarInner">#FF3A1860</Color>
+        <Color x:Key="RecapStatFill">#0FB18CFF</Color>
+
+        <!-- Mod-driven alpha tints used by inline gradients on the card -->
+        <Color x:Key="RecapHeroTint">#3D7C3AED</Color>
+        <Color x:Key="RecapVerdictTintTop">#24E84CF2</Color>
+        <Color x:Key="RecapVerdictTintBottom">#147C3AED</Color>
+        <Color x:Key="RecapEdgeTint">#45E84CF2</Color>
+        <Color x:Key="RecapOgPillBg">#2EE84CF2</Color>
+        <Color x:Key="RecapOgPillBorder">#73E84CF2</Color>
+
+        <SolidColorBrush x:Key="RecapVoidBrush" Color="{StaticResource RecapVoid}"/>
+        <SolidColorBrush x:Key="RecapPanelBrush" Color="{StaticResource RecapPanel}"/>
+        <SolidColorBrush x:Key="RecapVioletBrush" Color="{StaticResource RecapViolet}"/>
+        <SolidColorBrush x:Key="RecapVioletLiteBrush" Color="{StaticResource RecapVioletLite}"/>
+        <SolidColorBrush x:Key="RecapMagentaBrush" Color="{StaticResource RecapMagenta}"/>
+        <SolidColorBrush x:Key="RecapFoilCyanBrush" Color="{StaticResource RecapFoilCyan}"/>
+        <SolidColorBrush x:Key="RecapGoldBrush" Color="{StaticResource RecapGold}"/>
+        <SolidColorBrush x:Key="RecapInkBrush" Color="{StaticResource RecapInk}"/>
+        <SolidColorBrush x:Key="RecapInkDimBrush" Color="{StaticResource RecapInkDim}"/>
+        <SolidColorBrush x:Key="RecapLineBrush" Color="{StaticResource RecapLine}"/>
+        <SolidColorBrush x:Key="RecapStatFillBrush" Color="{StaticResource RecapStatFill}"/>
+
+        <!-- Status pill: accent -> accent-light -->
+        <LinearGradientBrush x:Key="RecapStatusPillBrush" StartPoint="0%,0%" EndPoint="100%,100%">
+            <GradientStop Color="{StaticResource RecapMagenta}" Offset="0"/>
+            <GradientStop Color="{StaticResource RecapVioletLite}" Offset="1"/>
+        </LinearGradientBrush>
+
+        <!-- Hero numerals: white -> accent-light -->
+        <LinearGradientBrush x:Key="RecapHeroTextBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+            <GradientStop Color="#FFFFFFFF" Offset="0"/>
+            <GradientStop Color="{StaticResource RecapVioletLite}" Offset="1"/>
+        </LinearGradientBrush>
+
+        <!-- Verdict handle: foil-cyan -> accent -> accent-light -->
+        <LinearGradientBrush x:Key="RecapNameBrush" StartPoint="0%,0%" EndPoint="100%,0%">
+            <GradientStop Color="{StaticResource RecapFoilCyan}" Offset="0"/>
+            <GradientStop Color="{StaticResource RecapMagenta}" Offset="0.55"/>
+            <GradientStop Color="{StaticResource RecapVioletLite}" Offset="1"/>
+        </LinearGradientBrush>
+
+        <!-- Inner card background: radial accent-dark -> panel -> void -->
+        <RadialGradientBrush x:Key="RecapInnerBgBrush" GradientOrigin="50%,38%" Center="50%,38%"
+                             RadiusX="75%" RadiusY="60%">
+            <GradientStop Color="{StaticResource RecapPanelMid}" Offset="0"/>
+            <GradientStop Color="{StaticResource RecapPanel}" Offset="0.55"/>
+            <GradientStop Color="{StaticResource RecapVoid}" Offset="1"/>
+        </RadialGradientBrush>
+    </UserControl.Resources>
+
+    <Border x:Name="OuterFoil" CornerRadius="26" Padding="3">
+        <Border.Background>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                <GradientStop Color="{StaticResource RecapFoilCyan}" Offset="0"/>
+                <GradientStop Color="{StaticResource RecapMagenta}" Offset="0.35"/>
+                <GradientStop Color="{StaticResource RecapVioletLite}" Offset="0.65"/>
+                <GradientStop Color="{StaticResource RecapFoilCyan}" Offset="1"/>
+            </LinearGradientBrush>
+        </Border.Background>
+        <Border.Effect>
+            <DropShadowEffect Color="{StaticResource RecapMagenta}" BlurRadius="40" OffsetX="0" OffsetY="0" Opacity="0.35"/>
+        </Border.Effect>
+
+        <Border x:Name="InnerCard" CornerRadius="23" ClipToBounds="True"
+                Background="{StaticResource RecapInnerBgBrush}">
+            <Grid>
+                <!-- Seasonal neon art backdrop (faded), mode-sensitive per active mod -->
+                <Image Source="{Binding BackgroundImage}" Stretch="UniformToFill"
+                       Opacity="0.20" IsHitTestVisible="False"/>
+
+                <!-- Hypnotic spiral (geometry built in code-behind), slow rotation, subtle over the art -->
+                <Canvas x:Name="SpiralCanvas" Opacity="0.22" RenderTransformOrigin="50%,50%"
+                        Width="820" Height="820" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Canvas.RenderTransform>
+                        <RotateTransform Angle="0"/>
+                    </Canvas.RenderTransform>
+                </Canvas>
+
+                <!-- Holographic sweep -->
+                <Rectangle x:Name="Holo" IsHitTestVisible="False" Opacity="0.85"
+                           Width="1340" Height="900" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Rectangle.Fill>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#0034E0E8" Offset="0.30"/>
+                            <GradientStop Color="#2634E0E8" Offset="0.45"/>
+                            <GradientStop Color="#33E84CF2" Offset="0.50"/>
+                            <GradientStop Color="#26B18CFF" Offset="0.55"/>
+                            <GradientStop Color="#00B18CFF" Offset="0.70"/>
+                        </LinearGradientBrush>
+                    </Rectangle.Fill>
+                    <Rectangle.RenderTransform>
+                        <TranslateTransform X="-260" Y="-200"/>
+                    </Rectangle.RenderTransform>
+                </Rectangle>
+
+                <!-- Legibility scrim so the faded art doesn't wash out text -->
+                <Rectangle IsHitTestVisible="False" Fill="#66000000"/>
+
+                <!-- ===================== CONTENT ===================== -->
+                <Grid Margin="34,24,34,22" RowDefinitions="Auto,*,Auto">
+
+                    <!-- ===== HEADER BAR ===== -->
+                    <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+                        <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock Text="{Binding SeasonLabel}" FontSize="17" FontWeight="Medium"
+                                       Foreground="{StaticResource RecapInkDimBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding SeasonNumberText}" FontSize="42" FontWeight="Black"
+                                       Foreground="{StaticResource RecapInkBrush}" VerticalAlignment="Center">
+                                <TextBlock.Effect><DropShadowEffect Color="{StaticResource RecapVioletLite}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.6"/></TextBlock.Effect>
+                            </TextBlock>
+                            <TextBlock Text="{Binding DateRangeText}" FontSize="16" FontWeight="Medium"
+                                       Foreground="{StaticResource RecapInkDimBrush}" VerticalAlignment="Bottom" Margin="16,0,0,9"/>
+                        </StackPanel>
+                        <Border Grid.Column="1" VerticalAlignment="Center" CornerRadius="999"
+                                Background="{StaticResource RecapStatusPillBrush}" Padding="17,8">
+                            <Border.Effect><DropShadowEffect Color="{StaticResource RecapMagenta}" BlurRadius="22" OffsetX="0" OffsetY="0" Opacity="0.7"/></Border.Effect>
+                            <TextBlock Text="{Binding StatusText}" FontSize="16" FontWeight="Bold" Foreground="#FF160826"/>
+                        </Border>
+                    </Grid>
+
+                    <!-- ===== BODY ===== -->
+                    <Grid Grid.Row="1" Margin="0,16,0,12" ColumnDefinitions="396,*">
+
+                        <!-- LEFT: identity + hero + status -->
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,24,0">
+                            <StackPanel Orientation="Horizontal">
+                                <Border Width="68" Height="68" CornerRadius="19"
+                                        BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                    <Border.Background>
+                                        <RadialGradientBrush GradientOrigin="50%,40%" Center="50%,40%" RadiusX="60%" RadiusY="60%">
+                                            <GradientStop Color="{StaticResource RecapAvatarInner}" Offset="0"/>
+                                            <GradientStop Color="#FF170A2B" Offset="1"/>
+                                        </RadialGradientBrush>
+                                    </Border.Background>
+                                    <Grid Width="40" Height="40">
+                                        <Ellipse Width="38" Height="38" Stroke="{StaticResource RecapVioletLiteBrush}" StrokeThickness="1.5"/>
+                                        <Ellipse Width="22" Height="22" Stroke="{StaticResource RecapVioletLiteBrush}" StrokeThickness="1.5"/>
+                                        <Ellipse Width="9" Height="9" Fill="{StaticResource RecapMagentaBrush}"/>
+                                    </Grid>
+                                </Border>
+                                <StackPanel VerticalAlignment="Center" Margin="15,0,0,0">
+                                    <TextBlock Text="{Binding Handle}" FontSize="30" FontWeight="Bold"
+                                               Foreground="{StaticResource RecapInkBrush}" TextTrimming="CharacterEllipsis" MaxWidth="290"/>
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                        <Rectangle Width="10" Height="10" RadiusX="2" RadiusY="2" Margin="0,0,7,0">
+                                            <Rectangle.Fill>
+                                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                    <GradientStop Color="{StaticResource RecapFoilCyan}" Offset="0"/>
+                                                    <GradientStop Color="{StaticResource RecapMagenta}" Offset="1"/>
+                                                </LinearGradientBrush>
+                                            </Rectangle.Fill>
+                                            <Rectangle.RenderTransform><RotateTransform Angle="45" CenterX="5" CenterY="5"/></Rectangle.RenderTransform>
+                                        </Rectangle>
+                                        <TextBlock Text="{Binding TitleText}" FontSize="17" FontWeight="SemiBold"
+                                                   Foreground="{StaticResource RecapVioletLiteBrush}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!-- hero -->
+                            <Border Margin="0,16,0,0" CornerRadius="18" Padding="18,14,18,13"
+                                    BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                                        <GradientStop Color="{StaticResource RecapHeroTint}" Offset="0"/>
+                                        <GradientStop Color="#3D0A0414" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <StackPanel HorizontalAlignment="Center">
+                                    <TextBlock Text="{Binding HeroLabel}" FontSize="15" FontWeight="Medium"
+                                               Foreground="{StaticResource RecapInkDimBrush}" HorizontalAlignment="Center"/>
+                                    <TextBlock x:Name="HeroSeasonTime" FontSize="60" FontWeight="Black"
+                                               Foreground="{StaticResource RecapHeroTextBrush}" HorizontalAlignment="Center" Margin="0,2,0,0">
+                                        <TextBlock.Effect><DropShadowEffect Color="{StaticResource RecapVioletLite}" BlurRadius="28" OffsetX="0" OffsetY="0" Opacity="0.4"/></TextBlock.Effect>
+                                    </TextBlock>
+                                    <TextBlock Text="{Binding SessionsSubline}" FontSize="16"
+                                               Foreground="{StaticResource RecapInkDimBrush}" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                                    <Border Margin="0,11,0,0" Padding="0,10,0,0" BorderThickness="0,1,0,0" BorderBrush="{StaticResource RecapLineBrush}">
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                            <TextBlock Text="{Binding AllTimeLabel}" FontSize="14" FontWeight="Medium"
+                                                       Foreground="{StaticResource RecapInkDimBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                                            <TextBlock x:Name="HeroAllTime" FontSize="28" FontWeight="Black"
+                                                       Foreground="{StaticResource RecapGoldBrush}" VerticalAlignment="Center">
+                                                <TextBlock.Effect><DropShadowEffect Color="{StaticResource RecapGold}" BlurRadius="16" OffsetX="0" OffsetY="0" Opacity="0.35"/></TextBlock.Effect>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
+                            </Border>
+
+                            <!-- status pills (supporter / OG) -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,12,0,0"
+                                        IsVisible="{Binding IsStatusRowVisible}">
+                                <Border IsVisible="{Binding IsSupporter}" CornerRadius="999" Padding="13,6" Margin="0,0,8,0"
+                                        Background="#2EFFD166" BorderBrush="#73FFD166" BorderThickness="1">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="7" Height="7" Fill="{StaticResource RecapGoldBrush}" VerticalAlignment="Center" Margin="0,0,7,0"/>
+                                        <TextBlock Text="{Binding SupporterLabel}" FontSize="13" FontWeight="SemiBold" Foreground="{StaticResource RecapGoldBrush}"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border IsVisible="{Binding IsOg}" CornerRadius="999" Padding="13,6" BorderThickness="1">
+                                    <Border.Background><SolidColorBrush Color="{StaticResource RecapOgPillBg}"/></Border.Background>
+                                    <Border.BorderBrush><SolidColorBrush Color="{StaticResource RecapOgPillBorder}"/></Border.BorderBrush>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Ellipse Width="7" Height="7" Fill="{StaticResource RecapMagentaBrush}" VerticalAlignment="Center" Margin="0,0,7,0"/>
+                                        <TextBlock Text="{Binding OgLabel}" FontSize="13" FontWeight="SemiBold" Foreground="{StaticResource RecapMagentaBrush}"/>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!-- RIGHT: verdict (big, on top) + stats + badges -->
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                            <!-- VERDICT (enlarged, above the stat boxes) -->
+                            <Border CornerRadius="16" Padding="18,13" Margin="0,0,0,12" BorderThickness="1">
+                                <Border.BorderBrush>
+                                    <SolidColorBrush Color="{StaticResource RecapEdgeTint}"/>
+                                </Border.BorderBrush>
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                                        <GradientStop Color="{StaticResource RecapVerdictTintTop}" Offset="0"/>
+                                        <GradientStop Color="{StaticResource RecapVerdictTintBottom}" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                                <TextBlock FontSize="27" TextAlignment="Center" TextWrapping="Wrap" LineHeight="32"
+                                           Foreground="{StaticResource RecapInkBrush}" xml:space="preserve"><Run Text="{Binding VerdictBefore}"/><Run Text="{Binding VerdictName}" FontWeight="Black" Foreground="{StaticResource RecapNameBrush}"/><Run Text="{Binding VerdictAfter}"/></TextBlock>
+                            </Border>
+
+                            <!-- STAT GRID -->
+                            <UniformGrid Columns="2">
+                                <Border CornerRadius="14" Margin="0,0,5,5" Padding="16,11"
+                                        Background="{StaticResource RecapStatFillBrush}" BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding StatPeakRankLabel}" FontSize="14" FontWeight="Medium" Foreground="{StaticResource RecapInkDimBrush}"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                            <TextBlock x:Name="StatRank" FontSize="26" FontWeight="Bold" Foreground="{StaticResource RecapMagentaBrush}"/>
+                                            <TextBlock Text="{Binding PeakRankOfText}" FontSize="15" Foreground="{StaticResource RecapInkDimBrush}" VerticalAlignment="Bottom" Margin="7,0,0,4"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                                <Border CornerRadius="14" Margin="5,0,0,5" Padding="16,11"
+                                        Background="{StaticResource RecapStatFillBrush}" BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding StatPercentileLabel}" FontSize="14" FontWeight="Medium" Foreground="{StaticResource RecapInkDimBrush}"/>
+                                        <TextBlock Text="{Binding PercentileText}" FontSize="26" FontWeight="Bold" Foreground="{StaticResource RecapGoldBrush}" Margin="0,2,0,0"/>
+                                    </StackPanel>
+                                </Border>
+                                <Border CornerRadius="14" Margin="0,5,5,0" Padding="16,11"
+                                        Background="{StaticResource RecapStatFillBrush}" BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding StatDaysActiveLabel}" FontSize="14" FontWeight="Medium" Foreground="{StaticResource RecapInkDimBrush}"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                            <TextBlock Text="{Binding DaysActiveText}" FontSize="26" FontWeight="Bold" Foreground="{StaticResource RecapInkBrush}"/>
+                                            <TextBlock Text="{Binding DaysActiveOfText}" FontSize="15" Foreground="{StaticResource RecapInkDimBrush}" VerticalAlignment="Bottom" Margin="7,0,0,4"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                                <Border CornerRadius="14" Margin="5,5,0,0" Padding="16,11"
+                                        Background="{StaticResource RecapStatFillBrush}" BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding StatStreakLabel}" FontSize="14" FontWeight="Medium" Foreground="{StaticResource RecapInkDimBrush}"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                            <TextBlock Text="{Binding LongestStreakText}" FontSize="26" FontWeight="Bold" Foreground="{StaticResource RecapInkBrush}"/>
+                                            <TextBlock Text="{Binding StreakUnitText}" FontSize="15" Foreground="{StaticResource RecapInkDimBrush}" VerticalAlignment="Bottom" Margin="7,0,0,4"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                            </UniformGrid>
+
+                            <!-- PRESTIGE (lifetime points spent; hidden on pre-schema-2 snapshots) -->
+                            <TextBlock Text="{Binding PrestigeLineText}" IsVisible="{Binding IsPrestigeVisible}"
+                                       FontSize="14" FontWeight="SemiBold"
+                                       Foreground="{StaticResource RecapGoldBrush}" Margin="2,8,0,0"/>
+
+                            <!-- BADGES -->
+                            <Grid Margin="0,14,0,8">
+                                <TextBlock Text="{Binding BadgesTitle}" FontSize="18" FontWeight="SemiBold"
+                                           Foreground="{StaticResource RecapInkBrush}" HorizontalAlignment="Left"/>
+                                <TextBlock Text="{Binding FeaturesUsedText}" FontSize="15" FontWeight="Medium"
+                                           Foreground="{StaticResource RecapInkDimBrush}" HorizontalAlignment="Right" VerticalAlignment="Bottom"/>
+                            </Grid>
+                            <ItemsControl ItemsSource="{Binding TopBadges}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate><UniformGrid Columns="6"/></ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="local:FeatureBadgeViewModel">
+                                        <StackPanel Margin="3,0" HorizontalAlignment="Center">
+                                            <Border Width="58" Height="58" CornerRadius="16"
+                                                    BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                                                <Border.Background>
+                                                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="60%,100%">
+                                                        <GradientStop Color="#FF2B1448" Offset="0"/>
+                                                        <GradientStop Color="#FF160A29" Offset="1"/>
+                                                    </LinearGradientBrush>
+                                                </Border.Background>
+                                                <Image Source="{Binding Image}" Width="38" Height="38" Stretch="Uniform"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       RenderOptions.BitmapInterpolationMode="HighQuality"/>
+                                            </Border>
+                                            <TextBlock Text="{Binding Label}" FontSize="13" FontWeight="Medium"
+                                                       Foreground="{StaticResource RecapInkDimBrush}" HorizontalAlignment="Center"
+                                                       TextAlignment="Center" Margin="0,5,0,0" TextTrimming="CharacterEllipsis" MaxWidth="84"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- ===== FOOTER (reset + brand) ===== -->
+                    <StackPanel Grid.Row="2">
+                        <TextBlock FontSize="16" TextAlignment="Center" TextWrapping="Wrap" MaxWidth="940"
+                                   Foreground="{StaticResource RecapInkDimBrush}" xml:space="preserve"><Run Text="{Binding ResetBefore}"/><Run Text="{Binding ResetBold}" FontWeight="SemiBold" Foreground="{StaticResource RecapInkBrush}"/><Run Text="{Binding ResetAfter}"/></TextBlock>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,8,0,0">
+                            <Ellipse Width="6" Height="6" Fill="{StaticResource RecapMagentaBrush}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding BrandText}" FontSize="14" FontWeight="Medium"
+                                       Foreground="{StaticResource RecapInkDimBrush}" Margin="9,0,9,0"/>
+                            <Ellipse Width="6" Height="6" Fill="{StaticResource RecapMagentaBrush}" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+            </Grid>
+        </Border>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml.cs
@@ -1,0 +1,428 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// Animated, fully data-bound Season Recap card.
+    ///
+    /// PORTED from ConditioningControlPanel/Controls/SeasonRecapCard.xaml.cs. Deviations:
+    ///  - Spiral spin and holo sweep are Avalonia <see cref="Animation"/>s on the Canvas and the
+    ///    Rectangle (TransformAnimator). The foil shimmer animated <c>GradientStop.Offset</c>, which
+    ///    is not Animatable here, so it is dropped: the foil sits at its still offsets.
+    ///  - The parameterless constructor seeds a sample snapshot with <c>AnimateReveal = false</c>
+    ///    so <c>--render-all</c> captures final figures, not a frame of the count-up.
+    /// </summary>
+    public partial class SeasonRecapCard : UserControl
+    {
+        private SeasonRecapCardViewModel? _vm;
+        private DispatcherTimer? _countTimer;
+        private CancellationTokenSource? _ambient;
+
+        private readonly Canvas _spiralCanvas;
+        private readonly Rectangle _holo;
+        private readonly TextBlock _heroSeasonTime;
+        private readonly TextBlock _heroAllTime;
+        private readonly TextBlock _statRank;
+
+        // Representative angle for the frozen still: the spiral reads as a spiral, not axis-aligned.
+        private const double StillSpiralAngle = 24;
+
+        /// <summary>When false, the card renders at its final values with no count-up.</summary>
+        public bool AnimateReveal { get; set; } = true;
+
+        public SeasonRecapCard()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _spiralCanvas = this.FindControl<Canvas>("SpiralCanvas")!;
+            _holo = this.FindControl<Rectangle>("Holo")!;
+            _heroSeasonTime = this.FindControl<TextBlock>("HeroSeasonTime")!;
+            _heroAllTime = this.FindControl<TextBlock>("HeroAllTime")!;
+            _statRank = this.FindControl<TextBlock>("StatRank")!;
+            Loaded += OnLoaded;
+            Unloaded += (_, _) => { _countTimer?.Stop(); StopAmbientLoops(); };
+
+            // Render constructor: sample data so the headless proof draws every string.
+            AnimateReveal = false;
+            SetViewModel(SeasonRecapCardViewModel.Sample());
+        }
+
+        public void SetViewModel(SeasonRecapCardViewModel vm)
+        {
+            _vm = vm;
+            DataContext = vm;
+            // Seed the count-up targets immediately so a non-animated render is correct even
+            // before Loaded fires.
+            SetFinalFigures();
+        }
+
+        private void OnLoaded(object? sender, EventArgs e)
+        {
+            BuildSpiral();
+            StartAmbientLoops();
+
+            if (AnimateReveal) RunCountUps();
+            else SetFinalFigures();
+        }
+
+        // ---------- spiral geometry (two interleaved Archimedean arms, like the mockup) ----------
+        private void BuildSpiral()
+        {
+            if (_spiralCanvas.Children.Count > 0) return; // build once
+            double cx = 260, cy = 260, b = 7.4, step = 0.18, turns = 15.5 * Math.PI;
+
+            _spiralCanvas.Children.Add(MakeArm(cx, cy, b, step, turns, 0,
+                Color.FromArgb(0x66, 0xB1, 0x8C, 0xFF), 3.2));
+            _spiralCanvas.Children.Add(MakeArm(cx, cy, b, step, turns, Math.PI,
+                Color.FromArgb(0x38, 0xE8, 0x4C, 0xF2), 2.2));
+        }
+
+        private static Path MakeArm(double cx, double cy, double b, double step, double turns,
+            double offset, Color color, double thickness)
+        {
+            var fig = new PathFigure { IsClosed = false };
+            bool first = true;
+            for (double t = 0; t <= turns; t += step)
+            {
+                double r = 3 + b * t;
+                var pt = new Point(cx + r * Math.Cos(t + offset), cy + r * Math.Sin(t + offset));
+                if (first) { fig.StartPoint = pt; first = false; }
+                else fig.Segments!.Add(new LineSegment { Point = pt });
+            }
+            var geo = new PathGeometry();
+            geo.Figures!.Add(fig);
+
+            return new Path
+            {
+                Data = geo,
+                Stroke = new SolidColorBrush(color),
+                StrokeThickness = thickness,
+                StrokeJoin = PenLineJoin.Round,
+                StrokeLineCap = PenLineCap.Round,
+            };
+        }
+
+        // ---------- ambient loops ----------
+        private void StartAmbientLoops()
+        {
+            StopAmbientLoops();
+            _ambient = new CancellationTokenSource();
+            var token = _ambient.Token;
+
+            // Spiral: full rotation every 26s, forever.
+            var spin = new Animation { Duration = TimeSpan.FromSeconds(26), IterationCount = IterationCount.Infinite };
+            spin.Children.Add(Frame(0d, new Setter(RotateTransform.AngleProperty, 0d)));
+            spin.Children.Add(Frame(1d, new Setter(RotateTransform.AngleProperty, 360d)));
+            _ = spin.RunAsync(_spiralCanvas, token);
+
+            // Holo sweep: diagonal translate, autoreverse, 6s.
+            var sweep = new Animation
+            {
+                Duration = TimeSpan.FromSeconds(6),
+                IterationCount = IterationCount.Infinite,
+                PlaybackDirection = PlaybackDirection.Alternate,
+                Easing = new SineEaseInOut(),
+            };
+            sweep.Children.Add(Frame(0d, new Setter(TranslateTransform.XProperty, -200d), new Setter(TranslateTransform.YProperty, -200d)));
+            sweep.Children.Add(Frame(1d, new Setter(TranslateTransform.XProperty, 200d), new Setter(TranslateTransform.YProperty, 200d)));
+            _ = sweep.RunAsync(_holo, token);
+
+            // ponytail: the WPF foil shimmer drifts two GradientStop offsets; GradientStop is not
+            // Animatable on Avalonia, so the foil holds its still offsets (0.35 / 0.65).
+        }
+
+        private void StopAmbientLoops()
+        {
+            _ambient?.Cancel();
+            _ambient?.Dispose();
+            _ambient = null;
+        }
+
+        private static KeyFrame Frame(double cue, params Setter[] setters)
+        {
+            var f = new KeyFrame { Cue = new Cue(cue) };
+            foreach (var s in setters) f.Setters.Add(s);
+            return f;
+        }
+
+        // ---------- count-ups ----------
+        private void RunCountUps()
+        {
+            if (_vm == null) { SetFinalFigures(); return; }
+
+            var start = DateTime.UtcNow;
+            var dur = TimeSpan.FromMilliseconds(950);
+
+            _countTimer?.Stop();
+            _countTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
+            _countTimer.Tick += (s, e) =>
+            {
+                var elapsed = DateTime.UtcNow - start;
+                double p = Math.Min(1.0, elapsed.TotalMilliseconds / dur.TotalMilliseconds);
+                double eased = 1 - Math.Pow(1 - p, 3); // ease-out cubic
+
+                _heroSeasonTime.Text = SeasonRecapCardViewModel.FormatHm(_vm.SeasonMinutes * eased);
+                _heroAllTime.Text = SeasonRecapCardViewModel.FormatHm(_vm.AllTimeMinutes * eased);
+                _statRank.Text = _vm.PeakRankTarget > 0
+                    ? "#" + Math.Max(1, (int)Math.Round(_vm.PeakRankTarget * eased))
+                    : _vm.PeakRankText;
+
+                if (p >= 1.0)
+                {
+                    _countTimer?.Stop();
+                    SetFinalFigures();
+                }
+            };
+            // Start from zero so the count-up is visible from the first frame.
+            _heroSeasonTime.Text = SeasonRecapCardViewModel.FormatHm(0);
+            _heroAllTime.Text = SeasonRecapCardViewModel.FormatHm(0);
+            _statRank.Text = _vm.PeakRankTarget > 0 ? "#0" : _vm.PeakRankText;
+            _countTimer.Start();
+        }
+
+        private void SetFinalFigures()
+        {
+            if (_vm == null) return;
+            _heroSeasonTime.Text = _vm.SeasonTimeText;
+            _heroAllTime.Text = _vm.AllTimeText;
+            _statRank.Text = _vm.PeakRankText;
+        }
+
+        /// <summary>
+        /// Freeze every animation to a clean representative frame and set the figures to their
+        /// final values. Call this immediately before rendering the card to PNG.
+        /// </summary>
+        public void PrepareForStill()
+        {
+            _countTimer?.Stop();
+            SetFinalFigures();
+
+            try
+            {
+                StopAmbientLoops();
+                ((RotateTransform)_spiralCanvas.RenderTransform!).Angle = StillSpiralAngle;
+                var holo = (TranslateTransform)_holo.RenderTransform!;
+                holo.X = 0;
+                holo.Y = 0;
+            }
+            catch { /* freezing is best-effort; a still with default offsets is still fine */ }
+
+            UpdateLayout();
+        }
+    }
+
+    public class FeatureBadgeViewModel
+    {
+        public string Label { get; init; } = "";
+        public int Count { get; init; }
+        /// <summary>ponytail: badge art resolves through ModResourceResolver (WPF head); null
+        /// draws the empty badge tile until it moves to Core.</summary>
+        public IImage? Image { get; init; }
+    }
+
+    /// <summary>
+    /// Avalonia twin of ConditioningControlPanel/ViewModels/SeasonRecapViewModel.cs. Same property
+    /// names and the same Loc keys; every helper it uses (SeasonNumbering, TitleTiers,
+    /// SeasonFeatureKeys, SeasonRecapSnapshot) is already in CCP.Core. Only two things pin the
+    /// original to the WPF head: <c>Visibility</c> (bool here) and pack:// image paths (IImage,
+    /// null placeholders here).
+    /// </summary>
+    public class SeasonRecapCardViewModel
+    {
+        private readonly SeasonRecapSnapshot _s;
+
+        public SeasonRecapCardViewModel(SeasonRecapSnapshot snapshot)
+        {
+            _s = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        /// <summary>Placeholder data for the headless render.</summary>
+        public static SeasonRecapCardViewModel Sample() => new(new SeasonRecapSnapshot
+        {
+            SeasonKey = "2026-08",
+            Handle = "bambi",
+            SeasonMinutes = 47 * 60 + 12,
+            AllTimeMinutes = 312 * 60 + 5,
+            SessionCount = 63,
+            PeakRank = 17,
+            PeakRankTotal = 1284,
+            Percentile = 4,
+            DaysActive = 22,
+            SeasonLengthDays = 31,
+            LongestStreak = 9,
+            LifetimePointsSpent = 4200,
+            PointsSpentSeason = 950,
+            IsSupporter = true,
+            IsOg = true,
+            FeatureUse = new Dictionary<string, int>
+            {
+                [SeasonFeatureKeys.Flash] = 812, [SeasonFeatureKeys.Video] = 140,
+                [SeasonFeatureKeys.Subliminal] = 96, [SeasonFeatureKeys.Bubbles] = 40,
+                [SeasonFeatureKeys.Overlay] = 12, [SeasonFeatureKeys.LockCard] = 7,
+                [SeasonFeatureKeys.MindWipe] = 3,
+            },
+        });
+
+        /// <summary>ponytail: RecapBackgrounds.ForMod names a pack:// resource; null until the art ships in Core.</summary>
+        public IImage? BackgroundImage => null;
+
+        // ---------- header ----------
+        public int SeasonNumber => SeasonNumbering.ToSeasonNumber(_s.SeasonKey);
+        public int NextSeasonNumber => SeasonNumber + 1;
+        public string SeasonLabel => Loc.Get("recap_header_season");
+        public string SeasonNumberText => SeasonNumber >= 0 ? SeasonNumber.ToString("00") : "--";
+        public string StatusText => Loc.Get("recap_status_complete");
+
+        public string DateRangeText
+        {
+            get
+            {
+                var (start, end) = SeasonNumbering.DateRange(_s.SeasonKey);
+                if (start == DateTime.MinValue) return "";
+                string fmt(DateTime d) => d.ToString("MMM dd", CultureInfo.InvariantCulture).ToLowerInvariant();
+                return $"{fmt(start)} - {fmt(end)} · {start.Year}";
+            }
+        }
+
+        // ---------- identity ----------
+        public string Handle => string.IsNullOrWhiteSpace(_s.Handle) ? Loc.Get("recap_default_handle") : _s.Handle;
+        public string TitleText => Loc.Get(TitleTiers.Resolve(AllTimeHours, _s.Percentile));
+
+        public string SupporterLabel => Loc.Get("recap_badge_supporter");
+        public string OgLabel => Loc.Get("recap_badge_og");
+        public bool IsSupporter => _s.IsSupporter;
+        public bool IsOg => _s.IsOg;
+        public bool IsStatusRowVisible => _s.IsSupporter || _s.IsOg;
+
+        // ---------- hero ----------
+        public double SeasonMinutes => _s.SeasonMinutes;
+        public double AllTimeMinutes => _s.AllTimeMinutes;
+        public double AllTimeHours => _s.AllTimeMinutes / 60.0;
+
+        public string SeasonTimeText => FormatHm(_s.SeasonMinutes);
+        public string AllTimeText => FormatHm(_s.AllTimeMinutes);
+        public string HeroLabel => Loc.Get("recap_hero_label");
+        public string AllTimeLabel => Loc.Get("recap_alltime_label");
+        public string SessionsSubline => Loc.GetF("recap_sessions_subline", _s.SessionCount);
+
+        // ---------- stats ----------
+        public string PeakRankText => _s.PeakRank > 0 ? $"#{_s.PeakRank}" : "—";
+        public int PeakRankTarget => _s.PeakRank;
+        public string PeakRankOfText => _s.PeakRank > 0 && _s.PeakRankTotal > 0
+            ? Loc.GetF("recap_rank_of", _s.PeakRankTotal.ToString("N0"))
+            : "";
+        public string PercentileText => _s.Percentile > 0 ? Loc.GetF("recap_top_percent", _s.Percentile) : "—";
+        public string DaysActiveText => _s.DaysActive.ToString();
+        public string DaysActiveOfText => _s.SeasonLengthDays > 0 ? $"/ {_s.SeasonLengthDays}" : "";
+        public string LongestStreakText => _s.LongestStreak.ToString();
+        public string StreakUnitText => Loc.Get("recap_streak_days");
+
+        public string StatPeakRankLabel => Loc.Get("recap_stat_peak_rank");
+        public string StatPercentileLabel => Loc.Get("recap_stat_percentile");
+        public string StatDaysActiveLabel => Loc.Get("recap_stat_days_active");
+        public string StatStreakLabel => Loc.Get("recap_stat_longest_streak");
+
+        // ---------- prestige strip ----------
+        public bool IsPrestigeVisible => _s.LifetimePointsSpent > 0;
+        public string PrestigeLineText
+        {
+            get
+            {
+                var t = $"✦ {Loc.Get("recap_prestige_label")} {_s.LifetimePointsSpent:N0}";
+                if (_s.PointsSpentSeason > 0)
+                    t += "  ·  " + Loc.GetF("recap_prestige_delta", _s.PointsSpentSeason);
+                return t;
+            }
+        }
+
+        // ---------- badge row ----------
+        public string BadgesTitle => Loc.Get("recap_badges_title");
+        public int FeaturesUsedCount => _s.FeatureUse.Count(kv => kv.Value > 0);
+        public int FeaturesTotal => _s.FeaturesTotal > 0 ? _s.FeaturesTotal : SeasonFeatureKeys.TotalCount;
+        public string FeaturesUsedText => Loc.GetF("recap_features_used", FeaturesUsedCount, FeaturesTotal);
+
+        public IReadOnlyList<FeatureBadgeViewModel> TopBadges =>
+            _s.FeatureUse
+                .Where(kv => kv.Value > 0)
+                .OrderByDescending(kv => kv.Value)
+                .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                .Take(6)
+                .Select(kv =>
+                {
+                    var def = SeasonFeatureKeys.Find(kv.Key);
+                    return new FeatureBadgeViewModel
+                    {
+                        Label = def != null ? Loc.Get(def.LabelLocKey) : kv.Key,
+                        Count = kv.Value,
+                    };
+                })
+                .ToList();
+
+        // ---------- verdict ----------
+        private string VerdictKey
+        {
+            get
+            {
+                var pct = _s.Percentile;
+                if (pct > 0 && pct <= 2) return "recap_verdict_elite";
+                if (pct > 0 && pct <= 10) return "recap_verdict_strong";
+                if (AllTimeHours >= 50 || _s.SeasonMinutes >= 600) return "recap_verdict_mid";
+                return "recap_verdict_gentle";
+            }
+        }
+        public string VerdictBefore => SplitVerdict().before;
+        public string VerdictName => Handle;
+        public string VerdictAfter => SplitVerdict().after;
+
+        private (string before, string after) SplitVerdict()
+        {
+            var t = Loc.Get(VerdictKey); // raw template, still contains "{0}"
+            const string token = "{0}";
+            var idx = t.IndexOf(token, StringComparison.Ordinal);
+            if (idx < 0) return (t, "");
+            return (t.Substring(0, idx), t.Substring(idx + token.Length));
+        }
+
+        // ---------- reset / brand ----------
+        public int AllTimeHoursRounded => (int)Math.Round(AllTimeHours, MidpointRounding.AwayFromZero);
+        public string ResetBefore => Loc.GetF("recap_reset_before", SeasonNumberText);
+        public string ResetBold => Loc.GetF("recap_reset_bold", AllTimeHoursRounded);
+        public string ResetAfter => Loc.GetF("recap_reset_after", NextSeasonNumber.ToString("00"));
+        public string BrandText => Loc.Get("recap_brand");
+
+        public string SharePrefillText => Loc.GetF(
+            "recap_share_prefill",
+            SeasonNumberText,
+            FormatHmCompact(_s.SeasonMinutes),
+            FormatHmCompact(_s.AllTimeMinutes),
+            _s.Percentile > 0 ? _s.Percentile.ToString() : "?");
+
+        public string SuggestedFileName => $"cclabs-season-{_s.SeasonKey}.png";
+
+        public static string FormatHm(double totalMinutes)
+        {
+            var t = Math.Max(0, totalMinutes);
+            return Loc.GetF("recap_time_hm", (int)(t / 60), (int)(t % 60));
+        }
+
+        public static string FormatHmCompact(double totalMinutes)
+        {
+            var hours = (int)Math.Round(Math.Max(0, totalMinutes) / 60.0, MidpointRounding.AwayFromZero);
+            return $"{hours}h";
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/SeasonRecapWindow.axaml
+++ b/CCP.Avalonia/Views/Controls/SeasonRecapWindow.axaml
@@ -1,0 +1,114 @@
+<!-- PORTED from ConditioningControlPanel/Controls/SeasonRecapWindow.xaml.
+     Structure, x:Names and spacing preserved. Deviations, all forced:
+
+       <Style x:Key TargetType="Button">   -> <ControlTheme> with the same Template; the
+                                              IsMouseOver trigger is a ^:pointerover selector
+       <ContentPresenter/>                 -> ContentPresenter Content="{TemplateBinding Content}"
+       Recap* StaticResources              -> local copies (they live on the card's resources now)
+       ResizeMode="NoResize"               -> CanResize="False"
+       Content set from code (Loc.Get)     -> a TextBlock child with {loc:Str}; the formatted
+                                              continue label stays Loc.GetF in the code-behind
+       Visibility="Collapsed"              -> IsVisible="False" -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Controls.SeasonRecapWindow"
+        Title="Season Recap"
+        SizeToContent="WidthAndHeight"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        Background="{StaticResource RecapVoidBrush}"
+        FontFamily="Segoe UI, Liberation Sans, sans-serif">
+    <Window.Resources>
+        <!-- ponytail: local copy of Resources/Theme/SeasonRecapCard.xaml: RecapVoid, RecapInk,
+             RecapInkDim, RecapLine, RecapVioletLite, RecapMagenta and their brushes; hoist when a
+             third view needs them -->
+        <Color x:Key="RecapVoid">#FF0A0414</Color>
+        <Color x:Key="RecapInk">#FFF3ECFF</Color>
+        <Color x:Key="RecapInkDim">#FFA78FD6</Color>
+        <Color x:Key="RecapLine">#2EB18CFF</Color>
+        <Color x:Key="RecapVioletLite">#FFB18CFF</Color>
+        <Color x:Key="RecapMagenta">#FFE84CF2</Color>
+        <SolidColorBrush x:Key="RecapVoidBrush" Color="{StaticResource RecapVoid}"/>
+        <SolidColorBrush x:Key="RecapInkBrush" Color="{StaticResource RecapInk}"/>
+        <SolidColorBrush x:Key="RecapInkDimBrush" Color="{StaticResource RecapInkDim}"/>
+        <SolidColorBrush x:Key="RecapLineBrush" Color="{StaticResource RecapLine}"/>
+        <SolidColorBrush x:Key="RecapVioletLiteBrush" Color="{StaticResource RecapVioletLite}"/>
+        <LinearGradientBrush x:Key="RecapStatusPillBrush" StartPoint="0%,0%" EndPoint="100%,100%">
+            <GradientStop Color="{StaticResource RecapMagenta}" Offset="0"/>
+            <GradientStop Color="{StaticResource RecapVioletLite}" Offset="1"/>
+        </LinearGradientBrush>
+
+        <!-- Share pill button -->
+        <ControlTheme x:Key="SharePill" TargetType="Button">
+            <Setter Property="Foreground" Value="{StaticResource RecapInkBrush}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="Medium"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Margin" Value="5,0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" CornerRadius="13" Padding="14,9"
+                            Background="#14B18CFF"
+                            BorderBrush="{StaticResource RecapLineBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Background" Value="#29B18CFF"/>
+                <Setter Property="BorderBrush" Value="{StaticResource RecapVioletLiteBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- Continue button (primary) -->
+        <ControlTheme x:Key="ContinueBtn" TargetType="Button">
+            <Setter Property="Foreground" Value="#FF160826"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" CornerRadius="13" Padding="22,11"
+                            Background="{StaticResource RecapStatusPillBrush}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Opacity" Value="0.9"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <StackPanel Margin="26,22,26,20" HorizontalAlignment="Center">
+        <!-- live animated card -->
+        <Border x:Name="PART_CardHost" HorizontalAlignment="Center"/>
+
+        <!-- share row -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,18,0,0">
+            <Button x:Name="BtnCopy" Theme="{StaticResource SharePill}"><TextBlock Text="{loc:Str recap_btn_copy}"/></Button>
+            <Button x:Name="BtnSave" Theme="{StaticResource SharePill}"><TextBlock Text="{loc:Str recap_btn_save}"/></Button>
+            <Button x:Name="BtnShareX" Theme="{StaticResource SharePill}"><TextBlock Text="{loc:Str recap_btn_share_x}"/></Button>
+            <Button x:Name="BtnShareReddit" Theme="{StaticResource SharePill}"><TextBlock Text="{loc:Str recap_btn_share_reddit}"/></Button>
+        </StackPanel>
+
+        <!-- in-window status line (the recap window sits above the MainWindow toast host, so
+             share confirmations surface here instead) -->
+        <TextBlock x:Name="PART_Status" FontSize="11.5" TextAlignment="Center" TextWrapping="Wrap"
+                   Foreground="{StaticResource RecapInkDimBrush}" Margin="0,12,0,0"
+                   MaxWidth="420" IsVisible="False"/>
+
+        <!-- continue to next season -->
+        <Button x:Name="BtnContinue" Theme="{StaticResource ContinueBtn}"
+                HorizontalAlignment="Center" Margin="0,16,0,0">
+            <TextBlock x:Name="TxtContinue"/>
+        </Button>
+
+        <TextBlock x:Name="PART_Note" Text="{loc:Str recap_share_note}"
+                   FontSize="10.5" TextAlignment="Center" TextWrapping="Wrap"
+                   Foreground="{StaticResource RecapInkDimBrush}" Margin="0,12,0,0" MaxWidth="420"/>
+    </StackPanel>
+</Window>

--- a/CCP.Avalonia/Views/Controls/SeasonRecapWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/SeasonRecapWindow.axaml.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// The season-rollover surface: the recap card plus the share actions and a "continue to next
+    /// season" button. Also reused as the secondary re-view surface from the profile/stats screen.
+    ///
+    /// PORTED from ConditioningControlPanel/Controls/SeasonRecapWindow.xaml.cs. Deviations:
+    ///  - <c>CardExporter</c> (RenderTargetBitmap, clipboard, Pictures folder) is WPF-head only, so
+    ///    the four share actions report <c>recap_toast_error</c> rather than claiming a card was
+    ///    copied or saved. <see cref="OpenUrl"/> is kept: UseShellExecute works on Linux.
+    ///  - A parameterless constructor with sample data exists for the headless render.
+    /// </summary>
+    public partial class SeasonRecapWindow : Window
+    {
+        private readonly SeasonRecapCardViewModel _vm;
+        private readonly SeasonRecapCard _card;
+        private readonly TextBlock _status;
+        private DispatcherTimer? _statusTimer;
+
+        /// <summary>Render constructor: sample data, so --render-all can discover the window.</summary>
+        public SeasonRecapWindow() : this(SeasonRecapCardViewModel.Sample()) { }
+
+        public SeasonRecapWindow(SeasonRecapCardViewModel vm)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _vm = vm ?? throw new ArgumentNullException(nameof(vm));
+
+            _card = new SeasonRecapCard { AnimateReveal = true };
+            _card.SetViewModel(vm);
+            this.FindControl<Border>("PART_CardHost")!.Child = _card;
+            _status = this.FindControl<TextBlock>("PART_Status")!;
+
+            this.FindControl<Button>("BtnCopy")!.Click += OnCopy;
+            this.FindControl<Button>("BtnSave")!.Click += OnSave;
+            this.FindControl<Button>("BtnShareX")!.Click += OnShareX;
+            this.FindControl<Button>("BtnShareReddit")!.Click += OnShareReddit;
+            this.FindControl<Button>("BtnContinue")!.Click += OnContinue;
+            this.FindControl<TextBlock>("TxtContinue")!.Text =
+                Loc.GetF("recap_btn_continue", _vm.NextSeasonNumber.ToString("00"));
+        }
+
+        // ---------- share actions ----------
+        // ponytail: needs CardExporter (WPF RenderTargetBitmap + clipboard + Pictures folder),
+        // wired when an Avalonia exporter exists. Until then every action says the card could not
+        // be prepared, which is true.
+        private void OnCopy(object? sender, RoutedEventArgs e) => ShowStatus(Loc.Get("recap_toast_error"));
+
+        private void OnSave(object? sender, RoutedEventArgs e) => ShowStatus(Loc.Get("recap_toast_error"));
+
+        private void OnShareX(object? sender, RoutedEventArgs e) => ShowStatus(Loc.Get("recap_toast_error"));
+
+        private void OnShareReddit(object? sender, RoutedEventArgs e) => ShowStatus(Loc.Get("recap_toast_error"));
+
+        private void OnContinue(object? sender, RoutedEventArgs e) => Close();
+
+        // ---------- helpers ----------
+        private static bool OpenUrl(string url)
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "SeasonRecap: failed to open URL {Url}", url);
+                return false;
+            }
+        }
+
+        private void ShowStatus(string message)
+        {
+            _status.Text = message;
+            _status.IsVisible = true;
+
+            _statusTimer?.Stop();
+            _statusTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(8) };
+            _statusTimer.Tick += (s, e) =>
+            {
+                _statusTimer?.Stop();
+                _status.IsVisible = false;
+            };
+            _statusTimer.Start();
+        }
+    }
+}


### PR DESCRIPTION
1,013 lines, 4 files; the window hosts the card. Card uses Liberation Sans metrics so the 585px layout fits; foil shimmer dropped.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351