### PR TITLE
feat(avalonia): port Deeper, part 1/2 - GazePickerWindow, NewEnhancementDialog

### DIFF
--- a/CCP.Avalonia/Views/Deeper/GazePickerWindow.axaml
+++ b/CCP.Avalonia/Views/Deeper/GazePickerWindow.axaml
@@ -1,0 +1,102 @@
+<!-- PORTED from ConditioningControlPanel/Views/Deeper/GazePickerWindow.xaml.
+     Structure, ordering and every resource key preserved. Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency  -> SystemDecorations="None" / TransparencyLevelHint
+       ResizeMode="NoResize"                    -> CanResize="False"
+       Visibility="Collapsed"                   -> IsVisible="False"
+       Mouse* / KeyDown events                  -> Pointer* / KeyDown, wired in code-behind
+       Cursor="SizeNWSE" etc.                   -> Avalonia's StandardCursorType names
+       TxtHint set from code                    -> {loc:Str} here; same static key
+
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key and every loc key here is snake_case. See the porting notes in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Deeper.GazePickerWindow"
+        SystemDecorations="None"
+        CanResize="False"
+        ShowInTaskbar="False"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        WindowStartupLocation="Manual">
+
+    <Grid>
+        <!-- Semi-transparent backdrop so the user can see the video underneath
+             but knows they're in pick mode. -->
+        <Border Background="{DynamicResource DeeperGazePickerBackdropBrush}"/>
+
+        <!-- The pick canvas. All click/drag happens against this. -->
+        <Canvas x:Name="PickCanvas" Background="Transparent">
+
+            <!-- The live rect outline. Fill is semi-transparent so the user
+                 can still see what's inside. Stroke + fill pick up the Deeper
+                 accent — change DeeperAccent in Colors.xaml and this follows. -->
+            <Rectangle x:Name="RectShape"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="2"
+                       Fill="{DynamicResource DeeperAccentTransparent40Brush}"
+                       IsVisible="False"/>
+
+            <!-- Eight resize handles. Created here so they share z-order with
+                 the rect; positioned in code. -->
+            <Rectangle x:Name="HandleNW" Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="TopLeftCorner" IsVisible="False" Tag="NW"/>
+            <Rectangle x:Name="HandleN"  Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="SizeNorthSouth" IsVisible="False" Tag="N"/>
+            <Rectangle x:Name="HandleNE" Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="TopRightCorner" IsVisible="False" Tag="NE"/>
+            <Rectangle x:Name="HandleE"  Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="SizeWestEast" IsVisible="False" Tag="E"/>
+            <Rectangle x:Name="HandleSE" Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="BottomRightCorner" IsVisible="False" Tag="SE"/>
+            <Rectangle x:Name="HandleS"  Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="SizeNorthSouth" IsVisible="False" Tag="S"/>
+            <Rectangle x:Name="HandleSW" Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="BottomLeftCorner" IsVisible="False" Tag="SW"/>
+            <Rectangle x:Name="HandleW"  Width="12" Height="12"
+                       Fill="{DynamicResource DeeperGazePickerHandleFillBrush}"
+                       Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="1.5"
+                       Cursor="SizeWestEast" IsVisible="False" Tag="W"/>
+        </Canvas>
+
+        <!-- Top hint bar with live coords + Done / Cancel. -->
+        <Border VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,12,0,0"
+                Background="{DynamicResource DeeperGazePickerToolbarBgBrush}" Padding="14,8" CornerRadius="6"
+                BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+            <DockPanel LastChildFill="False">
+                <TextBlock x:Name="TxtHint" DockPanel.Dock="Left" Text="{loc:Str deeper_editor_gaze_pick_hint}"
+                           Foreground="White" FontSize="12"
+                           VerticalAlignment="Center" Margin="0,0,16,0"/>
+                <TextBlock x:Name="TxtCoords" DockPanel.Dock="Left"
+                           Foreground="{DynamicResource DeeperAccentSoftBrush}" FontSize="11"
+                           FontFamily="Consolas, Courier New" VerticalAlignment="Center" Margin="0,0,16,0"/>
+                <Button x:Name="BtnDone" DockPanel.Dock="Right" Margin="8,0,0,0"
+                        Padding="14,6" Cursor="Hand" FontSize="11" FontWeight="SemiBold"
+                        Background="{DynamicResource DeeperAccentBrush}" Foreground="White" BorderThickness="0">
+                    <TextBlock Text="{loc:Str deeper_editor_gaze_pick_done}"/>
+                </Button>
+                <Button x:Name="BtnCancel" DockPanel.Dock="Right"
+                        Padding="14,6" Cursor="Hand" FontSize="11"
+                        Background="Transparent" Foreground="White"
+                        BorderBrush="{DynamicResource DeeperGazePickerCancelBorderBrush}" BorderThickness="1">
+                    <TextBlock Text="{loc:Str deeper_editor_gaze_pick_cancel}"/>
+                </Button>
+            </DockPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Deeper/GazePickerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/GazePickerWindow.axaml.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// Transparent borderless window positioned over the editor's video preview
+    /// area for picking a gaze-target rect. Coordinates fed back to the caller are
+    /// normalized [x, y, w, h] in [0, 1] relative to the preview host.
+    ///
+    /// PORTED from ConditioningControlPanel/Views/Deeper/GazePickerWindow.xaml.cs. Deviations:
+    ///  - Mouse* handlers become Pointer* handlers; capture goes through e.Pointer.
+    ///  - ActualWidth/Height become Bounds.Width/Height.
+    ///  - Handlers are wired in the constructor, per the porting convention.
+    /// </summary>
+    public partial class GazePickerWindow : Window
+    {
+        private double[] _rect = new[] { 0.25, 0.25, 0.5, 0.5 };
+        private DragMode _drag = DragMode.None;
+        private Point _dragStart;          // canvas coords at pointer-down
+        private readonly double[] _dragStartRect = new double[4];
+
+        private readonly Canvas _canvas;
+        private readonly Rectangle _rectShape;
+        private readonly TextBlock _txtCoords;
+        private readonly Rectangle _nw, _n, _ne, _e, _se, _s, _sw, _w;
+
+        /// <summary>Set true if the user clicked Done (rect should be applied).</summary>
+        public bool Committed { get; private set; }
+
+        /// <summary>Final normalized rect; meaningful only if <see cref="Committed"/> is true.</summary>
+        public double[] ResultRect => (double[])_rect.Clone();
+
+        /// <summary>Render constructor: the default quarter-inset rect, so --render-all can draw it.</summary>
+        public GazePickerWindow() : this(null) { }
+
+        public GazePickerWindow(double[]? initial)
+        {
+            AvaloniaXamlLoader.Load(this);
+            if (initial != null && initial.Length >= 4)
+                _rect = (double[])initial.Clone();
+            ClampRect();
+
+            _canvas = this.FindControl<Canvas>("PickCanvas")!;
+            _rectShape = this.FindControl<Rectangle>("RectShape")!;
+            _txtCoords = this.FindControl<TextBlock>("TxtCoords")!;
+            _nw = this.FindControl<Rectangle>("HandleNW")!;
+            _n = this.FindControl<Rectangle>("HandleN")!;
+            _ne = this.FindControl<Rectangle>("HandleNE")!;
+            _e = this.FindControl<Rectangle>("HandleE")!;
+            _se = this.FindControl<Rectangle>("HandleSE")!;
+            _s = this.FindControl<Rectangle>("HandleS")!;
+            _sw = this.FindControl<Rectangle>("HandleSW")!;
+            _w = this.FindControl<Rectangle>("HandleW")!;
+
+            foreach (var h in new[] { _nw, _n, _ne, _e, _se, _s, _sw, _w })
+                h.PointerPressed += Handle_PointerPressed;
+
+            _canvas.PointerPressed += PickCanvas_PointerPressed;
+            _canvas.PointerMoved += PickCanvas_PointerMoved;
+            _canvas.PointerReleased += PickCanvas_PointerReleased;
+            _canvas.SizeChanged += (_, _) => RenderRect();
+
+            this.FindControl<Button>("BtnDone")!.Click += (_, _) => { Committed = true; Close(); };
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => { Committed = false; Close(); };
+            KeyDown += Window_KeyDown;
+        }
+
+        private enum DragMode { None, NewRect, Move, ResizeNW, ResizeN, ResizeNE, ResizeE, ResizeSE, ResizeS, ResizeSW, ResizeW }
+
+        // -- Pointer on the picker canvas (background) ------------------------
+
+        private void PickCanvas_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(_canvas).Properties.IsLeftButtonPressed) return;
+            var p = e.GetPosition(_canvas);
+            // If the click is inside the existing rect, it's a move. Otherwise
+            // start a fresh rectangle (overwriting the existing one).
+            if (_rect[2] > 0 && _rect[3] > 0 && IsInsideRect(p))
+            {
+                BeginDrag(DragMode.Move, p);
+            }
+            else
+            {
+                BeginDrag(DragMode.NewRect, p);
+                _rect[0] = p.X / Math.Max(1, _canvas.Bounds.Width);
+                _rect[1] = p.Y / Math.Max(1, _canvas.Bounds.Height);
+                _rect[2] = 0.001;
+                _rect[3] = 0.001;
+                RenderRect();
+            }
+            e.Pointer.Capture(_canvas);
+            e.Handled = true;
+        }
+
+        private void PickCanvas_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_drag == DragMode.None || !e.GetCurrentPoint(_canvas).Properties.IsLeftButtonPressed) return;
+            ApplyDrag(e.GetPosition(_canvas));
+        }
+
+        private void PickCanvas_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (_drag == DragMode.None) return;
+            e.Pointer.Capture(null);
+            _drag = DragMode.None;
+            // Drop sub-pixel rects from accidental clicks so the rect picker
+            // doesn't end up with a 0.001 x 0.001 ghost.
+            if (_rect[2] < 0.01 || _rect[3] < 0.01)
+            {
+                _rect[2] = Math.Max(_rect[2], 0.05);
+                _rect[3] = Math.Max(_rect[3], 0.05);
+                ClampRect();
+                RenderRect();
+            }
+        }
+
+        // -- Pointer on a resize handle ---------------------------------------
+
+        private void Handle_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is not Rectangle r || r.Tag is not string tag) return;
+            if (!e.GetCurrentPoint(_canvas).Properties.IsLeftButtonPressed) return;
+            var mode = tag switch
+            {
+                "NW" => DragMode.ResizeNW,
+                "N"  => DragMode.ResizeN,
+                "NE" => DragMode.ResizeNE,
+                "E"  => DragMode.ResizeE,
+                "SE" => DragMode.ResizeSE,
+                "S"  => DragMode.ResizeS,
+                "SW" => DragMode.ResizeSW,
+                "W"  => DragMode.ResizeW,
+                _ => DragMode.None
+            };
+            if (mode == DragMode.None) return;
+            BeginDrag(mode, e.GetPosition(_canvas));
+            e.Pointer.Capture(_canvas);
+            e.Handled = true;
+        }
+
+        // -- Drag mechanics ----------------------------------------------------
+
+        private void BeginDrag(DragMode mode, Point p)
+        {
+            _drag = mode;
+            _dragStart = p;
+            Array.Copy(_rect, _dragStartRect, 4);
+        }
+
+        private void ApplyDrag(Point p)
+        {
+            var w = Math.Max(1, _canvas.Bounds.Width);
+            var h = Math.Max(1, _canvas.Bounds.Height);
+            var dx = (p.X - _dragStart.X) / w;
+            var dy = (p.Y - _dragStart.Y) / h;
+            var px = p.X / w;
+            var py = p.Y / h;
+            var sx = _dragStartRect[0];
+            var sy = _dragStartRect[1];
+            var sw = _dragStartRect[2];
+            var sh = _dragStartRect[3];
+
+            switch (_drag)
+            {
+                case DragMode.NewRect:
+                    _rect[0] = Math.Min(sx, px);
+                    _rect[1] = Math.Min(sy, py);
+                    _rect[2] = Math.Abs(px - sx);
+                    _rect[3] = Math.Abs(py - sy);
+                    break;
+                case DragMode.Move:
+                    _rect[0] = Math.Clamp(sx + dx, 0, 1 - sw);
+                    _rect[1] = Math.Clamp(sy + dy, 0, 1 - sh);
+                    break;
+                case DragMode.ResizeNW:
+                    ResizeFromAnchor(sx + sw, sy + sh, px, py);
+                    break;
+                case DragMode.ResizeN:
+                    _rect[1] = Math.Min(sy + sh - 0.005, py);
+                    _rect[3] = (sy + sh) - _rect[1];
+                    break;
+                case DragMode.ResizeNE:
+                    ResizeFromAnchor(sx, sy + sh, px, py);
+                    break;
+                case DragMode.ResizeE:
+                    _rect[2] = Math.Max(0.005, px - sx);
+                    break;
+                case DragMode.ResizeSE:
+                    ResizeFromAnchor(sx, sy, px, py);
+                    break;
+                case DragMode.ResizeS:
+                    _rect[3] = Math.Max(0.005, py - sy);
+                    break;
+                case DragMode.ResizeSW:
+                    ResizeFromAnchor(sx + sw, sy, px, py);
+                    break;
+                case DragMode.ResizeW:
+                    _rect[0] = Math.Min(sx + sw - 0.005, px);
+                    _rect[2] = (sx + sw) - _rect[0];
+                    break;
+            }
+            ClampRect();
+            RenderRect();
+        }
+
+        private void ResizeFromAnchor(double anchorX, double anchorY, double px, double py)
+        {
+            _rect[0] = Math.Min(anchorX, px);
+            _rect[1] = Math.Min(anchorY, py);
+            _rect[2] = Math.Abs(anchorX - px);
+            _rect[3] = Math.Abs(anchorY - py);
+        }
+
+        private void ClampRect()
+        {
+            _rect[0] = Math.Clamp(_rect[0], 0, 1);
+            _rect[1] = Math.Clamp(_rect[1], 0, 1);
+            _rect[2] = Math.Max(0.005, Math.Min(_rect[2], 1 - _rect[0]));
+            _rect[3] = Math.Max(0.005, Math.Min(_rect[3], 1 - _rect[1]));
+        }
+
+        private bool IsInsideRect(Point p)
+        {
+            var w = _canvas.Bounds.Width;
+            var h = _canvas.Bounds.Height;
+            if (w <= 0 || h <= 0) return false;
+            var rx = _rect[0] * w;
+            var ry = _rect[1] * h;
+            var rw = _rect[2] * w;
+            var rh = _rect[3] * h;
+            // Inset slightly so click-on-handle is preferred over click-inside-edge.
+            const double inset = 8;
+            return p.X > rx + inset && p.X < rx + rw - inset
+                && p.Y > ry + inset && p.Y < ry + rh - inset;
+        }
+
+        // -- Render ------------------------------------------------------------
+
+        private void RenderRect()
+        {
+            var w = _canvas.Bounds.Width;
+            var h = _canvas.Bounds.Height;
+            if (w <= 0 || h <= 0) return;
+
+            var rx = _rect[0] * w;
+            var ry = _rect[1] * h;
+            var rw = Math.Max(2, _rect[2] * w);
+            var rh = Math.Max(2, _rect[3] * h);
+
+            _rectShape.IsVisible = true;
+            _rectShape.Width = rw;
+            _rectShape.Height = rh;
+            Canvas.SetLeft(_rectShape, rx);
+            Canvas.SetTop(_rectShape, ry);
+
+            PositionHandle(_nw, rx, ry);
+            PositionHandle(_n,  rx + rw / 2, ry);
+            PositionHandle(_ne, rx + rw, ry);
+            PositionHandle(_e,  rx + rw, ry + rh / 2);
+            PositionHandle(_se, rx + rw, ry + rh);
+            PositionHandle(_s,  rx + rw / 2, ry + rh);
+            PositionHandle(_sw, rx, ry + rh);
+            PositionHandle(_w,  rx, ry + rh / 2);
+
+            _txtCoords.Text = string.Format(CultureInfo.InvariantCulture,
+                "x={0:0.000}  y={1:0.000}  w={2:0.000}  h={3:0.000}",
+                _rect[0], _rect[1], _rect[2], _rect[3]);
+        }
+
+        private static void PositionHandle(Rectangle h, double cx, double cy)
+        {
+            h.IsVisible = true;
+            Canvas.SetLeft(h, cx - h.Width / 2);
+            Canvas.SetTop(h, cy - h.Height / 2);
+        }
+
+        // -- Commit / cancel ---------------------------------------------------
+
+        private void Window_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape) { Committed = false; Close(); }
+            else if (e.Key == Key.Enter) { Committed = true; Close(); }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml
+++ b/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml
@@ -1,0 +1,141 @@
+<!-- PORTED from ConditioningControlPanel/Views/Deeper/NewEnhancementDialog.xaml.
+     Structure, ordering and every resource key preserved. Deviations, all forced:
+
+       WindowStyle="None"          -> SystemDecorations="None"
+       ResizeMode="NoResize"       -> CanResize="False"
+       ToolTip="{loc:Str …}"       -> ToolTip.Tip="{loc:Str …}"
+       Click="…"                   -> wired in the constructor
+       MessageBox on empty source  -> TxtError TextBlock under the source hint (Avalonia has no
+                                      MessageBox; same pattern as Dialogs/UrlPromptDialog)
+
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key and every loc key here is snake_case. See the porting notes in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Deeper.NewEnhancementDialog"
+        Title="{loc:Str deeper_dialog_new_title}"
+        Height="410" Width="540"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False"
+        SystemDecorations="None">
+
+    <Border BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1" CornerRadius="0">
+        <Grid Margin="22">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/> <!-- title -->
+                <RowDefinition Height="Auto"/> <!-- subtitle -->
+                <RowDefinition Height="Auto"/> <!-- media type label -->
+                <RowDefinition Height="Auto"/> <!-- media type radios -->
+                <RowDefinition Height="Auto"/> <!-- source label -->
+                <RowDefinition Height="Auto"/> <!-- source picker -->
+                <RowDefinition Height="Auto"/> <!-- source hint -->
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/> <!-- buttons -->
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="{loc:Str deeper_dialog_new_title}"
+                       Foreground="{DynamicResource DeeperAccentBrush}"
+                       FontSize="18" FontWeight="Bold" Margin="0,0,0,4"/>
+            <TextBlock Grid.Row="1" Text="{loc:Str deeper_dialog_new_subtitle}"
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                       TextWrapping="Wrap" Margin="0,0,0,18"/>
+
+            <TextBlock Grid.Row="2" Text="{loc:Str deeper_dialog_media_type_label}"
+                       Foreground="{DynamicResource TextLightBrush}" FontSize="12" FontWeight="SemiBold"
+                       Margin="0,0,0,6"/>
+
+            <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,0,0,16">
+                <RadioButton x:Name="RbVideo" Content="🎬  Video" IsChecked="True" GroupName="MediaType"
+                             Foreground="{DynamicResource TextLightBrush}" FontSize="13"
+                             Padding="8,6" Margin="0,0,16,0"/>
+                <RadioButton x:Name="RbAudio" Content="🎵  Audio" GroupName="MediaType"
+                             Foreground="{DynamicResource TextLightBrush}" FontSize="13"
+                             Padding="8,6"/>
+            </StackPanel>
+
+            <TextBlock Grid.Row="4" Text="{loc:Str deeper_dialog_source_label}"
+                       Foreground="{DynamicResource TextLightBrush}" FontSize="12" FontWeight="SemiBold"
+                       Margin="0,0,0,6"/>
+
+            <Grid Grid.Row="5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="TxtSource" Grid.Column="0"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White"
+                         BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                         Padding="10,8" FontSize="13"/>
+                <Button x:Name="BtnBrowse" Grid.Column="1"
+                        Padding="14,8" Margin="8,0,0,0" Cursor="Hand"
+                        Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                        Foreground="{DynamicResource DeeperAccentSoftBrush}"
+                        BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                    <TextBlock Text="{loc:Str btn_browse}"/>
+                </Button>
+            </Grid>
+
+            <StackPanel Grid.Row="6">
+                <TextBlock Text="{loc:Str deeper_dialog_source_hint}"
+                           Foreground="{DynamicResource TextDimBrush}" FontSize="11"
+                           Margin="0,6,0,0" TextWrapping="Wrap"/>
+                <TextBlock x:Name="TxtError" Text="{loc:Str deeper_dialog_source_required}"
+                           Foreground="#FFFF6B6B" FontSize="11"
+                           Margin="0,4,0,0" TextWrapping="Wrap" IsVisible="False"/>
+            </StackPanel>
+
+            <!-- Three interactive on-rails tutorials: each walks the user through
+                 producing a finished .ccpenh.json file end-to-end. -->
+            <StackPanel Grid.Row="7" Orientation="Vertical" Margin="0,12,0,0">
+                <TextBlock Text="{loc:Str deeper_tutorial_header}"
+                           Foreground="{DynamicResource TextDimBrush}" FontSize="11"
+                           Margin="0,0,0,6"/>
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="BtnLocalVideoTutorial"
+                            ToolTip.Tip="{loc:Str deeper_tutorial_local_video_tooltip}"
+                            Padding="10,6" Margin="0,0,8,0" Cursor="Hand" FontSize="11"
+                            Background="Transparent"
+                            Foreground="{DynamicResource DeeperAccentSoftBrush}"
+                            BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                            BorderThickness="1">
+                        <TextBlock Text="{loc:Str deeper_tutorial_local_video_btn}"/>
+                    </Button>
+                    <Button x:Name="BtnLocalAudioTutorial"
+                            ToolTip.Tip="{loc:Str deeper_tutorial_local_audio_tooltip}"
+                            Padding="10,6" Margin="0,0,8,0" Cursor="Hand" FontSize="11"
+                            Background="Transparent"
+                            Foreground="{DynamicResource DeeperAccentSoftBrush}"
+                            BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                            BorderThickness="1">
+                        <TextBlock Text="{loc:Str deeper_tutorial_local_audio_btn}"/>
+                    </Button>
+                    <Button x:Name="BtnTryHypnoTubeTutorial"
+                            ToolTip.Tip="{loc:Str deeper_tutorial_ht_tooltip}"
+                            Padding="10,6" Cursor="Hand" FontSize="11"
+                            Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                            Foreground="{DynamicResource DeeperAccentSoftBrush}"
+                            BorderBrush="{DynamicResource DeeperAccentBrush}"
+                            BorderThickness="1">
+                        <TextBlock Text="{loc:Str deeper_tutorial_ht_btn}"/>
+                    </Button>
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+                <Button x:Name="BtnCancel" Width="90" Padding="10,8" Margin="0,0,10,0"
+                        Background="{DynamicResource PanelAccentBrush}" Foreground="White" BorderThickness="0"
+                        Cursor="Hand">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnCreate" Width="120" Padding="10,8"
+                        Background="{DynamicResource DeeperAccentBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold"
+                        Cursor="Hand">
+                    <TextBlock Text="{loc:Str deeper_dialog_create}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models.Deeper;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Deeper/NewEnhancementDialog.xaml.cs. Deviations:
+    ///  - DialogResult becomes Close(bool); callers use ShowDialog&lt;bool&gt;.
+    ///  - OpenFileDialog becomes the StorageProvider file picker.
+    ///  - The three interactive tutorials and the last-directory memory are stubs: TutorialService,
+    ///    TutorialOverlay, EnhancementLibrary and AppSettings all still live in the WPF head.
+    /// </summary>
+    public partial class NewEnhancementDialog : Window
+    {
+        public string SelectedMediaType { get; private set; } = MediaTypes.Video;
+        public string SelectedSource { get; private set; } = "";
+
+        private readonly RadioButton _rbVideo;
+        private readonly RadioButton _rbAudio;
+        private readonly TextBox _txtSource;
+        private readonly TextBlock _txtError;
+
+        public NewEnhancementDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _rbVideo = this.FindControl<RadioButton>("RbVideo")!;
+            _rbAudio = this.FindControl<RadioButton>("RbAudio")!;
+            _txtSource = this.FindControl<TextBox>("TxtSource")!;
+            _txtError = this.FindControl<TextBlock>("TxtError")!;
+
+            this.FindControl<Button>("BtnBrowse")!.Click += async (_, _) => await BrowseAsync();
+            this.FindControl<Button>("BtnLocalVideoTutorial")!.Click += (_, _) => { _rbVideo.IsChecked = true; StartInteractiveTutorial(); };
+            this.FindControl<Button>("BtnLocalAudioTutorial")!.Click += (_, _) => { _rbAudio.IsChecked = true; StartInteractiveTutorial(); };
+            this.FindControl<Button>("BtnTryHypnoTubeTutorial")!.Click += (_, _) => BtnTryHypnoTubeTutorial_Click();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnCreate")!.Click += (_, _) => BtnCreate_Click();
+        }
+
+        private async System.Threading.Tasks.Task BrowseAsync()
+        {
+            var isVideo = _rbVideo.IsChecked == true;
+            // ponytail: needs EnhancementLibrary.LastDirectory for SuggestedStartLocation, wired when it moves to Core
+            var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = Loc.Get(isVideo ? "deeper_dialog_pick_video" : "deeper_dialog_pick_audio"),
+                AllowMultiple = false,
+                FileTypeFilter = new List<FilePickerFileType>
+                {
+                    isVideo
+                        ? new FilePickerFileType("Video files") { Patterns = new[] { "*.mp4", "*.webm", "*.mkv", "*.mov", "*.avi", "*.m4v" } }
+                        : new FilePickerFileType("Audio files") { Patterns = new[] { "*.mp3", "*.wav", "*.m4a", "*.aac", "*.flac", "*.ogg" } },
+                    FilePickerFileTypes.All,
+                },
+            });
+            if (files.Count > 0)
+                _txtSource.Text = files[0].TryGetLocalPath() ?? files[0].Path.ToString();
+        }
+
+        private void BtnTryHypnoTubeTutorial_Click()
+        {
+            // ponytail: needs AvatarTubeWindow.KnownVideoLinks and AppSettings.HasSeenDeeperHTInteractiveTutorial, wired when they move to Core
+            _rbVideo.IsChecked = true;
+            _txtSource.Text = "https://hypnotube.com/video/bambis-naughty-tiktok-collection-117314.html";
+            StartInteractiveTutorial();
+        }
+
+        private void StartInteractiveTutorial()
+        {
+            // ponytail: needs TutorialService + TutorialOverlay + TutorialEventBus.PendingPart2Tutorial, wired when they move to Core
+        }
+
+        private void BtnCreate_Click()
+        {
+            var source = _txtSource.Text?.Trim() ?? "";
+            if (string.IsNullOrEmpty(source))
+            {
+                _txtError.IsVisible = true;
+                return;
+            }
+            SelectedMediaType = _rbVideo.IsChecked == true ? MediaTypes.Video : MediaTypes.Audio;
+            SelectedSource = source;
+            Close(true);
+        }
+    }
+}


### PR DESCRIPTION
624 lines, 4 files.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351