### PR TITLE
feat(avalonia): port reports, part 2/2 - BugReportWindow, MyReportsWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/BugReportWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/BugReportWindow.axaml
@@ -1,0 +1,174 @@
+<!-- PORTED from ConditioningControlPanel/Windows/BugReportWindow.xaml.
+     Structure, ordering and every resource key preserved. Deviations, all forced:
+
+       Style="{StaticResource X}"        -> Theme="{StaticResource X}"; FormBox is a ControlTheme
+                                            BasedOn the default TextBox (trap 4 in CLAUDE.md)
+       ResizeMode="CanResizeWithGrip"    -> CanResize="True"
+       Visibility="Collapsed"            -> IsVisible="False"
+       VerticalScrollBarVisibility       -> ScrollViewer.VerticalScrollBarVisibility (attached)
+       IsReadOnlyCaretVisible            -> dropped, no Avalonia equivalent
+       Click / TextChanged / Checked     -> wired in the constructor
+       Title/TxtHeaderTitle/TxtPrivacyNotice/LblDescription lose {loc:Str}: they depend on
+       ReportKind and a local Text set does not clear an Avalonia binding, so a language
+       change would revert a suggestion dialog to bug wording. ApplyKind sets them.
+
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key and every loc key here is snake_case. See the porting notes in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.BugReportWindow"
+        Width="760" Height="780"
+        WindowStartupLocation="CenterOwner"
+        Background="#0F0F1E"
+        Foreground="#E0E0E0"
+        CanResize="True"
+        MinWidth="560" MinHeight="560">
+    <Window.Resources>
+        <!-- ponytail: local copy of Windows/BugReportWindow.xaml:FormLabel/FormBox, hoist when a second view needs them -->
+        <ControlTheme x:Key="FormLabel" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0,10,0,4"/>
+        </ControlTheme>
+        <ControlTheme x:Key="FormBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="Background" Value="#1A1A2E"/>
+            <Setter Property="Foreground" Value="#E0E0E0"/>
+            <Setter Property="BorderBrush" Value="#3D3D60"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="8,6"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="AcceptsReturn" Value="True"/>
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,6">
+            <TextBlock x:Name="TxtHeaderTitle"
+                       Foreground="{DynamicResource PinkBrush}"
+                       FontSize="20" FontWeight="Bold"/>
+            <TextBlock x:Name="TxtPrivacyNotice"
+                       Foreground="#9898B0" FontSize="11" TextWrapping="Wrap"
+                       Margin="0,6,0,0"/>
+        </StackPanel>
+
+        <!-- Scrollable form body -->
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,8,0,8">
+            <StackPanel>
+                <TextBlock x:Name="LblDescription" Theme="{StaticResource FormLabel}"/>
+                <TextBox x:Name="TxtDescription" Theme="{StaticResource FormBox}"
+                         Height="80" MaxLength="4000"/>
+
+                <TextBlock x:Name="LblSteps" Text="{loc:Str bug_report_steps_label}" Theme="{StaticResource FormLabel}"/>
+                <TextBox x:Name="TxtSteps" Theme="{StaticResource FormBox}"
+                         Height="70" MaxLength="4000"/>
+
+                <TextBlock Text="{loc:Str bug_report_metadata_label}" Theme="{StaticResource FormLabel}"/>
+                <Border Background="#14142A" BorderBrush="#3D3D60" BorderThickness="1" CornerRadius="4" Padding="10,8">
+                    <TextBlock x:Name="TxtMetadataSummary" Foreground="#B0B0C8" FontSize="11"
+                               FontFamily="Consolas, Courier New" TextWrapping="Wrap"/>
+                </Border>
+
+                <CheckBox x:Name="ChkIncludeAppLog"
+                          Foreground="#D0D0E0" FontSize="12"
+                          Margin="0,14,0,0" IsChecked="False">
+                    <TextBlock Text="{loc:Str bug_report_include_log_checkbox}"/>
+                </CheckBox>
+
+                <TextBlock x:Name="TxtScrubberCounts" Foreground="#9898B0" FontSize="11"
+                           Margin="0,10,0,0" TextWrapping="Wrap"/>
+
+                <TextBlock Text="{loc:Str bug_report_preview_label}" Theme="{StaticResource FormLabel}"/>
+                <Border Background="#0A0A18" BorderBrush="#3D3D60" BorderThickness="1" CornerRadius="4">
+                    <TextBox x:Name="TxtPreview" IsReadOnly="True" TextWrapping="NoWrap"
+                             Background="Transparent" Foreground="#B0B0C8" BorderThickness="0"
+                             FontFamily="Consolas, Courier New" FontSize="11"
+                             Height="260"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
+
+        <!-- Footer buttons -->
+        <Grid Grid.Row="2" Margin="0,4,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Name="TxtStatus" Grid.Column="0" Foreground="#9898B0" FontSize="11"
+                       VerticalAlignment="Center" TextWrapping="Wrap"/>
+            <Button x:Name="BtnCancel" Grid.Column="1"
+                    Background="#1A1A2E" Foreground="#C0C0D0" BorderBrush="#3D3D60"
+                    BorderThickness="1" Padding="18,8" Margin="0,0,10,0" Cursor="Hand">
+                <TextBlock Text="{loc:Str bug_report_cancel}"/>
+            </Button>
+            <Button x:Name="BtnSend" Grid.Column="2"
+                    Background="{DynamicResource PinkBrush}" Foreground="White"
+                    BorderThickness="0" Padding="22,8" Cursor="Hand"
+                    FontWeight="SemiBold" IsEnabled="False">
+                <TextBlock Text="{loc:Str bug_report_send}"/>
+            </Button>
+        </Grid>
+
+        <!-- Success panel (#769). Covers the form once the report is filed so the report
+             number is selectable + copyable instead of vanishing with a MessageBox. -->
+        <Border x:Name="SuccessPanel" Grid.Row="0" Grid.RowSpan="3"
+                IsVisible="False"
+                Background="#0F0F1E" Margin="-20">
+            <Border Background="#14142A" BorderBrush="{DynamicResource PinkBrush}"
+                    BorderThickness="2" CornerRadius="12" Padding="24"
+                    Margin="34" VerticalAlignment="Center" HorizontalAlignment="Stretch">
+                <StackPanel>
+                    <TextBlock x:Name="TxtSuccessHeadline"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="18" FontWeight="Bold" TextWrapping="Wrap"/>
+
+                    <TextBlock x:Name="LblSuccessTokenLabel" Text="{loc:Str bug_report_token_label}"
+                               Theme="{StaticResource FormLabel}" Margin="0,18,0,4"/>
+                    <Grid x:Name="SuccessTokenRow">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox x:Name="TxtSuccessToken" Grid.Column="0"
+                                 IsReadOnly="True"
+                                 Background="#0A0A18" Foreground="#FFFFFF"
+                                 BorderBrush="#3D3D60" BorderThickness="1"
+                                 FontFamily="Consolas, Courier New" FontSize="16" FontWeight="Bold"
+                                 Padding="10,8" VerticalContentAlignment="Center"
+                                 TextWrapping="NoWrap" AcceptsReturn="False"/>
+                        <Button x:Name="BtnCopyToken" Grid.Column="1"
+                                Background="#1A1A2E" Foreground="#E0E0E0" BorderBrush="#3D3D60"
+                                BorderThickness="1" Padding="18,8" Margin="8,0,0,0" Cursor="Hand">
+                            <TextBlock x:Name="TxtCopyToken" Text="{loc:Str btn_copy}"/>
+                        </Button>
+                    </Grid>
+
+                    <TextBlock x:Name="TxtSuccessHint" Text="{loc:Str bug_report_token_hint}"
+                               Foreground="#9898B0" FontSize="12" TextWrapping="Wrap"
+                               Margin="0,14,0,0"/>
+
+                    <Button x:Name="BtnSuccessDone"
+                            HorizontalAlignment="Right" Margin="0,20,0,0"
+                            Background="{DynamicResource PinkBrush}" Foreground="White"
+                            BorderThickness="0" Padding="26,8" Cursor="Hand"
+                            FontWeight="SemiBold">
+                        <TextBlock Text="{loc:Str btn_done}"/>
+                    </Button>
+                </StackPanel>
+            </Border>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/BugReportWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/BugReportWindow.axaml.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Modal bug report dialog. Collects description + steps from the user, shows the exact
+    /// outgoing payload in a read-only preview, and submits when the user clicks Send.
+    /// Send is disabled for 2 seconds after the window opens to force the user to look at the
+    /// preview before submitting.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/BugReportWindow.xaml.cs. Deviations:
+    ///  - BugReportService still lives in the WPF head, so the draft/preview are placeholder text
+    ///    and Send stays disabled with a "coming soon" status. The 2 s enable timer and the
+    ///    submit/error paths come back with the service. The success panel is reachable only
+    ///    through the internal render hook.
+    ///  - Clipboard goes through TopLevel.Clipboard (async).
+    /// </summary>
+    public partial class BugReportWindow : Window
+    {
+        /// <summary>Mirrors BugReportService.ReportKind, which is still in the WPF head.</summary>
+        public enum ReportKind { Bug, Suggestion }
+
+        private readonly ReportKind _kind;
+
+        private readonly TextBox _txtDescription, _txtSteps, _txtPreview, _txtSuccessToken;
+        private readonly TextBlock _txtMetadataSummary, _txtScrubberCounts, _txtStatus, _txtSuccessHeadline,
+            _lblSuccessTokenLabel, _txtSuccessHint, _txtCopyToken;
+        private readonly CheckBox _chkIncludeAppLog;
+        private readonly Button _btnSend, _btnCancel, _btnSuccessDone;
+        private readonly Border _successPanel;
+        private readonly Grid _successTokenRow;
+
+        public BugReportWindow() : this(ReportKind.Bug) { }
+
+        public BugReportWindow(ReportKind kind)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _kind = kind;
+
+            _txtDescription = this.FindControl<TextBox>("TxtDescription")!;
+            _txtSteps = this.FindControl<TextBox>("TxtSteps")!;
+            _txtPreview = this.FindControl<TextBox>("TxtPreview")!;
+            _txtSuccessToken = this.FindControl<TextBox>("TxtSuccessToken")!;
+            _txtMetadataSummary = this.FindControl<TextBlock>("TxtMetadataSummary")!;
+            _txtScrubberCounts = this.FindControl<TextBlock>("TxtScrubberCounts")!;
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+            _txtSuccessHeadline = this.FindControl<TextBlock>("TxtSuccessHeadline")!;
+            _lblSuccessTokenLabel = this.FindControl<TextBlock>("LblSuccessTokenLabel")!;
+            _txtSuccessHint = this.FindControl<TextBlock>("TxtSuccessHint")!;
+            _txtCopyToken = this.FindControl<TextBlock>("TxtCopyToken")!;
+            _chkIncludeAppLog = this.FindControl<CheckBox>("ChkIncludeAppLog")!;
+            _btnSend = this.FindControl<Button>("BtnSend")!;
+            _btnCancel = this.FindControl<Button>("BtnCancel")!;
+            _btnSuccessDone = this.FindControl<Button>("BtnSuccessDone")!;
+            _successPanel = this.FindControl<Border>("SuccessPanel")!;
+            _successTokenRow = this.FindControl<Grid>("SuccessTokenRow")!;
+
+            ApplyKind();
+
+            _txtDescription.TextChanged += (_, _) => RefreshPreview();
+            _txtSteps.TextChanged += (_, _) => RefreshPreview();
+            _chkIncludeAppLog.IsCheckedChanged += (_, _) => RefreshPreview();
+            _btnCancel.Click += (_, _) => Close();
+            this.FindControl<Button>("BtnCopyToken")!.Click += async (_, _) => await CopyTokenAsync();
+            _btnSuccessDone.Click += (_, _) => Close();
+
+            // WPF ran this from Loaded. The preview is filled here so the headless render shows it.
+            RefreshPreview();
+            // ponytail: needs BugReportService.SubmitAsync, wired when it moves to Core. Until then
+            // Send stays disabled (XAML) and the status line says so; label_coming_soon is the
+            // closest existing key.
+            _txtStatus.Text = Loc.Get("label_coming_soon");
+            Opened += (_, _) => _txtDescription.Focus();
+        }
+
+        /// <summary>
+        /// Word the dialog for its kind. Both kinds are set from code: these four controls carry
+        /// no {loc:Str} binding, because a local Text set does not clear an Avalonia binding and
+        /// the next language change would have reverted a suggestion dialog to bug wording.
+        /// Suggestion mode also hides the defect-only fields (repro steps, log opt-in, counts).
+        /// </summary>
+        private void ApplyKind()
+        {
+            var suggestion = _kind == ReportKind.Suggestion;
+            Title = Loc.Get(suggestion ? "suggestion_title" : "bug_report_title");
+            this.FindControl<TextBlock>("TxtHeaderTitle")!.Text = Title;
+            this.FindControl<TextBlock>("TxtPrivacyNotice")!.Text = Loc.Get(suggestion ? "suggestion_privacy_notice" : "bug_report_privacy_notice");
+            this.FindControl<TextBlock>("LblDescription")!.Text = Loc.Get(suggestion ? "suggestion_description_label" : "bug_report_description_label");
+
+            this.FindControl<TextBlock>("LblSteps")!.IsVisible = !suggestion;
+            _txtSteps.IsVisible = !suggestion;
+            _chkIncludeAppLog.IsVisible = !suggestion;
+            _txtScrubberCounts.IsVisible = !suggestion;
+        }
+
+        private void RefreshPreview()
+        {
+            // ponytail: needs BugReportService.CreateDraft/RenderPreview, wired when it moves to Core.
+            // Until then the metadata is what this process can see and the counts are zero.
+            var appVersion = typeof(BugReportWindow).Assembly.GetName().Version?.ToString(3) ?? "?";
+            _txtMetadataSummary.Text =
+                $"app_version : {appVersion}\n" +
+                $"os          : {RuntimeInformation.OSDescription}\n" +
+                $".NET        : {Environment.Version}\n" +
+                $"language    : {LocalizationManager.Instance.CurrentLanguage}\n" +
+                $"active_mod  : (none)";
+
+            _txtScrubberCounts.Text = Loc.GetF("bug_report_scrubber_count", 0, 0, 0, 0);
+
+            _txtPreview.Text =
+                $"kind        : {(_kind == ReportKind.Suggestion ? "suggestion" : "bug")}\n" +
+                $"description : {_txtDescription.Text}\n" +
+                $"steps       : {_txtSteps.Text}\n" +
+                $"include_log : {_chkIncludeAppLog.IsChecked == true}\n" +
+                _txtMetadataSummary.Text;
+        }
+
+        /// <summary>Render-only: draws the success panel with a placeholder token so
+        /// --render-view can prove it. Nothing is submitted.</summary>
+        internal void ShowSuccessPanelForRender()
+        {
+            const string token = "BUG-0000000000";
+            ShowSuccessPanel(Loc.GetF(_kind == ReportKind.Suggestion ? "suggestion_success_toast" : "bug_report_success_toast", token), token);
+        }
+
+        /// <summary>
+        /// Swap the form for the success panel (#769). The report number stays on screen in a
+        /// read-only, selectable box with a Copy button until the user clicks Done. A 202 without
+        /// a token still shows the headline, minus the box.
+        /// </summary>
+        private void ShowSuccessPanel(string headline, string? token)
+        {
+            _txtSuccessHeadline.Text = headline;
+
+            bool hasToken = !string.IsNullOrWhiteSpace(token);
+            _txtSuccessToken.Text = token ?? string.Empty;
+
+            _lblSuccessTokenLabel.IsVisible = hasToken;
+            _successTokenRow.IsVisible = hasToken;
+            _txtSuccessHint.IsVisible = hasToken;
+
+            _successPanel.IsVisible = true;
+            _btnSuccessDone.Focus();
+        }
+
+        private async System.Threading.Tasks.Task CopyTokenAsync()
+        {
+            try
+            {
+                var token = _txtSuccessToken.Text;
+                if (string.IsNullOrWhiteSpace(token) || Clipboard is null) return;
+                await Clipboard.SetTextAsync(token);
+                _txtCopyToken.Text = Loc.Get("btn_copied");
+            }
+            catch
+            {
+                // Clipboard can be locked by another process — never crash the dialog over it.
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MyReportsWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/MyReportsWindow.axaml
@@ -1,0 +1,96 @@
+<!-- PORTED from ConditioningControlPanel/Windows/MyReportsWindow.xaml.
+     Structure, ordering and every resource key preserved. Deviations, all forced:
+
+       ResizeMode="CanResizeWithGrip"  -> CanResize="True"
+       Visibility="Collapsed"          -> IsVisible="False"
+       Click="…" inside DataTemplate   -> one Button.Click handler on the ItemsControl (a
+                                          DataTemplate has no name scope)
+       {Binding X, Mode=OneTime}       -> {Binding X} with x:DataType on the template
+
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key and every loc key here is snake_case. See the porting notes in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Windows"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.MyReportsWindow"
+        Title="{loc:Str my_reports_title}"
+        Width="520" Height="480"
+        MinWidth="420" MinHeight="320"
+        WindowStartupLocation="CenterOwner"
+        Background="#0F0F1E"
+        Foreground="#E0E0E0"
+        CanResize="True">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="{loc:Str my_reports_title}"
+                       Foreground="{DynamicResource PinkBrush}"
+                       FontSize="20" FontWeight="Bold"/>
+            <TextBlock Text="{loc:Str my_reports_subtitle}"
+                       Foreground="#9898B0" FontSize="11" TextWrapping="Wrap"
+                       Margin="0,6,0,0"/>
+        </StackPanel>
+
+        <!-- List -->
+        <Border Grid.Row="1" Background="#14142A" BorderBrush="#3D3D60"
+                BorderThickness="1" CornerRadius="8" Padding="6">
+            <Grid>
+                <TextBlock x:Name="TxtEmpty" Text="{loc:Str my_reports_empty}"
+                           Foreground="#707080" FontSize="13" FontStyle="Italic"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           TextWrapping="Wrap" TextAlignment="Center" Margin="20"
+                           IsVisible="False"/>
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="ReportsList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="local:MyReportsWindow+Row">
+                                <Border Background="#1A1A2E" BorderBrush="#2A2A44"
+                                        BorderThickness="1" CornerRadius="6"
+                                        Padding="10,8" Margin="2,3">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Token}"
+                                                       Foreground="White" FontFamily="Consolas, Courier New"
+                                                       FontSize="14" FontWeight="Bold"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding SubtitleText}"
+                                                       Foreground="#7A7A90" FontSize="11"
+                                                       Margin="0,3,0,0"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="1" Tag="{Binding Token}"
+                                                VerticalAlignment="Center" Cursor="Hand"
+                                                Background="#252540" Foreground="#D8D8E8"
+                                                BorderBrush="#3A3A58" BorderThickness="1"
+                                                Padding="14,5" Margin="10,0,0,0">
+                                            <TextBlock Text="{loc:Str btn_copy}"/>
+                                        </Button>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+
+        <!-- Footer -->
+        <Button Grid.Row="2" x:Name="BtnClose"
+                HorizontalAlignment="Right" Margin="0,12,0,0"
+                Background="{DynamicResource PinkBrush}" Foreground="White"
+                BorderThickness="0" Padding="24,8" Cursor="Hand"
+                FontWeight="SemiBold">
+            <TextBlock Text="{loc:Str btn_close}"/>
+        </Button>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/MyReportsWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MyReportsWindow.axaml.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// #769: small read-only list of the report numbers (BUG-XXXXXXXXXX) this user has been given
+    /// for bug reports and suggestions, newest first, each with a Copy button.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/MyReportsWindow.xaml.cs. Deviations:
+    ///  - The rows come from AppSettings.RecentBugReports via BugReportService.ParseRecentReports,
+    ///    both still in the WPF head, so LoadRows has no rows and the empty state shows.
+    ///  - The per-row Copy click is one handler on the ItemsControl; the row Button carries the
+    ///    token in Tag exactly as before.
+    /// </summary>
+    public partial class MyReportsWindow : Window
+    {
+        /// <summary>Row view-model — pre-formatted so the DataTemplate stays binding-only.</summary>
+        public class Row
+        {
+            public string Token { get; set; } = string.Empty;
+            public string SubtitleText { get; set; } = string.Empty;
+        }
+
+        private readonly ItemsControl _reportsList;
+        private readonly TextBlock _txtEmpty;
+
+        public MyReportsWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _reportsList = this.FindControl<ItemsControl>("ReportsList")!;
+            _txtEmpty = this.FindControl<TextBlock>("TxtEmpty")!;
+
+            _reportsList.AddHandler(Button.ClickEvent, BtnCopyRow_Click);
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            LoadRows();
+        }
+
+        private void LoadRows()
+        {
+            // ponytail: needs AppSettings.RecentBugReports + BugReportService.ParseRecentReports,
+            // wired when they move to Core. No source means no rows, so the empty state shows;
+            // the row subtitle is "{local date}  •  {kind}" as in the WPF code-behind.
+            var rows = new List<Row>();
+
+            _reportsList.ItemsSource = rows;
+            _txtEmpty.IsVisible = rows.Count == 0;
+        }
+
+        private async void BtnCopyRow_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (e.Source is not Button btn || btn.Tag is not string token) return;
+                if (string.IsNullOrWhiteSpace(token) || Clipboard is null) return;
+                await Clipboard.SetTextAsync(token);
+                if (btn.Content is TextBlock label) label.Text = Loc.Get("btn_copied");
+            }
+            catch
+            {
+                // Clipboard can be locked by another process — never crash the dialog over it.
+            }
+        }
+    }
+}


### PR DESCRIPTION
507 lines, 4 files. Send stays disabled with a real Coming Soon string; the success panel is reachable only by a render-only hook; reports show the empty state.

Re-cut from the fork's reviewed unit PR onto the stack, ≤ ~1,000 changed lines, new files only. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view (PNG read: real strings, no blank templated controls), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351