### PR TITLE
feat(avalonia): port AchievementPopup, ItemUnlockedPopup

### DIFF
--- a/CCP.Avalonia/Views/Windows/AchievementPopup.axaml
+++ b/CCP.Avalonia/Views/Windows/AchievementPopup.axaml
@@ -1,0 +1,90 @@
+<!-- PORTED from ConditioningControlPanel/Windows/AchievementPopup.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"              -> SystemDecorations="None"
+       AllowsTransparency="True"       -> TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"           -> CanResize="False"
+       MouseLeftButtonDown="..."       -> PointerPressed, wired in the constructor
+       ShadowDepth="0"                 -> OffsetX="0" OffsetY="0"  (Avalonia's DropShadowEffect
+                                          takes a vector, not depth+direction)
+       Image + EmojiToImageSource      -> TextBlock "🏆"           (Avalonia draws COLR/CPAL colour
+                                          fonts natively; see CLAUDE.md trap 3)
+       Button.Style + IsMouseOver      -> Style Selector="Button.closeGlyph:pointerover" below.
+                                          Shape-for-shape: the local Foreground on the button
+                                          outranks it, so it was already dead in WPF and is dead
+                                          here for the same reason. Kept so the two still diff.
+
+     The close button carries a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key. See the porting notes in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.AchievementPopup"
+        Title="Achievement Unlocked!"
+        Width="400" Height="200"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        Focusable="False"
+        CanResize="False"
+        WindowStartupLocation="Manual">
+
+    <Window.Styles>
+        <Style Selector="Button.closeGlyph:pointerover">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="#E0151530" CornerRadius="12" BorderBrush="{StaticResource PinkBrush}" BorderThickness="2"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <Grid Margin="15">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Achievement Image -->
+            <Border Grid.Column="0" Width="120" Height="120" Background="{DynamicResource DarkerBgBrush}" CornerRadius="8" Margin="0,0,15,0">
+                <Image x:Name="AchievementImage" Stretch="Uniform" Margin="5"/>
+            </Border>
+
+            <!-- Text Content -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <!-- Trophy Icon + "Achievement Unlocked" -->
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <TextBlock x:Name="TxtHeaderIcon" Text="🏆" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBlock x:Name="TxtHeaderText" Text="ACHIEVEMENT UNLOCKED!" Foreground="#FFD700"
+                               FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <!-- Achievement Name -->
+                <TextBlock x:Name="TxtName" Text="Achievement Name"
+                           Foreground="{StaticResource PinkBrush}"
+                           FontWeight="Bold" FontSize="18"
+                           TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+                <!-- Flavor Text -->
+                <TextBlock x:Name="TxtFlavor" Text="Flavor text goes here..."
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                           TextWrapping="Wrap" FontStyle="Italic"/>
+            </StackPanel>
+
+            <!-- Close Button -->
+            <Button x:Name="BtnClose" Grid.Column="1" Classes="closeGlyph"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="24" Height="24" Margin="0,-5,-5,0" Padding="0"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand">
+                <TextBlock Text="✕"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/AchievementPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/AchievementPopup.axaml.cs
@@ -1,0 +1,151 @@
+using System;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Popup window shown when an achievement is unlocked.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/AchievementPopup.xaml.cs. Deviations:
+    ///  - The constructor takes the three fields it actually reads instead of an
+    ///    <c>Achievement</c>: that model lives in the WPF head, and this project may not
+    ///    reference it. Call shape is <c>new AchievementPopup(a.Name, a.FlavorText, a.ImageName)</c>.
+    ///  - <c>DoubleAnimation</c> on Opacity becomes a <see cref="DoubleTransition"/> plus a plain
+    ///    Opacity assignment - Avalonia animates through the property system, not a Storyboard.
+    ///  - <c>SystemParameters.WorkArea</c> becomes <c>Screens.Primary.WorkingArea</c>, which is only
+    ///    populated once the window has a platform handle, so placement moves to OnOpened.
+    ///  - <c>MouseLeftButtonDown</c> becomes PointerPressed, wired in the constructor.
+    ///  - <c>App.Logger</c> calls are dropped; there is no logger on this head yet.
+    /// </summary>
+    public partial class AchievementPopup : Window
+    {
+        private const double FadeMs = 300;
+
+        private readonly DispatcherTimer _autoCloseTimer;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the popup.</summary>
+        internal AchievementPopup() : this("Good Girl", "The first time it stopped feeling like a choice.", "good_girl.png")
+        {
+            // The fade-in cannot complete inside a headless render's two dispatcher passes, so the
+            // PNG would capture a fully transparent window. Skip the animation for the render.
+            Transitions = null;
+            Opacity = 1;
+        }
+
+        /// <param name="name">Achievement.Name.</param>
+        /// <param name="flavorText">Achievement.FlavorText.</param>
+        /// <param name="imageName">Achievement.ImageName - the file under Resources/achievements/.</param>
+        /// <param name="headerIcon">Optional emoji replacing the trophy.</param>
+        /// <param name="headerText">Optional shout replacing "ACHIEVEMENT UNLOCKED!".</param>
+        public AchievementPopup(string name, string flavorText, string imageName,
+                                string? headerIcon = null, string? headerText = null)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // Set content
+            this.FindControl<TextBlock>("TxtName")!.Text = name;
+            this.FindControl<TextBlock>("TxtFlavor")!.Text = flavorText;
+
+            // Custom header text/icon if provided. The WPF original ran headerIcon through
+            // EmojiImage/Twemoji; Avalonia draws the codepoint directly (CLAUDE.md trap 3).
+            if (headerIcon != null) this.FindControl<TextBlock>("TxtHeaderIcon")!.Text = headerIcon;
+            if (headerText != null) this.FindControl<TextBlock>("TxtHeaderText")!.Text = headerText;
+
+            LoadAchievementImage(imageName);
+
+            // Never take the foreground - same focus-theft gap as the Pink Rush toast (ccp-bugs
+            // #1000). ponytail: needs Helpers.PassiveToastWindow (Win32 WS_EX_NOACTIVATE), wired
+            // when the per-platform equivalent lands. ShowActivated="False" is the portable half.
+
+            // Auto-close after 6 seconds
+            _autoCloseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(6) };
+            _autoCloseTimer.Tick += (_, _) =>
+            {
+                _autoCloseTimer.Stop();
+                FadeOutAndClose();
+            };
+            _autoCloseTimer.Start();
+
+            // Fade in animation
+            Transitions = new Transitions
+            {
+                new DoubleTransition { Property = OpacityProperty, Duration = TimeSpan.FromMilliseconds(FadeMs) }
+            };
+            Opacity = 0;
+            Loaded += (_, _) => Opacity = 1;
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) =>
+            {
+                _autoCloseTimer.Stop();
+                FadeOutAndClose();
+            };
+            AddHandler(InputElement.PointerPressedEvent, Window_PointerPressed, handledEventsToo: false);
+        }
+
+        /// <summary>
+        /// Position the window in the bottom-right corner of the primary screen.
+        /// Screens is null until the window has a handle, so this runs on open rather than in the
+        /// constructor as WPF's SystemParameters.WorkArea allowed.
+        /// </summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            try
+            {
+                var workArea = Screens.Primary?.WorkingArea
+                    ?? throw new InvalidOperationException("no primary screen");
+
+                // Position in bottom-right corner with 20px margin
+                Position = new PixelPoint(
+                    workArea.Right - (int)Width - 20,
+                    workArea.Bottom - (int)Height - 20);
+            }
+            catch
+            {
+                // Fallback: centre on screen, as the WPF original did.
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+        }
+
+        /// <summary>
+        /// ponytail: needs Services.ModResourceResolver (mod override, then a pack:// resource) and
+        /// the Resources/achievements/ payload; both stay in the WPF head. The art box renders empty
+        /// until they move to Core, exactly as the WPF original does for a missing file.
+        /// </summary>
+        private void LoadAchievementImage(string imageName)
+        {
+            _ = imageName;
+        }
+
+        private void FadeOutAndClose()
+        {
+            try
+            {
+                Opacity = 0;
+                DispatcherTimer.RunOnce(() => { try { Close(); } catch { /* Ignore close errors */ } },
+                    TimeSpan.FromMilliseconds(FadeMs));
+            }
+            catch
+            {
+                try { Close(); } catch { }
+            }
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            FadeOutAndClose();   // the original does not stop the timer here either; OnClosed does
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _autoCloseTimer.Stop();
+            base.OnClosed(e);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/ItemUnlockedPopup.axaml
+++ b/CCP.Avalonia/Views/Windows/ItemUnlockedPopup.axaml
@@ -1,0 +1,82 @@
+<!-- PORTED from ConditioningControlPanel/Windows/ItemUnlockedPopup.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"              -> SystemDecorations="None"
+       AllowsTransparency="True"       -> TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"           -> CanResize="False"
+       MouseLeftButtonDown="..."       -> PointerPressed, wired in the constructor
+       Visibility="Collapsed"          -> IsVisible="False"
+       HeaderIcon (Image + Twemoji)    -> TextBlock "🎀"   (Avalonia draws COLR/CPAL colour fonts
+       FallbackGlyphImage (Image)      -> deleted          natively, so the SVG fallback pair
+                                                            collapses to one TextBlock each;
+                                                            CLAUDE.md trap 3)
+       TxtHeader / TxtSub set in code  -> {loc:Str}, same keys. They were only set from code in
+                                          WPF because the Twemoji fallback prefixed the glyph;
+                                          with the glyph in its own TextBlock they are static, and
+                                          a binding survives a language change where an assigned
+                                          .Text would not.
+       CardBorder VerticalAlignment    -> "Top" with the card's natural height. The WPF window is
+                                          exactly card-sized (340x104) and never resizes, so
+                                          pinning the card to its content is identical on the
+                                          desktop - and it keeps the render harness' minimum window
+                                          height from stretching the card down the whole PNG.
+
+     BorderBrush + Effect on CardBorder are still set in code-behind from the item's mod accent. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.ItemUnlockedPopup"
+        Title="New Item Unlocked!"
+        Width="340" Height="104"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        Focusable="False"
+        CanResize="False"
+        WindowStartupLocation="Manual">
+
+    <!-- 10px transparent margin so the accent glow has room to bleed: 340x104 window = 320x84 card -->
+    <Border x:Name="CardBorder" Background="#E0151530" CornerRadius="12" BorderThickness="2"
+            Margin="10" VerticalAlignment="Top" Height="84">
+
+        <Grid Margin="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Item art (or a gift glyph when the PNG never landed) -->
+            <Border Grid.Column="0" Width="64" Height="64" CornerRadius="10"
+                    Background="{DynamicResource DarkerBgBrush}" Margin="0,0,10,0">
+                <Grid>
+                    <Image x:Name="ItemImage" Stretch="Uniform" Margin="4"/>
+                    <TextBlock x:Name="FallbackGlyphText" Text="&#x1F381;" FontSize="26" IsVisible="False"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Grid>
+            </Border>
+
+            <!-- Header / item name / call to action -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,2">
+                    <TextBlock x:Name="HeaderIcon" Text="&#x1F380;" FontSize="11" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                    <TextBlock x:Name="TxtHeader" Text="{loc:Str toast_item_unlocked_header}" Foreground="#FFD700"
+                               FontWeight="Bold" FontSize="11" VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"/>
+                </StackPanel>
+
+                <!-- Registry proper noun - deliberately NOT localized -->
+                <TextBlock x:Name="TxtItemName" Text="Item Name"
+                           FontWeight="Bold" FontSize="16"
+                           TextTrimming="CharacterEllipsis"/>
+
+                <TextBlock x:Name="TxtSub" Text="{loc:Str toast_item_unlocked_sub}"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="10" Margin="0,2,0,0"
+                           TextTrimming="CharacterEllipsis"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/ItemUnlockedPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ItemUnlockedPopup.axaml.cs
@@ -1,0 +1,202 @@
+using System;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// The reward half of an achievement unlock: a small toast naming the wardrobe item the
+    /// achievement just handed over. Shown ~900ms after <see cref="AchievementPopup"/> so it reads
+    /// as a consequence of it, and stacked directly ABOVE it in the bottom-right corner.
+    ///
+    /// Same window recipe as <see cref="AchievementPopup"/> (borderless, transparent, topmost,
+    /// never activated, click-anywhere dismiss, 300ms fades, auto-close) - deliberately, so both
+    /// toasts behave identically no matter which one the user clicks at.
+    ///
+    /// No haptics here: <c>AchievementService</c> already fires exactly one achievement pattern per
+    /// unlock, and a second pattern only stacks two overlapping copies on the toy.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/ItemUnlockedPopup.xaml.cs. Deviations:
+    ///  - The constructor takes the item's name and mod instead of a <c>WardrobeItem</c>: that type
+    ///    lives in the WPF head (Services/Profile/WardrobeCatalog.cs) and this project may not
+    ///    reference it. Call shape is <c>new ItemUnlockedPopup(item.Name, item.Mod, stackIndex)</c>.
+    ///  - <c>DoubleAnimation</c> on Opacity becomes a <see cref="DoubleTransition"/>.
+    ///  - <c>SystemParameters.WorkArea</c> becomes <c>Screens.Primary.WorkingArea</c>, populated only
+    ///    once the window has a handle, so placement moves to OnOpened.
+    ///  - The Twemoji header/gift SVG lookups and their fallbacks collapse to plain TextBlocks.
+    ///  - <c>App.Logger</c> calls are dropped; there is no logger on this head yet.
+    /// </summary>
+    public partial class ItemUnlockedPopup : Window
+    {
+        /// <summary>
+        /// <see cref="AchievementPopup"/>'s window height. This toast sits above that popup, so its
+        /// height is part of our own placement maths - keep in sync with AchievementPopup.axaml.
+        /// </summary>
+        private const double AchievementPopupHeight = 200;
+
+        /// <summary>Gap between this toast and the achievement popup below it.</summary>
+        private const double StackGap = 12;
+
+        /// <summary>Gap between two stacked item toasts.</summary>
+        private const double SiblingGap = 8;
+
+        private const double FadeMs = 300;
+
+        private readonly DispatcherTimer _autoCloseTimer;
+        private readonly int _stackIndex;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the toast.</summary>
+        internal ItemUnlockedPopup() : this("Silk Bow", "bambi")
+        {
+            // The fade-in cannot complete inside a headless render's two dispatcher passes, so the
+            // PNG would capture a fully transparent window. Skip the animation for the render.
+            Transitions = null;
+            Opacity = 1;
+        }
+
+        /// <param name="itemName">WardrobeItem.Name - a registry proper noun, deliberately NOT localized.</param>
+        /// <param name="mod">WardrobeItem.Mod ("bambi" / "sissy" / "drone" / "circe"); drives the accent.</param>
+        /// <param name="stackIndex">
+        /// 0 for the first toast of this unlock, 1/2/... for extra items on the same achievement -
+        /// each one is pushed a further (Height + gap) upward so they never overlap.
+        /// </param>
+        public ItemUnlockedPopup(string itemName, string? mod = null, int stackIndex = 0)
+        {
+            if (itemName == null) throw new ArgumentNullException(nameof(itemName));
+
+            AvaloniaXamlLoader.Load(this);
+
+            _stackIndex = stackIndex < 0 ? 0 : stackIndex;
+
+            var accent = AccentFor(mod);
+            ApplyAccent(accent);
+
+            // Header glyph and shout are static in the markup now ({loc:Str toast_item_unlocked_header}
+            // / _sub): the WPF original only set them from code so the Twemoji fallback could prefix
+            // the ribbon onto the text, and that fallback no longer exists.
+
+            // Item name is a registry proper noun - NOT localized (DESIGN.md / WardrobeItem.Name).
+            var txtItemName = this.FindControl<TextBlock>("TxtItemName")!;
+            txtItemName.Text = itemName;
+            txtItemName.Foreground = new SolidColorBrush(accent);
+
+            LoadItemArt();
+
+            // Never take the foreground - same focus-theft gap as the Pink Rush toast (ccp-bugs
+            // #1000). ponytail: needs Helpers.PassiveToastWindow (Win32 WS_EX_NOACTIVATE), wired
+            // when the per-platform equivalent lands. ShowActivated="False" is the portable half.
+
+            _autoCloseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+            _autoCloseTimer.Tick += (_, _) =>
+            {
+                _autoCloseTimer.Stop();
+                FadeOutAndClose();
+            };
+            _autoCloseTimer.Start();
+
+            Transitions = new Transitions
+            {
+                new DoubleTransition { Property = OpacityProperty, Duration = TimeSpan.FromMilliseconds(FadeMs) }
+            };
+            Opacity = 0;
+            Loaded += (_, _) => Opacity = 1;
+
+            AddHandler(InputElement.PointerPressedEvent, Window_PointerPressed, handledEventsToo: false);
+        }
+
+        /// <summary>Mod accent for the border, glow and item name. Unknown mods fall back to bambi pink.</summary>
+        private static Color AccentFor(string? mod)
+        {
+            return (mod ?? string.Empty).Trim().ToLowerInvariant() switch
+            {
+                "sissy" => Color.FromRgb(0xB4, 0x78, 0xFF),
+                "drone" => Color.FromRgb(0x5E, 0xC8, 0xF2),
+                "circe" => Color.FromRgb(0x5E, 0xC8, 0xF2),
+                _ => Color.FromRgb(0xFF, 0x69, 0xB4),
+            };
+        }
+
+        private void ApplyAccent(Color accent)
+        {
+            var card = this.FindControl<Border>("CardBorder")!;
+            card.BorderBrush = new SolidColorBrush(accent);
+            card.Effect = new DropShadowEffect
+            {
+                Color = accent,
+                BlurRadius = 20,
+                OffsetX = 0,
+                OffsetY = 0,
+                Opacity = 0.5,
+            };
+        }
+
+        /// <summary>
+        /// Paints the item art, or a gift glyph when the PNG never landed. "No art" is a normal
+        /// path, not an error - what must never happen is a broken-image box in the toast.
+        ///
+        /// ponytail: needs Services.WardrobeCatalog.GetImage(item.Id), which resolves pack:// art in
+        /// the WPF head. Until it moves to Core every toast takes the gift-glyph branch.
+        /// </summary>
+        private void LoadItemArt()
+        {
+            this.FindControl<Image>("ItemImage")!.IsVisible = false;
+            this.FindControl<TextBlock>("FallbackGlyphText")!.IsVisible = true;
+        }
+
+        /// <summary>
+        /// Bottom-right of the work area, stacked ABOVE the achievement popup (and above any earlier
+        /// toast from the same unlock). Falls back to CenterScreen if the work area is unreadable -
+        /// same contract as AchievementPopup.
+        /// </summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            try
+            {
+                var workArea = Screens.Primary?.WorkingArea
+                    ?? throw new InvalidOperationException("no primary screen");
+
+                Position = new PixelPoint(
+                    workArea.Right - (int)Width - 20,
+                    (int)(workArea.Bottom - AchievementPopupHeight - Height - StackGap
+                          - _stackIndex * (Height + SiblingGap)));
+            }
+            catch
+            {
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+        }
+
+        private void FadeOutAndClose()
+        {
+            try
+            {
+                Opacity = 0;
+                DispatcherTimer.RunOnce(() => { try { Close(); } catch { /* Ignore close errors */ } },
+                    TimeSpan.FromMilliseconds(FadeMs));
+            }
+            catch
+            {
+                try { Close(); } catch { }
+            }
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            _autoCloseTimer.Stop();
+            FadeOutAndClose();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _autoCloseTimer.Stop();
+            base.OnClosed(e);
+        }
+    }
+}


### PR DESCRIPTION
525 lines. Constructors take the primitives each popup reads rather than the WPF-head model types; art resolution and the wardrobe image lookup are ponytail stubs, so both fall back exactly as WPF does for a missing file.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351