### PR TITLE
feat(avalonia): port TeaseRevealPopup, QuizReportWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/QuizReportWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/QuizReportWindow.axaml
@@ -1,0 +1,87 @@
+<!-- PORTED from ConditioningControlPanel/Windows/QuizReportWindow.xaml.
+     Structure, x:Names, ordering and every loc key preserved. Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency  -> SystemDecorations="None" / TransparencyLevelHint
+       RadialGradient Center="0.5,0.5"          -> "50%,50%" (and RadiusX/Y "80%" / "75%"):
+         RadiusX="0.8" GradientOrigin="0.5,0.4"    bare numbers are ABSOLUTE pixels in Avalonia,
+                                                   so both washes would render as a dot
+       DropShadowEffect ShadowDepth="0"         -> dropped; Avalonia's effect has OffsetX/Y, both 0
+       DynamicResource on a shadow Color        -> StaticResource (SeasonRecapCard precedent)
+       Button.Resources <Style TargetType=      -> CornerRadius="10" on the Button itself; the WPF
+         "Border"> CornerRadius hack               hack existed because WPF's Button has no such
+                                                   property, Avalonia's does
+       KeyDown / Click in markup                -> wired in the constructor
+
+     The close button carries a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key and every loc key here is snake_case. See CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.QuizReportWindow"
+        Title="{loc:Str dialog_quiz_report}"
+        Width="700" Height="750"
+        WindowStartupLocation="CenterScreen"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Black">
+
+    <Grid>
+        <!-- Background -->
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,40%" RadiusX="80%" RadiusY="80%">
+                    <GradientStop Color="#1A0A2E" Offset="0"/>
+                    <GradientStop Color="#0A0514" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Vignette -->
+        <Border IsHitTestVisible="False">
+            <Border.Background>
+                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" RadiusX="75%" RadiusY="75%">
+                    <GradientStop Color="Transparent" Offset="0.5"/>
+                    <GradientStop Color="#80000000" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <Grid Margin="30,20,30,20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Header -->
+            <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,0,0,16">
+                <TextBlock Text="{loc:Str label_quiz_report}" FontSize="28" FontWeight="Bold" Foreground="White"
+                           HorizontalAlignment="Center" Margin="0,0,0,4">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="25" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+                <TextBlock x:Name="TxtSubtitle" Foreground="#808090" FontSize="13"
+                           HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                <TextBlock x:Name="TxtScore" FontSize="32" FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
+                           HorizontalAlignment="Center">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="15" OffsetX="0" OffsetY="0" Opacity="0.4"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Scrollable content -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0,0,0,12">
+                <StackPanel x:Name="ContentPanel" MaxWidth="600" HorizontalAlignment="Center"/>
+            </ScrollViewer>
+
+            <!-- Close button -->
+            <Button x:Name="BtnClose" Grid.Row="2" Cursor="Hand" HorizontalAlignment="Center"
+                    Background="#20FFFFFF" Foreground="#B0B0C8" FontWeight="Bold" FontSize="14"
+                    BorderBrush="#40FFFFFF" BorderThickness="1" CornerRadius="10" Padding="28,10">
+                <TextBlock Text="{loc:Str btn_close}"/>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/QuizReportWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuizReportWindow.axaml.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// The per-question breakdown of one finished quiz run: every option the taker saw, which one
+    /// they picked, what each was worth, and the archetype card underneath.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/QuizReportWindow.xaml.cs. Deviations:
+    ///  - <c>QuizHistoryEntry</c> / <c>QuizAnswerRecord</c> / <c>QuizCategory</c> live in the WPF
+    ///    head's Services/Quiz/QuizService.cs, not in CCP.Core, and neither may be touched by this
+    ///    port - so they are copied verbatim below (the TextEditorDialog/TextItem precedent).
+    ///  - <c>FontWeights.Bold</c> -> <c>FontWeight.Bold</c>; the alignment enums come from
+    ///    Avalonia.Layout.
+    ///  - The two-colour <c>LinearGradientBrush</c> constructor does not exist in Avalonia, so the
+    ///    profile card's rim is built from two GradientStops at the same 0-degree angle.
+    ///  - KeyDown/Click are wired in the constructor rather than in markup.
+    /// "YOUR PROFILE" stays hardcoded English exactly as in WPF - there is no loc key for it.
+    /// </summary>
+    public partial class QuizReportWindow : Window
+    {
+        /// <summary>Render/design constructor: one two-question run with a profile, so
+        /// --render-view draws the question rows AND the archetype card. Internal, so no
+        /// production caller can ship the sample.</summary>
+        internal QuizReportWindow() : this(SampleEntry()) { }
+
+        public QuizReportWindow(QuizHistoryEntry entry)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            var categoryDisplay = !string.IsNullOrEmpty(entry.CategoryName) ? entry.CategoryName : entry.Category.ToString();
+            this.FindControl<TextBlock>("TxtSubtitle")!.Text = $"{categoryDisplay}  ·  {entry.TakenAt:MMM d, yyyy  h:mm tt}";
+            var pct = entry.MaxScore > 0 ? (int)Math.Round((double)entry.TotalScore / entry.MaxScore * 100) : 0;
+            this.FindControl<TextBlock>("TxtScore")!.Text = $"{entry.TotalScore} / {entry.MaxScore}  ({pct}%)";
+
+            BuildQuestions(entry);
+            BuildProfileCard(entry.ProfileText);
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            KeyDown += (_, e) => { if (e.Key == Key.Escape) Close(); };
+        }
+
+        private void BuildQuestions(QuizHistoryEntry entry)
+        {
+            var letters = new[] { "A", "B", "C", "D" };
+            var contentPanel = this.FindControl<StackPanel>("ContentPanel")!;
+
+            foreach (var answer in entry.Answers)
+            {
+                // Question header
+                var qHeader = new TextBlock
+                {
+                    Text = $"Q{answer.QuestionNumber}. {answer.QuestionText}",
+                    Foreground = Brushes.White,
+                    FontWeight = FontWeight.Bold,
+                    FontSize = 15,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 14, 0, 6)
+                };
+                contentPanel.Children.Add(qHeader);
+
+                // Answer options
+                for (int i = 0; i < 4; i++)
+                {
+                    if (i >= answer.AllAnswers.Length) break;
+
+                    bool isChosen = i == answer.ChosenIndex;
+
+                    var row = new Border
+                    {
+                        CornerRadius = new CornerRadius(6),
+                        Padding = new Thickness(12, 7, 12, 7),
+                        Margin = new Thickness(0, 2, 0, 2),
+                        Background = isChosen
+                            ? new SolidColorBrush(Color.FromArgb(0x30, 0xFF, 0x69, 0xB4))
+                            : new SolidColorBrush(Color.FromArgb(0x08, 0xFF, 0xFF, 0xFF)),
+                        BorderBrush = isChosen
+                            ? new SolidColorBrush(Color.FromArgb(0x50, 0xFF, 0x69, 0xB4))
+                            : new SolidColorBrush(Color.FromArgb(0x10, 0xFF, 0xFF, 0xFF)),
+                        BorderThickness = new Thickness(1)
+                    };
+
+                    var grid = new Grid();
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(28) });
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                    var letterTxt = new TextBlock
+                    {
+                        Text = letters[i],
+                        FontWeight = FontWeight.Bold,
+                        FontSize = 13,
+                        Foreground = isChosen
+                            ? new SolidColorBrush(Color.FromRgb(0xFF, 0x69, 0xB4))
+                            : new SolidColorBrush(Color.FromArgb(0x60, 0xFF, 0xFF, 0xFF)),
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+                    Grid.SetColumn(letterTxt, 0);
+                    grid.Children.Add(letterTxt);
+
+                    var answerTxt = new TextBlock
+                    {
+                        Text = answer.AllAnswers[i],
+                        FontSize = 13,
+                        TextWrapping = TextWrapping.Wrap,
+                        Foreground = isChosen
+                            ? new SolidColorBrush(Color.FromRgb(0xE0, 0xE0, 0xF0))
+                            : new SolidColorBrush(Color.FromArgb(0x70, 0xC0, 0xC0, 0xD0)),
+                        VerticalAlignment = VerticalAlignment.Center
+                    };
+                    Grid.SetColumn(answerTxt, 1);
+                    grid.Children.Add(answerTxt);
+
+                    var pointsTxt = new TextBlock
+                    {
+                        Text = isChosen ? $"+{answer.PointsEarned}" : $"{answer.AllPoints[i]}",
+                        FontSize = 12,
+                        Foreground = isChosen
+                            ? new SolidColorBrush(Color.FromRgb(0xFF, 0x69, 0xB4))
+                            : new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x90)),
+                        VerticalAlignment = VerticalAlignment.Center,
+                        Margin = new Thickness(8, 0, 0, 0)
+                    };
+                    Grid.SetColumn(pointsTxt, 2);
+                    grid.Children.Add(pointsTxt);
+
+                    row.Child = grid;
+                    contentPanel.Children.Add(row);
+                }
+            }
+        }
+
+        private void BuildProfileCard(string profileText)
+        {
+            if (string.IsNullOrWhiteSpace(profileText)) return;
+
+            var contentPanel = this.FindControl<StackPanel>("ContentPanel")!;
+
+            var headerTxt = new TextBlock
+            {
+                Text = "YOUR PROFILE",
+                Foreground = new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x90)),
+                FontWeight = FontWeight.Bold,
+                FontSize = 12,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 20, 0, 8)
+            };
+            contentPanel.Children.Add(headerTxt);
+
+            var card = new Border
+            {
+                CornerRadius = new CornerRadius(12),
+                Padding = new Thickness(20, 16, 20, 16),
+                Margin = new Thickness(0, 0, 0, 8),
+                Background = new SolidColorBrush(Color.FromArgb(0x12, 0xFF, 0xFF, 0xFF)),
+                BorderThickness = new Thickness(1)
+            };
+            // WPF's LinearGradientBrush(start, end, angle) ctor has no Avalonia twin; angle 0 is a
+            // left-to-right sweep, which is what these two relative points describe.
+            card.BorderBrush = new LinearGradientBrush
+            {
+                StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+                EndPoint = new RelativePoint(1, 0, RelativeUnit.Relative),
+                GradientStops =
+                {
+                    new GradientStop(Color.FromArgb(0x40, 0xFF, 0x69, 0xB4), 0),
+                    new GradientStop(Color.FromArgb(0x40, 0x9B, 0x59, 0xB6), 1),
+                }
+            };
+
+            var profileTxt = new TextBlock
+            {
+                Text = profileText,
+                FontSize = 15,
+                Foreground = new SolidColorBrush(Color.FromRgb(0xC0, 0xC0, 0xD8)),
+                TextWrapping = TextWrapping.Wrap,
+                LineHeight = 24,
+                TextAlignment = TextAlignment.Center
+            };
+
+            card.Child = profileTxt;
+            contentPanel.Children.Add(card);
+        }
+
+        /// <summary>Placeholder run for the render constructor - not production data.</summary>
+        private static QuizHistoryEntry SampleEntry() => new()
+        {
+            TakenAt = new DateTime(2026, 3, 14, 21, 5, 0),
+            Category = QuizCategory.Obedience,
+            CategoryName = "Obedience",
+            TotalScore = 7,
+            MaxScore = 10,
+            ProfileText = "You answer before you weigh it. The pause you used to take is shorter every week, "
+                        + "and you have stopped noticing that it is gone.",
+            Answers =
+            {
+                new QuizAnswerRecord
+                {
+                    QuestionNumber = 1,
+                    QuestionText = "When you are told to wait, how long before you check the clock?",
+                    AllAnswers = new[] { "Immediately", "After a minute", "I do not check", "I never waited" },
+                    AllPoints = new[] { 1, 2, 4, 0 },
+                    ChosenIndex = 2,
+                    PointsEarned = 4,
+                },
+                new QuizAnswerRecord
+                {
+                    QuestionNumber = 2,
+                    QuestionText = "An instruction arrives that you do not understand. You...",
+                    AllAnswers = new[] { "Ask why", "Follow it anyway", "Stall", "Refuse" },
+                    AllPoints = new[] { 1, 3, 2, 0 },
+                    ChosenIndex = 1,
+                    PointsEarned = 3,
+                },
+            },
+        };
+    }
+
+    /// <summary>
+    /// Copied from ConditioningControlPanel/Services/Quiz/QuizService.cs: the report's payload
+    /// types live in the WPF head, not in CCP.Core, and neither may be touched by this port.
+    /// ponytail: needs QuizService, delete these three when the quiz types move to Core.
+    /// </summary>
+    public enum QuizCategory
+    {
+        Sissy,
+        Bambi,
+        Obedience,
+        Mindlessness,
+        Submission
+    }
+
+    /// <inheritdoc cref="QuizCategory"/>
+    public class QuizAnswerRecord
+    {
+        public int QuestionNumber { get; set; }
+        public string QuestionText { get; set; } = string.Empty;
+        public string[] AllAnswers { get; set; } = new string[4];
+        public int[] AllPoints { get; set; } = new int[4];
+        public int ChosenIndex { get; set; }
+        public int PointsEarned { get; set; }
+    }
+
+    /// <inheritdoc cref="QuizCategory"/>
+    public class QuizHistoryEntry
+    {
+        public DateTime TakenAt { get; set; }
+        public QuizCategory Category { get; set; }
+        public int TotalScore { get; set; }
+        public int MaxScore { get; set; }
+        public string ProfileText { get; set; } = string.Empty;
+        public List<QuizAnswerRecord> Answers { get; set; } = new();
+
+        /// <summary>String category ID for custom categories. Falls back to Category enum name for built-in.</summary>
+        public string CategoryId { get; set; } = string.Empty;
+
+        /// <summary>Display name for the category (useful for custom categories where enum doesn't apply).</summary>
+        public string CategoryName { get; set; } = string.Empty;
+    }
+}

--- a/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml
+++ b/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml
@@ -1,0 +1,126 @@
+<!-- PORTED from ConditioningControlPanel/Windows/TeaseRevealPopup.xaml.
+     Structure, x:Names, spacing and every loc key preserved. Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency  -> SystemDecorations="None" / TransparencyLevelHint
+       ResizeMode="NoResize"                    -> CanResize="False"
+       Visibility="Collapsed"                   -> IsVisible="False"
+       DropShadowEffect ShadowDepth="0"         -> dropped; Avalonia's effect has OffsetX/Y, both 0
+       DynamicResource on the shadow Color      -> StaticResource (SeasonRecapCard precedent)
+       LinearGradient 0,0 -> 1,0                -> 0%,0% -> 100%,0%: bare numbers are ABSOLUTE
+                                                   pixels in Avalonia, so the sheen would smear
+       Button.Style + IsMouseOver/IsPressed     -> the TeaseDismiss ControlTheme below, with
+         triggers                                  ^:pointerover / ^:pressed selectors
+       PreviewKeyDown / MouseLeftButtonDown     -> KeyDown / PointerPressed, wired in the ctor
+
+     The dismiss button carries a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key and every loc key here is snake_case. See CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.TeaseRevealPopup"
+        Title="???"
+        Width="430" SizeToContent="Height"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Windows/TeaseRevealPopup.xaml:BtnDismiss inline Style,
+             hoist when a second view needs it -->
+        <ControlTheme x:Key="TeaseDismiss" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="#12121F"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}"
+                            CornerRadius="18" Padding="18,6">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Opacity" Value="0.85"/>
+            </Style>
+            <Style Selector="^:pressed /template/ Border#border">
+                <Setter Property="Opacity" Value="0.7"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <!-- The house dark/pink dialog card (same surface, radius and margin as
+         FeatureIntroPopup), re-trimmed in TIER LIVERY: the rim, the glow and the
+         glyph are all painted from Features\TierLivery in code, so a gold tease and
+         a diamond tease are the same window with one number changed. -->
+    <Border x:Name="CardBorder" Background="#F0151530" CornerRadius="14"
+            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+            ClipToBounds="True"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect Color="{StaticResource PinkColor}"
+                              BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <Grid>
+            <!-- SHIMMER. A single sheen bar swept across the card, and the only clock in
+                 this window. Under the content in z-order so it never washes out the copy. -->
+            <Border x:Name="ShimmerHost" CornerRadius="12"
+                    IsHitTestVisible="False" ClipToBounds="True"
+                    IsVisible="False">
+                <Rectangle x:Name="ShimmerBar" Width="150" HorizontalAlignment="Left">
+                    <Rectangle.Fill>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#00FFFFFF" Offset="0"/>
+                            <GradientStop Color="#30FFFFFF" Offset="0.5"/>
+                            <GradientStop Color="#00FFFFFF" Offset="1"/>
+                        </LinearGradientBrush>
+                    </Rectangle.Fill>
+                    <Rectangle.RenderTransform>
+                        <TransformGroup>
+                            <SkewTransform AngleX="-18"/>
+                            <TranslateTransform X="-200"/>
+                        </TransformGroup>
+                    </Rectangle.RenderTransform>
+                </Rectangle>
+            </Border>
+
+            <StackPanel Margin="26,24,26,20">
+                <!-- The mark. A text glyph, not emoji, exactly as in WPF - the shape is the
+                     point, and the livery brush paints it. -->
+                <TextBlock x:Name="TxtGlyph"
+                           Text="?"
+                           FontSize="54" FontWeight="Bold"
+                           HorizontalAlignment="Center"
+                           Margin="0,2,0,10"/>
+
+                <TextBlock x:Name="TxtTitle"
+                           Text="{loc:Str tease_popup_title}"
+                           FontSize="19" FontWeight="Bold"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,0,0,10"/>
+
+                <TextBlock x:Name="TxtBody"
+                           Text="{loc:Str tease_popup_body}"
+                           Foreground="#CCD5D5E5" FontSize="13"
+                           LineHeight="20"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,0,0,20"/>
+
+                <Button x:Name="BtnDismiss"
+                        Theme="{StaticResource TeaseDismiss}"
+                        HorizontalAlignment="Center"
+                        MinWidth="140" Height="36"
+                        Cursor="Hand"
+                        FontSize="14" FontWeight="SemiBold"
+                        IsDefault="True">
+                    <TextBlock Text="{loc:Str tease_popup_dismiss}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// The teaser card behind a nameless tease tile (see <c>FeatureCard.TeaseTier</c>).
+    ///
+    /// <para>It exists to say ONE thing - something is coming, and it is a Tier N thing - and it
+    /// must never say more than that. The three strings come from the language files
+    /// (<c>tease_popup_title</c> / <c>_body</c> / <c>_dismiss</c>) so the tease reads in nine
+    /// languages the day it ships.</para>
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/TeaseRevealPopup.xaml.cs. Deviations:
+    ///  - <c>TierLivery</c> lives in the WPF head's Features namespace and may not be referenced
+    ///    from here, so <see cref="LiveryBrush"/> / <see cref="AccentColor"/> below resolve the
+    ///    SAME Tier1Gold/Tier2Diamond keys from Theme/Brushes.xaml with the same flat fallbacks.
+    ///  - The WPF keyframe timeline becomes one Avalonia <see cref="Animation"/> run against the
+    ///    sheen bar's TranslateTransform. Avalonia has no DesiredFrameRate knob; it is dropped.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>; <c>App.Logger</c> -> Serilog's static Log.
+    /// </summary>
+    public partial class TeaseRevealPopup : Window
+    {
+        /// <summary>One sweep, then the bar sits off-frame until the next one. The dwell is
+        /// what makes it read as a glint rather than a barber pole.</summary>
+        private static readonly TimeSpan ShimmerSweep = TimeSpan.FromSeconds(1.6);
+        private static readonly TimeSpan ShimmerCycle = TimeSpan.FromSeconds(4.4);
+
+        /// <summary>Travel bounds for the sheen bar, in the card's own coordinates: fully off the
+        /// left edge to fully off the right. The window is a fixed 430 wide, so these are literals
+        /// rather than a measure pass.</summary>
+        private const double ShimmerFromX = -180;
+        private const double ShimmerToX = 470;
+
+        /// <summary>Gold #F0C24B - the Tier 1 base tone. Copied from Features/TierLivery.cs.</summary>
+        private static readonly Color GoldAccent = Color.FromRgb(0xF0, 0xC2, 0x4B);
+
+        /// <summary>Diamond #8FD4EF - the Tier 2 base tone.</summary>
+        private static readonly Color DiamondAccent = Color.FromRgb(0x8F, 0xD4, 0xEF);
+
+        private readonly Border _shimmerHost;
+        private readonly Rectangle _shimmerBar;
+
+        /// <summary>Render/design constructor: a gold tease, so --render-view can draw the card
+        /// without an owner. Internal, so no production caller can ship the sample.</summary>
+        internal TeaseRevealPopup() : this(1) { }
+
+        internal TeaseRevealPopup(int teaseTier)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _shimmerHost = this.FindControl<Border>("ShimmerHost")!;
+            _shimmerBar = this.FindControl<Rectangle>("ShimmerBar")!;
+
+            ApplyLivery(teaseTier);
+
+            // Handlers live here rather than in markup, per the porting convention.
+            this.FindControl<Button>("BtnDismiss")!.Click += (_, _) => { try { Close(); } catch { } };
+
+            KeyDown += (_, e) =>
+            {
+                if (e.Key != Key.Escape) return;
+                e.Handled = true;
+                try { Close(); } catch { }
+            };
+
+            // Chromeless window, so dragging the card is the only way to move it.
+            PointerPressed += (_, e) =>
+            {
+                if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+                try { BeginMoveDrag(e); } catch { }
+            };
+
+            Loaded += (_, _) => StartShimmer();
+        }
+
+        /// <summary>
+        /// Opens the teaser for <paramref name="teaseTier"/> (1 = gold, 2 = diamond). Guarded end
+        /// to end: a teaser failing to open must never be the reason a dashboard click looks
+        /// broken, so the worst case is a logged warning and nothing on screen.
+        /// </summary>
+        internal static void ShowFor(int teaseTier, Window? owner)
+        {
+            try
+            {
+                var popup = new TeaseRevealPopup(teaseTier);
+                if (owner is { IsLoaded: true }) popup.ShowDialog(owner);
+                else popup.Show();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Tease teaser popup failed to open");
+            }
+        }
+
+        /// <summary>The persistent border gradient for <paramref name="tier"/>. Tier 2 and up wear
+        /// diamond; everything else wears gold. A missing brush degrades to the flat accent, never
+        /// to a throw inside card construction.</summary>
+        private IBrush LiveryBrush(int tier)
+        {
+            var key = tier >= 2 ? "Tier2DiamondBorderBrush" : "Tier1GoldBorderBrush";
+            if (this.TryFindResource(key, out var found) && found is IBrush brush) return brush;
+            return new SolidColorBrush(AccentColor(tier));
+        }
+
+        /// <summary>The single flat tone behind the livery, for the drop shadow.</summary>
+        private static Color AccentColor(int tier) => tier >= 2 ? DiamondAccent : GoldAccent;
+
+        /// <summary>Rim, glow, glyph and button in the tease's metal - the one thing the card is
+        /// allowed to disclose is the price band.</summary>
+        private void ApplyLivery(int teaseTier)
+        {
+            try
+            {
+                var livery = LiveryBrush(teaseTier);
+                var accent = AccentColor(teaseTier);
+
+                var card = this.FindControl<Border>("CardBorder")!;
+                card.BorderBrush = livery;
+                if (card.Effect is DropShadowEffect shadow) shadow.Color = accent;
+
+                this.FindControl<TextBlock>("TxtGlyph")!.Foreground = livery;
+                this.FindControl<TextBlock>("TxtTitle")!.Foreground = livery;
+                this.FindControl<Button>("BtnDismiss")!.Background = livery;
+            }
+            catch (Exception ex)
+            {
+                // The pink defaults from XAML stand; the card is still readable.
+                Log.Debug("TeaseRevealPopup.ApplyLivery: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Arms the sheen sweep. The WPF original gates it on PerformanceProfile.AllowGlow AND
+        /// MotionFx.AllowAmbientLoops, and leaves the card on its static livery rim when either
+        /// says no.
+        /// ponytail: needs MotionFx/PerformanceProfile, gate the sweep when they move to Core
+        /// (FeatureCard/SplitFeatureCard run their loops ungated here for the same reason).
+        /// </summary>
+        private void StartShimmer()
+        {
+            try
+            {
+                if (_shimmerBar.RenderTransform is not TransformGroup group) return;
+                var slide = group.Children.OfType<TranslateTransform>().FirstOrDefault();
+                if (slide is null) return;
+
+                _shimmerHost.IsVisible = true;
+
+                var sweep = ShimmerSweep.TotalSeconds / ShimmerCycle.TotalSeconds;
+                var anim = new Animation
+                {
+                    Duration = ShimmerCycle,
+                    IterationCount = IterationCount.Infinite,
+                    Easing = new SineEaseInOut(),
+                    Children =
+                    {
+                        Frame(0.0, ShimmerFromX),
+                        Frame(sweep, ShimmerToX),
+                        // Hold off-frame for the rest of the cycle: the dwell IS the effect.
+                        Frame(1.0, ShimmerToX),
+                    },
+                };
+                _ = anim.RunAsync(slide);
+            }
+            catch (Exception ex)
+            {
+                try { _shimmerHost.IsVisible = false; } catch { }
+                Log.Debug("TeaseRevealPopup.StartShimmer: {E}", ex.Message);
+            }
+        }
+
+        private static KeyFrame Frame(double cue, double x) => new()
+        {
+            Cue = new Cue(cue),
+            Setters = { new Setter(TranslateTransform.XProperty, x) },
+        };
+    }
+}


### PR DESCRIPTION
669 lines. Found that WPF's relative gradient coordinates are absolute pixels on Avalonia; both radial washes and the sheen bar became percentages. Quiz record types are copied locally since they live in the WPF head's service.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351