### PR TITLE
feat(avalonia): port RoadmapStepPopup, UsernamePickerDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml
@@ -1,0 +1,106 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/RoadmapStepPopup.xaml.
+     Structure, order, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                     -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       Background="Transparent"      -> kept (the rounded Border is the visible surface)
+       ResizeMode="NoResize"         -> CanResize="False"
+       DropShadowEffect ShadowDepth  -> OffsetX/OffsetY (Avalonia spells the offset out)
+       {DynamicResource PinkColor}   -> {StaticResource PinkColor} on the effect: Avalonia's
+                                       DropShadowEffect.Color is not a styled property, so it
+                                       cannot carry a DynamicResource
+       Image + EmojiToImageSource    -> TextBlock (CLAUDE.md trap 3: Avalonia draws colour emoji)
+       Visibility="Collapsed"        -> IsVisible="False"
+       ImageBrush x:Name="PhotoBrush"-> the Ellipse is named instead and its Fill is assigned in
+                                       code; FindControl only reaches Controls, not brushes
+       Button.Style IsMouseOver trig -> the Button.popupclose :pointerover selector below
+       MouseLeftButtonDown / Click   -> wired in the constructor
+
+     The close button carries a TextBlock rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.RoadmapStepPopup"
+        Title="Step Complete!"
+        Width="400" Height="180"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        Focusable="False"
+        CanResize="False"
+        WindowStartupLocation="Manual">
+
+    <Window.Styles>
+        <!-- The WPF <Style TargetType="Button"> trigger block, verbatim in intent. The Fluent
+             theme paints its own hover plate, so the rest state has to be pinned too or the
+             borderless close button grows a grey background on hover. -->
+        <Style Selector="Button.popupclose /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="Button.popupclose:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="#E01A1A2E" CornerRadius="12" BorderBrush="{StaticResource PinkBrush}" BorderThickness="2"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <Grid Margin="15">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Step Photo/Icon -->
+            <Border Grid.Column="0" Width="100" Height="100" Background="{DynamicResource DarkerBgBrush}"
+                    CornerRadius="50" Margin="0,0,15,0" ClipToBounds="True"
+                    VerticalAlignment="Center">
+                <Grid>
+                    <!-- Photo thumbnail (if available) -->
+                    <Ellipse x:Name="PhotoEllipse" Width="96" Height="96" IsVisible="False"/>
+                    <!-- Default checkmark icon -->
+                    <TextBlock x:Name="CheckmarkIcon" Text="✓" FontSize="48" FontWeight="Bold"
+                               Foreground="#00E676" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Grid>
+            </Border>
+
+            <!-- Text Content -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <!-- Star Icon + "Step Complete" -->
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <TextBlock Text="✨" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBlock Text="STEP COMPLETE!" Foreground="#FFD700"
+                               FontWeight="Bold" FontSize="12" VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <!-- Step Title -->
+                <TextBlock x:Name="TxtStepTitle" Text="Step Title"
+                           Foreground="{StaticResource PinkBrush}"
+                           FontWeight="Bold" FontSize="18"
+                           TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+                <!-- Track Name -->
+                <TextBlock x:Name="TxtTrackName" Text="Track Name"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                           TextWrapping="Wrap" FontStyle="Italic"/>
+            </StackPanel>
+
+            <!-- Close Button -->
+            <Button x:Name="BtnClose" Grid.Column="1" Classes="popupclose"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="24" Height="24" Margin="0,-5,-5,0" Padding="0"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                <TextBlock Text="✕"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml.cs
@@ -1,0 +1,191 @@
+using System;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Popup window shown when a roadmap step is completed.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/RoadmapStepPopup.xaml.cs. Deviations:
+    ///  - <c>App.Logger</c> calls are dropped; the logger lives on the WPF App singleton.
+    ///  - <c>App.Roadmap.GetFullPhotoPath</c> is stubbed, so the thumbnail never loads yet and the
+    ///    checkmark stays. <see cref="LoadPhotoThumbnail"/> is otherwise the WPF body.
+    ///  - <c>SystemParameters.WorkArea</c> -> <c>Screens.Primary.WorkingArea</c>, which is in
+    ///    physical pixels, so the 20px margin and the window size are scaled before subtracting.
+    ///  - <c>BeginAnimation(OpacityProperty, DoubleAnimation)</c> has no Avalonia equivalent. A
+    ///    <see cref="DoubleTransition"/> on Opacity does the same 300ms fade for a plain assignment,
+    ///    and the close is deferred by one timer tick so the fade-out is seen.
+    ///  - The fade is skipped in the render constructor: a headless render never advances the
+    ///    animation clock, so a window that starts at Opacity 0 would capture a blank PNG.
+    /// </summary>
+    public partial class RoadmapStepPopup : Window
+    {
+        private static readonly TimeSpan FadeDuration = TimeSpan.FromMilliseconds(300);
+
+        private readonly DispatcherTimer _autoCloseTimer;
+        private readonly TextBlock _txtStepTitle;
+        private readonly TextBlock _txtTrackName;
+        private readonly TextBlock _checkmarkIcon;
+        private readonly Ellipse _photoEllipse;
+        private readonly bool _animate;
+        private bool _closing;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the popup.</summary>
+        internal RoadmapStepPopup()
+            : this(new RoadmapStepDefinition("sample", RoadmapTrack.EmptyDoll, 3, "Wear the collar all evening",
+                       "Objective", "Photo requirement"),
+                   new RoadmapStepProgress("sample"),
+                   animate: false)
+        {
+        }
+
+        public RoadmapStepPopup(RoadmapStepDefinition stepDef, RoadmapStepProgress progress)
+            : this(stepDef, progress, animate: true)
+        {
+        }
+
+        private RoadmapStepPopup(RoadmapStepDefinition stepDef, RoadmapStepProgress progress, bool animate)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _animate = animate;
+
+            _txtStepTitle = this.FindControl<TextBlock>("TxtStepTitle")!;
+            _txtTrackName = this.FindControl<TextBlock>("TxtTrackName")!;
+            _checkmarkIcon = this.FindControl<TextBlock>("CheckmarkIcon")!;
+            _photoEllipse = this.FindControl<Ellipse>("PhotoEllipse")!;
+
+            // Set content
+            _txtStepTitle.Text = stepDef.Title;
+
+            // Get track name
+            var trackDef = RoadmapTrackDefinition.GetByTrack(stepDef.Track);
+            _txtTrackName.Text = trackDef != null
+                ? $"{trackDef.Name} - {trackDef.Subtitle}"
+                : stepDef.Track.ToString();
+
+            // Load photo thumbnail if available
+            LoadPhotoThumbnail(progress);
+
+            // Position in bottom-right corner of primary screen
+            PositionWindow();
+
+            // Auto-close after 5 seconds
+            _autoCloseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+            _autoCloseTimer.Tick += (s, e) =>
+            {
+                _autoCloseTimer.Stop();
+                FadeOutAndClose();
+            };
+            _autoCloseTimer.Start();
+
+            // Handlers live here rather than in markup, per the porting convention. After the timer
+            // exists, because the close button stops it.
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => { _autoCloseTimer.Stop(); FadeOutAndClose(); };
+            PointerPressed += Window_PointerPressed;
+
+            if (!_animate) return;
+
+            // Fade in animation
+            Transitions = new Transitions
+            {
+                new DoubleTransition { Property = OpacityProperty, Duration = FadeDuration }
+            };
+            Opacity = 0;
+            Loaded += (s, e) => Opacity = 1;
+        }
+
+        /// <summary>
+        /// Position the window in the bottom-right corner of the primary screen
+        /// </summary>
+        private void PositionWindow()
+        {
+            try
+            {
+                // Get the working area of the primary screen (excludes taskbar)
+                var screen = Screens.Primary;
+                if (screen is null) return;
+
+                // WorkingArea is physical pixels; Width/Height and the 20px margin are DIPs.
+                var scale = screen.Scaling;
+                var area = screen.WorkingArea;
+
+                // Position in bottom-right corner with 20px margin
+                Position = new PixelPoint(
+                    area.Right - (int)((Width + 20) * scale),
+                    area.Bottom - (int)((Height + 20) * scale));
+            }
+            catch
+            {
+                // Fallback: centre on screen. Screens is unavailable on some backends before the
+                // window is shown, exactly as the WPF original guarded against.
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+        }
+
+        private void LoadPhotoThumbnail(RoadmapStepProgress progress)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(progress.PhotoPath)) return;
+
+                // ponytail: needs App.Roadmap (RoadmapService.GetFullPhotoPath), wired when it moves to Core
+                string? fullPath = null;
+                if (string.IsNullOrEmpty(fullPath) || !System.IO.File.Exists(fullPath)) return;
+
+                using var stream = System.IO.File.OpenRead(fullPath);
+                var bitmap = Bitmap.DecodeToWidth(stream, 100);
+
+                _photoEllipse.Fill = new ImageBrush(bitmap) { Stretch = Stretch.UniformToFill };
+                _photoEllipse.IsVisible = true;
+                _checkmarkIcon.IsVisible = false;
+            }
+            catch
+            {
+                // Keep showing checkmark icon
+            }
+        }
+
+        private void FadeOutAndClose()
+        {
+            if (_closing) return;
+            _closing = true;
+
+            if (!_animate)
+            {
+                Close();
+                return;
+            }
+
+            try
+            {
+                Opacity = 0;
+                DispatcherTimer.RunOnce(() => { try { Close(); } catch { /* already closed */ } }, FadeDuration);
+            }
+            catch
+            {
+                try { Close(); } catch { /* Ignore close errors */ }
+            }
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                FadeOutAndClose();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _autoCloseTimer.Stop();
+            base.OnClosed(e);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml
@@ -1,0 +1,96 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/UsernamePickerDialog.xaml.
+     Structure, order, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                  -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"      -> CanResize="False"
+       Visibility="Collapsed"     -> IsVisible="False"
+       {loc:Str key}              -> {loc:Str key} unchanged, via the Avalonia twin extension in
+                                     Localization/StrExtension.cs
+       MouseLeftButtonDown / TextChanged / Click -> wired in the constructor
+
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.UsernamePickerDialog"
+        Title="{loc:Str dialog_choose_your_display_name}" Height="350" Width="450"
+        WindowStartupLocation="CenterOwner" CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}"
+        SystemDecorations="None" TransparencyLevelHint="Transparent">
+
+    <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" CornerRadius="10">
+        <Grid Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <TextBlock Grid.Row="0" Text="{loc:Str dialog_choose_your_display_name}"
+                       FontSize="24" FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
+                       HorizontalAlignment="Center" Margin="0,0,0,10"/>
+
+            <!-- Subtitle for new users -->
+            <TextBlock x:Name="TxtSubtitle" Grid.Row="1"
+                       Text="{loc:Str label_this_name_will_be_shown_on_the_leaderboard_an}"
+                       FontSize="12" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap"
+                       HorizontalAlignment="Center" Margin="0,0,0,15"/>
+
+            <!-- OG Welcome message (hidden by default) -->
+            <Border x:Name="OgWelcomePanel" Grid.Row="2" IsVisible="False"
+                    Background="#30FFD700" BorderBrush="#FFD700" BorderThickness="1"
+                    CornerRadius="5" Padding="10" Margin="0,0,0,15">
+                <StackPanel>
+                    <TextBlock Text="{loc:Str label_welcome_back_pioneer}"
+                               FontSize="16" FontWeight="Bold" Foreground="#FFD700"
+                               HorizontalAlignment="Center"/>
+                    <TextBlock Text="{loc:Str label_you_ve_been_recognized_as_a_season_0_og_your}"
+                               FontSize="11" Foreground="White" TextWrapping="Wrap"
+                               HorizontalAlignment="Center" Margin="0,5,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Username input -->
+            <StackPanel Grid.Row="3" Margin="0,0,0,10">
+                <TextBlock Text="{loc:Str label_display_name}" Foreground="White" FontSize="14" Margin="0,0,0,5"/>
+                <TextBox x:Name="TxtUsername" FontSize="18" Padding="10,8"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                         MaxLength="30"/>
+                <TextBlock x:Name="TxtAvailability" FontSize="11" Margin="0,5,0,0"
+                           Foreground="{DynamicResource TextMutedBrush}" Text="{loc:Str label_enter_a_unique_display_name_3_30_characters}"/>
+            </StackPanel>
+
+            <!-- Suggested name (from legacy data or provider) -->
+            <StackPanel x:Name="SuggestionPanel" Grid.Row="4" IsVisible="False" Margin="0,0,0,10">
+                <TextBlock Text="{loc:Str label_suggested_name_from_your_previous_account}"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="11"/>
+                <Button x:Name="BtnUseSuggestion" Padding="10,5"
+                        Background="{DynamicResource AccentTintedBgBrush}" Foreground="{DynamicResource PinkBrush}" BorderThickness="0"
+                        Cursor="Hand" Margin="0,3,0,0"
+                        HorizontalAlignment="Left">
+                    <TextBlock/>
+                </Button>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                <Button x:Name="BtnCancel" Padding="20,10"
+                        Background="{DynamicResource AccentTintedBgBrush}" Foreground="White" BorderThickness="0"
+                        Cursor="Hand" Margin="0,0,10,0">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnConfirm" Padding="20,10"
+                        Background="{DynamicResource PinkBrush}" Foreground="White" BorderThickness="0"
+                        Cursor="Hand" IsEnabled="False">
+                    <TextBlock Text="{loc:Str btn_confirm}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Dialog for choosing a display name on first login.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/UsernamePickerDialog.xaml.cs. Deviations:
+    ///  - <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result through
+    ///    <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>MouseLeftButtonDown</c> + <c>DragMove()</c> -> <c>PointerPressed</c> + <c>BeginMoveDrag</c>.
+    ///  - Newtonsoft's <c>JObject</c> -> <c>System.Text.Json</c>: the head has no Newtonsoft
+    ///    reference and one bool read does not justify adding one.
+    ///  - <c>App.Logger</c> in the availability catch is dropped; the logger is on the WPF App.
+    ///  - <c>ConfigureForNewUser</c> no longer re-assigns TxtSubtitle.Text. The WPF body set it to
+    ///    the very key the XAML already carries, and assigning over a <c>{loc:Str}</c> binding is
+    ///    undone on the next language change (see CLAUDE.md).
+    ///  - <c>_isAvailable</c> is gone: it only ever mirrored <c>BtnConfirm.IsEnabled</c>.
+    ///
+    /// ponytail: the display-name endpoint is hardcoded here exactly as in WPF. It belongs behind a
+    /// Core API client; hoist it when a second view needs the same call.
+    /// </summary>
+    public partial class UsernamePickerDialog : Window
+    {
+        private static readonly HttpClient _http = new();
+        private readonly string _serverUrl = "https://codebambi-proxy.vercel.app";
+        private CancellationTokenSource? _checkCts;
+
+        private readonly TextBox _txtUsername;
+        private readonly TextBlock _txtAvailability;
+        private readonly Button _btnConfirm;
+
+        /// <summary>
+        /// The chosen display name (null if cancelled)
+        /// </summary>
+        public string? ChosenDisplayName { get; private set; }
+
+        public UsernamePickerDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtUsername = this.FindControl<TextBox>("TxtUsername")!;
+            _txtAvailability = this.FindControl<TextBlock>("TxtAvailability")!;
+            _btnConfirm = this.FindControl<Button>("BtnConfirm")!;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            _txtUsername.TextChanged += TxtUsername_TextChanged;
+            this.FindControl<Button>("BtnUseSuggestion")!.Click += (_, _) => BtnUseSuggestion_Click();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => BtnCancel_Click();
+            _btnConfirm.Click += (_, _) => BtnConfirm_Click();
+            PointerPressed += Window_PointerPressed;
+        }
+
+        /// <summary>
+        /// Show the dialog configured for a new user
+        /// </summary>
+        public void ConfigureForNewUser()
+        {
+            this.FindControl<Border>("OgWelcomePanel")!.IsVisible = false;
+            this.FindControl<StackPanel>("SuggestionPanel")!.IsVisible = false;
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            // Bubbling, so the TextBox and the buttons have already marked their own presses
+            // handled - the same reason WPF's DragMove() never fired from inside them.
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                BeginMoveDrag(e);
+        }
+
+        private async void TxtUsername_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            var name = (_txtUsername.Text ?? "").Trim();
+
+            // Cancel any pending check
+            _checkCts?.Cancel();
+            _checkCts = new CancellationTokenSource();
+            var token = _checkCts.Token;
+
+            // Validate locally first
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                SetAvailabilityStatus(Loc.Get("login_enter_unique_display_name"), Brushes.Gray, false);
+                return;
+            }
+
+            if (name.Length < 3)
+            {
+                SetAvailabilityStatus(Loc.Get("login_name_min_3_chars"), Brushes.Orange, false);
+                return;
+            }
+
+            if (name.Length > 30)
+            {
+                SetAvailabilityStatus(Loc.Get("login_name_max_30_chars"), Brushes.Orange, false);
+                return;
+            }
+
+            // Check server availability after a short delay
+            SetAvailabilityStatus(Loc.Get("login_checking_availability"), Brushes.Gray, false);
+
+            try
+            {
+                await Task.Delay(500, token); // Debounce
+                if (token.IsCancellationRequested) return;
+
+                var available = await CheckNameAvailabilityAsync(name);
+
+                if (token.IsCancellationRequested) return;
+
+                if (available)
+                {
+                    SetAvailabilityStatus(Loc.GetF("login_name_available", name), Brushes.LightGreen, true);
+                }
+                else
+                {
+                    SetAvailabilityStatus(Loc.GetF("login_name_already_taken", name), Brushes.Orange, false);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // Ignore
+            }
+            catch (Exception ex)
+            {
+                SetAvailabilityStatus(Loc.GetF("login_could_not_check", ex.Message), Brushes.Orange, false);
+            }
+        }
+
+        private void SetAvailabilityStatus(string message, IBrush color, bool available)
+        {
+            _txtAvailability.Text = message;
+            _txtAvailability.Foreground = color;
+            _btnConfirm.IsEnabled = available;
+        }
+
+        private async Task<bool> CheckNameAvailabilityAsync(string name)
+        {
+            try
+            {
+                var response = await _http.GetAsync($"{_serverUrl}/user/check-display-name?display_name={Uri.EscapeDataString(name)}");
+                if (response.IsSuccessStatusCode)
+                {
+                    var json = await response.Content.ReadAsStringAsync();
+                    using var doc = JsonDocument.Parse(json);
+                    return doc.RootElement.TryGetProperty("available", out var flag)
+                           && flag.ValueKind == JsonValueKind.True;
+                }
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _checkCts?.Cancel();
+            _checkCts?.Dispose();
+            _checkCts = null;
+            base.OnClosed(e);
+        }
+
+        private void BtnUseSuggestion_Click()
+        {
+            // Legacy suggestion panel - always collapsed, kept for XAML compatibility
+        }
+
+        private void BtnCancel_Click()
+        {
+            ChosenDisplayName = null;
+            Close(false);
+        }
+
+        private void BtnConfirm_Click()
+        {
+            if (!_btnConfirm.IsEnabled) return;
+
+            ChosenDisplayName = (_txtUsername.Text ?? "").Trim();
+            Close(true);
+        }
+    }
+}


### PR DESCRIPTION
586 lines. Fade animation becomes a DoubleTransition, skipped in the render constructor because a headless capture never advances the clock. Newtonsoft becomes System.Text.Json; the head has no Newtonsoft reference.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351