### PR TITLE
feat(avalonia): port UpdateFailedDialog, UpdateNotificationDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/UpdateFailedDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/UpdateFailedDialog.axaml
@@ -1,0 +1,141 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/UpdateFailedDialog.xaml.
+     Structure, order, spacing and every x:Name / resource key preserved. Deviations, all forced:
+       Style="{StaticResource X}"   -> Theme="{StaticResource X}"   (keyed styles are ControlThemes)
+       inline <Button.Style>        -> a keyed ControlTheme below; an Avalonia Button cannot carry
+                                       an anonymous Style, and a property-only ControlTheme would
+                                       draw nothing (CLAUDE.md trap 4), so both carry a Template
+                                       whose ContentPresenter binds Content (trap 6)
+       ControlTemplate.Triggers     -> ^:pointerover /template/ Border#border selectors
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" +
+         AllowsTransparency="True"  -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       Visibility="Collapsed"       -> IsVisible="False"
+       Click="Handler"              -> wired in the constructor
+       Content="{loc:Str …}"        -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case, trap 1)
+       TxtTitle Text="{loc:Str …}"  -> dropped; the ctor always assigns TxtTitle.Text, and in
+                                       Avalonia a local value sits UNDER the binding and is undone
+                                       on the next language change. Dead after construction in
+                                       WPF too, so nothing is lost.
+       BtnDownload                  -> gained HorizontalAlignment="Stretch" +
+                                       HorizontalContentAlignment="Center": WPF's Button stretched
+                                       to its StackPanel by default, Avalonia's does not. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.UpdateFailedDialog"
+        Title="{loc:Str title_update_failed}"
+        SizeToContent="Height" Width="520"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of ConditioningControlPanel/App.xaml:Font.Mono, hoist when a second view needs it -->
+        <FontFamily x:Key="Font.Mono">Cascadia Mono, Consolas, Courier New</FontFamily>
+
+        <!-- Secondary button: same shape as the "Later" button on the update dialog -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/UpdateFailedDialog.xaml:SecondaryButtonStyle, hoist when a second view needs it -->
+        <ControlTheme x:Key="SecondaryButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="#E0E0E0"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Padding" Value="18,12"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#303050"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The inline <Button.Style> on BtnDownload, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/UpdateFailedDialog.xaml:BtnDownload inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="DownloadButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Padding" Value="18,12"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#FF8DC7"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,16">
+                <TextBlock Text="&#x26A0;" FontSize="26" Foreground="{DynamicResource PinkBrush}" VerticalAlignment="Center" Margin="0,0,14,0"/>
+                <TextBlock x:Name="TxtTitle" Foreground="{DynamicResource PinkBrush}"
+                           FontSize="22" FontWeight="Bold" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- What happened -->
+            <TextBlock x:Name="TxtMessage" Grid.Row="1"
+                       Foreground="#E0E0E0" FontSize="14" TextWrapping="Wrap" LineHeight="21" Margin="0,0,0,14"/>
+
+            <!-- Technical detail, only shown when we have one -->
+            <Border x:Name="DetailPanel" Grid.Row="2" Background="{DynamicResource PanelBgBrush}" CornerRadius="6"
+                    Padding="12" Margin="0,0,0,14" IsVisible="False">
+                <TextBlock x:Name="TxtDetail" Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                           TextWrapping="Wrap" FontFamily="{DynamicResource Font.Mono}"/>
+            </Border>
+
+            <!-- Manual download hint -->
+            <TextBlock Grid.Row="3" Text="{loc:Str msg_update_manual_download_hint}"
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="12.5" TextWrapping="Wrap"
+                       LineHeight="19" Margin="0,0,0,20"/>
+
+            <!-- Buttons. The primary action gets its own full-width row so long translations of
+                 "Download installer manually" cannot squeeze the secondary actions off the dialog. -->
+            <StackPanel Grid.Row="4">
+                <Button x:Name="BtnDownload" Theme="{StaticResource DownloadButtonStyle}"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" IsDefault="True">
+                    <TextBlock Text="{loc:Str btn_download_installer_manually}"/>
+                </Button>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                    <Button x:Name="BtnCopyLink" Margin="0,0,10,0" Theme="{StaticResource SecondaryButtonStyle}">
+                        <TextBlock x:Name="TxtCopyLink" Text="{loc:Str btn_copy_link}"/>
+                    </Button>
+                    <Button x:Name="BtnClose" Theme="{StaticResource SecondaryButtonStyle}" IsCancel="True">
+                        <TextBlock Text="{loc:Str btn_close}"/>
+                    </Button>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/UpdateFailedDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UpdateFailedDialog.axaml.cs
@@ -1,0 +1,154 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input.Platform;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Shown whenever an automatic update could not be downloaded or installed. The point of this
+    /// dialog is the way out: a plain OK box left users stranded on the old build with nowhere to
+    /// go, so volunteers ended up pasting the GitHub releases link into support by hand. Every
+    /// failure path now offers the manual installer directly.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/UpdateFailedDialog.xaml.cs. Deviations:
+    ///  - <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result through
+    ///    <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>UpdateService.ReleasesPageUrl</c>, <c>BrowserLauncher</c> and <c>App.Logger</c> all
+    ///    live in the WPF head, so they are stubbed here (see the ponytail notes below).
+    ///  - The copy-link label is swapped by rebinding, not by assigning Text: the TextBlock carries
+    ///    a <c>{loc:Str}</c> binding and a local value would be undone on the next language change
+    ///    (CLAUDE.md, "setting text from code").
+    /// </summary>
+    public partial class UpdateFailedDialog : Window
+    {
+        // ponytail: needs UpdateService.ReleasesPageUrl, wired when UpdateService moves to Core
+        private const string ReleasesPageUrl =
+            "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/releases/latest";
+
+        private DispatcherTimer? _copyResetTimer;
+        private readonly TextBlock _txtCopyLink;
+
+        /// <summary>
+        /// Whether the user opened (or was handed) the manual download link.
+        /// </summary>
+        public bool ManualDownloadRequested { get; private set; }
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal UpdateFailedDialog() : this(
+            Loc.Get("title_update_failed"),
+            "The update could not be installed. The download was interrupted before it finished.",
+            "System.IO.IOException: The process cannot access the file because it is being used by another process.")
+        { }
+
+        /// <param name="title">Dialog heading, e.g. "Update Failed".</param>
+        /// <param name="message">Plain-language explanation of what went wrong.</param>
+        /// <param name="detail">Optional technical detail (the exception message). Hidden when empty.</param>
+        public UpdateFailedDialog(string title, string message, string? detail = null)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtCopyLink = this.FindControl<TextBlock>("TxtCopyLink")!;
+
+            this.FindControl<TextBlock>("TxtTitle")!.Text = title;
+            this.FindControl<TextBlock>("TxtMessage")!.Text = message;
+
+            if (!string.IsNullOrWhiteSpace(detail))
+            {
+                this.FindControl<TextBlock>("TxtDetail")!.Text = detail;
+                this.FindControl<Border>("DetailPanel")!.IsVisible = true;
+            }
+
+            this.FindControl<Button>("BtnDownload")!.Click += (_, _) => BtnDownload_Click();
+            this.FindControl<Button>("BtnCopyLink")!.Click += (_, _) => BtnCopyLink_Click();
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => BtnClose_Click();
+        }
+
+        /// <summary>
+        /// Shows the dialog modally, parented to <paramref name="owner"/> when it is usable.
+        /// Never throws - a broken owner window must not swallow the update failure.
+        /// </summary>
+        public static void ShowFor(Window? owner, string title, string message, string? detail = null)
+        {
+            try
+            {
+                var dialog = new UpdateFailedDialog(title, message, detail) { Topmost = true };
+
+                if (owner is { IsVisible: true })
+                {
+                    dialog.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                    _ = dialog.ShowDialog(owner);
+                }
+                else
+                {
+                    // ShowDialog needs an owner on Avalonia; without one this is a modeless window.
+                    dialog.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                    dialog.Show();
+                }
+            }
+            catch
+            {
+                // ponytail: needs App.Logger and a MessageBox equivalent for the fallback path,
+                // wired when the logger moves to Core. Swallowed for now, as WPF did.
+            }
+        }
+
+        private void BtnDownload_Click()
+        {
+            ManualDownloadRequested = true;
+
+            // ponytail: needs BrowserLauncher.OpenUrlOrPrompt(ReleasesPageUrl, "open the download page"),
+            // wired when BrowserLauncher moves to Core
+
+            Close(true);
+        }
+
+        private async void BtnCopyLink_Click()
+        {
+            ManualDownloadRequested = true;
+
+            try
+            {
+                if (Clipboard is null) return;
+                await Clipboard.SetTextAsync(ReleasesPageUrl);
+            }
+            catch
+            {
+                // Clipboard can be locked by another app - say nothing, the button just won't confirm.
+                // ponytail: needs App.Logger for the warning, wired when the logger moves to Core
+                return;
+            }
+
+            SetCopyLinkKey("btn_copied");
+
+            _copyResetTimer?.Stop();
+            _copyResetTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
+            _copyResetTimer.Tick += (_, _) =>
+            {
+                _copyResetTimer?.Stop();
+                try { SetCopyLinkKey("btn_copy_link"); } catch { }
+            };
+            _copyResetTimer.Start();
+        }
+
+        /// <summary>
+        /// Rebinds the copy button's label to another loc key. Assigning .Text instead would sit
+        /// under the {loc:Str} binding the XAML installed and be undone on the next language change.
+        /// </summary>
+        private void SetCopyLinkKey(string key) =>
+            _txtCopyLink.Bind(TextBlock.TextProperty, new Binding($"[{key}]")
+            {
+                Source = LocalizationManager.Instance,
+                Mode = BindingMode.OneWay,
+            });
+
+        private void BtnClose_Click()
+        {
+            _copyResetTimer?.Stop();
+            Close(false);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml
@@ -1,0 +1,159 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/UpdateNotificationDialog.xaml.
+     Structure, order, spacing and every x:Name / resource key preserved. Deviations, all forced:
+       inline <Button.Style>        -> keyed ControlThemes below; an Avalonia Button cannot carry
+                                       an anonymous Style, and a property-only ControlTheme would
+                                       draw nothing (CLAUDE.md trap 4), so both carry a Template
+                                       whose ContentPresenter binds Content (trap 6)
+       ControlTemplate.Triggers     -> ^:pointerover /template/ Border#border selectors
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" +
+         AllowsTransparency="True"  -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       <Hyperlink> inside TextBlock -> HyperlinkButton (Avalonia has no inline Hyperlink); its
+                                       Click still runs the handler, wired in the constructor
+       Click="Handler"              -> wired in the constructor
+       Content="{loc:Str …}"        -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case, trap 1)
+       TxtReleaseNotes Text=
+         "{loc:Str label_no_release
+          _notes_available}"        -> dropped; the ctor always assigns TxtReleaseNotes.Text, and
+                                       in Avalonia a local value sits UNDER the binding and is
+                                       undone on the next language change - the notes would be
+                                       replaced by "No release notes available.". Dead after
+                                       construction in WPF too, so nothing is lost.
+       BtnLater / BtnInstall        -> gained HorizontalAlignment="Stretch" +
+                                       HorizontalContentAlignment="Center": WPF's Button filled
+                                       its Grid column by default, Avalonia's does not. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.UpdateNotificationDialog"
+        Title="{loc:Str dialog_update_available}"
+        Height="585" Width="520"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- The inline <Button.Style> on BtnLater, setters verbatim. Same shape as
+             UpdateFailedDialog's SecondaryButtonStyle but a larger font and padding. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/UpdateNotificationDialog.xaml:BtnLater inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="LaterButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="#E0E0E0"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#303050"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The inline <Button.Style> on BtnInstall, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/UpdateNotificationDialog.xaml:BtnInstall inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="InstallButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#FF8DC7"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,18">
+                <TextBlock Text="{loc:Str label_text_10}" FontSize="28" Foreground="{DynamicResource PinkBrush}" VerticalAlignment="Center" Margin="0,0,14,0"/>
+                <TextBlock Text="{loc:Str label_update_available}" Foreground="{DynamicResource PinkBrush}" FontSize="24" FontWeight="Bold" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Version Info -->
+            <StackPanel Grid.Row="1" Margin="0,0,0,16">
+                <TextBlock x:Name="TxtVersionInfo"
+                           Foreground="#E0E0E0" FontSize="15" TextWrapping="Wrap" LineHeight="22"/>
+                <TextBlock x:Name="TxtFileSize"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="13" Margin="0,6,0,0"/>
+            </StackPanel>
+
+            <!-- Release Notes -->
+            <Border Grid.Row="2" Background="{DynamicResource PanelBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,20">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="{loc:Str label_what_s_new}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="280">
+                        <TextBlock x:Name="TxtReleaseNotes"
+                                   Foreground="#C0C0C0" FontSize="13" TextWrapping="Wrap"/>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+
+            <!-- Manual download escape hatch, for people who would rather install it themselves -->
+            <HyperlinkButton x:Name="LinkManualDownload" Grid.Row="3" Margin="0,0,0,14" Padding="0"
+                             HorizontalAlignment="Left"
+                             Foreground="#B084DC">
+                <TextBlock Text="{loc:Str link_update_download_manually}" FontSize="12.5"
+                           TextWrapping="Wrap" TextDecorations="Underline"/>
+            </HyperlinkButton>
+
+            <!-- Buttons -->
+            <Grid Grid.Row="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Button x:Name="BtnLater" Grid.Column="0" Margin="0,0,10,0"
+                        Theme="{StaticResource LaterButtonStyle}"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        IsCancel="True">
+                    <TextBlock Text="{loc:Str btn_later}"/>
+                </Button>
+
+                <Button x:Name="BtnInstall" Grid.Column="1" Margin="10,0,0,0"
+                        Theme="{StaticResource InstallButtonStyle}"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center">
+                    <TextBlock Text="{loc:Str btn_install_update}"/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/UpdateNotificationDialog.xaml.cs. Deviations:
+    ///  - <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result through
+    ///    <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>UpdateService.GetCurrentVersion()</c>, <c>UpdateService.ReleasesPageUrl</c> and
+    ///    <c>BrowserLauncher</c> live in the WPF head, so they are stubbed (see below).
+    ///  - The version/size/notes strings are English literals in the WPF original too - there are
+    ///    no loc keys for them - so they are copied verbatim rather than invented.
+    /// </summary>
+    public partial class UpdateNotificationDialog : Window
+    {
+        /// <summary>
+        /// Whether the user chose to install the update
+        /// </summary>
+        public bool InstallRequested { get; private set; }
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal UpdateNotificationDialog() : this(new UpdateInfo
+        {
+            Version = "7.0.0",
+            FileSizeBytes = 320_050_000,
+            ReleaseNotes = "## The Spiral\n\n- **Avalonia head** now renders every ported view headless.\n- Fixed a [crash](https://example.invalid) on startup when no audio device was present.\n\n---\n\n### Known issues\n- Chaos overlays are still Windows-only.",
+        })
+        { }
+
+        public UpdateNotificationDialog(UpdateInfo updateInfo)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // ponytail: needs UpdateService.GetCurrentVersion(), wired when UpdateService moves to Core
+            const string currentVersion = "0.0.0";
+
+            this.FindControl<TextBlock>("TxtVersionInfo")!.Text =
+                $"Version {updateInfo.Version} is now available.\n" +
+                $"You are currently on version {currentVersion}.";
+
+            this.FindControl<TextBlock>("TxtFileSize")!.Text = $"Download size: {updateInfo.FormattedFileSize}";
+
+            // Use release notes from GitHub (fetched during update check)
+            // Don't fallback to CurrentPatchNotes as those are for the CURRENT version, not the new one
+            var notes = this.FindControl<TextBlock>("TxtReleaseNotes")!;
+            notes.Text = !string.IsNullOrWhiteSpace(updateInfo.ReleaseNotes)
+                ? ConvertMarkdownToPlainText(updateInfo.ReleaseNotes)
+                : $"Version {updateInfo.Version} is available.\n\nRelease notes were not provided for this update.";
+
+            this.FindControl<HyperlinkButton>("LinkManualDownload")!.Click += (_, _) => LinkManualDownload_Click();
+            this.FindControl<Button>("BtnLater")!.Click += (_, _) => BtnLater_Click();
+            this.FindControl<Button>("BtnInstall")!.Click += (_, _) => BtnInstall_Click();
+        }
+
+        /// <summary>
+        /// Convert GitHub markdown release notes to readable plain text for the TextBlock.
+        /// </summary>
+        private static string ConvertMarkdownToPlainText(string markdown)
+        {
+            var text = markdown;
+
+            // Remove horizontal rules
+            text = Regex.Replace(text, @"^---+\s*$", "", RegexOptions.Multiline);
+
+            // Convert ### headers to uppercase with newline
+            text = Regex.Replace(text, @"^###\s*(.+)$", "\n$1", RegexOptions.Multiline);
+
+            // Convert ## headers to uppercase with newline
+            text = Regex.Replace(text, @"^##\s*(.+)$", "\n$1", RegexOptions.Multiline);
+
+            // Remove bold markers **text** -> text
+            text = Regex.Replace(text, @"\*\*(.+?)\*\*", "$1");
+
+            // Convert markdown list items to bullet points
+            text = Regex.Replace(text, @"^- ", "• ", RegexOptions.Multiline);
+
+            // Remove markdown links [text](url) -> text
+            text = Regex.Replace(text, @"\[([^\]]+)\]\([^\)]+\)", "$1");
+
+            // Collapse excessive newlines
+            text = Regex.Replace(text, @"\n{3,}", "\n\n");
+
+            return text.Trim();
+        }
+
+        /// <summary>
+        /// Opens the GitHub releases page so the user can install the update by hand. The dialog
+        /// stays open - they may still want the automatic install if the browser route falls over.
+        /// </summary>
+        private void LinkManualDownload_Click()
+        {
+            // ponytail: needs BrowserLauncher.OpenUrlOrPrompt(UpdateService.ReleasesPageUrl,
+            // "open the download page"), wired when both move to Core
+        }
+
+        private void BtnLater_Click()
+        {
+            InstallRequested = false;
+            Close(false);
+        }
+
+        private void BtnInstall_Click()
+        {
+            InstallRequested = true;
+            Close(true);
+        }
+    }
+}


### PR DESCRIPTION
565 lines. Update service, browser launcher and logger are ponytail stubs. The two loc bindings that code always overwrote are dropped: an Avalonia local value sits under a binding rather than replacing it.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351