### PR TITLE
feat(avalonia): port LinkPhoneDialog, WebcamLoadingSplash

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml
@@ -1,0 +1,88 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/LinkPhoneDialog.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency="True" -> SystemDecorations="None" /
+                                                         TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                          -> CanResize="False"
+       MouseLeftButtonDown="Window_..."               -> PointerPressed, wired in the constructor
+       Click="BtnRefresh_Click" / "BtnClose_Click"    -> wired in the constructor
+       RenderOptions.BitmapScalingMode="NearestNeighbor"
+                                                      -> RenderOptions.BitmapInterpolationMode="None"
+       FontFamily="Consolas, Courier New"             -> + ", monospace" (Linux fallback, as the
+                                                         other ported views do)
+       The Close button gained x:Name BtnClose, because handlers are wired in code-behind.
+
+     Buttons carry a TextBlock child rather than Content, the repo convention (CLAUDE.md trap 1);
+     neither label has an underscore, so that is convention here, not necessity.
+     Every string is a literal exactly as in the WPF original - there are no loc keys to carry
+     over, and no bindings, hence no x:DataType. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.LinkPhoneDialog"
+        Title="Link your phone" Height="560" Width="420"
+        WindowStartupLocation="CenterOwner" CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}"
+        SystemDecorations="None" TransparencyLevelHint="Transparent">
+
+    <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" CornerRadius="10">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Margin="0,0,0,15">
+                <TextBlock Text="Link your phone"
+                           FontSize="24" FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Scan this code with the CCP mobile app to sign in as this account."
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap" TextAlignment="Center"
+                           HorizontalAlignment="Center" Margin="0,5,0,0"/>
+            </StackPanel>
+
+            <StackPanel Grid.Row="1" VerticalAlignment="Center">
+                <!-- QR -->
+                <Border Background="White" CornerRadius="8" Padding="10"
+                        HorizontalAlignment="Center" Margin="0,0,0,12">
+                    <Image x:Name="ImgQrCode" Width="220" Height="220"
+                           RenderOptions.BitmapInterpolationMode="None"/>
+                </Border>
+
+                <!-- Manual fallback code -->
+                <TextBlock Text="No camera? Enter this code in the app:"
+                           FontSize="11" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" CornerRadius="6"
+                        Background="{DynamicResource PanelBgBrush}" Padding="20,10"
+                        HorizontalAlignment="Center" Margin="0,0,0,10">
+                    <TextBlock x:Name="TxtLinkCode" Text="--- ---"
+                               FontSize="28" FontWeight="Bold" Foreground="White"
+                               FontFamily="Consolas, Courier New, monospace"
+                               HorizontalAlignment="Center" TextAlignment="Center"/>
+                </Border>
+
+                <TextBlock x:Name="TxtStatus" Text="Fetching code..."
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap"
+                           HorizontalAlignment="Center" TextAlignment="Center" Margin="0,0,0,10"/>
+
+                <Button x:Name="BtnRefresh"
+                        Padding="14,8" HorizontalAlignment="Center"
+                        Background="{DynamicResource AccentTintedBgBrush}" Foreground="{DynamicResource PinkBrush}"
+                        BorderThickness="0" FontSize="12" FontWeight="Bold" Cursor="Hand">
+                    <TextBlock Text="Get a new code"/>
+                </Button>
+            </StackPanel>
+
+            <!-- Close -->
+            <Button x:Name="BtnClose" Grid.Row="2"
+                    Padding="20,8" HorizontalAlignment="Right"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand">
+                <TextBlock Text="Close"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Shows a short-lived one-time QR code (proxy /v2/auth/device/authorize) that the
+    /// CCP mobile app scans to sign in as this account. The phone redeems the code for
+    /// its own device token, so this desktop session is never invalidated. Codes live
+    /// ~3 minutes; a countdown timer auto-refreshes the UI state on expiry.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/LinkPhoneDialog.xaml.cs. Deviations:
+    ///  - <c>V2AuthService.AuthorizeMobileLinkAsync</c> and QRCoder both live in the WPF head,
+    ///    so <see cref="FetchCode"/> is a stub with placeholder data. Everything downstream of it
+    ///    - the ABC-DEF formatting, the countdown, the expiry reset - is the original logic.
+    ///  - The stub runs from the constructor, not from <c>Loaded</c>, so the headless render does
+    ///    not depend on <c>Loaded</c> timing: a placeholder that never ran would be
+    ///    indistinguishable from one that failed.
+    ///  - <c>Unloaded</c> -> <c>Closed</c> for stopping the timer. --render-all runs every view in
+    ///    one process; a 1s timer still ticking against a closed window is pure noise.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>; Serilog is dropped, the head has no
+    ///    reference to it and the stub has nothing to log.
+    /// </summary>
+    public partial class LinkPhoneDialog : Window
+    {
+        private readonly DispatcherTimer _countdown = new() { Interval = TimeSpan.FromSeconds(1) };
+        private readonly Image _imgQrCode;
+        private readonly TextBlock _txtLinkCode;
+        private readonly TextBlock _txtStatus;
+        private readonly Button _btnRefresh;
+        private DateTimeOffset _expiresAt;
+
+        public LinkPhoneDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _imgQrCode = this.FindControl<Image>("ImgQrCode")!;
+            _txtLinkCode = this.FindControl<TextBlock>("TxtLinkCode")!;
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+            _btnRefresh = this.FindControl<Button>("BtnRefresh")!;
+
+            _countdown.Tick += Countdown_Tick;
+            _btnRefresh.Click += (_, _) => FetchCode();
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            PointerPressed += Window_PointerPressed;
+            Closed += (_, _) => _countdown.Stop();
+
+            FetchCode();
+        }
+
+        /// <summary>
+        /// ponytail: needs V2AuthService.AuthorizeMobileLinkAsync + QRCoder, wired when they move
+        /// to Core. Until then this hands the real display path a placeholder code and expiry, so
+        /// the formatting, the QR scaling and the countdown are all still exercised.
+        /// </summary>
+        private void FetchCode()
+        {
+            _countdown.Stop();
+            _btnRefresh.IsEnabled = false;
+
+            var code = "ABCDEF";
+
+            // Format ABC-DEF for readability; the app strips the dash on entry.
+            _txtLinkCode.Text = code.Length == 6 ? $"{code[..3]}-{code[3..]}" : code;
+            RenderQr($"ccpmobile://link?c={code}");
+
+            _expiresAt = DateTimeOffset.UtcNow.AddMinutes(3);
+            _countdown.Start();
+            Countdown_Tick(null, EventArgs.Empty);
+        }
+
+        private void Countdown_Tick(object? sender, EventArgs e)
+        {
+            var remaining = _expiresAt - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+            {
+                _countdown.Stop();
+                _imgQrCode.Source = null;
+                _txtLinkCode.Text = "--- ---";
+                _txtStatus.Text = "Code expired — get a new one.";
+                _btnRefresh.IsEnabled = true;
+                return;
+            }
+            _btnRefresh.IsEnabled = true;
+            _txtStatus.Text = $"Code expires in {remaining.Minutes}:{remaining.Seconds:D2}";
+        }
+
+        /// <summary>
+        /// Placeholder stand-in for the QRCoder render (dark-pink modules on the white card).
+        /// A real payload needs the generator; a 25x25 bitmap blown up to 220 still proves the
+        /// Image draws and that BitmapInterpolationMode="None" keeps the modules square.
+        /// </summary>
+        private void RenderQr(string payload)
+        {
+            const int n = 25;
+            var bmp = new WriteableBitmap(new PixelSize(n, n), new Vector(96, 96), PixelFormats.Bgra8888, AlphaFormat.Opaque);
+            using (var fb = bmp.Lock())
+            {
+                var row = new byte[fb.RowBytes];
+                for (var y = 0; y < n; y++)
+                {
+                    for (var x = 0; x < n; x++)
+                    {
+                        // Deterministic from the payload so a different code looks different, and
+                        // a 7x7 finder square in each of the three usual corners.
+                        var finder = (x < 7 || x >= n - 7) && y < 7 || x < 7 && y >= n - 7;
+                        var dark = finder
+                            ? x % 6 != 1 && y % 6 != 1
+                            : ((x * 7 + y * 13 + payload.Length) % 5) < 2;
+                        row[x * 4 + 0] = dark ? (byte)0x50 : (byte)0xFF; // B
+                        row[x * 4 + 1] = dark ? (byte)0x0A : (byte)0xFF; // G
+                        row[x * 4 + 2] = dark ? (byte)0x8B : (byte)0xFF; // R
+                        row[x * 4 + 3] = 0xFF;
+                    }
+                    Marshal.Copy(row, 0, fb.Address + y * fb.RowBytes, fb.RowBytes);
+                }
+            }
+            _imgQrCode.Source = bmp;
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                BeginMoveDrag(e);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/WebcamLoadingSplash.axaml
+++ b/CCP.Avalonia/Views/Windows/WebcamLoadingSplash.axaml
@@ -1,0 +1,131 @@
+<!-- PORTED from ConditioningControlPanel/Windows/WebcamLoadingSplash.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency="True" -> SystemDecorations="None" /
+                                                         TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                          -> CanResize="False"
+       MouseLeftButtonDown="Window_..."               -> PointerPressed, wired in the constructor
+       Border.Effect DropShadowEffect                 -> BoxShadow="3.5 3.5 20 0 #99000000"
+                                                         (Direction 315 + ShadowDepth 5 = 3.5,3.5;
+                                                          Opacity 0.6 = alpha 0x99)
+       ScaleTransform x:Name="ProgressScale"          -> unnamed; FindControl only finds Controls,
+                                                         so the code-behind reaches it through
+                                                         ProgressFill.RenderTransform
+       DoubleAnimation on ScaleX (SetProgress)        -> a DoubleTransition on the transform: the
+                                                         code-behind just assigns ScaleX
+       DoubleAnimation on Opacity (StartPulse)        -> the Border.pulse style animation below,
+                                                         toggled by a class from code-behind
+       <Border.CornerRadius><CornerRadius .../>       -> CornerRadius="4" (all four were 4)
+       RenderTransformOrigin Point 0,0.5              -> "0%,50%" (Avalonia reads a bare number
+                                                         as pixels)
+       FontFamily="Segoe UI"                          -> "Segoe UI, Liberation Sans, sans-serif",
+                                                         as the other ported views do
+
+     Every string is a literal exactly as in the WPF original - no loc keys, no bindings, hence
+     no x:DataType. ScaleX stays 0: MainWindow.LabTab's InstallWebcamLoadingSplash calls
+     SetProgress immediately after Show(), so an empty bar is the true first frame. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.WebcamLoadingSplash"
+        Title="Starting Eye Tracking"
+        Height="200" Width="420"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Topmost="True">
+
+    <Window.Styles>
+        <!-- The WPF StartPulse() DoubleAnimation, verbatim: 1.0 -> 0.55 over 900ms, autoreversed
+             forever on a sine ease. StopPulse() removes the class. -->
+        <Style Selector="Border.pulse">
+            <Style.Animations>
+                <Animation Duration="0:0:0.9" IterationCount="INFINITE"
+                           PlaybackDirection="Alternate" Easing="SineEaseInOut">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="1.0"/></KeyFrame>
+                    <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0.55"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="15" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+            BoxShadow="3.5 3.5 20 0 #99000000">
+
+        <Grid Margin="28,18">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock Text="&#x1F441;" FontSize="20" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                <TextBlock Text="Starting Eye Tracking"
+                           FontSize="20"
+                           FontWeight="Bold"
+                           Foreground="{DynamicResource PinkBrush}"
+                           VerticalAlignment="Center"
+                           FontFamily="Segoe UI, Liberation Sans, sans-serif"/>
+            </StackPanel>
+
+            <!-- Loading status -->
+            <TextBlock x:Name="TxtStatus"
+                       Grid.Row="1"
+                       Text="Preparing eye-tracking engine…"
+                       FontSize="12"
+                       Foreground="{DynamicResource TextSecondaryBrush}"
+                       HorizontalAlignment="Center"
+                       Margin="0,12,0,12"
+                       FontFamily="Segoe UI, Liberation Sans, sans-serif"/>
+
+            <!-- Progress bar -->
+            <Grid Grid.Row="2" Height="8">
+                <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="4"/>
+                <Border x:Name="ProgressFill" CornerRadius="4" RenderTransformOrigin="0%,50%">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+                            <GradientStop Color="#DA70D6" Offset="1"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                    <Border.RenderTransform>
+                        <ScaleTransform ScaleX="0" ScaleY="1">
+                            <ScaleTransform.Transitions>
+                                <Transitions>
+                                    <DoubleTransition Property="ScaleX" Duration="0:0:0.18" Easing="QuadraticEaseOut"/>
+                                </Transitions>
+                            </ScaleTransform.Transitions>
+                        </ScaleTransform>
+                    </Border.RenderTransform>
+                </Border>
+            </Grid>
+
+            <!-- Hint -->
+            <TextBlock Grid.Row="3"
+                       Text="First run can take a few seconds while the camera warms up and the AI models load."
+                       FontSize="11"
+                       Foreground="{DynamicResource TextMutedBrush}"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       Margin="0,14,0,0"
+                       FontFamily="Segoe UI, Liberation Sans, sans-serif"/>
+
+            <!-- Drag affordance -->
+            <TextBlock Grid.Row="4"
+                       Text="drag to move"
+                       FontSize="9"
+                       Foreground="#555555"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Bottom"
+                       Margin="0,8,0,0"
+                       FontFamily="Segoe UI, Liberation Sans, sans-serif"/>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/WebcamLoadingSplash.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamLoadingSplash.axaml.cs
@@ -1,0 +1,139 @@
+using System;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Small, movable splash shown while the webcam / eye-tracking engine
+    /// starts up. WebcamTrackingService.Start() opens the camera and constructs
+    /// three ONNX inference sessions on a worker thread, which can block several
+    /// seconds (longer on first run or slow USB cameras). This window is driven
+    /// by WebcamTrackingService.OnStartupProgress so the user sees what's
+    /// happening instead of an unresponsive button, and can drag it out of the
+    /// way while they wait.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/WebcamLoadingSplash.xaml.cs. Deviations:
+    ///  - The progress DoubleAnimation is a DoubleTransition on the ScaleTransform in the XAML,
+    ///    so SetProgress is a plain assignment. Same 180ms quadratic-ease-out shape.
+    ///  - The breathing pulse is a keyframe animation on the "pulse" style class; Start/StopPulse
+    ///    add and remove it, since Avalonia has no BeginAnimation(property, null) to cancel one.
+    ///  - The fade-out uses Animation.RunAsync, Avalonia's equivalent of BeginAnimation.
+    ///  - Dispatcher.CheckAccess/BeginInvoke -> Dispatcher.UIThread.CheckAccess/Post.
+    ///  - DragMove() -> BeginMoveDrag(e), which does not throw on a released button, so the
+    ///    swallowing try/catch the WPF original needed is gone.
+    /// </summary>
+    public partial class WebcamLoadingSplash : Window
+    {
+        private readonly TextBlock _txtStatus;
+        private readonly Border _progressFill;
+        private readonly ScaleTransform _progressScale;
+        private bool _closing;
+
+        public WebcamLoadingSplash()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+            _progressFill = this.FindControl<Border>("ProgressFill")!;
+            _progressScale = (ScaleTransform)_progressFill.RenderTransform!;
+
+            PointerPressed += Window_PointerPressed;
+            StartPulse();
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            // Borderless window — let the user drag it anywhere.
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                BeginMoveDrag(e);
+        }
+
+        /// <summary>
+        /// Update the progress bar (0.0–1.0) and status text. Safe to call from
+        /// any thread.
+        /// </summary>
+        public void SetProgress(double progress, string status)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => SetProgress(progress, status));
+                return;
+            }
+            if (_closing) return;
+
+            if (!string.IsNullOrEmpty(status)) _txtStatus.Text = status;
+
+            _progressScale.ScaleX = Math.Min(1.0, Math.Max(0.0, progress));
+        }
+
+        /// <summary>
+        /// Show a failure message on the splash, then auto-close after a short
+        /// beat so the user can read WHY eye-tracking didn't start (camera in
+        /// use, OS-denied, engine error, or open timed out) instead of the bar
+        /// silently vanishing or hanging forever (#300, #311). Safe to call from
+        /// any thread; idempotent with CloseSplash.
+        /// </summary>
+        public void ShowErrorAndClose(string message)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => ShowErrorAndClose(message));
+                return;
+            }
+            if (_closing) return;
+            StopPulse();
+            if (!string.IsNullOrEmpty(message)) _txtStatus.Text = message;
+
+            var hold = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(2800) };
+            hold.Tick += (s, e) => { hold.Stop(); CloseSplash(); };
+            hold.Start();
+        }
+
+        /// <summary>
+        /// Fade the splash out and close it. Safe to call from any thread, and
+        /// idempotent.
+        /// </summary>
+        public async void CloseSplash()
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(CloseSplash);
+                return;
+            }
+            if (_closing) return;
+            _closing = true;
+            StopPulse();
+
+            var fadeOut = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(200),
+                FillMode = FillMode.Forward,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(OpacityProperty, 1.0) } },
+                    new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(OpacityProperty, 0.0) } }
+                }
+            };
+            await fadeOut.RunAsync(this);
+            try { Close(); } catch { /* already closed */ }
+        }
+
+        // Gentle breathing pulse on the fill so the long phases (camera warmup,
+        // ONNX session construction) don't look frozen between the discrete
+        // progress jumps.
+        private void StartPulse() => _progressFill.Classes.Add("pulse");
+
+        private void StopPulse()
+        {
+            _progressFill.Classes.Remove("pulse");
+            _progressFill.Opacity = 1.0;
+        }
+    }
+}


### PR DESCRIPTION
492 lines. The auth call and the QR render are stubbed (QRCoder is a WPF-head package); the code formatting, countdown and expiry reset are the original logic.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351