### PR TITLE
feat(avalonia): port CatalogueSubmitDialog, AssetSubmitDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/AssetSubmitDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/AssetSubmitDialog.axaml
@@ -1,0 +1,218 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/AssetSubmitDialog.xaml.
+     Structure, ordering, spacing and every x:Name / resource key preserved. Deviations, all forced:
+
+       Style="{StaticResource X}" / inline Button.Style / CheckBox.Style
+                                    -> Theme="{StaticResource X}" + the ControlThemes below
+       ControlTemplate.Triggers     -> ^:pointerover / ^:disabled / ^:checked selectors
+       Visibility="Collapsed"       -> IsVisible="False"
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" + AllowsTransparency + Background="Transparent"
+                                    -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+                                       + Background="Transparent"
+       Image + EmojiToImageSource   -> a plain TextBlock (Avalonia renders colour emoji natively;
+                                       see the porting notes in CLAUDE.md)
+       Hyperlink + RequestNavigate  -> HyperlinkButton NavigateUri (native; replaces Process.Start,
+                                       so the handler disappears rather than becoming a stub)
+       CaretBrush                   -> CaretBrush (same name in Avalonia)
+       Click / Checked / Unchecked / TextChanged -> wired in the constructor
+       Content="{loc:Str …}"        -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.AssetSubmitDialog"
+        Title="{loc:Str dialog_catalogue_submit_title}"
+        SizeToContent="Height" MinHeight="480" MaxHeight="820" Width="620"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/AssetSubmitDialog.xaml's inline CheckBox.Style and
+             Button.Style templates (identical to CatalogueSubmitDialog.axaml's), hoist when a
+             third view needs them -->
+        <ControlTheme x:Key="AffirmCheckBox" TargetType="CheckBox">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid>
+                        <Border x:Name="border" Width="24" Height="24" CornerRadius="4"
+                                Background="{DynamicResource PanelBgBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" Cursor="Hand"/>
+                        <TextBlock x:Name="check" Text="✔" Foreground="{DynamicResource PinkBrush}" FontSize="16"
+                                   FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   IsVisible="False"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ TextBlock#check">
+                <Setter Property="IsVisible" Value="True"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#border">
+                <Setter Property="Background" Value="#3A2040"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="DlgCancelButton" TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="#303050"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="DlgSubmitButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" Opacity="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="#FF85C5"/>
+            </Style>
+            <Style Selector="^:disabled /template/ Border#border">
+                <Setter Property="Opacity" Value="0.4"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBlock Text="📤" FontSize="24" Width="30" Height="30"
+                           VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_title}"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontSize="22" FontWeight="Bold" VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Subtitle: which asset is being submitted -->
+            <TextBlock Grid.Row="1" x:Name="TxtSubtitle"
+                       Foreground="#B0B0C0" FontSize="13" Margin="0,0,0,16"
+                       TextTrimming="CharacterEllipsis"/>
+
+            <!-- Body copy (swapped to the mod-specific explainer when the ctor
+                 asks for a download URL - mods are creator-hosted on MEGA) -->
+            <TextBlock Grid.Row="2" x:Name="TxtBody"
+                       Text="{loc:Str dialog_catalogue_submit_asset_body}"
+                       Foreground="#E0E0E0" FontSize="14" TextWrapping="Wrap" LineHeight="20"
+                       VerticalAlignment="Top" Margin="0,0,0,6"/>
+
+            <!-- Creator name -->
+            <StackPanel Grid.Row="3" Margin="0,12,0,0">
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_creator_label}"
+                           Foreground="#B0B0C0" FontSize="12" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox x:Name="TxtCreator" MaxLength="100"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="#E0E0E0"
+                         BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
+                         Padding="8,6" FontSize="14" CaretBrush="{DynamicResource PinkBrush}"/>
+            </StackPanel>
+
+            <!-- Tags -->
+            <StackPanel Grid.Row="4" Margin="0,12,0,0">
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_tags_label}"
+                           Foreground="#B0B0C0" FontSize="12" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox x:Name="TxtTags"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="#E0E0E0"
+                         BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
+                         Padding="8,6" FontSize="14" CaretBrush="{DynamicResource PinkBrush}"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_tags_hint}"
+                           Foreground="#808090" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Download URL (mods only: creator-hosted binary, catalogue keeps the link).
+                 Hidden unless the ctor asks for it. -->
+            <StackPanel Grid.Row="5" x:Name="PnlDownloadUrl" Margin="0,12,0,0" IsVisible="False">
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_mega_label}"
+                           Foreground="#B0B0C0" FontSize="12" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                <TextBox x:Name="TxtDownloadUrl" MaxLength="500"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="#E0E0E0"
+                         BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
+                         Padding="8,6" FontSize="14" CaretBrush="{DynamicResource PinkBrush}"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_mega_hint}"
+                           Foreground="#808090" FontSize="11" Margin="0,4,0,0" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Guidelines hyperlink + affirmation checkbox -->
+            <StackPanel Grid.Row="6" Margin="0,14,0,0">
+                <HyperlinkButton x:Name="LinkGuidelines" Padding="0"
+                                 HorizontalAlignment="Left"
+                                 Foreground="#B084DC"
+                                 NavigateUri="https://app.cclabs.app/catalogue/guidelines">
+                    <TextBlock Text="{loc:Str dialog_catalogue_submit_view_guidelines}"
+                               FontSize="13" TextDecorations="Underline"/>
+                </HyperlinkButton>
+
+                <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
+                    <CheckBox x:Name="ChkAffirm" VerticalAlignment="Top"
+                              Theme="{StaticResource AffirmCheckBox}"/>
+                    <TextBlock Text="{loc:Str dialog_catalogue_submit_confirm_checkbox}"
+                               Foreground="#E0E0E0" FontSize="14" Margin="12,2,0,0" VerticalAlignment="Top" TextWrapping="Wrap"
+                               MaxWidth="520"/>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Spinner -->
+            <StackPanel Grid.Row="7" x:Name="PnlSpinner" Orientation="Horizontal" Margin="0,16,0,12" IsVisible="False">
+                <TextBlock Text="⌛" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_spinner}" Foreground="#B0B0C0" FontSize="13" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <Grid Grid.Row="8" Margin="0,20,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Button x:Name="BtnCancel" Grid.Column="0" Margin="0,0,10,0"
+                        Theme="{StaticResource DlgCancelButton}" IsCancel="True">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+
+                <Button x:Name="BtnSubmit" Grid.Column="1" Margin="10,0,0,0"
+                        Theme="{StaticResource DlgSubmitButton}" IsEnabled="False">
+                    <TextBlock Text="{loc:Str dialog_catalogue_submit_btn}"/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/AssetSubmitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AssetSubmitDialog.axaml.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Affirmation + metadata modal for Preset/Session catalogue submissions.
+    /// Unlike <see cref="CatalogueSubmitDialog"/> (enhancements carry their own
+    /// creator/tags in the bundle), preset/session native files have neither, so
+    /// this dialog collects a creator name + tags before the POST. Submit is gated
+    /// on a non-empty creator AND the affirmation checkbox.
+    ///
+    /// Usage:
+    ///   var d = new AssetSubmitDialog(assetName, defaultCreator);
+    ///   if (await d.ShowDialog&lt;bool&gt;(owner)) {
+    ///       // d.Creator, d.Tags ready for SubmitCatalogueAssetAsync
+    ///   }
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/AssetSubmitDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> property becomes <c>Close(bool)</c>; Avalonia carries the
+    ///    result through <c>ShowDialog&lt;bool&gt;</c>.
+    ///  - <c>LinkGuidelines_RequestNavigate</c> is gone: <c>HyperlinkButton.NavigateUri</c> opens
+    ///    the browser itself, so there is no <c>Process.Start</c> to port.
+    ///  - The mod-body swap REBINDS TxtBody rather than assigning <c>.Text</c>. The control carries
+    ///    a <c>{loc:Str}</c> binding; a local value would be overwritten on the next language
+    ///    change (see the porting notes in CLAUDE.md). Same key, chosen in code.
+    ///  - Checked/Unchecked collapse into <c>IsCheckedChanged</c>; <c>TextChanged</c> keeps its name.
+    /// </summary>
+    public partial class AssetSubmitDialog : Window
+    {
+        public bool Confirmed { get; private set; }
+        public string Creator { get; private set; } = "";
+        public IReadOnlyList<string> Tags { get; private set; } = Array.Empty<string>();
+        public string DownloadUrl { get; private set; } = "";
+
+        private readonly bool _requireDownloadUrl;
+        private readonly TextBox _txtCreator;
+        private readonly TextBox _txtTags;
+        private readonly TextBox _txtDownloadUrl;
+        private readonly CheckBox _chkAffirm;
+        private readonly Button _btnSubmit;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.
+        /// It asks for a download URL, which is the branch that draws the most - the MEGA panel
+        /// and the mod explainer are otherwise invisible in the render proof.</summary>
+        internal AssetSubmitDialog() : this("Deep Trance Session", "bambi", requireDownloadUrl: true, defaultTags: "gentle, 30min") { }
+
+        public AssetSubmitDialog(string assetName, string? defaultCreator = null,
+            bool requireDownloadUrl = false, string? defaultTags = null)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _requireDownloadUrl = requireDownloadUrl;
+
+            _txtCreator = this.FindControl<TextBox>("TxtCreator")!;
+            _txtTags = this.FindControl<TextBox>("TxtTags")!;
+            _txtDownloadUrl = this.FindControl<TextBox>("TxtDownloadUrl")!;
+            _chkAffirm = this.FindControl<CheckBox>("ChkAffirm")!;
+            _btnSubmit = this.FindControl<Button>("BtnSubmit")!;
+
+            this.FindControl<TextBlock>("TxtSubtitle")!.Text = string.IsNullOrWhiteSpace(assetName)
+                ? string.Empty
+                : Loc.GetF("dialog_catalogue_submit_subtitle_fmt", assetName);
+
+            if (!string.IsNullOrWhiteSpace(defaultCreator))
+                _txtCreator.Text = defaultCreator.Trim();
+            if (!string.IsNullOrWhiteSpace(defaultTags))
+                _txtTags.Text = defaultTags.Trim();
+
+            if (requireDownloadUrl)
+            {
+                this.FindControl<StackPanel>("PnlDownloadUrl")!.IsVisible = true;
+                _txtDownloadUrl.TextChanged += (_, _) => UpdateSubmitEnabled();
+                // Mods get their own explainer: they are user-created and stay
+                // hosted on the creator's MEGA - the catalogue lists only the
+                // link, so the flow (export -> MEGA -> paste link) needs
+                // spelling out where presets/sessions don't.
+                this.FindControl<TextBlock>("TxtBody")!.Bind(TextBlock.TextProperty,
+                    new Binding("[dialog_catalogue_submit_mod_body]")
+                    {
+                        Source = LocalizationManager.Instance,
+                        Mode = BindingMode.OneWay,
+                    });
+            }
+
+            _chkAffirm.IsCheckedChanged += (_, _) => UpdateSubmitEnabled();
+            _txtCreator.TextChanged += (_, _) => UpdateSubmitEnabled();
+
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) =>
+            {
+                Confirmed = false;
+                Close(false);
+            };
+            _btnSubmit.Click += (_, _) => Submit();
+
+            UpdateSubmitEnabled();
+        }
+
+        private void UpdateSubmitEnabled()
+        {
+            _btnSubmit.IsEnabled = _chkAffirm.IsChecked == true
+                && !string.IsNullOrWhiteSpace(_txtCreator.Text)
+                && (!_requireDownloadUrl || IsValidMegaUrl(_txtDownloadUrl.Text));
+        }
+
+        // The catalogue only stores a link to the creator-hosted binary; v1
+        // restricts hosting to MEGA so the server-side allowlist stays simple.
+        internal static bool IsValidMegaUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return false;
+            if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri)) return false;
+            if (uri.Scheme != Uri.UriSchemeHttps) return false;
+            var host = uri.Host;
+            return host.Equals("mega.nz", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("www.mega.nz", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("mega.co.nz", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("www.mega.co.nz", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void Submit()
+        {
+            if (_chkAffirm.IsChecked != true || string.IsNullOrWhiteSpace(_txtCreator.Text)) return;
+            if (_requireDownloadUrl && !IsValidMegaUrl(_txtDownloadUrl.Text)) return;
+
+            Creator = _txtCreator.Text!.Trim();
+            DownloadUrl = _requireDownloadUrl ? _txtDownloadUrl.Text!.Trim() : "";
+            // Accept comma- or whitespace-separated tags; dedup, lowercase-trim, cap length.
+            Tags = (_txtTags.Text ?? string.Empty)
+                .Split(new[] { ',', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(t => t.Trim())
+                .Where(t => t.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(12)
+                .ToList();
+
+            Confirmed = true;
+            Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/CatalogueSubmitDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/CatalogueSubmitDialog.axaml
@@ -1,0 +1,181 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/CatalogueSubmitDialog.xaml.
+     Structure, ordering, spacing and every x:Name / resource key preserved. Deviations, all forced:
+
+       Style="{StaticResource X}" / inline Button.Style / CheckBox.Style
+                                    -> Theme="{StaticResource X}" + the ControlThemes below
+       ControlTemplate.Triggers     -> ^:pointerover / ^:disabled / ^:checked selectors
+       Visibility="Collapsed"       -> IsVisible="False"
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" + AllowsTransparency + Background="Transparent"
+                                    -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+                                       + Background="Transparent"
+       Image + EmojiToImageSource   -> a plain TextBlock (Avalonia renders colour emoji natively;
+                                       see the porting notes in CLAUDE.md)
+       Hyperlink + RequestNavigate  -> HyperlinkButton NavigateUri (native; replaces Process.Start,
+                                       so the handler disappears rather than becoming a stub)
+       Click / Checked / Unchecked  -> wired in the constructor
+       Content="{loc:Str …}"        -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case) -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.CatalogueSubmitDialog"
+        Title="{loc:Str dialog_catalogue_submit_title}"
+        SizeToContent="Height" MinHeight="420" MaxHeight="780" Width="620"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of Dialogs/CatalogueSubmitDialog.xaml's inline CheckBox.Style and
+             Button.Style templates, hoist when a third view needs them -->
+        <ControlTheme x:Key="AffirmCheckBox" TargetType="CheckBox">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid>
+                        <Border x:Name="border" Width="24" Height="24" CornerRadius="4"
+                                Background="{DynamicResource PanelBgBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" Cursor="Hand"/>
+                        <TextBlock x:Name="check" Text="✔" Foreground="{DynamicResource PinkBrush}" FontSize="16"
+                                   FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   IsVisible="False"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ TextBlock#check">
+                <Setter Property="IsVisible" Value="True"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#border">
+                <Setter Property="Background" Value="#3A2040"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="DlgCancelButton" TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="#303050"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="DlgSubmitButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" Opacity="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover">
+                <Setter Property="Background" Value="#FF85C5"/>
+            </Style>
+            <Style Selector="^:disabled /template/ Border#border">
+                <Setter Property="Opacity" Value="0.4"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBlock Text="📤" FontSize="24" Width="30" Height="30"
+                           VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_title}"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontSize="22" FontWeight="Bold" VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Subtitle: which enhancement is being submitted -->
+            <TextBlock Grid.Row="1" x:Name="TxtSubtitle"
+                       Foreground="#B0B0C0" FontSize="13" Margin="0,0,0,16"
+                       TextTrimming="CharacterEllipsis"/>
+
+            <!-- Body copy (verbatim per spec) -->
+            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" MaxHeight="320">
+                <TextBlock x:Name="TxtBody"
+                           Text="{loc:Str dialog_catalogue_submit_body}"
+                           Foreground="#E0E0E0" FontSize="14" TextWrapping="Wrap" LineHeight="20"
+                           VerticalAlignment="Top"/>
+            </ScrollViewer>
+
+            <!-- Guidelines hyperlink — separate localized string, sibling element.
+                 Keeps each translation atomic and avoids placeholder-inside-prose
+                 fragility across 9 languages. -->
+            <HyperlinkButton Grid.Row="3" x:Name="LinkGuidelines" Margin="0,14,0,0" Padding="0"
+                             HorizontalAlignment="Left"
+                             Foreground="#B084DC"
+                             NavigateUri="https://app.cclabs.app/catalogue/guidelines">
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_view_guidelines}"
+                           FontSize="13" TextDecorations="Underline"/>
+            </HyperlinkButton>
+
+            <!-- Affirmation checkbox -->
+            <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,20,0,24">
+                <CheckBox x:Name="ChkAffirm" VerticalAlignment="Top"
+                          Theme="{StaticResource AffirmCheckBox}"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_submit_confirm_checkbox}"
+                           Foreground="#E0E0E0" FontSize="14" Margin="12,2,0,0" VerticalAlignment="Top" TextWrapping="Wrap"
+                           MaxWidth="520"/>
+            </StackPanel>
+
+            <!-- Spinner (visible during submission) -->
+            <StackPanel Grid.Row="5" x:Name="PnlSpinner" Orientation="Horizontal" Margin="0,0,0,12" IsVisible="False">
+                <TextBlock Text="⌛" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <TextBlock Text="Submitting..." Foreground="#B0B0C0" FontSize="13" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <Grid Grid.Row="6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Button x:Name="BtnCancel" Grid.Column="0" Margin="0,0,10,0"
+                        Theme="{StaticResource DlgCancelButton}" IsCancel="True">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+
+                <Button x:Name="BtnSubmit" Grid.Column="1" Margin="10,0,0,0"
+                        Theme="{StaticResource DlgSubmitButton}" IsEnabled="False">
+                    <TextBlock Text="{loc:Str dialog_catalogue_submit_btn}"/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/CatalogueSubmitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CatalogueSubmitDialog.axaml.cs
@@ -1,0 +1,68 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Affirmation modal for catalogue submissions. Shown before a user-
+    /// initiated POST to the catalogue API. The user must tick the
+    /// affirmation checkbox before Submit is enabled — same gating pattern as
+    /// WarningDialog.cs.
+    ///
+    /// Usage:
+    ///   var d = new CatalogueSubmitDialog(enhancementName);
+    ///   if (await d.ShowDialog&lt;bool&gt;(owner)) {
+    ///       // d.Confirmed == true, proceed with CatalogueService submit
+    ///   }
+    ///
+    /// Body copy is verbatim from the W2 spec — translators can edit
+    /// dialog_catalogue_submit_body, but the canonical English text is the
+    /// ToS-anchoring reference. The guidelines hyperlink is a separate
+    /// localized string (sibling element, not embedded in the body prose) so
+    /// each translation is atomic.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/CatalogueSubmitDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> property becomes <c>Close(bool)</c>; Avalonia carries the
+    ///    result through <c>ShowDialog&lt;bool&gt;</c>.
+    ///  - <c>LinkGuidelines_RequestNavigate</c> is gone: <c>HyperlinkButton.NavigateUri</c> opens
+    ///    the browser itself, so there is no <c>Process.Start</c> to port.
+    ///  - Checked/Unchecked collapse into <c>IsCheckedChanged</c>.
+    /// </summary>
+    public partial class CatalogueSubmitDialog : Window
+    {
+        public bool Confirmed { get; private set; }
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal CatalogueSubmitDialog() : this("Deeper Spiral Pack") { }
+
+        public CatalogueSubmitDialog(string enhancementName)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            var subtitle = this.FindControl<TextBlock>("TxtSubtitle")!;
+            var chkAffirm = this.FindControl<CheckBox>("ChkAffirm")!;
+            var btnSubmit = this.FindControl<Button>("BtnSubmit")!;
+
+            subtitle.Text = string.IsNullOrWhiteSpace(enhancementName)
+                ? string.Empty
+                : Loc.GetF("dialog_catalogue_submit_subtitle_fmt", enhancementName);
+
+            // Checkbox gates the Submit button — same pattern as WarningDialog.
+            chkAffirm.IsCheckedChanged += (_, _) => btnSubmit.IsEnabled = chkAffirm.IsChecked == true;
+
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) =>
+            {
+                Confirmed = false;
+                Close(false);
+            };
+
+            btnSubmit.Click += (_, _) =>
+            {
+                if (chkAffirm.IsChecked != true) return;
+                Confirmed = true;
+                Close(true);
+            };
+        }
+    }
+}


### PR DESCRIPTION
611 lines. Nothing stubbed: neither dialog reaches a service. The WPF Hyperlink navigation handler is replaced by a native HyperlinkButton.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351