### PR TITLE
feat(avalonia): port CataloguePickerDialog, SessionLogHistoryWindow

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/CataloguePickerDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/CataloguePickerDialog.axaml
@@ -1,0 +1,111 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/CataloguePickerDialog.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       AllowsTransparency="True" / WindowStyle="None"
+                                     -> TransparencyLevelHint="Transparent" + SystemDecorations="None"
+       ResizeMode="CanResize"        -> CanResize="True"
+       Image + EmojiToImageSource    -> plain TextBlock (CLAUDE.md trap 3: Avalonia draws colour
+                                        emoji natively, so the converter and its pack:// URI go)
+       Hyperlink + RequestNavigate   -> HyperlinkButton NavigateUri (native; replaces Process.Start,
+                                        matching MicConsentDialog and the other ported dialogs)
+       Button.Style inline template  -> a Window.Styles class selector carrying the Template. A
+                                        property-only theme would draw nothing (trap 4) and the
+                                        ContentPresenter needs Content= (trap 6).
+       IsCancel="True"               -> the Esc handler in the code-behind, which the WPF original
+                                        also carried; Avalonia has no IsCancel.
+     The close button carries a TextBlock child rather than Content: Avalonia parses "_" in Content
+     as an access key and every loc key here is snake_case (trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.CataloguePickerDialog"
+        Title="{loc:Str dialog_catalogue_picker_title}"
+        Height="620" Width="640" MinHeight="420" MinWidth="540"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Styles>
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/CataloguePickerDialog.xaml:BtnClose
+             inline Button.Style, hoist when a second view needs it. -->
+        <Style Selector="Button.pickerClose">
+            <Setter Property="Background" Value="{StaticResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Padding" Value="20,10"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="Button.pickerClose:pointerover /template/ Border#border">
+            <Setter Property="Background" Value="#303050"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25" KeyboardNavigation.TabNavigation="Cycle">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
+                <TextBlock Text="📥" FontSize="24" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                <TextBlock Text="{loc:Str dialog_catalogue_picker_title}"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontSize="22" FontWeight="Bold" VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Subtitle: how many enhancements for this video -->
+            <TextBlock Grid.Row="1" x:Name="TxtSubtitle"
+                       Foreground="#B0B0C0" FontSize="13" Margin="0,0,0,14"
+                       TextTrimming="CharacterEllipsis"/>
+
+            <!-- Entries list -->
+            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled" Focusable="False">
+                <ItemsControl x:Name="EntriesList" Focusable="False">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </ScrollViewer>
+
+            <!-- Footer: web link + close -->
+            <Grid Grid.Row="3" Margin="0,14,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <HyperlinkButton Grid.Column="0" x:Name="LinkBrowseWeb" Padding="0"
+                                 VerticalAlignment="Center" HorizontalAlignment="Left"
+                                 Foreground="#B084DC">
+                    <TextBlock Text="{loc:Str dialog_catalogue_picker_browse_web}"
+                               FontSize="13" TextDecorations="Underline"/>
+                </HyperlinkButton>
+
+                <Button x:Name="BtnClose" Grid.Column="1" Classes="pickerClose" MinWidth="110">
+                    <TextBlock Text="{loc:Str dialog_catalogue_picker_close}"/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/CataloguePickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CataloguePickerDialog.axaml.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// W3 Piece 1 — picker dialog shown when /api/enhancements/by-ht-url returns
+    /// 2+ entries for the user's current HT video. Clicking a row dismisses the
+    /// dialog and exposes the chosen entry via <see cref="SelectedEntry"/>; the
+    /// caller is responsible for kicking off the download/open flow.
+    ///
+    /// Single-result lookups SKIP this dialog entirely — they go straight to
+    /// the download path from the toast's "Use one" action.
+    ///
+    /// Keyboard model:
+    ///   • Tab cycles through row borders + footer controls
+    ///   • Enter or Space on a focused row selects it
+    ///   • Esc / Close button dismisses without selecting (result = false)
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/CataloguePickerDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>, because Avalonia carries the result
+    ///    through <c>ShowDialog&lt;bool?&gt;</c> (same shape as the ported TextEditorDialog).
+    ///  - <c>MouseLeftButtonUp</c> -> <c>PointerReleased</c>, <c>MouseEnter/MouseLeave</c> ->
+    ///    <c>PointerEntered/PointerExited</c>, <c>PreviewKeyDown</c> -> <c>KeyDown</c> with
+    ///    <c>RoutingStrategies.Tunnel</c>.
+    ///  - <c>WindowChromeHelper.ApplyDarkTitleBar</c> is a Win32 head service and is dropped:
+    ///    the window has no system decorations to darken.
+    ///  - The remote thumbnail is not fetched (see <see cref="BuildThumbnail"/>); the placeholder
+    ///    tile the WPF original also shows is what draws.
+    ///  - <see cref="CatalogueEntry"/> is copied from
+    ///    ConditioningControlPanel/Services/CatalogueLookupService.cs: the record lives in the WPF
+    ///    head, not CCP.Core, and neither may be touched by this port.
+    /// </summary>
+    public partial class CataloguePickerDialog : Window
+    {
+        public CatalogueEntry? SelectedEntry { get; private set; }
+
+        private readonly ItemsControl _entriesList;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal CataloguePickerDialog() : this(SampleEntries(), "ht-9f2c41") { }
+
+        public CataloguePickerDialog(List<CatalogueEntry> entries, string? htVideoId)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _entriesList = this.FindControl<ItemsControl>("EntriesList")!;
+
+            this.FindControl<TextBlock>("TxtSubtitle")!.Text =
+                Loc.GetF("dialog_catalogue_picker_subtitle_fmt", entries.Count);
+
+            // Browse all on web: deep-link to the catalogue filtered to this HT video. Falls back
+            // to the unfiltered catalogue when we couldn't extract an id (defensive — won't happen
+            // in practice since the dialog only opens for HT-eligible URLs). HyperlinkButton opens
+            // it through the platform launcher, which is what Process.Start(UseShellExecute) did.
+            this.FindControl<HyperlinkButton>("LinkBrowseWeb")!.NavigateUri = new Uri(
+                string.IsNullOrEmpty(htVideoId)
+                    ? "https://app.cclabs.app/catalogue"
+                    : $"https://app.cclabs.app/catalogue?video={Uri.EscapeDataString(htVideoId)}");
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) =>
+            {
+                SelectedEntry = null;
+                Close(false);
+            };
+
+            var rows = new List<Control>();
+            foreach (var entry in entries)
+                rows.Add(BuildEntryRow(entry));
+            _entriesList.ItemsSource = rows;
+
+            // Esc to dismiss (WPF got this from PreviewKeyDown plus IsCancel="True" on BtnClose;
+            // Avalonia has neither, so one tunnelling handler covers both).
+            AddHandler(KeyDownEvent, (_, e) =>
+            {
+                if (e.Key == Key.Escape)
+                {
+                    SelectedEntry = null;
+                    Close(false);
+                }
+            }, global::Avalonia.Interactivity.RoutingStrategies.Tunnel);
+        }
+
+        private IBrush Res(string key) => (IBrush)this.FindResource(key)!;
+
+        private Border BuildEntryRow(CatalogueEntry entry)
+        {
+            // Whole row is one focusable, clickable Border with a faux button
+            // role for screen readers. Inline thumbnail (left), text body (center),
+            // metadata footer (bottom).
+            var row = new Border
+            {
+                Background = Res("PanelBgBrush"),
+                BorderBrush = Res("DeeperAccentTransparent40Brush"),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(12, 10, 12, 10),
+                Margin = new Thickness(0, 0, 0, 8),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Focusable = true,
+            };
+            AutomationProperties.SetName(row,
+                $"{entry.Title} {(string.IsNullOrEmpty(entry.RemixerName)
+                    ? Loc.GetF("dialog_catalogue_picker_by_fmt", entry.CreatorName)
+                    : Loc.GetF("dialog_catalogue_picker_remix_by_fmt", entry.RemixerName))}");
+
+            row.PointerReleased += (_, e) =>
+            {
+                if (e.InitialPressMouseButton == MouseButton.Left) Select(entry);
+            };
+            row.KeyDown += (_, e) =>
+            {
+                if (e.Key == Key.Enter || e.Key == Key.Space)
+                {
+                    e.Handled = true;
+                    Select(entry);
+                }
+            };
+            row.PointerEntered += (_, _) => row.Background = Res("DeeperAccentTransparent20Brush");
+            row.PointerExited += (_, _) => row.Background = Res("PanelBgBrush");
+
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            // Thumbnail (or placeholder when the server didn't send one).
+            grid.Children.Add(BuildThumbnail(entry));
+
+            var textStack = new StackPanel { Margin = new Thickness(12, 0, 0, 0) };
+            Grid.SetColumn(textStack, 1);
+
+            var title = new TextBlock
+            {
+                Text = string.IsNullOrWhiteSpace(entry.Title) ? "Untitled" : entry.Title,
+                Foreground = Res("TextLightBrush"),
+                FontSize = 15,
+                FontWeight = FontWeight.SemiBold,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            };
+            textStack.Children.Add(title);
+
+            var byline = new TextBlock
+            {
+                Text = string.IsNullOrEmpty(entry.RemixerName)
+                    ? Loc.GetF("dialog_catalogue_picker_by_fmt", entry.CreatorName)
+                    : Loc.GetF("dialog_catalogue_picker_remix_by_fmt", entry.RemixerName),
+                Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xC0)),
+                FontSize = 12,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            textStack.Children.Add(byline);
+
+            if (!string.IsNullOrWhiteSpace(entry.Description))
+            {
+                var desc = new TextBlock
+                {
+                    Text = entry.Description,
+                    Foreground = new SolidColorBrush(Color.FromRgb(0xE0, 0xE0, 0xE0)),
+                    FontSize = 13,
+                    TextWrapping = TextWrapping.Wrap,
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                    MaxHeight = 38, // ~2 lines at 13pt
+                    Margin = new Thickness(0, 6, 0, 0),
+                };
+                textStack.Children.Add(desc);
+            }
+
+            if (entry.Tags != null && entry.Tags.Count > 0)
+            {
+                var tagWrap = new WrapPanel { Margin = new Thickness(0, 8, 0, 0) };
+                foreach (var tag in entry.Tags)
+                {
+                    tagWrap.Children.Add(new Border
+                    {
+                        Background = Res("DeeperAccentTransparent20Brush"),
+                        CornerRadius = new CornerRadius(10),
+                        Padding = new Thickness(8, 2, 8, 2),
+                        Margin = new Thickness(0, 0, 6, 4),
+                        Child = new TextBlock
+                        {
+                            Text = tag,
+                            FontSize = 11,
+                            Foreground = Res("TextLightBrush"),
+                        },
+                    });
+                }
+                textStack.Children.Add(tagWrap);
+            }
+
+            // Footer row: view count + license, separated visually from body
+            // copy by a thin gap.
+            var footer = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Thickness(0, 8, 0, 0),
+            };
+            footer.Children.Add(new TextBlock
+            {
+                Text = $"👁 {entry.ViewCount}",
+                FontSize = 11,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x90, 0x90, 0xA8)),
+                Margin = new Thickness(0, 0, 14, 0),
+            });
+            footer.Children.Add(new TextBlock
+            {
+                Text = string.IsNullOrWhiteSpace(entry.License)
+                    ? Loc.Get("dialog_catalogue_picker_no_license")
+                    : entry.License,
+                FontSize = 11,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x90, 0x90, 0xA8)),
+            });
+            textStack.Children.Add(footer);
+
+            grid.Children.Add(textStack);
+            row.Child = grid;
+            return row;
+        }
+
+        // Build the 80x50 thumbnail tile. The WPF original decoded an http(s)
+        // ThumbnailPath straight into a BitmapImage, which downloads on the UI
+        // thread; Avalonia's Bitmap takes a stream, so the fetch needs an HTTP
+        // client this view is not allowed to reach for yet.
+        // ponytail: needs an image-fetch service, wired when it moves to Core.
+        // The placeholder below is what the WPF version also shows for the
+        // storage-path case, so nothing regresses in the meantime.
+        private Control BuildThumbnail(CatalogueEntry entry)
+        {
+            var container = new Border
+            {
+                Width = 80,
+                Height = 50,
+                CornerRadius = new CornerRadius(4),
+                Background = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)),
+                BorderBrush = Res("DeeperAccentTransparent20Brush"),
+                BorderThickness = new Thickness(1),
+                VerticalAlignment = VerticalAlignment.Center,
+                ClipToBounds = true,
+            };
+
+            container.Child = new TextBlock
+            {
+                Text = "▶",
+                FontSize = 22,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x60, 0x60, 0x80)),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            return container;
+        }
+
+        private void Select(CatalogueEntry entry)
+        {
+            SelectedEntry = entry;
+            Close(true);
+        }
+
+        private static List<CatalogueEntry> SampleEntries() => new()
+        {
+            new CatalogueEntry("e1", "Spiral Descent — Deep Focus Mix",
+                "A slow ten-minute induction layered over the original audio, with breath cues on the downbeat.",
+                "velvet", null, new List<string> { "induction", "spiral", "slow" }, "CC BY-SA 4.0", 1842,
+                "https://hypnotube.example/v/9f2c41", null, "https://app.cclabs.app/files/e1.ccp"),
+            new CatalogueEntry("e2", "Spiral Descent — Trigger Remix",
+                "Adds three keyword triggers and a shorter tail. Built on velvet's mix.",
+                "velvet", "mirrorfade", new List<string> { "triggers", "remix" }, null, 613,
+                "https://hypnotube.example/v/9f2c41", null, "https://app.cclabs.app/files/e2.ccp"),
+            new CatalogueEntry("e3", "Quiet Version", "", "cinder", null,
+                new List<string>(), "CC BY-NC 4.0", 97,
+                "https://hypnotube.example/v/9f2c41", null, "https://app.cclabs.app/files/e3.ccp"),
+        };
+    }
+
+    /// <summary>
+    /// One catalogue entry as returned by /api/enhancements/by-ht-url. All
+    /// fields are server-truth; the client doesn't enrich or transform
+    /// (except for graceful defaults when fields are missing).
+    ///
+    /// Copied verbatim from ConditioningControlPanel/Services/CatalogueLookupService.cs — the
+    /// record lives in the WPF head and this port may reference neither it nor CCP.Core for it.
+    /// Delete this copy when CatalogueLookupService moves to Core.
+    /// </summary>
+    public record CatalogueEntry(
+        string Id,
+        string Title,
+        string Description,
+        string CreatorName,
+        string? RemixerName,
+        List<string> Tags,
+        string? License,
+        int ViewCount,
+        string HtUrl,
+        string? ThumbnailPath,
+        string FileUrl
+    );
+}

--- a/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml
@@ -1,0 +1,148 @@
+<!-- PORTED from ConditioningControlPanel/Windows/SessionLogHistoryWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       AllowsTransparency="True" / WindowStyle="None"
+                                      -> TransparencyLevelHint="Transparent" + SystemDecorations="None"
+       <Style x:Key TargetType>       -> <ControlTheme x:Key TargetType>, applied with Theme=
+                                         rather than Style= (keyed styles are ControlThemes)
+       ControlTemplate.Triggers       -> ^:pointerover nested selectors inside the ControlTheme
+       <ContentPresenter/>            -> Content="{TemplateBinding Content}" (trap 6: a bare
+                                         presenter draws nothing in Avalonia)
+       Visibility="Collapsed"         -> IsVisible="False"
+       <Run Text="{Binding X}"/> runs -> one bound Text per line. Avalonia's Run does not take a
+                                         binding under compiled bindings, and the runs here only
+                                         concatenated; HistoryRow exposes Headline and Meta.
+       Click="..."                    -> wired in the constructor
+     The close button carries a TextBlock child rather than Content (trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Windows"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.SessionLogHistoryWindow"
+        Title="{loc:Str dialog_session_history}"
+        Width="560" Height="640"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowInTaskbar="False">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of
+             ConditioningControlPanel/Windows/SessionLogHistoryWindow.xaml:HistoryRowButtonStyle,
+             hoist when a second view needs it. -->
+        <ControlTheme x:Key="HistoryRowButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="#252540"/>
+            <Setter Property="BorderBrush" Value="#3A3A58"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="14,10"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#2F2F52"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The WPF footer button's inline Style was template-only; the theme keys the same shape
+             so the ContentPresenter can carry its Content binding (trap 6). -->
+        <ControlTheme x:Key="HistoryCloseButtonStyle" TargetType="Button">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="3" CornerRadius="20" Padding="24">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <DockPanel Grid.Row="0" Margin="0,0,0,14">
+                <TextBlock DockPanel.Dock="Left" Text="{loc:Str dialog_session_history}"
+                           Foreground="{DynamicResource PinkBrush}" FontSize="22" FontWeight="Bold"
+                           VerticalAlignment="Center"/>
+                <TextBlock DockPanel.Dock="Right" x:Name="TxtCount"
+                           Foreground="#808090" FontSize="12"
+                           VerticalAlignment="Center" HorizontalAlignment="Right"/>
+            </DockPanel>
+
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                <Grid>
+                    <TextBlock x:Name="TxtEmpty"
+                               Text="{loc:Str label_no_session_logs}"
+                               Foreground="#707080" FontSize="14" FontStyle="Italic"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Margin="0,40" IsVisible="False"/>
+                    <ItemsControl x:Name="LogList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:HistoryRow">
+                                <Button Theme="{StaticResource HistoryRowButtonStyle}"
+                                        Tag="{Binding}"
+                                        Margin="0,0,0,8">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                                   Text="{Binding Headline}"
+                                                   Foreground="White" FontSize="15" FontWeight="Bold"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Row="0" Grid.Column="1"
+                                                   Text="{Binding StatusText}"
+                                                   Foreground="{Binding StatusBrush}"
+                                                   FontSize="11" FontWeight="Bold"
+                                                   VerticalAlignment="Center"/>
+
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                                   Text="{Binding Meta}"
+                                                   Foreground="#808090" FontSize="12"
+                                                   Margin="0,4,0,0"/>
+                                    </Grid>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
+            </ScrollViewer>
+
+            <Button Grid.Row="2" x:Name="BtnClose" Theme="{StaticResource HistoryCloseButtonStyle}"
+                    Background="{DynamicResource PinkBrush}" Foreground="White"
+                    BorderThickness="0" Padding="28,10" FontSize="14" FontWeight="Bold"
+                    Cursor="Hand" HorizontalAlignment="Center" Margin="0,14,0,0">
+                <TextBlock Text="{loc:Str btn_close}"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Windows/SessionLogHistoryWindow.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(true)</c>, because Avalonia carries the result
+    ///    through <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>Visibility</c> -> <c>IsVisible</c>.
+    ///  - The row Click handler moves out of the DataTemplate onto the ItemsControl: template
+    ///    content has no name scope to bind a markup handler through. The Tag still carries the
+    ///    row, exactly as the WPF original read it.
+    ///  - <see cref="HistoryRow"/> takes the fields it formats rather than a
+    ///    <c>Models.SessionLog</c>: that model lives in the WPF head, not CCP.Core, and this port
+    ///    may reference neither. The formatting it does — duration, media counts, status — is
+    ///    ported verbatim, so restoring the <c>HistoryRow(SessionLog)</c> constructor when the model
+    ///    reaches Core is a one-liner.
+    /// </summary>
+    public partial class SessionLogHistoryWindow : Window
+    {
+        private readonly TextBlock _txtEmpty;
+        private readonly TextBlock _txtCount;
+        private readonly ItemsControl _logList;
+
+        public SessionLogHistoryWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtEmpty = this.FindControl<TextBlock>("TxtEmpty")!;
+            _txtCount = this.FindControl<TextBlock>("TxtCount")!;
+            _logList = this.FindControl<ItemsControl>("LogList")!;
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close(true);
+
+            // One handler on the list instead of one inside the DataTemplate; Click bubbles.
+            _logList.AddHandler(Button.ClickEvent, LogRow_Click);
+
+            Loaded += (_, _) => LoadLogs();
+        }
+
+        private void LoadLogs()
+        {
+            var rows = LoadRecentRows();
+
+            if (rows.Count == 0)
+            {
+                _txtEmpty.IsVisible = true;
+                _logList.IsVisible = false;
+                _txtCount.Text = "";
+            }
+            else
+            {
+                _txtEmpty.IsVisible = false;
+                _logList.IsVisible = true;
+                _logList.ItemsSource = rows;
+                _txtCount.Text = Loc.GetF("label_session_count", rows.Count);
+            }
+        }
+
+        /// <summary>
+        /// WPF read <c>App.SessionLog.LoadRecentLogs()</c>.
+        /// ponytail: needs SessionLogService, wired when it moves to Core. Until then this returns
+        /// placeholder rows so the window renders the populated state rather than the empty one.
+        /// </summary>
+        private static List<HistoryRow> LoadRecentRows() => new()
+        {
+            new HistoryRow("🌀", "Deep Spiral", new DateTime(2026, 8, 30, 21, 14, 0),
+                TimeSpan.FromMinutes(42) + TimeSpan.FromSeconds(18), videos: 12, images: 48, completed: true),
+            new HistoryRow("💗", "Soft Start", new DateTime(2026, 8, 29, 19, 2, 0),
+                TimeSpan.FromMinutes(11) + TimeSpan.FromSeconds(5), videos: 3, images: 20, completed: true),
+            new HistoryRow("🔒", "Lockdown Hour", new DateTime(2026, 8, 27, 23, 40, 0),
+                TimeSpan.FromHours(1) + TimeSpan.FromMinutes(6) + TimeSpan.FromSeconds(31), videos: 21, images: 0, completed: false),
+        };
+
+        private void LogRow_Click(object? sender, RoutedEventArgs e)
+        {
+            if (e.Source is not Control c) return;
+            if (c.Tag is not HistoryRow) return;
+
+            // WPF opened SessionCompleteWindow(row.Log, playSound: false) as a modal child.
+            // ponytail: needs SessionCompleteWindow (not ported yet) and the SessionLog model,
+            // wired when they move to Core.
+        }
+    }
+
+    /// <summary>
+    /// One row of the history list. Private nested class in the WPF original; public and top-level
+    /// here because a compiled binding's <c>x:DataType</c> cannot name a nested type.
+    /// </summary>
+    public sealed class HistoryRow
+    {
+        public string Icon { get; }
+        public string Name { get; }
+        public string StartedText { get; }
+        public string DurationText { get; }
+        public string MediaText { get; }
+        public string StatusText { get; }
+        public IBrush StatusBrush { get; }
+
+        /// <summary>Icon + name, one bound string. WPF drew this as three Runs in one TextBlock.</summary>
+        public string Headline => $"{Icon} {Name}";
+
+        /// <summary>The WPF footer line's five Runs, joined with the same separator.</summary>
+        public string Meta => $"{StartedText}  ·  {DurationText}  ·  {MediaText}";
+
+        public HistoryRow(string? icon, string? name, DateTime startedAt, TimeSpan duration,
+                          int videos, int images, bool completed)
+        {
+            Icon = icon ?? "";
+            Name = name ?? "";
+            StartedText = startedAt.ToString("g");
+
+            var d = duration;
+            DurationText = d.TotalHours >= 1
+                ? $"{(int)d.TotalHours}:{d.Minutes:D2}:{d.Seconds:D2}"
+                : $"{d.Minutes:D2}:{d.Seconds:D2}";
+
+            MediaText = Loc.GetF("label_media_count_videos_images", videos, images);
+
+            if (completed)
+            {
+                StatusText = Loc.Get("label_completed");
+                StatusBrush = new SolidColorBrush(Color.FromRgb(144, 238, 144));
+            }
+            else
+            {
+                StatusText = Loc.Get("label_aborted");
+                StatusBrush = new SolidColorBrush(Color.FromRgb(255, 165, 0));
+            }
+        }
+    }
+}


### PR DESCRIPTION
701 lines. Thumbnail fetch and the session-log read are ponytail stubs with placeholder rows so the populated state renders. Two WPF-head model types are copied locally with delete-me notes.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351