### PR TITLE
feat(avalonia): port WebcamQuickRecalWindow, CornerGifWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/CornerGifWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/CornerGifWindow.axaml
@@ -1,0 +1,59 @@
+<!-- PORTED from ConditioningControlPanel/Windows/CornerGifWindow.xaml.
+     Structure, ordering, spacing and every colour preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       Style="{DynamicResource OutlineButton}" -> Theme="{StaticResource OutlineButton}"
+                                                  (keyed styles are ControlThemes)
+       ResizeMode="CanResizeWithGrip"          -> CanResize="True" (Avalonia has no resize grip;
+                                                  the window still resizes)
+       VerticalScrollBarVisibility             -> ScrollViewer.VerticalScrollBarVisibility
+       Click="BtnClose_Click"                  -> wired in the constructor
+
+     The window carries no {loc:Str}: every string in the WPF original is a literal.
+     The Done button holds a TextBlock rather than a string Content, per the access-key
+     trap in CLAUDE.md. The slot cards are still built in code-behind, as in WPF. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.CornerGifWindow"
+        Title="Corner GIFs"
+        Width="460" Height="640"
+        WindowStartupLocation="CenterOwner"
+        Background="#0F0F1E"
+        Foreground="#E0E0E0"
+        CanResize="True"
+        MinWidth="420" MinHeight="480">
+    <Grid Margin="18">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="🖼 Corner GIFs"
+                   Foreground="{DynamicResource PinkBrush}"
+                   FontSize="20"
+                   FontWeight="SemiBold"/>
+
+        <TextBlock Grid.Row="1"
+                   Text="Pin a looping GIF to a screen corner. Turn on one or both slots and point each at a different corner (great for covering minimaps, HUD corners, or just decoration). Overlays are click-through; a session that brings its own corner GIF borrows the slot and hands it back after."
+                   Foreground="#A0A0B0"
+                   FontSize="12"
+                   TextWrapping="Wrap"
+                   Margin="0,6,0,14"/>
+
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+            <StackPanel x:Name="SlotsPanel"/>
+        </ScrollViewer>
+
+        <Button Grid.Row="3"
+                x:Name="BtnClose"
+                Theme="{StaticResource OutlineButton}"
+                Padding="16,8"
+                HorizontalAlignment="Right"
+                Margin="0,14,0,0">
+            <TextBlock Text="Done"/>
+        </Button>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/CornerGifWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/CornerGifWindow.axaml.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Config window for the standalone corner-GIF overlays (opened from the Spiral card).
+    /// Exposes two slots - each an on/off toggle, a GIF picker, a corner selector, and
+    /// size/opacity sliders - and live-applies every change.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/CornerGifWindow.xaml.cs. Deviations:
+    ///  - App.Settings and App.CornerGif are still in the WPF head, so the slot list is
+    ///    in-memory placeholder data and <see cref="ApplyLive"/> is a stub. Everything the user
+    ///    can touch - toggle, picker, corner buttons, both sliders, the debounce - is real and
+    ///    edits the setting objects; only the persist-and-reapply tail is missing.
+    ///  - CornerGifOverlaySetting / CornerPosition live in the WPF project, which this head may
+    ///    not reference, so they are copied as private nested types (see TextItem in
+    ///    TextEditorDialog for the same call). They delete when the models reach Core.
+    ///  - Microsoft.Win32.OpenFileDialog -> TopLevel.StorageProvider.OpenFilePickerAsync, which
+    ///    is async, so the pick handler awaits instead of blocking.
+    ///  - MouseLeftButtonUp -> PointerReleased with an InitialPressMouseButton check.
+    ///  - The picker button holds a TextBlock, not a string Content: Avalonia parses "_" in
+    ///    Content as an access key and GIF file names routinely carry underscores.
+    /// </summary>
+    public partial class CornerGifWindow : Window
+    {
+        private const int SlotCount = 2;
+
+        private static readonly Color SelectedAccent = Color.FromRgb(0xFF, 0x69, 0xB4);
+        private static readonly Color IdleAccent = Color.FromRgb(0x33, 0x33, 0x3A);
+
+        /// <summary>Copy of ConditioningControlPanel.Models.CornerGifOverlaySetting. The type lives
+        /// in the WPF head, not in CCP.Core, and neither may be touched by this port.</summary>
+        private sealed class CornerGifOverlaySetting
+        {
+            public bool Enabled { get; set; }
+            /// <summary>Absolute path to the GIF/image. Empty => fall back to the built-in spiral.</summary>
+            public string GifPath { get; set; } = "";
+            public CornerPosition Position { get; set; } = CornerPosition.BottomLeft;
+            /// <summary>Longest-edge target size in logical pixels.</summary>
+            public int Size { get; set; } = 300;
+            /// <summary>Opacity in percent (1-100).</summary>
+            public int Opacity { get; set; } = 18;
+        }
+
+        /// <summary>Copy of ConditioningControlPanel.Models.CornerPosition, same reason.</summary>
+        private enum CornerPosition { TopLeft, TopRight, BottomLeft, BottomRight }
+
+        // ponytail: needs App.Settings.Current.CornerGifOverlays. Placeholder so the window has
+        // something to draw; slot 1 is on so at least one card renders at full opacity.
+        private readonly List<CornerGifOverlaySetting> _slots = new();
+
+        private readonly StackPanel _slotsPanel;
+
+        // Slider drags recreate an overlay window on every tick; debounce so a drag
+        // doesn't thrash Close/Show (the recreate is the safe path, but still not free).
+        private readonly DispatcherTimer _applyDebounce;
+
+        // Slot awaiting the debounced apply: null = nothing pending, -1 = rebuild everything.
+        private int? _pendingSlot;
+
+        public CornerGifWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _slotsPanel = this.FindControl<StackPanel>("SlotsPanel")!;
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+
+            _applyDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(150) };
+            _applyDebounce.Tick += (_, _) =>
+            {
+                _applyDebounce.Stop();
+                var slot = _pendingSlot ?? -1;
+                _pendingSlot = null;
+                ApplyLive(slot);
+            };
+
+            EnsureSlots();
+            BuildSlots();
+        }
+
+        /// <summary>Pads the list to <see cref="SlotCount"/> entries with sensible defaults, and
+        /// trims anything beyond them - the UI only ever edits the first <see cref="SlotCount"/>,
+        /// so extra entries in a hand-edited settings file would be invisible overlays.</summary>
+        private void EnsureSlots()
+        {
+            while (_slots.Count < SlotCount)
+            {
+                // Second slot defaults to the opposite bottom corner so two-at-once looks sensible.
+                _slots.Add(new CornerGifOverlaySetting
+                {
+                    Enabled = _slots.Count == 0,   // placeholder: one card on, one off
+                    Position = _slots.Count == 0 ? CornerPosition.BottomLeft : CornerPosition.BottomRight,
+                });
+            }
+            if (_slots.Count > SlotCount) _slots.RemoveRange(SlotCount, _slots.Count - SlotCount);
+        }
+
+        private void BuildSlots()
+        {
+            _slotsPanel.Children.Clear();
+            for (int i = 0; i < SlotCount; i++)
+                _slotsPanel.Children.Add(BuildSlotCard(i, _slots[i]));
+        }
+
+        private Border BuildSlotCard(int index, CornerGifOverlaySetting setting)
+        {
+            var card = new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0x3D, 0x3D, 0x60)),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(10),
+                Padding = new Thickness(16, 14, 16, 16),
+                Margin = new Thickness(0, 0, 0, 12),
+            };
+
+            var root = new StackPanel();
+
+            // -- Header row: title + enable toggle --------------------------------
+            var headerGrid = new Grid();
+            headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            headerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            var title = new TextBlock
+            {
+                Text = $"Corner GIF {index + 1}",
+                Foreground = Brushes.White,
+                FontSize = 15,
+                FontWeight = FontWeight.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(title, 0);
+            headerGrid.Children.Add(title);
+
+            var toggle = new CheckBox
+            {
+                IsChecked = setting.Enabled,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            if (this.TryFindResource("ToggleStyle", out var toggleTheme) && toggleTheme is ControlTheme ct)
+                toggle.Theme = ct;
+            Grid.SetColumn(toggle, 1);
+            headerGrid.Children.Add(toggle);
+            root.Children.Add(headerGrid);
+
+            // -- Settings sub-panel (dimmed/disabled when off) --------------------
+            var body = new StackPanel { Margin = new Thickness(0, 12, 0, 0) };
+
+            // GIF picker
+            body.Children.Add(SectionLabel("GIF"));
+            var pickLabel = new TextBlock { Text = PickerLabel(setting.GifPath) };
+            var pickBtn = new Button
+            {
+                Content = pickLabel,
+                Padding = new Thickness(12, 8, 12, 8),
+                HorizontalContentAlignment = HorizontalAlignment.Left,
+                Margin = new Thickness(0, 0, 0, 2),
+            };
+            if (this.TryFindResource("OutlineButton", out var outline) && outline is ControlTheme ot)
+                pickBtn.Theme = ot;
+            pickBtn.Click += async (_, _) =>
+            {
+                var top = GetTopLevel(this);
+                if (top is null) return;
+
+                var start = !string.IsNullOrEmpty(setting.GifPath) && File.Exists(setting.GifPath)
+                    ? await top.StorageProvider.TryGetFolderFromPathAsync(Path.GetDirectoryName(setting.GifPath)!)
+                    : null;
+
+                var picked = await top.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = "Select a corner GIF",
+                    AllowMultiple = false,
+                    SuggestedStartLocation = start,
+                    FileTypeFilter = new[]
+                    {
+                        new FilePickerFileType("GIF Files") { Patterns = new[] { "*.gif" } },
+                        new FilePickerFileType("All Image Files")
+                        {
+                            Patterns = new[] { "*.gif", "*.png", "*.jpg", "*.jpeg", "*.webp", "*.bmp" }
+                        },
+                    },
+                });
+
+                var path = picked.FirstOrDefault()?.TryGetLocalPath();
+                if (string.IsNullOrEmpty(path)) return;
+
+                setting.GifPath = path;
+                pickLabel.Text = PickerLabel(path);
+                ApplyLive(index);
+            };
+            body.Children.Add(pickBtn);
+            body.Children.Add(new TextBlock
+            {
+                Text = "Leave unset to use the built-in spiral (a mod pack can swap in its own).",
+                Foreground = new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x90)),
+                FontSize = 10,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 12),
+            });
+
+            // Position selector (4 corner buttons)
+            body.Children.Add(SectionLabel("Position"));
+            var cornerPanel = new WrapPanel { Margin = new Thickness(0, 2, 0, 12) };
+            var cornerButtons = new Dictionary<CornerPosition, Border>();
+            void AddCorner(CornerPosition pos, string label)
+            {
+                var b = new Border
+                {
+                    Background = new SolidColorBrush(Color.FromRgb(0x12, 0x12, 0x20)),
+                    BorderBrush = new SolidColorBrush(pos == setting.Position ? SelectedAccent : IdleAccent),
+                    BorderThickness = new Thickness(2),
+                    CornerRadius = new CornerRadius(6),
+                    Padding = new Thickness(10, 6, 10, 6),
+                    Margin = new Thickness(0, 0, 6, 6),
+                    Cursor = new Cursor(StandardCursorType.Hand),
+                    Child = new TextBlock
+                    {
+                        Text = label,
+                        Foreground = Brushes.White,
+                        FontSize = 11,
+                    },
+                };
+                b.PointerReleased += (_, e) =>
+                {
+                    if (e.InitialPressMouseButton != MouseButton.Left) return;
+                    setting.Position = pos;
+                    foreach (var kv in cornerButtons)
+                        kv.Value.BorderBrush = new SolidColorBrush(kv.Key == pos ? SelectedAccent : IdleAccent);
+                    // Full rebuild: moving one slot into (or out of) another slot's corner changes
+                    // the other slot's same-corner nudge too.
+                    ApplyLiveAll();
+                };
+                cornerButtons[pos] = b;
+                cornerPanel.Children.Add(b);
+            }
+            AddCorner(CornerPosition.TopLeft, "↖ Top left");
+            AddCorner(CornerPosition.TopRight, "↗ Top right");
+            AddCorner(CornerPosition.BottomLeft, "↙ Bottom left");
+            AddCorner(CornerPosition.BottomRight, "↘ Bottom right");
+            body.Children.Add(cornerPanel);
+
+            // Size slider
+            var sizeValue = new TextBlock
+            {
+                Text = $"{setting.Size}px",
+                Foreground = new SolidColorBrush(SelectedAccent),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                HorizontalAlignment = HorizontalAlignment.Right,
+            };
+            body.Children.Add(LabeledRow("Size", sizeValue));
+            // Minimum/Maximum before Value: RangeBase clamps on assignment, so a Value set first
+            // would be pinned to the default 0..100 range.
+            var sizeSlider = NewSlider(100, 800, setting.Size);
+            sizeSlider.ValueChanged += (_, e) =>
+            {
+                setting.Size = (int)e.NewValue;
+                sizeValue.Text = $"{setting.Size}px";
+                ApplyLiveDebounced(index);
+            };
+            body.Children.Add(sizeSlider);
+
+            // Opacity slider
+            var opacityValue = new TextBlock
+            {
+                Text = $"{setting.Opacity}%",
+                Foreground = new SolidColorBrush(SelectedAccent),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                HorizontalAlignment = HorizontalAlignment.Right,
+            };
+            body.Children.Add(LabeledRow("Opacity", opacityValue));
+            var opacitySlider = NewSlider(5, 100, setting.Opacity);
+            opacitySlider.Margin = new Thickness(0, 0, 0, 2);
+            opacitySlider.ValueChanged += (_, e) =>
+            {
+                setting.Opacity = (int)e.NewValue;
+                opacityValue.Text = $"{setting.Opacity}%";
+                ApplyLiveDebounced(index);
+            };
+            body.Children.Add(opacitySlider);
+
+            body.IsEnabled = setting.Enabled;
+            body.Opacity = setting.Enabled ? 1.0 : 0.45;
+            root.Children.Add(body);
+
+            // WPF's Checked + Unchecked, which Avalonia folds into one event.
+            toggle.IsCheckedChanged += (_, _) =>
+            {
+                bool on = toggle.IsChecked == true;
+                setting.Enabled = on;
+                body.IsEnabled = on;
+                body.Opacity = on ? 1.0 : 0.45;
+                ApplyLiveAll(); // enabling/disabling a slot shifts the other slot's same-corner nudge
+            };
+
+            card.Child = root;
+            return card;
+        }
+
+        /// <summary>WPF applies PinkSlider implicitly (Resources/Theme/MainWindow.xaml has a keyless
+        /// <c>Style TargetType="Slider" BasedOn="{StaticResource PinkSlider}"</c>), so the original's
+        /// bare <c>new Slider</c> was pink. Avalonia has no implicit style, so the theme is looked up
+        /// by key here. Height=32 because PinkSlider sets Height=18 and clips its own thumb without
+        /// it - the same fix DevicesSettingsSection carries.
+        /// Minimum/Maximum before Value: RangeBase clamps on assignment, so a Value set first would
+        /// be pinned to the default 0..100 range.</summary>
+        private Slider NewSlider(double min, double max, double value)
+        {
+            var s = new Slider { Minimum = min, Maximum = max, Value = value };
+            if (this.TryFindResource("PinkSlider", out var theme) && theme is ControlTheme t)
+            {
+                s.Theme = t;
+                s.Height = 32;
+            }
+            return s;
+        }
+
+        private static TextBlock SectionLabel(string text) => new TextBlock
+        {
+            Text = text,
+            Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xC0)),
+            FontSize = 12,
+            FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(0, 0, 0, 4),
+        };
+
+        private static Grid LabeledRow(string label, Control right)
+        {
+            var g = new Grid { Margin = new Thickness(0, 6, 0, 2) };
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            g.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            var l = new TextBlock
+            {
+                Text = label,
+                Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xC0)),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(l, 0);
+            Grid.SetColumn(right, 1);
+            g.Children.Add(l);
+            g.Children.Add(right);
+            return g;
+        }
+
+        private static string PickerLabel(string path) =>
+            string.IsNullOrEmpty(path) || !File.Exists(path)
+                ? "📁 Choose GIF…  (uses selected spiral)"
+                : $"📁 {Path.GetFileName(path)}";
+
+        private void ApplyLiveDebounced(int index)
+        {
+            // Two different slots dragged inside one debounce window would drop the first slot's
+            // pending rebuild, so widen to a full refresh in that case.
+            _pendingSlot = _pendingSlot == null || _pendingSlot == index ? index : -1;
+            _applyDebounce.Stop();
+            _applyDebounce.Start();
+        }
+
+        private void ApplyLiveAll()
+        {
+            _applyDebounce.Stop();
+            _pendingSlot = null;
+            ApplyLive(-1);
+        }
+
+        /// <summary>Persists and re-applies. <paramref name="index"/> &gt;= 0 rebuilds only that
+        /// slot's overlay window - the other slot's handle (and its running animation) is left
+        /// alone, which is what keeps a slider drag from re-realizing every overlay per tick.</summary>
+        private void ApplyLive(int index = -1)
+        {
+            // ponytail: needs App.Settings (Save) + CornerGifService (RefreshSlot/RefreshOverlays),
+            // wired when they move to Core. The edits above already live in _slots.
+            _ = index;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml
@@ -1,0 +1,76 @@
+<!-- PORTED from ConditioningControlPanel/Windows/WebcamQuickRecalWindow.xaml.
+     Structure, ordering, spacing and every colour preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"        -> SystemDecorations="None"
+       ResizeMode="NoResize"     -> CanResize="False"
+       Visibility="Collapsed"    -> IsVisible="False"
+       DropShadowEffect          -> Avalonia.Media.DropShadowEffect; ShadowDepth="0" is
+                                    OffsetX/OffsetY="0", the rest copies verbatim
+       KeyDown/Loaded/Closed     -> wired in the constructor (Loaded becomes Opened)
+
+     The window carries no {loc:Str}: every string in the WPF original is a literal, and
+     inventing keys here would be worse than keeping them. The Close button holds a
+     TextBlock rather than a string Content, per the access-key trap in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.WebcamQuickRecalWindow"
+        Title="Quick Recalibrate"
+        Background="#000000"
+        SystemDecorations="None"
+        WindowState="Maximized"
+        CanResize="False"
+        Topmost="True"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Ellipse x:Name="Dot" Width="40" Height="40"
+                 HorizontalAlignment="Center" VerticalAlignment="Center"
+                 IsVisible="False">
+            <Ellipse.Fill>
+                <RadialGradientBrush>
+                    <GradientStop Color="#FFFFB6E1" Offset="0"/>
+                    <GradientStop Color="#FFFF69B4" Offset="0.6"/>
+                    <GradientStop Color="#FFC71585" Offset="1"/>
+                </RadialGradientBrush>
+            </Ellipse.Fill>
+            <Ellipse.Effect>
+                <DropShadowEffect Color="#FF69B4" BlurRadius="32" OffsetX="0" OffsetY="0" Opacity="0.9"/>
+            </Ellipse.Effect>
+        </Ellipse>
+
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,40,0,0">
+            <TextBlock Text="Quick Recalibrate" Foreground="White"
+                       FontSize="22" FontWeight="Bold" HorizontalAlignment="Center"/>
+            <TextBlock x:Name="TxtStatus"
+                       Text="Get comfortable, then look at the pink dot."
+                       Foreground="#FFB6E1" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Center"/>
+            <TextBlock Text="ESC to cancel."
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,4,0,0" HorizontalAlignment="Center"/>
+            <!-- Teaches the global chord at the one moment it is guaranteed to be relevant:
+                 the user has just dug this window out of a setup card. Text is set in the
+                 constructor (it quotes the user's own, rebindable, camera chord). -->
+            <TextBlock x:Name="TxtHotkeyHint" Text=""
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,10,0,0"
+                       MaxWidth="620" TextWrapping="Wrap" TextAlignment="Center" HorizontalAlignment="Center"/>
+        </StackPanel>
+
+        <Border x:Name="ErrorPanel" IsVisible="False"
+                Background="#221A1A" BorderBrush="#FF69B4" BorderThickness="2"
+                CornerRadius="10" Padding="24" HorizontalAlignment="Center" VerticalAlignment="Center"
+                MaxWidth="520">
+            <StackPanel>
+                <TextBlock Text="Quick recal unavailable" Foreground="#FF69B4" FontSize="18"
+                           FontWeight="Bold" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtErrorDetail" Text="" Foreground="White" FontSize="13"
+                           Margin="0,12,0,16" TextWrapping="Wrap" HorizontalAlignment="Center"/>
+                <Button x:Name="BtnErrorClose" Padding="20,8"
+                        Background="#FF69B4" Foreground="Black" BorderThickness="0"
+                        FontWeight="Bold" Cursor="Hand"
+                        HorizontalAlignment="Center">
+                    <TextBlock Text="Close"/>
+                </Button>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs
@@ -1,0 +1,77 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// One-dot quick recal: shows a center pink dot, samples ~2 s of gaze projections while the
+    /// user stares at it, computes the mean drift from screen center and persists it as the
+    /// webcam calibration's runtime offset. At runtime the offset is added after the polynomial
+    /// projection so the cursor lands where the user is actually looking - no full 16-point
+    /// recalibration needed.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/WebcamQuickRecalWindow.xaml.cs. Deviations:
+    ///  - The whole sampling sequence is gone. It only exists to talk to WebcamTrackingService
+    ///    (OnGazeMove / SetRuntimeOffset / Calibration) and CalibrationSoundService, all still in
+    ///    the WPF head, so there is nothing left for the median math or the offset write to act
+    ///    on. <see cref="OnOpened"/> shows the dot and the opening status line instead, which is
+    ///    the state the sequence starts in.
+    ///  - WPF's <c>DialogResult = x; Close();</c> becomes <c>Close(x)</c>: Avalonia carries the
+    ///    result through <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - Loaded -> Opened, and the KeyDown / Click handlers are wired in the constructor rather
+    ///    than in markup, per the porting convention.
+    /// </summary>
+    public partial class WebcamQuickRecalWindow : Window
+    {
+        private readonly Ellipse _dot;
+        private readonly TextBlock _txtStatus, _txtHotkeyHint, _txtErrorDetail;
+        private readonly Border _errorPanel;
+
+        public WebcamQuickRecalWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _dot = this.FindControl<Ellipse>("Dot")!;
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+            _txtHotkeyHint = this.FindControl<TextBlock>("TxtHotkeyHint")!;
+            _txtErrorDetail = this.FindControl<TextBlock>("TxtErrorDetail")!;
+            _errorPanel = this.FindControl<Border>("ErrorPanel")!;
+
+            // Discoverability: this window is the one place every user of Quick Recal provably
+            // reaches, so it is where the global chord gets taught. The real line quotes the
+            // user's own (rebindable) camera shortcut alongside it.
+            // ponytail: needs MainWindow.QuickRecalHotkeyHint, wired when the hotkey map moves to Core
+            _txtHotkeyHint.Text = "Tip: the same quick recal runs from anywhere with the global quick-recal chord.";
+
+            // WPF closed with `DialogResult = _completedOk`, but the error panel is only ever
+            // shown on a failure path, so that flag was false every time this button was
+            // reachable. It comes back with the sampling sequence.
+            this.FindControl<Button>("BtnErrorClose")!.Click += (_, _) => Close(false);
+            KeyDown += (_, e) => { if (e.Key == Key.Escape) Close(false); };
+        }
+
+        protected override void OnOpened(System.EventArgs e)
+        {
+            base.OnOpened(e);
+
+            // ponytail: needs WebcamTrackingService (IsRunning / Calibration / OnGazeMove /
+            // SetRuntimeOffset) + CalibrationSoundService. With those back this shows the dot,
+            // samples for 2 s, takes the per-axis median after dropping the saccade onto the
+            // dot, and writes (window centre - median) as the runtime offset. Without them
+            // there is nothing to sample, so the window just parks in its opening state.
+            _dot.IsVisible = true;
+            _txtStatus.Text = "Get comfortable, then look at the pink dot.";
+        }
+
+        /// <summary>The WPF original's error path: no tracking, or no calibration to nudge.</summary>
+        private void ShowError(string detail)
+        {
+            _dot.IsVisible = false;
+            _txtStatus.IsVisible = false;
+            _txtErrorDetail.Text = detail;
+            _errorPanel.IsVisible = true;
+        }
+    }
+}


### PR DESCRIPTION
605 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351