### PR TITLE
feat(avalonia): port SplashScreen, GoonTestWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/GoonTestWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/GoonTestWindow.axaml
@@ -1,0 +1,171 @@
+<!-- PORTED from ConditioningControlPanel/GoonTestWindow.xaml (a repo-root view -> Views/Windows/).
+     Structure, ordering and every resource key preserved so the two diff cleanly.
+     No {loc:Str}: this is a dev-only cockpit and the original has no loc keys at all - every
+     string is a hardcoded English literal there, and inventing keys is forbidden.
+     Deviations, all forced:
+
+       <Style TargetType="X"> (implicit, no key)  ->  <Style Selector="X"> in Window.Styles.
+                             NOT a ControlTheme: a keyless WPF Style overrides setters and keeps
+                             the default template, which is what a Selector style does here. A
+                             ControlTheme would replace the template wholesale (trap 4).
+       <Style TargetType="TextBlock">  ->  DROPPED, its three setters inlined on the one TextBlock
+                             that needed them ("Mode:"). Avalonia styles reach INSIDE control
+                             templates and WPF implicit styles do not, so a window-wide TextBlock
+                             Foreground would have repainted the ComboBox popup's own item text
+                             light-on-light.
+       ControlTemplate + ControlTemplate.Triggers on Button
+                             ->  setters plus `Button:pointerover /template/ ContentPresenter`
+                             (hover) and `Button:disabled` (the 0.4 opacity). The Fluent template
+                             already draws a rounded, bordered, TemplateBinding-fed button, so
+                             re-declaring one buys nothing.
+       {StaticResource GgX}  ->  {DynamicResource GgX} inside Window.Styles, where a Styles block
+                             does not see Window.Resources at parse time.
+       DockPanel children    ->  unchanged, but LastChildFill is explicit (Avalonia defaults it
+                             true as well; stated so the intent survives).
+
+     The two player panels are GoonTestPanel, a code-built WPF UserControl in the head that owns
+     GoonGameService/GoonMatchService. Nothing of that is in Core, so PanelHostA/B carry
+     placeholder content - see the code-behind. The TextBox/CheckBox/ListBox/ListBoxItem/Slider
+     styles below are unused until that panel lands; they are the panel's, kept verbatim. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.GoonTestWindow"
+        Title="Goon Game Test Cockpit"
+        Height="940" Width="1560"
+        MinHeight="640" MinWidth="1100"
+        WindowStartupLocation="CenterScreen"
+        Background="#FF1A1A2E">
+
+    <!-- Dev-only play-test cockpit for the Goon Game 1v1 duel (Services\GoonGame\).
+         Two independent player panels in one process: real server signaling + WebRTC,
+         or the in-process loopback transport pair. Launched with the goon-test flag.
+         Converters/styles live HERE (Window.Resources/Window.Styles) per CLAUDE.md,
+         never in a child Grid. -->
+
+    <Window.Resources>
+        <SolidColorBrush x:Key="GgBg" Color="#FF1A1A2E" />
+        <SolidColorBrush x:Key="GgPanel" Color="#FF252542" />
+        <SolidColorBrush x:Key="GgPanelDeep" Color="#FF15152B" />
+        <SolidColorBrush x:Key="GgAccent" Color="#FFFF69B4" />
+        <SolidColorBrush x:Key="GgText" Color="#FFEDEDF5" />
+        <SolidColorBrush x:Key="GgMuted" Color="#FF9A9ABF" />
+        <SolidColorBrush x:Key="GgButton" Color="#FF35355F" />
+        <SolidColorBrush x:Key="GgButtonHot" Color="#FF4A4A82" />
+    </Window.Resources>
+
+    <Window.Styles>
+        <Style Selector="Button">
+            <Setter Property="Foreground" Value="{DynamicResource GgText}" />
+            <Setter Property="Background" Value="{DynamicResource GgButton}" />
+            <Setter Property="BorderBrush" Value="#FF50508C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="3" />
+            <Setter Property="Padding" Value="8,3" />
+            <Setter Property="Margin" Value="2" />
+            <Setter Property="FontSize" Value="12" />
+        </Style>
+        <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource GgButtonHot}" />
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource GgText}" />
+        </Style>
+        <Style Selector="Button:disabled">
+            <Setter Property="Opacity" Value="0.4" />
+        </Style>
+
+        <Style Selector="TextBox">
+            <Setter Property="Foreground" Value="{DynamicResource GgText}" />
+            <Setter Property="Background" Value="#FF1E1E38" />
+            <Setter Property="BorderBrush" Value="#FF50508C" />
+            <Setter Property="Padding" Value="3,2" />
+            <Setter Property="Margin" Value="2" />
+            <Setter Property="FontSize" Value="12" />
+        </Style>
+
+        <Style Selector="CheckBox">
+            <Setter Property="Foreground" Value="{DynamicResource GgText}" />
+            <Setter Property="Margin" Value="4,2" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+
+        <Style Selector="RadioButton">
+            <Setter Property="Foreground" Value="{DynamicResource GgText}" />
+            <Setter Property="Margin" Value="6,2" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+
+        <!-- The cockpit opens in Server mode, so this box starts DISABLED and the render proof
+             shows Avalonia's own disabled chrome, not the light #D8D8EC these setters ask for:
+             the Fluent ComboBox theme repaints its background from a template-child style while
+             :disabled. The setters are still the right copy of the WPF style and take effect the
+             moment Loopback mode enables the box. Not worth chasing a template part name for a
+             dev-only cockpit. -->
+        <Style Selector="ComboBox">
+            <Setter Property="Foreground" Value="#FF101024" />
+            <Setter Property="Background" Value="#FFD8D8EC" />
+            <Setter Property="Margin" Value="2" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="MinWidth" Value="90" />
+        </Style>
+
+        <Style Selector="ListBox">
+            <Setter Property="Foreground" Value="{DynamicResource GgText}" />
+            <Setter Property="Background" Value="{DynamicResource GgPanelDeep}" />
+            <Setter Property="BorderBrush" Value="#FF3A3A68" />
+            <Setter Property="FontFamily" Value="Consolas, Courier New" />
+            <Setter Property="FontSize" Value="11" />
+        </Style>
+
+        <Style Selector="ListBoxItem">
+            <Setter Property="Foreground" Value="{DynamicResource GgText}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Padding" Value="2,0" />
+        </Style>
+
+        <Style Selector="Slider">
+            <Setter Property="Margin" Value="4,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </Window.Styles>
+
+    <DockPanel LastChildFill="True">
+
+        <!-- Mode bar -->
+        <Border DockPanel.Dock="Top" Background="{StaticResource GgPanel}" Padding="10,6" Margin="0,0,0,2">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="GOON GAME TEST COCKPIT" FontWeight="Bold" FontSize="14"
+                           Foreground="{StaticResource GgAccent}" Margin="0,0,20,0"
+                           VerticalAlignment="Center" />
+                <TextBlock Text="Mode:" Margin="0,0,4,0"
+                           Foreground="{StaticResource GgText}" FontSize="12" VerticalAlignment="Center" />
+                <RadioButton x:Name="RadioServer" Content="Server (real /v2/goon + WebRTC)" IsChecked="True"
+                             GroupName="GgMode" />
+                <RadioButton x:Name="RadioLoopback" Content="Loopback (in-process, no server)"
+                             GroupName="GgMode" />
+                <ComboBox x:Name="CmbLoopProfile" SelectedIndex="0" IsEnabled="False" Width="150"
+                          VerticalAlignment="Center">
+                    <ComboBoxItem Content="P2P (25ms)" />
+                    <ComboBoxItem Content="Relay (900ms)" />
+                    <ComboBoxItem Content="Instant (0ms)" />
+                </ComboBox>
+                <Button x:Name="BtnCreateLoopback" Content="Create Loopback Pair" IsEnabled="False" />
+                <Button x:Name="BtnOutage" Content="Simulate 20s Outage" IsEnabled="False" />
+                <Button x:Name="BtnTearDown" Content="Tear Down Both" />
+            </StackPanel>
+        </Border>
+
+        <!-- Status strip -->
+        <Border DockPanel.Dock="Bottom" Background="{StaticResource GgPanel}" Padding="10,4" Margin="0,2,0,0">
+            <TextBlock x:Name="TxtStatus" Text="idle" Foreground="{StaticResource GgMuted}"
+                       FontSize="12" TextWrapping="Wrap" />
+        </Border>
+
+        <Grid ColumnDefinitions="*,*">
+            <Border x:Name="PanelHostA" Grid.Column="0" Background="{StaticResource GgPanel}"
+                    Margin="2" Padding="6" CornerRadius="4" />
+            <Border x:Name="PanelHostB" Grid.Column="1" Background="{StaticResource GgPanel}"
+                    Margin="2" Padding="6" CornerRadius="4" />
+        </Grid>
+    </DockPanel>
+</Window>

--- a/CCP.Avalonia/Views/Windows/GoonTestWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/GoonTestWindow.axaml.cs
@@ -1,0 +1,163 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+// ============================================================================
+// GOON GAME — dev play-test cockpit (launched with `--goon-test`).
+//
+// PORTED from ConditioningControlPanel/GoonTestWindow.xaml.cs.
+//
+// The WPF original drove two INDEPENDENT player panels, each with its own
+// GoonGameService, over either the real /v2/goon signaling + WebRTC transport or
+// GoonLoopbackTransport.CreatePair(). None of that is available here:
+// GoonTestPanel, GoonGameService, GoonMatchService, GoonLoopbackTransport and
+// GoonLoopbackOptions all still live in the WPF head (only GoonContracts,
+// GoonDraft, GoonMatchTypes, GoonRng, GoonScoring and GoonWire made it to
+// CCP.Core). So this layer ports the COCKPIT CHROME — mode bar, enablement
+// rules, status strip, panel hosts — and stubs every verb that would touch a
+// service. The ordering comment that mattered most on the original (AdoptLobby
+// BEFORE ConnectAsync, or both sides strand in Idle) is preserved verbatim on
+// the stub so it is not lost when the wiring comes back.
+// ============================================================================
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class GoonTestWindow : Window
+    {
+        private readonly RadioButton _radioLoopback;
+        private readonly ComboBox _cmbLoopProfile;
+        private readonly Button _btnCreateLoopback, _btnOutage, _btnTearDown;
+        private readonly TextBlock _txtStatus;
+
+        public GoonTestWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _radioLoopback = this.FindControl<RadioButton>("RadioLoopback")!;
+            _cmbLoopProfile = this.FindControl<ComboBox>("CmbLoopProfile")!;
+            _btnCreateLoopback = this.FindControl<Button>("BtnCreateLoopback")!;
+            _btnOutage = this.FindControl<Button>("BtnOutage")!;
+            _btnTearDown = this.FindControl<Button>("BtnTearDown")!;
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+
+            // ponytail: needs GoonTestPanel (+ GoonGameService/GoonMatchService), wired when they
+            // move to Core. The WPF original built two panels with different sim seeds — 1337 and
+            // 8675309 — because two sides posting the SAME round time make every sudden-death
+            // round a draw and the ladder never resolves. Keep the two seeds different when this
+            // comes back.
+            this.FindControl<Border>("PanelHostA")!.Child = PanelPlaceholder("Player A", 1337);
+            this.FindControl<Border>("PanelHostB")!.Child = PanelPlaceholder("Player B", 8675309);
+
+            // Handlers live here rather than in markup, per the porting convention.
+            // WPF's Checked= becomes IsCheckedChanged; it fires for both halves of the group, and
+            // Mode_Changed is idempotent, so that is harmless.
+            this.FindControl<RadioButton>("RadioServer")!.IsCheckedChanged += (_, _) => Mode_Changed();
+            _radioLoopback.IsCheckedChanged += (_, _) => Mode_Changed();
+            _btnCreateLoopback.Click += (_, _) => BtnCreateLoopback_Click();
+            _btnOutage.Click += (_, _) => BtnOutage_Click();
+            _btnTearDown.Click += (_, _) => BtnTearDown_Click();
+
+            // ponytail: the WPF 1 s DispatcherTimer polled _a.RefreshLive()/_b.RefreshLive(). With
+            // the panels stubbed there is nothing live to poll, so the timer is dropped rather
+            // than left spinning; restore it with the panels.
+            UpdateStatus();
+        }
+
+        // ---------------------------------------------------------------- mode
+
+        private bool LoopbackSelected => _radioLoopback.IsChecked == true;
+
+        private void Mode_Changed()
+        {
+            var loopback = LoopbackSelected;
+            _cmbLoopProfile.IsEnabled = loopback;
+            _btnCreateLoopback.IsEnabled = loopback;
+            // WPF: `loopback && _pair != null`. There is never a pair without the transport.
+            _btnOutage.IsEnabled = false;
+            UpdateStatus();
+        }
+
+        private void BtnCreateLoopback_Click()
+        {
+            // ponytail: needs GoonLoopbackTransport.CreatePair + GoonMatchService, wired when they
+            // move to Core. The profile index maps 1 -> Relay(), 2 -> Instant(), default -> P2P().
+            //
+            // ORDER MATTERS when this comes back. AdoptLobby BEFORE ConnectAsync: the hello is sent
+            // from the transport's connected state change, and a hello that lands while the peer is
+            // still Idle is dropped (HandleHello only advances a match that is in Lobby), which
+            // would strand both sides forever.
+            Stub("Create Loopback Pair");
+        }
+
+        private void BtnOutage_Click()
+        {
+            // ponytail: needs GoonLoopbackPair.SimulateOutage(20000), wired when it moves to Core.
+            // Expect Wobbly at 15 s and Dead/abandon at 60 s once it is back.
+            Stub("Simulate 20s Outage");
+        }
+
+        private void BtnTearDown_Click()
+        {
+            // ponytail: needs GoonTestPanel.LeaveAsync + the loopback dispose chain, wired when
+            // they move to Core.
+            Stub("Tear Down Both");
+        }
+
+        // -------------------------------------------------------------- render
+
+        private void UpdateStatus()
+        {
+            var mode = LoopbackSelected ? "loopback (no pair)" : "server";
+            _txtStatus.Text = $"mode={mode}   ||   Player A: not wired   ||   Player B: not wired";
+        }
+
+        private void Stub(string verb)
+        {
+            _txtStatus.Text = $"{verb}: not wired on this head — GoonGame transports are still in the WPF project.";
+        }
+
+        /// <summary>
+        /// Stands in for a GoonTestPanel until that control is ported. Placeholder only: it names
+        /// the side and the sim seed the real panel would carry, so the two hosts are visibly
+        /// distinct in the render proof rather than two identical empty panes.
+        /// </summary>
+        private static Control PanelPlaceholder(string side, int simSeed)
+        {
+            return new StackPanel
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Spacing = 6,
+                Children =
+                {
+                    new TextBlock
+                    {
+                        Text = side,
+                        FontSize = 20,
+                        FontWeight = FontWeight.Bold,
+                        Foreground = new SolidColorBrush(Color.Parse("#FFFF69B4")),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                    },
+                    new TextBlock
+                    {
+                        Text = $"sim seed {simSeed}",
+                        FontSize = 12,
+                        Foreground = new SolidColorBrush(Color.Parse("#FF9A9ABF")),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                    },
+                    new TextBlock
+                    {
+                        Text = "GoonTestPanel is not ported yet.\nIt owns GoonGameService and the WebRTC / loopback\ntransports, which are still in the WPF project.",
+                        FontSize = 12,
+                        TextAlignment = TextAlignment.Center,
+                        Foreground = new SolidColorBrush(Color.Parse("#FFEDEDF5")),
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Margin = new global::Avalonia.Thickness(0, 10, 0, 0),
+                    },
+                },
+            };
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/SplashScreen.axaml
+++ b/CCP.Avalonia/Views/Windows/SplashScreen.axaml
@@ -1,0 +1,132 @@
+<!-- PORTED from ConditioningControlPanel/Windows/SplashScreen.xaml.
+     Structure, ordering, spacing and every literal colour preserved so the two diff cleanly.
+     No {loc:Str}: the original has no loc keys at all - every string here is a hardcoded
+     English literal in the WPF XAML/code-behind, and inventing keys is forbidden.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                     -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"         -> CanResize="False"
+       DropShadowEffect ShadowDepth=5 (WPF default Direction 315) -> OffsetX/OffsetY 3.5 each
+       ScaleTransform x:Name         -> unnamed; the Border's RenderTransform is assigned from
+                                        code-behind (Avalonia generates no field for a named
+                                        non-Control element)
+       TranslateTransform x:Name + a Forever DoubleAnimation
+                                     -> a Style.Animations sweep on Border#Shimmer. The WPF sweep
+                                        distance was Math.Max(200, ActualWidth-60); the window is
+                                        a fixed 400 wide and cannot resize, so that is 340.
+       RenderTransformOrigin Point 0,0.5 -> RelativePoint "0%,50%"
+       FontFamily="Segoe UI"         -> dropped; the head ships Inter and Segoe UI does not exist
+                                        on Linux, so naming it only forces a fallback lookup.
+       <RowDefinition> block         -> RowDefinitions="Auto,Auto,Auto,Auto,*" (same rows)
+
+     Title/status/hint text stays literal, exactly as in the original. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.SplashScreen"
+        Title="Loading..."
+        Height="215" Width="400"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        WindowStartupLocation="CenterScreen"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Topmost="True">
+
+    <!-- NOTE: on WPF this window ran on its OWN UI thread (SplashScreen.ShowOnOwnThread) so it
+         stayed responsive while App.OnStartup ground through service init. Avalonia has exactly
+         one UI thread, so that trick is gone (see the code-behind). The window stays fully
+         self-contained anyway - hardcoded colours, no resource lookups - because that costs
+         nothing and keeps it renderable before App resources exist. -->
+
+    <Window.Styles>
+        <!-- ponytail: local copy of Windows/SplashScreen.xaml.cs:StartShimmer (a code-behind
+             DoubleAnimation there), hoist when a second view needs a sweep -->
+        <Style Selector="Border#Shimmer">
+            <Style.Animations>
+                <Animation Duration="0:0:1.6" IterationCount="Infinite">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="TranslateTransform.X" Value="-90"/>
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="TranslateTransform.X" Value="340"/>
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="#FF121220" CornerRadius="15" BorderBrush="#FFFF69B4" BorderThickness="2">
+        <Border.Effect>
+            <DropShadowEffect Color="Black" BlurRadius="20" OffsetX="3.5" OffsetY="3.5" Opacity="0.6"/>
+        </Border.Effect>
+
+        <Grid Margin="30,20" RowDefinitions="Auto,Auto,Auto,Auto,*">
+
+            <!-- Title -->
+            <TextBlock Grid.Row="0"
+                       Text="Conditioning Control Panel"
+                       FontSize="22"
+                       FontWeight="Bold"
+                       Foreground="#FFFF69B4"
+                       HorizontalAlignment="Center"/>
+
+            <!-- Loading status -->
+            <TextBlock x:Name="TxtStatus"
+                       Grid.Row="1"
+                       Text="Starting up..."
+                       FontSize="12"
+                       Foreground="#AAAAAA"
+                       HorizontalAlignment="Center"
+                       Margin="0,10,0,12"/>
+
+            <!-- Progress bar -->
+            <Grid Grid.Row="2" Height="8">
+                <Border Background="#FF1C1C35" CornerRadius="4"/>
+                <Border x:Name="ProgressFill" CornerRadius="4" RenderTransformOrigin="0%,50%">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#FFFF69B4" Offset="0"/>
+                            <GradientStop Color="#DA70D6" Offset="1"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                </Border>
+                <!-- Shimmer sweep: a continuously-animated highlight band. On WPF it was proof the
+                     app had not hung while the main thread was busy; with one UI thread it stops
+                     when startup blocks, so it is decoration now. -->
+                <Grid ClipToBounds="True">
+                    <Border x:Name="Shimmer" Width="90" HorizontalAlignment="Left" CornerRadius="4">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                <GradientStop Color="#00FFFFFF" Offset="0"/>
+                                <GradientStop Color="#50FFFFFF" Offset="0.5"/>
+                                <GradientStop Color="#00FFFFFF" Offset="1"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                </Grid>
+            </Grid>
+
+            <!-- Patience hint (escalates to reassurance text on long loads) -->
+            <TextBlock x:Name="TxtHint"
+                       Grid.Row="3"
+                       Text="Please wait, this can take a moment..."
+                       FontSize="10"
+                       Foreground="#8888A0"
+                       HorizontalAlignment="Center"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap"
+                       Margin="0,10,0,0"/>
+
+            <!-- Version -->
+            <TextBlock x:Name="TxtVersion"
+                       Grid.Row="4"
+                       Text="v4.3.12"
+                       FontSize="10"
+                       Foreground="#666666"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Bottom"/>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/SplashScreen.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SplashScreen.axaml.cs
@@ -1,0 +1,221 @@
+using System;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Splash screen shown during application startup while services initialize.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/SplashScreen.xaml.cs. Deviations:
+    ///  - THE OWN-THREAD TRICK IS GONE. The WPF original ran on a dedicated STA thread with its
+    ///    own dispatcher so it kept animating while App.OnStartup blocked the main UI thread.
+    ///    Avalonia has exactly one UI thread per process and no per-window dispatcher, so
+    ///    <see cref="ShowOnOwnThread"/> now just shows the window on the UI thread. The fix for
+    ///    the problem it solved is to make startup async rather than to fork a UI thread; that
+    ///    belongs to whoever ports App.OnStartup, not here.
+    ///  - Every public member stays thread-safe the same way, marshalling with
+    ///    <c>Dispatcher.UIThread.Post</c> (never a blocking Invoke) instead of the window's own
+    ///    dispatcher.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag</c>, which needs the PointerPressed args.
+    ///  - <c>BeginAnimation(OpacityProperty, ...)</c> -> an <see cref="Animation"/> run with
+    ///    <c>RunAsync</c>; Avalonia has no per-property BeginAnimation.
+    ///  - The shimmer sweep moved into the XAML as a Style.Animations block.
+    ///  - The named <c>ScaleTransform</c> became a field: Avalonia generates fields only for
+    ///    named Controls, so the transform is built here and assigned to ProgressFill.
+    /// </summary>
+    public partial class SplashScreen : Window
+    {
+        private readonly TextBlock _txtStatus, _txtHint;
+        private readonly ScaleTransform _progressScale = new ScaleTransform(0, 1);
+
+        private double _targetProgress;
+        private double _displayedProgress;
+        private DispatcherTimer? _creepTimer;
+        private DispatcherTimer? _reassureTimer;
+        private int _reassureStage;
+        private bool _closing;
+
+        public SplashScreen()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+            _txtHint = this.FindControl<TextBlock>("TxtHint")!;
+            this.FindControl<Border>("ProgressFill")!.RenderTransform = _progressScale;
+
+            // ponytail: needs Services.UpdateService.AppVersion, wired when it moves to Core. The
+            // WPF ctor did `TxtVersion.Text = $"v{UpdateService.AppVersion}"` here; until that type
+            // exists on this head TxtVersion keeps the literal the XAML carries — the same stale
+            // one the WPF XAML showed before its ctor overwrote it.
+
+            // ponytail: placeholder progress. App.OnStartup is the only caller of SetProgress and
+            // it is still in the WPF head, so nothing drives the bar in this head yet. Seeding a
+            // mid-load value keeps the gradient visible in the render proof; delete this whole
+            // four-line block when startup calls SetProgress.
+            _targetProgress = 0.62;
+            _displayedProgress = 0.62;
+            _progressScale.ScaleX = 0.62;
+            _txtStatus.Text = "Loading services...";
+
+            // Let impatient clicks do something harmless: drag the splash around.
+            PointerPressed += (_, e) => { try { BeginMoveDrag(e); } catch { } };
+
+            // Progress creep: advance the displayed bar toward the reported target, and
+            // when the target itself is stalled (a long init step), keep inching a few
+            // percent past it so the bar never looks frozen mid-load.
+            _creepTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(120), DispatcherPriority.Render, (_, _) => CreepTick());
+            _creepTimer.Start();
+
+            // Reassurance text: on a long load, tell the user explicitly that the app
+            // is fine and will open on its own.
+            _reassureTimer = new DispatcherTimer(TimeSpan.FromSeconds(8), DispatcherPriority.Normal, (_, _) => ReassureTick());
+            _reassureTimer.Start();
+
+            Closed += (_, _) =>
+            {
+                _closing = true;
+                try { _creepTimer?.Stop(); } catch { }
+                try { _reassureTimer?.Stop(); } catch { }
+            };
+        }
+
+        /// <summary>
+        /// Create and show the splash. Returns null if it could not be created (startup then
+        /// simply proceeds without one — every caller uses ?. access).
+        ///
+        /// The name is kept so the WPF call sites port across unchanged, but there is no longer
+        /// an own thread: see the class remarks.
+        /// </summary>
+        public static SplashScreen? ShowOnOwnThread()
+        {
+            try
+            {
+                var splash = new SplashScreen();
+                splash.Show();
+                return splash;
+            }
+            catch
+            {
+                // A cosmetic window must never take the app down.
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Update the progress bar target and status text. Safe to call from any thread.
+        /// </summary>
+        /// <param name="progress">Progress value from 0.0 to 1.0</param>
+        /// <param name="status">Status message to display</param>
+        public void SetProgress(double progress, string status)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => SetProgress(progress, status));
+                return;
+            }
+            if (_closing) return;
+
+            _txtStatus.Text = status;
+            _targetProgress = Math.Min(1.0, Math.Max(0.0, progress));
+        }
+
+        /// <summary>
+        /// Close the splash screen with a fade-out animation. Safe to call from any thread.
+        /// The optional callback fires after the window has closed.
+        /// </summary>
+        public void FadeOutAndClose(Action? afterClosed = null)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => FadeOutAndClose(afterClosed));
+                return;
+            }
+            if (_closing) { afterClosed?.Invoke(); return; }
+            _closing = true;
+
+            // Drop Topmost first so windows/dialogs appearing behind the fade
+            // (What's New, Age Verification) aren't hidden under the splash.
+            try { Topmost = false; } catch { }
+
+            if (afterClosed != null)
+                Closed += (_, _) => { try { afterClosed(); } catch { } };
+
+            FadeThenClose();
+        }
+
+        private async void FadeThenClose()
+        {
+            var fadeOut = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(200),
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(OpacityProperty, 1.0) } },
+                    new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(OpacityProperty, 0.0) } },
+                },
+            };
+
+            try { await fadeOut.RunAsync(this); } catch { }
+            try { Close(); } catch { }
+        }
+
+        /// <summary>
+        /// Close the splash immediately, no animation. Safe to call from any thread.
+        /// Used by early-exit paths (second instance) and error handlers.
+        /// </summary>
+        public void CloseImmediate()
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(CloseImmediate);
+                return;
+            }
+            _closing = true;
+            try { Close(); } catch { }
+        }
+
+        private void CreepTick()
+        {
+            if (_closing) return;
+
+            if (_displayedProgress < _targetProgress)
+            {
+                // Catch up to a newly-reported target quickly but smoothly.
+                _displayedProgress = Math.Min(_targetProgress,
+                    _displayedProgress + Math.Max(0.008, (_targetProgress - _displayedProgress) * 0.22));
+            }
+            else if (_targetProgress < 1.0)
+            {
+                // Target is stalled (a slow init step): idle-creep up to 5% past it,
+                // capped at 99%, so the bar visibly keeps moving.
+                double cap = Math.Min(_targetProgress + 0.05, 0.99);
+                if (_displayedProgress < cap)
+                    _displayedProgress = Math.Min(cap, _displayedProgress + 0.0015);
+            }
+
+            _progressScale.ScaleX = _displayedProgress;
+        }
+
+        private void ReassureTick()
+        {
+            if (_closing) return;
+            _reassureStage++;
+            switch (_reassureStage)
+            {
+                case 1:
+                    _txtHint.Text = "Still loading... the app is fine and will open on its own.";
+                    break;
+                case 2:
+                    _txtHint.Text = "Almost there. Large libraries can take a minute to warm up.";
+                    _reassureTimer?.Stop();
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
687 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351