### PR TITLE
feat(avalonia): port HelpVideoWindow, ProgramEnrollDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/ProgramEnrollDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/ProgramEnrollDialog.axaml
@@ -1,0 +1,264 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/ProgramEnrollDialog.xaml. Structure, ordering,
+     spacing and every resource key preserved so the two diff cleanly. Deviations, all forced:
+
+       Style="{StaticResource X}"          -> Theme="{StaticResource X}"  (keyed styles are ControlThemes)
+       <Style x:Key TargetType>            -> <ControlTheme x:Key TargetType>
+       Style.Triggers / ControlTemplate.Triggers
+                                           -> ^:disabled / ^:pointerover / ^:checked selectors
+       AllowsTransparency="True"           -> TransparencyLevelHint="Transparent"
+       Background="Transparent"              + SystemDecorations="None"
+       WindowStyle="None" / ResizeMode      -> SystemDecorations="None" / CanResize="False"
+       Visibility="Collapsed"              -> IsVisible="False"
+       {Binding RewardVisibility}          -> IsVisible="{Binding RewardVisible}"  (Avalonia binds
+                                              IsVisible to a bool directly)
+       helpers:EmojiTextBlock              -> TextBlock (Avalonia renders colour emoji natively)
+       FocusVisualStyle="{x:Null}"         -> dropped; Avalonia has no such property
+       PreviewKeyDown / MouseLeftButtonDown / TextChanged / Click
+                                           -> KeyDown / PointerPressed / TextChanged / Click,
+                                              wired in the constructor
+
+     The CardRadio template gained Content/ContentTemplate on its ContentPresenter: a bare
+     presenter draws nothing in Avalonia (CLAUDE.md trap 6). Footer buttons carry a TextBlock
+     child rather than Content, because Avalonia parses "_" in Content as an access key and the
+     loc keys here are snake_case (trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Dialogs"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.ProgramEnrollDialog"
+        Title="{loc:Str program_enroll_title}"
+        Width="660"
+        SizeToContent="Height"
+        MinHeight="380"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <!--
+        Height is CONTENT-driven and clamped to the work area in the code-behind, not a fixed 760.
+        Chromeless + no resize + a taller-than-the-screen window is unrecoverable: the footer's
+        Cancel and Enroll buttons sit below the bottom edge with no title bar to drag by. The
+        middle section is already a ScrollViewer in a star row, so the clamp costs the arc some
+        height and never the footer. Escape and click-drag are wired for the same reason.
+    -->
+
+    <Window.Resources>
+        <!-- The shared PinkButton has no disabled visual state, so a gated Enroll button renders
+             identically whether it is armed or not - which is exactly wrong on the one screen
+             whose whole point is that Enroll stays shut until the contract is typed. Local
+             override, as in WPF; the shared theme is left alone. -->
+        <ControlTheme x:Key="GatedPinkButton" TargetType="Button" BasedOn="{StaticResource PinkButton}">
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.35"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- Selectable card. Radio semantics give us mutual exclusion for free; the template
+             turns the card itself into the hit target. -->
+        <ControlTheme x:Key="CardRadio" TargetType="RadioButton">
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="RadioButton">
+                    <Border x:Name="cb" CornerRadius="10" Padding="14,12"
+                            Background="{DynamicResource SurfaceBgBrush}"
+                            BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#cb">
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#cb">
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+                <Setter Property="Background" Value="{DynamicResource TransparentPinkBrush}"/>
+                <Setter Property="BorderThickness" Value="2"/>
+            </Style>
+            <Style Selector="^:disabled /template/ Border#cb">
+                <Setter Property="Opacity" Value="0.4"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{DynamicResource PinkBrush}"
+            BorderThickness="2" CornerRadius="12">
+        <Grid Margin="24,20,24,20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- ============ Header ============ -->
+            <StackPanel Grid.Row="0" Margin="0,0,0,14">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock x:Name="TxtProgramIcon" FontSize="26" VerticalAlignment="Center"/>
+                    <StackPanel Margin="12,0,0,0" VerticalAlignment="Center">
+                        <TextBlock x:Name="TxtProgramTitle" Foreground="{DynamicResource TextLightBrush}"
+                                   FontSize="19" FontWeight="Bold" TextWrapping="Wrap"/>
+                        <TextBlock x:Name="TxtProgramSubtitle" Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="12" Margin="0,2,0,0" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </StackPanel>
+                <TextBlock x:Name="TxtProgramPitch" Foreground="{DynamicResource TextLightBrush}"
+                           FontSize="12" TextWrapping="Wrap" LineHeight="19" Margin="0,12,0,0"/>
+            </StackPanel>
+
+            <!-- ============ Body ============ -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="0,0,10,0">
+                <StackPanel>
+
+                    <!-- (a) The whole arc, up front -->
+                    <TextBlock Text="{loc:Str program_enroll_arc_header}"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="13" FontWeight="Bold" Margin="0,0,0,4"/>
+                    <TextBlock Text="{loc:Str program_enroll_arc_note}"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                    <ItemsControl x:Name="ChapterList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:ProgramChapterItem">
+                                <Border Padding="14,12" CornerRadius="10" Margin="0,0,0,8"
+                                        Background="{DynamicResource SurfaceBgBrush}">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Width="3" CornerRadius="2" Margin="0,1,12,1"
+                                                Background="{Binding AccentBrush}"/>
+                                        <StackPanel Grid.Column="1">
+                                            <TextBlock Text="{Binding Name}" Foreground="{DynamicResource TextLightBrush}"
+                                                       FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                                            <TextBlock Text="{Binding Subtitle}" Foreground="{DynamicResource TextMutedBrush}"
+                                                       FontSize="11" Margin="0,3,0,0" TextWrapping="Wrap" LineHeight="17"/>
+                                            <TextBlock Text="{Binding RewardText}" IsVisible="{Binding RewardVisible}"
+                                                       Foreground="{DynamicResource PinkBrush}"
+                                                       FontSize="11" Margin="0,5,0,0" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <TextBlock Grid.Column="2" Text="{Binding DaysLabel}"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="11" Margin="12,0,0,0" VerticalAlignment="Top"/>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock x:Name="TxtCommitment" Foreground="{DynamicResource TextLightBrush}"
+                               FontSize="12" TextWrapping="Wrap" LineHeight="19" Margin="0,6,0,18"/>
+
+                    <!-- (b) Standard vs Strict -->
+                    <TextBlock Text="{loc:Str program_enroll_mode_header}"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="13" FontWeight="Bold" Margin="0,0,0,8"/>
+                    <UniformGrid Columns="2" Margin="0,0,0,6">
+                        <RadioButton x:Name="RadioModeStandard" GroupName="ProgramMode"
+                                     Theme="{StaticResource CardRadio}" IsChecked="True">
+                            <StackPanel>
+                                <TextBlock Text="{loc:Str program_enroll_mode_standard}"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                                <TextBlock x:Name="TxtModeStandardBody" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" TextWrapping="Wrap" LineHeight="17" Margin="0,5,0,0"/>
+                            </StackPanel>
+                        </RadioButton>
+                        <RadioButton x:Name="RadioModeStrict" GroupName="ProgramMode"
+                                     Theme="{StaticResource CardRadio}" Margin="8,0,0,0">
+                            <StackPanel>
+                                <TextBlock Text="{loc:Str program_enroll_mode_strict}"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           FontSize="13" FontWeight="Bold"/>
+                                <TextBlock Text="{loc:Str program_enroll_mode_strict_body}"
+                                           Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" TextWrapping="Wrap" LineHeight="17" Margin="0,5,0,0"/>
+                            </StackPanel>
+                        </RadioButton>
+                    </UniformGrid>
+                    <TextBlock x:Name="TxtStrictUnavailable" IsVisible="False"
+                               Text="{loc:Str program_enroll_mode_strict_unavailable}"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11" FontStyle="Italic" Margin="0,0,0,18"/>
+
+                    <!-- (c) The clock -->
+                    <TextBlock Text="{loc:Str program_enroll_clock_header}"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="13" FontWeight="Bold" Margin="0,12,0,8"/>
+                    <Grid Margin="0,0,0,4">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Margin="0,0,8,0">
+                            <TextBlock Text="{loc:Str program_enroll_boundary_label}"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11"/>
+                            <ComboBox x:Name="CmbBoundaryHour" Theme="{StaticResource DarkComboBoxStyle}"
+                                      HorizontalAlignment="Stretch" Margin="0,5,0,0"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1">
+                            <TextBlock Text="{loc:Str program_enroll_nudge_label}"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11"/>
+                            <ComboBox x:Name="CmbNudgeHour" Theme="{StaticResource DarkComboBoxStyle}"
+                                      HorizontalAlignment="Stretch" Margin="0,5,0,0"/>
+                        </StackPanel>
+                    </Grid>
+                    <TextBlock Text="{loc:Str program_enroll_boundary_note}"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11" TextWrapping="Wrap" Margin="0,0,0,18"/>
+
+                    <!-- Safety note: plain, out of character, visually apart from the fiction -->
+                    <Border Padding="16,14" CornerRadius="10" Margin="0,0,0,18"
+                            Background="{DynamicResource SurfaceBgBrush}"
+                            BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1">
+                        <StackPanel>
+                            <TextBlock Text="{loc:Str program_enroll_safety_header}"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       FontSize="11" FontWeight="Bold" Margin="0,0,0,6"/>
+                            <TextBlock x:Name="TxtSafetyNote" Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12" TextWrapping="Wrap" LineHeight="19"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Typed contract phrase -->
+                    <TextBlock Text="{loc:Str program_enroll_contract_header}"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="13" FontWeight="Bold" Margin="0,0,0,8"/>
+                    <Border Padding="14,10" CornerRadius="10" Margin="0,0,0,8"
+                            Background="{DynamicResource SurfaceBgBrush}">
+                        <TextBlock x:Name="TxtContractPhrase" Foreground="{DynamicResource TextLightBrush}"
+                                   FontSize="13" FontStyle="Italic" TextWrapping="Wrap"/>
+                    </Border>
+                    <TextBox x:Name="TxtContractInput" Theme="{StaticResource FocusGlowTextBox}"
+                             FontSize="13" Padding="10,8"/>
+                    <TextBlock Text="{loc:Str program_enroll_contract_hint}"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11" Margin="0,6,0,0"/>
+
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- ============ Footer ============ -->
+            <StackPanel Grid.Row="2" Margin="0,14,0,0">
+                <TextBlock x:Name="TxtBlockedHint" Foreground="{DynamicResource TextMutedBrush}"
+                           FontSize="11" TextWrapping="Wrap" Margin="0,0,0,8"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button x:Name="BtnCancel" Theme="{StaticResource SecondaryButton}"
+                            MinWidth="110" Padding="20,10" Margin="0,0,10,0">
+                        <TextBlock Text="{loc:Str btn_cancel}"/>
+                    </Button>
+                    <Button x:Name="BtnConfirmEnroll" Theme="{StaticResource GatedPinkButton}"
+                            MinWidth="150" IsEnabled="False">
+                        <TextBlock Text="{loc:Str btn_program_enroll_confirm}"/>
+                    </Button>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/ProgramEnrollDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ProgramEnrollDialog.axaml.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// The enrollment ceremony. Three steps on one scrollable panel: the whole arc up front,
+    /// Standard vs Strict, and the clock plus a typed contract phrase.
+    ///
+    /// The dialog decides nothing - it collects. The caller reads <see cref="StrictMode"/>,
+    /// <see cref="DayBoundaryHour"/> and <see cref="NudgeHour"/> and calls the program service.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/ProgramEnrollDialog.xaml.cs. Deviations:
+    ///  - <c>ProgramDefinition</c> lives in the WPF head (Models/Program), which this head may not
+    ///    reference, so the dialog takes <see cref="ProgramEnrollInfo"/> - the same fields under
+    ///    the same names, nothing more. See the ponytail note on that type.
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>, as in TextEditorDialog: Avalonia
+    ///    carries the result through <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>SystemParameters.WorkArea</c> -> <c>Screens.Primary.WorkingArea</c> (also the primary
+    ///    monitor, also excluding the taskbar) divided by the screen scaling, because Avalonia
+    ///    reports it in physical pixels where WPF reported device-independent units.
+    ///  - <c>ProgramShareLevel ShareLevel</c> is dropped: the enum is the head's, every new
+    ///    enrollment is Private, and nothing in this head reads it.
+    ///  - <c>ColorConverter.ConvertFromString</c> -> <c>Color.TryParse</c>; <c>Freeze()</c> ->
+    ///    <c>ToImmutable()</c>.
+    ///  - PreviewKeyDown -> KeyDown, DragMove() -> BeginMoveDrag(e).
+    /// </summary>
+    public partial class ProgramEnrollDialog : Window
+    {
+        private readonly ProgramEnrollInfo _program;
+
+        private readonly RadioButton _radioModeStrict;
+        private readonly ComboBox _cmbBoundaryHour;
+        private readonly ComboBox _cmbNudgeHour;
+        private readonly TextBox _txtContractInput;
+        private readonly TextBlock _txtBlockedHint;
+        private readonly Button _btnConfirmEnroll;
+
+        public bool StrictMode { get; private set; }
+        public int DayBoundaryHour { get; private set; } = 4;
+        public int NudgeHour { get; private set; } = 20;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal ProgramEnrollDialog() : this(SampleProgram()) { }
+
+        public ProgramEnrollDialog(ProgramEnrollInfo program)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _program = program ?? throw new ArgumentNullException(nameof(program));
+
+            _radioModeStrict = this.FindControl<RadioButton>("RadioModeStrict")!;
+            _cmbBoundaryHour = this.FindControl<ComboBox>("CmbBoundaryHour")!;
+            _cmbNudgeHour = this.FindControl<ComboBox>("CmbNudgeHour")!;
+            _txtContractInput = this.FindControl<TextBox>("TxtContractInput")!;
+            _txtBlockedHint = this.FindControl<TextBlock>("TxtBlockedHint")!;
+            _btnConfirmEnroll = this.FindControl<Button>("BtnConfirmEnroll")!;
+
+            var accent = ParseBrush(_program.AccentColor);
+
+            this.FindControl<TextBlock>("TxtProgramIcon")!.Text = _program.Icon;
+            this.FindControl<TextBlock>("TxtProgramTitle")!.Text = _program.Title;
+            this.FindControl<TextBlock>("TxtProgramSubtitle")!.Text = _program.Subtitle;
+            this.FindControl<TextBlock>("TxtProgramPitch")!.Text = _program.Pitch;
+
+            // (a) The whole arc, up front.
+            var chapters = new List<ProgramChapterItem>();
+            foreach (var chapter in _program.Chapters)
+            {
+                var days = chapter.Days.Select(d => d.DayIndex).ToList();
+                var first = days.Count > 0 ? days.Min() : 0;
+                var last = days.Count > 0 ? days.Max() : 0;
+
+                var hasReward = !string.IsNullOrWhiteSpace(chapter.RewardDescription);
+                chapters.Add(new ProgramChapterItem
+                {
+                    Name = chapter.Name,
+                    Subtitle = chapter.Subtitle,
+                    DaysLabel = Loc.GetF("program_enroll_chapter_days", first, last),
+                    RewardText = hasReward ? chapter.RewardDescription! : "",
+                    RewardVisible = hasReward,
+                    AccentBrush = string.IsNullOrWhiteSpace(chapter.AccentColor)
+                        ? accent
+                        : ParseBrush(chapter.AccentColor)
+                });
+            }
+            this.FindControl<ItemsControl>("ChapterList")!.ItemsSource = chapters;
+
+            var allDays = _program.AllDays.ToList();
+            var minMinutes = allDays.Count > 0 ? allDays.Min(d => d.SessionMinutes) : 0;
+            var maxMinutes = allDays.Count > 0 ? allDays.Max(d => d.SessionMinutes) : 0;
+            this.FindControl<TextBlock>("TxtCommitment")!.Text = minMinutes == maxMinutes
+                ? Loc.GetF("program_enroll_commitment_flat", _program.LengthDays, minMinutes)
+                : Loc.GetF("program_enroll_commitment", _program.LengthDays, minMinutes, maxMinutes);
+
+            // (b) Standard vs Strict.
+            this.FindControl<TextBlock>("TxtModeStandardBody")!.Text =
+                Loc.GetF("program_enroll_mode_standard_body", _program.Rules.DaysOffAllowed);
+            if (!_program.Rules.StrictAvailable)
+            {
+                _radioModeStrict.IsEnabled = false;
+                this.FindControl<TextBlock>("TxtStrictUnavailable")!.IsVisible = true;
+            }
+
+            // (d) The clock.
+            for (int h = 0; h < 24; h++)
+                _cmbBoundaryHour.Items.Add(Loc.GetF("program_enroll_hour_format", h));
+            _cmbBoundaryHour.SelectedIndex = Math.Clamp(_program.Rules.DefaultDayBoundaryHour, 0, 23);
+
+            _cmbNudgeHour.Items.Add(Loc.Get("program_enroll_nudge_off"));
+            for (int h = 0; h < 24; h++)
+                _cmbNudgeHour.Items.Add(Loc.GetF("program_enroll_hour_format", h));
+            _cmbNudgeHour.SelectedIndex = 21; // 20:00, one past the "Off" row
+
+            this.FindControl<TextBlock>("TxtSafetyNote")!.Text = _program.SafetyNote;
+            this.FindControl<TextBlock>("TxtContractPhrase")!.Text = _program.ContractPhrase;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            _txtContractInput.TextChanged += (_, _) => UpdateConfirmState();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            _btnConfirmEnroll.Click += (_, _) => BtnConfirm_Click();
+            KeyDown += Window_KeyDown;
+            PointerPressed += Window_PointerPressed;
+
+            UpdateConfirmState();
+        }
+
+        /// <summary>
+        /// Caps the content-driven height at the screen the dialog opens on. Runs on open rather
+        /// than in the constructor because <see cref="TopLevel.Screens"/> only has a screen list
+        /// once the window has a platform impl.
+        ///
+        /// <para>Not expressible in XAML: the work area is a runtime value, and it is the one that
+        /// matters - it excludes the taskbar. The 40 DIP of slack keeps the shadowless chromeless
+        /// border off the very edge. Once the clamp binds, the Grid's star row shrinks, the
+        /// ScrollViewer inside it takes over, and the Auto footer keeps its buttons.</para>
+        /// </summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            try
+            {
+                var screen = Screens?.Primary;
+                if (screen is null) return;
+                var available = screen.WorkingArea.Height / screen.Scaling - 40;
+                if (available > 0) MaxHeight = Math.Max(MinHeight, available);
+            }
+            catch
+            {
+                // No work area (a locked session, a headless render): the content height stands.
+            }
+        }
+
+        /// <summary>
+        /// Escape cancels. A chromeless, non-resizable modal with no close button otherwise leaves
+        /// Alt+F4 as the only exit, and this is a screen the user is explicitly allowed to walk
+        /// away from. Closing with false is what tells the caller not to enroll.
+        /// </summary>
+        private void Window_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape) return;
+            e.Handled = true;
+            try { Close(false); } catch { /* already closing */ }
+        }
+
+        /// <summary>
+        /// Chromeless window, so dragging the card is the only way to move it - which matters when
+        /// the clamp above has it filling the work area. The controls inside (TextBox, ComboBox,
+        /// Buttons, the card radios) all mark the event handled for their own focus handling, so
+        /// this only ever fires on the dialog's own dead space.
+        /// </summary>
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            try { BeginMoveDrag(e); } catch { /* not a drag-able moment */ }
+        }
+
+        private static IBrush ParseBrush(string hex)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(hex) && Color.TryParse(hex, out var color))
+                    return new SolidColorBrush(color).ToImmutable();
+            }
+            catch { /* a bad accent must never block enrollment */ }
+
+            try
+            {
+                if (Application.Current is { } app &&
+                    app.TryFindResource("PinkBrush", out var res) && res is IBrush brush)
+                    return brush;
+            }
+            catch { /* fall through */ }
+
+            return Brushes.HotPink;
+        }
+
+        private static string Normalize(string? value) =>
+            Regex.Replace((value ?? "").Trim(), @"\s+", " ");
+
+        private bool ContractMatches() =>
+            string.IsNullOrWhiteSpace(_program.ContractPhrase) ||
+            string.Equals(Normalize(_txtContractInput.Text), Normalize(_program.ContractPhrase),
+                StringComparison.OrdinalIgnoreCase);
+
+        private void UpdateConfirmState()
+        {
+            var contractOk = ContractMatches();
+            _btnConfirmEnroll.IsEnabled = contractOk;
+
+            _txtBlockedHint.Text = contractOk ? "" : Loc.Get("program_enroll_contract_hint");
+        }
+
+        private void BtnConfirm_Click()
+        {
+            StrictMode = _radioModeStrict.IsChecked == true && _program.Rules.StrictAvailable;
+
+            DayBoundaryHour = Math.Clamp(_cmbBoundaryHour.SelectedIndex, 0, 23);
+            NudgeHour = _cmbNudgeHour.SelectedIndex <= 0 ? -1 : _cmbNudgeHour.SelectedIndex - 1;
+
+            Close(true);
+        }
+
+        private static ProgramEnrollInfo SampleProgram() => new()
+        {
+            Icon = "🌸",
+            Title = "The Descent",
+            Subtitle = "28 days, four chapters",
+            Pitch = "A month of careful, escalating conditioning. One session a day, and a short list of tasks around it.",
+            AccentColor = "#FF69B4",
+            LengthDays = 28,
+            SafetyNote = "You can stop at any time, and nothing is lost when you do. Days off are built in. "
+                       + "If a day feels wrong, skip it - the program is a schedule, not a contract with anyone but yourself.",
+            ContractPhrase = "I choose this, and I choose to keep choosing it.",
+            Rules = new ProgramEnrollRules { DaysOffAllowed = 2, StrictAvailable = true, DefaultDayBoundaryHour = 4 },
+            Chapters =
+            {
+                new ProgramEnrollChapter
+                {
+                    Name = "Chapter I - Settling",
+                    Subtitle = "Short sessions, gentle pacing. Learning what the routine feels like.",
+                    AccentColor = "#FF8FC7",
+                    Days = Enumerable.Range(1, 7).Select(i => new ProgramEnrollDay { DayIndex = i, SessionMinutes = 30 }).ToList()
+                },
+                new ProgramEnrollChapter
+                {
+                    Name = "Chapter II - Deepening",
+                    Subtitle = "The sessions lengthen and the task list grows a little teeth.",
+                    AccentColor = "#E85BB0",
+                    RewardDescription = "Unlocks the Deepening ambient track, permanently.",
+                    Days = Enumerable.Range(8, 7).Select(i => new ProgramEnrollDay { DayIndex = i, SessionMinutes = 45 }).ToList()
+                },
+                new ProgramEnrollChapter
+                {
+                    Name = "Chapter III - Holding",
+                    Subtitle = "Consistency over intensity. The same weight, every day, without flinching.",
+                    AccentColor = "#C44BA0",
+                    Days = Enumerable.Range(15, 7).Select(i => new ProgramEnrollDay { DayIndex = i, SessionMinutes = 60 }).ToList()
+                },
+                new ProgramEnrollChapter
+                {
+                    Name = "Chapter IV - The Descent",
+                    Subtitle = "The last week. Longest sessions, and the boss day at the end of it.",
+                    AccentColor = "#9B3A8C",
+                    RewardDescription = "Files the final session into your own catalogue, replayable forever.",
+                    Days = Enumerable.Range(22, 7).Select(i => new ProgramEnrollDay { DayIndex = i, SessionMinutes = 75 }).ToList()
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// What the enrollment ceremony reads off a program, and nothing else.
+    ///
+    /// ponytail: local stand-in for ConditioningControlPanel.Models.Program.ProgramDefinition,
+    /// which lives in the WPF head and cannot be referenced from here. Field names and shapes are
+    /// the original's, so when Models/Program moves to Core this type is deleted and the
+    /// constructor's parameter type changed - no other edit.
+    /// </summary>
+    public class ProgramEnrollInfo
+    {
+        public string Icon { get; set; } = "📅";
+        public string Title { get; set; } = "";
+        public string Subtitle { get; set; } = "";
+        public string Pitch { get; set; } = "";
+        public string AccentColor { get; set; } = "#FF69B4";
+        public int LengthDays { get; set; }
+        public string SafetyNote { get; set; } = "";
+        public string ContractPhrase { get; set; } = "";
+        public List<ProgramEnrollChapter> Chapters { get; set; } = new();
+        public ProgramEnrollRules Rules { get; set; } = new();
+
+        public IEnumerable<ProgramEnrollDay> AllDays =>
+            Chapters.SelectMany(c => c.Days).OrderBy(d => d.DayIndex);
+    }
+
+    /// <summary>A named block of days. See <see cref="ProgramEnrollInfo"/>.</summary>
+    public class ProgramEnrollChapter
+    {
+        public string Name { get; set; } = "";
+        public string Subtitle { get; set; } = "";
+        /// <summary>Hex, e.g. "#FF69B4". Falls back to the program accent when blank.</summary>
+        public string AccentColor { get; set; } = "";
+        public string? RewardDescription { get; set; }
+        public List<ProgramEnrollDay> Days { get; set; } = new();
+    }
+
+    /// <summary>One day. See <see cref="ProgramEnrollInfo"/>.</summary>
+    public class ProgramEnrollDay
+    {
+        public int DayIndex { get; set; }
+        public int SessionMinutes { get; set; } = 30;
+    }
+
+    /// <summary>Program-wide rules the ceremony shows. See <see cref="ProgramEnrollInfo"/>.</summary>
+    public class ProgramEnrollRules
+    {
+        public int DaysOffAllowed { get; set; } = 1;
+        public bool StrictAvailable { get; set; } = true;
+        public int DefaultDayBoundaryHour { get; set; } = 4;
+    }
+
+    /// <summary>
+    /// One row of the arc list. Copied from ConditioningControlPanel/Views/Tabs/ProgramsTabItems.cs:
+    /// the type lives in the WPF head, not in Core. RewardVisibility becomes a bool, because
+    /// Avalonia binds IsVisible to a bool directly.
+    /// </summary>
+    public class ProgramChapterItem
+    {
+        public string Name { get; set; } = "";
+        public string Subtitle { get; set; } = "";
+        public string DaysLabel { get; set; } = "";
+        public string RewardText { get; set; } = "";
+        public bool RewardVisible { get; set; }
+        public IBrush? AccentBrush { get; set; }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/HelpVideoWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/HelpVideoWindow.axaml
@@ -1,0 +1,154 @@
+<!-- PORTED from ConditioningControlPanel/Windows/HelpVideoWindow.xaml. Structure, ordering,
+     spacing and every resource key preserved so the two diff cleanly. Deviations, all forced:
+
+       WindowStyle="None" / ResizeMode="NoResize" -> SystemDecorations="None" / CanResize="False"
+       AllowsTransparency="False"                 -> dropped (the window is opaque either way)
+       Visibility="Collapsed"                     -> IsVisible="False"
+       ToolTip="..."                              -> ToolTip.Tip="..."
+       MouseLeftButtonDown                        -> PointerPressed, wired in the constructor
+       Click="..."                                -> wired in the constructor
+       Button.Template ControlTemplate.Triggers   -> the same inline template plus :pointerover
+                                                     selectors on the named template parts
+                                                     (Avalonia has no ControlTemplate.Triggers)
+
+     The close button keeps its own inline template rather than borrowing a shared theme: it is
+     the WPF original's. Its glyph is a literal TextBlock inside the template, so the missing
+     ContentPresenter of CLAUDE.md trap 6 is not a hazard here. BtnFullTutorial carries a
+     TextBlock child rather than Content, because Avalonia parses "_" in Content as an access
+     key and every loc key here is snake_case (trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.HelpVideoWindow"
+        Title="Help"
+        Width="480"
+        SizeToContent="Height"
+        MinWidth="480"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        CanResize="False"
+        SystemDecorations="None"
+        ShowInTaskbar="False">
+
+    <Window.Styles>
+        <!-- The close button's ControlTemplate.Triggers block, as selectors. -->
+        <Style Selector="Button.close:pointerover /template/ Border#border">
+            <Setter Property="Background" Value="{DynamicResource DangerBrush}"/>
+        </Style>
+        <Style Selector="Button.close:pointerover /template/ TextBlock#glyph">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Titlebar -->
+            <Border x:Name="Titlebar"
+                    Grid.Row="0"
+                    Background="{DynamicResource ElevatedSurfaceBrush}"
+                    BorderBrush="{DynamicResource GlassBorderBrush}"
+                    BorderThickness="0,0,0,1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Icon (glyph) -->
+                    <Border Grid.Column="0"
+                            Width="28" Height="28"
+                            Margin="14,10,10,10"
+                            CornerRadius="6"
+                            Background="{DynamicResource TransparentPinkBrush}">
+                        <TextBlock x:Name="TxtGlyph"
+                                   FontSize="16"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource PinkBrush}"/>
+                    </Border>
+
+                    <!-- Title -->
+                    <TextBlock Grid.Column="1"
+                               x:Name="TxtTitle"
+                               Text="Help"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="15"
+                               FontWeight="SemiBold"
+                               TextTrimming="CharacterEllipsis"/>
+
+                    <!-- Close button -->
+                    <Button Grid.Column="2"
+                            x:Name="BtnClose"
+                            Classes="close"
+                            Cursor="Hand"
+                            Width="38" Height="38"
+                            Padding="0"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Foreground="{DynamicResource TextMutedBrush}"
+                            ToolTip.Tip="{loc:Str tooltip_close_escape}">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border x:Name="border"
+                                        Background="{TemplateBinding Background}"
+                                        CornerRadius="0">
+                                    <TextBlock x:Name="glyph"
+                                               Text="✕"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               FontSize="14"
+                                               Foreground="{TemplateBinding Foreground}"/>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- Video surface (hidden when no clip / no player available: fail soft) -->
+            <Border x:Name="VideoContainer"
+                    Grid.Row="1"
+                    Height="270"
+                    Background="#000000"
+                    IsVisible="False">
+                <!-- video view added programmatically -->
+            </Border>
+
+            <!-- Caption (below the clip) -->
+            <TextBlock x:Name="TxtCaption"
+                       Grid.Row="2"
+                       Margin="16,14,16,8"
+                       Foreground="{DynamicResource TextLightBrush}"
+                       FontSize="13"
+                       TextWrapping="Wrap"
+                       LineHeight="19"
+                       IsVisible="False"/>
+
+            <!-- Watch full tutorial (hidden when no URL) -->
+            <Button x:Name="BtnFullTutorial"
+                    Grid.Row="3"
+                    Margin="16,4,16,16"
+                    HorizontalAlignment="Left"
+                    Padding="14,7"
+                    Cursor="Hand"
+                    Background="{DynamicResource TransparentPinkBrush}"
+                    Foreground="{DynamicResource PinkBrush}"
+                    BorderBrush="{DynamicResource PinkBrush}"
+                    BorderThickness="1"
+                    FontSize="13"
+                    FontWeight="SemiBold"
+                    IsVisible="False">
+                <TextBlock Text="{loc:Str help_video_watch_full_tutorial}"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/HelpVideoWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/HelpVideoWindow.axaml.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Diagnostics;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Borderless popup that plays a short muted, looping tutorial clip for a
+    /// <see cref="HelpContent"/> topic, with a caption below and an optional
+    /// "watch full tutorial" link.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/HelpVideoWindow.xaml.cs. Deviations:
+    ///  - LibVLCSharp.WPF's VideoView, the MediaPlayer and the whole load/loop/mute/dispose block
+    ///    are gone: they are the WPF head's, hung off Services.VideoService.SharedLibVLC, and no
+    ///    service may move in this layer. StartClip is the ponytail stub below. The fail-soft path
+    ///    the original already had - hidden video surface, caption and link still shown - is
+    ///    exactly what that stub produces, so the window is correct, just always silent.
+    ///  - App.Logger is the head's; the catch blocks swallow as before.
+    ///  - DragMove() -> BeginMoveDrag(e); PreviewKeyDown -> KeyDown (tunnelling has no twin, and
+    ///    nothing in this window consumes Escape first).
+    ///
+    /// Fail-soft as the original: never throws to the caller.
+    /// </summary>
+    public partial class HelpVideoWindow : Window
+    {
+        // Only one help video may be open at a time. Opening a new one closes whichever is
+        // already open, exactly as the WPF original did to keep two players off the box.
+        private static HelpVideoWindow? _current;
+
+        private readonly string? _fullTutorialUrl;
+        private readonly string? _whatItDoes;
+        private bool _captionShown;
+
+        private readonly TextBlock _txtCaption;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the window.</summary>
+        internal HelpVideoWindow() : this(SampleContent()) { }
+
+        /// <summary>
+        /// A real topic out of Core's HelpContentService, copied rather than handed over, so the
+        /// sample tutorial URL cannot leak into the shared instance. No shipped topic sets
+        /// FullTutorialUrl yet (the docs page is not live), and the render should still prove the
+        /// button draws.
+        /// </summary>
+        private static HelpContent SampleContent()
+        {
+            var real = HelpContentService.GetContent("FlashImages");
+            return new HelpContent
+            {
+                SectionId = real.SectionId,
+                Icon = real.Icon,
+                Title = real.Title,
+                WhatItDoes = real.WhatItDoes,
+                ClipFile = real.ClipFile,
+                CaptionKey = real.CaptionKey,
+                FullTutorialUrl = "https://example.invalid/tutorials/flash-images"
+            };
+        }
+
+        public HelpVideoWindow(HelpContent content)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtCaption = this.FindControl<TextBlock>("TxtCaption")!;
+
+            this.FindControl<TextBlock>("TxtGlyph")!.Text =
+                string.IsNullOrEmpty(content.Icon) ? "?" : content.Icon;
+            this.FindControl<TextBlock>("TxtTitle")!.Text = content.Title;
+            Title = content.Title; // also set Window.Title for accessibility
+
+            // Caption: reproduce {loc:Str CaptionKey} as a live OneWay binding to the
+            // LocalizationManager indexer, so it hot-swaps on language change exactly like
+            // StrExtension would for a literal key. (This is StrExtension's own binding, built
+            // by hand because the key is only known at runtime.)
+            if (!string.IsNullOrWhiteSpace(content.CaptionKey))
+            {
+                _txtCaption.Bind(TextBlock.TextProperty, new Binding($"[{content.CaptionKey}]")
+                {
+                    Source = LocalizationManager.Instance,
+                    Mode = BindingMode.OneWay
+                });
+                _txtCaption.IsVisible = true;
+                _captionShown = true;
+            }
+
+            // Fallback so the window is never empty: with no clip and no caption, show the
+            // topic's "what it does" blurb.
+            _whatItDoes = content.WhatItDoes;
+            if (!content.HasClip) ShowWhatItDoesFallback();
+
+            _fullTutorialUrl = content.FullTutorialUrl;
+            var btnFullTutorial = this.FindControl<Button>("BtnFullTutorial")!;
+            if (!string.IsNullOrWhiteSpace(_fullTutorialUrl))
+            {
+                btnFullTutorial.IsVisible = true;
+            }
+
+            // Handlers live here rather than in markup, per the porting convention.
+            btnFullTutorial.Click += (_, _) => BtnFullTutorial_Click();
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            this.FindControl<Border>("Titlebar")!.PointerPressed += Titlebar_PointerPressed;
+            KeyDown += OnKeyDown;
+
+            StartClip(content);
+        }
+
+        /// <summary>
+        /// Opens a modeless help video popup for the given topic, centered on owner.
+        /// Never throws. Any help video already open is closed first (single live instance).
+        /// </summary>
+        public static void Show(HelpContent content, Window? owner, bool topmost = false)
+        {
+            try
+            {
+                CloseCurrent();
+
+                var win = new HelpVideoWindow(content) { Topmost = topmost };
+                _current = win;
+                if (owner is not null) win.Show(owner); else win.Show();
+            }
+            catch
+            {
+                // ponytail: needs App.Logger, wired when logging moves to Core
+            }
+        }
+
+        private static void CloseCurrent()
+        {
+            var existing = _current;
+            _current = null;
+            if (existing != null)
+            {
+                try { existing.Close(); } catch { /* ignore */ }
+            }
+        }
+
+        /// <summary>
+        /// Shows the topic's "what it does" text in the caption slot when nothing else would fill
+        /// it (no clip playing and no localized caption). Idempotent.
+        /// </summary>
+        private void ShowWhatItDoesFallback()
+        {
+            if (_captionShown) return;
+            if (string.IsNullOrWhiteSpace(_whatItDoes)) return;
+            _txtCaption.Text = _whatItDoes;
+            _txtCaption.IsVisible = true;
+            _captionShown = true;
+        }
+
+        private void StartClip(HelpContent content)
+        {
+            // ponytail: needs Services.VideoService (LibVLC) and an Avalonia video surface, wired
+            // when the player moves to Core. Until then this takes the fail-soft branch the WPF
+            // original already had for a missing clip: video surface stays hidden, caption and
+            // link still show. VideoContainer is IsVisible="False" in the markup.
+            _ = content;
+            ShowWhatItDoesFallback();
+        }
+
+        private void BtnFullTutorial_Click()
+        {
+            if (string.IsNullOrWhiteSpace(_fullTutorialUrl)) return;
+            try
+            {
+                Process.Start(new ProcessStartInfo(_fullTutorialUrl) { UseShellExecute = true });
+            }
+            catch
+            {
+                // ponytail: needs App.Logger, wired when logging moves to Core
+            }
+        }
+
+        private void OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+                e.Handled = true;
+            }
+        }
+
+        private void Titlebar_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            try { BeginMoveDrag(e); } catch { /* dragging can throw if not pressed */ }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            // Drop the single-instance reference if it points at us (whether we were closed by the
+            // user or superseded by a newer help video). The WPF player teardown that followed has
+            // no counterpart until StartClip is wired.
+            if (ReferenceEquals(_current, this)) _current = null;
+            base.OnClosed(e);
+        }
+    }
+}


### PR DESCRIPTION
966 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351