### PR TITLE
feat(avalonia): port SessionCompleteWindow, ProgramsIntroPopup

### DIFF
--- a/CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml
+++ b/CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml
@@ -1,0 +1,227 @@
+<!-- PORTED from ConditioningControlPanel/Windows/ProgramsIntroPopup.xaml.
+     Structure, ordering, spacing, x:Names and every comment preserved. Copy is hardcoded English in
+     the original (see the class doc) so there are no loc keys to carry across. Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency -> SystemDecorations="None" +
+                                                  TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                   -> CanResize="False"
+       DropShadowEffect ShadowDepth="0"        -> OffsetX="0" OffsetY="0"
+       LinearGradientBrush "0,0" / "0.3,1"     -> "0%,0%" / "30%,100%". Avalonia's RelativePoint
+                                                  parses a bare pair as ABSOLUTE pixels, so the WPF
+                                                  spelling would have drawn a 0.3px gradient.
+       Panel.ZIndex                            -> ZIndex
+       <Style x:Key TargetType="Button">       -> <ControlTheme> with the same Template; the
+                                                  IsMouseOver/IsPressed triggers are ^:pointerover /
+                                                  ^:pressed selectors
+       <ContentPresenter/>                     -> ContentPresenter Content="{TemplateBinding Content}"
+                                                  (CLAUDE.md trap 6)
+       Visibility="Collapsed"                  -> IsVisible="False" (set from code)
+       PreviewKeyDown / MouseLeftButtonDown    -> KeyDown / PointerPressed, wired in the constructor
+       Click="BtnDismiss_Click"                -> wired in the constructor -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.ProgramsIntroPopup"
+        Title="Training Programs"
+        Width="620" SizeToContent="Height" MaxHeight="640"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+
+    <Window.Resources>
+        <!-- The WPF inline <Button.Style> on BtnDismiss, setters verbatim. -->
+        <ControlTheme x:Key="DismissButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}"
+                            CornerRadius="18" Padding="16,6">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="{DynamicResource PinkButtonHoveredBrush}"/>
+            </Style>
+            <Style Selector="^:pressed /template/ Border#border">
+                <Setter Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Window.Styles>
+        <!-- The WPF <Style.Triggers> IsMouseOver setter on the ✕ button. -->
+        <Style Selector="Button.closeX:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="#F0151530" CornerRadius="14"
+            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <!--
+            Two columns: the program's sigil on the left, the explainer on the right.
+
+            The art column is Auto and its host is Collapsed when no sigil resolves, and a Collapsed
+            child in an Auto column measures to zero width - so a mod that ships no program art gets
+            the copy across the full card rather than a gap where a picture should be.
+        -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Sigil rail -->
+            <Border x:Name="ArtPanel" Grid.Column="0"
+                    Width="196" CornerRadius="12,0,0,12" ClipToBounds="True">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="30%,100%">
+                        <GradientStop Color="#3C2159" Offset="0"/>
+                        <GradientStop Color="#252542" Offset="0.55"/>
+                        <GradientStop Color="#1A1A2E" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+
+                <Grid>
+                    <!-- Ambient wash behind the sigil, so the rail is never a flat panel even when
+                         the sigil itself is a sparse glyph. Fill is set in code from the program
+                         accent. -->
+                    <Rectangle x:Name="ArtGlow" Margin="8"/>
+
+                    <!--
+                        The sigil is accent-filled and MASKED by the art, never drawn as an Image.
+                        Program art ships as white RGB with its luminance in the ALPHA channel (see
+                        Services/Program/ProgramArt.cs), so an <Image> would render a near-invisible
+                        white-on-transparent smear. Fill + OpacityMask is what makes bright source
+                        read as full accent and dark source as transparent.
+                    -->
+                    <Rectangle x:Name="ArtSigil" Width="122" Height="122"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Margin="0,0,0,26"
+                               IsVisible="False"/>
+
+                    <!-- Which program the art belongs to. Named so it can be hidden independently:
+                         the rail can resolve a shared fallback plate with no program title to show. -->
+                    <StackPanel VerticalAlignment="Bottom" Margin="12,0,12,16">
+                        <TextBlock x:Name="TxtArtProgramTitle"
+                                   FontSize="14" FontWeight="Bold"
+                                   TextWrapping="Wrap" TextAlignment="Center"/>
+                        <TextBlock x:Name="TxtArtProgramSubtitle"
+                                   Foreground="#AABBBBCC" FontSize="11"
+                                   TextWrapping="Wrap" TextAlignment="Center"
+                                   Margin="0,3,0,0"/>
+                    </StackPanel>
+
+                    <!-- Hairline seam so the rail reads as part of the card, not a pasted panel -->
+                    <Rectangle Width="1" HorizontalAlignment="Right" Fill="#55FF69B4"/>
+                </Grid>
+            </Border>
+
+            <!-- Close button -->
+            <Button x:Name="BtnCloseX" Classes="closeX"
+                    Content="✕"
+                    Grid.Column="1"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="28" Height="28" Margin="0,8,12,0"
+                    Padding="0"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand"
+                    ZIndex="1"/>
+
+            <StackPanel Grid.Column="1" Margin="24,22,24,20" VerticalAlignment="Center">
+                <TextBlock Text="📅  Training Programs"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontWeight="Bold" FontSize="21"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,4"/>
+
+                <TextBlock Text="Multi-day arcs, not one-off sessions."
+                           Foreground="#CCD5D5E5" FontSize="13"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,16"/>
+
+                <!-- The four things a program actually does. Authored as rows rather than a bulleted
+                     TextBlock so the accent glyph stays aligned when a line wraps. -->
+                <StackPanel Margin="0,0,0,6">
+                    <Grid Margin="0,0,0,9">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="Bullet1" Text="●" FontSize="9" VerticalAlignment="Top"
+                                   Margin="0,5,9,0"/>
+                        <TextBlock Grid.Column="1" Foreground="White" FontSize="13.5"
+                                   TextWrapping="Wrap" LineHeight="20"
+                                   Text="You get one session a day, on a schedule the program sets for you."/>
+                    </Grid>
+
+                    <Grid Margin="0,0,0,9">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="Bullet2" Text="●" FontSize="9" VerticalAlignment="Top"
+                                   Margin="0,5,9,0"/>
+                        <TextBlock Grid.Column="1" Foreground="White" FontSize="13.5"
+                                   TextWrapping="Wrap" LineHeight="20"
+                                   Text="Each day also sets a few small tasks you do by hand on the Dashboard."/>
+                    </Grid>
+
+                    <Grid Margin="0,0,0,9">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="Bullet3" Text="●" FontSize="9" VerticalAlignment="Top"
+                                   Margin="0,5,9,0"/>
+                        <TextBlock Grid.Column="1" Foreground="White" FontSize="13.5"
+                                   TextWrapping="Wrap" LineHeight="20"
+                                   Text="Progress is tracked day by day. Days off are allowed, and missing too many ends the run."/>
+                    </Grid>
+
+                    <Grid Margin="0,0,0,9">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="Bullet4" Text="●" FontSize="9" VerticalAlignment="Top"
+                                   Margin="0,5,9,0"/>
+                        <!-- Deliberately does NOT name First Week. The rail beside this copy is
+                             dressed with whichever program matches the ACTIVE mod, so on a Sissy
+                             install the card introduced Presentation while the text talked about a
+                             program the user was not being shown. The fact is mod-independent either
+                             way: exactly one program is free, and it is the seven-day one. -->
+                        <TextBlock Grid.Column="1" Foreground="White" FontSize="13.5"
+                                   TextWrapping="Wrap" LineHeight="20"
+                                   Text="One program is free and runs seven days. The longer ones need a subscription."/>
+                    </Grid>
+                </StackPanel>
+
+                <TextBlock Foreground="#99AAAABB" FontSize="12"
+                           TextWrapping="Wrap" LineHeight="18"
+                           Margin="0,4,0,16"
+                           Text="Pick one to begin. Withdraw is on every screen, and nothing is asked of you when you use it."/>
+
+                <Button x:Name="BtnDismiss" Theme="{StaticResource DismissButtonStyle}"
+                        HorizontalAlignment="Left"
+                        Width="132" Height="37"
+                        Cursor="Hand"
+                        FontSize="14" FontWeight="SemiBold">
+                    <TextBlock Text="Got it"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml.cs
@@ -1,0 +1,175 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// One-time explainer for the Training Programs tab, shown the first time the user opens it.
+    ///
+    /// Dressed with the sigil of whichever program matches the ACTIVE MOD, so a Sissy Hypno install
+    /// is introduced to programs by Presentation rather than by Bambi's First Week. Everything else
+    /// on the card is mod-neutral: the copy describes the mechanic, not the fiction, because the
+    /// mechanic is identical whichever program the user eventually picks.
+    ///
+    /// Copy is hardcoded English, matching AnnouncementPopup and the other one-shot popups in this
+    /// folder. That is deliberate rather than lazy - see the note on ShowIfFirstTime.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/ProgramsIntroPopup.xaml.cs. Deviations:
+    ///  - <c>ShowIfFirstTime</c> is dropped, not stubbed: every line of it is App.Settings /
+    ///    App.Programs / App.Mods / Dispatcher gating, none of which exists here, and an empty
+    ///    gate that silently never shows the card would be worse than no gate. It comes back with
+    ///    those services.
+    ///  - <c>ProgramDefinition</c> is in the WPF head, so <see cref="Featured"/> is a local
+    ///    stand-in holding exactly the four fields the card dresses itself from.
+    ///  - <c>ProgramArt.Sigil/DayPlate</c> is a head service: the sigil stays hidden and the rail
+    ///    shows its gradient, glow and program title, which is what the WPF fallback plate draws.
+    ///  - <c>PreviewKeyDown</c> -&gt; <c>KeyDown</c>; <c>DragMove()</c> -&gt; <c>BeginMoveDrag(e)</c>.
+    /// </summary>
+    public partial class ProgramsIntroPopup : Window
+    {
+        /// <summary>Render constructor: sample data, so --render-all can discover the window.</summary>
+        internal ProgramsIntroPopup() : this(Featured.Sample()) { }
+
+        public ProgramsIntroPopup(Featured? featured)
+        {
+            AvaloniaXamlLoader.Load(this);
+            ApplyFeaturedProgram(featured);
+
+            this.FindControl<Button>("BtnDismiss")!.Click += (_, _) => TryClose();
+            this.FindControl<Button>("BtnCloseX")!.Click += (_, _) => TryClose();
+
+            KeyDown += (_, e) =>
+            {
+                if (e.Key != Key.Escape) return;
+                e.Handled = true;
+                TryClose();
+            };
+
+            // Chromeless window, so dragging the card is the only way to move it.
+            PointerPressed += (_, e) =>
+            {
+                if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+                try { BeginMoveDrag(e); } catch { /* dragging can throw if the press was consumed */ }
+            };
+        }
+
+        /// <summary>
+        /// Points the sigil rail at the featured program, or collapses it.
+        ///
+        /// Same null contract as ProgramArt: no art means the rail goes away and the copy takes the
+        /// whole card. The sigil is preferred over the program's dashboard banner on purpose - the
+        /// banner is a 2800x113 texture strip authored to wash behind a one-line card, and at this
+        /// size it would read as a smear rather than as the program's emblem.
+        /// </summary>
+        private void ApplyFeaturedProgram(Featured? program)
+        {
+            var artPanel = this.FindControl<Border>("ArtPanel")!;
+            try
+            {
+                if (program == null)
+                {
+                    artPanel.IsVisible = false;
+                    return;
+                }
+
+                var accent = AccentBrush(program.AccentColor);
+
+                // The bullet glyphs pick up the program accent so the card reads as one object with
+                // the rail beside it, rather than a pink card with an unrelated picture stapled on.
+                for (int i = 1; i <= 4; i++)
+                    this.FindControl<TextBlock>("Bullet" + i)!.Foreground = accent;
+
+                // ponytail: needs ProgramArt.Sigil / ProgramArt.DayPlate, wired when they move to
+                // Core. The sigil Rectangle stays hidden (its Fill would be `accent` and its
+                // OpacityMask an ImageBrush over that art); the rail still draws its gradient, glow
+                // and title, which is what the WPF shared-fallback-plate path looks like.
+                this.FindControl<Rectangle>("ArtGlow")!.Fill = GlowBrush(accent);
+
+                var title = this.FindControl<TextBlock>("TxtArtProgramTitle")!;
+                title.Text = program.Title;
+                title.Foreground = accent;
+
+                var subtitle = this.FindControl<TextBlock>("TxtArtProgramSubtitle")!;
+                subtitle.Text = program.Subtitle;
+                subtitle.IsVisible = !string.IsNullOrWhiteSpace(program.Subtitle);
+
+                artPanel.IsVisible = true;
+            }
+            catch
+            {
+                // Dressing is decoration - lose the rail, keep the explainer.
+                try { artPanel.IsVisible = false; } catch { }
+            }
+        }
+
+        /// <summary>Program accent, falling back to the app pink a bad hex would otherwise cost us.</summary>
+        private IBrush AccentBrush(string? hex)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(hex))
+                    return new SolidColorBrush(Color.Parse(hex!));
+            }
+            catch { /* a bad accent must never break the card */ }
+
+            return this.TryFindResource("PinkBrush", out var found) && found is IBrush brush
+                ? brush
+                : Brushes.HotPink;
+        }
+
+        private static IBrush GlowBrush(IBrush accent)
+        {
+            try
+            {
+                if (accent is ISolidColorBrush solid)
+                {
+                    var c = solid.Color;
+                    return new RadialGradientBrush
+                    {
+                        GradientStops =
+                        {
+                            new GradientStop(Color.FromArgb(90, c.R, c.G, c.B), 0),
+                            new GradientStop(Color.FromArgb(0, c.R, c.G, c.B), 1),
+                        },
+                        Center = new RelativePoint(0.5, 0.42, RelativeUnit.Relative),
+                        GradientOrigin = new RelativePoint(0.5, 0.42, RelativeUnit.Relative),
+                        RadiusX = new RelativeScalar(0.7, RelativeUnit.Relative),
+                        RadiusY = new RelativeScalar(0.7, RelativeUnit.Relative),
+                    };
+                }
+            }
+            catch { /* a glow failing must never break the card */ }
+
+            return Brushes.Transparent;
+        }
+
+        private void TryClose()
+        {
+            try { Close(); } catch { }
+        }
+
+        /// <summary>
+        /// Stand-in for the head's ProgramDefinition: the four fields the card dresses itself from,
+        /// nothing more. Replaced by the real definition when Models/Program moves to Core.
+        /// </summary>
+        public sealed class Featured
+        {
+            public string Title { get; set; } = "";
+            public string Subtitle { get; set; } = "";
+            public string? AccentColor { get; set; }
+            public string? ModId { get; set; }
+
+            internal static Featured Sample() => new()
+            {
+                Title = "First Week",
+                Subtitle = "Seven days, one session a day",
+                AccentColor = "#FF8AB4",
+            };
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/SessionCompleteWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/SessionCompleteWindow.axaml
@@ -1,0 +1,224 @@
+<!-- PORTED from ConditioningControlPanel/Windows/SessionCompleteWindow.xaml.
+     Structure, ordering, spacing, x:Names and every resource key preserved. Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" +
+                                                   TransparencyLevelHint="Transparent"
+       <Style x:Key TargetType="Button">        -> <ControlTheme> with the SAME Template; the
+                                                   IsMouseOver trigger is a ^:pointerover selector
+       <ContentPresenter/>                      -> ContentPresenter Content="{TemplateBinding Content}"
+                                                   (CLAUDE.md trap 6 - a bare presenter draws nothing)
+       Visibility="Collapsed"                   -> IsVisible="False"
+       Image.Clip RectangleGeometry RadiusX/Y   -> a CornerRadius Border with ClipToBounds
+                                                   (Avalonia's RectangleGeometry has no corner radii)
+       RenderOptions.BitmapScalingMode          -> RenderOptions.BitmapInterpolationMode
+       ToolTip="..."                            -> ToolTip.Tip="..."
+       Click="MediaRow_Click" in a DataTemplate -> one Button.Click handler on the ItemsControl
+                                                   (a DataTemplate has no name scope)
+       Click="BtnClose_Click"                   -> wired in the constructor
+
+     The inline Button.Style on BtnClose is the same ControlTheme treatment, keyed CloseButtonStyle
+     because Avalonia has no anonymous per-instance style carrying a Template. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Windows"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.SessionCompleteWindow"
+        Title="{loc:Str dialog_session_complete}"
+        Width="540" Height="700"
+        WindowStartupLocation="CenterScreen"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False">
+
+    <Window.Resources>
+        <ControlTheme x:Key="MediaRowButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="#2A2A48"/>
+            <Setter Property="BorderBrush" Value="#3A3A58"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="10,8"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Background" Value="#36365A"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The WPF inline <Button.Style> on BtnClose, setters verbatim. -->
+        <ControlTheme x:Key="CloseButtonStyle" TargetType="Button">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="3" CornerRadius="20" Padding="30">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Card Image -->
+            <Border Grid.Row="0" CornerRadius="12" Margin="0,0,0,15" HorizontalAlignment="Center"
+                    Background="#252540" Padding="5" x:Name="CardBorder">
+                <Border CornerRadius="8" ClipToBounds="True">
+                    <Image x:Name="ImgCard" Width="200" Height="140" Stretch="UniformToFill"
+                           RenderOptions.BitmapInterpolationMode="HighQuality"/>
+                </Border>
+            </Border>
+
+            <!-- Main Message.
+                 Neither carries {loc:Str} here, unlike the WPF original: both are set from
+                 ApplyLog, and Avalonia keeps a XAML binding alive UNDER a local value, so the next
+                 language change would clobber the code-set text with the design-time key (the
+                 "setting text from code" trap in CLAUDE.md). The headline still re-localizes -
+                 ApplyLog binds it to whichever key it picked. -->
+            <StackPanel Grid.Row="1" HorizontalAlignment="Center">
+                <TextBlock x:Name="TxtMainMessage"
+                           Foreground="{DynamicResource PinkBrush}" FontSize="32" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtSubMessage"
+                           Foreground="#808090" FontSize="15"
+                           HorizontalAlignment="Center" Margin="0,5,0,0"/>
+            </StackPanel>
+
+            <!-- Stats -->
+            <Border Grid.Row="2" Background="#252540" CornerRadius="12" Padding="20" Margin="0,15,0,12">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" HorizontalAlignment="Center">
+                        <TextBlock Text="{loc:Str label_session}" Foreground="#808090" FontSize="12" HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="TxtSessionName" Foreground="White" FontSize="14" FontWeight="Bold"
+                                   HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+                        <TextBlock Text="{loc:Str setting_duration}" Foreground="#808090" FontSize="12" HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="TxtDuration" Foreground="White" FontSize="14" FontWeight="Bold"
+                                   HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2" x:Name="XpPanel" HorizontalAlignment="Center">
+                        <TextBlock Text="{loc:Str label_xp_earned}" Foreground="#808090" FontSize="12" HorizontalAlignment="Center"/>
+                        <TextBlock x:Name="TxtXP" Foreground="#90EE90" FontSize="18" FontWeight="Bold"
+                                   HorizontalAlignment="Center" Margin="0,4,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- Media Played -->
+            <Border Grid.Row="3" Background="#1F1F38" CornerRadius="12" Padding="14" Margin="0,0,0,12">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,8">
+                        <TextBlock x:Name="TxtMediaHeader" DockPanel.Dock="Left"
+                                   Text="{loc:Str label_media_played}"
+                                   Foreground="{DynamicResource PinkBrush}" FontSize="14" FontWeight="Bold"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock x:Name="TxtMediaCount" DockPanel.Dock="Right"
+                                   Foreground="#808090" FontSize="12"
+                                   VerticalAlignment="Center"/>
+                    </DockPanel>
+
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <Grid>
+                            <TextBlock x:Name="TxtNoMedia"
+                                       Text="{loc:Str label_no_media_played}"
+                                       Foreground="#707080" FontSize="13" FontStyle="Italic"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       Margin="0,30" IsVisible="False"/>
+                            <ItemsControl x:Name="MediaList">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="local:SessionCompleteWindow+MediaRow">
+                                        <Button Theme="{StaticResource MediaRowButtonStyle}"
+                                                Tag="{Binding FilePath}"
+                                                ToolTip.Tip="{Binding FilePath}"
+                                                Margin="0,0,0,6">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="56"/>
+                                                    <ColumnDefinition Width="60"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{Binding TimeOffsetText}"
+                                                           Foreground="#A0A0B0" FontSize="12"
+                                                           FontFamily="Consolas, Courier New, monospace"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Grid.Column="1"
+                                                           Text="{Binding TypeLabel}"
+                                                           Foreground="{Binding TypeBrush}"
+                                                           FontSize="11" FontWeight="Bold"
+                                                           VerticalAlignment="Center"/>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding DisplayName}"
+                                                           Foreground="White" FontSize="13"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           VerticalAlignment="Center"
+                                                           Margin="6,0,8,0"/>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="↗"
+                                                           Foreground="#808090" FontSize="14"
+                                                           VerticalAlignment="Center"/>
+                                            </Grid>
+                                        </Button>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+
+            <!-- Close Button -->
+            <Button Grid.Row="4" x:Name="BtnClose" Theme="{StaticResource CloseButtonStyle}"
+                    Background="{DynamicResource PinkBrush}" Foreground="White"
+                    BorderThickness="0" Padding="30,12" FontSize="16" FontWeight="Bold"
+                    Cursor="Hand"
+                    HorizontalAlignment="Center">
+                <!-- A TextBlock child, not Content: Avalonia parses "_" in Content as an access key
+                     and every loc key here is snake_case (CLAUDE.md trap 1). -->
+                <TextBlock Text="{loc:Str btn_continue}"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/SessionCompleteWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionCompleteWindow.axaml.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// The end-of-session recap: a random card image, the headline, three stats and the list of
+    /// media the session played.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/SessionCompleteWindow.xaml.cs. Deviations:
+    ///  - <c>SessionLog</c>, <c>MediaLogEntry</c>, <c>Session</c> and their enums are still in the
+    ///    WPF head, and this project may not reference it, so <see cref="Recap"/> /
+    ///    <see cref="MediaRow"/> are local stand-ins with the same fields <c>ApplyLog</c> reads.
+    ///    The two legacy constructors collapse into one: the legacy overload only built a
+    ///    <c>SessionLog</c> from raw fields, which is what <see cref="Recap"/> already is.
+    ///  - <c>DialogResult = true</c> becomes <c>Close(true)</c>, as in TextEditorDialog; the
+    ///    "shown non-modally" guard the WPF comment describes is not needed - Avalonia's Close
+    ///    works either way.
+    ///  - <c>PreviewKeyDown</c> -> <c>KeyDown</c>. Escape still closes.
+    ///  - The per-row Click is one handler on the ItemsControl; the row Button carries the path in
+    ///    Tag exactly as before.
+    /// </summary>
+    public partial class SessionCompleteWindow : Window
+    {
+        // Resource-relative paths - the mod compatibility surface. A mod's
+        // resources/Cards/<name>.png wins; never rename these strings.
+        private static readonly string[] CardImages = new[]
+        {
+            "Cards/fireworks.png",
+            "Cards/hearth.png",
+            "Cards/spotlight.png"
+        };
+
+        /// <summary>Render constructor: sample data, so --render-all can discover the window.</summary>
+        internal SessionCompleteWindow() : this(Recap.Sample()) { }
+
+        public SessionCompleteWindow(Recap log, bool playSound = true)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            LoadRandomCard();
+            ApplyLog(log);
+
+            if (playSound && log.Completed)
+            {
+                PlayCompletionSound();
+            }
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => CloseRecap();
+            this.FindControl<ItemsControl>("MediaList")!.AddHandler(Button.ClickEvent, MediaRow_Click);
+
+            // SystemDecorations=None + ShowInTaskbar=False means there is no X button at all, and
+            // the non-modal (buried-video) path has no owner to fall back on. Escape is the
+            // keyboard escape hatch for both.
+            KeyDown += (_, e) =>
+            {
+                if (e.Key == Key.Escape)
+                {
+                    e.Handled = true;
+                    CloseRecap();
+                }
+            };
+        }
+
+        private void ApplyLog(Recap log)
+        {
+            var txtMainMessage = this.FindControl<TextBlock>("TxtMainMessage")!;
+            var txtSubMessage = this.FindControl<TextBlock>("TxtSubMessage")!;
+            var txtXP = this.FindControl<TextBlock>("TxtXP")!;
+
+            // Header. The headline is BOUND to its key rather than assigned: assigning .Text would
+            // survive only until the next language change, because Avalonia keeps the XAML binding
+            // alive under a local value (CLAUDE.md, "setting text from code"). The sub-message is a
+            // composite string, so it stays a plain assignment - as in WPF.
+            if (log.Completed)
+            {
+                BindLoc(txtMainMessage, log.SessionId == "gamer_girl"
+                    ? "label_gg_good_girl"
+                    : "label_good_girl_3");
+                txtSubMessage.Text = $"{log.SessionIcon} {log.SessionName} {Loc.Get("label_completed")}".Trim();
+            }
+            else
+            {
+                BindLoc(txtMainMessage, "label_session_ended_early");
+                txtSubMessage.Text = $"{log.SessionIcon} {log.SessionName}".Trim();
+                // No XP for aborted sessions - hide that column.
+                this.FindControl<StackPanel>("XpPanel")!.IsVisible = false;
+            }
+
+            // Stats
+            this.FindControl<TextBlock>("TxtSessionName")!.Text = log.SessionName;
+            this.FindControl<TextBlock>("TxtDuration")!.Text = $"{log.Duration.Minutes:D2}:{log.Duration.Seconds:D2}";
+            txtXP.Text = $"+{log.XPEarned}";
+            txtXP.Foreground = log.SessionDifficulty switch
+            {
+                Difficulty.Easy => new SolidColorBrush(Color.FromRgb(144, 238, 144)),
+                Difficulty.Medium => new SolidColorBrush(Color.FromRgb(255, 215, 0)),
+                Difficulty.Hard => new SolidColorBrush(Color.FromRgb(255, 165, 0)),
+                Difficulty.Extreme => new SolidColorBrush(Color.FromRgb(255, 99, 71)),
+                _ => new SolidColorBrush(Color.FromRgb(144, 238, 144))
+            };
+
+            // Media list - newest entries last (chronological order matches the session timeline).
+            var rows = log.Media ?? new List<MediaRow>();
+
+            var noMedia = this.FindControl<TextBlock>("TxtNoMedia")!;
+            var mediaList = this.FindControl<ItemsControl>("MediaList")!;
+            var mediaCount = this.FindControl<TextBlock>("TxtMediaCount")!;
+
+            if (rows.Count == 0)
+            {
+                noMedia.IsVisible = true;
+                mediaList.IsVisible = false;
+                mediaCount.Text = "";
+            }
+            else
+            {
+                noMedia.IsVisible = false;
+                mediaList.IsVisible = true;
+                mediaList.ItemsSource = rows;
+                int videoCount = rows.Count(r => r.Type == MediaKind.Video);
+                int imageCount = rows.Count - videoCount;
+                mediaCount.Text = Loc.GetF("label_media_count_videos_images", videoCount, imageCount);
+            }
+        }
+
+        /// <summary>What {loc:Str} does, for a key only known at runtime.</summary>
+        private static void BindLoc(TextBlock target, string key) =>
+            target[!TextBlock.TextProperty] = new Binding($"[{key}]") { Source = LocalizationManager.Instance };
+
+        private void LoadRandomCard()
+        {
+            // ponytail: needs ModResourceResolver.ResolveImage, wired when it moves to Core. Nothing
+            // resolves a card yet, so the host Border collapses - which is the WPF null path, not a
+            // blank plate. CardImages is kept because the mod path names are the compat surface.
+            _ = CardImages;
+            this.FindControl<Border>("CardBorder")!.IsVisible = false;
+        }
+
+        private void PlayCompletionSound()
+        {
+            // ponytail: needs App.Audio + App.Settings.Current.MasterVolume, wired when they move to
+            // Core. The WPF version probes Resources/sounds/lvup.mp3 and friends and plays a
+            // volume-curved one-shot.
+        }
+
+        private void MediaRow_Click(object? sender, RoutedEventArgs e)
+        {
+            if (e.Source is not Control c) return;
+            if (c.Tag as string is not { Length: > 0 } path) return;
+
+            // ponytail: needs Helpers.ExplorerLauncher.RevealInExplorer (Win32 shell) plus a
+            // MessageBox for the "file is gone" case, wired when a portable file-reveal lands in
+            // Core. Until then the row is inert rather than opening the wrong thing.
+            _ = path;
+        }
+
+        /// <summary>The one close path, kept from the WPF original.</summary>
+        private void CloseRecap() => Close(true);
+
+        /// <summary>
+        /// Stand-in for the head's SessionLog. Same fields ApplyLog reads, nothing more - this is
+        /// deliberately not a second model, it is the argument shape until SessionLog is in Core.
+        /// </summary>
+        public sealed class Recap
+        {
+            public string SessionId { get; set; } = "";
+            public string SessionName { get; set; } = "";
+            public string SessionIcon { get; set; } = "";
+            public Difficulty SessionDifficulty { get; set; } = Difficulty.Easy;
+            public TimeSpan Duration { get; set; }
+            public int XPEarned { get; set; }
+            public bool Completed { get; set; }
+            public List<MediaRow>? Media { get; set; }
+
+            internal static Recap Sample() => new()
+            {
+                SessionId = "sample",
+                SessionName = "Deep Focus",
+                SessionIcon = "🌀",
+                SessionDifficulty = Difficulty.Medium,
+                Duration = TimeSpan.FromSeconds(23 * 60 + 41),
+                XPEarned = 180,
+                Completed = true,
+                Media = new List<MediaRow>
+                {
+                    new(MediaKind.Video, "/media/loops/spiral-intro.mp4", "spiral-intro.mp4", TimeSpan.FromSeconds(12)),
+                    new(MediaKind.Image, "/media/stills/mantra-01.png", "mantra-01.png", TimeSpan.FromSeconds(4 * 60 + 8)),
+                    new(MediaKind.Video, "/media/loops/deep-drop.mp4", "deep-drop.mp4", TimeSpan.FromSeconds(11 * 60 + 37)),
+                    new(MediaKind.Image, "/media/stills/mantra-07.png", "mantra-07.png", TimeSpan.FromSeconds(19 * 60 + 2)),
+                }
+            };
+        }
+
+        public enum Difficulty { Easy, Medium, Hard, Extreme }
+
+        public enum MediaKind { Image, Video }
+
+        /// <summary>View model for a single row in the media list. Formatting copied verbatim from
+        /// the WPF nested MediaRow; it took a MediaLogEntry, which is not available here.</summary>
+        public sealed class MediaRow
+        {
+            public string DisplayName { get; }
+            public string FilePath { get; }
+            public string TimeOffsetText { get; }
+            public string TypeLabel { get; }
+            public IBrush TypeBrush { get; }
+            public MediaKind Type { get; }
+
+            public MediaRow(MediaKind type, string? filePath, string? displayName, TimeSpan sessionTime)
+            {
+                Type = type;
+                FilePath = filePath ?? "";
+                DisplayName = !string.IsNullOrEmpty(displayName)
+                    ? displayName!
+                    : (string.IsNullOrEmpty(FilePath) ? "" : Path.GetFileName(FilePath));
+
+                var t = sessionTime;
+                TimeOffsetText = t.TotalHours >= 1
+                    ? $"{(int)t.TotalHours}:{t.Minutes:D2}:{t.Seconds:D2}"
+                    : $"{t.Minutes:D2}:{t.Seconds:D2}";
+
+                if (type == MediaKind.Video)
+                {
+                    TypeLabel = Loc.Get("label_video");
+                    TypeBrush = new SolidColorBrush(Color.FromRgb(255, 105, 180)); // pink
+                }
+                else
+                {
+                    TypeLabel = Loc.Get("label_image");
+                    TypeBrush = new SolidColorBrush(Color.FromRgb(135, 206, 250)); // light blue
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
871 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351