### PR TITLE
feat(avalonia): port DailyQuestCard, ChaosSlotPickerWindow

### DIFF
--- a/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml
+++ b/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml
@@ -1,0 +1,163 @@
+<!-- PORTED from ConditioningControlPanel/Chaos/ChaosSlotPickerWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" + TransparencyLevelHint
+       Background="Transparent" (was x:Null-ish) -> Background="Transparent" (unchanged)
+       ResizeMode="NoResize"                    -> CanResize="False"
+       shell:WindowChrome                       -> dropped; Win32-only, and SystemDecorations
+                                                   already removes the caption
+       <Style x:Key TargetType="Button">        -> <ControlTheme x:Key TargetType="Button">
+       Style="{StaticResource X}"               -> Theme="{StaticResource X}"
+       ControlTemplate.Triggers                 -> ^:pointerover / ^:disabled selectors
+       bare <ContentPresenter/>                 -> Content/ContentTemplate TemplateBindings
+                                                   (Avalonia's presenter does not find its content)
+       LinearGradientBrush "0,0"/"1,1"          -> "0%,0%"/"100%,100%" (a bare pair is ABSOLUTE px,
+                                                   which collapses the ramp to one pixel)
+       DropShadowEffect ShadowDepth="0"         -> OffsetX="0" OffsetY="0"
+       FontFamily="Segoe UI"                    -> dropped (Windows-only face)
+       Click= / MouseLeftButtonDown=            -> wired in the constructor
+
+     Buttons carry a TextBlock child rather than Content: Avalonia parses "_" in Content as an
+     access key. See the porting notes in CLAUDE.md. Every string here is hardcoded English in
+     the WPF original too - the picker was never localized - so there is no {loc:Str} in this
+     view and no key has been invented for one. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Chaos.ChaosSlotPickerWindow"
+        Title="Down the Rabbit Hole"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="Manual" Width="720" Height="560">
+
+    <Window.Resources>
+        <SolidColorBrush x:Key="Pink" Color="#FFE84393"/>
+        <SolidColorBrush x:Key="Purple" Color="#FF8B5CF6"/>
+        <SolidColorBrush x:Key="Bg" Color="#FF14122A"/>
+        <SolidColorBrush x:Key="TextDim" Color="#AAB8B8D0"/>
+        <SolidColorBrush x:Key="TextMut" Color="#88A0A0C0"/>
+        <!-- ponytail: local copy of ChaosSlotPickerWindow.xaml:Brand, hoist when a second view
+             needs it. Theme/Brushes.xaml has BrandGradient with the same two stops, but its
+             endpoints are written "0,0"/"1,1", which Avalonia reads as absolute pixels. -->
+        <LinearGradientBrush x:Key="Brand" StartPoint="0%,0%" EndPoint="100%,100%">
+            <GradientStop Color="#FFE84393" Offset="0"/>
+            <GradientStop Color="#FF8B5CF6" Offset="1"/>
+        </LinearGradientBrush>
+
+        <!-- Ghost / flat button (Cancel, Open Folder) -->
+        <ControlTheme x:Key="GhostBtn" TargetType="Button">
+            <Setter Property="Foreground" Value="{StaticResource TextDim}"/>
+            <Setter Property="Background" Value="#22FFFFFF"/>
+            <Setter Property="BorderBrush" Value="#33E84393"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="16,9"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="b" Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="8" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#b">
+                <Setter Property="Background" Value="#33FFFFFF"/>
+            </Style>
+            <Style Selector="^:pointerover">
+                <Setter Property="Foreground" Value="White"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.4"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- Primary CTA (Descend) -->
+        <ControlTheme x:Key="PrimaryBtn" TargetType="Button">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Background" Value="{StaticResource Brand}"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="30,10"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="b" Background="{TemplateBinding Background}" CornerRadius="9"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#b">
+                <Setter Property="Opacity" Value="0.9"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.4"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border CornerRadius="16" Background="{StaticResource Bg}" BorderBrush="#55E84393" BorderThickness="1">
+        <Border.Effect>
+            <DropShadowEffect Color="#000000" BlurRadius="28" OffsetX="0" OffsetY="0" Opacity="0.7"/>
+        </Border.Effect>
+        <Grid Margin="26,22,26,22" RowDefinitions="Auto,*,Auto,Auto">
+
+            <!-- Header (also the drag handle) -->
+            <Grid Grid.Row="0" x:Name="HeaderBar" Background="Transparent">
+                <StackPanel HorizontalAlignment="Left">
+                    <TextBlock Text="🐇 Down the Rabbit Hole" FontSize="13" Foreground="{StaticResource Pink}"
+                               FontWeight="SemiBold" Opacity="0.85"/>
+                    <TextBlock Text="Choose your save" FontSize="26" FontWeight="Bold" Foreground="White" Margin="0,2,0,0"/>
+                    <TextBlock Text="Pick a slot to descend into. Each keeps its own progress." FontSize="13"
+                               Foreground="{StaticResource TextDim}" Margin="0,3,0,0"/>
+                </StackPanel>
+                <Button x:Name="BtnClose" Width="34" Height="34" VerticalAlignment="Top"
+                        HorizontalAlignment="Right" Theme="{StaticResource GhostBtn}" Padding="0"
+                        FontSize="15" ToolTip.Tip="Cancel">
+                    <TextBlock Text="✕"/>
+                </Button>
+            </Grid>
+
+            <!-- Slot cards get built in code-behind -->
+            <StackPanel Grid.Row="1" x:Name="SlotsPanel" Orientation="Horizontal"
+                        HorizontalAlignment="Center" VerticalAlignment="Center"/>
+
+            <!-- Local-storage note -->
+            <Border Grid.Row="2" Background="#1AFFFFFF" CornerRadius="9" Padding="14,10" Margin="0,4,0,14">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock Text="🔒" FontSize="14" VerticalAlignment="Center" Margin="0,0,9,0"/>
+                    <StackPanel>
+                        <TextBlock Text="All saves are stored locally on this PC" FontSize="12.5"
+                                   Foreground="{StaticResource TextDim}" FontWeight="SemiBold"/>
+                        <TextBlock x:Name="PathText" FontSize="11" Foreground="{StaticResource TextMut}"
+                                   TextTrimming="CharacterEllipsis" Margin="0,1,0,0"/>
+                    </StackPanel>
+                    <Button x:Name="BtnOpenFolder" Theme="{StaticResource GhostBtn}"
+                            Padding="12,6" FontSize="12" Margin="14,0,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="Open folder"/>
+                    </Button>
+                </StackPanel>
+            </Border>
+
+            <!-- Actions -->
+            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="BtnCancel" Theme="{StaticResource GhostBtn}" Margin="0,0,10,0">
+                    <TextBlock Text="Cancel"/>
+                </Button>
+                <Button x:Name="BtnDescend" Theme="{StaticResource PrimaryBtn}">
+                    <TextBlock Text="Descend  ↓"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Chaos
+{
+    /// <summary>
+    /// The pre-descent save picker: shown right before the Rabbit Hole opens so the player
+    /// chooses which of the three local saves to play. Each card summarises a slot (rank /
+    /// descents / sparks / gold / last played) or reads "New Journey" when empty, can be
+    /// deleted, and the footer tells the player exactly where the saves live on disk.
+    ///
+    /// PORTED from ConditioningControlPanel/Chaos/ChaosSlotPickerWindow.xaml.cs. Deviations:
+    ///  - <c>ChaosMeta</c> / <c>ChaosMetaStore</c> / <c>ChaosRanks</c> are WPF-head services, so
+    ///    the picker draws <see cref="SampleSummaries"/> and the delete action is a stub. The
+    ///    three card shapes (a live save, an empty slot, a stitched-shut slot) are all exercised
+    ///    by that sample, so the render still proves every builder.
+    ///  - <c>DialogResult = x; Close()</c> -> <c>Close(x)</c>; <see cref="Pick"/> is async, because
+    ///    Avalonia's <c>ShowDialog</c> is.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>; <c>MouseLeftButtonUp</c> ->
+    ///    <c>PointerReleased</c>; <c>Cursors.Hand</c> -> <c>StandardCursorType.Hand</c>;
+    ///    <c>ToolTip =</c> -> <c>ToolTip.SetTip</c>; <c>App.Logger</c> -> Serilog's static Log.
+    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so the
+    ///    erase confirmation is not raised at all (see <see cref="DeleteSlot_Click"/>).
+    ///  - The constructor is <c>internal</c> and parameterless, as in WPF; that also makes it the
+    ///    render constructor <c>--render-all</c> discovers.
+    /// </summary>
+    public partial class ChaosSlotPickerWindow : Window
+    {
+        /// <summary>Headline stats for one save slot. Mirrors the head's
+        /// <c>ConditioningControlPanel.Services.Chaos.SlotSummary</c> field for field.
+        /// ponytail: needs ChaosMetaStore.ReadSummary, wired when it moves to Core.</summary>
+        internal sealed class SlotSummary
+        {
+            public int Slot { get; set; }
+            public bool Exists { get; set; }
+            public int Sparks { get; set; }
+            public int Gold { get; set; }
+            public int RunsCompleted { get; set; }
+            public long BestScore { get; set; }
+            public DateTime? LastPlayedUtc { get; set; }
+            public bool HasRagdoll { get; set; }
+            public bool HasPorcelain { get; set; }
+        }
+
+        private static readonly Color BrandPink = Color.FromRgb(0xE8, 0x43, 0x93);
+        private static readonly IBrush CardBg = new SolidColorBrush(Color.FromRgb(0x1C, 0x1A, 0x36));
+        private static readonly IBrush CardBgSel = new SolidColorBrush(Color.FromRgb(0x2A, 0x20, 0x42));
+        private static readonly IBrush CardBorder = new SolidColorBrush(Color.FromArgb(0x44, 0xE8, 0x43, 0x93));
+        private static readonly IBrush CardBorderSel = new SolidColorBrush(BrandPink);
+        private static readonly IBrush TextDim = new SolidColorBrush(Color.FromArgb(0xAA, 0xB8, 0xB8, 0xD0));
+        private static readonly IBrush TextMut = new SolidColorBrush(Color.FromArgb(0x88, 0xA0, 0xA0, 0xC0));
+        private static readonly IBrush White = Brushes.White;
+
+        private readonly StackPanel _slotsPanel;
+        private int _selected;
+        private readonly Dictionary<int, Border> _cards = new();
+        private readonly HashSet<int> _locked = new();
+
+        /// <summary>The slot the player committed to (only meaningful when the dialog returned true).</summary>
+        public int ChosenSlot { get; private set; }
+
+        internal ChaosSlotPickerWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _slotsPanel = this.FindControl<StackPanel>("SlotsPanel")!;
+            // ponytail: needs ChaosMeta.ActiveSlot, wired when it moves to Core.
+            _selected = 1;
+            // ChaosMetaStore.SaveFolder is exactly this expression in the head.
+            this.FindControl<TextBlock>("PathText")!.Text = CorePaths.UserData;
+
+            var header = this.FindControl<Grid>("HeaderBar")!;
+            header.PointerPressed += (_, e) =>
+            {
+                if (!e.GetCurrentPoint(header).Properties.IsLeftButtonPressed) return;
+                try { BeginMoveDrag(e); } catch { /* dragging can throw if not pressed */ }
+            };
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnDescend")!.Click += (_, _) => { ChosenSlot = _selected; Close(true); };
+            this.FindControl<Button>("BtnOpenFolder")!.Click += BtnOpenFolder_Click;
+
+            RebuildCards();
+        }
+
+        /// <summary>Modal entry point. Returns the chosen slot (1-3), or null if the player cancelled.</summary>
+        public static async Task<int?> Pick(Window? owner)
+        {
+            var w = new ChaosSlotPickerWindow();
+            if (owner == null || !owner.IsVisible)
+            {
+                w.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+                w.Show();
+                return null;   // ponytail: needs an owner to be modal against; callers always have one.
+            }
+            return await w.ShowDialog<bool?>(owner) == true ? w.ChosenSlot : (int?)null;
+        }
+
+        /// <summary>
+        /// Stand-in for <c>ChaosMeta.AllSlotSummaries()</c>. Slot 1 is a played save that owns the
+        /// Ragdoll, slot 2 is therefore an open but empty seat, slot 3 has no Porcelain anywhere
+        /// and is stitched shut - one of each card the picker can draw.
+        /// ponytail: needs ChaosMeta, wired when it moves to Core.
+        /// </summary>
+        private static List<SlotSummary> SampleSummaries() => new()
+        {
+            new SlotSummary
+            {
+                Slot = 1, Exists = true, RunsCompleted = 4, Sparks = 1820, Gold = 640,
+                BestScore = 12400, LastPlayedUtc = new DateTime(2026, 8, 30, 21, 15, 0, DateTimeKind.Utc),
+                HasRagdoll = true,
+            },
+            new SlotSummary { Slot = 2 },
+            new SlotSummary { Slot = 3 },
+        };
+
+        /// <summary>Stand-in for <c>ChaosRanks.Name(ChaosRanks.For(runs))</c>; same thresholds and
+        /// same words. ponytail: needs ChaosRanks, wired when it moves to Core.</summary>
+        private static string RankName(int runsCompleted) => runsCompleted switch
+        {
+            >= 100 => "Claimed",
+            >= 50 => "Devoted",
+            >= 25 => "Entranced",
+            >= 10 => "Slipping",
+            >= 3 => "Tempted",
+            _ => "Curious",
+        };
+
+        private void RebuildCards()
+        {
+            _slotsPanel.Children.Clear();
+            _cards.Clear();
+            _locked.Clear();
+
+            // Crafting Part 2: slots 2/3 are stitched shut until the Ragdoll / Porcelain
+            // dolls are crafted in THE BOUDOIR. Any save's craft unlocks globally, and a
+            // pre-existing save keeps its slot open (back-compat with pre-craft slots).
+            var summaries = SampleSummaries();
+            bool anyRagdoll = false, anyPorcelain = false;
+            foreach (var s in summaries)
+            {
+                anyRagdoll |= s.HasRagdoll;
+                anyPorcelain |= s.HasPorcelain;
+            }
+            foreach (var s in summaries)
+            {
+                bool locked = (s.Slot == 2 && !anyRagdoll && !s.Exists)
+                           || (s.Slot == 3 && !anyPorcelain && !s.Exists);
+                if (locked) _locked.Add(s.Slot);
+                var card = locked ? BuildLockedCard(s) : BuildCard(s);
+                _cards[s.Slot] = card;
+                _slotsPanel.Children.Add(card);
+            }
+            if (_locked.Contains(_selected)) _selected = 1;
+            UpdateSelectionVisuals();
+        }
+
+        /// <summary>A stitched-shut slot: dimmed, no click, no delete — crafting the doll opens it.</summary>
+        private static Border BuildLockedCard(SlotSummary s)
+        {
+            var body = new StackPanel { Margin = new Thickness(16, 14, 16, 16) };
+            body.Children.Add(new TextBlock
+            {
+                Text = $"SAVE {s.Slot}",
+                FontSize = 12,
+                FontWeight = FontWeight.Bold,
+                Foreground = TextMut,
+            });
+            body.Children.Add(new TextBlock
+            {
+                Text = "🔒",
+                FontSize = 34,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 34, 0, 8),
+            });
+            body.Children.Add(new TextBlock
+            {
+                Text = "Stitched Shut",
+                FontSize = 18,
+                FontWeight = FontWeight.SemiBold,
+                Foreground = White,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            });
+            body.Children.Add(new TextBlock
+            {
+                Text = s.Slot == 2
+                    ? "craft the Ragdoll in THE BOUDOIR to open a second life"
+                    : "craft the Porcelain doll in THE BOUDOIR to open a third life",
+                FontSize = 11.5,
+                Foreground = TextMut,
+                TextWrapping = TextWrapping.Wrap,
+                TextAlignment = TextAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 3, 0, 0),
+            });
+
+            return new Border
+            {
+                Width = 196,
+                Height = 268,
+                CornerRadius = new CornerRadius(13),
+                Background = CardBg,
+                BorderBrush = CardBorder,
+                BorderThickness = new Thickness(1.5),
+                Margin = new Thickness(9, 0, 9, 0),
+                Opacity = 0.45,
+                Child = body,
+                Tag = s.Slot,
+            };
+        }
+
+        private Border BuildCard(SlotSummary s)
+        {
+            var body = new StackPanel { Margin = new Thickness(16, 14, 16, 16) };
+
+            // slot label
+            body.Children.Add(new TextBlock
+            {
+                Text = $"SAVE {s.Slot}",
+                FontSize = 12,
+                FontWeight = FontWeight.Bold,
+                Foreground = TextMut,
+            });
+
+            if (!s.Exists)
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = "✨",
+                    FontSize = 34,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(0, 34, 0, 8),
+                });
+                body.Children.Add(new TextBlock
+                {
+                    Text = "New Journey",
+                    FontSize = 18,
+                    FontWeight = FontWeight.SemiBold,
+                    Foreground = White,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                });
+                body.Children.Add(new TextBlock
+                {
+                    Text = "Empty slot — start fresh",
+                    FontSize = 11.5,
+                    Foreground = TextMut,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(0, 3, 0, 0),
+                });
+            }
+            else
+            {
+                body.Children.Add(new TextBlock
+                {
+                    Text = RankName(s.RunsCompleted),
+                    FontSize = 20,
+                    FontWeight = FontWeight.Bold,
+                    Foreground = new SolidColorBrush(BrandPink),
+                    Margin = new Thickness(0, 10, 0, 2),
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                });
+                body.Children.Add(StatRow($"{s.RunsCompleted}", s.RunsCompleted == 1 ? "descent" : "descents"));
+                body.Children.Add(StatRow($"✦ {s.Sparks:N0}", "drops"));
+                body.Children.Add(StatRow($"🪙 {s.Gold:N0}", "gold"));
+                if (s.BestScore > 0) body.Children.Add(StatRow($"{s.BestScore:N0}", "best score"));
+
+                var when = s.LastPlayedUtc.HasValue
+                    ? "Last played " + s.LastPlayedUtc.Value.ToLocalTime().ToString("MMM d, h:mm tt", CultureInfo.CurrentCulture)
+                    : "";
+                if (when.Length > 0)
+                    body.Children.Add(new TextBlock
+                    {
+                        Text = when,
+                        FontSize = 10.5,
+                        Foreground = TextMut,
+                        Margin = new Thickness(0, 12, 0, 0),
+                        TextWrapping = TextWrapping.Wrap,
+                    });
+            }
+
+            var content = new Grid();
+            content.Children.Add(body);
+
+            // delete (only when there's something to erase)
+            if (s.Exists)
+            {
+                var del = new Button
+                {
+                    Content = new TextBlock { Text = "🗑" },
+                    Width = 28,
+                    Height = 28,
+                    Padding = new Thickness(0),
+                    FontSize = 12,
+                    Cursor = new Cursor(StandardCursorType.Hand),
+                    Background = new SolidColorBrush(Color.FromArgb(0x22, 0xFF, 0xFF, 0xFF)),
+                    BorderThickness = new Thickness(0),
+                    Foreground = TextDim,
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Margin = new Thickness(0, 10, 10, 0),
+                    Tag = s.Slot,
+                };
+                ToolTip.SetTip(del, $"Erase Save {s.Slot}");
+                del.Click += DeleteSlot_Click;
+                content.Children.Add(del);
+            }
+
+            var card = new Border
+            {
+                Width = 196,
+                Height = 268,
+                CornerRadius = new CornerRadius(13),
+                Background = CardBg,
+                BorderBrush = CardBorder,
+                BorderThickness = new Thickness(1.5),
+                Margin = new Thickness(9, 0, 9, 0),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Child = content,
+                Tag = s.Slot,
+            };
+            card.PointerReleased += Card_Click;
+            return card;
+        }
+
+        private static StackPanel StatRow(string value, string label)
+        {
+            var row = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 4, 0, 0) };
+            row.Children.Add(new TextBlock { Text = value, FontSize = 14, FontWeight = FontWeight.SemiBold, Foreground = White });
+            row.Children.Add(new TextBlock { Text = "  " + label, FontSize = 12, Foreground = TextDim, VerticalAlignment = VerticalAlignment.Center });
+            return row;
+        }
+
+        private void Card_Click(object? sender, PointerReleasedEventArgs e)
+        {
+            if (e.InitialPressMouseButton != MouseButton.Left) return;
+            if (sender is Border { Tag: int slot })
+            {
+                _selected = slot;
+                UpdateSelectionVisuals();
+            }
+        }
+
+        private void UpdateSelectionVisuals()
+        {
+            foreach (var (slot, card) in _cards)
+            {
+                bool sel = slot == _selected;
+                card.BorderBrush = sel ? CardBorderSel : CardBorder;
+                card.BorderThickness = new Thickness(sel ? 2.5 : 1.5);
+                card.Background = sel ? CardBgSel : CardBg;
+                card.Effect = sel
+                    ? new DropShadowEffect { Color = BrandPink, BlurRadius = 18, OffsetX = 0, OffsetY = 0, Opacity = 0.55 }
+                    : null;
+            }
+        }
+
+        // ponytail: needs ChaosMeta.DeleteSlot plus a confirmation dialog (WPF used MessageBox,
+        // which Avalonia has no equivalent of), wired when they move to Core. Erasing a save
+        // unprompted is worse than not erasing it, so this only logs until both exist.
+        private void DeleteSlot_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            e.Handled = true;   // don't let the click also select the card
+            if (sender is not Button { Tag: int slot }) return;
+            Log.Debug("ChaosSlotPicker: erase Save {Slot} requested; no service on this head yet", slot);
+        }
+
+        private void BtnOpenFolder_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            try
+            {
+                System.IO.Directory.CreateDirectory(CorePaths.UserData);
+                Process.Start(new ProcessStartInfo { FileName = CorePaths.UserData, UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("ChaosSlotPicker: open folder failed: {E}", ex.Message);
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Controls/DailyQuestCard.axaml
+++ b/CCP.Avalonia/Views/Controls/DailyQuestCard.axaml
@@ -1,0 +1,140 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/DailyQuestCard.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     The original's long design essay is not transcribed; it still explains the WPF file, and the
+     shape it argues for (vertical card, near-square art frame, caption printed ON the art, body
+     down to bar + reroll, everything painted from code) is preserved here unchanged.
+
+     Deviations, all forced:
+
+       Style="{StaticResource OutlineButton}" -> Theme="{StaticResource OutlineButton}"
+       Visibility="Collapsed"                 -> IsVisible="False"
+       helpers:EmojiTextBlock                 -> TextBlock (Avalonia draws colour emoji natively)
+       hover:HoverPop.IsEnabled               -> dropped; the behaviour lives in the WPF head
+       DropShadowEffect ShadowDepth="2"       -> OffsetX/OffsetY (Avalonia has no ShadowDepth)
+       RenderTransformOrigin="0.5,0.5"        -> "50%,50%"  (a bare pair parses as ABSOLUTE px)
+       LinearGradientBrush 0,0 -> 0,1         -> 0%,0% -> 0%,100%  (same reason: the scrim would
+                                                 otherwise be a 1px-tall ramp)
+       Click="BtnReroll_Click"                -> wired in the constructor
+       ToolTipService.ShowOnDisabled          -> ToolTip.ShowOnDisabled
+       FontFamily="Segoe UI Emoji, ..."       -> dropped (Windows-only face list)
+       d:DesignWidth/Height                   -> MaxWidth/MaxHeight, the same 257x320 the WPF
+                                                 header argues the board caps the seat at. In WPF
+                                                 the board imposed it; here the card also renders
+                                                 alone in the render proof, and without the cap the
+                                                 star-height art frame eats the whole host window.
+
+     BtnReroll holds a TextBlock rather than Content: Avalonia parses "_" in Content as an access
+     key. See the porting notes in CLAUDE.md. No string in this view is localized in the WPF
+     original either - every one is set from code by MainWindow - so there is no {loc:Str} here. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.DailyQuestCard"
+             MaxWidth="257" MaxHeight="320">
+
+    <Border x:Name="Root" CornerRadius="12" Background="{DynamicResource PanelBgBrush}"
+            BorderThickness="1.5" BorderBrush="#3D3D60"
+            RenderTransformOrigin="50%,50%">
+        <!-- NO Effect at rest, on purpose: a shadow at rest is a shader pass per frame on a tab
+             that is mostly static. The hover glow is attached in code and cleared on exit. -->
+
+        <Grid RowDefinitions="*,Auto">
+
+            <!-- ============================ ART ============================ -->
+            <Border Grid.Row="0" MinHeight="240" Background="{DynamicResource DarkerBgBrush}"
+                    CornerRadius="11,11,0,0" ClipToBounds="True">
+                <Grid>
+                    <Image x:Name="Art" Stretch="UniformToFill"/>
+
+                    <!-- Bottom scrim. It carries the whole caption, so it reaches high and lands
+                         nearly opaque: most shipped quest art has the quest's own name baked into
+                         the bottom of the picture, and the ramp buries it. -->
+                    <Border Height="112" VerticalAlignment="Bottom" IsHitTestVisible="False">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                                <GradientStop Color="#00000000" Offset="0"/>
+                                <GradientStop Color="#8A000000" Offset="0.28"/>
+                                <GradientStop Color="#FC000000" Offset="0.52"/>
+                                <GradientStop Color="#FF000000" Offset="1"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+
+                    <!-- Stamped. Sits UNDER the caption: a finished quest should still say which
+                         quest it was. -->
+                    <Border x:Name="CompletedOverlay" Background="#992D4A2D" IsVisible="False">
+                        <TextBlock Text="&#x2713;" Foreground="#00E676" FontSize="72" FontWeight="Bold"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   Margin="0,0,0,38">
+                            <TextBlock.Effect>
+                                <DropShadowEffect Color="Black" BlurRadius="8" OffsetX="0" OffsetY="2"/>
+                            </TextBlock.Effect>
+                        </TextBlock>
+                    </Border>
+
+                    <!-- Seat number: with three cards up, "which one is this" has to be answerable
+                         without reading the quest name. -->
+                    <Border x:Name="SlotChip" Background="#B01A1A2E" CornerRadius="9"
+                            Padding="7,2" Margin="8" HorizontalAlignment="Left" VerticalAlignment="Top"
+                            IsHitTestVisible="False">
+                        <TextBlock x:Name="TxtSlot" Text="1" Foreground="#FFD700"
+                                   FontSize="11" FontWeight="Bold"/>
+                    </Border>
+
+                    <!-- XP on the art, not in the body: it is the price tag. -->
+                    <Border x:Name="XpChip" Background="#B01A1A2E" CornerRadius="9"
+                            Padding="7,2" Margin="8" HorizontalAlignment="Right" VerticalAlignment="Top"
+                            IsHitTestVisible="False">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock x:Name="TxtXp" Text="" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="11" FontWeight="Bold" VerticalAlignment="Center"/>
+                            <TextBlock x:Name="TxtXpBonus" Text="" Foreground="#FFB347"
+                                       FontSize="10" FontWeight="Bold" Margin="4,0,0,0"
+                                       VerticalAlignment="Center" IsVisible="False"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- CAPTION. Name and ask, on the picture, over the scrim. -->
+                    <StackPanel VerticalAlignment="Bottom" Margin="11,0,11,9" IsHitTestVisible="False">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,2">
+                            <TextBlock x:Name="TxtIcon" Text="" FontSize="15"
+                                       VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock x:Name="TxtName" Text="" Foreground="White" FontSize="14" FontWeight="Bold"
+                                       TextWrapping="Wrap" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <TextBlock x:Name="TxtDesc" Text="" Foreground="#D6D6E8"
+                                   FontSize="11" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"
+                                   MaxHeight="31"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- ============================ BODY: TWO ROWS ============================ -->
+            <Grid Grid.Row="1" Margin="11,9,11,11" RowDefinitions="Auto,Auto">
+
+                <!-- ROW 1: the bar and, beside it, what is left of the quest. The counts sit ON
+                     the bar's line, not under it - a bar alone never says how much is missing. -->
+                <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+                    <Border x:Name="Track" Grid.Column="0" Background="{DynamicResource DarkerBgBrush}"
+                            CornerRadius="4" Height="10" VerticalAlignment="Center" Margin="0,0,10,0">
+                        <Border x:Name="Fill" Background="#FFD700" CornerRadius="4"
+                                HorizontalAlignment="Left" Width="0"/>
+                    </Border>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock x:Name="TxtProgress" Text="" Foreground="#FFD700"
+                                   FontSize="12" FontWeight="Bold" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="TxtRemaining" Text="" Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="11" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
+
+                <!-- ROW 2: per-seat reroll. The rerolls are still one shared daily pool; this
+                     button only chooses WHICH seat one is spent on. -->
+                <Button x:Name="BtnReroll" Grid.Row="1" Theme="{StaticResource OutlineButton}"
+                        FontSize="11" Padding="8,4" Margin="0,8,0,0"
+                        ToolTip.ShowOnDisabled="True">
+                    <TextBlock x:Name="TxtReroll" Text=""/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/DailyQuestCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/DailyQuestCard.axaml.cs
@@ -1,0 +1,278 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// Everything one seat of the daily board needs to paint itself. Built by the shell's quest
+    /// refresh, which owns the quest/localization/mod lookups; the card owns only how it looks.
+    /// Copied from the WPF code-behind with <c>ImageSource</c> -> <see cref="IImage"/>.
+    /// </summary>
+    internal sealed class DailyQuestCardModel
+    {
+        public int Slot { get; init; }                  // zero-based
+        public string Icon { get; init; } = "";
+        public string Name { get; init; } = "";
+        public string Description { get; init; } = "";
+        public int Current { get; init; }
+        public int Target { get; init; }
+        public bool IsCompleted { get; init; }
+        public string XpText { get; init; } = "";
+        public string? BonusText { get; init; }         // streak / reroll multipliers, or null
+        public IImage? Art { get; init; }
+        public bool CanReroll { get; init; }
+        public string RerollText { get; init; } = "";
+        public string? RerollTooltip { get; init; }
+    }
+
+    /// <summary>
+    /// One card of the three-up daily board.
+    ///
+    /// PORTED from ConditioningControlPanel/Views/Controls/DailyQuestCard.xaml.cs. Deviations:
+    ///  - <c>MotionFx</c> (HoverLift, BarFill, the reduced-motion gate) lives in the WPF head, so
+    ///    the bar is seated directly and the hover glow is attached/detached with no tween.
+    ///  - <c>FrameworkElement</c> -> <see cref="Control"/>, <c>Visibility</c> -> <c>IsVisible</c>,
+    ///    <c>MouseEnter/Leave</c> -> <c>PointerEntered/Exited</c>, <c>ToolTip=</c> ->
+    ///    <c>ToolTip.SetTip</c>, <c>App.Logger</c> -> Serilog's static <c>Log</c>.
+    ///  - The reroll caption goes on an inner TextBlock, not <c>Content</c>: Avalonia would read a
+    ///    "_" in it as an access key.
+    ///  - The parameterless constructor seeds a sample seat so <c>--render-all</c> draws a card
+    ///    with real text rather than an empty frame. Production callers overwrite it with
+    ///    <see cref="Apply"/>, exactly as the WPF original does.
+    ///
+    /// <para><b>The bar belongs to the card.</b> Apply can run before the tab has ever been
+    /// measured, and a bar cannot be filled against a zero-width track, so each card remembers its
+    /// own fraction and re-applies it on its track's SizeChanged.</para>
+    /// </summary>
+    public partial class DailyQuestCard : UserControl
+    {
+        /// <summary>Raised when this seat's reroll button is pressed. The shell spends the reroll;
+        /// the card never touches quest state.</summary>
+        internal event EventHandler? RerollRequested;
+
+        /// <summary>Zero-based seat index, echoed back on <see cref="RerollRequested"/> by way of
+        /// the sender. Set by <see cref="Apply"/>.</summary>
+        internal int Slot { get; private set; }
+
+        /// <summary>Exposed so a burst effect can anchor at the cap of the bar that just filled.</summary>
+        internal Control ProgressTrack => _track;
+        internal Control ProgressFill => _fill;
+
+        private readonly Border _root;
+        private readonly Border _track;
+        private readonly Border _fill;
+        private readonly Border _completedOverlay;
+        private readonly TextBlock _txtSlot, _txtIcon, _txtName, _txtDesc;
+        private readonly TextBlock _txtXp, _txtXpBonus, _txtProgress, _txtRemaining, _txtReroll;
+        private readonly Image _art;
+        private readonly Button _btnReroll;
+
+        private double _fraction;
+        private bool _hasFraction;
+        private DropShadowEffect? _hoverGlow;
+
+        private static readonly IBrush GoldFill = new SolidColorBrush(Color.FromRgb(0xFF, 0xD7, 0x00));
+        private static readonly IBrush DoneFill = new SolidColorBrush(Color.FromRgb(0x00, 0xE6, 0x76));
+        private static readonly IBrush RestBorder = new SolidColorBrush(Color.FromRgb(0x3D, 0x3D, 0x60));
+        private static readonly IBrush LiveBorder = new SolidColorBrush(Color.FromArgb(0x99, 0xFF, 0xD7, 0x00));
+        private static readonly IBrush DoneBorder = new SolidColorBrush(Color.FromArgb(0x99, 0x00, 0xE6, 0x76));
+
+        public DailyQuestCard()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _root = this.FindControl<Border>("Root")!;
+            _track = this.FindControl<Border>("Track")!;
+            _fill = this.FindControl<Border>("Fill")!;
+            _completedOverlay = this.FindControl<Border>("CompletedOverlay")!;
+            _txtSlot = this.FindControl<TextBlock>("TxtSlot")!;
+            _txtIcon = this.FindControl<TextBlock>("TxtIcon")!;
+            _txtName = this.FindControl<TextBlock>("TxtName")!;
+            _txtDesc = this.FindControl<TextBlock>("TxtDesc")!;
+            _txtXp = this.FindControl<TextBlock>("TxtXp")!;
+            _txtXpBonus = this.FindControl<TextBlock>("TxtXpBonus")!;
+            _txtProgress = this.FindControl<TextBlock>("TxtProgress")!;
+            _txtRemaining = this.FindControl<TextBlock>("TxtRemaining")!;
+            _txtReroll = this.FindControl<TextBlock>("TxtReroll")!;
+            _art = this.FindControl<Image>("Art")!;
+            _btnReroll = this.FindControl<Button>("BtnReroll")!;
+
+            _track.SizeChanged += (_, _) => ApplyFraction();
+            _root.PointerEntered += OnCardPointerEntered;
+            _root.PointerExited += OnCardPointerExited;
+            _btnReroll.Click += (_, _) => RerollRequested?.Invoke(this, EventArgs.Empty);
+
+            // Render/design seat: sample data so the headless proof draws every string and a
+            // partially filled bar. Overwritten by the first Apply.
+            Apply(new DailyQuestCardModel
+            {
+                Slot = 0,
+                Icon = "🌀",
+                Name = "Surrender",
+                Description = "Complete 5 minutes of guided breathing.",
+                Current = 3,
+                Target = 5,
+                XpText = "+120 XP",
+                BonusText = "×1.5 streak",
+                CanReroll = true,
+                RerollText = "Reroll this seat",
+                RerollTooltip = "1 reroll left today",
+            });
+        }
+
+        // ---- PAINT ---------------------------------------------------------------
+
+        /// <summary>Paint this seat from live quest state.</summary>
+        internal void Apply(DailyQuestCardModel m)
+        {
+            Slot = m.Slot;
+            IsVisible = true;
+            Opacity = 1.0;
+
+            _txtSlot.Text = (m.Slot + 1).ToString();
+            _txtIcon.Text = m.Icon;
+            _txtName.Text = m.Name;
+            _txtDesc.Text = m.Description;
+            _txtDesc.IsVisible = !string.IsNullOrWhiteSpace(m.Description);
+
+            _txtXp.Text = m.XpText;
+            if (string.IsNullOrWhiteSpace(m.BonusText))
+            {
+                _txtXpBonus.IsVisible = false;
+            }
+            else
+            {
+                _txtXpBonus.Text = m.BonusText;
+                _txtXpBonus.IsVisible = true;
+            }
+
+            if (m.Art != null) _art.Source = m.Art;
+
+            // A stamped seat reads 100% whatever its stored counter says: a quest completed by a
+            // tracker that overshot its target (minutes arrive in whole-minute lumps) would
+            // otherwise paint a bar that is not quite full under a green check.
+            double fraction = m.IsCompleted ? 1.0
+                            : m.Target > 0 ? Math.Max(0, Math.Min(1.0, (double)m.Current / m.Target))
+                            : 0;
+
+            int current = m.IsCompleted ? Math.Max(m.Current, m.Target) : m.Current;
+            _txtProgress.Text = $"{current} / {m.Target}";
+
+            if (m.IsCompleted)
+            {
+                _completedOverlay.IsVisible = true;
+                _root.BorderBrush = DoneBorder;
+                _fill.Background = DoneFill;
+                _txtProgress.Foreground = DoneFill;
+                // The separator lives in this string rather than in a third TextBlock, so an empty
+                // remainder leaves no orphaned dot on the line.
+                _txtRemaining.Text = "· done";
+            }
+            else
+            {
+                _completedOverlay.IsVisible = false;
+                _root.BorderBrush = LiveBorder;
+                _fill.Background = GoldFill;
+                _txtProgress.Foreground = GoldFill;
+                int left = Math.Max(0, m.Target - m.Current);
+                _txtRemaining.Text = left > 0 ? $"· {left} to go" : "";
+            }
+
+            _txtReroll.Text = m.RerollText;
+            _btnReroll.IsEnabled = m.CanReroll;
+            _btnReroll.IsVisible = !m.IsCompleted;
+            ToolTip.SetTip(_btnReroll, m.RerollTooltip);
+
+            SetFraction(fraction);
+        }
+
+        /// <summary>
+        /// A seat the pool could not fill. Rare (it needs every legal quest to be excluded or
+        /// locked), but it must render as an obviously empty seat rather than as a broken card.
+        /// </summary>
+        internal void ShowEmpty(int slot, string title, string subtitle)
+        {
+            Slot = slot;
+            IsVisible = true;
+            Opacity = 0.55;
+
+            _txtSlot.Text = (slot + 1).ToString();
+            _txtIcon.Text = "";
+            _txtName.Text = title;
+            _txtDesc.Text = subtitle;
+            _txtDesc.IsVisible = true;
+            _txtXp.Text = "";
+            _txtXpBonus.IsVisible = false;
+            _art.Source = null;
+            _completedOverlay.IsVisible = false;
+            _root.BorderBrush = RestBorder;
+            _txtProgress.Text = "";
+            _txtRemaining.Text = "";
+            _btnReroll.IsVisible = false;
+
+            SetFraction(0);
+        }
+
+        // ---- BAR -----------------------------------------------------------------
+
+        private void SetFraction(double fraction)
+        {
+            if (double.IsNaN(fraction)) fraction = 0;
+            _fraction = Math.Max(0, Math.Min(1, fraction));
+            _hasFraction = true;
+            ApplyFraction();
+        }
+
+        /// <summary>
+        /// Seat the fill against the track's CURRENT width. Called both from Apply (which can run
+        /// before the tab has ever been measured, in which case the track is 0 wide and this is a
+        /// no-op) and from the track's SizeChanged, which is what finally lands it.
+        /// ponytail: needs MotionFx.BarFill for the tween, wired when it moves to Core; the width
+        /// is set directly here, so the bar is correct but never animates.
+        /// </summary>
+        private void ApplyFraction()
+        {
+            try
+            {
+                if (!_hasFraction) return;
+                double available = _track.Bounds.Width;
+                if (available <= 0) return;
+
+                _fill.Width = available * _fraction;
+            }
+            catch (Exception ex) { Log.Debug("DailyQuestCard bar: {E}", ex.Message); }
+        }
+
+        // ---- INTERACTION ---------------------------------------------------------
+
+        // ponytail: needs MotionFx.HoverLift + the reduced-motion gate, wired when it moves to
+        // Core. The glow still attaches and clears; it just arrives at full strength instead of
+        // blooming over 180ms.
+        private void OnCardPointerEntered(object? sender, PointerEventArgs e)
+        {
+            try
+            {
+                _hoverGlow ??= new DropShadowEffect
+                {
+                    Color = Color.FromRgb(0xFF, 0xD7, 0x00),
+                    OffsetX = 0,
+                    OffsetY = 0,
+                    BlurRadius = 18,
+                    Opacity = 0.5,
+                };
+                _root.Effect = _hoverGlow;
+            }
+            catch (Exception ex) { Log.Debug("DailyQuestCard hover in: {E}", ex.Message); }
+        }
+
+        private void OnCardPointerExited(object? sender, PointerEventArgs e)
+        {
+            try { _root.Effect = null; }
+            catch (Exception ex) { Log.Debug("DailyQuestCard hover out: {E}", ex.Message); }
+        }
+    }
+}


### PR DESCRIPTION
972 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351