### PR TITLE
feat(avalonia): port MiniPlayerWindow, LayeredAudioWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/LayeredAudioWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/LayeredAudioWindow.axaml
@@ -1,0 +1,126 @@
+<!-- PORTED from ConditioningControlPanel/Windows/LayeredAudioWindow.xaml.
+     Structure, ordering, spacing and every literal colour preserved so the two diff cleanly.
+     The original carries no {loc:Str} at all - every string is hard-coded English there, so
+     inventing keys here would be a fidelity loss, not a gain. Deviations, all forced:
+
+       Style="{DynamicResource X}"     -> Theme="{StaticResource X}"  (ToggleStyle and
+                                          OutlineButton are ControlThemes in Theme/Styles.xaml)
+       ResizeMode="CanResizeWithGrip" -> CanResize="True"   (Avalonia has no resize grip)
+       Checked/Unchecked              -> ToggleButton.IsCheckedChanged, wired in the ctor
+       ValueChanged / Click           -> wired in the ctor
+
+     Buttons keep Content: none of these strings contains an underscore, so Avalonia's
+     access-key parsing has nothing to swallow. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.LayeredAudioWindow"
+        Title="Audio Layers"
+        Width="480" Height="660"
+        WindowStartupLocation="CenterOwner"
+        Background="#0F0F1E"
+        Foreground="#E0E0E0"
+        CanResize="True"
+        MinWidth="420" MinHeight="480">
+    <Grid Margin="18">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="🎧 Audio Layers"
+                   Foreground="{DynamicResource PinkBrush}"
+                   FontSize="20"
+                   FontWeight="SemiBold"/>
+
+        <TextBlock Grid.Row="1"
+                   Text="Build your own looping soundscape — add several audio files and they all play together, each on its own volume. Everything mixes through one output so it stays light. Turn the master on to hear it now; it also plays automatically for audio-only sessions."
+                   Foreground="#A0A0B0"
+                   FontSize="12"
+                   TextWrapping="Wrap"
+                   Margin="0,6,0,14"/>
+
+        <!-- Master enable + master volume -->
+        <Border Grid.Row="2"
+                Background="#1A1A2E" BorderBrush="#3D3D60" BorderThickness="1"
+                CornerRadius="10" Padding="14,12" Margin="0,0,0,10">
+            <StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Play layered audio"
+                               Foreground="White" FontSize="14" FontWeight="SemiBold"
+                               VerticalAlignment="Center"/>
+                    <CheckBox Grid.Column="1" x:Name="ChkMasterEnable"
+                              Theme="{StaticResource ToggleStyle}"
+                              VerticalAlignment="Center"/>
+                </Grid>
+                <Grid Margin="0,10,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="Master" Foreground="#B0B0C0" FontSize="12"
+                               VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <Slider Grid.Column="1" x:Name="SliderMaster"
+                            Minimum="0" Maximum="100" Value="70"
+                            VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="2" x:Name="TxtMaster" Text="70%"
+                               Foreground="{DynamicResource PinkBrush}" FontSize="12"
+                               FontWeight="SemiBold" Width="40" TextAlignment="Right"
+                               VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- #668 Audio-Only Hypno session mode -->
+                <Border Background="#12121F" BorderBrush="#2E2E4A" BorderThickness="1"
+                        CornerRadius="8" Padding="10,8" Margin="0,12,0,0">
+                    <StackPanel>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Audio-only session"
+                                       Foreground="White" FontSize="13" FontWeight="SemiBold"
+                                       VerticalAlignment="Center"/>
+                            <CheckBox Grid.Column="1" x:Name="ChkAudioOnly"
+                                      Theme="{StaticResource ToggleStyle}"
+                                      VerticalAlignment="Center"/>
+                        </Grid>
+                        <TextBlock Text="When on, starting a session hides the visuals (flashes, spiral, video, mini-games) and plays only this layered audio."
+                                   Foreground="#8A8A9A" FontSize="11" TextWrapping="Wrap"
+                                   Margin="0,6,0,0"/>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </Border>
+
+        <!-- Add track -->
+        <Button Grid.Row="3"
+                x:Name="BtnAddTrack"
+                Content="➕  Add audio file…"
+                Theme="{StaticResource OutlineButton}"
+                Padding="12,8"
+                HorizontalAlignment="Left"
+                Margin="0,0,0,10"/>
+
+        <ScrollViewer Grid.Row="4" VerticalScrollBarVisibility="Auto">
+            <StackPanel x:Name="SlotsPanel"/>
+        </ScrollViewer>
+
+        <Button Grid.Row="5"
+                x:Name="BtnClose"
+                Content="Done"
+                Theme="{StaticResource OutlineButton}"
+                Padding="16,8"
+                HorizontalAlignment="Right"
+                Margin="0,14,0,0"/>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/LayeredAudioWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/LayeredAudioWindow.axaml.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Config window for suggestion #659 "Audio Layers". Maintains the user's list of looping
+    /// audio tracks (add file / per-track enable + volume / remove) plus a master enable and
+    /// master volume.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/LayeredAudioWindow.xaml.cs. Deviations:
+    ///  - App.Settings and App.LayeredAudio are both still in the WPF head, so the track list is
+    ///    an in-memory placeholder seeded with two sample tracks, and every Save/Start/Stop/
+    ///    Restart/SetVolumeLive call is a marked stub. The card building, the toggles, the
+    ///    dim-when-off body, the empty state and its master-on warning are ported for real -
+    ///    they are the whole point of this window and none of them touches a service.
+    ///  - The file picker uses Avalonia's StorageProvider (async) instead of
+    ///    Microsoft.Win32.OpenFileDialog, and adds to the placeholder list.
+    ///  - The static Open(DependencyObject) helper is DROPPED. Its three jobs - best-effort
+    ///    Owner, single-instance re-surface, and EnsureOnScreen against SystemParameters'
+    ///    virtual-desktop metrics - are WPF window-manager repairs with no caller in this head.
+    ///    It comes back (over Avalonia's Screens API) with the call sites that need it.
+    ///  - TryFindResource("ToggleStyle") returns a ControlTheme here, assigned to Theme.
+    ///  - Checked/Unchecked collapse into IsCheckedChanged; Slider.ValueChanged carries
+    ///    RangeBaseValueChangedEventArgs.
+    /// </summary>
+    public partial class LayeredAudioWindow : Window
+    {
+        private static readonly Color Accent = Color.FromRgb(0xFF, 0x69, 0xB4);
+
+        // Slider drags apply live (no rebuild); debounce the settings save so a drag
+        // doesn't hammer the disk.
+        private readonly DispatcherTimer _saveDebounce;
+        // Kept from the original: the master slider's Value="70" is set during XAML load, and the
+        // handlers must stay inert until LoadMasterControls owns the flag.
+        private bool _loading = true;
+
+        // ponytail: needs App.Settings.Current.AudioLayers, wired when settings move to Core.
+        // Two sample tracks so --render-view draws the row cards rather than the empty state;
+        // the empty state and its master-on warning are still reachable by removing both.
+        private readonly List<AudioLayerTrack> _tracks = new()
+        {
+            new AudioLayerTrack { Path = "/music/rain-loop.mp3", Volume = 70, Enabled = true },
+            new AudioLayerTrack { Path = "/music/deep-hum.ogg", Volume = 45, Enabled = false },
+        };
+
+        private readonly CheckBox _chkMasterEnable, _chkAudioOnly;
+        private readonly Slider _sliderMaster;
+        private readonly TextBlock _txtMaster;
+        private readonly StackPanel _slotsPanel;
+
+        public LayeredAudioWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _chkMasterEnable = this.FindControl<CheckBox>("ChkMasterEnable")!;
+            _chkAudioOnly = this.FindControl<CheckBox>("ChkAudioOnly")!;
+            _sliderMaster = this.FindControl<Slider>("SliderMaster")!;
+            _txtMaster = this.FindControl<TextBlock>("TxtMaster")!;
+            _slotsPanel = this.FindControl<StackPanel>("SlotsPanel")!;
+
+            _saveDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
+            _saveDebounce.Tick += (_, _) => { _saveDebounce.Stop(); SaveSettings(); };
+
+            _chkMasterEnable.IsCheckedChanged += (_, _) => ChkMasterEnable_Changed();
+            _chkAudioOnly.IsCheckedChanged += (_, _) => ChkAudioOnly_Changed();
+            _sliderMaster.AddHandler(RangeBase.ValueChangedEvent, SliderMaster_Changed);
+            this.FindControl<Button>("BtnAddTrack")!.Click += async (_, _) => await AddTrackAsync();
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+
+            LoadMasterControls();
+            BuildRows();
+        }
+
+        private List<AudioLayerTrack> Tracks() => _tracks;
+
+        private void LoadMasterControls()
+        {
+            _loading = true;
+            // ponytail: needs App.Settings.Current (AudioLayersEnabled / AudioLayersMasterVolume /
+            // AudioOnlySession). The XAML defaults stand in until settings move to Core.
+            _chkMasterEnable.IsChecked = true;
+            _sliderMaster.Value = 70;
+            _txtMaster.Text = $"{(int)_sliderMaster.Value}%";
+            _chkAudioOnly.IsChecked = false;
+            _loading = false;
+        }
+
+        private void BuildRows()
+        {
+            _slotsPanel.Children.Clear();
+            var list = Tracks();
+            if (list.Count == 0)
+            {
+                _slotsPanel.Children.Add(new TextBlock
+                {
+                    Text = "No tracks yet. Add an audio file to get started.",
+                    Foreground = new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x90)),
+                    FontSize = 12,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(2, 4, 0, 0),
+                });
+                // "Is this button bugged?" support-cost guard: with the master on and nothing
+                // in the list the feature is audibly indistinguishable from broken.
+                if (_chkMasterEnable.IsChecked == true)
+                {
+                    _slotsPanel.Children.Add(new TextBlock
+                    {
+                        Text = "⚠ The master switch is on, but with no layers there is nothing to play - it stays silent until you add a file.",
+                        Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0xA8, 0x4C)),
+                        FontSize = 12,
+                        TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(2, 8, 0, 0),
+                    });
+                }
+                return;
+            }
+            for (int i = 0; i < list.Count; i++)
+                _slotsPanel.Children.Add(BuildRowCard(list[i]));
+        }
+
+        private Border BuildRowCard(AudioLayerTrack track)
+        {
+            var card = new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0x3D, 0x3D, 0x60)),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(10),
+                Padding = new Thickness(14, 12, 14, 12),
+                Margin = new Thickness(0, 0, 0, 10),
+            };
+
+            var root = new StackPanel();
+
+            // Header: enable toggle + filename + remove
+            var header = new Grid();
+            header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            header.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            header.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            var toggle = new CheckBox
+            {
+                IsChecked = track.Enabled,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 10, 0),
+            };
+            if (this.TryFindResource("ToggleStyle", out var toggleTheme) && toggleTheme is ControlTheme ct)
+                toggle.Theme = ct;
+            Grid.SetColumn(toggle, 0);
+            header.Children.Add(toggle);
+
+            var name = new TextBlock
+            {
+                Text = track.DisplayName,
+                Foreground = Brushes.White,
+                FontSize = 13,
+                FontWeight = FontWeight.SemiBold,
+                VerticalAlignment = VerticalAlignment.Center,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+            };
+            if (!string.IsNullOrEmpty(track.Path)) ToolTip.SetTip(name, track.Path);
+            Grid.SetColumn(name, 1);
+            header.Children.Add(name);
+
+            var remove = new Button
+            {
+                Content = "✕",
+                Width = 26,
+                Height = 26,
+                Padding = new Thickness(0),
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                Background = new SolidColorBrush(Color.FromRgb(0x33, 0x1A, 0x2A)),
+                Foreground = new SolidColorBrush(Accent),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0x5A, 0x2A, 0x40)),
+                BorderThickness = new Thickness(1),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            ToolTip.SetTip(remove, "Remove this track");
+            Grid.SetColumn(remove, 2);
+            header.Children.Add(remove);
+            root.Children.Add(header);
+
+            // Volume row (dimmed when the track is off)
+            var body = new StackPanel { Margin = new Thickness(0, 10, 0, 0) };
+            var volGrid = new Grid();
+            volGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            volGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            volGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+            var volLabel = new TextBlock
+            {
+                Text = "Volume",
+                Foreground = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xC0)),
+                FontSize = 12,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 8, 0),
+            };
+            Grid.SetColumn(volLabel, 0);
+            volGrid.Children.Add(volLabel);
+
+            var volValue = new TextBlock
+            {
+                Text = $"{track.Volume}%",
+                Foreground = new SolidColorBrush(Accent),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                Width = 40,
+                TextAlignment = TextAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            Grid.SetColumn(volValue, 2);
+
+            var volSlider = new Slider
+            {
+                Minimum = 0,
+                Maximum = 100,
+                Value = track.Volume,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            volSlider.AddHandler(RangeBase.ValueChangedEvent, (EventHandler<RangeBaseValueChangedEventArgs>)((_, e) =>
+            {
+                track.Volume = (int)e.NewValue;
+                volValue.Text = $"{track.Volume}%";
+                // ponytail: needs App.LayeredAudio.SetTrackVolumeLive - live per-track gain, no
+                // graph rebuild, so drags stay smooth.
+                SaveDebounced();
+            }));
+            Grid.SetColumn(volSlider, 1);
+            volGrid.Children.Add(volSlider);
+            volGrid.Children.Add(volValue);
+            body.Children.Add(volGrid);
+
+            body.IsEnabled = track.Enabled;
+            body.Opacity = track.Enabled ? 1.0 : 0.45;
+            root.Children.Add(body);
+
+            toggle.IsCheckedChanged += (_, _) =>
+            {
+                var on = toggle.IsChecked == true;
+                track.Enabled = on;
+                body.IsEnabled = on;
+                body.Opacity = on ? 1.0 : 0.45;
+                ApplyStructural(); // enable/disable adds/removes a mixer input -> rebuild
+            };
+
+            remove.Click += (_, _) =>
+            {
+                Tracks().Remove(track);
+                BuildRows();
+                ApplyStructural();
+            };
+
+            card.Child = root;
+            return card;
+        }
+
+        private async System.Threading.Tasks.Task AddTrackAsync()
+        {
+            var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Add an audio layer",
+                AllowMultiple = true,
+                FileTypeFilter = new[]
+                {
+                    new FilePickerFileType("Audio Files")
+                    {
+                        Patterns = new[] { "*.mp3", "*.wav", "*.ogg", "*.flac", "*.m4a", "*.aac", "*.wma" }
+                    },
+                    FilePickerFileTypes.All,
+                },
+            });
+            if (files.Count == 0) return;
+
+            foreach (var file in files)
+                Tracks().Add(new AudioLayerTrack { Path = file.TryGetLocalPath() ?? file.Name, Volume = 70, Enabled = true });
+
+            BuildRows();
+            ApplyStructural();
+        }
+
+        private void ChkMasterEnable_Changed()
+        {
+            if (_loading) return;
+            // ponytail: needs App.Settings (AudioLayersEnabled) and App.LayeredAudio.Start/Stop.
+            SaveSettings();
+
+            // The empty-state warning above depends on this toggle.
+            if (Tracks().Count == 0) BuildRows();
+        }
+
+        private void ChkAudioOnly_Changed()
+        {
+            if (_loading) return;
+            // ponytail: needs App.Settings (AudioOnlySession).
+            SaveSettings();
+        }
+
+        private void SliderMaster_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_loading) return;
+            // ponytail: needs App.Settings (AudioLayersMasterVolume) and
+            // App.LayeredAudio.SetMasterVolumeLive.
+            _txtMaster.Text = $"{(int)e.NewValue}%";
+            SaveDebounced();
+        }
+
+        /// <summary>A structural change (add/remove/enable): rebuild the mixer if it's on.</summary>
+        private void ApplyStructural()
+        {
+            SaveSettings();
+            // ponytail: needs App.LayeredAudio.Restart when AudioLayersEnabled is true.
+        }
+
+        /// <summary>ponytail: needs App.Settings.Save, wired when settings move to Core.</summary>
+        private void SaveSettings() { }
+
+        private void SaveDebounced()
+        {
+            _saveDebounce.Stop();
+            _saveDebounce.Start();
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MiniPlayerWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/MiniPlayerWindow.axaml
@@ -1,0 +1,127 @@
+<!-- PORTED from ConditioningControlPanel/Windows/MiniPlayerWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" + TransparencyLevelHint
+       ResizeMode="CanResizeWithGrip"           -> CanResize="True"   (Avalonia has no grip)
+       Visibility="Collapsed"                   -> IsVisible="False"
+       ToolTip="..."                            -> ToolTip.Tip="..."
+       MouseLeftButtonDown / KeyDown / Click    -> wired in the constructor
+       RenderOptions.BitmapScalingMode          -> RenderOptions.BitmapInterpolationMode
+       Style="{StaticResource {x:Type Slider}}" -> dropped; that was "use the default theme"
+       vlc:VideoView / gif: namespaces          -> dropped, both are WPF-only packages
+       <Button.Style> with a ControlTemplate    -> the default Button template plus the two
+                                                   pointerover setters below. A property-only
+                                                   ControlTheme would blank the button (trap 4),
+                                                   and re-templating just to paint a hover is
+                                                   more markup than the selector.
+       TxtFileName / Title lose {loc:Str}: LoadFile overwrites both with the file name, and in
+       Avalonia a local set does NOT clear a binding, so the next language change would put
+       "Preview" back over the file name. The constructor sets them from Loc instead. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.MiniPlayerWindow"
+        Height="350" Width="450"
+        MinHeight="200" MinWidth="300"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource DarkerBgBrush}"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        CanResize="True">
+
+    <Window.Styles>
+        <!-- The WPF ControlTemplate.Triggers block for the close button, setters verbatim.
+             #PART_ContentPresenter is the default Button template's own presenter, so the
+             content still draws (trap 6). -->
+        <Style Selector="Button#BtnClose /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="CornerRadius" Value="0"/>
+        </Style>
+        <Style Selector="Button#BtnClose:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#E81123"/>
+            <Setter Property="TextElement.Foreground" Value="White"/>
+        </Style>
+        <!-- Not in the original: Avalonia's Fluent Button lightens on hover, which on this dark
+             chrome reads as the button flashing white. Hold the WPF colours instead. -->
+        <Style Selector="Button#BtnPlayPause /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#353555"/>
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource PinkBrush}"/>
+        </Style>
+    </Window.Styles>
+
+    <Border CornerRadius="8" Background="{DynamicResource DarkerBgBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="32"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title Bar -->
+            <Grid Grid.Row="0" Background="{DynamicResource PanelBgBrush}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="TxtFileName"
+                           Foreground="{DynamicResource PinkBrush}" FontSize="12" FontWeight="SemiBold"
+                           VerticalAlignment="Center" Margin="12,0,0,0"
+                           TextTrimming="CharacterEllipsis"/>
+                <Button x:Name="BtnClose" Grid.Column="1" Content="✕" Width="32" Height="32"
+                        Padding="0" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                        BorderThickness="0" FontSize="14" Cursor="Hand"
+                        ToolTip.Tip="{loc:Str tooltip_close_escape}"/>
+            </Grid>
+
+            <!-- Content Area -->
+            <Grid Grid.Row="1" Background="#000000">
+                <!-- Video Player (LibVLC) -->
+                <Border x:Name="VideoContainer" IsVisible="False">
+                    <!-- VideoView added programmatically -->
+                </Border>
+
+                <!-- Image/GIF Display -->
+                <Image x:Name="ImagePreview" Stretch="Uniform" IsVisible="False"
+                       RenderOptions.BitmapInterpolationMode="HighQuality"/>
+
+                <!-- Loading Indicator -->
+                <Grid x:Name="LoadingOverlay" IsVisible="False">
+                    <TextBlock Text="{loc:Str label_loading_2}" Foreground="{DynamicResource TextMutedBrush}" FontSize="14"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                </Grid>
+            </Grid>
+
+            <!-- Video Controls (only shown for videos) -->
+            <Grid x:Name="VideoControls" Grid.Row="2" Background="{DynamicResource PanelBgBrush}" Height="40" IsVisible="False">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Play/Pause Button -->
+                <Button x:Name="BtnPlayPause" Grid.Column="0"
+                        Content="▶" Width="36" Height="28"
+                        Padding="0" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Background="#353555" Foreground="{DynamicResource PinkBrush}"
+                        BorderThickness="0" FontSize="12" Cursor="Hand"
+                        Margin="8,0,0,0"
+                        ToolTip.Tip="{loc:Str tooltip_play_pause_space}"/>
+
+                <!-- Seek Slider -->
+                <Slider x:Name="SeekSlider" Grid.Column="1"
+                        Minimum="0" Maximum="100" Value="0"
+                        VerticalAlignment="Center" Margin="10,0"/>
+
+                <!-- Time Display -->
+                <TextBlock x:Name="TxtTime" Grid.Column="2"
+                           Text="00:00 / 00:00" Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                           VerticalAlignment="Center" Margin="0,0,12,0"
+                           FontFamily="Consolas, Courier New"/>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/MiniPlayerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MiniPlayerWindow.axaml.cs
@@ -1,0 +1,230 @@
+using System;
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Borderless mini preview window: plays a video (LibVLC), animates a GIF, or shows a still
+    /// image, with a drag-anywhere title bar and keyboard transport.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/MiniPlayerWindow.xaml.cs. Deviations:
+    ///  - LibVLCSharp.WPF (VideoView/MediaPlayer/Media) and XamlAnimatedGif are both WPF-only
+    ///    packages, and Services.VideoService.SharedLibVLC still lives in the WPF head. So
+    ///    LoadVideo, LoadGif's animation, the position timer, seeking and play/pause are stubs;
+    ///    each is marked. Everything that is view-only - the chrome, the drag, Escape/Space/
+    ///    arrow key routing, the play glyph, the time formatting - is ported for real.
+    ///  - LoadImage IS real: Avalonia's Bitmap loads from a path with no WPF dependency, and a
+    ///    GIF falls back to its first frame through it, exactly as the WPF catch block did.
+    ///  - MessageBox.Show has no Avalonia equivalent and no package may be added; the failure
+    ///    paths log to the console and close, which is what the user saw anyway.
+    ///  - PreviewMouseDown/Up become plain PointerPressed/PointerReleased. The tunnelling pass
+    ///    existed to beat the Thumb to the event; Avalonia's Slider raises these on the way out
+    ///    too, and the flag they set is only read by the position timer.
+    ///  - DragMove() -> BeginMoveDrag(e), which needs the event args.
+    /// </summary>
+    public partial class MiniPlayerWindow : Window
+    {
+        private static readonly string[] VideoExtensions = { ".mp4", ".avi", ".mkv", ".mov", ".wmv", ".webm", ".m4v", ".flv", ".mpeg", ".mpg", ".3gp" };
+        private static readonly string[] GifExtensions = { ".gif" };
+
+        private readonly TextBlock _txtFileName, _txtTime;
+        private readonly Button _btnPlayPause;
+        private readonly Slider _seekSlider;
+        private readonly Border _videoContainer;
+        private readonly Image _imagePreview;
+        private readonly Grid _loadingOverlay, _videoControls;
+
+        private bool _isDraggingSlider;
+        private bool _isPlaying;
+        private string? _currentFilePath;
+
+        public MiniPlayerWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtFileName = this.FindControl<TextBlock>("TxtFileName")!;
+            _txtTime = this.FindControl<TextBlock>("TxtTime")!;
+            _btnPlayPause = this.FindControl<Button>("BtnPlayPause")!;
+            _seekSlider = this.FindControl<Slider>("SeekSlider")!;
+            _videoContainer = this.FindControl<Border>("VideoContainer")!;
+            _imagePreview = this.FindControl<Image>("ImagePreview")!;
+            _loadingOverlay = this.FindControl<Grid>("LoadingOverlay")!;
+            _videoControls = this.FindControl<Grid>("VideoControls")!;
+
+            // Set, not bound: LoadFile overwrites both, and an Avalonia binding survives a local
+            // set. See the header comment in the .axaml.
+            _txtFileName.Text = Loc.Get("section_preview");
+            Title = Loc.Get("section_preview");
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            _btnPlayPause.Click += (_, _) => TogglePlayPause();
+            _seekSlider.PointerPressed += (_, _) => _isDraggingSlider = true;
+            _seekSlider.PointerReleased += (_, _) => { _isDraggingSlider = false; SeekToSliderPosition(); };
+            _seekSlider.AddHandler(RangeBase.ValueChangedEvent, SeekSlider_ValueChanged);
+            PointerPressed += Window_PointerPressed;
+            KeyDown += Window_KeyDown;
+
+            // ponytail: placeholder state, needs Services.VideoService (LibVLC) to move to Core.
+            // Without it nothing ever calls LoadFile here, and an all-collapsed window renders as
+            // a black rectangle that proves nothing. This is the state LoadVideo leaves behind
+            // one line in - overlay up, transport visible - so --render-view draws the real
+            // slider and button templates. LoadFile still drives these normally.
+            _loadingOverlay.IsVisible = true;
+            _videoControls.IsVisible = true;
+        }
+
+        public void LoadFile(string filePath)
+        {
+            _currentFilePath = filePath;
+            var fileName = Path.GetFileName(filePath);
+            _txtFileName.Text = fileName;
+            Title = $"Preview - {fileName}";
+
+            var extension = Path.GetExtension(filePath).ToLowerInvariant();
+
+            if (IsVideoFile(extension))
+            {
+                LoadVideo(filePath);
+            }
+            else if (IsGifFile(extension))
+            {
+                LoadGif(filePath);
+            }
+            else
+            {
+                LoadImage(filePath);
+            }
+        }
+
+        private bool IsVideoFile(string extension)
+        {
+            return Array.Exists(VideoExtensions, e => e.Equals(extension, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private bool IsGifFile(string extension)
+        {
+            return Array.Exists(GifExtensions, e => e.Equals(extension, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private void LoadVideo(string filePath)
+        {
+            // ponytail: needs Services.VideoService.SharedLibVLC plus a non-WPF VideoView, wired
+            // when it moves to Core. The WPF original built a MediaPlayer here, hung Playing/
+            // Paused/EndReached/LengthChanged off it, parented a VideoView into VideoContainer
+            // and started a 100ms DispatcherTimer to drive SeekSlider. Until then the window
+            // shows the transport in its loading state and nothing plays.
+            _videoContainer.IsVisible = true;
+            _loadingOverlay.IsVisible = true;
+            _videoControls.IsVisible = true;
+            _isPlaying = false;
+            _btnPlayPause.Content = "▶";
+            UpdateTimeDisplay();
+        }
+
+        private void LoadGif(string filePath)
+        {
+            // ponytail: needs an Avalonia GIF animator (XamlAnimatedGif is WPF-only). The WPF
+            // original set AnimationBehavior's SourceUri/AutoStart/RepeatBehavior here and fell
+            // back to LoadImage on failure - which is the still first frame, so take it directly.
+            LoadImage(filePath);
+        }
+
+        private void LoadImage(string filePath)
+        {
+            try
+            {
+                _imagePreview.IsVisible = true;
+                _videoControls.IsVisible = false;
+                _loadingOverlay.IsVisible = false;
+
+                _imagePreview.Source = new Bitmap(filePath);
+            }
+            catch (Exception ex)
+            {
+                // ponytail: needs App.Logger and a message box, both still in the WPF head.
+                Console.Error.WriteLine("MiniPlayerWindow: Failed to load image: " + ex.Message);
+                Close();
+            }
+        }
+
+        private void UpdateTimeDisplay()
+        {
+            // ponytail: needs the MediaPlayer for Time/Length; the format is the WPF one verbatim.
+            var current = TimeSpan.Zero;
+            var total = TimeSpan.Zero;
+
+            _txtTime.Text = $"{current:mm\\:ss} / {total:mm\\:ss}";
+        }
+
+        private void TogglePlayPause()
+        {
+            // ponytail: needs the MediaPlayer to Pause()/Play(); the glyph swap is the view half
+            // of the WPF Playing/Paused handlers and is kept so the button is not inert.
+            _isPlaying = !_isPlaying;
+            _btnPlayPause.Content = _isPlaying ? "⏸" : "▶";
+        }
+
+        private void SeekSlider_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isDraggingSlider)
+            {
+                // Live preview while dragging
+                UpdateTimeDisplay();
+            }
+        }
+
+        private void SeekToSliderPosition()
+        {
+            // ponytail: needs the MediaPlayer; Position is a 0-1 float of SeekSlider.Value / 100.
+            _ = Math.Clamp(_seekSlider.Value / 100.0, 0.0, 1.0);
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            // Allow dragging the window
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            {
+                BeginMoveDrag(e);
+            }
+        }
+
+        private void Window_KeyDown(object? sender, KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case Key.Escape:
+                    Close();
+                    break;
+                case Key.Space:
+                    TogglePlayPause();
+                    e.Handled = true;
+                    break;
+                case Key.Left:
+                    // ponytail: needs the MediaPlayer - this was Time -= 5000ms.
+                    e.Handled = true;
+                    break;
+                case Key.Right:
+                    // ponytail: needs the MediaPlayer - this was Time += 5000ms, clamped to Length.
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            // The WPF original tore down the position timer, the VideoView, the MediaPlayer, the
+            // Media and the GIF animation here. All of those come back with the video service; the
+            // Bitmap LoadImage sets is the only unmanaged handle this port owns.
+            try { (_imagePreview.Source as Bitmap)?.Dispose(); } catch { /* already disposed */ }
+            _imagePreview.Source = null;
+
+            base.OnClosed(e);
+        }
+    }
+}


### PR DESCRIPTION
821 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351