### PR TITLE
feat(avalonia): port HapticsSetupWindow, AppSettingsTabView

### DIFF
--- a/CCP.Avalonia/Views/Tabs/AppSettingsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/AppSettingsTabView.axaml
@@ -1,0 +1,252 @@
+<!-- PORTED from ConditioningControlPanel/Views/Tabs/AppSettingsTabView.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two
+     diff cleanly. Deviations, all forced:
+
+       <Style x:Key="SectionPill">      -> <ControlTheme x:Key="SectionPill">, Style="..." -> Theme="..."
+       ControlTemplate.Triggers         -> ^:pointerover / ^:checked nested selectors, and the
+                                           ContentPresenter carries Content/ContentTemplate
+                                           TemplateBindings (CLAUDE.md traps 4 and 6)
+       Image + EmojiToImageSource       -> <TextBlock Text="emoji"/>  (Avalonia draws colour emoji)
+       Visibility                       -> IsVisible
+       Click="SectionPill_Click"        -> wired in the constructor
+       ScrollChanged="..."              -> wired in the constructor
+
+     No {Binding} survives the emoji change, so the file needs no x:DataType. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:appset="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.AppSettings"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.AppSettingsTabView"
+             mc:Ignorable="d"
+             d:DesignHeight="700" d:DesignWidth="1100">
+
+    <!-- ========================================================================
+         THE SETTINGS DOOR (UX restructure, Phase 2 · tab key "appsettings")
+
+         One vertical page, nine sections, one editor per setting. The left
+         mini-rail is a table of contents, not a tab strip: every section is
+         always instantiated and always in the scroll, so Ctrl+F-style hunting
+         works and a pill click is a scroll, never a swap. That is why nothing
+         here is lazy and nothing here is a TabControl.
+
+         QUIET SURFACE (PLAN §2.7, ground rule 8): no ambient loop is registered
+         for this view and none may be.
+         ======================================================================== -->
+
+    <UserControl.Resources>
+
+        <!-- ponytail: local copy of AppSettingsTabView.xaml:SectionPill, hoist when a second view needs it.
+
+             Mini-rail pill. A RadioButton so the group gives us single-selection
+             for free: the scroll-spy re-checks the pill the reader is looking at,
+             and a click scrolls. Deliberately calm - opacity and a 3px bar, the
+             same visual grammar as the nav rail's active indicator, no clock.
+             :checked is declared after :pointerover so checked wins on hover,
+             matching WPF's trigger order. -->
+        <ControlTheme x:Key="SectionPill" TargetType="RadioButton">
+            <Setter Property="GroupName" Value="AppSettingsSections"/>
+            <Setter Property="MinHeight" Value="30"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Focusable" Value="True"/>
+            <Setter Property="Margin" Value="0,1"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="RadioButton">
+                    <Grid Background="Transparent">
+                        <Border x:Name="PillFill" CornerRadius="8" Opacity="0"
+                                Background="{DynamicResource TransparentPink20Brush}"/>
+                        <Border x:Name="PillBar" Width="3" CornerRadius="2" Margin="0,5"
+                                HorizontalAlignment="Left" IsVisible="False"
+                                Background="{DynamicResource PinkBrush}"/>
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Margin="14,7,10,7" VerticalAlignment="Center"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+
+            <Style Selector="^:pointerover /template/ Border#PillFill">
+                <Setter Property="Opacity" Value="0.5"/>
+            </Style>
+            <Style Selector="^:pointerover">
+                <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#PillFill">
+                <Setter Property="Opacity" Value="1"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#PillBar">
+                <Setter Property="IsVisible" Value="True"/>
+            </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+            </Style>
+        </ControlTheme>
+
+    </UserControl.Resources>
+
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- ============================ page header ============================ -->
+        <Grid Grid.Row="0" Margin="4,2,4,14" ColumnDefinitions="Auto,*">
+            <TextBlock Grid.Column="0" Text="⚙️" FontSize="26" Margin="0,0,14,0" VerticalAlignment="Center"/>
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <TextBlock x:Name="TxtAppSettingsTitle" Text="{loc:Str set2_settings_title}"
+                           Foreground="White" FontSize="22" FontWeight="Bold"/>
+                <TextBlock Text="{loc:Str set2_settings_subtitle}"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="13"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- ====================== mini-rail + scrolling body ==================== -->
+        <Grid Grid.Row="1" ColumnDefinitions="Auto,*">
+
+            <!-- Table of contents. Fixed width, does not scroll with the body. -->
+            <Border Grid.Column="0" Width="186" Margin="0,0,16,0" VerticalAlignment="Top"
+                    Background="{DynamicResource SurfaceBgBrush}" BorderBrush="#2A2A46"
+                    BorderThickness="1" CornerRadius="12" Padding="8,10">
+                <StackPanel>
+                    <TextBlock Text="{loc:Str set2_rail_hint}" Margin="14,0,10,8"
+                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               FontWeight="Bold" Opacity="0.85"/>
+
+                    <RadioButton x:Name="SectionPillGeneral" Tag="general" IsChecked="True"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueGeneralBrush}"/>
+                            <TextBlock Grid.Column="1" Text="🎀" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_general}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillAudio" Tag="audio"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueAudioBrush}"/>
+                            <TextBlock Grid.Column="1" Text="🔊" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_audio}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillDevices" Tag="devices"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueDevicesBrush}"/>
+                            <TextBlock Grid.Column="1" Text="📷" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_devices}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillPerformance" Tag="performance"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHuePerformanceBrush}"/>
+                            <TextBlock Grid.Column="1" Text="⚡" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_performance}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillNotifications" Tag="notifications"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueNotificationsBrush}"/>
+                            <TextBlock Grid.Column="1" Text="🔔" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_notifications}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <Border Height="1" Background="#2A2A46" Margin="10,7,10,7"/>
+
+                    <!-- EMI DESK. Sits between Notifications and Account: it is a companion
+                         preference, and it must NOT be last - the tail spacer at the bottom of the
+                         section stack is sized off the LAST section's height, and Updates is the
+                         one it was measured against. -->
+                    <RadioButton x:Name="SectionPillEmidesk" Tag="emidesk"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueEmiDeskBrush}"/>
+                            <TextBlock Grid.Column="1" Text="📺" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_emidesk}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillAccount" Tag="account"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueAccountBrush}"/>
+                            <TextBlock Grid.Column="1" Text="💖" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_account}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillData" Tag="data"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueDataBrush}"/>
+                            <TextBlock Grid.Column="1" Text="💾" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_data}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+
+                    <RadioButton x:Name="SectionPillUpdates" Tag="updates"
+                                 Theme="{StaticResource SectionPill}">
+                        <Grid ColumnDefinitions="Auto,Auto,*">
+                            <Ellipse Width="8" Height="8" Margin="0,0,8,0" VerticalAlignment="Center"
+                                     Fill="{StaticResource SectionHueUpdatesBrush}"/>
+                            <TextBlock Grid.Column="1" Text="⬆️" FontSize="12" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{loc:Str set2_section_updates}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </Grid>
+                    </RadioButton>
+                </StackPanel>
+            </Border>
+
+            <!-- The page itself. Sections are always instantiated (ground rule §2.3)
+                 and always in this stack, in rail order. -->
+            <ScrollViewer x:Name="SectionScroll" Grid.Column="1"
+                          VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                          Padding="0,0,10,0">
+                <StackPanel x:Name="SectionStack">
+                    <appset:GeneralSettingsSection       x:Name="SectionGeneral"       Margin="0,0,0,10"/>
+                    <appset:AudioSettingsSection         x:Name="SectionAudio"         Margin="0,0,0,10"/>
+                    <appset:DevicesSettingsSection       x:Name="SectionDevices"       Margin="0,0,0,10"/>
+                    <appset:PerformanceSettingsSection   x:Name="SectionPerformance"   Margin="0,0,0,10"/>
+                    <appset:NotificationsSettingsSection x:Name="SectionNotifications" Margin="0,0,0,10"/>
+                    <appset:EmiDeskSettingsSection       x:Name="SectionEmidesk"       Margin="0,0,0,10"/>
+                    <appset:AccountSettingsSection       x:Name="SectionAccount"       Margin="0,0,0,10"/>
+                    <appset:DataSettingsSection          x:Name="SectionData"          Margin="0,0,0,10"/>
+                    <appset:UpdatesSettingsSection       x:Name="SectionUpdates"       Margin="0,0,0,10"/>
+
+                    <!-- Tail room so the last section can actually reach the top of the
+                         viewport when its pill is clicked. Without it "Updates" scrolls
+                         to wherever the content ends and the pill lies about where you are.
+                         The requirement is  spacer >= viewportHeight - heightOf(Updates);
+                         300 + ~415 covers the common maximised case. Transparent, so
+                         over-sizing costs nothing on a short window. -->
+                    <Border x:Name="SectionTailSpacer" Height="300" Background="Transparent"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Tabs/AppSettingsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AppSettingsTabView.axaml.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
+{
+    /// <summary>
+    /// Opt-in refresh hook for a Settings section. <see cref="Views.Tabs.AppSettingsTabView"/>
+    /// calls <see cref="OnSectionShown"/> on every section that implements this whenever the
+    /// Settings door is opened, so sections that have to re-read live state (device lists,
+    /// login cards, update status) get a seam without ShowTab knowing their names.
+    ///
+    /// ponytail: no ported section declares this interface yet - they carry a public
+    /// OnSectionShown() but not the `: IAppSettingsSection` - and a port may only add files
+    /// under Views/. So <see cref="Views.Tabs.AppSettingsTabView.RefreshSections"/> is a no-op
+    /// today; it starts working the moment a section adds the interface, with no change here.
+    /// </summary>
+    public interface IAppSettingsSection
+    {
+        /// <summary>Called on the UI thread each time the Settings door becomes visible.</summary>
+        void OnSectionShown();
+    }
+}
+
+namespace ConditioningControlPanel.Avalonia.Views.Tabs
+{
+    /// <summary>
+    /// The Settings door (tab key <c>appsettings</c>), PORTED from
+    /// ConditioningControlPanel/Views/Tabs/AppSettingsTabView.xaml.cs. A single scrolling page of
+    /// nine sections plus a left mini-rail that acts as its table of contents.
+    ///
+    /// <para><b>This file is the host only.</b> It owns the rail, the scroll, and
+    /// <see cref="FocusSection"/> - all view state, all ported for real. It owns no settings
+    /// logic; every control lives in its section UserControl under
+    /// <c>Views/Controls/AppSettings/</c>, already on this head.</para>
+    ///
+    /// <para>WPF -&gt; Avalonia API mapping in this file:
+    /// <c>TransformToAncestor(a).Transform(p).Y</c> -&gt; <c>TranslatePoint(p, a)?.Y</c>,
+    /// <c>ScrollToVerticalOffset(y)</c> -&gt; <c>Offset.WithY(y)</c>,
+    /// <c>ActualHeight</c> -&gt; <c>Bounds.Height</c>,
+    /// <c>ScrollChangedEventArgs.VerticalChange</c> -&gt; <c>OffsetDelta.Y</c>,
+    /// <c>Dispatcher.BeginInvoke</c> -&gt; <c>Dispatcher.UIThread.Post</c>,
+    /// <c>Visibility != Visible</c> -&gt; <c>!IsVisible</c>.
+    /// The WPF <c>App.Logger</c> calls are dropped: the logger is not on this head and the
+    /// catches exist to swallow, not to report.</para>
+    /// </summary>
+    public partial class AppSettingsTabView : UserControl
+    {
+        /// <summary>Rail order, and the only section keys <see cref="FocusSection"/> answers to.</summary>
+        internal static readonly string[] SectionKeys =
+        {
+            "general", "audio", "devices", "performance",
+            "notifications", "emidesk", "account", "data", "updates",
+        };
+
+        /// <summary>Guards the scroll-spy against re-checking a pill that is mid-click.</summary>
+        private bool _syncingPills;
+
+        public AppSettingsTabView()
+        {
+            InitializeComponent();
+
+            foreach (var key in SectionKeys)
+            {
+                var pill = PillFor(key);
+                if (pill != null) pill.Click += SectionPill_Click;
+            }
+            SectionScroll.ScrollChanged += SectionScroll_ScrollChanged;
+        }
+
+        // =====================================================================================
+        //  section lookup
+        // =====================================================================================
+
+        private Control? SectionElementFor(string? key) => (key ?? string.Empty).ToLowerInvariant() switch
+        {
+            "general" => SectionGeneral,
+            "audio" => SectionAudio,
+            "devices" => SectionDevices,
+            "performance" => SectionPerformance,
+            "notifications" => SectionNotifications,
+            "emidesk" => SectionEmidesk,
+            "account" => SectionAccount,
+            "data" => SectionData,
+            "updates" => SectionUpdates,
+            _ => null,
+        };
+
+        private RadioButton? PillFor(string? key) => (key ?? string.Empty).ToLowerInvariant() switch
+        {
+            "general" => SectionPillGeneral,
+            "audio" => SectionPillAudio,
+            "devices" => SectionPillDevices,
+            "performance" => SectionPillPerformance,
+            "notifications" => SectionPillNotifications,
+            "emidesk" => SectionPillEmidesk,
+            "account" => SectionPillAccount,
+            "data" => SectionPillData,
+            "updates" => SectionPillUpdates,
+            _ => null,
+        };
+
+        // =====================================================================================
+        //  public surface — what the shell calls
+        // =====================================================================================
+
+        /// <summary>
+        /// Scrolls the page to a section and lights its pill. An unknown key is a no-op rather
+        /// than a throw, because every caller is a navigation and none of them should be able to
+        /// break one. Valid keys: <see cref="SectionKeys"/>.
+        /// </summary>
+        internal void FocusSection(string? sectionKey)
+        {
+            try
+            {
+                var key = (sectionKey ?? string.Empty).ToLowerInvariant();
+                var target = SectionElementFor(key);
+                if (target == null || SectionScroll == null) return;
+
+                CheckPill(key);
+
+                // Layout first. On the first ever open the stack has never been measured and every
+                // section would transform to offset 0. UpdateLayout is synchronous; the deferred
+                // retry covers the case where the view is still hidden (nothing to measure yet).
+                if (!TryScrollTo(target))
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        try { TryScrollTo(SectionElementFor(key)); }
+                        catch { /* the retry is best-effort; a navigation must not throw */ }
+                    }, DispatcherPriority.Normal);
+                }
+            }
+            catch { /* see above */ }
+        }
+
+        /// <summary>
+        /// Per-open refresh: hands every section that implements <c>IAppSettingsSection</c> a
+        /// chance to re-read live state. One section throwing must not stop the rest, so each
+        /// call is guarded individually. See the interface's ponytail note: no ported section
+        /// declares it yet, so this is currently a no-op.
+        /// </summary>
+        internal void RefreshSections()
+        {
+            if (SectionStack == null) return;
+            foreach (var section in SectionStack.Children
+                                                .OfType<Controls.AppSettings.IAppSettingsSection>()
+                                                .ToList())
+            {
+                try { section.OnSectionShown(); }
+                catch { /* one bad section must not stop the other eight */ }
+            }
+        }
+
+        // =====================================================================================
+        //  rail behaviour
+        // =====================================================================================
+
+        private bool TryScrollTo(Control? target)
+        {
+            if (target == null || SectionScroll == null || SectionStack == null) return false;
+
+            SectionScroll.UpdateLayout();
+            if (SectionStack.Bounds.Height <= 0) return false;
+
+            var y = target.TranslatePoint(new Point(0, 0), SectionStack)?.Y;
+            if (y == null) return false;
+            SectionScroll.Offset = SectionScroll.Offset.WithY(Math.Max(0, y.Value - 4));
+            return true;
+        }
+
+        private void CheckPill(string key)
+        {
+            var pill = PillFor(key);
+            if (pill == null) return;
+            _syncingPills = true;
+            try { pill.IsChecked = true; }
+            finally { _syncingPills = false; }
+        }
+
+        private void SectionPill_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (sender is not RadioButton rb || rb.Tag is not string key) return;
+            FocusSection(key);
+        }
+
+        /// <summary>
+        /// Scroll spy: the rail follows the reader. No animation, no clock - it only ever moves
+        /// a checked state, which is why this is allowed on a quiet surface.
+        /// </summary>
+        private void SectionScroll_ScrollChanged(object? sender, ScrollChangedEventArgs e)
+        {
+            if (_syncingPills || Math.Abs(e.OffsetDelta.Y) < 0.5) return;
+            if (SectionScroll == null || SectionStack == null) return;
+            try
+            {
+                var offset = SectionScroll.Offset.Y + 24;
+                string? current = null;
+                foreach (var key in SectionKeys)
+                {
+                    var el = SectionElementFor(key);
+                    if (el == null || !el.IsVisible) continue;
+                    var y = el.TranslatePoint(new Point(0, 0), SectionStack)?.Y;
+                    if (y == null) continue;
+                    if (y <= offset) current = key; else break;
+                }
+                if (current != null) CheckPill(current);
+            }
+            catch { /* the spy is cosmetic; never let it break a scroll */ }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/HapticsSetupWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/HapticsSetupWindow.axaml
@@ -1,0 +1,269 @@
+<!-- PORTED from ConditioningControlPanel/Windows/HapticsSetupWindow.xaml.
+     Structure, order, spacing, every x:Name and every resource key are preserved so the two
+     diff cleanly. Deviations, all forced:
+
+       WindowStyle="None" / ResizeMode="NoResize"  -> SystemDecorations="None" / CanResize="False"
+       AllowsTransparency="True"                   -> TransparencyLevelHint="Transparent" plus
+                                                      Background="Transparent" (the outer Border
+                                                      still paints DarkerBgBrush)
+       Visibility="Collapsed"                      -> IsVisible="False"
+       Content="{loc:Str ...}" on a Button         -> a TextBlock child (CLAUDE.md trap 1: Avalonia
+                                                      parses "_" in Content as an access key and
+                                                      every key here is snake_case)
+       Click="..."                                 -> wired in the constructor
+       pack:// guide screenshots                   -> placeholder frames, see the ponytail note
+       DataTemplate {Binding}                      -> same, with x:DataType="sys:String" because
+                                                      compiled bindings are on -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:sys="using:System"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.HapticsSetupWindow"
+        Title="{loc:Str dialog_haptics_setup_guide}" Height="720" Width="520"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="False">
+
+    <!-- Wizard v2: this used to be a read-only slideshow. It now WRITES the v2 provider
+         flags + the Lovense address and runs the real Connect, with live progress, the
+         resulting device list and an actionable error. On this head the writing and the
+         connecting are stubs (see the code-behind); the three pages, the chrome and the
+         device list are what is proved here. -->
+    <Border CornerRadius="12" Background="{DynamicResource DarkerBgBrush}"
+            BorderBrush="{DynamicResource SecondaryBrush}" BorderThickness="2">
+        <Grid RowDefinitions="Auto,*,Auto">
+
+            <!-- Header -->
+            <Grid Grid.Row="0" Background="{DynamicResource PanelBgBrush}" ColumnDefinitions="*,Auto">
+                <StackPanel Orientation="Horizontal" Margin="15,10">
+                    <TextBlock x:Name="TxtTitle" Text="{loc:Str dialog_haptics_setup_guide}"
+                               Foreground="{DynamicResource PinkBrush}" FontSize="18" FontWeight="Bold"/>
+                </StackPanel>
+                <Button x:Name="BtnClose" Grid.Column="1" Width="30" Height="30"
+                        Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                        BorderThickness="0" FontSize="14" Cursor="Hand"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Margin="0,5,10,5">
+                    <TextBlock Text="X"/>
+                </Button>
+            </Grid>
+
+            <!-- Content -->
+            <Grid Grid.Row="1" Margin="20,16">
+
+                <!-- ===================== PAGE 1: pick a provider ===================== -->
+                <Grid x:Name="ProviderPage" IsVisible="True">
+                    <StackPanel VerticalAlignment="Center">
+                        <TextBlock Text="{loc:Str wizard_pick_provider}" Foreground="White"
+                                   FontSize="16" HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                        <TextBlock Text="{loc:Str wizard_pick_provider_sub}" Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="12" TextAlignment="Center" TextWrapping="Wrap"
+                                   HorizontalAlignment="Center" MaxWidth="380" Margin="0,0,0,22"/>
+
+                        <Button x:Name="BtnSelectLovense" Width="330" Height="76" Margin="0,8"
+                                Background="#2D2D4A" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+                                Cursor="Hand" HorizontalContentAlignment="Left">
+                            <StackPanel Margin="14,0">
+                                <TextBlock Text="{loc:Str wizard_provider_lovense}" Foreground="{DynamicResource PinkBrush}"
+                                           FontSize="17" FontWeight="Bold"/>
+                                <TextBlock Text="{loc:Str wizard_provider_lovense_sub}" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" TextWrapping="Wrap" MaxWidth="290"/>
+                            </StackPanel>
+                        </Button>
+
+                        <Button x:Name="BtnSelectButtplug" Width="330" Height="76" Margin="0,8"
+                                Background="#2D2D4A" BorderBrush="{DynamicResource SecondaryBrush}" BorderThickness="2"
+                                Cursor="Hand" HorizontalContentAlignment="Left">
+                            <StackPanel Margin="14,0">
+                                <TextBlock Text="{loc:Str wizard_provider_intiface}" Foreground="{DynamicResource SecondaryBrush}"
+                                           FontSize="17" FontWeight="Bold"/>
+                                <TextBlock Text="{loc:Str wizard_provider_intiface_sub}" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" TextWrapping="Wrap" MaxWidth="290"/>
+                            </StackPanel>
+                        </Button>
+
+                        <Button x:Name="BtnSelectMock" Width="330" Height="76" Margin="0,8"
+                                Background="#2D2D4A" BorderBrush="#4A4A6A" BorderThickness="2"
+                                Cursor="Hand" HorizontalContentAlignment="Left">
+                            <StackPanel Margin="14,0">
+                                <TextBlock Text="{loc:Str wizard_provider_mock}" Foreground="White"
+                                           FontSize="17" FontWeight="Bold"/>
+                                <TextBlock Text="{loc:Str wizard_provider_mock_sub}" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" TextWrapping="Wrap" MaxWidth="290"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+
+                <!-- ======================= PAGE 2: setup steps ======================= -->
+                <ScrollViewer x:Name="GuidePage" IsVisible="False" VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <!-- Lovense -->
+                        <StackPanel x:Name="LovenseGuide" IsVisible="False">
+                            <Border Background="{DynamicResource PinkBrush}" CornerRadius="4" Padding="8,4"
+                                    HorizontalAlignment="Left" Margin="0,0,0,10">
+                                <TextBlock Text="{loc:Str wizard_step_setup}" Foreground="White" FontWeight="Bold" FontSize="12"/>
+                            </Border>
+                            <TextBlock Text="{loc:Str wizard_lovense_title}" Foreground="White"
+                                       FontSize="16" FontWeight="Bold" Margin="0,0,0,6"/>
+                            <TextBlock Text="{loc:Str wizard_lovense_steps}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="13" LineHeight="20" Margin="0,0,0,12"/>
+                            <!-- ponytail: the four guide screenshots are pack:// resources in the WPF head and
+                                 this project ships no asset pipeline (the csproj includes Theme\**\*.xaml only,
+                                 and a port may not edit it). The frames are kept so the layout stays honest;
+                                 swap the placeholder for an Image when the PNGs become AvaloniaResource. -->
+                            <Border x:Name="ImgLovenseStep1" Background="#2D2D4A" CornerRadius="8" Padding="8"
+                                    Height="120" Margin="0,0,0,8">
+                                <TextBlock Text="lovense_step1.png" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border x:Name="ImgLovenseStep2" Background="#2D2D4A" CornerRadius="8" Padding="8"
+                                    Height="120" Margin="0,0,0,12">
+                                <TextBlock Text="lovense_step2.png" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+
+                            <TextBlock Text="{loc:Str wizard_lovense_ip_label}" Foreground="White"
+                                       FontSize="13" FontWeight="Bold" Margin="0,0,0,4"/>
+                            <TextBox x:Name="TxtWizardLovenseIp" Background="{DynamicResource DarkerBgBrush}"
+                                     Foreground="White" CaretBrush="{DynamicResource PinkBrush}"
+                                     BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1"
+                                     Padding="8,6" FontSize="14" FontFamily="Consolas, Courier New"/>
+                            <TextBlock Text="{loc:Str wizard_lovense_ip_hint}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,6,0,0"/>
+                            <TextBlock Text="{loc:Str wizard_lovense_wifi_tip}" TextWrapping="Wrap"
+                                       Foreground="#FFD700" FontSize="12" Margin="0,10,0,0"/>
+                        </StackPanel>
+
+                        <!-- Intiface -->
+                        <StackPanel x:Name="ButtplugGuide" IsVisible="False">
+                            <Border Background="{DynamicResource SecondaryBrush}" CornerRadius="4" Padding="8,4"
+                                    HorizontalAlignment="Left" Margin="0,0,0,10">
+                                <TextBlock Text="{loc:Str wizard_step_setup}" Foreground="White" FontWeight="Bold" FontSize="12"/>
+                            </Border>
+                            <TextBlock Text="{loc:Str wizard_intiface_title}" Foreground="White"
+                                       FontSize="16" FontWeight="Bold" Margin="0,0,0,6"/>
+                            <TextBlock Text="{loc:Str wizard_intiface_steps}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="13" LineHeight="20" Margin="0,0,0,12"/>
+                            <Border x:Name="ImgButtplugStep1" Background="#2D2D4A" CornerRadius="8" Padding="8"
+                                    Height="120" Margin="0,0,0,8">
+                                <TextBlock Text="buttplug_step1.png" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border x:Name="ImgButtplugStep2" Background="#2D2D4A" CornerRadius="8" Padding="8"
+                                    Height="120" Margin="0,0,0,12">
+                                <TextBlock Text="buttplug_step2.png" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="11" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <TextBlock Text="{loc:Str wizard_intiface_note}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11"/>
+                        </StackPanel>
+
+                        <!-- Mock -->
+                        <StackPanel x:Name="MockGuide" IsVisible="False">
+                            <Border Background="#4A4A6A" CornerRadius="4" Padding="8,4"
+                                    HorizontalAlignment="Left" Margin="0,0,0,10">
+                                <TextBlock Text="{loc:Str wizard_step_setup}" Foreground="White" FontWeight="Bold" FontSize="12"/>
+                            </Border>
+                            <TextBlock Text="{loc:Str wizard_mock_title}" Foreground="White"
+                                       FontSize="16" FontWeight="Bold" Margin="0,0,0,6"/>
+                            <TextBlock Text="{loc:Str wizard_mock_body}" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="13" LineHeight="20"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- ===================== PAGE 3: connect + test ===================== -->
+                <Grid x:Name="ConnectPage" IsVisible="False">
+                    <StackPanel VerticalAlignment="Top">
+                        <Border Background="{DynamicResource PinkBrush}" CornerRadius="4" Padding="8,4"
+                                HorizontalAlignment="Left" Margin="0,0,0,12">
+                            <TextBlock Text="{loc:Str wizard_step_connect}" Foreground="White" FontWeight="Bold" FontSize="12"/>
+                        </Border>
+
+                        <TextBlock x:Name="TxtConnectStatus" Text="{loc:Str wizard_connect_ready}" Foreground="White"
+                                   FontSize="15" FontWeight="Bold" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                        <ProgressBar x:Name="ConnectProgress" Height="4" IsIndeterminate="True"
+                                     IsVisible="False" Margin="0,0,0,12"
+                                     Foreground="{DynamicResource PinkBrush}" Background="#2D2D4A" BorderThickness="0"/>
+
+                        <Border x:Name="ConnectResultBox" Background="#2D2D4A" CornerRadius="8" Padding="14"
+                                IsVisible="False">
+                            <StackPanel>
+                                <TextBlock x:Name="TxtConnectResultTitle" Text="" Foreground="White"
+                                           FontSize="13" FontWeight="Bold" Margin="0,0,0,8" TextWrapping="Wrap"/>
+                                <ItemsControl x:Name="WizardDeviceList">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="sys:String">
+                                            <StackPanel Orientation="Horizontal" Margin="0,2">
+                                                <Ellipse Width="7" Height="7" Margin="0,0,8,0" VerticalAlignment="Center"
+                                                         Fill="{DynamicResource SuccessGreenBrush}"/>
+                                                <TextBlock Text="{Binding}" Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <TextBlock x:Name="TxtConnectHint" Text="" Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                                           TextWrapping="Wrap" Margin="0,6,0,0"/>
+                            </StackPanel>
+                        </Border>
+
+                        <Button x:Name="BtnWizardTestBuzz" IsVisible="False"
+                                HorizontalAlignment="Left" Margin="0,16,0,0"
+                                Background="{DynamicResource PinkBrush}" Foreground="White" BorderThickness="0"
+                                Padding="18,9" FontSize="13" FontWeight="Bold" Cursor="Hand">
+                            <TextBlock Text="{loc:Str wizard_test_buzz}"/>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Grid>
+
+            <!-- Footer -->
+            <Grid Grid.Row="2" Background="{DynamicResource PanelBgBrush}" ColumnDefinitions="*,Auto,*">
+
+                <Button x:Name="BtnPrevious"
+                        Grid.Column="0" HorizontalAlignment="Left"
+                        Background="#353555" Foreground="White"
+                        BorderThickness="0" Padding="20,10" Margin="15,10"
+                        FontSize="13" Cursor="Hand" IsVisible="False">
+                    <TextBlock Text="{loc:Str btn_previous}"/>
+                </Button>
+
+                <StackPanel x:Name="SlideIndicators" Grid.Column="1"
+                            Orientation="Horizontal" HorizontalAlignment="Center"
+                            VerticalAlignment="Center">
+                    <Ellipse x:Name="Dot1" Width="10" Height="10" Fill="{DynamicResource PinkBrush}" Margin="5,0"/>
+                    <Ellipse x:Name="Dot2" Width="10" Height="10" Fill="{DynamicResource PanelAccentBrush}" Margin="5,0"/>
+                    <Ellipse x:Name="Dot3" Width="10" Height="10" Fill="{DynamicResource PanelAccentBrush}" Margin="5,0"/>
+                </StackPanel>
+
+                <Button x:Name="BtnNext"
+                        Grid.Column="2" HorizontalAlignment="Right"
+                        Background="{DynamicResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" Padding="20,10" Margin="15,10"
+                        FontSize="13" Cursor="Hand" IsVisible="False">
+                    <TextBlock Text="{loc:Str btn_next}"/>
+                </Button>
+
+                <Button x:Name="BtnConnect"
+                        Grid.Column="2" HorizontalAlignment="Right"
+                        Background="{DynamicResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" Padding="20,10" Margin="15,10"
+                        FontSize="13" FontWeight="Bold" Cursor="Hand" IsVisible="False">
+                    <TextBlock Text="{loc:Str btn_connect}"/>
+                </Button>
+
+                <Button x:Name="BtnDone"
+                        Grid.Column="2" HorizontalAlignment="Right"
+                        Background="#00AA00" Foreground="White"
+                        BorderThickness="0" Padding="20,10" Margin="15,10"
+                        FontSize="13" Cursor="Hand" IsVisible="False">
+                    <TextBlock Text="{loc:Str btn_done}"/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/HapticsSetupWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/HapticsSetupWindow.axaml.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Haptics setup wizard v2, PORTED from ConditioningControlPanel/Windows/HapticsSetupWindow.xaml.cs.
+    ///
+    /// Three pages: pick a provider, follow the steps (and type the Lovense IP), then connect and
+    /// test. The navigation, the per-provider guide switching, the accent recolouring and the dot
+    /// indicators are all view state and are ported for real.
+    ///
+    /// What is NOT ported: everything that reaches a service. <c>App.Settings</c>,
+    /// <c>App.Haptics</c>, <c>App.Patreon</c>, <c>App.DailyFree</c> and <c>App.Mods</c> do not
+    /// exist on this head, so <see cref="ApplyProviderSettings"/>, the connect and the test buzz
+    /// are stubs and <see cref="AccentFor"/> uses the WPF fallback hexes. Each is marked.
+    ///
+    /// Strings that the WPF code-behind ASSIGNS to a control carrying <c>{loc:Str}</c> are bound
+    /// here instead (<see cref="BindLoc"/>): Avalonia keeps the XAML binding alive under a local
+    /// value, so a plain <c>.Text =</c> is undone on the next language change (CLAUDE.md).
+    /// </summary>
+    public partial class HapticsSetupWindow : Window
+    {
+        private enum WizardProvider { None, Lovense, Buttplug, Mock }
+        private enum Page { Provider = 1, Guide = 2, Connect = 3 }
+
+        private WizardProvider _provider = WizardProvider.None;
+        private Page _page = Page.Provider;
+        private bool _connected;
+
+        public HapticsSetupWindow()
+        {
+            InitializeComponent();
+
+            // ponytail: needs App.Settings (HapticsSettings.LovenseUrl), wired when it moves to Core.
+            TxtWizardLovenseIp.Text = "";
+
+            BtnClose.Click += (_, _) => Close();
+            BtnSelectLovense.Click += (_, _) => Select(WizardProvider.Lovense);
+            BtnSelectButtplug.Click += (_, _) => Select(WizardProvider.Buttplug);
+            BtnSelectMock.Click += (_, _) => Select(WizardProvider.Mock);
+            BtnPrevious.Click += (_, _) => BtnPrevious_Click();
+            BtnNext.Click += (_, _) => BtnNext_Click();
+            BtnConnect.Click += (_, _) => BtnConnect_Click();
+            BtnDone.Click += (_, _) => Close();
+            BtnWizardTestBuzz.Click += (_, _) => BtnWizardTestBuzz_Click();
+
+            UpdateChrome();
+        }
+
+        // ------------------------------------------------------------------ page 1
+
+        private void Select(WizardProvider provider)
+        {
+            _provider = provider;
+            _page = Page.Guide;
+            UpdateChrome();
+        }
+
+        // ------------------------------------------------------------------ nav
+
+        private void BtnPrevious_Click()
+        {
+            if (_page == Page.Guide) { _provider = WizardProvider.None; _page = Page.Provider; }
+            else if (_page == Page.Connect) _page = Page.Guide;
+            UpdateChrome();
+        }
+
+        private void BtnNext_Click()
+        {
+            if (_page != Page.Guide) return;
+
+            // Commit the choice before the connect page so a user who bails out mid-wizard still
+            // ends up with the provider they picked enabled on the tab.
+            ApplyProviderSettings();
+            _page = Page.Connect;
+            UpdateChrome();
+        }
+
+        /// <summary>Writes the v2 provider flags plus the Lovense address in the WPF head.</summary>
+        private void ApplyProviderSettings()
+        {
+            // ponytail: needs App.Settings (HapticsSettings.V2 provider flags, LovenseUrl) and
+            // Services.Haptics.HapticProviderType, wired when they move to Core.
+        }
+
+        // ------------------------------------------------------------------ page 3
+
+        private void BtnConnect_Click()
+        {
+            // ponytail: needs App.Haptics (ConnectAsync/ConnectedDevices), App.Patreon and
+            // App.DailyFree for the premium gate, wired when they move to Core. Until then the
+            // page shows a placeholder result so the device-list template is actually exercised.
+            // The real handler also has a failure path: ShowResult(false, "wizard_connect_failed",
+            // <"wizard_fail_hint_lovense" | "wizard_fail_hint_intiface" | "wizard_fail_hint_generic">,
+            // empty), and a premium gate on "gate_premium_locked" /
+            // "msg_haptic_feedback_patreon_only" — WPF's FailureHint(), not carried as dead code.
+            ApplyProviderSettings();
+            _connected = true;
+            ShowResult(true, "wizard_connect_ok", "wizard_connect_ok_hint",
+                       new[] { "Sample Toy (placeholder)", "Sample Toy 2 (placeholder)" });
+            UpdateChrome();
+        }
+
+        /// <summary>
+        /// Keys rather than strings, unlike the WPF original: the two TextBlocks it writes carry
+        /// {loc:Str} bindings, so they have to be re-bound, not assigned.
+        /// </summary>
+        private void ShowResult(bool success, string titleKey, string hintKey, IReadOnlyList<string> devices)
+        {
+            BindLoc(TxtConnectStatus, titleKey);
+            TxtConnectStatus.Foreground = success
+                ? (this.TryFindResource("SuccessGreenBrush", out var green) ? green as IBrush ?? Brushes.LimeGreen : Brushes.LimeGreen)
+                : new SolidColorBrush(Color.FromRgb(0xFF, 0x6B, 0x6B));
+
+            if (devices.Count > 0) BindLoc(TxtConnectResultTitle, "wizard_devices_found");
+            TxtConnectResultTitle.IsVisible = devices.Count > 0;
+            WizardDeviceList.ItemsSource = devices;
+            BindLoc(TxtConnectHint, hintKey);
+            ConnectResultBox.IsVisible = true;
+            BtnWizardTestBuzz.IsVisible = success;
+        }
+
+        private void BtnWizardTestBuzz_Click()
+        {
+            // ponytail: needs App.Haptics (TestAsync), wired when it moves to Core.
+            BindLoc(TxtConnectHint, "wizard_test_failed");
+        }
+
+        // ------------------------------------------------------------------ chrome
+
+        private void UpdateChrome()
+        {
+            ProviderPage.IsVisible = _page == Page.Provider;
+            GuidePage.IsVisible = _page == Page.Guide;
+            ConnectPage.IsVisible = _page == Page.Connect;
+
+            LovenseGuide.IsVisible = _provider == WizardProvider.Lovense;
+            ButtplugGuide.IsVisible = _provider == WizardProvider.Buttplug;
+            MockGuide.IsVisible = _provider == WizardProvider.Mock;
+
+            var accent = AccentFor(_provider);
+            BindLoc(TxtTitle, _provider switch
+            {
+                WizardProvider.Lovense => "label_lovense_setup_guide",
+                WizardProvider.Buttplug => "label_buttplug_io_setup_guide",
+                WizardProvider.Mock => "wizard_provider_mock",
+                _ => "dialog_haptics_setup_guide"
+            });
+            TxtTitle.Foreground = accent;
+            BtnNext.Background = accent;
+            BtnConnect.Background = accent;
+
+            BtnPrevious.IsVisible = _page != Page.Provider;
+            BtnNext.IsVisible = _page == Page.Guide;
+            BtnConnect.IsVisible = _page == Page.Connect && !_connected;
+            BtnDone.IsVisible = _page == Page.Connect && _connected;
+
+            var inactive = this.TryFindResource("PanelAccentBrush", out var pa) ? pa as IBrush ?? Brushes.Gray : Brushes.Gray;
+            Dot1.Fill = accent;
+            Dot2.Fill = (int)_page >= 2 ? accent : inactive;
+            Dot3.Fill = (int)_page >= 3 ? accent : inactive;
+        }
+
+        private static IBrush AccentFor(WizardProvider provider)
+        {
+            // ponytail: needs App.Mods (GetAccentColorHex/GetSecondaryColorHex), wired when it
+            // moves to Core. The hexes are the WPF fallbacks.
+            var hex = provider == WizardProvider.Buttplug ? "#9B59B6" : "#FF69B4";
+            try { return new SolidColorBrush(Color.Parse(hex)); }
+            catch { return Brushes.HotPink; }
+        }
+
+        /// <summary>
+        /// Re-binds a TextBlock to a loc key, the same binding {loc:Str} builds. Assigning .Text
+        /// over a {loc:Str} binding survives until the next language change and then reverts.
+        /// </summary>
+        private static void BindLoc(TextBlock target, string key) =>
+            target.Bind(TextBlock.TextProperty, new Binding($"[{key}]")
+            {
+                Source = LocalizationManager.Instance,
+                Mode = BindingMode.OneWay,
+            });
+    }
+}


### PR DESCRIPTION
925 lines. AppSettingsTabView is the host the four settings-section layers below plug into.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351