### PR TITLE
feat(avalonia): port RoadmapConfirmDialog, RoadmapStartDialog, WelcomeDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/RoadmapConfirmDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapConfirmDialog.axaml
@@ -1,0 +1,76 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/RoadmapConfirmDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None" -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="True"                  -> TransparencyLevelHint="Transparent"
+       helpers:EmojiTextBlock                     -> TextBlock (CLAUDE.md trap 3)
+       Button.Style + inline ControlTemplate      -> the button's own Background/CornerRadius plus
+                                                     Window.Styles :pointerover selectors on the
+                                                     .secondary / .primary classes, the same shape
+                                                     the sibling RoadmapDiaryDialog port uses
+       Click="..."                                -> wired in the constructor
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.RoadmapConfirmDialog"
+        Title="{loc:Str dialog_confirm_photo}"
+        Width="450" Height="280"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="False">
+
+    <Window.Styles>
+        <Style Selector="Button.secondary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+        </Style>
+        <Style Selector="Button.primary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#FF8DC7"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{StaticResource PinkBrush}" BorderThickness="2" CornerRadius="12">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,15">
+                <TextBlock Text="{loc:Str label_text_9}" FontSize="24" VerticalAlignment="Center"/>
+                <TextBlock Text="{loc:Str dialog_confirm_photo}" Foreground="{StaticResource PinkBrush}" FontSize="20"
+                           FontWeight="Bold" Margin="10,0,0,0" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Message Content -->
+            <StackPanel Grid.Row="1">
+                <TextBlock Text="{loc:Str label_does_this_photo_show_you_completing}" Foreground="#E0E0E0" FontSize="14"
+                           Margin="0,0,0,10"/>
+                <TextBlock x:Name="TxtStepTitle" Foreground="{StaticResource PinkBrush}" FontSize="16"
+                           FontWeight="Bold" TextWrapping="Wrap" Margin="0,0,0,15"/>
+                <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8" Padding="12">
+                    <TextBlock x:Name="TxtRequirement" Foreground="{DynamicResource TextMutedBrush}" FontSize="13"
+                               TextWrapping="Wrap"/>
+                </Border>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                <Button x:Name="BtnNo" Classes="secondary" Cursor="Hand" Margin="0,0,10,0"
+                        Background="{DynamicResource PanelAccentBrush}" Foreground="White"
+                        FontWeight="Bold" FontSize="13" Padding="18,12"
+                        BorderThickness="0" CornerRadius="6">
+                    <TextBlock Text="{loc:Str btn_no_choose_another}"/>
+                </Button>
+                <Button x:Name="BtnYes" Classes="primary" Cursor="Hand"
+                        Background="{StaticResource PinkBrush}" Foreground="White"
+                        FontWeight="Bold" FontSize="13" Padding="24,12"
+                        BorderThickness="0" CornerRadius="6">
+                    <TextBlock Text="{loc:Str btn_yes_submit}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/RoadmapConfirmDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapConfirmDialog.axaml.cs
@@ -1,0 +1,33 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Themed dialog for confirming photo submission.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/RoadmapConfirmDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result
+    ///    through <c>ShowDialog&lt;bool?&gt;</c>. <c>Confirmed</c> is kept as-is.
+    ///  - The Click handlers are wired in the constructor rather than in markup.
+    /// </summary>
+    public partial class RoadmapConfirmDialog : Window
+    {
+        public bool Confirmed { get; private set; }
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal RoadmapConfirmDialog()
+            : this("The Blank Slate", "A photo of your empty desk, taken from above.") { }
+
+        public RoadmapConfirmDialog(string stepTitle, string photoRequirement)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            this.FindControl<TextBlock>("TxtStepTitle")!.Text = $"\"{stepTitle}\"";
+            this.FindControl<TextBlock>("TxtRequirement")!.Text = photoRequirement;
+
+            this.FindControl<Button>("BtnNo")!.Click += (_, _) => { Confirmed = false; Close(false); };
+            this.FindControl<Button>("BtnYes")!.Click += (_, _) => { Confirmed = true; Close(true); };
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/RoadmapStartDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapStartDialog.axaml
@@ -1,0 +1,87 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/RoadmapStartDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None" -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="True"                  -> TransparencyLevelHint="Transparent"
+       helpers:EmojiTextBlock                     -> TextBlock (CLAUDE.md trap 3)
+       Button.Style + inline ControlTemplate      -> the button's own Background/CornerRadius plus
+                                                     Window.Styles :pointerover selectors on the
+                                                     .secondary / .primary classes, the same shape
+                                                     the sibling RoadmapDiaryDialog port uses
+       Click="..."                                -> wired in the constructor
+     Buttons carry a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.RoadmapStartDialog"
+        Title="{loc:Str dialog_start_step}"
+        Width="480" Height="340"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="False">
+
+    <Window.Styles>
+        <Style Selector="Button.secondary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentHoverBrush}"/>
+        </Style>
+        <Style Selector="Button.primary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="#FF8DC7"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{StaticResource PinkBrush}" BorderThickness="2" CornerRadius="12">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Margin="0,0,0,15">
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                    <!-- The WPF original binds {loc:Str label_text_9} here and then overwrites
+                         .Text from the code-behind. Avalonia keeps the binding alive under a local
+                         value, so the boss trophy would revert to 📷 on the next language change;
+                         the icon is set from code for both step types instead. -->
+                    <TextBlock x:Name="TxtStepIcon" FontSize="24" VerticalAlignment="Center"/>
+                    <TextBlock Text="{loc:Str label_ready_to_complete}" Foreground="{StaticResource PinkBrush}" FontSize="20"
+                               FontWeight="Bold" Margin="10,0,0,0" VerticalAlignment="Center"/>
+                </StackPanel>
+                <TextBlock x:Name="TxtStepTitle" Foreground="White" FontSize="16" FontWeight="SemiBold"
+                           Margin="0,5,0,0"/>
+            </StackPanel>
+
+            <!-- Content -->
+            <StackPanel Grid.Row="1">
+                <!-- Objective -->
+                <TextBlock Text="{loc:Str label_objective_2}" Foreground="{DynamicResource TextMutedBrush}" FontSize="12" Margin="0,0,0,5"/>
+                <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,15">
+                    <TextBlock x:Name="TxtObjective" Foreground="#E0E0E0" FontSize="13" TextWrapping="Wrap"/>
+                </Border>
+
+                <!-- Photo Requirement -->
+                <TextBlock Text="{loc:Str label_photo_required}" Foreground="{DynamicResource TextMutedBrush}" FontSize="12" Margin="0,0,0,5"/>
+                <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8" Padding="12">
+                    <TextBlock x:Name="TxtPhotoRequirement" Foreground="{DynamicResource TextMutedBrush}" FontSize="13" TextWrapping="Wrap"/>
+                </Border>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+                <Button x:Name="BtnCancel" Classes="secondary" Cursor="Hand" Margin="0,0,10,0"
+                        Background="{DynamicResource PanelAccentBrush}" Foreground="White"
+                        FontWeight="Bold" FontSize="13" Padding="24,12"
+                        BorderThickness="0" CornerRadius="6">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+                <Button x:Name="BtnStart" Classes="primary" Cursor="Hand"
+                        Background="{StaticResource PinkBrush}" Foreground="White"
+                        FontWeight="Bold" FontSize="13" Padding="24,12"
+                        BorderThickness="0" CornerRadius="6">
+                    <TextBlock Text="{loc:Str btn_select_photo}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/RoadmapStartDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapStartDialog.axaml.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Themed dialog for starting a roadmap step.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/RoadmapStartDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result
+    ///    through <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - The step icon is set from code for BOTH step types, not just Boss: see the comment in
+    ///    the .axaml for why the {loc:Str} binding cannot stay under it.
+    ///  - The Click handlers are wired in the constructor rather than in markup.
+    /// </summary>
+    public partial class RoadmapStartDialog : Window
+    {
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.</summary>
+        internal RoadmapStartDialog()
+            : this(new RoadmapStepDefinition("t1_step1", RoadmapTrack.EmptyDoll, 1, "The Blank Slate",
+                "Sit still for five minutes and let every thought drain away.",
+                "A photo of your empty desk, taken from above.")) { }
+
+        public RoadmapStartDialog(RoadmapStepDefinition stepDef)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // Set icon based on step type
+            this.FindControl<TextBlock>("TxtStepIcon")!.Text =
+                stepDef.StepType == RoadmapStepType.Boss ? "🏆" : Loc.Get("label_text_9");
+
+            this.FindControl<TextBlock>("TxtStepTitle")!.Text = stepDef.StepType == RoadmapStepType.Boss
+                ? $"BOSS: {stepDef.Title}"
+                : $"Step {stepDef.StepNumber}: {stepDef.Title}";
+
+            this.FindControl<TextBlock>("TxtObjective")!.Text = stepDef.Objective;
+            this.FindControl<TextBlock>("TxtPhotoRequirement")!.Text = stepDef.PhotoRequirement;
+
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
+            this.FindControl<Button>("BtnStart")!.Click += (_, _) => Close(true);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/WelcomeDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/WelcomeDialog.axaml
@@ -1,0 +1,109 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/WelcomeDialog.xaml. Deviations, all forced:
+       ResizeMode="NoResize" / WindowStyle="None" -> CanResize="False" / SystemDecorations="None"
+       AllowsTransparency="True"                  -> TransparencyLevelHint="Transparent"
+       Image + EmojiToImageSource converter       -> <TextBlock Text="💖"/> (CLAUDE.md trap 3)
+       Button.Style + inline ControlTemplate      -> the button's own Background/CornerRadius; the
+                                                     WPF IsMouseOver trigger set the SAME PinkBrush
+                                                     it already had, so there is no hover style to
+                                                     port - the Fluent default hover tint is
+                                                     overridden back to PinkBrush below so the
+                                                     button does not change colour, as in WPF
+       Click="..."                                -> wired in the constructor
+     The button carries a TextBlock child rather than Content (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.WelcomeDialog"
+        Title="{loc:Str dialog_welcome}"
+        Height="670" Width="520"
+        WindowStartupLocation="CenterScreen"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="False">
+
+    <Window.Styles>
+        <Style Selector="Button.begin:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="30">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title Bar with Pink Background -->
+            <Border Grid.Row="0" Background="{DynamicResource PinkBrush}" CornerRadius="8" Margin="-10,-10,-10,20" Padding="20,15">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <TextBlock Text="💖" FontSize="24" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                    <TextBlock Text="{loc:Str app_title}" Foreground="White" FontSize="22" FontWeight="Bold" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Welcome Message — text set in code-behind to interpolate the active mod's Affirmation -->
+            <TextBlock x:Name="TxtWelcomeHeading" Grid.Row="1"
+                       Foreground="{DynamicResource PinkBrush}" FontSize="26" FontWeight="Bold"
+                       HorizontalAlignment="Center" Margin="0,10,0,20"/>
+
+            <!-- Description -->
+            <StackPanel Grid.Row="2" Margin="0,0,0,20">
+                <TextBlock Foreground="#E0E0E0" FontSize="14" TextWrapping="Wrap" LineHeight="24" TextAlignment="Center">
+                    <Run Text="{loc:Str label_this_application_is_designed_to_enhance_your}"/>
+                </TextBlock>
+
+                <TextBlock Foreground="#E0E0E0" FontSize="14" TextWrapping="Wrap" LineHeight="24" TextAlignment="Center" Margin="0,15,0,0">
+                    <Run Text="{loc:Str label_features_unlock_as_you_level_up_through_use_s}"/>
+                </TextBlock>
+
+                <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8" Padding="15" Margin="0,20,0,0">
+                    <StackPanel>
+                        <TextBlock Foreground="#FFB347" FontSize="13" FontWeight="SemiBold" HorizontalAlignment="Center">
+                            <Run Text="{loc:Str label_tips}"/>
+                        </TextBlock>
+                        <TextBlock Foreground="{DynamicResource PinkBrush}" FontSize="12" TextWrapping="Wrap" TextAlignment="Center" Margin="0,8,0,0" FontWeight="SemiBold">
+                            <Run Text="{loc:Str label_click_the}"/>
+                            <Run Text=" ? " FontWeight="Bold" Foreground="White" Background="{DynamicResource PinkBrush}"/>
+                            <Run Text="{loc:Str label_button_in_the_top_bar_for_a_full_tutorial}"/>
+                        </TextBlock>
+                        <TextBlock Foreground="{DynamicResource TextMutedBrush}" FontSize="12" TextWrapping="Wrap" TextAlignment="Center" Margin="0,4,0,0">
+                            <Run Text="{loc:Str label_hover_over_any_setting_to_see_what_it_does}"/>
+                        </TextBlock>
+                        <TextBlock Foreground="{DynamicResource TextMutedBrush}" FontSize="12" TextWrapping="Wrap" TextAlignment="Center" Margin="0,4,0,0">
+                            <Run Text="{loc:Str label_add_videos_to_assets_videos_and_images_to_ass}"/>
+                        </TextBlock>
+                        <TextBlock Foreground="{DynamicResource TextMutedBrush}" FontSize="12" TextWrapping="Wrap" TextAlignment="Center" Margin="0,4,0,0">
+                            <Run Text="{loc:Str label_for_gaming_use_borderless_windowed_mode_for_o}"/>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+
+                <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8" Padding="15" Margin="0,20,0,0">
+                    <StackPanel>
+                        <TextBlock Foreground="#FFB347" FontSize="13" FontWeight="SemiBold" HorizontalAlignment="Center">
+                            <Run Text="{loc:Str label_performance_warning}"/>
+                        </TextBlock>
+                        <TextBlock Foreground="#FFB347" FontSize="12" TextWrapping="Wrap" TextAlignment="Center" Margin="0,8,0,0">
+                            <Run Text="{loc:Str label_running_many_features_especially_with_high_fr}"/>
+                            <LineBreak/>
+                            <Run Text="{loc:Str label_if_you_experience_performance_issues_on_low_e}"/>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+
+            <!-- Button -->
+            <Button x:Name="BtnBegin" Grid.Row="3" Classes="begin" Cursor="Hand"
+                    Background="{StaticResource PinkBrush}" Foreground="White"
+                    FontWeight="Bold" FontSize="16" Padding="40,16"
+                    BorderThickness="0" CornerRadius="8"
+                    HorizontalAlignment="Center">
+                <TextBlock Text="{loc:Str btn_let_s_begin}"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/WelcomeDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WelcomeDialog.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Welcome dialog shown on first launch.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/WelcomeDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(true)</c>.
+    ///  - <c>App.Mods.GetAffirmation()</c> and <c>App.Settings</c> are head services; both are
+    ///    ponytail stubs below.
+    /// </summary>
+    public partial class WelcomeDialog : Window
+    {
+        public WelcomeDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // ponytail: needs App.Mods.GetAffirmation(), wired when it moves to Core
+            this.FindControl<TextBlock>("TxtWelcomeHeading")!.Text = Loc.GetF("label_welcome", "Subject");
+
+            this.FindControl<Button>("BtnBegin")!.Click += (_, _) => Close(true);
+        }
+
+        /// <summary>
+        /// Show welcome dialog if user hasn't been welcomed yet.
+        /// </summary>
+        /// <returns>True if welcome was shown (first launch), false otherwise</returns>
+        public static bool ShowIfNeeded()
+        {
+            // ponytail: needs App.Settings (Welcomed flag + Save), wired when it moves to Core.
+            // Until then this never fires, so first launch shows nothing rather than showing it
+            // on every launch.
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
389 lines. The step-icon loc binding is dropped on purpose: Avalonia keeps a binding alive under a code-assigned Text, so the trophy would revert to the camera glyph on a language change.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351