### PR TITLE
feat(avalonia): port WhatsNewDialog, WarningDialog, EasterEggWindow

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/WarningDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/WarningDialog.axaml
@@ -1,0 +1,171 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/WarningDialog.xaml.
+     Structure, order, spacing and every x:Name / resource key preserved. Deviations, all forced:
+       inline <Button.Style> /
+         <CheckBox.Style>           -> keyed ControlThemes below; an Avalonia control cannot carry
+                                       an anonymous Style, and a property-only ControlTheme on a
+                                       templated control would draw nothing (CLAUDE.md trap 4), so
+                                       each carries a Template whose ContentPresenter binds
+                                       Content (trap 6)
+       ControlTemplate.Triggers     -> ^:pointerover / ^:disabled / ^:checked /template/ selectors
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" +
+         AllowsTransparency="True"  -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       Visibility="Collapsed"       -> IsVisible="False"
+       SizeToContent=
+         "{loc:Str btn_height}"     -> SizeToContent="Height". The WPF original ran a blanket
+                                       string-to-loc-key pass over its XAML and caught this
+                                       enum attribute by accident; btn_height is literally
+                                       "Height" in en.json, so the two are the same value. An
+                                       Avalonia enum property will not take a binding, and a
+                                       localized enum name would break in every other language.
+       Click="Handler"              -> wired in the constructor
+       Checked/Unchecked            -> ToggleButton.IsCheckedChanged, wired in the constructor
+       Content="{loc:Str …}"        -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case, trap 1)
+       TxtTitle / TxtMessage /
+         TxtConfirmLabel {loc:Str}  -> dropped; the ctor always assigns all three, and in Avalonia
+                                       a local value sits UNDER the binding and is undone on the
+                                       next language change - the caller's message would be
+                                       replaced by the design-time default. Dead after
+                                       construction in WPF too, so nothing is lost.
+       BtnCancel / BtnConfirm       -> gained HorizontalAlignment="Stretch" +
+                                       HorizontalContentAlignment="Center": WPF's Button filled
+                                       its Grid column by default, Avalonia's does not. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.WarningDialog"
+        Title="{loc:Str dialog_warning}"
+        SizeToContent="Height" MinHeight="340" MaxHeight="800" Width="620"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- The inline <CheckBox.Style> on ChkConfirm, template and triggers verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/WarningDialog.xaml:ChkConfirm inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="ConfirmCheckBox" TargetType="CheckBox">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Grid>
+                        <Border x:Name="border" Width="24" Height="24" CornerRadius="4"
+                                Background="{DynamicResource PanelBgBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" Cursor="Hand"/>
+                        <TextBlock x:Name="check" Text="✔" Foreground="{DynamicResource PinkBrush}" FontSize="16"
+                                   FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   IsVisible="False"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ TextBlock#check">
+                <Setter Property="IsVisible" Value="True"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#border">
+                <Setter Property="Background" Value="#3A2040"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The inline <Button.Style> on BtnCancel, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/WarningDialog.xaml:BtnCancel inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="CancelButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#303050"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The inline <Button.Style> on BtnConfirm, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/WarningDialog.xaml:BtnConfirm inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="ConfirmButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="#FF4757"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="24,14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}" Opacity="1">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#FF6B81"/>
+            </Style>
+            <Style Selector="^:disabled /template/ Border#border">
+                <Setter Property="Opacity" Value="0.4"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,18">
+                <TextBlock x:Name="TxtIcon" Text="⚠" FontSize="32" VerticalAlignment="Center" Margin="0,0,14,0"/>
+                <TextBlock x:Name="TxtTitle" Foreground="{DynamicResource PinkBrush}" FontSize="24" FontWeight="Bold" VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Message -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" MaxHeight="500">
+                <TextBlock x:Name="TxtMessage"
+                           Foreground="#E0E0E0" FontSize="15" TextWrapping="Wrap" LineHeight="22"
+                           VerticalAlignment="Top"/>
+            </ScrollViewer>
+
+            <!-- Confirmation Checkbox -->
+            <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,20,0,24">
+                <CheckBox x:Name="ChkConfirm" VerticalAlignment="Center" Theme="{StaticResource ConfirmCheckBox}"/>
+                <TextBlock x:Name="TxtConfirmLabel"
+                           Foreground="#FFB347" FontSize="14" Margin="12,0,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- Buttons -->
+            <Grid Grid.Row="3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Button x:Name="BtnCancel" Grid.Column="0" Margin="0,0,10,0" IsCancel="True"
+                        Theme="{StaticResource CancelButtonStyle}"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center">
+                    <TextBlock Text="{loc:Str btn_cancel}"/>
+                </Button>
+
+                <Button x:Name="BtnConfirm" Grid.Column="1" Margin="10,0,0,0" IsEnabled="False"
+                        Theme="{StaticResource ConfirmButtonStyle}"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center">
+                    <TextBlock Text="{loc:Str btn_enable_anyway}"/>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/WarningDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WarningDialog.axaml.cs
@@ -1,0 +1,90 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Dialogs/WarningDialog.xaml.cs. Deviations:
+    ///  - <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result through
+    ///    <c>ShowDialog&lt;bool?&gt;</c>. <c>Confirmed</c> is kept, so callers that read it after
+    ///    the await still work.
+    ///  - <c>Checked</c>/<c>Unchecked</c> become the single
+    ///    <c>ToggleButton.IsCheckedChanged</c> event, wired here rather than in markup.
+    ///  - <c>ShowDoubleWarning</c> becomes <c>ShowDoubleWarningAsync</c>: Avalonia's
+    ///    <c>ShowDialog</c> is awaitable and has no blocking form, so the call site awaits. The
+    ///    loc keys and their argument order are copied from the WPF original unchanged.
+    ///  - The three design-time <c>{loc:Str}</c> defaults are gone from the markup and live in the
+    ///    render constructor instead; see the header comment in the .axaml for why.
+    /// </summary>
+    public partial class WarningDialog : Window
+    {
+        private readonly CheckBox _chkConfirm;
+
+        public bool Confirmed { get; private set; }
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog.
+        /// Built through the same Loc.GetF calls ShowDoubleWarningAsync uses, so the render shows
+        /// the strings a real caller gets. The box is pre-ticked so the render proves the checked
+        /// half of ConfirmCheckBox's template and the enabled Confirm button.</summary>
+        internal WarningDialog() : this(
+            Loc.GetF("warning_enable_feature_title", "Lockdown Mode"),
+            Loc.GetF("warning_enable_feature_body", "Lockdown Mode",
+                     "• The app cannot be closed until the timer runs out.\n" +
+                     "• Settings are frozen for the whole session.\n" +
+                     "• There is no emergency exit once it starts."),
+            Loc.GetF("warning_enable_feature_confirm", "Lockdown Mode"))
+        {
+            _chkConfirm.IsChecked = true;
+        }
+
+        public WarningDialog(string title, string message, string confirmText = "I understand the risks")
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            this.FindControl<TextBlock>("TxtTitle")!.Text = title;
+            this.FindControl<TextBlock>("TxtMessage")!.Text = message;
+            this.FindControl<TextBlock>("TxtConfirmLabel")!.Text = confirmText;
+
+            _chkConfirm = this.FindControl<CheckBox>("ChkConfirm")!;
+            var btnConfirm = this.FindControl<Button>("BtnConfirm")!;
+
+            _chkConfirm.IsCheckedChanged += (_, _) => btnConfirm.IsEnabled = _chkConfirm.IsChecked == true;
+
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => BtnCancel_Click();
+            btnConfirm.Click += (_, _) => BtnConfirm_Click();
+        }
+
+        private void BtnCancel_Click()
+        {
+            Confirmed = false;
+            Close(false);
+        }
+
+        private void BtnConfirm_Click()
+        {
+            if (_chkConfirm.IsChecked == true)
+            {
+                Confirmed = true;
+                Close(true);
+            }
+        }
+
+        /// <summary>
+        /// Shows a double warning dialog for dangerous features
+        /// </summary>
+        public static async Task<bool> ShowDoubleWarningAsync(Window owner, string feature, string consequences)
+        {
+            var title = Loc.GetF("warning_enable_feature_title", feature);
+            var message = Loc.GetF("warning_enable_feature_body", feature, consequences);
+
+            var dialog = new WarningDialog(title, message, Loc.GetF("warning_enable_feature_confirm", feature))
+            {
+                Topmost = true
+            };
+
+            return await dialog.ShowDialog<bool?>(owner) == true && dialog.Confirmed;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Dialogs/WhatsNewDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/WhatsNewDialog.axaml
@@ -1,0 +1,119 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/WhatsNewDialog.xaml.
+     Structure, order, spacing and every x:Name / resource key preserved. Deviations, all forced:
+       inline <Button.Style>        -> keyed ControlThemes below; an Avalonia Button cannot carry
+                                       an anonymous Style, and a property-only ControlTheme would
+                                       draw nothing (CLAUDE.md trap 4), so both carry a Template
+                                       whose ContentPresenter binds Content (trap 6)
+       ControlTemplate.Triggers     -> ^:pointerover /template/ Border#border selectors
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" +
+         AllowsTransparency="True"  -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       Visibility="Collapsed"       -> IsVisible="False"
+       Click="Handler"              -> wired in the constructor
+       Content="{loc:Str btn_ok}"   -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case, trap 1)
+       BtnTour Content              -> a named <TextBlock> child (TourLabel) the ctor assigns,
+                                       for the same access-key reason
+       BtnOk/BtnTour gained no size hints: they sit in a right-aligned StackPanel and size to
+       their own Padding on both frameworks. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.WhatsNewDialog"
+        Title="{loc:Str label_what_s_new}"
+        Height="560" Width="520"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- The inline <Button.Style> on BtnTour, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/WhatsNewDialog.xaml:BtnTour inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="TourButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="22,12"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#33FF69B4"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The inline <Button.Style> on BtnOk, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Dialogs/WhatsNewDialog.xaml:BtnOk inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="OkButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Padding" Value="40,12"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#FF8DC7"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,18">
+                <TextBlock Text="{loc:Str label_text_10}" FontSize="28" Foreground="{DynamicResource PinkBrush}" VerticalAlignment="Center" Margin="0,0,14,0"/>
+                <TextBlock x:Name="TxtTitle" Foreground="{DynamicResource PinkBrush}" FontSize="22" FontWeight="Bold" VerticalAlignment="Center"/>
+            </StackPanel>
+
+            <!-- Notes (scrollable, fills remaining space) -->
+            <Border Grid.Row="1" Background="{DynamicResource PanelBgBrush}" CornerRadius="6" Padding="12" Margin="0,0,0,20">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <TextBlock x:Name="TxtNotes"
+                               Foreground="#C0C0C0" FontSize="13" TextWrapping="Wrap" LineHeight="20"/>
+                </ScrollViewer>
+            </Border>
+
+            <!-- Action row (always pinned at the bottom). The optional tour CTA sits to the LEFT
+                 of OK and is hidden unless the caller passed one, so a notes-only dialog is
+                 pixel-identical to the version before it existed. -->
+            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="BtnTour" IsVisible="False" Margin="0,0,10,0"
+                        Theme="{StaticResource TourButtonStyle}">
+                    <TextBlock x:Name="TourLabel"/>
+                </Button>
+                <Button x:Name="BtnOk" IsDefault="True" IsCancel="True"
+                        Theme="{StaticResource OkButtonStyle}">
+                    <TextBlock Text="{loc:Str btn_ok}"/>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/WhatsNewDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WhatsNewDialog.axaml.cs
@@ -1,0 +1,88 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// "What's New" dialog shown once after an update. Uses a fixed window size with a
+    /// scrollable notes region and a pinned OK button, so long patch notes can never push
+    /// the button off-screen (the old MessageBox-based version could — see ccp-bugs #427).
+    ///
+    /// <para>A release that moves things around can also hand the dialog a secondary CTA
+    /// (<paramref name="tourAction"/>) - v6.8's "Show me around (60s)" upgrade tour. The button
+    /// is hidden whenever no action is passed, so every other caller gets the dialog it
+    /// always got. Copy is hardcoded English by repo convention (Windows/FeatureIntroPopup).</para>
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Dialogs/WhatsNewDialog.xaml.cs. Deviations:
+    ///  - <c>DialogResult = true</c> becomes <c>Close(true)</c>; Avalonia carries the result
+    ///    through <c>ShowDialog&lt;bool?&gt;</c>.
+    ///  - <c>Visibility.Visible</c> becomes <c>IsVisible = true</c>.
+    ///  - <c>BtnTour.Content = text</c> becomes <c>TourLabel.Text = text</c>: the button holds a
+    ///    TextBlock so Avalonia does not eat an underscore as an access key.
+    ///  - <c>Dispatcher.BeginInvoke(..., DispatcherPriority.Normal)</c> becomes
+    ///    <c>Dispatcher.UIThread.Post(..., DispatcherPriority.Normal)</c>, the same queued post.
+    ///  - <c>App.Logger</c> lives in the WPF head, so the catch is a stub.</para>
+    /// </summary>
+    public partial class WhatsNewDialog : Window
+    {
+        private readonly Action? _tourAction;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the dialog,
+        /// with a tour action so the optional CTA is drawn too.</summary>
+        internal WhatsNewDialog() : this(
+            "v7.0.0 — The Spiral",
+            "• The Avalonia head now renders every ported view headless on Linux.\n" +
+            "• Companion overlays no longer stutter when the spiral is at full intensity.\n" +
+            "• Fixed a crash on startup when no audio device was present.\n" +
+            "• Session logs keep their history across an update.\n\n" +
+            "Thanks for sticking around. There is more coming.",
+            () => { })
+        { }
+
+        public WhatsNewDialog(string title, string notes,
+                              Action? tourAction = null, string? tourButtonText = null)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            this.FindControl<TextBlock>("TxtTitle")!.Text = title;
+            this.FindControl<TextBlock>("TxtNotes")!.Text = notes;
+
+            this.FindControl<Button>("BtnOk")!.Click += (_, _) => BtnOk_Click();
+
+            var btnTour = this.FindControl<Button>("BtnTour")!;
+            btnTour.Click += (_, _) => BtnTour_Click();
+
+            _tourAction = tourAction;
+            if (tourAction != null)
+            {
+                this.FindControl<TextBlock>("TourLabel")!.Text = string.IsNullOrWhiteSpace(tourButtonText)
+                    ? "Show me around (60s)"
+                    : tourButtonText;
+                btnTour.IsVisible = true;
+            }
+        }
+
+        private void BtnOk_Click() => Close(true);
+
+        private void BtnTour_Click()
+        {
+            Close(true);
+
+            // QUEUED, never called inline: Close() only starts the unwind, so invoking here would
+            // run the tour from inside this dialog's modal message loop - before ShowDialog()
+            // returns to the caller and before the caller's finally block releases
+            // IsStartupDialogShowing. A Normal-priority post runs after the whole call stack that
+            // opened us has finished, which is exactly what the tour needs.
+            var action = _tourAction;
+            if (action == null) return;
+            Dispatcher.UIThread.Post(() =>
+            {
+                // ponytail: needs App.Logger, wired when logging moves to Core
+                try { action(); }
+                catch (Exception) { /* the tour action threw */ }
+            }, DispatcherPriority.Normal);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/EasterEggWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/EasterEggWindow.axaml
@@ -1,0 +1,132 @@
+<!-- PORTED from ConditioningControlPanel/Windows/EasterEggWindow.xaml.
+     Structure, order, spacing, every Run and every resource key preserved - the rant is the
+     content, so it is copied character for character. Deviations, all forced:
+       inline <Button.Style>        -> a keyed ControlTheme below; an Avalonia Button cannot carry
+                                       an anonymous Style, and a property-only ControlTheme would
+                                       draw nothing (CLAUDE.md trap 4), so it carries a Template
+                                       whose ContentPresenter binds Content (trap 6)
+       ControlTemplate.Triggers     -> ^:pointerover /template/ Border#border selector. The WPF
+                                       trigger set Background to PinkBrush, the same value as the
+                                       base setter, so hover is a no-op there and here. Kept so
+                                       the two files still diff, not "fixed".
+       ResizeMode="NoResize"        -> CanResize="False"
+       WindowStyle="None" +
+         AllowsTransparency="True"  -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       Visibility="Collapsed"       -> IsVisible="False"
+       Click="Handler"              -> wired in the constructor; both buttons gained x:Names
+                                       (BtnCloseTop / BtnCloseFooter) so the ctor can find them
+       Content="{loc:Str btn_close_2}" -> a <TextBlock> child (Avalonia parses "_" in Content as an
+                                       access key and every loc key here is snake_case, trap 1)
+       FontFamily="Consolas, Courier New" kept verbatim; neither face exists on Linux, so Avalonia
+       falls back to the app's Inter. That is a font-availability fact, not a port decision. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.EasterEggWindow"
+        Title="..."
+        Height="650" Width="550"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- The inline <Button.Style> on the footer button, setters verbatim. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EasterEggWindow.xaml:footer button inline style, hoist when a second view needs it -->
+        <ControlTheme x:Key="FooterCloseButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Padding" Value="30,10"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="{StaticResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Close Button -->
+            <Button x:Name="BtnCloseTop" Grid.Row="0" Content="×"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}" FontSize="20"
+                    BorderThickness="0" Cursor="Hand" Margin="0,10,15,0"
+                    Padding="0"
+                    Width="30" Height="30"/>
+
+            <!-- Content -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="25,10,25,10">
+                <StackPanel>
+                    <TextBlock TextWrapping="Wrap" FontFamily="Consolas, Courier New" FontSize="12" LineHeight="20">
+                        <Run Foreground="{DynamicResource PinkBrush}" FontWeight="Bold">congrats.</Run>
+                        <LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">Either you were rlly bored, or u r a coder and looked trough the code, either way doesnt rlly matter, had to write a cupple of lines down.</Run>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">Its new year's eve, soon is midnight. I rlly wanted to drop the relese for the new year, but life never goes how we want i guess...</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">so here i am. 3 am now actually. drinking this piss warm bubbling water someone gave me for christmas, recycled trash gift just like how i felt my whole life. my cat is asleep on the keyboard, only thing breathing in this cold ass apartment. funny how people got so mad about v1. </Run>
+                        <Run Foreground="{DynamicResource PinkBrush}">'oh she used ai'</Run>
+                        <Run Foreground="{DynamicResource TextMutedBrush}"> </Run>
+                        <Run Foreground="{DynamicResource PinkBrush}">'oh its insecure'</Run>
+                        <Run Foreground="{DynamicResource TextMutedBrush}"> </Run>
+                        <Run Foreground="{DynamicResource PinkBrush}">'learn to code properly'</Run>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">. shut up. just shut up. you think i dont know? you think i dont know what it feels like to be told im doing it wrong? acting wrong being wrong? existing wrong?</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">i spent my whole life in a town where breathing the wrong way got you stared at or worse so sorry if my python script wasnt clean enough for your github standards or whatever. they tell you how to dress how to talk how to be a man how to not be a freak. and when you finally escape, when you finally find a way to make something... well i guess you know what, fuck it, doeesnt matter.</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">well guess what. i spent the whole winter holidays here alone. while everyone else is kissing someone or lighting fireworks i was here fixing spirals overlays getting stuck or clippin sprites on canvas. </Run>
+                        <Run Foreground="{DynamicResource PinkBrush}" FontWeight="SemiBold">i built this. me.</Run>
+                        <Run Foreground="{DynamicResource TextMutedBrush}"> yeah i used tools who cares? do you build a house with your bare hands?</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">if ur reading this, maybe you get it. maybe ur lonely too. maybe its just pretentious crap. Either way, here we are.</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource PinkBrush}">i made this beautiful thing out of spite and cheap champagne and sleepless nights, but i never felt so alive</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">so cheers. to 2026. to not letting anyone tell us who we are or how we should build our world.</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}">im gonna go pet my cat and pass out. Happy new year.</Run>
+                        <LineBreak/>
+                        <Run Foreground="{DynamicResource TextMutedBrush}"> Love you , whoever u are.</Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource PinkBrush}" FontSize="18">&#x2764;</Run>
+                        <Run Foreground="{DynamicResource PinkBrush}" FontSize="14"> :3 </Run>
+                        <LineBreak/><LineBreak/>
+                        <Run Foreground="{DynamicResource PinkBrush}" FontWeight="Bold" FontStyle="Italic">CodeBambi</Run>
+                    </TextBlock>
+                    <TextBlock x:Name="TxtReaderCount"
+                               FontFamily="Consolas, Courier New" FontSize="11"
+                               Foreground="#FF4444"
+                               Margin="0,15,0,5"
+                               HorizontalAlignment="Center"
+                               IsVisible="False"/>
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- Footer -->
+            <Border Grid.Row="2" Background="{DynamicResource PanelBgBrush}" CornerRadius="0,0,10,10" Padding="20,12">
+                <Button x:Name="BtnCloseFooter" Cursor="Hand" HorizontalAlignment="Center"
+                        Theme="{StaticResource FooterCloseButtonStyle}">
+                    <TextBlock Text="{loc:Str btn_close_2}"/>
+                </Button>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/EasterEggWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EasterEggWindow.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Windows/EasterEggWindow.xaml.cs. Deviations:
+    ///  - <c>Visibility.Visible</c> becomes <c>IsVisible = true</c>.
+    ///  - <c>Click="BtnClose_Click"</c> is wired here for both buttons.
+    ///  - The <c>readerCount = -1</c> default is gone and a separate <c>internal</c> render
+    ///    constructor takes its place: an optional parameter does not satisfy
+    ///    <c>Type.EmptyTypes</c>, so --render-all could not construct the window, and keeping both
+    ///    would let <c>new EasterEggWindow()</c> silently pick the sample count. Every caller in
+    ///    the WPF head passes a count (MainWindow.UiUpdates.cs:1966), so nothing is lost.
+    ///  - The reader-count string is an English literal in the WPF original - there is no loc key
+    ///    for it - so it is copied verbatim rather than invented.
+    /// </summary>
+    public partial class EasterEggWindow : Window
+    {
+        /// <summary>Render/design constructor: a sample count so --render-view draws the
+        /// otherwise-hidden reader line too.</summary>
+        internal EasterEggWindow() : this(1337) { }
+
+        public EasterEggWindow(int readerCount)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            if (readerCount > 0)
+            {
+                var txt = this.FindControl<TextBlock>("TxtReaderCount")!;
+                txt.Text = $"This rant has been read {readerCount} times";
+                txt.IsVisible = true;
+            }
+
+            this.FindControl<Button>("BtnCloseTop")!.Click += (_, _) => Close();
+            this.FindControl<Button>("BtnCloseFooter")!.Click += (_, _) => Close();
+        }
+    }
+}


### PR DESCRIPTION
639 lines. Inline WPF styles become keyed ControlThemes with real templates; the blocking ShowDialog becomes an async call, since Avalonia has no blocking dialog.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351