### PR TITLE
feat(avalonia): port RampRackPanel, SchedulerRackPanel, PinkRushPopup

### DIFF
--- a/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml
+++ b/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml
@@ -1,0 +1,75 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Studio/RampRackPanel.xaml.
+     Structure, ordering, spacing, every x:Name and every loc key preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       Style="{StaticResource X}"       ->  Theme="{StaticResource X}"
+       helpers:EmojiTextBlock           ->  TextBlock (Avalonia draws COLR/CPAL colour fonts
+                                            natively; CLAUDE.md trap 3)
+       Image + EmojiToImageSource       ->  TextBlock with the same glyph, size and opacity -
+                                            same trap 3. It was the only {Binding} on this view,
+                                            so no x:DataType is needed.
+       feat:AdaptiveSideArt.CollapseBelow -> dropped (WPF-head attached behaviour), same call as
+                                            Views/Features/SpiralFeatureControl.axaml.
+       x:FieldModifier="internal"       ->  dropped; x:Names kept. No host on this head pokes
+                                            those fields.
+
+     The hosted editor is the already-ported Views/Features/IntensityRampFeatureControl - this
+     panel is a frame, exactly as on WPF. Root stays a StackPanel and the direct UserControl
+     content: MainWindow.SessionFeatureLock.cs inserts the session-lock banner at index 0 of
+     ((Panel)content.Content).Children. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:feat="clr-namespace:ConditioningControlPanel.Avalonia.Views.Features"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Studio.RampRackPanel">
+
+    <StackPanel x:Name="StudioRampPanel">
+
+        <!-- HERO. Carries the help "?" that only the dead ProgressionTab copy ever had
+             (HelpContentService ships an "IntensityRamp" entry). -->
+        <Border Height="72" CornerRadius="16" Margin="0,0,0,10"
+                Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2">
+            <Grid ClipToBounds="True" ColumnDefinitions="*,Auto">
+                <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="16,0,10,0">
+                    <TextBlock Text="{loc:Str section_intensity_ramp}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str st4_ramp_hint}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+                </StackPanel>
+                <Button Grid.Column="1" x:Name="HelpBtnStudioRamp"
+                        Theme="{StaticResource HelpButtonStyle}" Tag="IntensityRamp"
+                        VerticalAlignment="Center" Margin="0,0,14,0"/>
+            </Grid>
+        </Border>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY. The settings column is capped (3*, MaxWidth 780) so
+             a slider stops being a ~1200px runway in the wide Studio detail pane, and the width
+             that buys back becomes ONE big art card instead of dead margin. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- The live control, verbatim: enable, duration, multiplier, curve,
+                     end-at-complete, and the five ramp links. -->
+                <feat:IntensityRampFeatureControl x:Name="RampHost"/>
+            </StackPanel>
+
+            <!-- SIDE CARD, no art: this feature has no plate in Resources/features and round 3
+                 invents no assets. The page's own glyph, huge and nearly transparent, on the
+                 section wash. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <TextBlock Text="&#x1F4C8;" FontSize="100" Opacity="0.18"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml.cs
@@ -1,0 +1,42 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
+{
+    /// <summary>
+    /// Studio rack entry <c>ramp</c>. Hosts the live
+    /// <see cref="Features.IntensityRampFeatureControl"/> (which owns every handler and writes
+    /// <c>App.Settings.Current</c> on the WPF head) and adds the help "?" that only the dead
+    /// ProgressionTab copy carried.
+    ///
+    /// <para>No service is touched from here on either head. The global ramp runs on MainWindow's
+    /// own <c>RampTimer_Tick</c>; the per-session ramp is <c>SessionEngine.UpdateRampingValues</c>.
+    /// Both read the settings the hosted control writes.</para>
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Views/Controls/Studio/RampRackPanel.xaml.cs.
+    /// Deviations: <c>ISettingsRebindable</c> / <c>RebindToCurrentSettings</c> are dropped - the
+    /// ported <see cref="Features.IntensityRampFeatureControl"/> has no settings hook to rebind
+    /// yet - and <c>OnLoaded</c> is gone with them, since its whole body was the help attach.</para>
+    /// </summary>
+    public partial class RampRackPanel : UserControl
+    {
+        /// <summary>
+        /// Bark key for <c>NotifyFeatureOpened</c>. Deliberately the same <c>"SchedulerRamp"</c>
+        /// the popup fired (the popup was one control for both halves) - it is the only
+        /// <c>feature_eq</c> value with rules in the mods' bark_rules.json.
+        /// See <see cref="SchedulerRackPanel.BarkFeatureKey"/>.
+        /// </summary>
+        internal const string BarkFeatureKey = "SchedulerRamp";
+
+        public RampRackPanel()
+        {
+            AvaloniaXamlLoader.Load(this);
+            // ponytail: needs Controls.HelpPopover.Attach + Services.HelpContentService
+            // .GetContent("IntensityRamp") on HelpBtnStudioRamp, wired when they move to Core.
+        }
+
+        /// <summary>The live control this panel hosts, for callers that need the real editor.</summary>
+        internal Features.IntensityRampFeatureControl Inner =>
+            this.FindControl<Features.IntensityRampFeatureControl>("RampHost")!;
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml
+++ b/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml
@@ -1,0 +1,82 @@
+<!-- PORTED from ConditioningControlPanel/Views/Controls/Studio/SchedulerRackPanel.xaml.
+     Structure, ordering, spacing, every x:Name and every loc key preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       Style="{StaticResource X}"       ->  Theme="{StaticResource X}"
+       helpers:EmojiTextBlock           ->  TextBlock (Avalonia draws COLR/CPAL colour fonts
+                                            natively; CLAUDE.md trap 3)
+       Image + EmojiToImageSource       ->  TextBlock with the same glyph, size and opacity -
+                                            same trap 3. It was the only {Binding} on this view,
+                                            so no x:DataType is needed.
+       feat:AdaptiveSideArt.CollapseBelow -> dropped (WPF-head attached behaviour), same call as
+                                            Views/Features/SpiralFeatureControl.axaml.
+       x:FieldModifier="internal"       ->  dropped; x:Names kept. No host on this head pokes
+                                            those fields.
+
+     WHY THIS IS A HOST AND NOT A REBUILD, unchanged from the WPF header: the hosted
+     Views/Features/SchedulerFeatureControl is the only editor for all nine scheduler settings;
+     rebuilding it here would create a second one. This panel adds only the help "?".
+
+     Root stays a StackPanel and the direct UserControl content: MainWindow.SessionFeatureLock.cs
+     inserts the session-lock banner at index 0 of ((Panel)content.Content).Children - so no
+     ScrollViewer here, the rack's detail host owns the scroller and the padding.
+
+     NOTHING here is SessionLock.Owned, deliberately: the scheduler decides when a session
+     begins, it prescribes no dose inside one. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:feat="clr-namespace:ConditioningControlPanel.Avalonia.Views.Features"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.Studio.SchedulerRackPanel">
+
+    <StackPanel x:Name="StudioSchedulerPanel">
+
+        <!-- HERO. Carries the rescued help button - HelpContentService already ships a full
+             "Scheduler" entry; it was unreachable from the moment the ProgressionTab went dark
+             until this button rescued it. -->
+        <Border Height="72" CornerRadius="16" Margin="0,0,0,10"
+                Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2">
+            <Grid ClipToBounds="True" ColumnDefinitions="*,Auto">
+                <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="16,0,10,0">
+                    <TextBlock Text="{loc:Str section_scheduler}" FontSize="17" FontWeight="Bold"
+                               Foreground="{StaticResource TextLightBrush}"/>
+                    <TextBlock Text="{loc:Str st4_scheduler_hint}" FontSize="11.5"
+                               Foreground="{StaticResource TextMutedBrush}"
+                               TextWrapping="Wrap" Margin="0,2,0,0"/>
+                </StackPanel>
+                <Button Grid.Column="1" x:Name="HelpBtnStudioScheduler"
+                        Theme="{StaticResource HelpButtonStyle}" Tag="Scheduler"
+                        VerticalAlignment="Center" Margin="0,0,14,0"/>
+            </Grid>
+        </Border>
+
+        <!-- VELVET KIT 2 · ROUND 3 · DENSITY. The settings column is capped (3*, MaxWidth 780) so
+             a slider stops being a ~1200px runway in the wide Studio detail pane, and the width
+             that buys back becomes ONE big art card instead of dead margin. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" MaxWidth="780"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0">
+                <!-- The live control, verbatim. Its own handlers write App.Settings and Save()
+                     on every edit (velvet-mosaic rule) on the WPF head. -->
+                <feat:SchedulerFeatureControl x:Name="SchedulerHost"/>
+            </StackPanel>
+
+            <!-- SIDE CARD, no art: this feature has no plate in Resources/features and round 3
+                 invents no assets. The page's own glyph, huge and nearly transparent, on the
+                 section wash. -->
+            <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                    BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                    Background="{StaticResource SectionHueStudioWashBrush}"
+                    VerticalAlignment="Stretch" MinHeight="200">
+                <TextBlock Text="&#x1F4C5;" FontSize="100" Opacity="0.18"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+        </Grid>
+
+    </StackPanel>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml.cs
@@ -1,0 +1,43 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
+{
+    /// <summary>
+    /// Studio rack entry <c>scheduler</c>. A host, not a rewrite: the settings logic lives in
+    /// <see cref="Features.SchedulerFeatureControl"/>, and this panel adds the help "?" that only
+    /// the dead ProgressionTab copy ever had.
+    ///
+    /// <para><b>Nothing here talks to a service.</b> On WPF the scheduler is driven entirely off
+    /// <c>App.Settings.Current</c>: <c>MainWindow.StartStop.cs SchedulerTimer_Tick</c> polls every
+    /// 30s and starts/stops the engine.</para>
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Views/Controls/Studio/SchedulerRackPanel.xaml.cs.
+    /// Deviations: <c>ISettingsRebindable</c> / <c>RebindToCurrentSettings</c> are dropped - the
+    /// ported <see cref="Features.SchedulerFeatureControl"/> has no settings hook to rebind yet -
+    /// and <c>OnLoaded</c> is gone with them, since its whole body was the help attach.</para>
+    /// </summary>
+    public partial class SchedulerRackPanel : UserControl
+    {
+        /// <summary>
+        /// Bark key for <c>BarkService.NotifyFeatureOpened</c>. The rack must keep firing the key
+        /// the popup path fired, and the popup that hosted Scheduler+Ramp was
+        /// <c>SchedulerRampFeatureControl</c> -> <c>"SchedulerRamp"</c>. That string is the
+        /// <c>feature_eq</c> value of a live rule in all three built-in mods' bark_rules.json;
+        /// deriving a key from THIS type's name would fire nothing. The ramp panel returns the
+        /// same key on purpose - one rule, two doors, cooldown handles the double-fire.
+        /// </summary>
+        internal const string BarkFeatureKey = "SchedulerRamp";
+
+        public SchedulerRackPanel()
+        {
+            AvaloniaXamlLoader.Load(this);
+            // ponytail: needs Controls.HelpPopover.Attach + Services.HelpContentService
+            // .GetContent("Scheduler") on HelpBtnStudioScheduler, wired when they move to Core.
+        }
+
+        /// <summary>The live control this panel hosts, for callers that need the real editor.</summary>
+        internal Features.SchedulerFeatureControl Inner =>
+            this.FindControl<Features.SchedulerFeatureControl>("SchedulerHost")!;
+    }
+}

--- a/CCP.Avalonia/Views/Windows/PinkRushPopup.axaml
+++ b/CCP.Avalonia/Views/Windows/PinkRushPopup.axaml
@@ -1,0 +1,88 @@
+<!-- PORTED from ConditioningControlPanel/Windows/PinkRushPopup.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"              -> SystemDecorations="None"
+       AllowsTransparency="True"       -> TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"           -> CanResize="False"
+       MouseLeftButtonDown="..."       -> PointerPressed, wired in the constructor
+       DropShadowEffect ShadowDepth=0  -> OffsetX="0" OffsetY="0"
+       Button.Style + IsMouseOver      -> Style Selector="Button.closeGlyph:pointerover" below,
+                                          same shape as Windows/AchievementPopup.axaml. The
+                                          local Foreground on the button outranks it, so it was
+                                          already dead in WPF and is dead here for the reason.
+       Skill art (pack:// PNG)         -> a "⚡" TextBlock. Resources/skills/*.png is not an
+                                          AvaloniaResource in this head; the glyph stands in,
+                                          same call as ItemUnlockedPopup's gift fallback.
+       CardBorder VerticalAlignment    -> "Top" with an explicit 130px height (150 window minus
+                                          the 2x10 margin). The WPF window is exactly card-sized
+                                          and never resizes, so pinning the card to its own
+                                          height is identical on the desktop - and it keeps the
+                                          render harness' 200px minimum window height from
+                                          stretching the card down the whole PNG.
+
+     The close button carries a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key (CLAUDE.md trap 1). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.PinkRushPopup"
+        Title="Pink Rush!"
+        Width="350" Height="150"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        Focusable="False"
+        CanResize="False"
+        WindowStartupLocation="Manual">
+
+    <Window.Styles>
+        <Style Selector="Button.closeGlyph:pointerover">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <!-- Fluent paints a hover plate behind the glyph that WPF's trigger-only style never had. -->
+        <Style Selector="Button.closeGlyph:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+    </Window.Styles>
+
+    <!-- 10px transparent margin so the pink glow has room to bleed: 350x150 window = 330x130 card -->
+    <Border Background="#E0151530" CornerRadius="12" BorderBrush="#FF1493" BorderThickness="2"
+            Margin="10" VerticalAlignment="Top" Height="130">
+        <Border.Effect>
+            <DropShadowEffect Color="#FF1493" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <Grid Margin="15" ColumnDefinitions="Auto,*">
+
+            <!-- Skill Image -->
+            <Border Grid.Column="0" Width="80" Height="80" Background="{DynamicResource DarkerBgBrush}"
+                    CornerRadius="8" Margin="0,0,15,0">
+                <TextBlock Text="&#x26A1;" FontSize="36"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+
+            <!-- Text Content -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <TextBlock x:Name="TxtPinkRushTitle" Text="⚡ PINK RUSH!" Foreground="#FF1493"
+                           FontWeight="Bold" FontSize="18" Margin="0,0,0,4"/>
+                <TextBlock x:Name="TxtPinkRushSubtitle" Text="3x XP for 60 seconds!" Foreground="{DynamicResource PinkBrush}"
+                           FontSize="13" Margin="0,0,0,6"/>
+                <TextBlock x:Name="TxtCountdown" Text="60s remaining" Foreground="{DynamicResource TextMutedBrush}"
+                           FontSize="12"/>
+            </StackPanel>
+
+            <!-- Close Button -->
+            <Button x:Name="BtnClose" Grid.Column="1" Classes="closeGlyph"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="24" Height="24" Margin="0,-5,-5,0" Padding="0"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand">
+                <TextBlock Text="✕"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/PinkRushPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/PinkRushPopup.axaml.cs
@@ -1,0 +1,143 @@
+using System;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Popup window shown when Pink Rush activates, with a live countdown timer.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/PinkRushPopup.xaml.cs. Deviations:
+    ///  - The constructor takes the boost's end time instead of reading
+    ///    <c>App.Settings.Current.PinkRushEndTime</c>: AppSettings lives in the WPF head and this
+    ///    project may not reference it. Call shape is <c>new PinkRushPopup(endTime)</c>.
+    ///  - <c>DoubleAnimation</c> on Opacity becomes a <see cref="DoubleTransition"/> plus a plain
+    ///    Opacity assignment - Avalonia animates through the property system, not a Storyboard.
+    ///  - <c>SystemParameters.WorkArea</c> becomes <c>Screens.Primary.WorkingArea</c>, populated
+    ///    only once the window has a handle, so placement moves to OnOpened.
+    ///  - <c>App.Logger</c> calls are dropped; there is no logger on this head yet.
+    /// </summary>
+    public partial class PinkRushPopup : Window
+    {
+        private const double FadeMs = 300;
+
+        private readonly DispatcherTimer _countdownTimer;
+        private readonly DateTime _endTime;
+        private readonly TextBlock _txtCountdown;
+
+        /// <summary>Render/design constructor: a sample 60s boost so --render-view can draw it.</summary>
+        internal PinkRushPopup() : this(DateTime.Now.AddSeconds(60))
+        {
+            // The fade-in cannot complete inside a headless render's two dispatcher passes, so the
+            // PNG would capture a fully transparent window. Skip the animation for the render.
+            Transitions = null;
+            Opacity = 1;
+        }
+
+        /// <param name="endTime">When the boost expires - <c>AppSettings.PinkRushEndTime</c> on WPF.</param>
+        public PinkRushPopup(DateTime endTime)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _endTime = endTime;
+            _txtCountdown = this.FindControl<TextBlock>("TxtCountdown")!;
+
+            // ponytail: needs App.Mods.GetPinkRushName()/GetPinkRushDescription() to override the
+            // title and subtitle per mod, wired when the mod registry moves to Core. The markup
+            // literals are the un-modded defaults, exactly as in the WPF original.
+
+            // ponytail: needs Helpers.PassiveToastWindow (Win32 WS_EX_NOACTIVATE), which kept this
+            // toast from stealing mouse capture from fullscreen games (ccp-bugs #1000), wired when
+            // a per-platform equivalent lands. ShowActivated="False" is the portable half.
+
+            _countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _countdownTimer.Tick += CountdownTimer_Tick;
+            _countdownTimer.Start();
+
+            // Update immediately
+            UpdateCountdown();
+
+            // Fade in
+            Transitions = new Transitions
+            {
+                new DoubleTransition { Property = OpacityProperty, Duration = TimeSpan.FromMilliseconds(FadeMs) }
+            };
+            Opacity = 0;
+            Loaded += (_, _) => Opacity = 1;
+
+            this.FindControl<Button>("BtnClose")!.Click += BtnClose_Click;
+            AddHandler(InputElement.PointerPressedEvent, Window_PointerPressed, handledEventsToo: false);
+        }
+
+        /// <summary>Bottom-right of the work area, or centred if the work area is unreadable.</summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            try
+            {
+                var workArea = Screens.Primary?.WorkingArea
+                    ?? throw new InvalidOperationException("no primary screen");
+
+                Position = new PixelPoint(
+                    workArea.Right - (int)Width - 20,
+                    workArea.Bottom - (int)Height - 20);
+            }
+            catch
+            {
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+        }
+
+        private void CountdownTimer_Tick(object? sender, EventArgs e) => UpdateCountdown();
+
+        private void UpdateCountdown()
+        {
+            var remaining = _endTime - DateTime.Now;
+            if (remaining.TotalSeconds <= 0)
+            {
+                _countdownTimer.Stop();
+                FadeOutAndClose();
+                return;
+            }
+
+            _txtCountdown.Text = $"{(int)remaining.TotalSeconds}s remaining";
+        }
+
+        private void FadeOutAndClose()
+        {
+            try
+            {
+                Opacity = 0;
+                DispatcherTimer.RunOnce(() => { try { Close(); } catch { /* already closing */ } },
+                    TimeSpan.FromMilliseconds(FadeMs));
+            }
+            catch
+            {
+                try { Close(); } catch { /* already closing */ }
+            }
+        }
+
+        private void BtnClose_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            _countdownTimer.Stop();
+            FadeOutAndClose();
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            _countdownTimer.Stop();
+            FadeOutAndClose();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _countdownTimer.Stop();
+            base.OnClosed(e);
+        }
+    }
+}


### PR DESCRIPTION
473 lines. Both racks host the feature editors ported in earlier layers.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351