### PR TITLE
feat(avalonia): port EmiMutePromptWindow, WebcamGazeTrackerWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiMutePromptWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiMutePromptWindow.axaml
@@ -1,0 +1,103 @@
+<!-- PORTED from ConditioningControlPanel/Windows/EmiDesk/EmiMutePromptWindow.xaml.
+     Structure, ordering, spacing and every colour literal preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" +
+                                                   TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                    -> CanResize="False"
+       <Style x:Key TargetType="Button">        -> <ControlTheme> with the SAME Template; the
+                                                   IsMouseOver trigger is a ^:pointerover selector
+       <ContentPresenter/>                      -> ContentPresenter Content="{TemplateBinding Content}"
+                                                   (CLAUDE.md trap 6 - a bare presenter draws nothing)
+       English literal Text/Content             -> {loc:Str <same key>}. The WPF original writes the
+                                                   literal in markup and overwrites it from the
+                                                   constructor with Loc.Get; on Avalonia a local
+                                                   .Text assignment survives a language change and
+                                                   the binding does not, so the five keys the
+                                                   constructor used move into the markup verbatim.
+
+     Buttons carry a TextBlock rather than a string Content: Avalonia parses "_" in Content as an
+     access key and every loc key here is snake_case. See the porting notes in CLAUDE.md.
+     The root Border is Top-aligned so SizeToContent="Height" still reads as a compact card under
+     the render harness, which forces a Height onto any window that declares none. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk.EmiMutePromptWindow"
+        Title="EMI"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        CanResize="False"
+        SizeToContent="Height"
+        Width="420"
+        WindowStartupLocation="CenterOwner">
+
+    <!--
+        The summon-time mute question. Deliberately self-contained: every brush is a literal, so it
+        cannot take a BAML EndOfStream from a cross-dictionary StaticResource lookup the way the
+        Velvet Kit work did. Three answers, no default button: the user has to say which.
+    -->
+    <Window.Resources>
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiMutePromptWindow.xaml:EmiPromptButton, hoist when a second view needs it -->
+        <ControlTheme x:Key="EmiPromptButton" TargetType="Button">
+            <Setter Property="Foreground" Value="#FFF2FA"/>
+            <Setter Property="Background" Value="#252542"/>
+            <Setter Property="BorderBrush" Value="#4A3A63"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="14,8"/>
+            <Setter Property="Margin" Value="6,0,0,0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Chrome">
+                <Setter Property="Background" Value="#33294F"/>
+                <Setter Property="BorderBrush" Value="#FF69B4"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="#1A1A2E" BorderBrush="#FF69B4" BorderThickness="1" CornerRadius="10"
+            VerticalAlignment="Top">
+        <StackPanel Margin="22,20,22,18">
+            <TextBlock x:Name="TxtTitle"
+                       Text="{loc:Str emi_desk_mute_prompt_title}"
+                       Foreground="#FF69B4"
+                       FontSize="15" FontWeight="SemiBold"
+                       Margin="0,0,0,8"/>
+            <TextBlock x:Name="TxtBody"
+                       Text="{loc:Str emi_desk_mute_prompt_body}"
+                       Foreground="#D8D2E8"
+                       FontSize="12.5"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,18"/>
+
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button x:Name="BtnDontAsk" Theme="{StaticResource EmiPromptButton}">
+                    <TextBlock Text="{loc:Str emi_desk_mute_prompt_dontask}"/>
+                </Button>
+                <Button x:Name="BtnKeep" Theme="{StaticResource EmiPromptButton}">
+                    <TextBlock Text="{loc:Str emi_desk_mute_prompt_keep}"/>
+                </Button>
+                <Button x:Name="BtnMute" Theme="{StaticResource EmiPromptButton}"
+                        Background="#3A2350" BorderBrush="#FF69B4">
+                    <TextBlock Text="{loc:Str emi_desk_mute_prompt_mute}"/>
+                </Button>
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiMutePromptWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiMutePromptWindow.axaml.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
+{
+    /// <summary>What the user said when asked whether to mute the avatar while EMI is out.</summary>
+    public enum EmiMuteChoice
+    {
+        /// <summary>Keep the avatar talking. Also what a dismissed dialog means.</summary>
+        Keep = 0,
+
+        /// <summary>Mute the avatar for this visit.</summary>
+        Mute = 1,
+
+        /// <summary>Mute, and stop asking. Persisted as <c>EmiDeskMuteDontAsk</c>.</summary>
+        DontAsk = 2
+    }
+
+    /// <summary>
+    /// The one question EMI Desk asks: two voices at once is the failure mode, so when she arrives
+    /// while something that talks is already switched on, the user picks which voice wins.
+    ///
+    /// Shown at most once per app session, and only when a talking feature is actually live. Closing
+    /// it without answering keeps the avatar: silence is never read as consent to being silenced.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/EmiDesk/EmiMutePromptWindow.xaml.cs. Deviations:
+    ///  - WPF's <c>_choice</c> field plus <c>DialogResult = true</c> collapses into
+    ///    <c>Close(choice)</c>: Avalonia carries the result through
+    ///    <c>ShowDialog&lt;EmiMuteChoice&gt;</c>, and a dismissed window yields default(TResult),
+    ///    which is <see cref="EmiMuteChoice.Keep"/> - the same "silence is not consent" answer.
+    ///  - The five <c>Loc.Get</c> assignments are gone; the same five keys are <c>{loc:Str}</c> in
+    ///    the markup, so a language change re-renders them (see the porting notes in CLAUDE.md).
+    ///  - The constructor is public rather than private: it is also the render constructor, and
+    ///    with no <c>Loc.Get</c> lines left there is nothing for a private one to guard.
+    ///  - <c>PreviewKeyDown</c> -> <c>KeyDown</c>, wired in the constructor per the porting
+    ///    convention. Avalonia has no preview phase and no button here handles Escape.
+    ///  - The try/catch around the answer is dropped with the thing it guarded: WPF's
+    ///    <c>DialogResult</c> setter throws when the window was not shown modally,
+    ///    <c>Close(object)</c> does not.
+    ///  - The namespace is the flat WPF one no longer: the WinRT <c>Windows</c>-shadowing trap the
+    ///    original's header describes is a WPF-head problem, and this head has no OCR service.
+    /// </summary>
+    public partial class EmiMutePromptWindow : Window
+    {
+        public EmiMutePromptWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            this.FindControl<Button>("BtnMute")!.Click += (_, _) => Close(EmiMuteChoice.Mute);
+            this.FindControl<Button>("BtnKeep")!.Click += (_, _) => Close(EmiMuteChoice.Keep);
+            this.FindControl<Button>("BtnDontAsk")!.Click += (_, _) => Close(EmiMuteChoice.DontAsk);
+
+            // Escape is "keep", matching a dismissed dialog. Never "mute": a reflex key press must not
+            // silence something the user did not choose to silence.
+            KeyDown += (_, e) => { if (e.Key == Key.Escape) Close(EmiMuteChoice.Keep); };
+        }
+
+        /// <summary>
+        /// Ask, modally. The safe default is leaving the app as it was, so every path that is not
+        /// an explicit answer - dismissing the window included - comes back
+        /// <see cref="EmiMuteChoice.Keep"/>.
+        /// </summary>
+        // ponytail: needs App.MainWindowRef for WPF's ownerless CenterScreen fallback, wired when
+        // the app shell moves to Core. Avalonia's ShowDialog requires an owner, so the caller
+        // passes the one it already has.
+        public static Task<EmiMuteChoice> Ask(Window owner) =>
+            new EmiMutePromptWindow().ShowDialog<EmiMuteChoice>(owner);
+    }
+}

--- a/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml
@@ -1,0 +1,79 @@
+<!-- PORTED from ConditioningControlPanel/Windows/WebcamGazeTrackerWindow.xaml.
+     Structure, ordering, spacing and every colour preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"        -> SystemDecorations="None"
+       ResizeMode="NoResize"     -> CanResize="False"
+       Visibility="Collapsed"    -> IsVisible="False"
+       DropShadowEffect          -> Avalonia.Media.DropShadowEffect; ShadowDepth="0" is
+                                    OffsetX/OffsetY="0", the rest copies verbatim
+       KeyDown/Loaded/Closed     -> wired in the constructor (Loaded becomes OnOpened)
+       Click="BtnErrorClose_Click" -> wired in the constructor, both buttons
+
+     The window carries no {loc:Str}: every string in the WPF original is a literal, and
+     inventing keys here would be worse than keeping them. Both Close buttons hold a
+     TextBlock rather than a string Content, per the access-key trap in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.WebcamGazeTrackerWindow"
+        Title="Gaze Tracker Test"
+        Background="#000000"
+        SystemDecorations="None"
+        WindowState="Maximized"
+        CanResize="False"
+        Topmost="True"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Canvas x:Name="DotCanvas">
+            <Ellipse x:Name="Dot" Width="36" Height="36" IsVisible="False">
+                <Ellipse.Fill>
+                    <RadialGradientBrush>
+                        <GradientStop Color="#FF80E0FF" Offset="0"/>
+                        <GradientStop Color="#FF00B0FF" Offset="0.6"/>
+                        <GradientStop Color="#FF005080" Offset="1"/>
+                    </RadialGradientBrush>
+                </Ellipse.Fill>
+                <Ellipse.Effect>
+                    <DropShadowEffect Color="#00B0FF" BlurRadius="30" OffsetX="0" OffsetY="0" Opacity="0.9"/>
+                </Ellipse.Effect>
+            </Ellipse>
+        </Canvas>
+
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,40,0,0">
+            <TextBlock Text="Gaze Tracker Test" Foreground="White"
+                       FontSize="22" FontWeight="Bold" HorizontalAlignment="Center"/>
+            <TextBlock Text="Look around the screen. The cyan dot should follow your gaze."
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="13" Margin="0,8,0,0" HorizontalAlignment="Center"/>
+            <TextBlock x:Name="TxtCoords" Text="" Foreground="#00B0FF" FontSize="12"
+                       Margin="0,4,0,0" HorizontalAlignment="Center" FontFamily="Consolas, Courier New"/>
+            <!-- Always-visible, mouse-clickable close. Lockdown's global keyboard hook swallows
+                 Escape/Alt+F4 (#528), so a key-based exit can strand the user inside this test
+                 window; a button click bypasses the keyboard hook entirely. -->
+            <Button x:Name="BtnClose" Padding="20,8" Margin="0,16,0,0"
+                    Background="#00B0FF" Foreground="Black" BorderThickness="0"
+                    FontWeight="Bold" Cursor="Hand"
+                    HorizontalAlignment="Center">
+                <TextBlock Text="✕ Close Test"/>
+            </Button>
+        </StackPanel>
+
+        <Border x:Name="ErrorPanel" IsVisible="False"
+                Background="#221A1A" BorderBrush="#FF4040" BorderThickness="2"
+                CornerRadius="10" Padding="24" HorizontalAlignment="Center" VerticalAlignment="Center"
+                MaxWidth="520">
+            <StackPanel>
+                <TextBlock Text="Tracker test unavailable" Foreground="#FF8080" FontSize="18"
+                           FontWeight="Bold" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtErrorDetail" Text="" Foreground="White" FontSize="13"
+                           Margin="0,12,0,16" TextWrapping="Wrap" HorizontalAlignment="Center"/>
+                <Button x:Name="BtnErrorClose" Padding="20,8"
+                        Background="#00B0FF" Foreground="Black" BorderThickness="0"
+                        FontWeight="Bold" Cursor="Hand"
+                        HorizontalAlignment="Center">
+                    <TextBlock Text="Close"/>
+                </Button>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Fullscreen black overlay with a single cyan dot that follows the user's
+    /// calibrated gaze in real time. Pure visualization — does not modify the
+    /// service or persist anything. Useful for eyeballing tracking precision
+    /// after calibration.
+    ///
+    /// Caller must ensure App.Webcam is running AND has a calibration loaded
+    /// (the dot's position comes from OnGazeMove, which only fires when a
+    /// homography is available).
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/WebcamGazeTrackerWindow.xaml.cs. Deviations:
+    ///  - Loaded -> <see cref="OnOpened"/>, and the KeyDown / Click handlers are wired in the
+    ///    constructor rather than in markup, per the porting convention.
+    ///  - <c>ActualWidth</c>/<c>ActualHeight</c> -> <c>Bounds.Width</c>/<c>Bounds.Height</c>.
+    ///  - <c>OnWebcamStateChanged</c> is gone with its <c>WebcamTrackingState</c> enum, which lives
+    ///    in the WPF head's Services/Webcam and may not be referenced from here.
+    ///  - <c>Window_Closed</c> only unsubscribed from the service, so it goes with the
+    ///    subscription; there is nothing left for it to do.
+    /// </summary>
+    public partial class WebcamGazeTrackerWindow : Window
+    {
+        private const int SmoothFrames = 5;     // small extra smoothing on top of the upstream iris-vector smoothing
+
+        private readonly Queue<Point> _smoothBuffer = new();
+
+        private readonly Canvas _dotCanvas;
+        private readonly Ellipse _dot;
+        private readonly TextBlock _txtCoords, _txtErrorDetail;
+        private readonly Border _errorPanel;
+
+        public WebcamGazeTrackerWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _dotCanvas = this.FindControl<Canvas>("DotCanvas")!;
+            _dot = this.FindControl<Ellipse>("Dot")!;
+            _txtCoords = this.FindControl<TextBlock>("TxtCoords")!;
+            _txtErrorDetail = this.FindControl<TextBlock>("TxtErrorDetail")!;
+            _errorPanel = this.FindControl<Border>("ErrorPanel")!;
+
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            this.FindControl<Button>("BtnErrorClose")!.Click += (_, _) => Close();
+            KeyDown += (_, e) => { if (e.Key == Key.Escape) Close(); };
+        }
+
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+
+            // ponytail: needs WebcamTrackingService (IsRunning / Calibration / OnGazeMove /
+            // OnTrackingStateChanged), wired when it moves to Core. With it back, this checks
+            // both preconditions, subscribes OnGazeMove and closes the window when the service
+            // stops. Without it there is no tracking to visualise, which is exactly the WPF
+            // original's first error path, so it takes that path verbatim.
+            ShowError("Webcam tracking is not running. Start tracking before opening the tracker test.");
+        }
+
+        /// <summary>
+        /// Pure view maths, kept intact: it averages the last <see cref="SmoothFrames"/> gaze
+        /// projections, clips the dot to the window and moves it. Unreachable until the service
+        /// above is back to raise it.
+        /// </summary>
+        private void OnGazeMove(Point screenPoint)
+        {
+            // OnGazeMove is marshalled onto the UI thread by the service (Service.Dispatch),
+            // so we can update UI directly.
+            _smoothBuffer.Enqueue(screenPoint);
+            while (_smoothBuffer.Count > SmoothFrames) _smoothBuffer.Dequeue();
+
+            double sumX = 0, sumY = 0;
+            foreach (var p in _smoothBuffer) { sumX += p.X; sumY += p.Y; }
+            double cx = sumX / _smoothBuffer.Count;
+            double cy = sumY / _smoothBuffer.Count;
+
+            // Clip to window bounds so the dot stays visible even when the
+            // homography projects the gaze slightly outside the display.
+            double w = Bounds.Width, h = Bounds.Height;
+            if (w <= 0 || h <= 0) return;
+            double dotW = _dot.Width, dotH = _dot.Height;
+            double left = Math.Max(0, Math.Min(w - dotW, cx - dotW / 2));
+            double top  = Math.Max(0, Math.Min(h - dotH, cy - dotH / 2));
+
+            Canvas.SetLeft(_dot, left);
+            Canvas.SetTop(_dot, top);
+            _dot.IsVisible = true;
+
+            _txtCoords.Text = $"x={cx,7:F1}  y={cy,7:F1}";
+        }
+
+        private void ShowError(string detail)
+        {
+            _dotCanvas.IsVisible = false;
+            _txtErrorDetail.Text = detail;
+            _errorPanel.IsVisible = true;
+        }
+    }
+}


### PR DESCRIPTION
360 lines. The mute prompt takes an owner window because Avalonia's ShowDialog requires one.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351