### PR TITLE
feat(avalonia): port TubeFitDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml
@@ -1,0 +1,260 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/TubeFitDialog.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" + TransparencyLevelHint
+       ResizeMode="NoResize"                    -> CanResize="False"
+       <Style x:Key TargetType>                 -> <ControlTheme x:Key TargetType>
+       Style="{StaticResource X}"               -> Theme="{StaticResource X}"
+       ControlTemplate.Triggers                 -> ^:pointerover / ^:checked selectors
+       bare <ContentPresenter/>                 -> Content/ContentTemplate TemplateBindings
+                                                   (Avalonia's presenter does not find its content)
+       MouseLeftButtonDown= / Click= / Checked= -> wired in the constructor
+       ValueChanged=                            -> RangeBase.ValueChanged, wired in the constructor
+       RenderTransformOrigin="0.5,0.5"          -> "50%,50%" (a bare pair is ABSOLUTE px, which
+                                                   would scale the avatar about its top-left)
+
+     Buttons and the mode pills carry a TextBlock child rather than Content: Avalonia parses "_"
+     in Content as an access key and every loc key here is snake_case. See CLAUDE.md.
+
+     The three Sliders gained Theme="{StaticResource PinkSlider}". The WPF original carries no
+     slider style because MainWindow.xaml:341 makes PinkSlider the IMPLICIT Slider style, and
+     Theme/Styles.xaml has only the keyed twin - without this they render in Fluent's blue, which
+     is not what the WPF dialog shows. Naming the key here is the smallest fix that does not touch
+     a file another layer owns; drop it if the implicit ControlTheme is ever added.
+
+     The two Image elements are placeholder Borders. tube.png / tube2.png and the four avatar
+     poses come from Services.ModResourceResolver (WPF head, pack:// URIs) and this head ships no
+     Resources/ PNGs yet - see the ponytail notes in the code-behind. Everything the dialog exists
+     to show (the nested-Viewbox tube geometry, the margin formulas, the scale transform and the
+     readouts) still runs against the placeholders. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.TubeFitDialog"
+        Title="{loc:Str tube_fit_title}"
+        Height="640" Width="760"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Window.Resources>
+        <!-- Attached/Detached pill. RadioButton (a ToggleButton) so the pair is mutually
+             exclusive for free; GroupName keeps them paired. -->
+        <ControlTheme x:Key="TubeFitModePill" TargetType="RadioButton">
+            <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Padding" Value="18,7"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="RadioButton">
+                    <Border x:Name="bd" Background="{DynamicResource PanelAccentBrush}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Opacity" Value="0.85"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#bd">
+                <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Foreground" Value="White"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- Flat pill button used by the bottom bar and the pose stepper -->
+        <ControlTheme x:Key="TubeFitButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PanelAccentBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Padding" Value="14,7"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Opacity" Value="0.85"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title Bar -->
+            <Border x:Name="TitleBar" Grid.Row="0" Background="{DynamicResource PanelBgBrush}" CornerRadius="12,12,0,0" Padding="20,12">
+                <Grid>
+                    <TextBlock Text="{loc:Str tube_fit_title}" Foreground="{DynamicResource PinkBrush}" FontSize="18" FontWeight="Bold"
+                               VerticalAlignment="Center"/>
+                    <Button x:Name="BtnClose" Content="X"
+                            HorizontalAlignment="Right" VerticalAlignment="Center"
+                            Background="Transparent" Foreground="{DynamicResource TextMutedBrush}" FontSize="16" FontWeight="Bold"
+                            BorderThickness="0" Cursor="Hand" Padding="8,2"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                            Width="30" Height="30"/>
+                </Grid>
+            </Border>
+
+            <!-- Main Content -->
+            <Grid Grid.Row="1" Margin="15,12,15,12">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="{loc:Str tube_fit_subtitle}"
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="12" TextWrapping="Wrap" Margin="0,0,0,10"/>
+
+                <!-- WYSIWYG preview. The nested Viewbox/Grid pair replicates the real tube window:
+                     the outer 780x1020 grid is the window rect (it clips, like the window bounds),
+                     the inner Viewbox + 780x1080 grid is the tube's ContentViewbox design canvas. -->
+                <Border Grid.Row="1" Grid.Column="0" Width="350" Height="458"
+                        ClipToBounds="True" Background="#10101E" CornerRadius="8">
+                    <Viewbox Stretch="Uniform">
+                        <Grid Width="780" Height="1020" ClipToBounds="True">
+                            <Viewbox Stretch="Uniform">
+                                <Grid Width="780" Height="1080" ClipToBounds="False">
+                                    <!-- Stands in for <Image x:Name="PreviewTube"/>. Its margin is
+                                         retargeted in code so the attached/detached switch moves the
+                                         tube exactly as swapping tube.png for tube2.png does. -->
+                                    <Border x:Name="PreviewTube" Width="330" Height="980"
+                                            HorizontalAlignment="Left" VerticalAlignment="Top"
+                                            CornerRadius="165" BorderThickness="10"
+                                            BorderBrush="{DynamicResource PinkBrush}">
+                                        <Border.Background>
+                                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                <GradientStop Color="#5520104A" Offset="0"/>
+                                                <GradientStop Color="#77402080" Offset="1"/>
+                                            </LinearGradientBrush>
+                                        </Border.Background>
+                                        <TextBlock x:Name="TxtTubeName" Foreground="#99FFFFFF" FontSize="34"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,44,0,0"/>
+                                    </Border>
+                                    <Border x:Name="PreviewAvatarBorder"
+                                            HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                                            RenderTransformOrigin="50%,50%">
+                                        <!-- Stands in for <Image x:Name="PreviewAvatar"/>, sized in
+                                             code to the uniform fit of a nominal source into the
+                                             198x306 legacy avatar box. -->
+                                        <Border x:Name="PreviewAvatar" CornerRadius="14"
+                                                BorderThickness="2" BorderBrush="#88FF69B4"
+                                                RenderTransformOrigin="50%,50%">
+                                            <Border.Background>
+                                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                                                    <GradientStop Color="#66FF69B4" Offset="0"/>
+                                                    <GradientStop Color="#66B478FF" Offset="1"/>
+                                                </LinearGradientBrush>
+                                            </Border.Background>
+                                            <TextBlock x:Name="TxtPoseGlyph" FontSize="96"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Border>
+                                    </Border>
+                                </Grid>
+                            </Viewbox>
+                        </Grid>
+                    </Viewbox>
+                </Border>
+
+                <!-- Controls -->
+                <StackPanel Grid.Row="1" Grid.Column="1" Margin="14,0,0,0">
+                    <!-- Attached / Detached -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+                        <RadioButton x:Name="RbAttached" GroupName="TubeFitMode" Theme="{StaticResource TubeFitModePill}"
+                                     Margin="0,0,8,0">
+                            <TextBlock Text="{loc:Str tube_fit_attached}"/>
+                        </RadioButton>
+                        <RadioButton x:Name="RbDetached" GroupName="TubeFitMode" Theme="{StaticResource TubeFitModePill}">
+                            <TextBlock Text="{loc:Str tube_fit_detached}"/>
+                        </RadioButton>
+                    </StackPanel>
+
+                    <!-- Avatar scale -->
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="{loc:Str tube_fit_scale}" Foreground="{DynamicResource TextLightBrush}" FontSize="13"/>
+                        <TextBlock x:Name="TxtScaleValue" HorizontalAlignment="Right" Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="13" FontWeight="SemiBold"/>
+                    </Grid>
+                    <Slider x:Name="SldScale" Theme="{StaticResource PinkSlider}" Minimum="0.1" Maximum="3.0" SmallChange="0.01" LargeChange="0.1"
+                            TickFrequency="0.01" IsSnapToTickEnabled="True"
+                            Margin="0,0,0,16"/>
+
+                    <!-- Horizontal offset -->
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="{loc:Str tube_fit_offset_x}" Foreground="{DynamicResource TextLightBrush}" FontSize="13"/>
+                        <TextBlock x:Name="TxtOffsetXValue" HorizontalAlignment="Right" Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="13" FontWeight="SemiBold"/>
+                    </Grid>
+                    <Slider x:Name="SldOffsetX" Theme="{StaticResource PinkSlider}" Minimum="-1000" Maximum="1000" SmallChange="1" LargeChange="10"
+                            TickFrequency="1" IsSnapToTickEnabled="True"
+                            Margin="0,0,0,16"/>
+
+                    <!-- Vertical offset -->
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="{loc:Str tube_fit_offset_y}" Foreground="{DynamicResource TextLightBrush}" FontSize="13"/>
+                        <TextBlock x:Name="TxtOffsetYValue" HorizontalAlignment="Right" Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="13" FontWeight="SemiBold"/>
+                    </Grid>
+                    <Slider x:Name="SldOffsetY" Theme="{StaticResource PinkSlider}" Minimum="-500" Maximum="500" SmallChange="1" LargeChange="10"
+                            TickFrequency="1" IsSnapToTickEnabled="True"
+                            Margin="0,0,0,18"/>
+
+                    <!-- Pose cycler -->
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                        <Button x:Name="BtnPrevPose" Theme="{StaticResource TubeFitButton}" Padding="10,5" Margin="0,0,8,0">
+                            <TextBlock Text="&#x25C0;"/>
+                        </Button>
+                        <TextBlock x:Name="TxtPose" Foreground="{DynamicResource TextLightBrush}" FontSize="13"
+                                   VerticalAlignment="Center" MinWidth="70" TextAlignment="Center"/>
+                        <Button x:Name="BtnNextPose" Theme="{StaticResource TubeFitButton}" Padding="10,5" Margin="8,0,0,0">
+                            <TextBlock Text="&#x25B6;"/>
+                        </Button>
+                    </StackPanel>
+
+                    <TextBlock x:Name="TxtImageInfo" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Bottom Bar -->
+            <Border Grid.Row="2" Background="{DynamicResource PanelBgBrush}" CornerRadius="0,0,12,12" Padding="15,10">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <Button x:Name="BtnSave" Theme="{StaticResource TubeFitButton}"
+                            Background="{DynamicResource PinkBrush}" Margin="0,0,10,0">
+                        <TextBlock Text="{loc:Str tube_fit_save}"/>
+                    </Button>
+                    <Button x:Name="BtnReset" Theme="{StaticResource TubeFitButton}" Foreground="#B084DC" Margin="0,0,10,0">
+                        <TextBlock Text="{loc:Str tube_fit_reset}"/>
+                    </Button>
+                    <Button x:Name="BtnCancel" Theme="{StaticResource TubeFitButton}">
+                        <TextBlock Text="{loc:Str tube_fit_cancel}"/>
+                    </Button>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
@@ -1,0 +1,360 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// "Tube Fit" editor — a WYSIWYG preview of how the ACTIVE mod's avatar PNG sits inside the
+    /// avatar tube, with an Attached/Detached switch and scale/offset sliders. The result is saved
+    /// as a per-mod user override (never into the mod itself) and the live tube window is
+    /// hot-refreshed.
+    ///
+    /// The preview replicates the real tube's geometry: the tube window is a 780x1020 rect holding a
+    /// Uniform Viewbox over a 780x1080 design canvas, so content renders at 1020/1080 and anything
+    /// outside the window rect is clipped. The nested Viewbox/Grid pair in the XAML mirrors that,
+    /// and the margin formulas below are copied from AvatarTubeWindow.ApplyTubeLayoutOffsets.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/TubeFitDialog.xaml.cs. Deviations:
+    ///  - <c>App.Settings</c> / <c>App.Mods</c> / <c>App.AvatarWindow</c> / <c>App.Logger</c>,
+    ///    <c>Services.ModResourceResolver</c>, <c>Services.AvatarPortraitLoader</c> and the
+    ///    <c>ModTubeLayout</c> model all live in the WPF head, so the load / save / reset paths are
+    ///    stubs and the five working values start at their defaults. Everything between them - the
+    ///    sliders, the mode switch, the margin maths, the transforms and the readouts - is the real
+    ///    ported logic and runs.
+    ///  - The two <c>Image</c> elements are placeholder Borders (the head ships no Resources/ PNGs);
+    ///    the avatar box is sized from <see cref="PlaceholderPixelWidth"/>/<see cref="PlaceholderPixelHeight"/>
+    ///    by the same uniform-fit formula the real readout uses.
+    ///  - WPF's <c>LayoutTransform</c> has no Avalonia twin on a plain control, so the avatar scale
+    ///    is a <c>RenderTransform</c> about the centre. It does not grow the parent Border, so a
+    ///    scaled avatar expands symmetrically rather than upward.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>; <c>MouseLeftButtonDown</c> ->
+    ///    <c>PointerPressed</c>; <c>RoutedPropertyChangedEventArgs&lt;double&gt;</c> ->
+    ///    <c>RangeBaseValueChangedEventArgs</c>; <c>TryFindResource</c> gains an out parameter.
+    /// </summary>
+    public partial class TubeFitDialog : Window
+    {
+        // Legacy avatar image box in design units (AvatarTubeWindow.xaml defaults for ImgAvatar).
+        private const double LegacyAvatarMaxWidth = 198;
+        private const double LegacyAvatarMaxHeight = 306;
+        private const double PortraitSizeScale = 0.88;   // matches AvatarTubeWindow.ApplyPortraitChrome
+        private const double PortraitRaisePx = 30;
+        private const double PortraitShiftX = 10;
+
+        // ponytail: nominal source size of the placeholder avatar, standing in for the real pose
+        // PNG's PixelWidth/PixelHeight. Delete both when ModResourceResolver moves to Core and the
+        // readout can ask the bitmap.
+        private const double PlaceholderPixelWidth = 512;
+        private const double PlaceholderPixelHeight = 768;
+
+        // Where the placeholder tube sits in the 780x1080 canvas, per mode. Chosen so the capsule
+        // is centred on the avatar column each margin formula below aims at (329.5 attached,
+        // 174.5 detached), which is what tube.png and tube2.png do with their own art.
+        private static readonly Thickness AttachedTubeMargin = new Thickness(165, 40, 0, 0);
+        private static readonly Thickness DetachedTubeMargin = new Thickness(10, 40, 0, 0);
+
+        // Working copy of the five tube-layout values. Committed to settings only on Save.
+        private int _offsetX;
+        private int _detachedOffsetX;
+        private double _scale = 1.0;
+        private int _offsetY;
+        private int _detachedOffsetY;
+
+        private bool _detachedMode;
+        private bool _suppressSliderEvents;
+
+        private readonly int _avatarSet;
+        private readonly bool _portraitMode;
+        private readonly string[] _poses = { "🧍", "🙋", "💃", "🧎" };
+        private int _poseIndex;
+
+        private readonly RadioButton _rbAttached;
+        private readonly RadioButton _rbDetached;
+        private readonly Slider _sldScale;
+        private readonly Slider _sldOffsetX;
+        private readonly Slider _sldOffsetY;
+        private readonly Border _previewTube;
+        private readonly Border _previewAvatarBorder;
+        private readonly Border _previewAvatar;
+        private readonly TextBlock _txtTubeName;
+        private readonly TextBlock _txtPoseGlyph;
+        private readonly TextBlock _txtScaleValue;
+        private readonly TextBlock _txtOffsetXValue;
+        private readonly TextBlock _txtOffsetYValue;
+        private readonly TextBlock _txtPose;
+        private readonly TextBlock _txtImageInfo;
+
+        public TubeFitDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // ponytail: needs App.Mods / App.Settings / Services.AvatarPortraitLoader, wired when
+            // they move to Core. Defaults are the first-run state: built-in mod, avatar set 1, no
+            // portrait manifest, attached tube.
+            _avatarSet = 1;
+            _portraitMode = false;
+
+            _rbAttached = this.FindControl<RadioButton>("RbAttached")!;
+            _rbDetached = this.FindControl<RadioButton>("RbDetached")!;
+            _sldScale = this.FindControl<Slider>("SldScale")!;
+            _sldOffsetX = this.FindControl<Slider>("SldOffsetX")!;
+            _sldOffsetY = this.FindControl<Slider>("SldOffsetY")!;
+            _previewTube = this.FindControl<Border>("PreviewTube")!;
+            _previewAvatarBorder = this.FindControl<Border>("PreviewAvatarBorder")!;
+            _previewAvatar = this.FindControl<Border>("PreviewAvatar")!;
+            _txtTubeName = this.FindControl<TextBlock>("TxtTubeName")!;
+            _txtPoseGlyph = this.FindControl<TextBlock>("TxtPoseGlyph")!;
+            _txtScaleValue = this.FindControl<TextBlock>("TxtScaleValue")!;
+            _txtOffsetXValue = this.FindControl<TextBlock>("TxtOffsetXValue")!;
+            _txtOffsetYValue = this.FindControl<TextBlock>("TxtOffsetYValue")!;
+            _txtPose = this.FindControl<TextBlock>("TxtPose")!;
+            _txtImageInfo = this.FindControl<TextBlock>("TxtImageInfo")!;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            this.FindControl<Border>("TitleBar")!.PointerPressed += TitleBar_PointerPressed;
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            _rbAttached.IsCheckedChanged += Mode_Checked;
+            _rbDetached.IsCheckedChanged += Mode_Checked;
+            _sldScale.ValueChanged += SldScale_ValueChanged;
+            _sldOffsetX.ValueChanged += SldOffsetX_ValueChanged;
+            _sldOffsetY.ValueChanged += SldOffsetY_ValueChanged;
+            this.FindControl<Button>("BtnPrevPose")!.Click += (_, _) => StepPose(-1);
+            this.FindControl<Button>("BtnNextPose")!.Click += (_, _) => StepPose(+1);
+            this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
+            this.FindControl<Button>("BtnReset")!.Click += (_, _) => BtnReset_Click();
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close();
+
+            LoadWorkingValues();
+
+            // Start on whatever state the real tube is in, so the preview matches what the user sees.
+            _suppressSliderEvents = true;
+            if (_detachedMode) _rbDetached.IsChecked = true; else _rbAttached.IsChecked = true;
+            _suppressSliderEvents = false;
+
+            PushSlidersFromWorkingValues();
+            UpdatePreview();
+        }
+
+        // ============================================================
+        // VALUE PLUMBING
+        // ============================================================
+
+        /// <summary>
+        /// ponytail: needs AppSettings.TubeLayoutOverridesByMod and ModManifest.TubeLayout (both
+        /// WPF-head models), wired when they move to Core. The clamps are the original's, so the
+        /// call site does not change when the real layout is handed in.
+        /// </summary>
+        private void LoadWorkingValues()
+        {
+            _offsetX = Math.Clamp(0, -1000, 1000);
+            _detachedOffsetX = Math.Clamp(0, -1000, 1000);
+            _scale = Math.Clamp(1.0, 0.1, 3.0);
+            _offsetY = Math.Clamp(0, -500, 500);
+            _detachedOffsetY = Math.Clamp(0, -500, 500);
+        }
+
+        /// <summary>
+        /// Points the sliders at the current mode's offset pair. Suppressed so the ValueChanged
+        /// handlers don't write the old mode's numbers back into the new mode's fields.
+        /// </summary>
+        private void PushSlidersFromWorkingValues()
+        {
+            _suppressSliderEvents = true;
+            try
+            {
+                _sldScale.Value = _scale;
+                _sldOffsetX.Value = _detachedMode ? _detachedOffsetX : _offsetX;
+                _sldOffsetY.Value = _detachedMode ? _detachedOffsetY : _offsetY;
+            }
+            finally
+            {
+                _suppressSliderEvents = false;
+            }
+        }
+
+        // ============================================================
+        // AVATAR POSES
+        // ============================================================
+
+        // ponytail: LoadPoses() needs Services.ModResourceResolver.ResolveImage plus the embedded
+        // Resources/avatar*_pose*.png; wired when the resolver moves to Core. Until then the four
+        // slots are placeholder glyphs, so the stepper and the "Pose n/4" readout still work.
+        private void StepPose(int delta)
+        {
+            _poseIndex = (_poseIndex + _poses.Length + delta) % _poses.Length;
+            UpdatePreview();
+        }
+
+        // ============================================================
+        // PREVIEW
+        // ============================================================
+
+        /// <summary>
+        /// True when the active mod overrides tube.png but not tube2.png — in that case the detached
+        /// state uses the mod's tube.png AND the attached margins, exactly like the real tube
+        /// (AvatarTubeWindow.ModOverridesAttachedTubeOnly, bug report #172).
+        /// ponytail: needs Services.ModResourceResolver.HasModOverride, wired when it moves to Core.
+        /// </summary>
+        private static bool ModOverridesAttachedTubeOnly() => false;
+
+        private void UpdatePreview()
+        {
+            bool useAttachedLayout = !_detachedMode || ModOverridesAttachedTubeOnly();
+
+            // Tube frame
+            _previewTube.Margin = useAttachedLayout ? AttachedTubeMargin : DetachedTubeMargin;
+            _txtTubeName.Text = useAttachedLayout ? "tube.png" : "tube2.png";
+
+            // Avatar pose
+            _txtPoseGlyph.Text = _poses[_poseIndex];
+
+            // Avatar box + glow (portrait mode shrinks the box and drops the pink glow)
+            double maxW = _portraitMode ? LegacyAvatarMaxWidth * PortraitSizeScale : LegacyAvatarMaxWidth;
+            double maxH = _portraitMode ? LegacyAvatarMaxHeight * PortraitSizeScale : LegacyAvatarMaxHeight;
+
+            // The placeholder has no intrinsic size, so Stretch="Uniform" is applied by hand: fit
+            // the nominal source into the box and take the result as the drawn size.
+            double fit = Math.Min(maxW / PlaceholderPixelWidth, maxH / PlaceholderPixelHeight);
+            _previewAvatar.Width = PlaceholderPixelWidth * fit;
+            _previewAvatar.Height = PlaceholderPixelHeight * fit;
+
+            _previewAvatar.Effect = _portraitMode ? null : new DropShadowEffect
+            {
+                Color = ResolvePinkColor(),
+                BlurRadius = 20,
+                OffsetX = 0,
+                OffsetY = 0,
+                Opacity = 0.6
+            };
+
+            // Avatar scale
+            _previewAvatar.RenderTransform = Math.Abs(_scale - 1.0) > 0.001
+                ? new ScaleTransform(_scale, _scale)
+                : null;
+
+            // Margins — copied from AvatarTubeWindow.ApplyTubeLayoutOffsets
+            _previewAvatarBorder.Margin = useAttachedLayout
+                ? new Thickness(5, 100, 126 - _offsetX, 210 + _offsetY)
+                : new Thickness(5, 100, 436 - _detachedOffsetX, 228 + _detachedOffsetY);
+
+            // Per-set border transform — copied from AvatarTubeWindow.ApplyAvatarTransform
+            _previewAvatarBorder.RenderTransform = BuildBorderTransform();
+
+            UpdateReadouts(maxW, maxH);
+        }
+
+        private ITransform? BuildBorderTransform()
+        {
+            if (_portraitMode)
+                return new TranslateTransform(PortraitShiftX, -PortraitRaisePx);
+
+            if (_avatarSet > 1)
+            {
+                var group = new TransformGroup();
+                group.Children.Add(new ScaleTransform(1.12, 1.12));
+                group.Children.Add(new TranslateTransform(10, 0));
+                return group;
+            }
+
+            // Locked's set 1 ("The Lure") art reads smaller than the other stages.
+            // ponytail: needs App.Mods.ActiveModId == BuiltInMods.LockedId, wired when ModService
+            // moves to Core.
+            return null;
+        }
+
+        private Color ResolvePinkColor()
+        {
+            if (this.TryFindResource("PinkColor", out var found) && found is Color themed) return themed;
+            return Color.FromRgb(0xFF, 0x69, 0xB4);
+        }
+
+        /// <summary>
+        /// Refreshes the slider value texts and the "Image WxH px, shown WxH px" line. The shown
+        /// size is the uniform fit of the source pixels into the scaled avatar box.
+        /// </summary>
+        private void UpdateReadouts(double maxW, double maxH)
+        {
+            _txtScaleValue.Text = $"×{_scale:0.00}";
+            _txtOffsetXValue.Text = $"{(_detachedMode ? _detachedOffsetX : _offsetX)} px";
+            _txtOffsetYValue.Text = $"{(_detachedMode ? _detachedOffsetY : _offsetY)} px";
+            _txtPose.Text = Loc.GetF("tube_fit_pose", _poseIndex + 1, _poses.Length);
+
+            double boxW = maxW * _scale;
+            double boxH = maxH * _scale;
+            double f = Math.Min(boxW / PlaceholderPixelWidth, boxH / PlaceholderPixelHeight);
+            _txtImageInfo.Text = Loc.GetF("tube_fit_image_info",
+                (int)PlaceholderPixelWidth, (int)PlaceholderPixelHeight,
+                (int)Math.Round(PlaceholderPixelWidth * f), (int)Math.Round(PlaceholderPixelHeight * f));
+        }
+
+        // ============================================================
+        // CONTROL HANDLERS
+        // ============================================================
+
+        private void Mode_Checked(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (_suppressSliderEvents) return;   // ctor is still wiring the initial state
+
+            _detachedMode = _rbDetached.IsChecked == true;
+            PushSlidersFromWorkingValues();      // retarget the offset sliders at this mode's pair
+            UpdatePreview();
+        }
+
+        private void SldScale_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressSliderEvents) return;
+            _scale = Math.Clamp(e.NewValue, 0.1, 3.0);
+            UpdatePreview();
+        }
+
+        private void SldOffsetX_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressSliderEvents) return;
+            var value = (int)Math.Round(Math.Clamp(e.NewValue, -1000, 1000));
+            if (_detachedMode) _detachedOffsetX = value; else _offsetX = value;
+            UpdatePreview();
+        }
+
+        private void SldOffsetY_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressSliderEvents) return;
+            var value = (int)Math.Round(Math.Clamp(e.NewValue, -500, 500));
+            if (_detachedMode) _detachedOffsetY = value; else _offsetY = value;
+            UpdatePreview();
+        }
+
+        // ============================================================
+        // SAVE / RESET / CANCEL
+        // ============================================================
+
+        private void BtnSave_Click()
+        {
+            // ponytail: needs AppSettings.TubeLayoutOverridesByMod + App.Settings.Save() +
+            // App.AvatarWindow.RefreshTubeLayout(), all WPF-head; wired when they move to Core.
+            // The five working values below are what gets written.
+            Close();
+        }
+
+        private void BtnReset_Click()
+        {
+            // ponytail: needs App.Settings (drop the override, save) and
+            // App.AvatarWindow.RefreshTubeLayout(); wired when they move to Core. The view-local
+            // half - reload the working values from the mod's shipped manifest and follow with the
+            // preview - is real and runs.
+            LoadWorkingValues();
+            PushSlidersFromWorkingValues();
+            UpdatePreview();
+        }
+
+        private void TitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                BeginMoveDrag(e);
+        }
+    }
+}


### PR DESCRIPTION
620 lines. Found that RenderTransformOrigin is absolute pixels in Avalonia, not a fraction: left as 0.5,0.5 the avatar would scale about its top-left corner. The geometry, margin formulas and both formatted readouts run for real.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351