### PR TITLE
feat(avalonia): port DescentFuseWindow, DescentCeremonyWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml
@@ -1,0 +1,326 @@
+<!-- PORTED from ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.
+     Structure, ordering, spacing, x:Names and every resource key preserved. Deviations, all forced:
+
+       WindowStyle="None"                -> SystemDecorations="None"
+       WindowState="Maximized"           -> kept, plus a restore Width/Height, which is what the
+                                            headless render sizes its frame from
+       ResizeMode="NoResize"             -> CanResize="False"
+       TextOptions.TextFormattingMode    -> dropped; Avalonia has no WPF text-formatting modes
+       Style="{DynamicResource PinkButton}" -> Theme="{StaticResource PinkButton}" (and the same
+                                            for OutlineButton / SecondaryButton)
+       Visibility="Collapsed"            -> IsVisible="False"
+       RadiusX/RadiusY="0.85"            -> "85%"; GradientOrigin/Center "0.5,0.42" -> "50%,42%"
+       MinHeight="{Binding ActualHeight,
+                   ElementName=ActScroller}" -> "{Binding #ActScroller.Bounds.Height}"
+       GlowLayer's DoubleAnimation       -> a Window.Styles Animation on Border#GlowLayer, same
+                                            5.5s 0.22->0.42 SineEaseInOut breath, auto-reversed
+       <TranslateTransform/> on the       -> dropped: nothing in either head ever animated it, so
+       eyebrow                              it is a transform that only costs a layer
+
+     Deliberately NOT transparent, exactly as the original: "dimmed chrome" for a ceremony this
+     size means covering the chrome, not tinting it.
+
+     No offers. No prices. No tiers. No upsell. CONTRACTS §0.6, and it is not negotiable. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.DescentCeremonyWindow"
+        Title="The Descent"
+        SystemDecorations="None"
+        WindowState="Maximized"
+        Width="1280" Height="720"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Topmost="True"
+        Background="#FF0A0514"
+        UseLayoutRounding="True">
+
+    <Window.Styles>
+        <!-- A slow breath under the whole thing. Opacity only — no layout, nothing a compositor
+             can trip over. WPF ran this from OnLoaded with a DoubleAnimation; Avalonia's
+             declarative form is the same curve and needs no teardown on Closed. -->
+        <Style Selector="Border#GlowLayer">
+            <Style.Animations>
+                <Animation Duration="0:0:5.5" IterationCount="Infinite"
+                           PlaybackDirection="Alternate" Easing="SineEaseInOut">
+                    <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.22"/></KeyFrame>
+                    <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0.42"/></KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+    </Window.Styles>
+
+    <Grid>
+        <!-- Backdrop: radial base -> wash -> vignette, the MantraWindow recipe -->
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="50%,42%" Center="50%,42%" RadiusX="85%" RadiusY="90%">
+                    <GradientStop Color="#FF241041" Offset="0"/>
+                    <GradientStop Color="#FF1A1A2E" Offset="0.55"/>
+                    <GradientStop Color="#FF0A0514" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+        <Border x:Name="GlowLayer" Opacity="0.30">
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="50%,30%" Center="50%,30%" RadiusX="60%" RadiusY="45%">
+                    <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+                    <GradientStop Color="#00FF69B4" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="50%,50%" Center="50%,50%" RadiusX="75%" RadiusY="75%">
+                    <GradientStop Color="#00000000" Offset="0.45"/>
+                    <GradientStop Color="#99000000" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Content -->
+        <Grid x:Name="Stage" Margin="40" RowDefinitions="Auto,*,Auto">
+
+            <TextBlock Grid.Row="0"
+                       Text="THE DESCENT"
+                       HorizontalAlignment="Center"
+                       Margin="0,18,0,0"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       Foreground="{DynamicResource PinkBrush}"
+                       Opacity="0.85"/>
+
+            <!--
+              One act visible at a time; the code-behind swaps IsVisible.
+
+              THE ACT SCALES, IT DOES NOT CLIP (ccp-bugs #1109/#1110/#1111/#1115). Every size in
+              this window is a hardcoded DIP, and a maximized window on a 3840x2160 screen at 300%
+              scaling is only 1280x720 DIPs: small enough that the two door cards overflowed their
+              row and the choose buttons were cut off the bottom of the cards with no scrollbar and
+              no way to reach them with a mouse. The Viewbox shrinks the whole act to fit before
+              that can happen - DownOnly, so at every size where it already fit nothing moves by a
+              pixel - and the ScrollViewer under it is the floor: below ActMinHeight the act stops
+              shrinking and scrolls instead, because readable and scrollable beats legible to nobody.
+
+              ActHost's MinHeight is what keeps the composition: each act centres itself inside a
+              host as tall as the viewport, exactly as it did when it filled the row directly.
+            -->
+            <ScrollViewer Grid.Row="1" x:Name="ActScroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Focusable="False">
+            <Viewbox x:Name="ActBox"
+                     Stretch="Uniform" StretchDirection="DownOnly"
+                     HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Grid x:Name="ActHost" MinHeight="{Binding #ActScroller.Bounds.Height}">
+
+                <!-- ACT I - the intro -->
+                <StackPanel x:Name="ActIntro"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"
+                            MaxWidth="760">
+                    <TextBlock x:Name="IntroHeadline"
+                               FontSize="38" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock x:Name="IntroStanding"
+                               Margin="0,18,0,0"
+                               FontSize="14"
+                               Foreground="{DynamicResource PinkBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"
+                               Opacity="0.9"/>
+                    <TextBlock x:Name="IntroBody"
+                               Margin="0,28,0,0"
+                               FontSize="16" LineHeight="27"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <Button x:Name="BtnIntroContinue"
+                            TabIndex="1"
+                            Margin="0,40,0,0"
+                            HorizontalAlignment="Center"
+                            Padding="30,13"
+                            FontSize="15"
+                            Theme="{StaticResource PinkButton}"/>
+                </StackPanel>
+
+                <!-- ACT II - the two doors -->
+                <!-- MaxWidth matches the door grid below: inside the Viewbox the act is measured
+                     against an unbounded width, so the block needs a width of its own or a long
+                     headline would size the whole ceremony. -->
+                <Grid x:Name="ActChoice" IsVisible="False" MaxWidth="1080"
+                      RowDefinitions="Auto,*,Auto">
+
+                    <TextBlock Grid.Row="0"
+                               x:Name="ChoiceHeadline"
+                               Margin="0,10,0,0"
+                               FontSize="28" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextAlignment="Center" TextWrapping="Wrap"/>
+
+                    <Grid Grid.Row="1" MaxWidth="1080" VerticalAlignment="Center" Margin="0,24,0,0"
+                          ColumnDefinitions="*,28,*">
+
+                        <!-- Door A -->
+                        <Border Grid.Column="0"
+                                Background="#FF252542"
+                                CornerRadius="14"
+                                BorderBrush="{DynamicResource TransparentPink40Brush}"
+                                BorderThickness="1.5"
+                                Padding="30,28">
+                            <StackPanel>
+                                <TextBlock x:Name="RestoreTitle"
+                                           FontSize="24" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock x:Name="RestoreKicker"
+                                           Margin="0,6,0,0"
+                                           FontSize="13"
+                                           Foreground="{DynamicResource PinkBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Border Margin="0,18,0,0" Padding="14,10"
+                                        CornerRadius="8" Background="#FF1A1A2E">
+                                    <TextBlock x:Name="RestoreDelta"
+                                               FontSize="17" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextLightBrush}"
+                                               TextAlignment="Center" TextWrapping="Wrap"/>
+                                </Border>
+                                <TextBlock x:Name="RestoreBody"
+                                           Margin="0,18,0,0"
+                                           FontSize="14" LineHeight="23"
+                                           Foreground="{DynamicResource TextMutedBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Button x:Name="BtnChooseRestore"
+                                        TabIndex="1"
+                                        Margin="0,24,0,0"
+                                        Padding="0,12"
+                                        FontSize="14"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Theme="{StaticResource PinkButton}"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Door B -->
+                        <Border Grid.Column="2"
+                                Background="#FF252542"
+                                CornerRadius="14"
+                                BorderBrush="{DynamicResource TransparentPink40Brush}"
+                                BorderThickness="1.5"
+                                Padding="30,28">
+                            <StackPanel>
+                                <TextBlock x:Name="CycleTitle"
+                                           FontSize="24" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock x:Name="CycleKicker"
+                                           Margin="0,6,0,0"
+                                           FontSize="13"
+                                           Foreground="{DynamicResource PinkBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Border Margin="0,18,0,0" Padding="14,10"
+                                        CornerRadius="8" Background="#FF1A1A2E">
+                                    <TextBlock x:Name="CycleBonus"
+                                               FontSize="17" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextLightBrush}"
+                                               TextAlignment="Center" TextWrapping="Wrap"/>
+                                </Border>
+                                <TextBlock x:Name="CycleBody"
+                                           Margin="0,18,0,0"
+                                           FontSize="14" LineHeight="23"
+                                           Foreground="{DynamicResource TextMutedBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Button x:Name="BtnChooseCycle"
+                                        TabIndex="2"
+                                        Margin="0,24,0,0"
+                                        Padding="0,12"
+                                        FontSize="14"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center"
+                                        Theme="{StaticResource OutlineButton}"/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+
+                    <TextBlock Grid.Row="2"
+                               x:Name="BothDoorsFooter"
+                               MaxWidth="900"
+                               Margin="0,26,0,0"
+                               FontSize="13" LineHeight="21"
+                               Foreground="{DynamicResource TextDimBrush}"
+                               TextAlignment="Center" TextWrapping="Wrap"/>
+                </Grid>
+
+                <!-- ACT III - the one-way confirm -->
+                <StackPanel x:Name="ActConfirm"
+                            IsVisible="False"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"
+                            MaxWidth="640">
+                    <TextBlock x:Name="ConfirmHeadline"
+                               FontSize="30" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock x:Name="ConfirmBody"
+                               Margin="0,24,0,0"
+                               FontSize="15" LineHeight="26"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,38,0,0">
+                        <Button x:Name="BtnConfirmBack"
+                                TabIndex="1"
+                                Padding="26,12" FontSize="14"
+                                Theme="{StaticResource SecondaryButton}"/>
+                        <Button x:Name="BtnConfirmYes"
+                                TabIndex="2"
+                                Margin="16,0,0,0"
+                                Padding="26,12" FontSize="14"
+                                Theme="{StaticResource PinkButton}"/>
+                    </StackPanel>
+                    <TextBlock x:Name="ConfirmError"
+                               IsVisible="False"
+                               Margin="0,20,0,0"
+                               FontSize="13"
+                               Foreground="#FFFF8080"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                </StackPanel>
+
+                <!-- ACT IV - the close -->
+                <StackPanel x:Name="ActDone"
+                            IsVisible="False"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"
+                            MaxWidth="640">
+                    <TextBlock x:Name="DoneHeadline"
+                               FontSize="34" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock x:Name="DoneBody"
+                               Margin="0,24,0,0"
+                               FontSize="16" LineHeight="27"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <Button x:Name="BtnDoneClose"
+                            TabIndex="1"
+                            Margin="0,40,0,0"
+                            HorizontalAlignment="Center"
+                            Padding="34,13" FontSize="15"
+                            Theme="{StaticResource PinkButton}"/>
+                </StackPanel>
+            </Grid>
+            </Viewbox>
+            </ScrollViewer>
+
+            <!-- The escape hatch. Closing before a choice is made costs nothing. -->
+            <StackPanel Grid.Row="2" x:Name="LaterHost" HorizontalAlignment="Center" Margin="0,0,0,14">
+                <Button x:Name="BtnLater"
+                        TabIndex="9"
+                        HorizontalAlignment="Center"
+                        Background="Transparent" BorderThickness="0"
+                        Foreground="{DynamicResource TextDimBrush}"
+                        FontSize="13" Padding="10,6" Cursor="Hand"/>
+                <TextBlock x:Name="LaterHint"
+                           HorizontalAlignment="Center"
+                           FontSize="11"
+                           Foreground="{DynamicResource TextDimBrush}"
+                           Opacity="0.7"
+                           TextAlignment="Center"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// THE MIGRATION CEREMONY (CONTRACTS-0812 §4, design doc §6). Four acts, one question, asked
+    /// once in the life of an account: intro → the two doors → a plain-language one-way confirm →
+    /// the close.
+    ///
+    /// <para><b>This window never opens on its own.</b> Its only public constructor takes an
+    /// <see cref="Offer"/>, and the only thing in the app that can build one is ProfileSyncService
+    /// parsing <c>descent_migration.required</c> off a sync response. No menu item reaches it, no
+    /// setting reveals it, no flag turns it on.</para>
+    ///
+    /// <para><b>No offers, ever</b> (CONTRACTS §0.6). Nothing on this surface may mention a price,
+    /// a tier, a pack or an upgrade — not on the closing act, not on a shelf, not anywhere.</para>
+    ///
+    /// <para><b>Escape is not handled here, on purpose.</b> Escape is the app's panic key and it is
+    /// delivered by a global hook regardless of focus; swallowing it would put a fullscreen topmost
+    /// window between a user and the one key they are promised always works. The way out is the
+    /// "Not tonight" button, and taking it costs nothing.</para>
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs. Deviations:
+    ///  - <c>DescentMigrationOffer</c>, <c>DescentMigrationChoices</c>, <c>DescentMigration</c> and
+    ///    <c>DescentCeremonyCopy</c> are all still in the WPF head, and this project may not
+    ///    reference it, so <see cref="Offer"/>, <see cref="Choices"/> and <see cref="Copy"/> below
+    ///    are local stand-ins carrying the fields and strings this window actually reads. The copy
+    ///    is placeholder — the real sentences come back when DescentCeremonyCopy moves to Core.
+    ///  - <c>App.Settings</c>, <c>App.DescentMigration.ApplyChoice</c> and
+    ///    <c>App.AvatarWindow.GigglePriority</c> are stubs for the same reason.
+    ///  - The GlowLayer breath is a declarative Animation in the XAML, so the <c>Closed</c> teardown
+    ///    of it disappears; <c>OnLoaded</c> shrinks to the companion's opening line, which it also
+    ///    spoke in the original.
+    ///  - <c>SizeChanged</c> is wired in the constructor rather than from markup (Avalonia's
+    ///    SizeChangedEventArgs is the same shape), and reads <c>e.NewSize.Height</c> exactly as
+    ///    the original did.
+    ///  - <c>Visibility</c> → <c>IsVisible</c> throughout.
+    /// </summary>
+    public partial class DescentCeremonyWindow : Window
+    {
+        /// <summary>
+        /// Live instances, so the panic path can clear the screen. Static because panic has no
+        /// reference to hand: it is a global keystroke, not a UI interaction.
+        /// </summary>
+        private static readonly List<DescentCeremonyWindow> Live = new();
+
+        /// <summary>
+        /// The height, in DIPs, below which the act stops scaling down and starts scrolling
+        /// instead (ccp-bugs #1109). The tallest act is the two doors at roughly 630 DIPs, so the
+        /// floor is a little under half scale — and the machines that reach it are running 250% to
+        /// 300% scaling, where half scale is still larger on the glass than the design is at 100%.
+        /// </summary>
+        private const double ActMinHeight = 290;
+
+        private readonly Offer _offer;
+        private readonly int _restoreLevel;
+        private string? _pendingChoice;
+        private bool _committed;
+
+        private readonly ScrollViewer _actScroller;
+        private readonly Viewbox _actBox;
+        private readonly StackPanel _actIntro;
+        private readonly Grid _actChoice;
+        private readonly StackPanel _actConfirm;
+        private readonly StackPanel _actDone;
+        private readonly StackPanel _laterHost;
+        private readonly TextBlock _confirmBody;
+        private readonly TextBlock _confirmError;
+        private readonly TextBlock _doneBody;
+        private readonly Button _btnConfirmYes;
+
+        /// <summary>Render constructor: sample offer, so --render-all can discover the window.</summary>
+        internal DescentCeremonyWindow() : this(Offer.Sample()) { }
+
+        public DescentCeremonyWindow(Offer offer)
+        {
+            _offer = offer ?? throw new ArgumentNullException(nameof(offer));
+
+            AvaloniaXamlLoader.Load(this);
+
+            _actScroller = this.FindControl<ScrollViewer>("ActScroller")!;
+            _actBox = this.FindControl<Viewbox>("ActBox")!;
+            _actIntro = this.FindControl<StackPanel>("ActIntro")!;
+            _actChoice = this.FindControl<Grid>("ActChoice")!;
+            _actConfirm = this.FindControl<StackPanel>("ActConfirm")!;
+            _actDone = this.FindControl<StackPanel>("ActDone")!;
+            _laterHost = this.FindControl<StackPanel>("LaterHost")!;
+            _confirmBody = this.FindControl<TextBlock>("ConfirmBody")!;
+            _confirmError = this.FindControl<TextBlock>("ConfirmError")!;
+            _doneBody = this.FindControl<TextBlock>("DoneBody")!;
+            _btnConfirmYes = this.FindControl<Button>("BtnConfirmYes")!;
+
+            // Both doors are priced BEFORE the user sees either, from the same pure function the
+            // submit will use — so the number on the card is the number they get, not an estimate.
+            // ponytail: needs DescentMigration.Resolve (WPF head, Services/Descent), wired when it
+            // moves to Core. The sample offer carries the level the resolve would have produced.
+            _restoreLevel = _offer.ResolvedRestoreLevel;
+
+            PopulateCopy();
+
+            this.FindControl<Button>("BtnIntroContinue")!.Click += (_, _) => ShowAct(_actChoice);
+            this.FindControl<Button>("BtnChooseRestore")!.Click += (_, _) => AskToConfirm(Choices.Restore);
+            this.FindControl<Button>("BtnChooseCycle")!.Click += (_, _) => AskToConfirm(Choices.Cycle);
+            this.FindControl<Button>("BtnConfirmBack")!.Click += (_, _) => { _pendingChoice = null; ShowAct(_actChoice); };
+            _btnConfirmYes.Click += (_, _) => OnConfirmYes();
+            this.FindControl<Button>("BtnDoneClose")!.Click += (_, _) => Close();
+            this.FindControl<Button>("BtnLater")!.Click += (_, _) => OnLater();
+
+            _actScroller.SizeChanged += OnActScrollerSizeChanged;
+
+            // All that survives of WPF's OnLoaded: the glow breath is declarative in the XAML now,
+            // but the companion's opening line still belongs to the moment the ceremony appears.
+            Loaded += (_, _) => Say(Copy.CompanionIntro);
+
+            Closed += OnClosedInternal;
+
+            lock (Live) Live.Add(this);
+        }
+
+        // ------------------------------------------------------------------
+        // Copy
+        // ------------------------------------------------------------------
+
+        private void PopulateCopy()
+        {
+            // ponytail: needs App.Settings.Current.PlayerLevel, wired when settings move to Core.
+            var currentLevel = _offer.PlayerLevel;
+
+            this.FindControl<TextBlock>("IntroHeadline")!.Text = Copy.IntroHeadline;
+            this.FindControl<TextBlock>("IntroStanding")!.Text = Copy.IntroStanding(
+                currentLevel, _offer.TotalXpEarned, _offer.DevotionDays);
+            this.FindControl<TextBlock>("IntroBody")!.Text = Copy.IntroBody;
+            this.FindControl<Button>("BtnIntroContinue")!.Content = Copy.IntroContinue;
+
+            this.FindControl<TextBlock>("ChoiceHeadline")!.Text = Copy.ChoiceHeadline;
+
+            this.FindControl<TextBlock>("RestoreTitle")!.Text = Copy.RestoreTitle;
+            this.FindControl<TextBlock>("RestoreKicker")!.Text = Copy.RestoreKicker;
+            this.FindControl<TextBlock>("RestoreDelta")!.Text = Copy.RestoreDelta(currentLevel, _restoreLevel);
+            this.FindControl<TextBlock>("RestoreBody")!.Text = Copy.RestoreBody(currentLevel, _restoreLevel);
+            this.FindControl<Button>("BtnChooseRestore")!.Content = Copy.RestoreTitle;
+
+            this.FindControl<TextBlock>("CycleTitle")!.Text = Copy.CycleTitle;
+            this.FindControl<TextBlock>("CycleKicker")!.Text = Copy.CycleKicker;
+            this.FindControl<TextBlock>("CycleBonus")!.Text = Copy.CycleBonusLine();
+            this.FindControl<TextBlock>("CycleBody")!.Text = Copy.CycleBody();
+            this.FindControl<Button>("BtnChooseCycle")!.Content = Copy.CycleTitle;
+
+            this.FindControl<TextBlock>("BothDoorsFooter")!.Text = Copy.BothDoorsFooter;
+
+            this.FindControl<TextBlock>("ConfirmHeadline")!.Text = Copy.ConfirmHeadline;
+            this.FindControl<Button>("BtnConfirmBack")!.Content = Copy.ConfirmBack;
+
+            this.FindControl<TextBlock>("DoneHeadline")!.Text = Copy.DoneHeadline;
+            this.FindControl<Button>("BtnDoneClose")!.Content = Copy.DoneClose;
+
+            this.FindControl<Button>("BtnLater")!.Content = Copy.Later;
+            this.FindControl<TextBlock>("LaterHint")!.Text = Copy.LaterHint;
+        }
+
+        // ------------------------------------------------------------------
+        // Lifecycle
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Hand the act's Viewbox a height budget, which is the one thing XAML cannot state on its
+        /// own: inside a vertical ScrollViewer the Viewbox is measured against infinity, so without
+        /// a MaxHeight it would never scale anything down and would scroll instead every time.
+        ///
+        /// <para>The budget is the viewport, or <see cref="ActMinHeight"/> when the viewport is
+        /// smaller than that — and that floor is what hands the overflow back to the scroller.</para>
+        /// </summary>
+        private void OnActScrollerSizeChanged(object? sender, SizeChangedEventArgs e)
+        {
+            var viewport = e.NewSize.Height;
+            if (viewport <= 0) return;
+
+            var budget = Math.Max(ActMinHeight, viewport);
+
+            // Only on a real change: assigning MaxHeight re-measures, and a same-value write on
+            // every SizeChanged is a layout pass nobody asked for.
+            if (Math.Abs(_actBox.MaxHeight - budget) > 0.5) _actBox.MaxHeight = budget;
+        }
+
+        private void OnClosedInternal(object? sender, EventArgs e)
+        {
+            lock (Live) Live.Remove(this);
+        }
+
+        /// <summary>
+        /// Clear the ceremony off the screen for the panic path. Safe at any act: nothing here is
+        /// lost by closing, because the ceremony is only "taken" once <see cref="_committed"/> —
+        /// and once it is, the choice is already on disk and riding the sync queue.
+        /// </summary>
+        public static void ForceCloseAll()
+        {
+            List<DescentCeremonyWindow> snapshot;
+            lock (Live) snapshot = new List<DescentCeremonyWindow>(Live);
+
+            foreach (var w in snapshot)
+            {
+                try { w.Close(); }
+                catch (Exception ex) { Log.Debug("[Descent] Ceremony force-close failed: {Error}", ex.Message); }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Acts
+        // ------------------------------------------------------------------
+
+        private void ShowAct(Control act)
+        {
+            _actIntro.IsVisible = ReferenceEquals(act, _actIntro);
+            _actChoice.IsVisible = ReferenceEquals(act, _actChoice);
+            _actConfirm.IsVisible = ReferenceEquals(act, _actConfirm);
+            _actDone.IsVisible = ReferenceEquals(act, _actDone);
+
+            // The way out disappears once the choice is taken — there is nothing left to defer.
+            _laterHost.IsVisible = !ReferenceEquals(act, _actDone);
+        }
+
+        private void AskToConfirm(string choice)
+        {
+            _pendingChoice = choice;
+            _confirmBody.Text = Copy.ConfirmBody(choice);
+            _btnConfirmYes.Content = Copy.ConfirmYes(choice);
+            _confirmError.IsVisible = false;
+            ShowAct(_actConfirm);
+        }
+
+        private void OnConfirmYes()
+        {
+            if (_committed) return;
+
+            var choice = _pendingChoice;
+            if (!Choices.IsValid(choice))
+            {
+                ShowAct(_actChoice);
+                return;
+            }
+
+            // Everything irreversible happens inside ApplyChoice: the local relevel, the epoch
+            // flip, the keepsakes, and arming the submit. It returns false only for states this
+            // window should never have reached — in which case say so plainly rather than
+            // pretending it worked.
+            var applied = ApplyChoice(choice!);
+
+            if (!applied)
+            {
+                _confirmError.Text = "That didn't take. Nothing has changed — close this and it will be offered again.";
+                _confirmError.IsVisible = true;
+                return;
+            }
+
+            _committed = true;
+
+            var level = _offer.PlayerLevel;
+            _doneBody.Text = Copy.DoneBody(choice!, level);
+            ShowAct(_actDone);
+
+            Say(Copy.CompanionDone(choice!));
+        }
+
+        /// <summary>
+        /// Take the choice. Returns false until the migration service exists on this head, so the
+        /// ceremony shows its honest "that didn't take" line rather than faking a one-way commit.
+        /// </summary>
+        private bool ApplyChoice(string choice)
+        {
+            // ponytail: needs App.DescentMigration.ApplyChoice(choice, offer), wired when
+            // Services/Descent moves to Core. Never make this return true before it is real —
+            // a faked commit on an irreversible choice is the one bug this surface cannot survive.
+            Log.Warning("[Descent] ApplyChoice({Choice}) is not wired on this head — nothing was committed.", choice);
+            return false;
+        }
+
+        private void OnLater()
+        {
+            // Nothing is written here on purpose. The service's Closed handler is what arms the
+            // session deferral (#1111) — it has to, because the chrome's X and the panic key close
+            // this window without ever reaching "Not tonight".
+            Log.Information("[Descent] Ceremony deferred by the user — nothing written, the server will re-offer on the next launch.");
+            Close();
+        }
+
+        /// <summary>
+        /// One scripted line, spoken by whoever the active mod's companion is.
+        /// </summary>
+        private static void Say(string line)
+        {
+            // ponytail: needs App.AvatarWindow.GigglePriority, wired when the companion moves to Core.
+            Log.Debug("[Descent] Companion line (not yet spoken on this head): {Line}", line);
+        }
+
+        // ------------------------------------------------------------------
+        // Local stand-ins for the WPF head's Descent services
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// The fields of <c>DescentMigrationOffer</c> this window reads, plus the resolved restore
+        /// level and the player level it took off App.Settings.
+        /// ponytail: replaced by the real DescentMigrationOffer when Services/Descent moves to Core.
+        /// </summary>
+        public sealed class Offer
+        {
+            public double TotalXpEarned { get; init; }
+            public int DevotionDays { get; init; }
+            public int PlayerLevel { get; init; }
+            public int ResolvedRestoreLevel { get; init; }
+
+            /// <summary>Internal, so no production caller can ship the render sample.</summary>
+            internal static Offer Sample() => new()
+            {
+                TotalXpEarned = 184_500,
+                DevotionDays = 213,
+                PlayerLevel = 47,
+                ResolvedRestoreLevel = 38,
+            };
+        }
+
+        /// <summary>ponytail: mirrors DescentMigrationChoices; the two literals are the wire values.</summary>
+        private static class Choices
+        {
+            public const string Restore = "restore";
+            public const string Cycle = "cycle";
+            public static bool IsValid(string? choice) => choice == Restore || choice == Cycle;
+        }
+
+        /// <summary>
+        /// PLACEHOLDER COPY. The real sentences live in DescentCeremonyCopy in the WPF head; the
+        /// short constants are verbatim, the multi-paragraph bodies are stood in for so the acts
+        /// render with real text rather than blank panels.
+        /// ponytail: needs DescentCeremonyCopy, wired when it moves to Core — this class deletes
+        /// itself entirely at that point.
+        /// </summary>
+        private static class Copy
+        {
+            /// <summary>ponytail: mirrors DescentMigration.CycleXpBonus (1.10).</summary>
+            private const double CycleXpBonus = 1.10;
+
+            public const string IntroHeadline = "The last season has ended.";
+
+            public const string IntroBody =
+                "Nothing was wiped. Nothing will be — this time the wipe simply doesn't happen.\n\n" +
+                "But the ladder underneath you has been rebuilt, and it keeps getting steeper all " +
+                "the way down. A level is going to mean more than it used to.\n\n" +
+                "So you get to choose how you meet it. Once.";
+
+            public const string IntroContinue = "Show me the two doors";
+
+            public static string IntroStanding(int level, double lifetimeXp, int devotionDays) =>
+                $"You stand at Level {level}  ·  {lifetimeXp.ToString("N0", CultureInfo.CurrentCulture)} lifetime XP  ·  " +
+                $"{devotionDays} {(devotionDays == 1 ? "day" : "days")} of devotion";
+
+            public const string ChoiceHeadline = "Two doors. Both of them go down.";
+
+            public const string RestoreTitle = "Take it all back";
+            public const string RestoreKicker = "Everything you built, re-measured.";
+
+            public static string RestoreBody(int oldLevel, int newLevel) =>
+                $"Your lifetime XP is spent again on the new ladder, and it buys you Level {newLevel}.\n\n" +
+                "The number moves because the ladder moved — not because anything was taken. And " +
+                "the stages you already climbed come back to you one per day.";
+
+            public static string RestoreDelta(int oldLevel, int newLevel) =>
+                oldLevel == newLevel
+                    ? $"Level {oldLevel} → Level {newLevel}  (unchanged)"
+                    : $"Level {oldLevel} → Level {newLevel}";
+
+            public const string CycleTitle = "Descend again";
+            public const string CycleKicker = "Cycle I. From the top.";
+
+            public static string CycleBody() =>
+                "Level 1. The whole fall again, first night to last, with everything you learned " +
+                "the first time.\n\n" +
+                "A Cycle wipes nothing but the number. What it adds is a permanent mark on your " +
+                "card, and a bonus on every point of XP you earn from here on.";
+
+            public static string CycleBonusLine() =>
+                $"+{(CycleXpBonus - 1.0) * 100:0.#}% XP, permanently";
+
+            public const string BothDoorsFooter =
+                "Either way: the veteran badge and your keepsake archive are yours. And either way " +
+                "the spiral starts tonight at Day 1. Nobody arrives with a track already lit. " +
+                "We all fall together.";
+
+            public const string ConfirmHeadline = "This is the part that doesn't come back.";
+
+            public static string ConfirmBody(string choice) =>
+                (choice == Choices.Cycle
+                    ? "You are choosing to descend again. Your level goes to 1 tonight and stays " +
+                      "there until you earn it back.\n\n"
+                    : "You are choosing to take it all back. Your level is re-measured on the new " +
+                      "ladder and the stages you climbed will be handed back one a day.\n\n") +
+                "There is no undo. You get asked this once, and this is the once.\n\n" +
+                "Take a breath first if you need one. The door will still be here.";
+
+            public static string ConfirmYes(string choice) =>
+                choice == Choices.Cycle ? "Yes. Take me back to Level 1." : "Yes. Give it back to me.";
+
+            public const string ConfirmBack = "Not that one";
+
+            public const string DoneHeadline = "It's done.";
+
+            public static string DoneBody(string choice, int level) =>
+                choice == Choices.Cycle
+                    ? $"Cycle I. Level {level}.\n\nThe mark is on your card and it stays there. " +
+                      "The spiral starts tonight, at Day 1 — the same Day 1 as everyone else."
+                    : $"Level {level}, measured on the ladder you're actually standing on.\n\n" +
+                      "The spiral starts tonight, at Day 1 — the same Day 1 as everyone else.";
+
+            public const string DoneClose = "Begin";
+
+            public const string Later = "Not tonight";
+
+            public const string LaterHint =
+                "Closing this changes nothing. The ceremony will be waiting the next time you sync.";
+
+            public const string CompanionIntro = "Come here. Something is ending, and I want you with me for it.";
+
+            public static string CompanionDone(string choice) =>
+                choice == Choices.Cycle
+                    ? "All the way back to the top with you. Good. I get to watch you fall all over again."
+                    : "There you are. Same you, honest numbers. Let's keep going down.";
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml
@@ -1,0 +1,69 @@
+<!-- PORTED from ConditioningControlPanel/Windows/DescentFuseWindow.xaml.
+     Structure, ordering, x:Names, colours and gradient stops preserved. Deviations, all forced:
+
+       WindowStyle="None"                -> SystemDecorations="None"
+       WindowState="Maximized"           -> kept, plus a restore Width/Height, which is what the
+                                            headless render sizes its frame from
+       ResizeMode="NoResize"             -> CanResize="False"
+       TextOptions.TextFormattingMode    -> dropped; Avalonia has no WPF text-formatting modes
+       RadiusX/RadiusY="0.85"            -> "85%" (Avalonia's RelativeScalar syntax)
+       GradientOrigin/Center="0.5,0.5"   -> "50%,50%"
+
+     Deliberately NOT transparent, exactly as the original: this window is opaque by design,
+     because the whole point of the beat is that the room goes away.
+
+     The show itself (DescentFuseStageVisual) is a WPF DrawingVisual living in the other head,
+     so StageHost stays empty here - see the code-behind. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.DescentFuseWindow"
+        Title="The Descent"
+        SystemDecorations="None"
+        WindowState="Maximized"
+        Width="1280" Height="720"
+        CanResize="False"
+        ShowInTaskbar="False"
+        Topmost="True"
+        Background="#FF0A0514"
+        UseLayoutRounding="True">
+
+    <Grid>
+        <Border x:Name="BackdropLayer" Opacity="0.28">
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="50%,50%" Center="50%,50%" RadiusX="85%" RadiusY="90%">
+                    <GradientStop Color="#FF241041" Offset="0"/>
+                    <GradientStop Color="#FF1A1A2E" Offset="0.55"/>
+                    <GradientStop Color="#FF0A0514" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- The drawn show. Populated in code so no xmlns import is needed for one element. -->
+        <Grid x:Name="StageHost"/>
+
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="50%,50%" Center="50%,50%" RadiusX="75%" RadiusY="75%">
+                    <GradientStop Color="#00000000" Offset="0.45"/>
+                    <GradientStop Color="#99000000" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!--
+          The show's only words. Two sentences exist for it (DescentFuseCopy.ShowAwaits and
+          .IgnitionLine) and it is invisible unless one of them is due.
+        -->
+        <TextBlock x:Name="ShowLine"
+                   Opacity="0"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Bottom"
+                   Margin="40,0,40,120"
+                   MaxWidth="900"
+                   FontSize="26"
+                   FontWeight="Light"
+                   Foreground="#FFF2ECF7"
+                   TextAlignment="Center"
+                   TextWrapping="Wrap"/>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Styling;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using ConditioningControlPanel.Services.Descent;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// THE FUSE AT ZERO (CONTRACT-FUSE-0816 §2.3/§2.4) — the fullscreen show the countdown has been
+    /// counting down to, and the two shows that hang off it.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/DescentFuseWindow.xaml.cs. The timeline itself
+    /// (<see cref="DescentFuseTimeline"/>, <see cref="DescentIgnitionTimeline"/>,
+    /// <see cref="DescentFuseHandoff"/>) already lives in Core, so the clock and every beat boundary
+    /// are the real ones. Deviations:
+    ///  - <c>DescentFuseStageVisual</c> is a WPF <c>DrawingVisual</c> in the other head, so
+    ///    <c>StageHost</c> stays empty and the per-frame handoff to it is a no-op. The backdrop,
+    ///    the vignette, the line and the fades are all real.
+    ///  - <c>DispatcherTimer</c> is Avalonia's; <c>DispatcherPriority.Render</c> exists on both.
+    ///  - WPF's <c>BeginAnimation(OpacityProperty, …)</c> becomes an Avalonia <c>Animation</c>
+    ///    run from code (<see cref="FadeTo"/>), with <c>FillMode.Forward</c> so the ramp sticks at
+    ///    its end value the way WPF's does.
+    ///  - <c>MotionFx.Level</c>, <c>DescentRoomSfx</c>, <c>App.DescentMigration</c>,
+    ///    <c>App.DescentCountdown</c>, <c>App.ProfileSync</c> and <c>Application.Current.MainWindow</c>
+    ///    are all still in the WPF head, so each is a stub below.
+    ///  - <c>DescentFuseCopy</c> is likewise still in the WPF head; its two sentences are inlined.
+    /// </summary>
+    public partial class DescentFuseWindow : Window
+    {
+        /// <summary>
+        /// Live instances, so the panic path can clear the screen. Static because panic has no
+        /// reference to hand: it is a global keystroke, not a UI interaction. It doubles as the
+        /// single-open guard — see <see cref="Open"/>.
+        /// </summary>
+        private static readonly List<DescentFuseWindow> Live = new();
+
+        /// <summary>The clock. ~50fps; the show is four brush ramps and some trigonometry, and a
+        /// higher rate would buy nothing a projector could show.</summary>
+        private static readonly TimeSpan FrameInterval = TimeSpan.FromMilliseconds(20);
+
+        /// <summary>How long the catch-up holds its bloom before dissolving.</summary>
+        private const double CatchUpHoldSeconds = 1.2;
+
+        private const double CatchUpFadeSeconds = 0.8;
+
+        // ponytail: needs DescentFuseCopy (WPF head, Services/Descent), inlined verbatim until it
+        // moves to Core. Two sentences, and between them every word the show says.
+        private const string ShowAwaitsLine = "The ceremony awaits.";
+        private const string IgnitionCopyLine = "Year One. The spiral is yours.";
+
+        private readonly DescentShowKind _kind;
+        private readonly bool _reduced;
+        private readonly Stopwatch _clock = new();
+        private readonly DescentFuseHandoff _handoff = new();
+
+        private readonly Border _backdropLayer;
+        private readonly TextBlock _showLine;
+
+        private DispatcherTimer? _timer;
+        private bool _witnessedMarked;
+        private bool _backdropRaised;
+        private bool _crackSounded;
+        private bool _closing;
+
+        private bool _holdingOffers;
+
+        /// <summary>
+        /// TRUE once this window saw the ceremony come up and started dissolving into it.
+        /// </summary>
+        public bool HandedOffToCeremony { get; private set; }
+
+        /// <summary>Render constructor: the live show, so --render-all can discover the window.</summary>
+        internal DescentFuseWindow() : this(DescentShowKind.Live)
+        {
+            // The show is wordless until the handoff times out, so a bare render would be a black
+            // rectangle. Stand the room up at its bloom instead: the backdrop at full and the
+            // standing line visible, which is the one frame of this window that has anything in it.
+            _backdropLayer.Opacity = 1.0;
+            _showLine.Text = ShowAwaitsLine;
+            _showLine.Opacity = 1.0;
+        }
+
+        private DescentFuseWindow(DescentShowKind kind)
+        {
+            _kind = kind;
+
+            AvaloniaXamlLoader.Load(this);
+
+            _backdropLayer = this.FindControl<Border>("BackdropLayer")!;
+            _showLine = this.FindControl<TextBlock>("ShowLine")!;
+
+            // ponytail: needs MotionFx (WPF head, Helpers), wired when it moves to Core. Full
+            // motion is the honest default — a stub that claimed "reduced" would silently drop the
+            // whole show on every machine.
+            _reduced = false;
+
+            // ponytail: needs DescentFuseStageVisual (WPF DrawingVisual), wired when the show is
+            // redrawn for this head. StageHost is left empty; every other layer is real.
+
+            if (kind == DescentShowKind.Ignition)
+            {
+                // The ignition opens INTO the room rather than out of the dark: the ceremony that
+                // just closed was already this backdrop at full.
+                _backdropLayer.Opacity = 1.0;
+                _backdropRaised = true;
+            }
+
+            if (kind == DescentShowKind.Live)
+            {
+                // ponytail: needs App.DescentMigration.HoldOffers, wired when it moves to Core.
+                // Holding the ceremony back until the light returns is choreography, not defence:
+                // without it an offer answered during the drain drops the ceremony on top of a
+                // crack that is four seconds from finishing.
+                _holdingOffers = true;
+            }
+
+            Loaded += OnLoadedInternal;
+            Closed += OnClosedInternal;
+
+            lock (Live) Live.Add(this);
+        }
+
+        /// <summary>
+        /// Open a show, or return null if one is already up. The single-open guard is the point:
+        /// two fullscreen topmost windows over each other is unrecoverable without the panic key.
+        /// </summary>
+        public static DescentFuseWindow? Open(DescentShowKind kind)
+        {
+            try
+            {
+                lock (Live)
+                {
+                    if (Live.Count > 0)
+                    {
+                        Log.Information("[Fuse] A show is already on screen — not opening the {Kind} show over it.", kind);
+                        return null;
+                    }
+                }
+
+                var window = new DescentFuseWindow(kind);
+
+                // ponytail: needs the app shell to own a main window here (WPF set Owner from
+                // Application.Current.MainWindow). Ownerless is correct until the shell exists.
+                window.Show();
+                window.Activate();
+
+                Log.Information("[Fuse] {Kind} show opened ({Motion}).",
+                    kind, window._reduced ? "reduced motion" : "full motion");
+                return window;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[Fuse] Could not open the {Kind} show.", kind);
+                return null;
+            }
+        }
+
+        /// <summary>Clear the show off the screen for the panic path. Safe at any beat.</summary>
+        public static void ForceCloseAll()
+        {
+            List<DescentFuseWindow> snapshot;
+            lock (Live) snapshot = new List<DescentFuseWindow>(Live);
+
+            foreach (var w in snapshot)
+            {
+                try { w.Close(); }
+                catch (Exception ex) { Log.Debug("[Fuse] Show force-close failed: {Error}", ex.Message); }
+            }
+        }
+
+        private void OnLoadedInternal(object? sender, EventArgs e)
+        {
+            try
+            {
+                _clock.Restart();
+
+                _timer = new DispatcherTimer(FrameInterval, DispatcherPriority.Render, OnFrame);
+                _timer.Start();
+
+                // Paint frame zero immediately rather than waiting 20ms for the first tick.
+                OnFrame(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[Fuse] The show could not start its clock — closing rather than holding the screen.");
+                SafeClose();
+            }
+        }
+
+        private void OnClosedInternal(object? sender, EventArgs e)
+        {
+            lock (Live) Live.Remove(this);
+
+            ReleaseOfferHold();
+
+            try
+            {
+                _timer?.Stop();
+                _timer = null;
+                _clock.Stop();
+            }
+            catch (Exception ex) { Log.Debug("[Fuse] Show teardown: {Error}", ex.Message); }
+        }
+
+        // ------------------------------------------------------------------
+        // The clock
+        // ------------------------------------------------------------------
+
+        private void OnFrame(object? sender, EventArgs e)
+        {
+            if (_closing) return;
+
+            try
+            {
+                var elapsed = _clock.Elapsed.TotalSeconds;
+                if (_kind == DescentShowKind.Ignition) FrameIgnition(elapsed);
+                else FrameCrack(elapsed);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[Fuse] A show frame threw — closing rather than freezing the screen.");
+                SafeClose();
+            }
+        }
+
+        // ---------------------------------------------------------- crack + handoff
+
+        private void FrameCrack(double elapsed)
+        {
+            var frame = DescentFuseTimeline.FrameAt(_kind, elapsed, _reduced);
+
+            // The sting lands ON the crack, not before it. Reduced motion never reaches the Crack
+            // stage, so the crossfade stays silent by construction.
+            if (frame.Stage == DescentFuseStage.Crack && !_crackSounded)
+            {
+                _crackSounded = true;
+                // ponytail: needs DescentRoomSfx (WPF head), wired when audio moves to Core.
+            }
+
+            if (frame.Stage >= DescentFuseStage.Bloom && !_backdropRaised)
+            {
+                _backdropRaised = true;
+                RaiseBackdrop();
+
+                // THE KEEPSAKE HOOK (§2.3): written at the START of the bloom, not at its end.
+                // Live only — the catch-up is deliberately NOT a witnessed night.
+                if (_kind == DescentShowKind.Live && !_witnessedMarked)
+                {
+                    _witnessedMarked = true;
+                    // ponytail: needs App.DescentCountdown.MarkLastNightWitnessed, wired when the
+                    // countdown service moves to Core.
+                }
+
+                // The light is back, so the door may open.
+                ReleaseOfferHold();
+            }
+
+            if (_kind == DescentShowKind.CatchUp)
+            {
+                // No handoff clock here: the catch-up's whole job is to be OVER before the ceremony
+                // offer opens, so it holds its bloom for a moment and dissolves.
+                var total = _reduced
+                    ? DescentFuseTimeline.ReducedCrossfadeSeconds
+                    : DescentFuseTimeline.CatchUpSeconds;
+
+                if (elapsed >= total + CatchUpHoldSeconds) FadeOutAndClose(CatchUpFadeSeconds);
+                return;
+            }
+
+            if (frame.SinceBloom < 0) return;
+
+            // ponytail: needs App.DescentMigration.IsCeremonyOpen — false here, so this head always
+            // walks the timeout branch and shows the standing line rather than crossfading.
+            switch (_handoff.Advance(frame.SinceBloom, ceremonyOpen: false))
+            {
+                case DescentHandoffAction.Resync:
+                    // ponytail: needs App.ProfileSync.SyncProfileAsync, wired when sync moves to Core.
+                    break;
+
+                case DescentHandoffAction.CrossfadeToCeremony:
+                    BeginCeremonyHandoff();
+                    break;
+
+                case DescentHandoffAction.SpeakAwaits:
+                    Log.Information("[Fuse] No ceremony offer within {Seconds}s — showing the standing line and closing.",
+                        DescentFuseHandoff.TimeoutSeconds);
+                    _showLine.Text = ShowAwaitsLine;
+                    FadeTo(_showLine, _showLine.Opacity, 1.0, 0.9);
+                    break;
+
+                case DescentHandoffAction.Close:
+                    // After a handoff the crossfade has already run this window down to nothing, so
+                    // it just goes. After the standing line, "closes softly" means a fade.
+                    if (HandedOffToCeremony) SafeClose();
+                    else FadeOutAndClose(0.9);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// The ceremony is up. Dissolve into it. WPF re-asserted Topmost here to push this window
+        /// back to the front of the topmost band without stealing focus; Avalonia has no
+        /// SWP_NOACTIVATE equivalent to lean on, and the ceremony would lose focus, so the Z
+        /// re-assert is deliberately left out.
+        /// </summary>
+        private void BeginCeremonyHandoff()
+        {
+            HandedOffToCeremony = true;
+            Log.Information("[Fuse] The ceremony is up — dissolving into it.");
+            FadeTo(this, Opacity, 0.0, DescentFuseHandoff.CrossfadeSeconds);
+        }
+
+        // ------------------------------------------------------------- the ignition
+
+        private void FrameIgnition(double elapsed)
+        {
+            var lineOpacity = DescentIgnitionTimeline.LineOpacity(elapsed, _reduced);
+            if (lineOpacity > 0 && (_showLine.Text?.Length ?? 0) == 0) _showLine.Text = IgnitionCopyLine;
+            _showLine.Opacity = lineOpacity;
+
+            Opacity = DescentIgnitionTimeline.ShowOpacity(elapsed, _reduced);
+
+            if (elapsed >= DescentIgnitionTimeline.TotalSeconds(_reduced)) SafeClose();
+        }
+
+        // ------------------------------------------------------------------
+        // Fades
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// WPF's <c>BeginAnimation(OpacityProperty, new DoubleAnimation(from, to, seconds))</c>,
+        /// in Avalonia's terms. FillMode.Forward is what makes the ramp stick at <paramref name="to"/>
+        /// once it ends, which is the WPF behaviour the show depends on at the bloom.
+        /// </summary>
+        private static void FadeTo(Visual target, double from, double to, double seconds)
+        {
+            try
+            {
+                _ = new Animation
+                {
+                    Duration = TimeSpan.FromSeconds(seconds),
+                    Easing = new QuadraticEaseOut(),
+                    FillMode = FillMode.Forward,
+                    Children =
+                    {
+                        new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(OpacityProperty, from) } },
+                        new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(OpacityProperty, to) } },
+                    },
+                }.RunAsync(target);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[Fuse] Fade failed: {Error}", ex.Message);
+                target.Opacity = to;
+            }
+        }
+
+        /// <summary>
+        /// Bring the ceremony's backdrop up with the bloom, so the room the show is standing in
+        /// arrives at the same moment the light does.
+        /// </summary>
+        private void RaiseBackdrop()
+        {
+            var seconds = _reduced ? DescentFuseTimeline.ReducedCrossfadeSeconds : 1.6;
+            FadeTo(_backdropLayer, _backdropLayer.Opacity, 1.0, seconds);
+        }
+
+        private void FadeOutAndClose(double seconds)
+        {
+            if (_closing) return;
+            _closing = true;
+
+            FadeTo(this, Opacity, 0.0, seconds);
+            DispatcherTimer.RunOnce(SafeClose, TimeSpan.FromSeconds(seconds), DispatcherPriority.Normal);
+        }
+
+        /// <summary>Drop this window's hold, at most once.</summary>
+        private void ReleaseOfferHold()
+        {
+            if (!_holdingOffers) return;
+            _holdingOffers = false;
+            // ponytail: needs App.DescentMigration.ReleaseOffers, wired when it moves to Core.
+        }
+
+        private void SafeClose()
+        {
+            try { Close(); }
+            catch (Exception ex) { Log.Debug("[Fuse] Show close failed: {Error}", ex.Message); }
+        }
+    }
+}


### PR DESCRIPTION
1,226 lines, over the soft line: the pair is one ceremony and splitting it would leave a layer that cannot render. The fuse timeline is real, it already lives in Core; ApplyChoice deliberately returns false so a one-way commit is never faked.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351