### PR TITLE
feat(avalonia): port MediaHistoryWindow, MantraWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/MantraWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/MantraWindow.axaml
@@ -1,0 +1,184 @@
+<!-- PORTED from ConditioningControlPanel/Windows/MantraWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                      -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       <Storyboard> resources         -> dropped. Avalonia has no Storyboard; the five here are all
+                                         begun from code (pulse / shake / letter-pulse / wrong-shake
+                                         / glow), and every trigger for them is a MantraService
+                                         event, which this port stubs. See the code-behind.
+       RadialGradientBrush 0.5,0.5 /
+       RadiusX="0.7"                  -> "50%,50%" / "70%" plus an explicit GradientOrigin. A bare
+                                         pair is ABSOLUTE pixels in Avalonia, which collapses the
+                                         ramp to one pixel; WPF's GradientOrigin defaulted to Center.
+       DropShadowEffect ShadowDepth   -> OffsetX="0" OffsetY="0"
+       {DynamicResource PinkColor}    -> {StaticResource PinkColor}. A GradientStop and an Effect
+                                         are not in the logical tree, so DynamicResource has no
+                                         scope to resolve through.
+       ScaleTransform CenterX/CenterY -> dropped (no such properties; centre is the default) and
+       RenderTransformOrigin 0.5,0.5  -> "50%,50%", same absolute-vs-relative trap as above.
+       x:Name on a brush / gradient stop / effect / transform
+                                      -> dropped. Avalonia only name-scopes StyledElements, so
+                                         BaseBrush, BaseCenter, BaseEdge, WashCenter, MantraGlow,
+                                         MantraScale, MantraTranslate and InputBorderBrush would
+                                         not compile (AVLN2000). The code-behind reaches them
+                                         through their owning control instead, which is why the
+                                         base layer and the input border gained x:Names.
+       Visibility="Collapsed"         -> IsVisible="False"
+       ContextMenu="{x:Null}"         -> ContextFlyout="{x:Null}"
+       AllowDrop="False"              -> DragDrop.AllowDrop="False"
+       KeyDown= / Loaded= / TextChanged= / PreviewKeyDown=
+                                      -> wired in the constructor -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.MantraWindow"
+        Title="{loc:Str dialog_mantra_lab}"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        WindowState="Maximized"
+        Background="Black"
+        Topmost="True">
+
+    <Window.Styles>
+        <!-- Fluent's TextBox paints PART_BorderElement opaque on hover and focus, and that setter
+             sits on the template child, so it outranks the TextBox's own Background="Transparent".
+             The window focuses TxtInput on load, so without this the input reads as a black slab
+             over the wash - the WPF original never changed background on focus.
+             ponytail: local copy, hoist to Theme/Styles.xaml when a second view needs it. -->
+        <Style Selector="TextBox.transparent /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid>
+        <!-- Layer 0: Radial gradient base -->
+        <Border x:Name="BaseLayer">
+            <Border.Background>
+                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%"
+                                     RadiusX="70%" RadiusY="70%">
+                    <GradientStop Color="#1A0A2E" Offset="0"/>
+                    <GradientStop Color="#0A0514" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Layer 1: Color wash overlay (intensity tied to streak) -->
+        <Border x:Name="ColorWashOverlay" Opacity="0">
+            <Border.Background>
+                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" RadiusX="60%" RadiusY="60%">
+                    <GradientStop Color="#6633AA" Offset="0"/>
+                    <GradientStop Color="Transparent" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Layer 2: Glow overlay (pulsing) -->
+        <Border x:Name="GlowOverlay" Opacity="0">
+            <Border.Background>
+                <RadialGradientBrush Center="50%,60%" GradientOrigin="50%,60%" RadiusX="40%" RadiusY="40%">
+                    <GradientStop Color="{StaticResource PinkColor}" Offset="0"/>
+                    <GradientStop Color="Transparent" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Layer 3: Vignette -->
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush Center="50%,50%" GradientOrigin="50%,50%" RadiusX="80%" RadiusY="80%">
+                    <GradientStop Color="Transparent" Offset="0.4"/>
+                    <GradientStop Color="#80000000" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Content Grid -->
+        <Grid Margin="40">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Top: Counters -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,0">
+                <StackPanel Margin="30,0">
+                    <TextBlock Text="{loc:Str label_reps}" Foreground="#606080" FontSize="11" HorizontalAlignment="Center" FontWeight="Bold"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock x:Name="TxtCompletions" Text="0" Foreground="White" FontSize="36" FontWeight="Bold"/>
+                        <TextBlock x:Name="TxtTarget" Text="/10" Foreground="#606080" FontSize="24" VerticalAlignment="Bottom" Margin="2,0,0,4"/>
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel Margin="30,0">
+                    <TextBlock Text="{loc:Str label_streak}" Foreground="#606080" FontSize="11" HorizontalAlignment="Center" FontWeight="Bold"/>
+                    <TextBlock x:Name="TxtStreak" Text="0" Foreground="{DynamicResource PinkBrush}" FontSize="36" FontWeight="Bold" HorizontalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Margin="30,0">
+                    <TextBlock Text="{loc:Str label_best}" Foreground="#606080" FontSize="11" HorizontalAlignment="Center" FontWeight="Bold"/>
+                    <TextBlock x:Name="TxtBestStreak" Text="0" Foreground="{DynamicResource SecondaryBrush}" FontSize="36" FontWeight="Bold" HorizontalAlignment="Center"/>
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Center: Mantra text (Inlines populated in code-behind) -->
+            <Viewbox Grid.Row="1" MaxWidth="1400" MaxHeight="300" VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock x:Name="TxtMantra"
+                           FontSize="72" FontWeight="Bold" TextAlignment="Center" TextWrapping="Wrap"
+                           MaxWidth="1400" Padding="20"
+                           RenderTransformOrigin="50%,50%">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="#9966CC" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                    </TextBlock.Effect>
+                    <TextBlock.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform/>
+                            <TranslateTransform/>
+                        </TransformGroup>
+                    </TextBlock.RenderTransform>
+                </TextBlock>
+            </Viewbox>
+
+            <!-- Bottom: Input area -->
+            <Border x:Name="InputBorder" Grid.Row="2" Background="#20FFFFFF" CornerRadius="12" Padding="20,14"
+                    HorizontalAlignment="Center" MaxWidth="800" MinWidth="500" Margin="0,0,0,40"
+                    BorderThickness="1.5">
+                <Border.BorderBrush>
+                    <SolidColorBrush Color="#40FF69B4"/>
+                </Border.BorderBrush>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBox x:Name="TxtInput" Grid.Column="0" Classes="transparent"
+                             Background="Transparent" Foreground="White" FontSize="22"
+                             BorderThickness="0" CaretBrush="{DynamicResource PinkBrush}"
+                             VerticalAlignment="Center"
+                             ContextFlyout="{x:Null}"
+                             DragDrop.AllowDrop="False"/>
+                    <TextBlock Grid.Column="1" Text="{loc:Str label_esc_to_exit}" Foreground="{DynamicResource PanelAccentBrush}" FontSize="11"
+                               VerticalAlignment="Center" Margin="10,0,0,0"/>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <!-- Session complete overlay -->
+        <Border x:Name="CompletionOverlay" Background="#E0000000" IsVisible="False">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock Text="{loc:Str label_session_complete}" Foreground="{DynamicResource PinkBrush}" FontSize="48" FontWeight="Bold"
+                           HorizontalAlignment="Center">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="30" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+                <TextBlock x:Name="TxtCompletionStats" Text="" Foreground="{DynamicResource SecondaryBrush}" FontSize="22"
+                           HorizontalAlignment="Center" Margin="0,16,0,0"/>
+                <TextBlock Text="{loc:Str label_press_any_key_to_close}" Foreground="#606080" FontSize="14"
+                           HorizontalAlignment="Center" Margin="0,24,0,0"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/MantraWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MantraWindow.axaml.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// The Mantra Lab: a full-screen typing drill where every correctly typed character lights up
+    /// and the whole scene warms from cold purple to hot pink as the streak climbs.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/MantraWindow.xaml.cs. Deviations:
+    ///  - <c>App.Mantra</c> (MantraService), <c>App.Audio</c> and <c>App.Settings</c> live in the
+    ///    WPF head, so the session itself is stubbed: no completion counting, no streak events, no
+    ///    NAudio drone or tones, no session-complete overlay trigger. What is ported verbatim is
+    ///    everything that only touches the view — the per-character highlight system, the streak
+    ///    intensity ramp, the colour lerp and the float drift — driven here by
+    ///    <see cref="SampleMantra"/> and <see cref="SampleStreak"/> so the render shows the live
+    ///    state rather than a cold empty one.
+    ///  - Five WPF Storyboards (pulse, shake, letter-pulse, wrong-shake, glow) are dropped:
+    ///    Avalonia has no Storyboard and every one of them is begun from a service event that is
+    ///    stubbed above. ponytail: re-add as Avalonia Animations when MantraService reaches Core.
+    ///  - <c>DispatcherTimer</c> exists in Avalonia; the float timer is stopped in
+    ///    <c>OnClosed</c> as well as <c>CleanupAndClose</c>, because --render-all closes the
+    ///    window externally and a 16ms tick would outlive the view in that shared process.
+    ///  - The idle timer is dropped entirely: it only calls <c>MantraService.BreakStreak</c>.
+    ///  - <c>DataObject.AddPastingHandler</c> -> <c>TextBox.PastingFromClipboardEvent</c>;
+    ///    <c>Visibility</c> -> <c>IsVisible</c>.
+    /// </summary>
+    public partial class MantraWindow : Window
+    {
+        /// <summary>ponytail: needs MantraService.CurrentMantra / TargetCount, wired when the
+        /// service moves to Core. Placeholder so the letter highlighting has something to draw.</summary>
+        private const string SampleMantra = "good girls sink deeper every time";
+        private const int SampleStreak = 7;
+        private const int SampleTarget = 10;
+
+        private DispatcherTimer? _floatTimer;
+        private DateTime _startTime;
+        private bool _sessionComplete;
+
+        // Per-character highlight state
+        private readonly List<Run> _mantraRuns = new();
+        private int _prevMatchCount;
+        private int _prevInputLength;
+        private Color _highlightColor = Color.FromRgb(0x99, 0x88, 0xDD);
+        private static readonly Color DimColor = Color.FromRgb(0x35, 0x35, 0x50);
+        private static readonly Color ErrorColor = Color.FromRgb(0xFF, 0x44, 0x44);
+        private static readonly Color FlashColor = Colors.White;
+
+        private readonly TextBlock _txtMantra, _txtCompletions, _txtTarget, _txtStreak, _txtBestStreak;
+        private readonly TextBox _txtInput;
+        private readonly Border _colorWashOverlay, _completionOverlay;
+        private readonly TextBlock _txtCompletionStats;
+        private readonly DropShadowEffect? _mantraGlow;
+        private readonly GradientStop? _washCenter, _baseCenter;
+        private readonly SolidColorBrush? _inputBorderBrush;
+        private readonly TranslateTransform? _mantraTranslate;
+
+        public MantraWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtMantra = this.FindControl<TextBlock>("TxtMantra")!;
+            _txtCompletions = this.FindControl<TextBlock>("TxtCompletions")!;
+            _txtTarget = this.FindControl<TextBlock>("TxtTarget")!;
+            _txtStreak = this.FindControl<TextBlock>("TxtStreak")!;
+            _txtBestStreak = this.FindControl<TextBlock>("TxtBestStreak")!;
+            _txtInput = this.FindControl<TextBox>("TxtInput")!;
+            _colorWashOverlay = this.FindControl<Border>("ColorWashOverlay")!;
+            _completionOverlay = this.FindControl<Border>("CompletionOverlay")!;
+            _txtCompletionStats = this.FindControl<TextBlock>("TxtCompletionStats")!;
+
+            // WPF named the brushes, the effect and the transform directly. Avalonia only
+            // name-scopes StyledElements, so each is reached through the control that owns it.
+            _mantraGlow = _txtMantra.Effect as DropShadowEffect;
+            _washCenter = (_colorWashOverlay.Background as GradientBrush)?.GradientStops[0];
+            _baseCenter = (this.FindControl<Border>("BaseLayer")!.Background as GradientBrush)?.GradientStops[0];
+            _inputBorderBrush = this.FindControl<Border>("InputBorder")!.BorderBrush as SolidColorBrush;
+            _mantraTranslate = (_txtMantra.RenderTransform as TransformGroup)?.Children[1] as TranslateTransform;
+
+            // Same anti-cheat hardening as the lock card (#734). Key blocking alone isn't enough:
+            // the pasting handler also covers the context menu and drag-drop, and undo has to be
+            // off because completing a mantra clears the box - Ctrl+Z would put the finished
+            // mantra straight back and every Ctrl+Z/Ctrl+Y pair counted as another repetition.
+            _txtInput.AddHandler(TextBox.PastingFromClipboardEvent, (_, e) => e.Handled = true);
+            _txtInput.IsUndoEnabled = false;
+
+            _txtInput.TextChanged += (_, _) => TxtInput_TextChanged();
+            _txtInput.AddHandler(KeyDownEvent, TxtInput_PreviewKeyDown, global::Avalonia.Interactivity.RoutingStrategies.Tunnel);
+            KeyDown += (_, e) => Window_KeyDown(e);
+            Loaded += (_, _) => Window_Loaded();
+        }
+
+        private void Window_Loaded()
+        {
+            _startTime = DateTime.UtcNow;
+
+            // ponytail: needs MantraService (StreakChanged / StreakBroken / MantraCompleted /
+            // SessionComplete), the NAudio drone and the tone player; all wired when the service
+            // moves to Core.
+
+            // Build initial letter display
+            BuildMantraRuns(SampleMantra);
+            _txtTarget.Text = $"/{SampleTarget}";
+            _txtCompletions.Text = "0";
+            _txtStreak.Text = "0";
+            _txtBestStreak.Text = "0";
+
+            // Start float animation (gentle sine-wave drift)
+            _floatTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
+            _floatTimer.Tick += FloatTimer_Tick;
+            _floatTimer.Start();
+
+            // Placeholder session state, so the highlight ramp and the warm palette both draw.
+            OnStreakChanged(SampleStreak);
+            UpdateHighlights(SampleMantra.Substring(0, 11));
+
+            _txtInput.Focus();
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _floatTimer?.Stop();
+            base.OnClosed(e);
+        }
+
+        #region Per-character highlight system
+
+        private void BuildMantraRuns(string mantra)
+        {
+            _txtMantra.Inlines ??= new InlineCollection();
+            _txtMantra.Inlines.Clear();
+            _mantraRuns.Clear();
+            _prevMatchCount = 0;
+            _prevInputLength = 0;
+
+            foreach (char c in mantra)
+            {
+                var run = new Run(c.ToString())
+                {
+                    Foreground = new SolidColorBrush(DimColor)
+                };
+                _mantraRuns.Add(run);
+                _txtMantra.Inlines.Add(run);
+            }
+        }
+
+        private int UpdateHighlights(string input)
+        {
+            var mantra = CurrentMantra;
+            if (mantra == null || _mantraRuns.Count == 0) return 0;
+
+            int matchCount = 0;
+            bool hasError = false;
+
+            for (int i = 0; i < mantra.Length && i < input.Length; i++)
+            {
+                if (char.ToLowerInvariant(input[i]) == char.ToLowerInvariant(mantra[i]))
+                    matchCount = i + 1;
+                else
+                {
+                    hasError = true;
+                    break;
+                }
+            }
+
+            // Color each Run
+            for (int i = 0; i < _mantraRuns.Count; i++)
+            {
+                Color color;
+                if (i < matchCount)
+                    color = _highlightColor;
+                else if (hasError && i == matchCount)
+                    color = ErrorColor;
+                else
+                    color = DimColor;
+
+                _mantraRuns[i].Foreground = new SolidColorBrush(color);
+            }
+
+            // Flash the latest correct char white briefly
+            bool newCharTyped = input.Length > _prevInputLength;
+            if (newCharTyped && matchCount > _prevMatchCount && matchCount > 0)
+            {
+                int flashIdx = matchCount - 1;
+                _mantraRuns[flashIdx].Foreground = new SolidColorBrush(FlashColor);
+
+                // Fade back to highlight color after a short delay
+                var idx = flashIdx;
+                var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(80) };
+                timer.Tick += (_, _) =>
+                {
+                    timer.Stop();
+                    if (idx < _mantraRuns.Count)
+                        _mantraRuns[idx].Foreground = new SolidColorBrush(_highlightColor);
+                };
+                timer.Start();
+
+                // ponytail: the WPF LetterPulseStoryboard fired here; re-add as an Avalonia
+                // Animation alongside the other four.
+            }
+
+            _prevMatchCount = matchCount;
+            _prevInputLength = input.Length;
+
+            return matchCount;
+        }
+
+        #endregion
+
+        /// <summary>ponytail: needs MantraService.CurrentMantra, wired when it moves to Core.</summary>
+        private static string? CurrentMantra => SampleMantra;
+
+        private void FloatTimer_Tick(object? sender, EventArgs e)
+        {
+            var elapsed = (DateTime.UtcNow - _startTime).TotalSeconds;
+            if (_mantraTranslate != null)
+                _mantraTranslate.Y = Math.Sin(elapsed * 0.5) * 6;
+
+            // ponytail: the drone gain ramp lived here; needs NAudio plus App.Settings.
+        }
+
+        private void TxtInput_TextChanged()
+        {
+            if (_sessionComplete) return;
+
+            var input = _txtInput.Text ?? "";
+            var target = CurrentMantra;
+            if (target == null) return;
+
+            int matchCount = UpdateHighlights(input);
+
+            // Check completion: all characters match and input length equals mantra length.
+            // ponytail: needs MantraService.TryCompleteMantra to count the rep and roll the next
+            // mantra; until then a finished line just stays lit.
+            _ = matchCount;
+        }
+
+        private void TxtInput_PreviewKeyDown(object? sender, KeyEventArgs e)
+        {
+            // WPF called LockCardWindow.IsBlockedInputGesture(e.Key, Keyboard.Modifiers) — shared
+            // deliberately so the two anti-cheat surfaces can't drift apart again (#734).
+            // ponytail: needs LockCardWindow, wired when that view is ported; inlining the gesture
+            // list here would recreate exactly the drift #734 removed.
+            _ = e;
+        }
+
+        private void OnStreakChanged(int streak)
+        {
+            _txtStreak.Text = streak.ToString();
+            _txtBestStreak.Text = streak.ToString();
+
+            UpdateVisualIntensity(streak);
+        }
+
+        /// <summary>
+        /// The MantraService.SessionComplete handler, ported view-side. Nothing calls it yet — the
+        /// event it hangs off is stubbed — so the overlay only draws once the service reaches Core.
+        /// The stats line is hardcoded English in the WPF original too; no loc key exists for it.
+        /// </summary>
+        private void OnSessionComplete(int totalReps, int bestStreak)
+        {
+            _sessionComplete = true;
+
+            _txtCompletionStats.Text = $"{totalReps} repetitions  |  Best streak: {bestStreak}";
+            _completionOverlay.IsVisible = true;
+            _txtInput.IsEnabled = false;
+
+            // ponytail: the completion tone needs NAudio, wired with the rest of the audio.
+
+            // Auto-close after 5 seconds
+            var closeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+            closeTimer.Tick += (_, _) =>
+            {
+                closeTimer.Stop();
+                CleanupAndClose();
+            };
+            closeTimer.Start();
+        }
+
+        private void UpdateVisualIntensity(int streak)
+        {
+            // Normalize streak 0-15 → 0-1
+            double t = Math.Min(streak / 15.0, 1.0);
+
+            // Update highlight color: cold purple → hot pink
+            _highlightColor = LerpColor(Color.FromRgb(0x99, 0x88, 0xDD), Color.FromRgb(0xFF, 0x69, 0xB4), t);
+
+            // Re-color already highlighted runs with new color
+            var input = _txtInput.Text ?? "";
+            var mantra = CurrentMantra;
+            if (mantra != null)
+            {
+                int matchLen = 0;
+                for (int i = 0; i < mantra.Length && i < input.Length; i++)
+                {
+                    if (char.ToLowerInvariant(input[i]) == char.ToLowerInvariant(mantra[i]))
+                        matchLen = i + 1;
+                    else break;
+                }
+                for (int i = 0; i < matchLen && i < _mantraRuns.Count; i++)
+                    _mantraRuns[i].Foreground = new SolidColorBrush(_highlightColor);
+            }
+
+            // Color wash: cold purples → hot pinks, opacity 0→0.8
+            _colorWashOverlay.Opacity = t * 0.8;
+            if (_washCenter != null)
+                _washCenter.Color = LerpColor(Color.FromRgb(0x66, 0x33, 0xAA), Color.FromRgb(0xFF, 0x69, 0xB4), t);
+
+            // Glow intensity
+            if (_mantraGlow != null)
+            {
+                _mantraGlow.BlurRadius = 20 + t * 30;
+                _mantraGlow.Opacity = 0.6 + t * 0.4;
+                _mantraGlow.Color = LerpColor(Color.FromRgb(0x99, 0x66, 0xCC), Color.FromRgb(0xFF, 0x69, 0xB4), t);
+            }
+
+            // Input border glow
+            if (_inputBorderBrush != null)
+                _inputBorderBrush.Color = LerpColor(Color.FromArgb(0x40, 0xFF, 0x69, 0xB4), Color.FromArgb(0xFF, 0xFF, 0x69, 0xB4), t);
+
+            // Base gradient warm up
+            if (_baseCenter != null)
+                _baseCenter.Color = LerpColor(Color.FromRgb(0x1A, 0x0A, 0x2E), Color.FromRgb(0x2E, 0x0A, 0x2E), t);
+
+            // ponytail: the drone target gain rode this same t; needs NAudio.
+        }
+
+        private static Color LerpColor(Color a, Color b, double t)
+        {
+            return Color.FromArgb(
+                (byte)(a.A + (b.A - a.A) * t),
+                (byte)(a.R + (b.R - a.R) * t),
+                (byte)(a.G + (b.G - a.G) * t),
+                (byte)(a.B + (b.B - a.B) * t));
+        }
+
+        private void Window_KeyDown(KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                CleanupAndClose();
+                e.Handled = true;
+                return;
+            }
+
+            if (_sessionComplete)
+            {
+                CleanupAndClose();
+                e.Handled = true;
+            }
+        }
+
+        private void CleanupAndClose()
+        {
+            _floatTimer?.Stop();
+
+            // ponytail: unsubscribing the four MantraService events and ending the session go here,
+            // wired when the service moves to Core.
+
+            Close();
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MediaHistoryWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/MediaHistoryWindow.axaml
@@ -1,0 +1,279 @@
+<!-- PORTED from ConditioningControlPanel/Windows/MediaHistoryWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                      -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       <Style x:Key TargetType>       -> <ControlTheme x:Key TargetType>, applied with Theme=
+       ControlTemplate.Triggers       -> ^:pointerover / ^:selected nested selectors
+       <ContentPresenter/>            -> Content="{TemplateBinding Content}" (trap 6: a bare
+                                         presenter draws nothing in Avalonia)
+       Visibility="Collapsed"         -> IsVisible="False"
+       ToolTip="..."                  -> ToolTip.Tip="..."
+       ItemContainerStyle             -> ItemContainerTheme
+       VirtualizingStackPanel.* /
+       ScrollViewer.CanContentScroll  -> dropped; Avalonia's ListBox virtualizes by default and
+                                         has no attached equivalents for these.
+       ListBox HorizontalContentAlignment
+                                      -> moved onto the ListBoxItem theme (Avalonia's ListBox is
+                                         not a ContentControl); the row still stretches.
+       <MediaElement PreviewVideo/>   -> dropped. Avalonia has no MediaElement and no package may
+                                         be added, so the video branch of ShowPreview is a stub.
+       Image + ThumbConverter         -> dropped. MediaThumbnailConverter lives in the WPF head;
+                                         the placeholder glyph the WPF markup draws underneath it
+                                         is what shows.
+       Click= / MouseLeftButtonDown=  -> wired in the constructor
+     Buttons carry a TextBlock child rather than Content (trap 1: "_" is an access key). -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:vm="clr-namespace:ConditioningControlPanel.Avalonia.Views.Windows"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.MediaHistoryWindow"
+        Title="{loc:Str dialog_media_log}"
+        Width="920" Height="640" MinWidth="720" MinHeight="440"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowInTaskbar="False">
+
+    <Window.Styles>
+        <!-- Fluent's TextBox paints PART_BorderElement opaque on hover and focus, and that setter
+             sits on the template child, so it outranks the TextBox's own Background="Transparent".
+             The WPF original stayed transparent over its host Border in every state.
+             ponytail: local copy, hoist to Theme/Styles.xaml when a second view needs it. -->
+        <Style Selector="TextBox.transparent /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+    </Window.Styles>
+
+    <Window.Resources>
+        <!-- Small secondary/icon button (Open-in-folder, filters, close).
+             ponytail: local copy of ConditioningControlPanel/Windows/MediaHistoryWindow.xaml:MlChip,
+             hoist when a second view needs it. -->
+        <ControlTheme x:Key="MlChip" TargetType="Button">
+            <Setter Property="Background" Value="#252540"/>
+            <Setter Property="BorderBrush" Value="#3A3A58"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Foreground" Value="#D8D8E8"/>
+            <Setter Property="Padding" Value="10,5"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#2F2F52"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The WPF ListBox.ItemContainerStyle, setters verbatim. -->
+        <ControlTheme x:Key="MlRow" TargetType="ListBoxItem">
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Margin" Value="4,2"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Border x:Name="RowBorder" Background="Transparent"
+                            CornerRadius="8" Padding="8,6">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Stretch"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#RowBorder">
+                <Setter Property="Background" Value="#20202F"/>
+            </Style>
+            <Style Selector="^:selected /template/ Border#RowBorder">
+                <Setter Property="Background" Value="#2C2340"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" BorderBrush="{DynamicResource PinkBrush}"
+            BorderThickness="3" CornerRadius="18" Padding="20">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Header (drag handle) -->
+            <DockPanel Grid.Row="0" x:Name="HeaderBar" Margin="0,0,0,12" Background="Transparent">
+                <TextBlock DockPanel.Dock="Left" Text="{loc:Str dialog_media_log}"
+                           Foreground="{DynamicResource PinkBrush}" FontSize="22" FontWeight="Bold"
+                           VerticalAlignment="Center"/>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right">
+                    <TextBlock x:Name="TxtCount" Foreground="#808090" FontSize="12"
+                               VerticalAlignment="Center" Margin="0,0,12,0"/>
+                    <Button x:Name="BtnClear" Theme="{StaticResource MlChip}"
+                            Margin="0,0,8,0"
+                            ToolTip.Tip="{loc:Str tooltip_clear_media_log}">
+                        <TextBlock Text="{loc:Str btn_clear_log}"/>
+                    </Button>
+                    <Button x:Name="BtnClose" Content="✕" Theme="{StaticResource MlChip}" Padding="10,5"/>
+                </StackPanel>
+            </DockPanel>
+
+            <!-- Filter / search bar -->
+            <Grid Grid.Row="1" Margin="0,0,0,10">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                    <Button x:Name="BtnFilterAll" Theme="{StaticResource MlChip}"
+                            Tag="all" Margin="0,0,6,0">
+                        <TextBlock Text="{loc:Str filter_all}"/>
+                    </Button>
+                    <Button x:Name="BtnFilterImages" Theme="{StaticResource MlChip}"
+                            Tag="image" Margin="0,0,6,0">
+                        <TextBlock Text="{loc:Str filter_images}"/>
+                    </Button>
+                    <Button x:Name="BtnFilterVideos" Theme="{StaticResource MlChip}"
+                            Tag="video">
+                        <TextBlock Text="{loc:Str filter_videos}"/>
+                    </Button>
+                </StackPanel>
+                <Border HorizontalAlignment="Right" Width="240" Background="#1C1C30"
+                        BorderBrush="#3A3A58" BorderThickness="1" CornerRadius="6" Padding="8,4">
+                    <Grid>
+                        <TextBlock x:Name="SearchPlaceholder" Text="{loc:Str placeholder_search_media}"
+                                   Foreground="#606078" FontSize="12" VerticalAlignment="Center"
+                                   IsHitTestVisible="False"/>
+                        <TextBox x:Name="TxtSearch" Classes="transparent" Background="Transparent" BorderThickness="0"
+                                 Foreground="White" CaretBrush="White" FontSize="12" VerticalAlignment="Center"/>
+                    </Grid>
+                </Border>
+            </Grid>
+
+            <!-- Body: list | preview -->
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" MinWidth="360"/>
+                    <ColumnDefinition Width="6"/>
+                    <ColumnDefinition Width="340" MinWidth="280"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- LEFT: virtualized list -->
+                <Border Grid.Column="0" Background="#161626" BorderBrush="#2A2A44" BorderThickness="1" CornerRadius="10">
+                    <Grid>
+                        <TextBlock x:Name="TxtEmpty" Text="{loc:Str label_no_media_yet}"
+                                   Foreground="#707080" FontSize="14" FontStyle="Italic"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   TextWrapping="Wrap" TextAlignment="Center" Margin="24"
+                                   IsVisible="False"/>
+                        <ListBox x:Name="MediaList" Background="Transparent" BorderThickness="0"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                 ItemContainerTheme="{StaticResource MlRow}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="vm:MediaHistoryRow">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <!-- Thumb (glyph shows through when no bitmap) -->
+                                        <Border Grid.Column="0" Width="40" Height="40" CornerRadius="6"
+                                                Background="#0E0E1C" ClipToBounds="True" Margin="0,0,10,0">
+                                            <Grid>
+                                                <TextBlock Text="{Binding PlaceholderGlyph, Mode=OneTime}"
+                                                           FontSize="18" HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center" Opacity="0.65"/>
+                                            </Grid>
+                                        </Border>
+
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding DisplayName, Mode=OneTime}"
+                                                       Foreground="White" FontSize="13"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                            <TextBlock Text="{Binding TimeText, Mode=OneTime}"
+                                                       Foreground="#7A7A90" FontSize="11" Margin="0,2,0,0"/>
+                                        </StackPanel>
+
+                                        <Border Grid.Column="2" VerticalAlignment="Center" Margin="8,0"
+                                                CornerRadius="4" Padding="6,2"
+                                                Background="{Binding BadgeBrush, Mode=OneTime}">
+                                            <TextBlock Text="{Binding TypeBadge, Mode=OneTime}"
+                                                       Foreground="White" FontSize="10" FontWeight="Bold"/>
+                                        </Border>
+
+                                        <Button Grid.Column="3" Content="📂" Theme="{StaticResource MlChip}"
+                                                Padding="7,4" VerticalAlignment="Center"
+                                                Tag="{Binding}"
+                                                ToolTip.Tip="{loc:Str tooltip_reveal_in_explorer}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Border>
+
+                <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch"
+                              Background="Transparent"/>
+
+                <!-- RIGHT: single live preview -->
+                <Border Grid.Column="2" Background="#161626" BorderBrush="#2A2A44" BorderThickness="1" CornerRadius="10" Padding="14">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- Preview surface -->
+                        <Border Grid.Row="0" Background="#0B0B16" CornerRadius="8" ClipToBounds="True">
+                            <Grid>
+                                <TextBlock x:Name="PreviewHint" Text="{loc:Str label_select_to_preview}"
+                                           Foreground="#606078" FontSize="13" FontStyle="Italic"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           TextWrapping="Wrap" TextAlignment="Center" Margin="16"/>
+                                <Image x:Name="PreviewImage" Stretch="Uniform" IsVisible="False"/>
+                                <TextBlock x:Name="PreviewMissing" Text="{loc:Str label_file_not_found}"
+                                           Foreground="#E08080" FontSize="13"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           TextWrapping="Wrap" TextAlignment="Center" Margin="16"
+                                           IsVisible="False"/>
+                            </Grid>
+                        </Border>
+
+                        <StackPanel Grid.Row="1" Margin="0,12,0,0">
+                            <TextBlock x:Name="PreviewName" Foreground="White" FontSize="14" FontWeight="Bold"
+                                       TextTrimming="CharacterEllipsis"/>
+                            <TextBlock x:Name="PreviewPath" Foreground="#7A7A90" FontSize="11" Margin="0,4,0,0"
+                                       TextWrapping="Wrap" MaxHeight="54"/>
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,12,0,0">
+                            <Button x:Name="BtnPreviewOpenFolder"
+                                    Theme="{StaticResource MlChip}"
+                                    Margin="0,0,8,0" IsEnabled="False">
+                                <TextBlock Text="{loc:Str btn_open_in_folder}"/>
+                            </Button>
+                            <Button x:Name="BtnPreviewOpenFile"
+                                    Theme="{StaticResource MlChip}"
+                                    IsEnabled="False">
+                                <TextBlock Text="{loc:Str btn_open_file}"/>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/MediaHistoryWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MediaHistoryWindow.axaml.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// "Media Log" recap window (opened from the Assets tab). Shows the app-lifetime history
+    /// of flashed images and played videos in a virtualized master list, with a single live
+    /// preview pane on the right.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/MediaHistoryWindow.xaml.cs. Deviations:
+    ///  - <c>App.MediaHistory</c> / <c>MediaLogEntry</c> / <c>MediaHistoryService</c> live in the
+    ///    WPF head, so <see cref="LoadRows"/> returns placeholder rows and the EntryAdded /
+    ///    Cleared subscriptions, the Clear button and reveal-in-explorer are stubs. The filter,
+    ///    search, count and preview logic are ported verbatim and run against those rows.
+    ///  - <see cref="MediaHistoryRow"/> takes the fields it formats rather than a
+    ///    <c>MediaLogEntry</c>, for the same reason. Restoring the model constructor when it
+    ///    reaches Core is a one-liner.
+    ///  - <c>Visibility</c> -> <c>IsVisible</c>; <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>;
+    ///    <c>Application.Current.TryFindResource</c> -> <c>this.TryFindResource</c>.
+    ///  - The video preview (WPF's <c>MediaElement</c>) and the animated-GIF branch
+    ///    (XamlAnimatedGif) have no Avalonia equivalent and no package may be added; both fall
+    ///    through to the still-image path.
+    ///  - <c>DisplayPath</c> normalised to backslashes; here it normalises to the platform
+    ///    separator, or the same call would mangle every Linux path.
+    ///  - The row's open-in-folder Click moves out of the DataTemplate onto the ListBox: template
+    ///    content has no name scope to bind a markup handler through. The Tag still carries the row.
+    /// </summary>
+    public partial class MediaHistoryWindow : Window
+    {
+        private readonly List<MediaHistoryRow> _allRows = new();          // newest first, unfiltered
+        private readonly ObservableCollection<MediaHistoryRow> _view = new();
+        private string _filter = "all";       // all | image | video
+        private string _search = "";
+
+        private readonly ListBox _mediaList;
+        private readonly TextBox _txtSearch;
+        private readonly TextBlock _txtCount, _txtEmpty, _searchPlaceholder;
+        private readonly TextBlock _previewHint, _previewMissing, _previewName, _previewPath;
+        private readonly Image _previewImage;
+        private readonly Button _btnFilterAll, _btnFilterImages, _btnFilterVideos;
+        private readonly Button _btnPreviewOpenFolder, _btnPreviewOpenFile;
+
+        public MediaHistoryWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _mediaList = this.FindControl<ListBox>("MediaList")!;
+            _txtSearch = this.FindControl<TextBox>("TxtSearch")!;
+            _txtCount = this.FindControl<TextBlock>("TxtCount")!;
+            _txtEmpty = this.FindControl<TextBlock>("TxtEmpty")!;
+            _searchPlaceholder = this.FindControl<TextBlock>("SearchPlaceholder")!;
+            _previewHint = this.FindControl<TextBlock>("PreviewHint")!;
+            _previewMissing = this.FindControl<TextBlock>("PreviewMissing")!;
+            _previewName = this.FindControl<TextBlock>("PreviewName")!;
+            _previewPath = this.FindControl<TextBlock>("PreviewPath")!;
+            _previewImage = this.FindControl<Image>("PreviewImage")!;
+            _btnFilterAll = this.FindControl<Button>("BtnFilterAll")!;
+            _btnFilterImages = this.FindControl<Button>("BtnFilterImages")!;
+            _btnFilterVideos = this.FindControl<Button>("BtnFilterVideos")!;
+            _btnPreviewOpenFolder = this.FindControl<Button>("BtnPreviewOpenFolder")!;
+            _btnPreviewOpenFile = this.FindControl<Button>("BtnPreviewOpenFile")!;
+
+            _mediaList.ItemsSource = _view;
+            _mediaList.SelectionChanged += MediaList_SelectionChanged;
+            _txtSearch.TextChanged += Search_TextChanged;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            _btnFilterAll.Click += Filter_Click;
+            _btnFilterImages.Click += Filter_Click;
+            _btnFilterVideos.Click += Filter_Click;
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
+            this.FindControl<Button>("BtnClear")!.Click += (_, _) => BtnClear_Click();
+            _btnPreviewOpenFolder.Click += (_, _) => RevealSelected();
+            _btnPreviewOpenFile.Click += (_, _) => OpenSelectedFile();
+
+            // One handler on the list instead of one inside the DataTemplate; Click bubbles.
+            _mediaList.AddHandler(Button.ClickEvent, OpenFolder_Click);
+            this.FindControl<DockPanel>("HeaderBar")!.PointerPressed += Header_PointerPressed;
+
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object? sender, RoutedEventArgs e)
+        {
+            foreach (var row in LoadRows())
+                _allRows.Add(row);
+
+            RebuildView();
+            UpdateFilterButtons();
+
+            // Show the populated preview state rather than the hint; WPF got here on the first
+            // click, and the render proof only ever sees the loaded window.
+            if (_view.Count > 0) _mediaList.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// WPF read <c>App.MediaHistory.GetSnapshot()</c> and subscribed to EntryAdded / Cleared.
+        /// ponytail: needs MediaHistoryService, wired when it moves to Core. Until then these
+        /// placeholder rows let the list, the filters and the preview all draw their real states.
+        /// </summary>
+        private static List<MediaHistoryRow> LoadRows()
+        {
+            var now = DateTime.Now;
+            return new List<MediaHistoryRow>
+            {
+                new("/home/user/Assets/images/soft-pink-01.gif", "soft-pink-01.gif", now.AddMinutes(-2), isVideo: false),
+                new("/home/user/Assets/videos/deep-spiral.mp4", "deep-spiral.mp4", now.AddMinutes(-9), isVideo: true),
+                new("/home/user/Assets/images/mantra-card-04.png", "mantra-card-04.png", now.AddMinutes(-21), isVideo: false),
+                new("/home/user/Assets/videos/loop-trance.webm", "loop-trance.webm", now.AddHours(-3), isVideo: true),
+                new("/home/user/Assets/images/glow-07.jpg", "glow-07.jpg", now.AddDays(-1), isVideo: false),
+                new("/home/user/Assets/images/sink-deeper.png", "sink-deeper.png", now.AddDays(-4), isVideo: false),
+            };
+        }
+
+        // ---- Filtering / search ------------------------------------------
+
+        private bool PassesFilter(MediaHistoryRow row)
+        {
+            if (_filter == "image" && row.IsVideo) return false;
+            if (_filter == "video" && !row.IsVideo) return false;
+            if (!string.IsNullOrEmpty(_search) &&
+                row.DisplayName.IndexOf(_search, StringComparison.OrdinalIgnoreCase) < 0)
+                return false;
+            return true;
+        }
+
+        private void RebuildView()
+        {
+            _view.Clear();
+            foreach (var row in _allRows)
+                if (PassesFilter(row)) _view.Add(row);
+
+            bool empty = _view.Count == 0;
+            _txtEmpty.IsVisible = empty;
+            _mediaList.IsVisible = !empty;
+            UpdateCount();
+        }
+
+        private void UpdateCount()
+        {
+            int total = _allRows.Count;
+            int shown = _view.Count;
+            _txtCount.Text = shown == total
+                ? Loc.GetF("label_media_entry_count", total)
+                : Loc.GetF("label_media_entry_count_filtered", shown, total);
+        }
+
+        private void Filter_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is Control fe && fe.Tag is string tag)
+            {
+                _filter = tag;
+                RebuildView();
+                UpdateFilterButtons();
+            }
+        }
+
+        private void UpdateFilterButtons()
+        {
+            SetActive(_btnFilterAll, _filter == "all");
+            SetActive(_btnFilterImages, _filter == "image");
+            SetActive(_btnFilterVideos, _filter == "video");
+        }
+
+        private void SetActive(Button btn, bool active)
+        {
+            btn.Background = active
+                ? (this.TryFindResource("PinkBrush", out var pink) && pink is IBrush b
+                    ? b
+                    : new SolidColorBrush(Color.FromRgb(0xFF, 0x69, 0xB4)))
+                : new SolidColorBrush(Color.FromRgb(0x25, 0x25, 0x40));
+            btn.Foreground = active ? Brushes.White : new SolidColorBrush(Color.FromRgb(0xD8, 0xD8, 0xE8));
+        }
+
+        private void Search_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            _search = _txtSearch.Text?.Trim() ?? "";
+            _searchPlaceholder.IsVisible = string.IsNullOrEmpty(_txtSearch.Text);
+            RebuildView();
+        }
+
+        // ---- Preview ------------------------------------------------------
+
+        private void MediaList_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_mediaList.SelectedItem is MediaHistoryRow row)
+                ShowPreview(row);
+            else
+                ShowPreviewNone();
+        }
+
+        private void ShowPreview(MediaHistoryRow row)
+        {
+            StopPreview();
+            _previewHint.IsVisible = false;
+            _previewName.Text = row.DisplayName;
+            _previewPath.Text = DisplayPath(row.FilePath);
+
+            bool exists = row.FileExists;
+            _btnPreviewOpenFolder.IsEnabled = exists;
+            _btnPreviewOpenFile.IsEnabled = exists;
+
+            if (!exists)
+            {
+                _previewImage.IsVisible = false;
+                _previewMissing.IsVisible = true;
+                return;
+            }
+            _previewMissing.IsVisible = false;
+
+            // ponytail: the video and animated-GIF branches need a media stack (WPF used
+            // MediaElement and XamlAnimatedGif); wired when one is chosen for the Avalonia head.
+            if (row.IsVideo)
+            {
+                _previewImage.IsVisible = false;
+                _previewMissing.IsVisible = true;
+                return;
+            }
+
+            try
+            {
+                _previewImage.IsVisible = true;
+                using var stream = File.OpenRead(row.FilePath);
+                // WPF capped the single preview with DecodePixelWidth=720; never full-res.
+                _previewImage.Source = global::Avalonia.Media.Imaging.Bitmap.DecodeToWidth(stream, 720);
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Debug("MediaHistoryWindow: preview failed for {Path}: {Error}", row.FilePath, ex.Message);
+                _previewImage.IsVisible = false;
+                _previewMissing.IsVisible = true;
+            }
+        }
+
+        private void ShowPreviewNone()
+        {
+            _previewHint.IsVisible = true;
+            _previewImage.IsVisible = false;
+            _previewMissing.IsVisible = false;
+            _previewName.Text = "";
+            _previewPath.Text = "";
+            _btnPreviewOpenFolder.IsEnabled = false;
+            _btnPreviewOpenFile.IsEnabled = false;
+        }
+
+        private void StopPreview()
+        {
+            try { _previewImage.Source = null; } catch { }
+        }
+
+        // ---- Open in the file manager -------------------------------------
+
+        private void OpenFolder_Click(object? sender, RoutedEventArgs e)
+        {
+            if ((e.Source as Control)?.Tag is MediaHistoryRow row)
+                RevealInExplorer(row.FilePath);
+        }
+
+        private void RevealSelected()
+        {
+            if (_mediaList.SelectedItem is MediaHistoryRow row)
+                RevealInExplorer(row.FilePath);
+        }
+
+        /// <summary>ponytail: needs Helpers.ExplorerLauncher (Win32 shell), wired when it moves to
+        /// Core with a Linux xdg-open path.</summary>
+        private static void RevealInExplorer(string path) { _ = path; }
+
+        /// <summary>ponytail: needs a shell-open helper, wired alongside ExplorerLauncher.</summary>
+        private void OpenSelectedFile() { }
+
+        /// <summary>ponytail: needs MediaHistoryService.Clear plus a confirm dialog
+        /// (confirm_clear_media_log), wired when the service moves to Core.</summary>
+        private void BtnClear_Click() { }
+
+        /// <summary>
+        /// Paths reach the log from a mix of sources, so a stored path can carry the wrong
+        /// separator and read back as "D:/Assets/images\personal\x.gif" (#1108). Display only -
+        /// the stored path is left alone. WPF hardcoded '\\'; this normalises to whatever the
+        /// platform uses, or the same line would mangle every Linux path.
+        /// </summary>
+        private static string DisplayPath(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return path;
+            return Path.DirectorySeparatorChar == '\\' ? path.Replace('/', '\\') : path.Replace('\\', '/');
+        }
+
+        // ---- Chrome -------------------------------------------------------
+
+        private void Header_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            {
+                try { BeginMoveDrag(e); } catch { }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Lightweight view-model for one history row. All display fields are precomputed once (rows
+    /// are immutable), keeping the virtualized list cheap. Top-level rather than nested so
+    /// <c>x:DataType</c> can name it.
+    /// </summary>
+    public sealed class MediaHistoryRow
+    {
+        public string FilePath { get; }
+        public bool IsVideo { get; }
+        public string DisplayName { get; }
+        public string TimeText { get; }
+        public string TypeBadge { get; }
+        public string PlaceholderGlyph { get; }
+        public IBrush BadgeBrush { get; }
+        public bool FileExists => SafeExists(FilePath);
+
+        public MediaHistoryRow(string filePath, string? displayName, DateTime timestamp, bool isVideo)
+        {
+            FilePath = filePath;
+            IsVideo = isVideo;
+            DisplayName = string.IsNullOrEmpty(displayName) ? SafeName(filePath) : displayName!;
+            TimeText = FormatTime(timestamp);
+
+            if (isVideo)
+            {
+                TypeBadge = Loc.Get("badge_video");
+                PlaceholderGlyph = "🎬";
+                BadgeBrush = new SolidColorBrush(Color.FromRgb(0x4A, 0x6C, 0xD0));
+            }
+            else
+            {
+                TypeBadge = Loc.Get("badge_image");
+                PlaceholderGlyph = "🖼";
+                BadgeBrush = new SolidColorBrush(Color.FromRgb(0xB0, 0x50, 0x9C));
+            }
+        }
+
+        private static string FormatTime(DateTime t)
+        {
+            var now = DateTime.Now;
+            if (t.Date == now.Date) return t.ToString("HH:mm:ss");
+            if (t.Date == now.Date.AddDays(-1)) return Loc.Get("label_yesterday") + " " + t.ToString("HH:mm");
+            return t.ToString("MMM d, HH:mm");
+        }
+
+        private static string SafeName(string path)
+        {
+            try { return Path.GetFileName(path) ?? path; } catch { return path; }
+        }
+
+        private static bool SafeExists(string path)
+        {
+            try { return !string.IsNullOrEmpty(path) && File.Exists(path); } catch { return false; }
+        }
+    }
+}


### PR DESCRIPTION
1,195 lines, over the soft line for the same reason. Found that x:Name on a brush, gradient stop, effect or transform is illegal in Avalonia; the code-behind reaches them through the owning control.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351