### PR TITLE
feat(avalonia): port QuizCategoryEditorWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml
@@ -1,0 +1,285 @@
+<!-- PORTED from ConditioningControlPanel/Windows/QuizCategoryEditorWindow.xaml.
+     Structure, x:Names, ordering, spacing and every loc key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency  -> SystemDecorations="None" / TransparencyLevelHint
+       DropShadowEffect ShadowDepth="0"         -> dropped; Avalonia's effect has OffsetX/Y, both 0
+       DynamicResource on a shadow Color        -> StaticResource (SeasonRecapCard/QuizReportWindow
+                                                   precedent: an effect Color is not a styled prop)
+       TextBox.Resources <Style TargetType=     -> CornerRadius="8" on the TextBox itself; the WPF
+         "Border"> CornerRadius hack               hack existed because WPF's TextBox has no such
+                                                   property, Avalonia's does
+       ComboBox.ItemContainerStyle              -> <ComboBox.Styles> with a ComboBoxItem selector;
+         + Trigger IsHighlighted                   the trigger becomes ComboBoxItem:pointerover.
+                                                   A Style (not a ControlTheme) only sets
+                                                   properties, so trap 4 in CLAUDE.md does not bite
+       SystemColors.WindowBrushKey override     -> dropped; that resource key is WPF-only and the
+                                                   dropdown popup is already dark in this theme
+       ComboBoxItem IsSelected="True"           -> SelectedIndex="0" on the ComboBox
+       LinearGradientBrush 0,0 -> 1,1           -> "0%,0%" -> "100%,100%"; bare numbers are
+                                                   ABSOLUTE pixels in Avalonia
+       Visibility="Collapsed"                   -> IsVisible="False"
+       MouseLeftButtonDown / MouseEnter/Leave   -> PointerPressed / PointerEntered / PointerExited,
+       KeyDown / SelectionChanged in markup        all wired in the constructor
+       {loc:Str} on TxtTitle and TxtPreviewHint -> set from code instead. Both are ALSO assigned
+                                                   from the code-behind, and Avalonia keeps a
+                                                   binding alive under a local value where WPF
+                                                   cleared it, so the assignment would be undone on
+                                                   the next language change. See CLAUDE.md.
+
+     The Cancel border gained an x:Name (BtnCancel) and the close X gained BtnClose, because their
+     handlers are wired in the ctor. Buttons carry a TextBlock child rather than Content: Avalonia
+     parses "_" in Content as an access key and every loc key here is snake_case. See CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.QuizCategoryEditorWindow"
+        Title="{loc:Str dialog_custom_quiz_category}"
+        Width="700" Height="750"
+        WindowStartupLocation="CenterOwner"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent">
+
+    <Border CornerRadius="16" Margin="8" BorderThickness="1.5">
+        <Border.Background>
+            <SolidColorBrush Color="#F0151530"/>
+        </Border.Background>
+        <Border.BorderBrush>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                <GradientStop Color="#60FF69B4" Offset="0"/>
+                <GradientStop Color="#609B59B6" Offset="1"/>
+            </LinearGradientBrush>
+        </Border.BorderBrush>
+        <Border.Effect>
+            <DropShadowEffect Color="Black" BlurRadius="20" Opacity="0.6"/>
+        </Border.Effect>
+
+        <Grid Margin="28,20" RowDefinitions="Auto,*,Auto">
+
+            <!-- Header -->
+            <StackPanel Grid.Row="0" Margin="0,0,0,16">
+                <Grid>
+                    <TextBlock x:Name="TxtTitle" FontSize="22" FontWeight="Bold"
+                               Foreground="{DynamicResource PinkBrush}" HorizontalAlignment="Left">
+                        <TextBlock.Effect>
+                            <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="15" Opacity="0.3"/>
+                        </TextBlock.Effect>
+                    </TextBlock>
+                    <!-- Close button -->
+                    <TextBlock x:Name="BtnClose" Text="X" FontSize="18" FontWeight="Bold" Foreground="#606080"
+                               HorizontalAlignment="Right" VerticalAlignment="Top" Cursor="Hand"/>
+                </Grid>
+                <TextBlock Text="{loc:Str label_design_your_own_quiz_theme_with_custom_archet}"
+                           Foreground="#606080" FontSize="13" Margin="0,4,0,0"/>
+            </StackPanel>
+
+            <!-- Scrollable content -->
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled" Margin="0,0,-8,0" Padding="0,0,8,0">
+                <StackPanel>
+                    <!-- Category Name -->
+                    <TextBlock Text="{loc:Str label_category_name}" Foreground="#808090" FontSize="11" FontWeight="Bold"
+                               Margin="0,0,0,4"/>
+                    <TextBox x:Name="TxtName" MaxLength="30" FontSize="15" Foreground="White"
+                             Background="#20FFFFFF" BorderBrush="#30FFFFFF" BorderThickness="1"
+                             Padding="10,8" CaretBrush="White" CornerRadius="8"/>
+
+                    <!-- Description -->
+                    <TextBlock Text="{loc:Str label_description}" Foreground="#808090" FontSize="11" FontWeight="Bold"
+                               Margin="0,14,0,4"/>
+                    <TextBox x:Name="TxtDescription" MaxLength="200" FontSize="13" Foreground="White"
+                             Background="#20FFFFFF" BorderBrush="#30FFFFFF" BorderThickness="1"
+                             Padding="10,8" CaretBrush="White" TextWrapping="Wrap" CornerRadius="8"
+                             AcceptsReturn="False" Height="50"/>
+
+                    <!-- Color picker -->
+                    <TextBlock Text="{loc:Str label_accent_color}" Foreground="#808090" FontSize="11" FontWeight="Bold"
+                               Margin="0,14,0,6"/>
+                    <WrapPanel x:Name="ColorPicker" Orientation="Horizontal"/>
+
+                    <!-- Template dropdown -->
+                    <TextBlock Text="{loc:Str label_start_from_template}" Foreground="#808090" FontSize="11" FontWeight="Bold"
+                               Margin="0,14,0,4"/>
+                    <ComboBox x:Name="CboTemplate" FontSize="13" Foreground="White"
+                              Background="#20FFFFFF" BorderBrush="#30FFFFFF" BorderThickness="1"
+                              Padding="8,6" SelectedIndex="0" HorizontalAlignment="Stretch">
+                        <ComboBox.Styles>
+                            <Style Selector="ComboBoxItem">
+                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="Background" Value="{DynamicResource DarkerBgBrush}"/>
+                                <Setter Property="Padding" Value="8,6"/>
+                            </Style>
+                            <Style Selector="ComboBoxItem:pointerover">
+                                <Setter Property="Background" Value="#30FF69B4"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Style>
+                        </ComboBox.Styles>
+                        <ComboBoxItem Content="{loc:Str btn_blank_write_your_own}" Tag=""/>
+                        <ComboBoxItem Content="{loc:Str btn_copy_from_sissy}" Tag="sissy"/>
+                        <ComboBoxItem Content="{loc:Str btn_copy_from_bambi}" Tag="bambi"/>
+                        <ComboBoxItem Content="{loc:Str btn_copy_from_obedience}" Tag="obedience"/>
+                        <ComboBoxItem Content="{loc:Str btn_copy_from_mindlessness}" Tag="mindlessness"/>
+                        <ComboBoxItem Content="{loc:Str btn_copy_from_submission}" Tag="submission"/>
+                    </ComboBox>
+
+                    <!-- CCBill AI Addendum: content-policy banner above the editable AI prompt. -->
+                    <Border x:Name="PolicyBannerFull"
+                            Margin="0,14,0,0"
+                            Padding="12" CornerRadius="4"
+                            Background="#3D3520"
+                            BorderBrush="#A98E3A" BorderThickness="1">
+                        <StackPanel>
+                            <DockPanel LastChildFill="True" Margin="0,0,0,6">
+                                <TextBlock Text="&#9888;" FontSize="16" Foreground="#E5C76B"
+                                           VerticalAlignment="Top" Margin="0,0,8,0"
+                                           DockPanel.Dock="Left"/>
+                                <TextBlock Text="{loc:Str prompt_editor_policy_full}"
+                                           Foreground="#F0E2A6" FontSize="12" TextWrapping="Wrap"
+                                           VerticalAlignment="Center"/>
+                            </DockPanel>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
+                                <Button x:Name="BtnPolicyReadFull"
+                                        Background="Transparent" Foreground="#E5C76B"
+                                        BorderThickness="0" FontSize="11" Cursor="Hand"
+                                        Padding="8,4" Margin="0,0,8,0">
+                                    <TextBlock Text="{loc:Str prompt_editor_policy_read}"/>
+                                </Button>
+                                <Button x:Name="BtnPolicyGotIt"
+                                        Background="#A98E3A" Foreground="White"
+                                        BorderThickness="0" FontSize="11" Cursor="Hand"
+                                        Padding="12,4">
+                                    <TextBlock Text="{loc:Str prompt_editor_policy_got_it}"/>
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                    <Border x:Name="PolicyBannerSlim" IsVisible="False"
+                            Margin="0,14,0,0"
+                            Padding="10,6" CornerRadius="4" Background="#2A2520"
+                            BorderBrush="#A98E3A" BorderThickness="0,0,0,2">
+                        <DockPanel LastChildFill="True">
+                            <TextBlock Text="&#9888;" FontSize="13" Foreground="#E5C76B"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"
+                                       DockPanel.Dock="Left"/>
+                            <Button x:Name="BtnPolicyReadSlim"
+                                    Background="Transparent" Foreground="#E5C76B"
+                                    BorderThickness="0" FontSize="11" Cursor="Hand"
+                                    Padding="4,0" VerticalAlignment="Center"
+                                    DockPanel.Dock="Right">
+                                <TextBlock Text="{loc:Str prompt_editor_policy_read}"/>
+                            </Button>
+                            <TextBlock Text="{loc:Str prompt_editor_policy_slim}"
+                                       Foreground="#C8B47A" FontSize="11" TextWrapping="Wrap"
+                                       VerticalAlignment="Center" Margin="0,0,8,0"/>
+                        </DockPanel>
+                    </Border>
+
+                    <!-- P1.3 PromptValidator warning banner. Hidden until Save is clicked. -->
+                    <Border x:Name="ValidatorBanner"
+                            IsVisible="False"
+                            Margin="0,14,0,0"
+                            Padding="10,8"
+                            CornerRadius="4"
+                            Background="#3D3520"
+                            BorderBrush="#E5C76B"
+                            BorderThickness="1">
+                        <TextBlock x:Name="TxtValidatorBanner"
+                                   Foreground="#F0E2A6"
+                                   FontSize="12"
+                                   TextWrapping="Wrap"/>
+                    </Border>
+
+                    <!-- System prompt -->
+                    <TextBlock Text="{loc:Str label_system_prompt}" Foreground="#808090" FontSize="11" FontWeight="Bold"
+                               Margin="0,14,0,4"/>
+                    <TextBlock Text="{loc:Str label_this_is_the_ai_instruction_that_generates_qui}"
+                               Foreground="#505060" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,4"/>
+                    <TextBox x:Name="TxtPrompt" FontSize="12" Foreground="#C0C0D0"
+                             Background="#10FFFFFF" BorderBrush="#20FFFFFF" BorderThickness="1"
+                             Padding="10,8" CaretBrush="White" TextWrapping="Wrap" CornerRadius="8"
+                             AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             Height="160" FontFamily="Consolas, Courier New"/>
+
+                    <!-- Archetypes -->
+                    <TextBlock Text="{loc:Str label_archetypes_5_tiers}" Foreground="#808090" FontSize="11" FontWeight="Bold"
+                               Margin="0,16,0,6"/>
+                    <TextBlock Text="{loc:Str label_define_the_personality_names_assigned_at_each}"
+                               Foreground="#505060" FontSize="11" Margin="0,0,0,8"/>
+
+                    <!-- Column headers -->
+                    <Grid Margin="0,0,0,4" ColumnDefinitions="*,55,55,*">
+                        <TextBlock Text="{loc:Str section_name}" Foreground="#606070" FontSize="10" Grid.Column="0" Margin="4,0,0,0"/>
+                        <TextBlock Text="{loc:Str label_min_2}" Foreground="#606070" FontSize="10" Grid.Column="1" Margin="4,0,0,0"/>
+                        <TextBlock Text="{loc:Str label_max}" Foreground="#606070" FontSize="10" Grid.Column="2" Margin="4,0,0,0"/>
+                        <TextBlock Text="{loc:Str label_description_2}" Foreground="#606070" FontSize="10" Grid.Column="3" Margin="4,0,0,0"/>
+                    </Grid>
+
+                    <StackPanel x:Name="ArchetypeRows"/>
+
+                    <!-- Preview button -->
+                    <Border x:Name="BtnPreview" Cursor="Hand" CornerRadius="8" Margin="0,16,0,0"
+                            Padding="12,8" HorizontalAlignment="Left" BorderThickness="1">
+                        <Border.Background>
+                            <SolidColorBrush Color="#15FFFFFF"/>
+                        </Border.Background>
+                        <Border.BorderBrush>
+                            <SolidColorBrush Color="#309B59B6"/>
+                        </Border.BorderBrush>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{loc:Str section_preview}" Foreground="{DynamicResource SecondaryBrush}" FontSize="13" FontWeight="SemiBold"/>
+                            <TextBlock x:Name="TxtPreviewHint" Foreground="#505060" FontSize="12"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Preview result -->
+                    <Border x:Name="PreviewResultPanel" IsVisible="False" CornerRadius="8"
+                            Margin="0,8,0,0" Padding="12,10"
+                            Background="#10FFFFFF" BorderBrush="#209B59B6" BorderThickness="1">
+                        <TextBlock x:Name="TxtPreviewResult" FontSize="12" Foreground="#A0A0B0"
+                                   TextWrapping="Wrap" FontFamily="Consolas, Courier New"/>
+                    </Border>
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- Bottom buttons -->
+            <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,4">
+                <!-- Delete button (only for editing existing) -->
+                <Border x:Name="BtnDelete" Cursor="Hand" CornerRadius="8" Padding="16,10"
+                        Margin="0,0,10,0" IsVisible="False" BorderThickness="1">
+                    <Border.Background>
+                        <SolidColorBrush Color="#15FF4444"/>
+                    </Border.Background>
+                    <Border.BorderBrush>
+                        <SolidColorBrush Color="#30FF4444"/>
+                    </Border.BorderBrush>
+                    <TextBlock Text="{loc:Str btn_delete}" Foreground="#FF6666" FontSize="14" FontWeight="SemiBold"/>
+                </Border>
+
+                <!-- Cancel -->
+                <Border x:Name="BtnCancel" Cursor="Hand" CornerRadius="8" Padding="16,10" Margin="0,0,10,0"
+                        BorderThickness="1">
+                    <Border.Background>
+                        <SolidColorBrush Color="#15FFFFFF"/>
+                    </Border.Background>
+                    <Border.BorderBrush>
+                        <SolidColorBrush Color="#20FFFFFF"/>
+                    </Border.BorderBrush>
+                    <TextBlock Text="{loc:Str btn_cancel}" Foreground="#808090" FontSize="14" FontWeight="SemiBold"/>
+                </Border>
+
+                <!-- Save -->
+                <Border x:Name="BtnSave" Cursor="Hand" CornerRadius="8" Padding="20,10" BorderThickness="1">
+                    <Border.Background>
+                        <SolidColorBrush Color="#25FF69B4"/>
+                    </Border.Background>
+                    <Border.BorderBrush>
+                        <SolidColorBrush Color="#50FF69B4"/>
+                    </Border.BorderBrush>
+                    <TextBlock x:Name="TxtSave" Text="{loc:Str label_save_category}" Foreground="{DynamicResource PinkBrush}"
+                               FontSize="14" FontWeight="Bold"/>
+                </Border>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml.cs
@@ -1,0 +1,487 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services.Moderation;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Editor for a user-authored quiz category: name, blurb, accent colour, the AI system prompt
+    /// that generates its questions, and the five archetypes the final score maps onto.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/QuizCategoryEditorWindow.xaml.cs. Deviations:
+    ///  - <c>QuizCategoryDefinition</c> / <c>QuizArchetypeDefinition</c> live in the WPF head's
+    ///    Services/Quiz/QuizService.cs, not in CCP.Core, and neither may be touched by this port -
+    ///    so they are copied below, trimmed to the fields this view reads or writes (the
+    ///    TextEditorDialog/QuizReportWindow precedent).
+    ///  - <c>QuizService</c> is not in Core either, so the template dropdown, the AI preview, the
+    ///    built-in name-collision check and Delete are stubs. Each carries a ponytail comment.
+    ///  - <c>PromptValidator</c> IS in Core, so <see cref="RunPromptValidation"/> runs for real.
+    ///  - The four <c>MessageBox.Show</c> calls have no Avalonia equivalent and no package may be
+    ///    added; they become ponytail comments, so the empty-field guards still block the save but
+    ///    do so silently (CompanionPromptEditorDialog precedent).
+    ///  - <c>DialogResult = x; Close()</c> -> <c>Close(x)</c>.
+    ///  - The public ctor loses its <c>= null</c> default: with a parameterless render ctor beside
+    ///    it, <c>new QuizCategoryEditorWindow()</c> would be ambiguous (CS0121).
+    ///  - The Tag-scan pair (<c>SetArchField</c>/<c>GetArchField</c>) is replaced by the
+    ///    <c>_arch</c> array the row builder already has to hold. Same behaviour, ~40 fewer lines.
+    ///  - <c>TxtTitle</c>/<c>TxtPreviewHint</c> are set from code only, never bound - see the
+    ///    header comment in the .axaml.
+    /// </summary>
+    public partial class QuizCategoryEditorWindow : Window
+    {
+        private readonly QuizCategoryDefinition? _existing;
+        private string _selectedColor = "#FF69B4";
+        private bool _policyAcked;
+
+        /// <summary>Row i holds { name, min, max, description } for archetype i.</summary>
+        private readonly List<TextBox[]> _arch = new();
+
+        private readonly TextBox _txtName, _txtDescription, _txtPrompt;
+        private readonly WrapPanel _colorPicker;
+        private readonly TextBlock _txtPreviewHint;
+
+        private static readonly string[] PresetColors = new[]
+        {
+            "#FF69B4", "#9B59B6", "#E67E22", "#3498DB",
+            "#E74C3C", "#2ECC71", "#F1C40F", "#1ABC9C"
+        };
+
+        // Default percentage ranges for 5 archetypes
+        private static readonly (int Min, int Max)[] DefaultRanges = new[]
+        {
+            (0, 25), (26, 50), (51, 70), (71, 85), (86, 100)
+        };
+
+        public QuizCategoryDefinition? Result { get; private set; }
+
+        /// <summary>Render/design constructor: an existing category, so --render-view draws the
+        /// edit title, the filled boxes, the populated archetype rows AND the Delete button.
+        /// Internal, so no production caller can ship the sample.</summary>
+        internal QuizCategoryEditorWindow() : this(SampleCategory()) { }
+
+        public QuizCategoryEditorWindow(QuizCategoryDefinition? existing)
+        {
+            AvaloniaXamlLoader.Load(this);
+            _existing = existing;
+
+            _txtName = this.FindControl<TextBox>("TxtName")!;
+            _txtDescription = this.FindControl<TextBox>("TxtDescription")!;
+            _txtPrompt = this.FindControl<TextBox>("TxtPrompt")!;
+            _colorPicker = this.FindControl<WrapPanel>("ColorPicker")!;
+            _txtPreviewHint = this.FindControl<TextBlock>("TxtPreviewHint")!;
+
+            _txtPreviewHint.Text = Loc.Get("label_generate_a_sample_question");
+            this.FindControl<TextBlock>("TxtTitle")!.Text = Loc.Get(
+                existing != null ? "label_edit_custom_category" : "label_create_custom_category");
+
+            BuildColorPicker();
+            BuildArchetypeRows();
+            ApplyPolicyBannerState();
+
+            if (existing != null)
+            {
+                _txtName.Text = existing.Name;
+                _txtDescription.Text = existing.Description;
+                _txtPrompt.Text = existing.SystemPromptTemplate;
+                SelectColor(existing.Color);
+                PopulateArchetypes(existing.Archetypes);
+                this.FindControl<Border>("BtnDelete")!.IsVisible = true;
+            }
+
+            // Handlers live here rather than in markup, per the porting convention. Wired after the
+            // loads above so the initial SelectedIndex="0" does not fire the template copy.
+            this.FindControl<ComboBox>("CboTemplate")!.SelectionChanged += CboTemplate_SelectionChanged;
+            this.FindControl<Button>("BtnPolicyGotIt")!.Click += (_, _) => BtnPolicyGotIt_Click();
+            this.FindControl<Button>("BtnPolicyReadFull")!.Click += (_, _) => BtnPolicyRead_Click();
+            this.FindControl<Button>("BtnPolicyReadSlim")!.Click += (_, _) => BtnPolicyRead_Click();
+
+            WireActionBorder("BtnPreview", BtnPreview_Click);
+            WireActionBorder("BtnDelete", BtnDelete_Click);
+            WireActionBorder("BtnCancel", _ => Close(false));
+            WireActionBorder("BtnSave", BtnSave_Click);
+
+            var close = this.FindControl<TextBlock>("BtnClose")!;
+            close.PointerPressed += (_, _) => Close(false);
+            close.PointerEntered += (_, _) => close.Foreground = Brushes.White;
+            close.PointerExited += (_, _) => close.Foreground = new SolidColorBrush(Color.FromRgb(0x60, 0x60, 0x80));
+
+            KeyDown += (_, e) => { if (e.Key == Key.Escape) Close(false); };
+        }
+
+        /// <summary>
+        /// WPF's MouseLeftButtonDown + the shared ActionBtn_MouseEnter/Leave pair, on one of the
+        /// four Borders that stand in for buttons. One deliberate divergence: WPF's MouseLeave set
+        /// EVERY border to #15FFFFFF, so Save and Delete lost their pink and red tint permanently
+        /// after the first hover. This captures each border's own idle brush and restores that.
+        /// </summary>
+        private void WireActionBorder(string name, Action<Border> onClick)
+        {
+            var border = this.FindControl<Border>(name)!;
+            var idle = border.Background;
+            border.PointerPressed += (_, e) =>
+            {
+                if (e.GetCurrentPoint(border).Properties.IsLeftButtonPressed) onClick(border);
+            };
+            border.PointerEntered += (_, _) =>
+                border.Background = new SolidColorBrush(Color.FromArgb(0x25, 0xFF, 0xFF, 0xFF));
+            border.PointerExited += (_, _) => border.Background = idle;
+        }
+
+        private void BuildColorPicker()
+        {
+            _colorPicker.Children.Clear();
+            foreach (var hex in PresetColors)
+            {
+                Color color;
+                try { color = Color.Parse(hex); }
+                catch { continue; }
+
+                var ellipse = new Ellipse
+                {
+                    Width = 32,
+                    Height = 32,
+                    Fill = new SolidColorBrush(color),
+                    Stroke = Brushes.Transparent,
+                    StrokeThickness = 2,
+                    Margin = new Thickness(0, 0, 8, 0),
+                    Cursor = new Cursor(StandardCursorType.Hand),
+                    Tag = hex
+                };
+                ellipse.PointerPressed += ColorSwatch_Click;
+                _colorPicker.Children.Add(ellipse);
+            }
+            SelectColor(_selectedColor);
+        }
+
+        private void SelectColor(string hex)
+        {
+            _selectedColor = hex;
+            foreach (var child in _colorPicker.Children)
+            {
+                if (child is Ellipse e)
+                {
+                    bool selected = e.Tag?.ToString() == hex;
+                    e.Stroke = selected ? Brushes.White : Brushes.Transparent;
+                    e.StrokeThickness = selected ? 2.5 : 2;
+                }
+            }
+        }
+
+        private void ColorSwatch_Click(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is Ellipse el && el.Tag is string hex)
+                SelectColor(hex);
+        }
+
+        private void BuildArchetypeRows()
+        {
+            var rows = this.FindControl<StackPanel>("ArchetypeRows")!;
+            rows.Children.Clear();
+            _arch.Clear();
+
+            // Hardcoded English in WPF too - there are no loc keys for the five default tier names.
+            string[] defaultNames = { "Tier 1 (Low)", "Tier 2", "Tier 3 (Mid)", "Tier 4", "Tier 5 (Max)" };
+
+            for (int i = 0; i < 5; i++)
+            {
+                var grid = new Grid
+                {
+                    Margin = new Thickness(0, 0, 0, 6),
+                    ColumnDefinitions = new ColumnDefinitions("*,55,55,*")
+                };
+
+                var cells = new[]
+                {
+                    MakeTextBox(defaultNames[i], 30),
+                    MakeTextBox(DefaultRanges[i].Min.ToString(), 3),
+                    MakeTextBox(DefaultRanges[i].Max.ToString(), 3),
+                    MakeTextBox("", 100),
+                };
+
+                for (int c = 0; c < cells.Length; c++)
+                {
+                    if (c > 0) cells[c].Margin = new Thickness(4, 0, 0, 0);
+                    Grid.SetColumn(cells[c], c);
+                    grid.Children.Add(cells[c]);
+                }
+
+                _arch.Add(cells);
+                rows.Children.Add(grid);
+            }
+        }
+
+        private static TextBox MakeTextBox(string text, int maxLength) => new()
+        {
+            MaxLength = maxLength,
+            FontSize = 12,
+            Foreground = Brushes.White,
+            Background = new SolidColorBrush(Color.FromArgb(0x15, 0xFF, 0xFF, 0xFF)),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x20, 0xFF, 0xFF, 0xFF)),
+            BorderThickness = new Thickness(1),
+            Padding = new Thickness(6, 4, 6, 4),
+            CaretBrush = Brushes.White,
+            Text = text
+        };
+
+        private void PopulateArchetypes(List<QuizArchetypeDefinition> archetypes)
+        {
+            for (int i = 0; i < Math.Min(_arch.Count, archetypes.Count); i++)
+            {
+                var arch = archetypes[i];
+                _arch[i][0].Text = arch.Name;
+                _arch[i][1].Text = arch.MinPercentage.ToString();
+                _arch[i][2].Text = arch.MaxPercentage.ToString();
+                _arch[i][3].Text = arch.Description;
+            }
+        }
+
+        private List<QuizArchetypeDefinition> CollectArchetypes()
+        {
+            var list = new List<QuizArchetypeDefinition>();
+            foreach (var row in _arch)
+            {
+                var name = (row[0].Text ?? "").Trim();
+                if (string.IsNullOrWhiteSpace(name)) continue;
+
+                int.TryParse((row[1].Text ?? "").Trim(), out int min);
+                int.TryParse((row[2].Text ?? "").Trim(), out int max);
+
+                list.Add(new QuizArchetypeDefinition
+                {
+                    Name = name,
+                    MinPercentage = Math.Clamp(min, 0, 100),
+                    MaxPercentage = Math.Clamp(max, 0, 100),
+                    Description = (row[3].Text ?? "").Trim()
+                });
+            }
+            return list;
+        }
+
+        private void CboTemplate_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (((ComboBox)sender!).SelectedItem is not ComboBoxItem item) return;
+            var templateId = item.Tag?.ToString();
+            if (string.IsNullOrEmpty(templateId)) return;
+
+            // ponytail: needs QuizService.GetBuiltInCategories()/FindCategory() for the real
+            // category name and its archetype table; wired when the quiz service moves to Core.
+            // The skeleton below is the WPF original's, minus the RESULT ARCHETYPES block it filled
+            // from the built-in definition.
+            _txtPrompt.Text = GetBuiltInPromptText(templateId);
+        }
+
+        private static string GetBuiltInPromptText(string categoryId) => $@"You are a quiz master for a ""{categoryId}"" personality quiz.
+
+TONE: [Describe the voice and attitude — e.g. warm, teasing, authoritative]
+
+QUESTION THEMES — You MUST rotate through these, one per question, no repeats:
+1. [Theme 1]
+2. [Theme 2]
+3. [Theme 3]
+4. [Theme 4]
+5. [Theme 5]
+6. [Theme 6]
+7. [Theme 7]
+8. [Theme 8]
+9. [Theme 9]
+10. [Theme 10]
+
+INTENSITY SCALING — Scale with score percentage:
+- LOW (below 50%): [Mild, everyday scenarios]
+- MEDIUM (50-74%): [More intense, specific scenarios]
+- HIGH (75%+): [Deep, extreme scenarios]
+
+FORMAT — You MUST use EXACTLY this format, nothing else:
+Q: [your question here]
+A: [mild answer] | 1
+B: [moderate answer] | 2
+C: [spicy answer] | 3
+D: [extreme answer] | 4
+
+Do NOT include any other text before or after the question format. Just the question and 4 answers.";
+
+        private void BtnPreview_Click(Border _)
+        {
+            var prompt = (_txtPrompt.Text ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(prompt))
+            {
+                ShowPreviewResult("Enter a system prompt first.", false);
+                return;
+            }
+
+            // ponytail: needs QuizService.StartQuizAsync to round-trip the prompt through the AI
+            // provider; wired when the quiz service moves to Core. Until then the panel opens with
+            // the same "couldn't generate" copy the WPF original shows on a null question, so the
+            // busy/idle hint swap and ShowPreviewResult stay exercised.
+            _txtPreviewHint.Text = Loc.Get("label_generating");
+            ShowPreviewResult("AI couldn't generate a valid question. Check your prompt format.", false);
+            _txtPreviewHint.Text = Loc.Get("label_generate_a_sample_question");
+        }
+
+        private void ShowPreviewResult(string text, bool success)
+        {
+            var box = this.FindControl<TextBlock>("TxtPreviewResult")!;
+            box.Text = text;
+            box.Foreground = new SolidColorBrush(
+                success ? Color.FromRgb(0xA0, 0xA0, 0xB0) : Color.FromRgb(0xFF, 0x66, 0x66));
+            this.FindControl<Border>("PreviewResultPanel")!.IsVisible = true;
+        }
+
+        private void BtnSave_Click(Border _)
+        {
+            var name = (_txtName.Text ?? "").Trim();
+            // ponytail: WPF showed MessageBox(msg_please_enter_a_category_name) here; no Avalonia
+            // equivalent and no package may be added, so the guard blocks silently.
+            if (string.IsNullOrWhiteSpace(name)) return;
+
+            if (name.Length > 30) name = name[..30];
+
+            var prompt = (_txtPrompt.Text ?? "").Trim();
+            // ponytail: WPF showed MessageBox(msg_please_enter_a_system_prompt_for_the_ai) here.
+            if (string.IsNullOrWhiteSpace(prompt)) return;
+
+            var archetypes = CollectArchetypes();
+            // ponytail: WPF showed MessageBox(msg_please_define_at_least_2_archetypes) here.
+            if (archetypes.Count < 2) return;
+
+            // ponytail: needs QuizService.GetBuiltInCategories() to reject a name that collides with
+            // a built-in one (msg_this_name_conflicts_with_a_built_in_category); wired when the
+            // quiz service moves to Core.
+
+            // P1.3 PromptValidator: soft validation, warns but does not block save.
+            RunPromptValidation(prompt);
+
+            Result = new QuizCategoryDefinition
+            {
+                Id = _existing?.Id ?? $"custom_{Guid.NewGuid():N}".Substring(0, 20),
+                Name = name,
+                Description = (_txtDescription.Text ?? "").Trim(),
+                SystemPromptTemplate = prompt,
+                Color = _selectedColor,
+                IsBuiltIn = false,
+                Archetypes = archetypes
+            };
+
+            Close(true);
+        }
+
+        /// <summary>
+        /// P1.3 — soft validator over the system prompt textbox. Hits paint the
+        /// TextBox yellow and raise the banner. Always returns; save is never blocked.
+        /// </summary>
+        private void RunPromptValidation(string prompt)
+        {
+            var result = new PromptValidator().Validate(prompt);
+            var banner = this.FindControl<Border>("ValidatorBanner")!;
+
+            if (result.Clean)
+            {
+                _txtPrompt.BorderBrush = new SolidColorBrush(Color.FromArgb(0x20, 0xFF, 0xFF, 0xFF));
+                _txtPrompt.BorderThickness = new Thickness(1);
+                _txtPrompt.ClearValue(ToolTip.TipProperty);
+                banner.IsVisible = false;
+                return;
+            }
+
+            _txtPrompt.BorderBrush = new SolidColorBrush(Color.FromRgb(0xE5, 0xC7, 0x6B));
+            _txtPrompt.BorderThickness = new Thickness(2);
+            ToolTip.SetTip(_txtPrompt, Loc.GetF("prompt_validator_warning", result.MatchedPatterns.Count));
+
+            // The literal 1 is the WPF original's: this editor has exactly one validated field.
+            this.FindControl<TextBlock>("TxtValidatorBanner")!.Text = Loc.GetF("prompt_validator_banner", 1);
+            banner.IsVisible = true;
+
+            // ponytail: App.ModerationLog?.RecordEdit("SystemPromptTemplate", count, "quiz_category")
+            // and the matching App.Logger line, wired when the moderation log moves to Core.
+        }
+
+        private void BtnDelete_Click(Border _)
+        {
+            if (_existing == null) return;
+
+            // ponytail: WPF confirmed with a Yes/No MessageBox and then called
+            // QuizService.DeleteCustomCategory(_existing.Id); both are stubbed, so the dialog just
+            // closes with a null Result - which is already the "deleted" signal the caller reads.
+            Result = null;
+            Close(true);
+        }
+
+        /// <summary>
+        /// CCBill AI Addendum: show full content-policy banner until acked, then slim version.
+        /// </summary>
+        private void ApplyPolicyBannerState()
+        {
+            // ponytail: needs App.Settings.Current.CompanionPrompt.PromptEditorDisclaimerAcknowledged,
+            // wired when settings move to Core. The default is "not yet acknowledged".
+            this.FindControl<Border>("PolicyBannerFull")!.IsVisible = !_policyAcked;
+            this.FindControl<Border>("PolicyBannerSlim")!.IsVisible = _policyAcked;
+        }
+
+        private void BtnPolicyGotIt_Click()
+        {
+            _policyAcked = true; // ponytail: persisted via App.Settings.Save() once settings move to Core
+            ApplyPolicyBannerState();
+        }
+
+        private void BtnPolicyRead_Click()
+        {
+            // ponytail: needs a launcher for https://app.cclabs.app/policies/prohibited-content;
+            // Process.Start(UseShellExecute) is per-platform and belongs behind a Core interface.
+        }
+
+        private static QuizCategoryDefinition SampleCategory() => new()
+        {
+            Id = "custom_sample",
+            Name = "Velvet Fog",
+            Description = "A slow, warm slide into agreeable emptiness.",
+            Color = "#9B59B6",
+            SystemPromptTemplate = "You are a quiz master for a \"Velvet Fog\" personality quiz.\n\n"
+                                 + "TONE: warm, unhurried, quietly certain.\n\n"
+                                 + "FORMAT — You MUST use EXACTLY this format:\n"
+                                 + "Q: [your question here]\nA: [mild] | 1\nB: [moderate] | 2\n"
+                                 + "C: [spicy] | 3\nD: [extreme] | 4",
+            Archetypes =
+            {
+                new QuizArchetypeDefinition { Name = "Clear Headed", MinPercentage = 0, MaxPercentage = 25, Description = "Still counting the exits." },
+                new QuizArchetypeDefinition { Name = "Softening", MinPercentage = 26, MaxPercentage = 50, Description = "The edges have gone kind." },
+                new QuizArchetypeDefinition { Name = "Drifting", MinPercentage = 51, MaxPercentage = 70, Description = "Agreeing before the sentence lands." },
+                new QuizArchetypeDefinition { Name = "Fogbound", MinPercentage = 71, MaxPercentage = 85, Description = "Thoughts arrive pre-approved." },
+                new QuizArchetypeDefinition { Name = "Velvet", MinPercentage = 86, MaxPercentage = 100, Description = "Nothing left to argue with." },
+            }
+        };
+    }
+
+    /// <summary>
+    /// One scoring band of a quiz category. Copied from the WPF head's
+    /// Services/Quiz/QuizService.cs: the type lives there, not in CCP.Core, and neither the WPF
+    /// head nor Core may be touched by this port.
+    /// </summary>
+    public class QuizArchetypeDefinition
+    {
+        public string Name { get; set; } = string.Empty;
+        public int MinPercentage { get; set; }
+        public int MaxPercentage { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+
+    /// <inheritdoc cref="QuizArchetypeDefinition"/>
+    /// <remarks>Trimmed to the fields this editor reads or writes: the original also carries
+    /// EnumCategory and GetArchetypeName, neither of which this view touches.</remarks>
+    public class QuizCategoryDefinition
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string SystemPromptTemplate { get; set; } = string.Empty;
+        public string Color { get; set; } = "#FF69B4";
+        public bool IsBuiltIn { get; set; }
+        public List<QuizArchetypeDefinition> Archetypes { get; set; } = new();
+    }
+}


### PR DESCRIPTION
772 lines.

Part of the Avalonia port stack. Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` for each view with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the renders. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351