### PR TITLE
feat(avalonia): port LoginDialog

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/LoginDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/LoginDialog.axaml
@@ -1,0 +1,304 @@
+<!-- PORTED from ConditioningControlPanel/Dialogs/LoginDialog.xaml.
+     Structure, ordering, spacing and every x:Name / resource key preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       WindowStyle="None" / AllowsTransparency="True" -> SystemDecorations="None" /
+                                                         TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                          -> CanResize="False"
+       Visibility="Collapsed"                         -> IsVisible="False"
+       MouseLeftButtonDown="…"                        -> PointerPressed, wired in the constructor
+       Click="…"                                      -> wired in the constructor
+       helpers:EmojiTextBlock                         -> TextBlock (Avalonia renders colour emoji
+                                                         natively; see CLAUDE.md)
+       PasswordBox                                    -> TextBox PasswordChar="●" (Avalonia has no
+                                                         PasswordBox; .Password becomes .Text)
+       TextBox CharacterCasing="Upper"                -> a TextChanged handler in code-behind
+                                                         (Avalonia's TextBox has no CharacterCasing)
+       FontFamily="Consolas, Courier New"             -> + ", monospace" (Linux fallback, as the
+                                                         other ported views do)
+       Cursor="IBeam"                                 -> Cursor="Ibeam" (Avalonia's spelling)
+       Content="{loc:Str …}"                          -> a <TextBlock> child (Avalonia parses "_" in
+                                                         Content as an access key and every loc key
+                                                         here is snake_case - CLAUDE.md trap 1)
+
+     Fluent's Button is content-sized and left-aligned where WPF's stretched, so the five provider
+     buttons gained HorizontalAlignment="Stretch" + HorizontalContentAlignment="Center".
+
+     The TxtAccountToggle Runs sit on one line with an explicit <Run Text=" "/> between them:
+     Avalonia drops the inter-element whitespace WPF kept, which is the same gap the WPF
+     code-behind added by hand ( + " " ) when it rebuilt the inlines. The code-behind rebinds
+     those two Runs by index rather than rebuilding Inlines, and the hardcoded colours it used
+     (#B0B0B0 / #FF69B4) become the theme keys they were copies of.
+
+     BtnAccountSubmit's label gained x:Name TxtAccountSubmitLabel, and TxtAccountToggle's two
+     clickable siblings gained x:Names (BtnAccountBack, BtnDeviceCodeCancel), because handlers and
+     the key swaps are wired in code-behind.
+
+     Every string is a loc key copied verbatim from the WPF XAML; the literal English strings in
+     the SubscribeStar and device-code blocks were literals there too and stay literals here. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.LoginDialog"
+        Title="{loc:Str btn_login}" Height="560" Width="420"
+        WindowStartupLocation="CenterOwner" CanResize="False"
+        Background="{DynamicResource DarkerBgBrush}"
+        SystemDecorations="None" TransparencyLevelHint="Transparent">
+
+    <Border BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2" CornerRadius="10">
+        <Grid Margin="25">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title -->
+            <StackPanel Grid.Row="0" Margin="0,0,0,20">
+                <TextBlock Text="{loc:Str login_welcome}"
+                           FontSize="28" FontWeight="Bold" Foreground="{DynamicResource PinkBrush}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="{loc:Str login_choose_method}"
+                           FontSize="13" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,5,0,0"/>
+            </StackPanel>
+
+            <!-- Provider Selection (Initial State) -->
+            <StackPanel x:Name="ProviderPanel" Grid.Row="2" VerticalAlignment="Center">
+                <Button x:Name="BtnLoginDiscord"
+                        Padding="20,15" Margin="0,0,0,15"
+                        Background="#5865F2" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="16"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        Cursor="Hand">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str label_text_6}" FontSize="20" Margin="0,0,10,0"/>
+                        <TextBlock Text="{loc:Str login_discord}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+                <Button x:Name="BtnLoginPatreon"
+                        Padding="20,15" Margin="0,0,0,15"
+                        Background="#FF424D" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="16"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        Cursor="Hand">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str label_text_7}" FontSize="20" Margin="0,0,10,0"/>
+                        <TextBlock Text="{loc:Str login_patreon}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+                <Button x:Name="BtnLoginSubscribeStar"
+                        Padding="20,15" Margin="0,0,0,15"
+                        Background="#009E8F" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="16"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        Cursor="Hand">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="★" FontSize="20" Margin="0,0,10,0"/>
+                        <TextBlock Text="Login with SubscribeStar" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+                <Button x:Name="BtnLoginAccount"
+                        Padding="20,15" Margin="0,0,0,15"
+                        Background="{DynamicResource AccentTintedBgBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="16"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        Cursor="Hand">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{loc:Str label_text_3}" FontSize="20" Margin="0,0,10,0"/>
+                        <TextBlock Text="{loc:Str login_anonymous}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+                <!-- SP3: Sign in via Web (device-code flow). -->
+                <Button x:Name="BtnLoginDeviceCode"
+                        Padding="20,15" Margin="0,0,0,15"
+                        Background="#9333EA" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="16"
+                        HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                        Cursor="Hand">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Sign in via Web" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+            </StackPanel>
+
+            <!-- Account Login/Register Panel -->
+            <StackPanel x:Name="AccountPanel" Grid.Row="2" IsVisible="False" VerticalAlignment="Center">
+                <TextBlock x:Name="TxtAccountTitle" Text="{loc:Str btn_login}"
+                           FontSize="16" FontWeight="Bold" Foreground="White"
+                           HorizontalAlignment="Center" Margin="0,0,0,15"/>
+
+                <!-- Invite code field (register mode only) -->
+                <TextBlock x:Name="LblInviteCodeHint"
+                           Text="{loc:Str label_for_an_invite_code_please_ask_a_discord_mod_a}"
+                           FontSize="11" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"
+                           IsVisible="False"/>
+                <TextBlock x:Name="LblInviteCode" Text="{loc:Str login_invite_code}"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" Margin="0,0,0,4"
+                           IsVisible="False"/>
+                <TextBox x:Name="TxtInviteCode" FontSize="14" Padding="10,8"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                         MaxLength="8" HorizontalAlignment="Stretch" IsVisible="False"/>
+
+                <!-- Display name field (login mode only) -->
+                <TextBlock x:Name="LblDisplayName" Text="{loc:Str login_display_name}"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" Margin="0,0,0,4"
+                           IsVisible="False"/>
+                <TextBox x:Name="TxtLoginDisplayName" FontSize="14" Padding="10,8"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                         MaxLength="30" HorizontalAlignment="Stretch" IsVisible="False"/>
+
+                <!-- Password -->
+                <TextBlock x:Name="LblPassword" Text="{loc:Str login_password}"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" Margin="0,10,0,4"/>
+                <TextBox x:Name="TxtPassword" FontSize="14" Padding="10,8" PasswordChar="●"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                         MaxLength="128"/>
+
+                <!-- Confirm password (register mode only) -->
+                <TextBlock x:Name="LblPasswordConfirm" Text="{loc:Str login_confirm_password}"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" Margin="0,10,0,4"
+                           IsVisible="False"/>
+                <TextBox x:Name="TxtPasswordConfirm" FontSize="14" Padding="10,8" PasswordChar="●"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                         MaxLength="128" IsVisible="False"/>
+
+                <TextBlock x:Name="TxtAccountError" FontSize="11" Margin="0,8,0,0"
+                           Foreground="Orange" Text="" TextWrapping="Wrap"
+                           HorizontalAlignment="Center"/>
+
+                <Button x:Name="BtnAccountSubmit"
+                        Padding="30,12" Margin="0,15,0,0"
+                        Background="{DynamicResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="14"
+                        Cursor="Hand" HorizontalAlignment="Center">
+                    <TextBlock x:Name="TxtAccountSubmitLabel" Text="{loc:Str btn_login}"/>
+                </Button>
+
+                <TextBlock x:Name="TxtAccountToggle" Margin="0,12,0,0"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Cursor="Hand"><Run Text="{loc:Str label_don_t_have_an_account}"/><Run Text=" "/><Run Text="{loc:Str btn_create_account}" Foreground="{DynamicResource PinkBrush}" TextDecorations="Underline"/></TextBlock>
+
+                <TextBlock x:Name="BtnAccountBack" Text="{loc:Str btn_back}" Margin="0,10,0,0"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Cursor="Hand"/>
+            </StackPanel>
+
+            <!-- Username Entry Panel (for new accounts) -->
+            <StackPanel x:Name="UsernamePanel" Grid.Row="2" IsVisible="False" VerticalAlignment="Center">
+                <TextBlock x:Name="TxtUsernameTitle" Text="{loc:Str label_choose_your_display_name}"
+                           FontSize="16" FontWeight="Bold" Foreground="White"
+                           HorizontalAlignment="Center" Margin="0,0,0,5"/>
+                <TextBlock x:Name="TxtUsernameSubtitle" Text="{loc:Str label_this_will_be_shown_on_the_leaderboard}"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,15"/>
+
+                <TextBox x:Name="TxtUsername" FontSize="18" Padding="12,10"
+                         Background="{DynamicResource PanelBgBrush}" Foreground="White" BorderBrush="{DynamicResource PinkBrush}"
+                         MaxLength="30"
+                         HorizontalAlignment="Stretch"/>
+
+                <TextBlock x:Name="TxtAvailability" FontSize="11" Margin="0,8,0,0"
+                           Foreground="{DynamicResource TextMutedBrush}" Text="{loc:Str label_enter_a_unique_name_3_30_characters}"
+                           HorizontalAlignment="Center"/>
+
+                <Button x:Name="BtnConfirmUsername"
+                        Padding="30,12" Margin="0,20,0,0"
+                        Background="{DynamicResource PinkBrush}" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="14"
+                        Cursor="Hand" IsEnabled="False"
+                        HorizontalAlignment="Center">
+                    <TextBlock Text="{loc:Str btn_confirm}"/>
+                </Button>
+            </StackPanel>
+
+            <!-- Loading Panel -->
+            <StackPanel x:Name="LoadingPanel" Grid.Row="2" IsVisible="False"
+                        VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock x:Name="TxtLoadingMessage" Text="{loc:Str login_connecting}"
+                           FontSize="16" Foreground="White" HorizontalAlignment="Center"/>
+                <ProgressBar IsIndeterminate="True" Width="200" Height="4" Margin="0,15,0,0"
+                             Foreground="{DynamicResource PinkBrush}" Background="{DynamicResource AccentTintedBgBrush}"/>
+            </StackPanel>
+
+            <!-- SP3: Device-Code Panel -->
+            <StackPanel x:Name="DeviceCodePanel" Grid.Row="2" IsVisible="False"
+                        VerticalAlignment="Center">
+                <TextBlock Text="Sign in via Web"
+                           FontSize="18" FontWeight="Bold" Foreground="White"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                <TextBlock Text="We've opened your browser to finish sign-in. Complete it there, then come back to this window. It's okay to leave this open."
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}" TextWrapping="Wrap"
+                           HorizontalAlignment="Center" Margin="0,0,0,15"
+                           TextAlignment="Center"/>
+
+                <TextBlock Text="Your code:"
+                           FontSize="11" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <Border BorderBrush="#9333EA" BorderThickness="2" CornerRadius="6"
+                        Background="{DynamicResource PanelBgBrush}" Padding="20,12"
+                        HorizontalAlignment="Center" Margin="0,0,0,12">
+                    <TextBlock x:Name="TxtDeviceCode" Text="------"
+                               FontSize="32" FontWeight="Bold" Foreground="White"
+                               FontFamily="Consolas, Courier New, monospace"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center"/>
+                </Border>
+
+                <!-- Manual fallback: if the browser launch failed, the user can read this URL and
+                     open it themselves. Selectable so they can copy. -->
+                <TextBlock Text="Or open this URL manually:"
+                           FontSize="11" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <TextBox x:Name="TxtVerificationUrl"
+                         IsReadOnly="True"
+                         BorderThickness="0" Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                         FontSize="12" FontFamily="Consolas, Courier New, monospace"
+                         HorizontalAlignment="Center" Margin="0,0,0,12"
+                         Cursor="Ibeam"/>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,15">
+                    <Button x:Name="BtnDeviceCodeCopy"
+                            Padding="14,6" Margin="0,0,8,0"
+                            Background="{DynamicResource AccentTintedBgBrush}" Foreground="White"
+                            BorderThickness="0" FontSize="12" Cursor="Hand">
+                        <TextBlock Text="Copy code"/>
+                    </Button>
+                    <Button x:Name="BtnDeviceCodeOpenBrowser"
+                            Padding="14,6"
+                            Background="{DynamicResource AccentTintedBgBrush}" Foreground="White"
+                            BorderThickness="0" FontSize="12" Cursor="Hand">
+                        <TextBlock Text="Open browser again"/>
+                    </Button>
+                </StackPanel>
+
+                <TextBlock x:Name="TxtDeviceStatus" Text="Waiting for browser confirmation..."
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"
+                           TextAlignment="Center" TextWrapping="Wrap"/>
+                <ProgressBar x:Name="DeviceProgressBar" IsIndeterminate="True"
+                             Width="200" Height="3" Margin="0,0,0,15"
+                             Foreground="#9333EA" Background="{DynamicResource AccentTintedBgBrush}"/>
+
+                <TextBlock x:Name="BtnDeviceCodeCancel" Text="Cancel" Margin="0,0,0,0"
+                           FontSize="12" Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center" Cursor="Hand"/>
+            </StackPanel>
+
+            <!-- Cancel Button -->
+            <Button x:Name="BtnCancel" Grid.Row="3"
+                    Padding="20,8" HorizontalAlignment="Right"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand">
+                <TextBlock Text="{loc:Str btn_cancel}"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs
@@ -1,0 +1,599 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Dialogs
+{
+    /// <summary>
+    /// Unified login dialog that handles provider selection and new user registration.
+    ///
+    /// PORTED from ConditioningControlPanel/Dialogs/LoginDialog.xaml.cs. Deviations:
+    ///  - WPF's <c>DialogResult</c> property becomes <c>Close(bool)</c>; Avalonia carries the
+    ///    result through <c>ShowDialog&lt;bool&gt;</c>. Only the cancel path can set it here - the
+    ///    success paths belong to the stubbed services.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>. The three clickable TextBlocks (the
+    ///    login/register toggle, Back and the device-code Cancel) mark their PointerPressed
+    ///    handled, or the window-level drag handler would fire on the same click.
+    ///  - <c>PasswordBox.Password</c> -> <c>TextBox.Text</c> (Avalonia has no PasswordBox; the
+    ///    markup uses <c>PasswordChar</c>).
+    ///  - <c>CharacterCasing="Upper"</c> has no Avalonia equivalent, so the invite-code box
+    ///    upper-cases in a TextChanged handler, preserving the caret.
+    ///  - <c>FocusSafely</c> collapses to a plain <c>Focus()</c>. Its dispatcher retry existed for
+    ///    a WPF template-trigger crash ("the 'Bd' name-scope bug") that has no Avalonia analogue.
+    ///  - Label swaps REBIND rather than assign <c>.Text</c>: those controls carry a
+    ///    <c>{loc:Str}</c> binding and a local value is undone on the next language change (see the
+    ///    porting notes in CLAUDE.md). Same keys, chosen in code. The two TxtAccountToggle Runs are
+    ///    rebound by index instead of the WPF <c>Inlines.Clear()</c>/<c>Add(new Run(...))</c>
+    ///    rebuild, for the same reason.
+    ///  - <c>ShowUsernamePanel</c>'s two title assignments are dropped: they set exactly the keys
+    ///    the markup already binds.
+    ///  - <c>SanitizeError</c> and <c>ShowError</c> are gone with their only callers. Both served
+    ///    the V2AuthService paths stubbed below, and WPF's <c>MessageBox</c> has no Avalonia
+    ///    equivalent and no package may be added; they return with the services.
+    ///  - <c>_firstProviderToken</c> is dropped: nothing can set it until the OAuth services move
+    ///    to Core, and a field that is only ever null makes the stubs read as dead branches.
+    ///
+    /// Placeholder behaviour while the services live in the WPF head: a provider button jumps
+    /// straight to the display-name picker (the "needs registration" branch), the name-availability
+    /// check always says available, and Sign in via Web shows a fixed sample code with no polling.
+    /// </summary>
+    public partial class LoginDialog : Window
+    {
+        /// <summary>
+        /// ponytail: copied from ConditioningControlPanel/Services/Account/V2DeviceCodeService.cs
+        /// (VerificationUrl). Point back at that constant when the service moves to Core.
+        /// </summary>
+        private const string VerificationUrl = "https://app.cclabs.app/dashboard/link-device";
+
+        private CancellationTokenSource? _checkCts;
+
+        // Track which provider was tried first
+        private string? _firstProvider;
+        private bool _isNameAvailable;
+        private bool _isAccountRegisterMode;  // True = register mode, false = login mode
+        private string? _pendingInviteCode;
+        private string? _pendingPassword;
+
+        private readonly StackPanel _providerPanel;
+        private readonly StackPanel _accountPanel;
+        private readonly StackPanel _usernamePanel;
+        private readonly StackPanel _loadingPanel;
+        private readonly StackPanel _deviceCodePanel;
+
+        private readonly TextBlock _txtAccountTitle;
+        private readonly TextBlock _lblInviteCodeHint;
+        private readonly TextBlock _lblInviteCode;
+        private readonly TextBox _txtInviteCode;
+        private readonly TextBlock _lblDisplayName;
+        private readonly TextBox _txtLoginDisplayName;
+        private readonly TextBlock _lblPasswordConfirm;
+        private readonly TextBox _txtPassword;
+        private readonly TextBox _txtPasswordConfirm;
+        private readonly TextBlock _txtAccountError;
+        private readonly Button _btnAccountSubmit;
+        private readonly TextBlock _txtAccountSubmitLabel;
+        private readonly Run _runToggleLead;
+        private readonly Run _runToggleLink;
+
+        private readonly TextBox _txtUsername;
+        private readonly TextBlock _txtAvailability;
+        private readonly Button _btnConfirmUsername;
+
+        private readonly TextBlock _txtLoadingMessage;
+
+        private readonly TextBlock _txtDeviceCode;
+        private readonly TextBox _txtVerificationUrl;
+        private readonly TextBlock _txtDeviceStatus;
+
+        private readonly Button _btnLoginDiscord;
+        private readonly Button _btnLoginPatreon;
+
+        /// <summary>
+        /// Result of the login process
+        /// </summary>
+        public LoginResult? Result { get; private set; }
+
+        public class LoginResult
+        {
+            public bool Success { get; set; }
+            public bool IsLegacyUser { get; set; }
+            public bool ShouldShowOgWelcome { get; set; }
+            public string? UnifiedId { get; set; }
+            public string? DisplayName { get; set; }
+            public string? Provider { get; set; }
+            public string? LinkedProvider { get; set; }
+        }
+
+        public LoginDialog()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _providerPanel = this.FindControl<StackPanel>("ProviderPanel")!;
+            _accountPanel = this.FindControl<StackPanel>("AccountPanel")!;
+            _usernamePanel = this.FindControl<StackPanel>("UsernamePanel")!;
+            _loadingPanel = this.FindControl<StackPanel>("LoadingPanel")!;
+            _deviceCodePanel = this.FindControl<StackPanel>("DeviceCodePanel")!;
+
+            _txtAccountTitle = this.FindControl<TextBlock>("TxtAccountTitle")!;
+            _lblInviteCodeHint = this.FindControl<TextBlock>("LblInviteCodeHint")!;
+            _lblInviteCode = this.FindControl<TextBlock>("LblInviteCode")!;
+            _txtInviteCode = this.FindControl<TextBox>("TxtInviteCode")!;
+            _lblDisplayName = this.FindControl<TextBlock>("LblDisplayName")!;
+            _txtLoginDisplayName = this.FindControl<TextBox>("TxtLoginDisplayName")!;
+            _lblPasswordConfirm = this.FindControl<TextBlock>("LblPasswordConfirm")!;
+            _txtPassword = this.FindControl<TextBox>("TxtPassword")!;
+            _txtPasswordConfirm = this.FindControl<TextBox>("TxtPasswordConfirm")!;
+            _txtAccountError = this.FindControl<TextBlock>("TxtAccountError")!;
+            _btnAccountSubmit = this.FindControl<Button>("BtnAccountSubmit")!;
+            _txtAccountSubmitLabel = this.FindControl<TextBlock>("TxtAccountSubmitLabel")!;
+
+            // FindControl cannot reach a Run - it is an Inline, not a Control - so the two loc Runs
+            // come off the collection by position. Index 1 is the literal single space between them.
+            var toggle = this.FindControl<TextBlock>("TxtAccountToggle")!;
+            _runToggleLead = (Run)toggle.Inlines![0];
+            _runToggleLink = (Run)toggle.Inlines![2];
+
+            _txtUsername = this.FindControl<TextBox>("TxtUsername")!;
+            _txtAvailability = this.FindControl<TextBlock>("TxtAvailability")!;
+            _btnConfirmUsername = this.FindControl<Button>("BtnConfirmUsername")!;
+
+            _txtLoadingMessage = this.FindControl<TextBlock>("TxtLoadingMessage")!;
+
+            _txtDeviceCode = this.FindControl<TextBlock>("TxtDeviceCode")!;
+            _txtVerificationUrl = this.FindControl<TextBox>("TxtVerificationUrl")!;
+            _txtDeviceStatus = this.FindControl<TextBlock>("TxtDeviceStatus")!;
+
+            _btnLoginDiscord = this.FindControl<Button>("BtnLoginDiscord")!;
+            _btnLoginPatreon = this.FindControl<Button>("BtnLoginPatreon")!;
+
+            // Handlers live here rather than in markup, per the porting convention.
+            _btnLoginDiscord.Click += (_, _) => TryLoginWithProvider("discord");
+            _btnLoginPatreon.Click += (_, _) => TryLoginWithProvider("patreon");
+            this.FindControl<Button>("BtnLoginSubscribeStar")!.Click += (_, _) => TryLoginWithProvider("substar");
+            this.FindControl<Button>("BtnLoginAccount")!.Click += (_, _) => ShowAccountPanel(isRegister: false);
+            this.FindControl<Button>("BtnLoginDeviceCode")!.Click += (_, _) => BtnLoginDeviceCode_Click();
+
+            _btnAccountSubmit.Click += (_, _) => BtnAccountSubmit_Click();
+            toggle.PointerPressed += (_, e) => { e.Handled = true; ShowAccountPanel(!_isAccountRegisterMode); };
+            this.FindControl<TextBlock>("BtnAccountBack")!.PointerPressed += (_, e) =>
+            {
+                e.Handled = true;
+                ClearSensitiveData();
+                ShowProviderSelection();
+            };
+
+            _txtUsername.TextChanged += TxtUsername_TextChanged;
+            _btnConfirmUsername.Click += (_, _) => BtnConfirmUsername_Click();
+
+            this.FindControl<Button>("BtnDeviceCodeCopy")!.Click += (_, _) => BtnDeviceCodeCopy_Click();
+            this.FindControl<Button>("BtnDeviceCodeOpenBrowser")!.Click += (_, _) => OpenVerificationUrl();
+            this.FindControl<TextBlock>("BtnDeviceCodeCancel")!.PointerPressed += (_, e) =>
+            {
+                e.Handled = true;
+                ShowProviderSelection();
+            };
+
+            this.FindControl<Button>("BtnCancel")!.Click += (_, _) => BtnCancel_Click();
+
+            // WPF's CharacterCasing="Upper". Assigning the same string does not re-raise
+            // TextChanged, so this cannot loop.
+            _txtInviteCode.TextChanged += (_, _) =>
+            {
+                var text = _txtInviteCode.Text;
+                if (string.IsNullOrEmpty(text)) return;
+                var upper = text.ToUpperInvariant();
+                if (upper == text) return;
+                var caret = _txtInviteCode.CaretIndex;
+                _txtInviteCode.Text = upper;
+                _txtInviteCode.CaretIndex = caret;
+            };
+
+            PointerPressed += Window_PointerPressed;
+
+            // Cancel any in-flight availability check on dialog close so alt+F4 / parent .Close() /
+            // session-end don't leave an orphan task running against a hidden window. The WPF
+            // original guarded its device-code poll loop here for the same reason; that loop needs
+            // the service and is stubbed below, so _checkCts is what is left to cancel.
+            Closed += (_, _) =>
+            {
+                _checkCts?.Cancel();
+                _checkCts?.Dispose();
+                _checkCts = null;
+            };
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                BeginMoveDrag(e);
+        }
+
+        /// <summary>Rebind a control's Text to a loc key, rather than assigning the string. A local
+        /// value would win over the {loc:Str} binding until the next language change and then be
+        /// silently replaced - see the porting notes in CLAUDE.md.</summary>
+        private static void BindLoc(TextBlock target, string key) =>
+            target.Bind(TextBlock.TextProperty, LocBinding(key));
+
+        private static void BindLoc(Run target, string key) =>
+            target.Bind(Run.TextProperty, LocBinding(key));
+
+        private static Binding LocBinding(string key) => new($"[{key}]")
+        {
+            Source = LocalizationManager.Instance,
+            Mode = BindingMode.OneWay,
+        };
+
+        /// <summary>Clear all sensitive data from memory and UI fields.</summary>
+        private void ClearSensitiveData()
+        {
+            _pendingInviteCode = null;
+            _pendingPassword = null;
+            _txtPassword.Text = "";
+            _txtPasswordConfirm.Text = "";
+            _checkCts?.Cancel();
+            _checkCts?.Dispose();
+            _checkCts = null;
+        }
+
+        #region Provider Selection
+
+        /// <summary>
+        /// ponytail: needs App.Discord / App.Patreon / App.SubscribeStar and V2AuthService, wired
+        /// when they move to Core. Until then this takes the "user needs registration" branch the
+        /// real flow reaches after a successful OAuth handshake, so the display-name picker and
+        /// everything downstream of it stays reachable from the provider buttons.
+        /// </summary>
+        private void TryLoginWithProvider(string provider)
+        {
+            ShowLoading(Loc.GetF("login_connecting_to_provider", provider));
+            _firstProvider = provider;
+            ShowUsernamePanel();
+        }
+
+        #endregion
+
+        #region Username Entry
+
+        private void ShowUsernamePanel()
+        {
+            _providerPanel.IsVisible = false;
+            _loadingPanel.IsVisible = false;
+            _usernamePanel.IsVisible = true;
+            _accountPanel.IsVisible = false;
+            _deviceCodePanel.IsVisible = false;
+
+            _btnConfirmUsername.IsEnabled = true;
+            _txtUsername.Focus();
+        }
+
+        private async void TxtUsername_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            var name = (_txtUsername.Text ?? "").Trim();
+
+            _checkCts?.Cancel();
+            _checkCts?.Dispose();
+            _checkCts = new CancellationTokenSource();
+            var token = _checkCts.Token;
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                SetAvailabilityStatus(Loc.Get("login_enter_unique_name"), Brushes.Gray, false);
+                return;
+            }
+
+            if (name.Length < 3)
+            {
+                SetAvailabilityStatus(Loc.Get("login_name_min_3_chars"), Brushes.Orange, false);
+                return;
+            }
+
+            if (name.Length > 30)
+            {
+                SetAvailabilityStatus(Loc.Get("login_name_max_30_chars"), Brushes.Orange, false);
+                return;
+            }
+
+            SetAvailabilityStatus(Loc.Get("login_checking"), Brushes.Gray, false);
+
+            try
+            {
+                await Task.Delay(400, token);
+                if (token.IsCancellationRequested) return;
+
+                var available = await CheckNameAvailabilityAsync(name);
+
+                if (token.IsCancellationRequested) return;
+
+                if (available)
+                {
+                    SetAvailabilityStatus(Loc.GetF("login_name_available", name), Brushes.LightGreen, true);
+                }
+                else
+                {
+                    SetAvailabilityStatus(Loc.GetF("login_name_already_taken", name), Brushes.Orange, false);
+                }
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception)
+            {
+                SetAvailabilityStatus(Loc.Get("login_error_checking_name"), Brushes.Orange, false);
+            }
+        }
+
+        private void SetAvailabilityStatus(string message, IBrush color, bool available)
+        {
+            _txtAvailability.Text = message;
+            _txtAvailability.Foreground = color;
+            _isNameAvailable = available;
+            _btnConfirmUsername.IsEnabled = available;
+        }
+
+        /// <summary>
+        /// ponytail: needs the proxy's /v2/auth/check-name and /user/check-display-name endpoints
+        /// (the WPF original picks one of three by provider and signs it with the OAuth token),
+        /// wired when V2AuthService moves to Core. Answering "available" keeps the picker usable.
+        /// </summary>
+        private static Task<bool> CheckNameAvailabilityAsync(string name) => Task.FromResult(true);
+
+        /// <summary>
+        /// ponytail: needs V2AuthService.RegisterAsync / AuthenticateWith*Async plus App.Settings
+        /// and App.UnifiedUserId, wired when they move to Core. The guards and the loading state
+        /// are the original's; the account creation itself is what is missing.
+        /// </summary>
+        private void BtnConfirmUsername_Click()
+        {
+            if (!_isNameAvailable) return;
+
+            if (_firstProvider == "invite"
+                && (string.IsNullOrEmpty(_pendingInviteCode) || string.IsNullOrEmpty(_pendingPassword)))
+            {
+                ClearSensitiveData();
+                _txtAvailability.Text = Loc.Get("login_session_expired");
+                return;
+            }
+
+            // Disable button during async (audit C2)
+            _btnConfirmUsername.IsEnabled = false;
+            ShowLoading(Loc.Get("login_creating_account"));
+        }
+
+        #endregion
+
+        #region Account Login (Invite Code + Password)
+
+        private void ShowAccountPanel(bool isRegister)
+        {
+            _isAccountRegisterMode = isRegister;
+
+            _providerPanel.IsVisible = false;
+            _loadingPanel.IsVisible = false;
+            _usernamePanel.IsVisible = false;
+            _accountPanel.IsVisible = true;
+            _deviceCodePanel.IsVisible = false;
+
+            // Clear all fields
+            _txtInviteCode.Text = "";
+            _txtLoginDisplayName.Text = "";
+            _txtPassword.Text = "";
+            _txtPasswordConfirm.Text = "";
+            _txtAccountError.Text = "";
+            _btnAccountSubmit.IsEnabled = true;
+
+            if (isRegister)
+            {
+                BindLoc(_txtAccountTitle, "label_create_account");
+                BindLoc(_txtAccountSubmitLabel, "btn_next");
+
+                // Show invite code + password + confirm; hide display name
+                _lblInviteCodeHint.IsVisible = true;
+                _lblInviteCode.IsVisible = true;
+                _txtInviteCode.IsVisible = true;
+                _lblDisplayName.IsVisible = false;
+                _txtLoginDisplayName.IsVisible = false;
+                _lblPasswordConfirm.IsVisible = true;
+                _txtPasswordConfirm.IsVisible = true;
+
+                BindLoc(_runToggleLead, "login_already_have_account");
+                BindLoc(_runToggleLink, "btn_login");
+
+                _txtInviteCode.Focus();
+            }
+            else
+            {
+                BindLoc(_txtAccountTitle, "btn_login");
+                BindLoc(_txtAccountSubmitLabel, "btn_login");
+
+                // Show display name + password; hide invite code + confirm
+                _lblInviteCodeHint.IsVisible = false;
+                _lblInviteCode.IsVisible = false;
+                _txtInviteCode.IsVisible = false;
+                _lblDisplayName.IsVisible = true;
+                _txtLoginDisplayName.IsVisible = true;
+                _lblPasswordConfirm.IsVisible = false;
+                _txtPasswordConfirm.IsVisible = false;
+
+                BindLoc(_runToggleLead, "login_dont_have_account");
+                BindLoc(_runToggleLink, "btn_create_account");
+
+                _txtLoginDisplayName.Focus();
+            }
+        }
+
+        private void BtnAccountSubmit_Click()
+        {
+            var password = _txtPassword.Text ?? "";
+
+            // Validate password (shared for both modes)
+            if (password.Length < 8)
+            {
+                _txtAccountError.Text = Loc.Get("label_password_must_be_at_least_8_characters");
+                return;
+            }
+
+            // Disable button during async (audit C2)
+            _btnAccountSubmit.IsEnabled = false;
+
+            if (_isAccountRegisterMode)
+            {
+                var inviteCode = (_txtInviteCode.Text ?? "").Trim();
+
+                // Validate invite code
+                if (string.IsNullOrWhiteSpace(inviteCode))
+                {
+                    _txtAccountError.Text = Loc.Get("label_please_enter_your_invite_code");
+                    _btnAccountSubmit.IsEnabled = true;
+                    return;
+                }
+
+                // Validate confirm password
+                if ((_txtPasswordConfirm.Text ?? "") != password)
+                {
+                    _txtAccountError.Text = Loc.Get("label_passwords_do_not_match");
+                    _btnAccountSubmit.IsEnabled = true;
+                    return;
+                }
+
+                // Save credentials and go to username panel
+                _pendingInviteCode = inviteCode;
+                _pendingPassword = password;
+                _firstProvider = "invite";
+                ShowUsernamePanel();
+            }
+            else
+            {
+                var displayName = (_txtLoginDisplayName.Text ?? "").Trim();
+
+                // Validate display name
+                if (string.IsNullOrWhiteSpace(displayName))
+                {
+                    _txtAccountError.Text = Loc.Get("label_please_enter_your_display_name");
+                    _btnAccountSubmit.IsEnabled = true;
+                    return;
+                }
+
+                // Login mode
+                TryAccountLogin(displayName, password);
+            }
+        }
+
+        /// <summary>
+        /// ponytail: needs V2AuthService.LoginAsync plus App.Settings / App.UnifiedUserId, wired
+        /// when they move to Core. The password is still wiped immediately after the (absent) call,
+        /// as audit C1 requires, and the failure path back to the form is the original's.
+        /// </summary>
+        private void TryAccountLogin(string displayName, string password)
+        {
+            ShowLoading(Loc.Get("login_logging_in"));
+
+            // Clear password from memory immediately after use (audit C1)
+            ClearSensitiveData();
+
+            ShowAccountPanel(_isAccountRegisterMode);
+            _txtLoginDisplayName.Text = displayName;
+            _txtAccountError.Text = Loc.Get("label_unexpected_response_from_server");
+        }
+
+        #endregion
+
+        #region UI Helpers
+
+        private void ShowProviderSelection()
+        {
+            _providerPanel.IsVisible = true;
+            _loadingPanel.IsVisible = false;
+            _usernamePanel.IsVisible = false;
+            _accountPanel.IsVisible = false;
+            _deviceCodePanel.IsVisible = false;
+            _btnLoginDiscord.IsEnabled = true;
+            _btnLoginPatreon.IsEnabled = true;
+        }
+
+        /// <summary>The message is composed at runtime (Loc.GetF), so this assigns rather than
+        /// rebinds; the label's {loc:Str} default returns on the next language change, which is the
+        /// caveat in CLAUDE.md and is harmless for a transient status line.</summary>
+        private void ShowLoading(string message)
+        {
+            _txtLoadingMessage.Text = message;
+            _providerPanel.IsVisible = false;
+            _loadingPanel.IsVisible = true;
+            _usernamePanel.IsVisible = false;
+            _accountPanel.IsVisible = false;
+            _deviceCodePanel.IsVisible = false;
+        }
+
+        private void BtnCancel_Click()
+        {
+            // ponytail: WPF logged the authenticated provider out here (App.Discord/SubscribeStar/
+            // Patreon .Logout()); wired when those services move to Core.
+
+            // Clear sensitive data (audit C1)
+            ClearSensitiveData();
+
+            Result = null;
+            Close(false);
+        }
+
+        #endregion
+
+        #region SP3 Device-Code Flow
+
+        /// <summary>
+        /// ponytail: needs V2DeviceCodeService.InitiateAsync and its /poll loop, wired when the
+        /// service moves to Core. The panel is shown with a sample code so the layout, the ABC-DEF
+        /// split and the manual-URL fallback are all still exercised; nothing polls.
+        /// </summary>
+        private void BtnLoginDeviceCode_Click()
+        {
+            ShowDeviceCodePanel("ABCDEF");
+            OpenVerificationUrl();
+        }
+
+        private void ShowDeviceCodePanel(string code)
+        {
+            _providerPanel.IsVisible = false;
+            _loadingPanel.IsVisible = false;
+            _usernamePanel.IsVisible = false;
+            _accountPanel.IsVisible = false;
+            _deviceCodePanel.IsVisible = true;
+
+            // Display 6-char code as "ABC-DEF" for legibility.
+            _txtDeviceCode.Text = code.Length == 6
+                ? $"{code[..3]}-{code[3..]}"
+                : code;
+            _txtVerificationUrl.Text = VerificationUrl;
+            _txtDeviceStatus.Text = "Waiting for browser confirmation...";
+        }
+
+        /// <summary>WPF used Process.Start with UseShellExecute; Avalonia's Launcher is the
+        /// cross-platform equivalent and needs no shell assumptions.</summary>
+        private async void OpenVerificationUrl()
+        {
+            try { await Launcher.LaunchUriAsync(new Uri(VerificationUrl)); }
+            catch (Exception) { /* no browser, or no launcher on this platform - best effort */ }
+        }
+
+        private async void BtnDeviceCodeCopy_Click()
+        {
+            try
+            {
+                if (Clipboard is null) return;
+                await Clipboard.SetTextAsync(_txtDeviceCode.Text?.Replace("-", "") ?? "");
+                _txtDeviceStatus.Text = "Code copied. Paste in your browser.";
+            }
+            catch (Exception)
+            {
+                // Clipboard can be locked by another app - say nothing, the button just won't confirm.
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
903 lines.

One large view per layer: an `.axaml` and its `.axaml.cs` are never split, so several of these exceed the ~1,000-line guideline. Nothing was dropped to hit a budget.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the render. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351