### PR TITLE
feat(avalonia): port FirstRunWizard

### DIFF
--- a/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml
+++ b/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml
@@ -1,0 +1,314 @@
+<!-- PORTED from ConditioningControlPanel/Windows/FirstRunWizard.xaml.
+     Structure, ordering, spacing, x:Names and every resource key preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" +
+                                                   TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                    -> CanResize="False"
+       <Style x:Key="FrCardShell" TargetType="Border"> -> <ControlTheme>; Border is not a
+                                                   templated control, so a property-only theme is
+                                                   safe here (CLAUDE.md trap 4 does not apply)
+       Style="{StaticResource X}"               -> Theme="{StaticResource X}"
+       Visibility="Collapsed"/"Visible"         -> IsVisible="False"/"True"
+       Visibility bindings on the card          -> bool properties of the same shape on
+                                                   FirstRunModCard bound to IsVisible; the WPF
+                                                   original already did the no-converter dance,
+                                                   only the property TYPE changed
+       MouseLeftButtonDown / MouseLeftButtonUp  -> PointerPressed / PointerReleased, both wired
+                                                   in the constructor (a DataTemplate has no name
+                                                   scope, so the card handler goes on the list)
+       PreviewKeyDown="Window_PreviewKeyDown"   -> KeyDownEvent added with RoutingStrategies.Tunnel
+       Click="..."                              -> wired in the constructor
+       RenderOptions.BitmapScalingMode          -> RenderOptions.BitmapInterpolationMode
+       hover:HoverPop.IsEnabled="True"          -> dropped; see the ponytail note on the art frame
+
+     Button captions are TextBlock children rather than Content: Avalonia parses "_" in Content as
+     an access key. See the porting notes in CLAUDE.md.
+
+     Every string on this screen is assigned from code-behind through the Str() fallback helper,
+     exactly as in WPF - so there is deliberately no {loc:Str} here. Str() renders the English
+     draft when a key is missing, which {loc:Str} cannot do. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:ConditioningControlPanel.Avalonia.Views.Windows"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.FirstRunWizard"
+        Title="Welcome"
+        Height="680" Width="900"
+        WindowStartupLocation="CenterScreen"
+        CanResize="False"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowInTaskbar="False">
+
+    <!-- Phase 8 · the three-step first run (Welcome -> mod pick -> doors tour) that replaces the
+         WelcomeDialog + ModPickerDialog + 7-step spotlight gauntlet.
+
+         Card visuals are driven by plain INPC properties on FirstRunModCard (the visibility flags
+         included) rather than value converters — a converter declared in the wrong resource scope
+         inside a DataTemplate is one of this codebase's recurring WPF traps. Same discipline as
+         ModPickerDialog, which this screen's mod step is modelled on.
+
+         Every string is assigned in code-behind through the Str() fallback helper, so a missing
+         fr8_ key renders its English draft instead of the raw key. -->
+    <Window.Resources>
+        <ControlTheme x:Key="FrCardShell" TargetType="Border">
+            <Setter Property="Background" Value="{DynamicResource PanelBgBrush}"/>
+            <Setter Property="CornerRadius" Value="10"/>
+            <Setter Property="Padding" Value="12"/>
+            <Setter Property="Margin" Value="0,0,0,10"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12"
+            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- ================= title bar ================= -->
+            <Border x:Name="TitleBar" Grid.Row="0" Background="{DynamicResource PanelBgBrush}"
+                    CornerRadius="12,12,0,0" Padding="20,12">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock x:Name="TxtWizardTitle" Grid.Column="0"
+                               Foreground="{DynamicResource PinkBrush}"
+                               FontSize="18" FontWeight="Bold" VerticalAlignment="Center"/>
+
+                    <TextBlock x:Name="TxtStepCounter" Grid.Column="1" Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="12" VerticalAlignment="Center" Margin="0,0,14,0"/>
+
+                    <Button x:Name="BtnCloseX" Grid.Column="2"
+                            Background="Transparent" Foreground="{DynamicResource TextMutedBrush}" FontSize="16" FontWeight="Bold"
+                            BorderThickness="0" Cursor="Hand" Padding="8,2" Width="30" Height="30"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
+                        <TextBlock Text="X"/>
+                    </Button>
+                </Grid>
+            </Border>
+
+            <!-- ================= body ================= -->
+            <Grid Grid.Row="1" x:Name="StepHost" Margin="0">
+
+                <!-- ========== step 1: welcome ========== -->
+                <Grid x:Name="Step1" IsVisible="True" Margin="26,18,26,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center"
+                                Margin="0,0,0,14">
+                        <!-- ponytail: needs ModResourceResolver for logo.png/logo2.png, wired when
+                             it moves to Core. This head ships no Resources/ PNGs, so the 46px
+                             frame is reserved and left empty rather than drawing the wrong mark. -->
+                        <Image x:Name="ImgWelcomeLogo" Width="46" Height="46" Margin="0,0,14,0"
+                               VerticalAlignment="Center"
+                               RenderOptions.BitmapInterpolationMode="HighQuality"/>
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock x:Name="TxtAppTitle" Foreground="White"
+                                       FontSize="20" FontWeight="Bold"/>
+                            <TextBlock x:Name="TxtWelcomeHeading" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="15" FontWeight="SemiBold" Margin="0,2,0,0"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="0,0,8,0">
+                        <StackPanel>
+                            <TextBlock x:Name="TxtWelcomeBody" Foreground="#E0E0E0" FontSize="13.5"
+                                       TextWrapping="Wrap" LineHeight="22" TextAlignment="Center"
+                                       Margin="20,0,20,16"/>
+
+                            <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8" Padding="16">
+                                <StackPanel>
+                                    <TextBlock x:Name="TxtTipsTitle" Foreground="#FFB347" FontSize="13"
+                                               FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                                    <TextBlock x:Name="TxtTipHelp" Foreground="{DynamicResource PinkBrush}"
+                                               FontSize="12.5" TextWrapping="Wrap" TextAlignment="Center"
+                                               FontWeight="SemiBold" Margin="0,9,0,0"/>
+                                    <TextBlock x:Name="TxtTipHover" Foreground="{DynamicResource TextMutedBrush}" FontSize="12.5"
+                                               TextWrapping="Wrap" TextAlignment="Center" Margin="0,5,0,0"/>
+                                    <TextBlock x:Name="TxtTipAssets" Foreground="{DynamicResource TextMutedBrush}" FontSize="12.5"
+                                               TextWrapping="Wrap" TextAlignment="Center" Margin="0,5,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Background="{DynamicResource PanelBgBrush}" CornerRadius="8"
+                                    Padding="16" Margin="0,12,0,0">
+                                <StackPanel>
+                                    <TextBlock x:Name="TxtPerfTitle" Foreground="#FFB347" FontSize="13"
+                                               FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                                    <TextBlock x:Name="TxtPerfBody" Foreground="#FFB347" FontSize="12.5"
+                                               TextWrapping="Wrap" TextAlignment="Center" Margin="0,9,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Button x:Name="BtnPickFolder"
+                                    Theme="{StaticResource OutlineButton}" FontSize="12"
+                                    Padding="18,9" Margin="0,14,0,4"
+                                    HorizontalAlignment="Center" Cursor="Hand">
+                                <TextBlock x:Name="TxtPickFolder" TextWrapping="Wrap"/>
+                            </Button>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+
+                <!-- ========== step 2: mod pick ========== -->
+                <Grid x:Name="Step2" IsVisible="False" Margin="26,18,26,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock x:Name="TxtModHeading" Grid.Row="0" Foreground="White"
+                               FontSize="17" FontWeight="Bold"/>
+                    <TextBlock x:Name="TxtModSub" Grid.Row="1" Foreground="#C0C0C0" FontSize="12.5"
+                               TextWrapping="Wrap" Margin="0,6,0,12"/>
+
+                    <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Padding="0,0,8,0">
+                        <ItemsControl x:Name="ModCardsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="local:FirstRunModCard">
+                                    <Border Theme="{StaticResource FrCardShell}"
+                                            BorderBrush="{Binding CardBorderBrush}"
+                                            BorderThickness="{Binding CardBorderThickness}">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBlock Grid.Column="0" Text="{Binding SelectMark}"
+                                                       Foreground="{Binding AccentBrush}" FontSize="16"
+                                                       VerticalAlignment="Center" Margin="2,0,12,0"/>
+
+                                            <!-- ClipToBounds was added in WPF with the hover pop:
+                                                 without it the 1.06 zoom painted the art over the
+                                                 accent border. Kept, though the pop itself is
+                                                 ponytail: needs Behaviors/HoverPop, wired when it
+                                                 moves to Core. The art is null here - see
+                                                 FirstRunModCard.Art. -->
+                                            <Border Grid.Column="1" Width="72" Height="72" CornerRadius="8"
+                                                    BorderBrush="{Binding AccentBrush}" BorderThickness="2"
+                                                    ClipToBounds="True"
+                                                    Background="#1A1A2E" Margin="0,0,14,0">
+                                                <Image Source="{Binding Art}" Stretch="UniformToFill"
+                                                       RenderOptions.BitmapInterpolationMode="HighQuality"/>
+                                            </Border>
+
+                                            <StackPanel Grid.Column="2" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding Name}" Foreground="White"
+                                                           FontSize="15" FontWeight="Bold"/>
+                                                <TextBlock Text="{Binding Description}" Foreground="#C0C0C0"
+                                                           FontSize="12" TextWrapping="Wrap" Margin="0,3,0,0"/>
+                                                <TextBlock Text="{Binding Note}" IsVisible="{Binding NoteVisible}"
+                                                           Foreground="#FFB347" FontSize="11" TextWrapping="Wrap"
+                                                           Margin="0,5,0,0"/>
+
+                                                <Grid IsVisible="{Binding ProgressVisible}" Margin="0,7,0,0">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <ProgressBar Grid.Row="0" Height="6" Minimum="0" Maximum="100"
+                                                                 Value="{Binding Percent, Mode=OneWay}"
+                                                                 Background="#252542" Foreground="{Binding AccentBrush}"
+                                                                 BorderThickness="0"/>
+                                                    <TextBlock Grid.Row="1" Text="{Binding StatusText}"
+                                                               Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,4,0,0"/>
+                                                </Grid>
+
+                                                <TextBlock Text="{Binding StatusText}"
+                                                           IsVisible="{Binding StatusOnlyVisible}"
+                                                           Foreground="{DynamicResource TextMutedBrush}" FontSize="11" Margin="0,7,0,0"/>
+                                            </StackPanel>
+
+                                            <StackPanel Grid.Column="3" VerticalAlignment="Center"
+                                                        HorizontalAlignment="Right" Margin="14,0,2,0">
+                                                <Border Background="{DynamicResource PanelAccentBrush}" CornerRadius="10"
+                                                        Padding="10,4" HorizontalAlignment="Right"
+                                                        IsVisible="{Binding SizeVisible}">
+                                                    <TextBlock Text="{Binding SizeText}" Foreground="#E0E0E0"
+                                                               FontSize="12" FontWeight="SemiBold"/>
+                                                </Border>
+                                                <TextBlock Text="{Binding InstalledText}"
+                                                           IsVisible="{Binding InstalledVisible}"
+                                                           Foreground="#4CAF50" FontSize="12" FontWeight="SemiBold"
+                                                           HorizontalAlignment="Right" Margin="0,6,0,0"/>
+                                            </StackPanel>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+
+                    <TextBlock x:Name="TxtModHint" Grid.Row="3" Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,8,0,0"/>
+                </Grid>
+
+                <!-- ========== step 3: the doors ========== -->
+                <Grid x:Name="Step3" IsVisible="False" Margin="26,18,26,10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock x:Name="TxtTourHeading" Grid.Row="0" Foreground="White"
+                               FontSize="17" FontWeight="Bold" Margin="0,0,0,10"/>
+
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="0,0,8,0">
+                        <StackPanel x:Name="DoorsHost"/>
+                    </ScrollViewer>
+
+                    <TextBlock x:Name="TxtTourOutro" Grid.Row="2" Foreground="{DynamicResource TextMutedBrush}" FontSize="11.5"
+                               TextWrapping="Wrap" Margin="0,10,0,0"/>
+                </Grid>
+            </Grid>
+
+            <!-- ================= footer ================= -->
+            <Border Grid.Row="2" Background="{DynamicResource PanelBgBrush}" CornerRadius="0,0,12,12"
+                    Padding="20,14">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Button x:Name="BtnBack" Grid.Column="0"
+                            Theme="{StaticResource OutlineButton}" FontSize="12" Padding="18,10"
+                            HorizontalAlignment="Left" Cursor="Hand" IsVisible="False">
+                        <TextBlock x:Name="TxtBack"/>
+                    </Button>
+
+                    <Button x:Name="BtnSkip" Grid.Column="2"
+                            Theme="{StaticResource OutlineButton}" FontSize="12" Padding="18,10"
+                            Margin="0,0,12,0" Cursor="Hand">
+                        <TextBlock x:Name="TxtSkip"/>
+                    </Button>
+
+                    <Button x:Name="BtnNext" Grid.Column="3"
+                            Theme="{StaticResource PinkButton}" Cursor="Hand">
+                        <TextBlock x:Name="TxtNext"/>
+                    </Button>
+                </Grid>
+            </Border>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
@@ -1,0 +1,725 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// One mod row on the wizard's second step. Deliberately a separate view-model from
+    /// <c>ModPickerCard</c> even though the two look alike: the picker's card is a multi-select
+    /// download queue (its checkbox hides for anything without a pack), while this one is a
+    /// single-choice "which flavour do you want to run", so CCP Default and already-installed mods
+    /// must be pickable too. Same discipline though - every visual decision is a plain INPC
+    /// property, including the visibility ones, so the DataTemplate needs no value converters.
+    ///
+    /// <para>PORTED from the WPF code-behind's nested-in-the-same-file class. Deviations, all
+    /// forced by Avalonia: <c>Brush</c> -> <c>IBrush</c>, and the five <c>Visibility</c> properties
+    /// become <c>bool</c> ones (<c>NoteVisible</c>, ...) because Avalonia's <c>IsVisible</c> binds a
+    /// bool directly - see CLAUDE.md. The names keep their shape so the two files still diff.</para>
+    /// </summary>
+    public sealed class FirstRunModCard : INotifyPropertyChanged
+    {
+        public string ModId { get; init; } = "";
+        public string? PackId { get; init; }
+        public string Name { get; init; } = "";
+        public string Description { get; init; } = "";
+        public IBrush AccentBrush { get; init; } = Brushes.HotPink;
+        public string Note { get; init; } = "";
+
+        /// <summary>
+        /// ponytail: the WPF card's ArtUri is a compiled <c>&lt;Resource&gt;</c> pack:// path
+        /// (Resources/intake/pass_card_*.png). This head ships no Resources/ PNGs and cannot
+        /// reference the WPF assembly, so the art frame draws its accent border over the flat
+        /// #1A1A2E ground. Bind a real IImage here when the art moves to Core as avares://.
+        /// </summary>
+        public IImage? Art => null;
+
+        public bool HasPack => !string.IsNullOrEmpty(PackId);
+
+        public bool NoteVisible => !string.IsNullOrEmpty(Note);
+
+        // ---- selection ----
+
+        private bool _isSelected;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                if (_isSelected == value) return;
+                _isSelected = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(SelectMark));
+                OnPropertyChanged(nameof(CardBorderBrush));
+                OnPropertyChanged(nameof(CardBorderThickness));
+            }
+        }
+
+        public string SelectMark => IsSelected ? "◉" : "○";
+
+        public IBrush CardBorderBrush => IsSelected ? AccentBrush : Brushes.Transparent;
+
+        public Thickness CardBorderThickness => new Thickness(IsSelected ? 2 : 0);
+
+        // ---- download state (mirrors ModPickerCard's, minus the queue affordances) ----
+
+        public enum CardState { Available, Queued, Downloading, Installing, Installed, Failed }
+
+        private CardState _state = CardState.Available;
+        public CardState State
+        {
+            get => _state;
+            set
+            {
+                if (_state == value) return;
+                _state = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ProgressVisible));
+                OnPropertyChanged(nameof(StatusOnlyVisible));
+                OnPropertyChanged(nameof(InstalledVisible));
+                OnPropertyChanged(nameof(SizeVisible));
+            }
+        }
+
+        private string _sizeText = "";
+        public string SizeText
+        {
+            get => _sizeText;
+            set
+            {
+                if (_sizeText == value) return;
+                _sizeText = value ?? "";
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(SizeVisible));
+            }
+        }
+
+        private string _statusText = "";
+        public string StatusText
+        {
+            get => _statusText;
+            set { if (_statusText == value) return; _statusText = value ?? ""; OnPropertyChanged(); }
+        }
+
+        private double _percent;
+        public double Percent
+        {
+            get => _percent;
+            set { if (Math.Abs(_percent - value) < 0.01) return; _percent = value; OnPropertyChanged(); }
+        }
+
+        public string InstalledText { get; init; } = "";
+
+        public bool IsInstalled => State == CardState.Installed;
+
+        public bool InstalledVisible => IsInstalled && HasPack;
+
+        public bool SizeVisible => !IsInstalled && !string.IsNullOrEmpty(SizeText);
+
+        public bool ProgressVisible => State == CardState.Downloading || State == CardState.Installing;
+
+        public bool StatusOnlyVisible => State == CardState.Queued || State == CardState.Failed;
+
+        public void MarkQueued()
+        {
+            State = CardState.Queued;
+            StatusText = Loc.Get("modpicker_status_queued");
+        }
+
+        public void MarkProgress(double percent)
+        {
+            Percent = Math.Max(0, Math.Min(100, percent));
+            if (Percent >= 100)
+            {
+                State = CardState.Installing;
+                StatusText = Loc.Get("modpicker_status_installing");
+            }
+            else
+            {
+                State = CardState.Downloading;
+                StatusText = Loc.GetF("modpicker_status_downloading", (int)Math.Round(Percent));
+            }
+        }
+
+        public void MarkInstalled()
+        {
+            Percent = 100;
+            State = CardState.Installed;
+            StatusText = Loc.Get("modpicker_status_done");
+        }
+
+        public void MarkFailed()
+        {
+            State = CardState.Failed;
+            StatusText = Loc.Get("modpicker_status_failed");
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    /// <summary>
+    /// Phase 8's first run: three steps (Welcome, mod pick, doors tour) in place of the up-to-ten
+    /// popup gauntlet a fresh install used to walk through.
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Windows/FirstRunWizard.xaml.cs. What survives is
+    /// everything the VIEW owns: the three steps and their copy, the step counter and footer
+    /// captions, card selection, the seven door rows, and the chrome (drag, Esc, X, Back/Next/Skip).
+    /// What does not survive is everything that reaches out of the view - the whole
+    /// <c>ShouldRunAndClaim</c> / <c>HandBackFirstRun</c> / <c>Run</c> entry-point trio, the
+    /// ReleaseContentService download and manifest paths, the offline offer bookkeeping and the mod
+    /// activation commit. Those need <c>App.Settings</c>, <c>App.ReleaseContent</c>,
+    /// <c>App.Mods</c>, <c>ModPickerDialog</c>, <c>PendingModActivation</c> and
+    /// <c>MainWindow</c>, all of which live in the WPF head; each is a stub with a ponytail note
+    /// naming what it needs. The mod cards therefore carry PLACEHOLDER catalogue data (see
+    /// <see cref="Catalogue"/>): the real <c>ModPackCatalog</c> is a WPF-head type.</para>
+    ///
+    /// <para>The hardening lessons the original documents are preserved as comments where the code
+    /// they guard still exists, and dropped with the code where it does not - a comment about
+    /// spending a one-shot flag on a method that no longer spends one is worse than no comment.</para>
+    /// </summary>
+    public partial class FirstRunWizard : Window
+    {
+        private const int StepCount = 3;
+
+        private readonly ObservableCollection<FirstRunModCard> _cards = new();
+
+        private int _step = 1;
+        private FirstRunModCard? _selected;
+
+        // Named controls. FindControl rather than the generated fields, matching the other ports.
+        private readonly TextBlock _txtWizardTitle;
+        private readonly TextBlock _txtStepCounter;
+        private readonly TextBlock _txtAppTitle;
+        private readonly TextBlock _txtWelcomeHeading;
+        private readonly TextBlock _txtWelcomeBody;
+        private readonly TextBlock _txtTipsTitle;
+        private readonly TextBlock _txtTipHelp;
+        private readonly TextBlock _txtTipHover;
+        private readonly TextBlock _txtTipAssets;
+        private readonly TextBlock _txtPerfTitle;
+        private readonly TextBlock _txtPerfBody;
+        private readonly TextBlock _txtModHeading;
+        private readonly TextBlock _txtModSub;
+        private readonly TextBlock _txtModHint;
+        private readonly TextBlock _txtTourHeading;
+        private readonly TextBlock _txtTourOutro;
+        private readonly TextBlock _txtPickFolder;
+        private readonly TextBlock _txtBack;
+        private readonly TextBlock _txtSkip;
+        private readonly TextBlock _txtNext;
+        private readonly Grid _step1;
+        private readonly Grid _step2;
+        private readonly Grid _step3;
+        private readonly Button _btnBack;
+        private readonly Button _btnPickFolder;
+        private readonly ItemsControl _modCardsList;
+        private readonly StackPanel _doorsHost;
+
+        /// <summary>Set by "Take the tour"; read by the caller after the modal returns.</summary>
+        public bool StartTourRequested { get; private set; }
+
+        /// <summary>Set by the Welcome step's folder button; the picker opens after this window closes.</summary>
+        public bool PickAssetsFolderRequested { get; private set; }
+
+        /// <summary>
+        /// The only constructor. WPF's took the owning MainWindow so the mod commit could call
+        /// back into it; nothing here can, so it takes nothing - which is also what
+        /// <c>--render-all</c> needs to discover the view. Internal for the same reason
+        /// TextEditorDialog's render constructor is: no production caller ships the placeholder.
+        /// </summary>
+        internal FirstRunWizard()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtWizardTitle = this.FindControl<TextBlock>("TxtWizardTitle")!;
+            _txtStepCounter = this.FindControl<TextBlock>("TxtStepCounter")!;
+            _txtAppTitle = this.FindControl<TextBlock>("TxtAppTitle")!;
+            _txtWelcomeHeading = this.FindControl<TextBlock>("TxtWelcomeHeading")!;
+            _txtWelcomeBody = this.FindControl<TextBlock>("TxtWelcomeBody")!;
+            _txtTipsTitle = this.FindControl<TextBlock>("TxtTipsTitle")!;
+            _txtTipHelp = this.FindControl<TextBlock>("TxtTipHelp")!;
+            _txtTipHover = this.FindControl<TextBlock>("TxtTipHover")!;
+            _txtTipAssets = this.FindControl<TextBlock>("TxtTipAssets")!;
+            _txtPerfTitle = this.FindControl<TextBlock>("TxtPerfTitle")!;
+            _txtPerfBody = this.FindControl<TextBlock>("TxtPerfBody")!;
+            _txtModHeading = this.FindControl<TextBlock>("TxtModHeading")!;
+            _txtModSub = this.FindControl<TextBlock>("TxtModSub")!;
+            _txtModHint = this.FindControl<TextBlock>("TxtModHint")!;
+            _txtTourHeading = this.FindControl<TextBlock>("TxtTourHeading")!;
+            _txtTourOutro = this.FindControl<TextBlock>("TxtTourOutro")!;
+            _txtPickFolder = this.FindControl<TextBlock>("TxtPickFolder")!;
+            _txtBack = this.FindControl<TextBlock>("TxtBack")!;
+            _txtSkip = this.FindControl<TextBlock>("TxtSkip")!;
+            _txtNext = this.FindControl<TextBlock>("TxtNext")!;
+            _step1 = this.FindControl<Grid>("Step1")!;
+            _step2 = this.FindControl<Grid>("Step2")!;
+            _step3 = this.FindControl<Grid>("Step3")!;
+            _btnBack = this.FindControl<Button>("BtnBack")!;
+            _btnPickFolder = this.FindControl<Button>("BtnPickFolder")!;
+            _modCardsList = this.FindControl<ItemsControl>("ModCardsList")!;
+            _doorsHost = this.FindControl<StackPanel>("DoorsHost")!;
+
+            ApplyStaticText();
+            BuildModCards();
+            BuildDoorRows();
+            _modCardsList.ItemsSource = _cards;
+
+            // ponytail: needs App.ReleaseContent (PackProgressChanged / PackInstalled) and App.Mods
+            // (ModAvailabilityChanged), wired when they move to Core. Nothing to unsubscribe either,
+            // so the WPF Closed handler's teardown half is gone with it.
+
+            // Handlers live here rather than in markup, per the porting convention.
+            this.FindControl<Border>("TitleBar")!.PointerPressed += TitleBar_PointerPressed;
+            this.FindControl<Button>("BtnCloseX")!.Click += (_, _) => CloseSafely();
+            _btnPickFolder.Click += BtnPickFolder_Click;
+            _btnBack.Click += (_, _) => ShowStep(_step - 1);
+            this.FindControl<Button>("BtnSkip")!.Click += (_, _) => CloseSafely();
+            this.FindControl<Button>("BtnNext")!.Click += BtnNext_Click;
+
+            // One handler on the list instead of one inside the DataTemplate: template content has
+            // no name scope to FindControl through, and PointerReleased bubbles the same way WPF's
+            // MouseLeftButtonUp did.
+            _modCardsList.AddHandler(InputElement.PointerReleasedEvent, ModCard_PointerReleased);
+
+            // WPF's PreviewKeyDown. Tunnel, so Esc closes the window before any focused child eats it.
+            AddHandler(KeyDownEvent, Window_PreviewKeyDown, RoutingStrategies.Tunnel);
+
+            Closed += OnWizardClosed;
+            ShowStep(1);
+        }
+
+        // ------------------------------------------------------------------ entry points
+
+        /// <summary>
+        /// ponytail: needs App.Settings (the Welcomed / FirstRunAssetsPromptShown /
+        /// LastSeenVersion one-shots) and UpdateService, wired when they move to Core. The WPF
+        /// original spends all three flags here, BEFORE the window opens, so a crash inside the
+        /// wizard can never turn it into an every-launch popup - keep that ordering when this is
+        /// filled in.
+        /// </summary>
+        public static bool ShouldRunAndClaim() => false;
+
+        /// <summary>
+        /// ponytail: needs App.Settings, wired when it moves to Core. Undoes
+        /// <see cref="ShouldRunAndClaim"/> when the caller decided NOT to open the wizard after all;
+        /// a crash INSIDE the wizard is deliberately not covered, which is what spending up front
+        /// buys.
+        /// </summary>
+        public static void HandBackFirstRun(string reason) { }
+
+        /// <summary>
+        /// ponytail: needs MainWindow (BtnPickAssetsFolder_Click, StartTutorial) and
+        /// TutorialService, wired when they move to Core. WPF opens the wizard modally and then, at
+        /// Dispatcher Normal priority (never Loaded - Loaded-priority work is starved in this app),
+        /// runs the content-folder picker first and the SHORT WALK tutorial second.
+        /// </summary>
+        public static void Run(object owner) { }
+
+        // ------------------------------------------------------------------ copy
+
+        /// <summary>
+        /// Localized string with an English fallback. New <c>fr8_</c> keys land in the language
+        /// files on their own schedule; until then (and for any language that has not caught up)
+        /// this renders the English draft rather than the raw key. Core's
+        /// <c>LocalizationManager.Get</c> returns the key itself on a miss, which is what the
+        /// equality check below detects.
+        /// </summary>
+        private static string Str(string key, string english)
+        {
+            try
+            {
+                var value = Loc.Get(key);
+                return string.IsNullOrEmpty(value) || string.Equals(value, key, StringComparison.Ordinal)
+                    ? english
+                    : value;
+            }
+            catch { return english; }
+        }
+
+        private static string StrF(string key, string english, params object[] args)
+        {
+            var template = Str(key, english);
+            try { return string.Format(template, args); }
+            catch (FormatException) { return template; }
+        }
+
+        private void ApplyStaticText()
+        {
+            Title = Str("fr8_wizard_title", "Getting started");
+            _txtWizardTitle.Text = Title;
+
+            // --- step 1 ---
+            // ponytail: needs ModResourceResolver (and App.Mods.IsCCPDefault / IsSissyMode to pick
+            // between logo.png and logo2.png), wired when they move to Core. WPF re-calls this from
+            // ShowStep(1) so Back-navigation after a mod pick repaints the right wordmark.
+
+            _txtAppTitle.Text = Loc.Get("app_title");
+            // ponytail: needs App.Mods.GetAffirmation(), wired when it moves to Core. "Subject" is
+            // the WPF fallback for exactly this case.
+            _txtWelcomeHeading.Text = StrF("fr8_welcome_heading", "Welcome, {0}.", "Subject");
+            _txtWelcomeBody.Text = Str("fr8_welcome_body",
+                "Conditioning Control Panel layers the effects you choose - flashes, videos, subliminals, " +
+                "screen overlays and a companion who reacts to all of it - over whatever you are already doing. " +
+                "Nothing runs until you press START, and every camera, microphone or screen-reading feature " +
+                "asks for your consent separately, the first time you use it.");
+
+            _txtTipsTitle.Text = Loc.Get("label_tips");
+            _txtTipHelp.Text = Str("fr8_welcome_tip_help",
+                "Click the ? button in the title bar any time for the full tour and per-feature guides.");
+            _txtTipHover.Text = Str("fr8_welcome_tip_hover", "Hover over any setting to see what it does.");
+            _txtTipAssets.Text = Str("fr8_welcome_tip_assets",
+                "Add your own images and videos from the Library door, or point the app at any folder you like.");
+
+            _txtPerfTitle.Text = Loc.Get("label_performance_warning");
+            _txtPerfBody.Text = Str("fr8_welcome_perf_warning",
+                "Running many features at once, especially at high frequencies, is heavy on older machines. " +
+                "Turn some off or lower their rates in Settings if things get sluggish.");
+
+            _txtPickFolder.Text = Str("fr8_welcome_pick_folder", "Choose a content folder");
+
+            // --- step 2 ---
+            _txtModHeading.Text = Str("fr8_modpick_heading", "Pick your flavour");
+            _txtModSub.Text = Str("fr8_modpick_sub",
+                "A mod re-skins the whole app: her name and voice, the art, the phrases, the programs. " +
+                "Pick the one you want to start with - you can switch any time from the title bar.");
+            _txtModHint.Text = Str("fr8_modpick_skip_hint",
+                "Skipping keeps the neutral CCP Default. Downloads carry on in the background, so you can " +
+                "close this window whenever you like.");
+
+            // --- step 3 ---
+            _txtTourHeading.Text = Str("fr8_tour_heading", "Seven doors");
+            _txtTourOutro.Text = Str("fr8_tour_outro",
+                "The rail on the left is always there. Take the tour for a ninety-second walk through the " +
+                "essentials, or explore on your own - the ? button replays it, and the full door-by-door " +
+                "tour is in there too.");
+
+            // --- chrome ---
+            _txtBack.Text = Str("fr8_wizard_back", "Back");
+        }
+
+        // ------------------------------------------------------------------ steps
+
+        private void ShowStep(int step)
+        {
+            _step = Math.Max(1, Math.Min(StepCount, step));
+
+            _step1.IsVisible = _step == 1;
+            _step2.IsVisible = _step == 2;
+            _step3.IsVisible = _step == 3;
+
+            _txtStepCounter.Text = StrF("fr8_wizard_step_of", "Step {0} of {1}", _step, StepCount);
+            _btnBack.IsVisible = _step != 1;
+
+            if (_step == 3)
+            {
+                _txtSkip.Text = Str("fr8_tour_explore", "Explore on my own");
+                _txtNext.Text = Str("fr8_tour_take", "Take the tour");
+            }
+            else
+            {
+                _txtSkip.Text = Str("fr8_wizard_skip", "Skip setup");
+                _txtNext.Text = Str("fr8_wizard_next", "Next");
+            }
+
+            if (_step == 2) PrepareModStep();
+
+            FadeInCurrentStep();
+        }
+
+        /// <summary>
+        /// ponytail: needs MotionFx.AllowTransitions (the reduced-motion gate), wired when it moves
+        /// to Core. The WPF original fades the step in over 140ms and simply swaps at MotionLevel
+        /// Off; the swap is what happens here, which is also the only behaviour a headless render
+        /// can capture - a step starting at Opacity 0 photographs blank.
+        /// </summary>
+        private void FadeInCurrentStep()
+        {
+            var host = _step == 1 ? (Control)_step1 : _step == 2 ? _step2 : _step3;
+            host.Opacity = 1;
+        }
+
+        // ------------------------------------------------------------------ step 2: mod pick
+
+        /// <summary>
+        /// ponytail: PLACEHOLDER for <c>ModPackCatalog.All</c>, which lives in the WPF head
+        /// (Dialogs/ModPackCatalog.cs) alongside BuiltInMods and ReleaseContentService's pack ids.
+        /// Mod ids and pack ids are the literals those constants hold; every name, description and
+        /// note is a real loc key, so the rendered copy is the real copy. Delete this and read the
+        /// catalogue when it moves to Core.
+        /// </summary>
+        private static readonly (string ModId, string? PackId, string NameLocKey, string DescriptionLocKey,
+                                 string AccentHex, long ApproxBytes, bool PremiumProgramNote, bool NoVoiceNote)[] Catalogue =
+        {
+            ("ccp_default",       null,            "modpicker_name_ccp_default", "modpicker_desc_ccp_default", "#E84393",         0, false, false),
+            ("bambi_sleep",       "mod-bambi",     "label_bambi_sleep",          "modpicker_desc_bambi",       "#FF69B4",  77 * Mb, false, false),
+            ("sissy_hypno",       "mod-sissy",     "label_sissy_hypno",          "modpicker_desc_sissy",       "#9B59B6", 331 * Mb, false, false),
+            ("locked",            "mod-locked",    "modpicker_name_circe",       "modpicker_desc_circe",       "#E81CA8", 329 * Mb, true,  false),
+            ("dronification",     "mod-drone",     "modpicker_name_drone",       "modpicker_desc_drone",       "#00FF41", 184 * Mb, true,  true),
+            ("infection_control", "mod-infection", "modpicker_name_infection",   "modpicker_desc_infection",   "#2855F0", 209 * Mb, false, false),
+        };
+
+        private const long Mb = 1024L * 1024L;
+
+        /// <summary>"331 MB" / "1.2 GB". Empty for a zero size. Copied from ModPackCatalog.FormatSize.</summary>
+        private static string FormatSize(long bytes)
+        {
+            try
+            {
+                if (bytes <= 0) return "";
+                var mb = bytes / (double)Mb;
+                if (mb >= 1024)
+                    return Loc.GetF("modpicker_size_gb", (mb / 1024.0).ToString("0.0"));
+                return Loc.GetF("modpicker_size_mb", Math.Max(1, (int)Math.Round(mb)));
+            }
+            catch { return ""; }
+        }
+
+        private void BuildModCards()
+        {
+            var installedBadge = Loc.Get("modpicker_installed_badge");
+            // ponytail: needs App.Mods.ActiveModId, wired when it moves to Core. A fresh install IS
+            // CCP Default, which is what the WPF fallback (BuiltInMods.CCPDefaultId) resolves to.
+            var activeModId = "ccp_default";
+
+            foreach (var entry in Catalogue)
+            {
+                IBrush accent;
+                try { accent = new SolidColorBrush(Color.Parse(entry.AccentHex)); }
+                catch { accent = Brushes.HotPink; }
+
+                var note = entry.PremiumProgramNote ? Loc.Get("modpicker_note_premium_programs") : "";
+                if (entry.NoVoiceNote)
+                {
+                    var voice = Loc.Get("modpicker_note_no_voice");
+                    note = string.IsNullOrEmpty(note) ? voice : note + "  " + voice;
+                }
+
+                var card = new FirstRunModCard
+                {
+                    ModId = entry.ModId,
+                    PackId = entry.PackId,
+                    Name = Loc.Get(entry.NameLocKey),
+                    Description = Loc.Get(entry.DescriptionLocKey),
+                    AccentBrush = accent,
+                    Note = note,
+                    InstalledText = installedBadge
+                };
+
+                if (!card.HasPack)
+                {
+                    // CCP Default ships in the box - always a legitimate choice, never a download.
+                    card.State = FirstRunModCard.CardState.Installed;
+                }
+                else
+                {
+                    // ponytail: needs App.ReleaseContent (IsFullInstall / IsInstalled) to mark the
+                    // packs already on disk, wired when it moves to Core. Every optional mod reads
+                    // as available with its baked-in size, which is the WPF no-service path.
+                    card.SizeText = FormatSize(entry.ApproxBytes);
+                }
+
+                _cards.Add(card);
+            }
+
+            // Pre-select what this install is already running (CCP Default on a fresh box), so the
+            // screen reads as "here is what you have, here is what you can have" and pressing Next
+            // without touching anything is a no-op rather than an accidental switch.
+            Select(_cards.FirstOrDefault(c => string.Equals(c.ModId, activeModId, StringComparison.OrdinalIgnoreCase))
+                   ?? _cards.FirstOrDefault());
+        }
+
+        private void Select(FirstRunModCard? card)
+        {
+            _selected = card;
+            foreach (var c in _cards) c.IsSelected = ReferenceEquals(c, card);
+        }
+
+        private void ModCard_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (e.InitialPressMouseButton != MouseButton.Left) return;
+            if ((e.Source as Control)?.DataContext is FirstRunModCard card) Select(card);
+        }
+
+        /// <summary>
+        /// ponytail: needs App.Settings, App.ReleaseContent and ModPickerDialog
+        /// (ShouldDeferForOffline / ShouldReArmAfterOfflineShowing / MaxOfflineOffers), wired when
+        /// they move to Core. In WPF this is where the picker's one-shot offer is spent - at the
+        /// moment the step is first shown, not when a download is queued - where a full/dev layout
+        /// marks every card installed, and where offline is handled as a first-class state that
+        /// hands the offer BACK rather than burning it. A reimplemented offline guard is how a
+        /// modular install loses its mod media permanently, so port the real one; do not restate it.
+        /// </summary>
+        private void PrepareModStep() { }
+
+        /// <summary>
+        /// ponytail: needs PendingModActivation, App.Mods and MainWindow.ActivateChosenMod, wired
+        /// when they move to Core. WPF hands the chosen mod to the EXACT existing switching path:
+        /// content on disk goes straight through ActivateChosenMod, content that must be fetched
+        /// records the intent and starts the download, so the switch happens the moment the pack
+        /// lands - even after this window is gone. Choosing a mod MEANS choosing to run it.
+        /// <see cref="_selected"/> is what it commits.
+        /// </summary>
+        private void CommitModChoice() { }
+
+        // ------------------------------------------------------------------ step 3: the doors
+
+        /// <summary>
+        /// The seven doors, in rail order. Mirrors <c>MainWindow.NavDoorMap</c> (which is private,
+        /// and is navigation truth - this list is only the wizard's description of it). Glyphs match
+        /// the rail headers; the labels reuse the existing <c>nav_door_*</c> keys, so only the
+        /// one-line blurbs are new copy.
+        /// </summary>
+        private static readonly (string Glyph, string LabelKey, string BlurbKey, string Blurb)[] Doors =
+        {
+            ("\U0001F3E0", "nav_door_home", "fr8_door_home_blurb",
+                "Your dashboard: the START hero, the feature mosaic, the browser card, today's program and the marquee."),
+            ("\U0001F39B️", "nav_door_studio", "fr8_door_studio_blurb",
+                "Where every effect is tuned: the rack, presets and sessions, the scheduler, the intensity ramp and your toys."),
+            ("\U0001F916", "nav_door_companion", "fr8_door_companion_blurb",
+                "Her room: personality, Takeover, She's Listening, Awareness, and every AI permission in one grid."),
+            ("\U0001F3AE", "nav_door_play", "fr8_door_play_blurb",
+                "The card wall: DTRH, Goon, Gaze, Bureau, Deeper, Graded Intake, Lockdown, Remote Control and the Showcase shelf."),
+            ("\U0001F464", "nav_door_you", "fr8_door_you_blurb",
+                "Your progress: Trainer Card, quests, achievements, the Skill Tree, training programs and the leaderboard."),
+            ("\U0001F4DA", "nav_door_library", "fr8_door_library_blurb",
+                "Everything you own: assets and content packs, mods, the catalogue, your phrase pools and the media log."),
+            ("⚙️", "nav_door_settings", "fr8_door_settings_blurb",
+                "The system side: language, audio, devices, performance, notifications, account, data and updates."),
+        };
+
+        private void BuildDoorRows()
+        {
+            foreach (var door in Doors)
+            {
+                var row = new Grid { Margin = new Thickness(0, 0, 0, 10) };
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                var glyph = new TextBlock
+                {
+                    Text = door.Glyph,
+                    FontSize = 20,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Margin = new Thickness(2, 0, 14, 0)
+                };
+                row.Children.Add(glyph);
+
+                var text = new StackPanel();
+                text.Children.Add(new TextBlock
+                {
+                    Text = Loc.Get(door.LabelKey),
+                    Foreground = Brushes.White,
+                    FontSize = 14,
+                    FontWeight = FontWeight.Bold
+                });
+                text.Children.Add(new TextBlock
+                {
+                    Text = Str(door.BlurbKey, door.Blurb),
+                    Foreground = new SolidColorBrush(Color.FromRgb(0xC0, 0xC0, 0xC0)),
+                    FontSize = 12,
+                    TextWrapping = TextWrapping.Wrap,
+                    LineHeight = 18,
+                    Margin = new Thickness(0, 2, 0, 0)
+                });
+                Grid.SetColumn(text, 1);
+                row.Children.Add(text);
+
+                var shell = new Border
+                {
+                    // Avalonia's TryFindResource is an extension on the control, not on Application:
+                    // the lookup has to start somewhere in the tree to see this window's resources.
+                    Background = this.TryFindResource("PanelBgBrush", out var bg) ? bg as IBrush : null,
+                    CornerRadius = new CornerRadius(8),
+                    Padding = new Thickness(12, 10, 12, 10),
+                    Margin = new Thickness(0, 0, 0, 8),
+                    Child = row
+                };
+                _doorsHost.Children.Add(shell);
+            }
+        }
+
+        // ------------------------------------------------------------------ pack events
+
+        // ponytail: needs App.ReleaseContent's PackProgressChanged / PackInstalled and App.Mods'
+        // ModAvailabilityChanged, wired when they move to Core. Each handler marshalled onto the UI
+        // thread and called FindCard(packId)?.MarkProgress/MarkInstalled; FindCard survives below
+        // because the commit path will want it back unchanged.
+
+        private FirstRunModCard? FindCard(string? packId) =>
+            string.IsNullOrEmpty(packId)
+                ? null
+                : _cards.FirstOrDefault(c => string.Equals(c.PackId, packId, StringComparison.OrdinalIgnoreCase));
+
+        // ------------------------------------------------------------------ chrome
+
+        private void TitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            try { BeginMoveDrag(e); } catch { /* as WPF's DragMove, throws if the button already went up */ }
+        }
+
+        private void BtnNext_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_step == 2) CommitModChoice();
+
+            if (_step >= StepCount)
+            {
+                // Last step's primary action is the doors tour itself.
+                StartTourRequested = true;
+                CloseSafely();
+                return;
+            }
+
+            ShowStep(_step + 1);
+        }
+
+        private void BtnPickFolder_Click(object? sender, RoutedEventArgs e)
+        {
+            // Deferred rather than opened here: in WPF the folder browser is a modal owned by
+            // MainWindow, and stacking it under this modal is exactly the modal-on-modal the wizard
+            // exists to remove. The caller opens it the instant this window is gone.
+            PickAssetsFolderRequested = true;
+            _btnPickFolder.IsEnabled = false;
+            _txtPickFolder.Text = Str("fr8_welcome_pick_folder_queued",
+                "We'll ask for your content folder right after this");
+        }
+
+        private void Window_PreviewKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape) return;
+            e.Handled = true;
+            CloseSafely();
+        }
+
+        private void CloseSafely()
+        {
+            try { Close(); } catch { }
+        }
+
+        private bool _closed;
+
+        private void OnWizardClosed(object? sender, EventArgs e)
+        {
+            if (_closed) return;
+            _closed = true;
+
+            // A choice made but never "Next"-ed (Esc, the X, Explore on my own) still counts - the
+            // user ticked a mod, and honouring it is what the picker's own contract promises.
+            CommitModChoice();
+        }
+    }
+}


### PR DESCRIPTION
1,039 lines.

One large view per layer: an `.axaml` and its `.axaml.cs` are never split, so several of these exceed the ~1,000-line guideline. Nothing was dropped to hit a budget.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the render. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351