### PR TITLE
feat(avalonia): port ChaosHubWindow

### DIFF
--- a/CCP.Avalonia/Views/Chaos/ChaosHubWindow.axaml
+++ b/CCP.Avalonia/Views/Chaos/ChaosHubWindow.axaml
@@ -1,0 +1,895 @@
+<!-- PORTED from ConditioningControlPanel/Chaos/ChaosHubWindow.xaml.
+     Structure, ordering, spacing, x:Name-s and every resource key preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" + TransparencyLevelHint
+       shell:WindowChrome                       -> dropped; Win32-only, and SystemDecorations
+                                                   already removes the caption. Edge-resize comes
+                                                   from CanResize + the platform frame instead.
+       FontFamily="Segoe UI"                    -> dropped (Windows-only face)
+       <Style x:Key TargetType>                 -> <ControlTheme x:Key TargetType>
+       Style="{StaticResource X}"               -> Theme="{StaticResource X}"
+       Stepper / WinBtn (property-only Button)  -> BasedOn="{StaticResource {x:Type Button}}", or
+                                                   the ControlTheme leaves Template null and the
+                                                   button draws NOTHING (CLAUDE.md trap 4)
+       ControlTemplate.Triggers                 -> ^:checked / ^:pointerover / ^:disabled selectors
+       bare <ContentPresenter/>                 -> Content/ContentTemplate/Foreground TemplateBindings
+       Visibility="Collapsed"                   -> IsVisible="False"
+       Panel.ZIndex                             -> ZIndex
+       ToolTip="…"                              -> ToolTip.Tip="…"
+       LinearGradientBrush "0,0"/"1,1"          -> "0%,0%"/"100%,100%" (a bare pair is ABSOLUTE px,
+                                                   which collapses the ramp to one pixel) — all
+                                                   FOUR gradients here, not just Brand
+       <Button.Resources><Style TargetType=     -> CornerRadius="N" on the Button; Avalonia's
+         "Border"><Setter CornerRadius>            Fluent template already TemplateBinds it
+       Chk BasedOn="{StaticResource {x:Type     -> a full local template; there is no app-wide
+         CheckBox}}" (Resources/Theme/Inputs)      implicit CheckBox on this head to inherit from
+       OptChk LayoutTransform 1.35              -> ONE LayoutTransformControl around the column
+                                                   (Avalonia has no LayoutTransform per control)
+       skia:SKElement MenuLogoFx / MenuFog      -> no SkiaSharp on this head and no package may be
+                                                   added from a view layer. The logo slot draws the
+                                                   static wordmark frame; the fog layer is inert.
+       bare <Slider> / <ComboBox>               -> Theme="{StaticResource PinkSlider}" /
+                                                   "{StaticResource DarkComboBoxStyle}". WPF got
+                                                   these from the app-wide IMPLICIT styles in
+                                                   Resources/Theme/Inputs.xaml; those two keys in
+                                                   Theme/Styles.xaml are that pair's port, and
+                                                   Avalonia has no implicit theme of ours, so they
+                                                   are named here or the controls fall back to
+                                                   Fluent blue.
+       x:Name on an ImageBrush                  -> dropped; Avalonia's XAML compiler rejects a
+                                                   name on a non-Control (AVLN2000). Nothing looks
+                                                   these up here — the sources come from ChaosArt,
+                                                   which is head-side.
+       MouseLeftButtonDown=                     -> PointerPressed, wired in the constructor
+       {Binding IsChecked, ElementName=X}       -> {Binding #X.IsChecked}
+
+     Every string in this view is hardcoded English in the WPF original too — the Dollhouse was
+     never localized — so there is no {loc:Str} here and no key has been invented for one. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Chaos.ChaosHubWindow"
+        Title="the Dollhouse"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        CanResize="True"
+        WindowStartupLocation="CenterScreen"
+        SizeToContent="Manual" Width="990" Height="930"
+        MinWidth="760" MinHeight="600">
+
+    <Window.Resources>
+        <SolidColorBrush x:Key="Pink" Color="#FFE84393"/>
+        <SolidColorBrush x:Key="Purple" Color="#FF8B5CF6"/>
+        <SolidColorBrush x:Key="Bg" Color="#FF14122A"/>
+        <SolidColorBrush x:Key="Card" Color="#FF1C1A36"/>
+        <SolidColorBrush x:Key="Card2" Color="#FF221F40"/>
+        <SolidColorBrush x:Key="Border1" Color="#44E84393"/>
+        <SolidColorBrush x:Key="TextDim" Color="#AAB8B8D0"/>
+        <SolidColorBrush x:Key="TextMut" Color="#88A0A0C0"/>
+        <!-- ponytail: local copy of ChaosHubWindow.xaml:Brand, hoist when a third view needs it.
+             Theme/Brushes.xaml has BrandGradient with the same two stops, but its endpoints are
+             written "0,0"/"1,1", which Avalonia reads as absolute pixels. -->
+        <LinearGradientBrush x:Key="Brand" StartPoint="0%,0%" EndPoint="100%,100%">
+            <GradientStop Color="#FFE84393" Offset="0"/>
+            <GradientStop Color="#FF8B5CF6" Offset="1"/>
+        </LinearGradientBrush>
+
+        <ControlTheme x:Key="SectionHdr" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource Pink}"/>
+            <Setter Property="FontFamily" Value="Consolas, Courier New"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Margin" Value="0,0,0,10"/>
+        </ControlTheme>
+        <ControlTheme x:Key="Lbl" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{StaticResource TextDim}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Width" Value="92"/>
+        </ControlTheme>
+        <ControlTheme x:Key="CardStyle" TargetType="Border">
+            <Setter Property="Background" Value="{StaticResource Card}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Border1}"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="16"/>
+            <Setter Property="Margin" Value="0,0,0,12"/>
+        </ControlTheme>
+        <ControlTheme x:Key="Seg" TargetType="ToggleButton">
+            <Setter Property="Margin" Value="0,0,6,0"/>
+            <Setter Property="Padding" Value="12,5"/>
+            <Setter Property="Foreground" Value="{StaticResource TextDim}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="b" CornerRadius="8" Background="#22FFFFFF" BorderBrush="#33FFFFFF" BorderThickness="1" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ Border#b">
+                <Setter Property="Background" Value="{StaticResource Pink}"/>
+                <Setter Property="BorderBrush" Value="{StaticResource Pink}"/>
+            </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="FontWeight" Value="Bold"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.4"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+        <!-- tab pill -->
+        <ControlTheme x:Key="Tab" TargetType="ToggleButton">
+            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="Padding" Value="16,8"/>
+            <Setter Property="Foreground" Value="{StaticResource TextDim}"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="b" CornerRadius="9" Background="Transparent" BorderBrush="Transparent" BorderThickness="0,0,0,2" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ Border#b">
+                <Setter Property="Background" Value="#22E84393"/>
+                <Setter Property="BorderBrush" Value="{StaticResource Pink}"/>
+            </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="FontWeight" Value="Bold"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.35"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+        <!-- Property-only in WPF, where a keyed Style keeps the control's default template.
+             An Avalonia ControlTheme REPLACES the theme, so without BasedOn this draws nothing. -->
+        <ControlTheme x:Key="Stepper" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="Width" Value="26"/><Setter Property="Height" Value="26"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Background" Value="#22FFFFFF"/><Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/><Setter Property="Cursor" Value="Hand"/><Setter Property="FontWeight" Value="Bold"/>
+        </ControlTheme>
+        <!-- ponytail: local copy of Resources/Theme/Inputs.xaml's implicit CheckBox (the 18px pink
+             dot with the 7px white core), hoist when a second view needs it. WPF's Chk was
+             BasedOn that implicit style; there is no implicit CheckBox on this head, and a
+             property-only ControlTheme would leave the Fluent tick box (CLAUDE.md trap 4).
+             The check-pop storyboard and the three-state middle value are dropped. -->
+        <ControlTheme x:Key="Chk" TargetType="CheckBox">
+            <Setter Property="Foreground" Value="{StaticResource TextDim}"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Margin" Value="0,3"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <!-- Grid, NOT a horizontal StackPanel: wrapped Content must still wrap. -->
+                    <Grid Background="Transparent" ColumnDefinitions="Auto,*">
+                        <Grid x:Name="DotHost" Grid.Column="0" Width="18" Height="18" VerticalAlignment="Center">
+                            <Border x:Name="Dot" CornerRadius="9"
+                                    Background="#332A2A4A" BorderBrush="#33FFFFFF" BorderThickness="1"/>
+                            <Ellipse x:Name="Core" Width="7" Height="7" Fill="White" IsVisible="False"/>
+                        </Grid>
+                        <ContentPresenter x:Name="ContentHost" Grid.Column="1" Margin="8,0,0,0"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:checked /template/ Border#Dot">
+                <Setter Property="Background" Value="{StaticResource Pink}"/>
+                <Setter Property="BorderBrush" Value="{StaticResource Pink}"/>
+                <Setter Property="Effect">
+                    <DropShadowEffect Color="#FFE84393" BlurRadius="8" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+                </Setter>
+            </Style>
+            <Style Selector="^:checked /template/ Ellipse#Core">
+                <Setter Property="IsVisible" Value="True"/>
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#Dot">
+                <Setter Property="BorderBrush" Value="{StaticResource Pink}"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.45"/>
+            </Style>
+        </ControlTheme>
+        <!-- big left-aligned main-menu list button -->
+        <ControlTheme x:Key="MenuBtn" TargetType="Button">
+            <Setter Property="Height" Value="58"/>
+            <Setter Property="Margin" Value="0,0,0,12"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontSize" Value="19"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Padding" Value="22,0"/>
+            <Setter Property="Background" Value="{StaticResource Card}"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="b" CornerRadius="10" Background="{TemplateBinding Background}"
+                            BorderBrush="{StaticResource Border1}" BorderThickness="1" Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#b">
+                <Setter Property="Background" Value="{StaticResource Card2}"/>
+                <Setter Property="BorderBrush" Value="{StaticResource Pink}"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.4"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+        <!-- big, scaled-up checkbox for the full-width OPTIONS panel. Inherits Chk's dot and
+             label colour transitively (a ControlTheme has ONE BasedOn, same as WPF). The WPF
+             1.35 LayoutTransform lives on the column instead — see MenuOptions. -->
+        <ControlTheme x:Key="OptChk" TargetType="CheckBox" BasedOn="{StaticResource Chk}">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Margin" Value="0,14"/>
+        </ControlTheme>
+        <!-- min / fullscreen / close window-control glyph button -->
+        <ControlTheme x:Key="WinBtn" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+            <Setter Property="Width" Value="30"/><Setter Property="Height" Value="28"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Background" Value="#22FFFFFF"/><Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/><Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Margin" Value="4,0,0,0"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border CornerRadius="16" Background="{StaticResource Bg}" BorderBrush="{StaticResource Pink}" BorderThickness="2">
+        <Grid>
+        <!-- Full-width top drag strip. First child = behind everything, so it never blocks a
+             button: it only catches drags in the transparent top gaps. The view title bars +
+             WinChrome render on top of it. -->
+        <Border x:Name="DragBar" Height="46" VerticalAlignment="Top" Background="Transparent"/>
+
+        <!-- THE DOLL HOUSE: the tabbed hub. Hidden until chosen from the main menu. -->
+        <Grid x:Name="DollhouseView" Margin="22" IsVisible="False"
+              RowDefinitions="Auto,Auto,*,Auto">
+
+            <!-- top bar -->
+            <Grid Grid.Row="0" x:Name="TitleBar" Background="Transparent" Margin="0,0,0,14">
+                <!-- Right-aligned decoration: Uniform keeps the art's full height visible at any
+                     window width (UniformToFill was eating the subject's bottom on wide bars);
+                     MaxHeight still guards the auto-sized title row against tall files. -->
+                <Image x:Name="BannerImage" Stretch="Uniform" HorizontalAlignment="Right"
+                       Opacity="0.30" IsVisible="False" MaxHeight="120"/>
+                <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top">
+                    <Button x:Name="BtnBackToMenu" Content="‹ Menu" Click="Back_To_Menu_Click"
+                            HorizontalAlignment="Left" Margin="0,0,0,8" Padding="10,3"
+                            Background="#22FFFFFF" Foreground="{StaticResource TextDim}" FontSize="12"
+                            BorderThickness="0" Cursor="Hand" CornerRadius="7"
+                            ToolTip.Tip="back to the main menu"/>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="🐇 DOWN THE RABBIT HOLE" Foreground="White" FontSize="22" FontWeight="Bold">
+                            <TextBlock.Effect><DropShadowEffect Color="#FFE84393" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.7"/></TextBlock.Effect>
+                        </TextBlock>
+                        <TextBlock Text="the dollhouse" Foreground="{StaticResource Pink}" FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="12" VerticalAlignment="Bottom" Margin="10,0,0,4"/>
+                    </StackPanel>
+                    <!-- rank / drops / gold under the title, left side — the banner art owns the right -->
+                    <StackPanel Orientation="Horizontal" Margin="2,10,0,0">
+                        <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="12,5" Margin="0,0,8,0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="RANK" Foreground="{StaticResource TextMut}" FontFamily="Consolas, Courier New" FontSize="10" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock x:Name="TxtRank" Text="Curious" Foreground="White" FontWeight="Bold" FontSize="13" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="12,5" Margin="0,0,8,0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="✦" Foreground="{StaticResource Purple}" FontSize="13" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock x:Name="TxtSparks" Text="0" Foreground="White" FontWeight="Bold" FontSize="14" VerticalAlignment="Center"/>
+                                <TextBlock Text="emotes" Foreground="{StaticResource TextMut}" FontSize="11" VerticalAlignment="Bottom" Margin="5,0,0,1"/>
+                            </StackPanel>
+                        </Border>
+                        <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="12,5" Margin="0,0,8,0">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="🪙" FontSize="13" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock x:Name="TxtGold" Text="0" Foreground="White" FontWeight="Bold" FontSize="14" VerticalAlignment="Center"/>
+                                <TextBlock Text="gold" Foreground="{StaticResource TextMut}" FontSize="11" VerticalAlignment="Bottom" Margin="5,0,0,1"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </StackPanel>
+                <!-- Close/minimize/fullscreen live in the shared WinChrome cluster (top-right of the
+                     root grid); the guide button sits left of it so they don't overlap. -->
+                <Button x:Name="BtnGuide" Content="?" Click="BtnGuide_Click"
+                        ToolTip.Tip="How to play — the rules card"
+                        HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,0,120,0"
+                        Width="28" Height="28" Padding="0" Background="#22FFFFFF" Foreground="White"
+                        HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        FontWeight="Bold" BorderThickness="0" Cursor="Hand"/>
+            </Grid>
+
+            <!-- tabs: BAG (glance: pockets + collections), the Toybox (toy/accessory/habit shop),
+                 Settings (run setup), the Looking Glass (stats/diary/mantras/bench) -->
+            <WrapPanel Grid.Row="1" Margin="0,0,0,14">
+                <ToggleButton x:Name="TabLoadout" Theme="{StaticResource Tab}" Content="BAG" Tag="loadout" Click="Tab_Click"/>
+                <ToggleButton x:Name="TabEnhance" Theme="{StaticResource Tab}" Content="the Toybox" Tag="enhance" Click="Tab_Click"/>
+                <ToggleButton x:Name="TabRun" Theme="{StaticResource Tab}" Content="Settings" Tag="run" Click="Tab_Click"/>
+                <ToggleButton x:Name="TabImprove" Theme="{StaticResource Tab}" Content="the Looking Glass" Tag="improve" Click="Tab_Click"/>
+                <ToggleButton x:Name="TabDiary" Theme="{StaticResource Tab}" Content="the Diary" Tag="diary" Click="Tab_Click" IsVisible="False"/>
+            </WrapPanel>
+
+            <!-- content -->
+            <Grid Grid.Row="2">
+
+                <!-- Faint dressing flourish behind every tab (assets/Chaos/hub/backdrop.png,
+                     loaded in LoadBanner; absent file = collapsed, the void returns). -->
+                <Image x:Name="HubBackdrop" Stretch="Uniform" MaxWidth="430" MaxHeight="430"
+                       HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,10,4"
+                       Opacity="0.12" IsHitTestVisible="False" IsVisible="False"/>
+
+                <!-- BAG: the glance page (pockets up top, then the whole collection as tiles) -->
+                <ScrollViewer x:Name="PanelLoadout" VerticalScrollBarVisibility="Auto" IsVisible="False">
+                    <StackPanel>
+                        <Border Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <TextBlock Text="POCKETS" Theme="{StaticResource SectionHdr}" Margin="0,0,0,2"/>
+                                <TextBlock x:Name="TxtPocketsSub" Text="what you take down with you. choose like it matters."
+                                           Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,10"/>
+                                <StackPanel x:Name="PocketSlotsHost" Orientation="Horizontal"/>
+                            </StackPanel>
+                        </Border>
+                        <Border x:Name="CardBagAccessories" Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <Grid Margin="0,0,0,10">
+                                    <TextBlock Text="ACCESSORIES" Theme="{StaticResource SectionHdr}" Margin="0"/>
+                                    <TextBlock x:Name="TxtAccCount" Foreground="{StaticResource TextMut}" FontSize="11" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                </Grid>
+                                <UniformGrid x:Name="TilesAccessories" Columns="4" HorizontalAlignment="Stretch"/>
+                            </StackPanel>
+                        </Border>
+                        <Border x:Name="CardBagToys" Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <Grid Margin="0,0,0,10">
+                                    <TextBlock Text="TOYS" Theme="{StaticResource SectionHdr}" Margin="0"/>
+                                    <TextBlock x:Name="TxtSkillCount" Foreground="{StaticResource TextMut}" FontSize="11" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                </Grid>
+                                <UniformGrid x:Name="TilesSkills" Columns="4" HorizontalAlignment="Stretch"/>
+                            </StackPanel>
+                        </Border>
+                        <Border Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <Grid Margin="0,0,0,2">
+                                    <TextBlock Text="HABITS" Theme="{StaticResource SectionHdr}" Margin="0"/>
+                                    <TextBlock x:Name="TxtHabitCount" Foreground="{StaticResource TextMut}" FontSize="11" HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                                </Grid>
+                                <TextBlock Text="trained habits follow you down. tap one to switch it on or off."
+                                           Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,10"/>
+                                <UniformGrid x:Name="TilesHabits" Columns="4" HorizontalAlignment="Stretch"/>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- THE TOYBOX: unlock + deepen toys, accessories and habits -->
+                <ScrollViewer x:Name="PanelEnhance" VerticalScrollBarVisibility="Auto" IsVisible="False">
+                    <StackPanel>
+                        <TextBlock Text="the Toybox" Theme="{StaticResource SectionHdr}" FontSize="20" Margin="2,0,0,2"/>
+                        <TextBlock Text="everything ordered here comes in an anonymous sealed package ;)"
+                                   Foreground="{StaticResource TextMut}" FontSize="11" Margin="2,0,0,14"/>
+                        <Border x:Name="HerCornerCard" Theme="{StaticResource CardStyle}" IsVisible="False">
+                            <StackPanel>
+                                <TextBlock Text="her corner" Theme="{StaticResource SectionHdr}" Margin="0,0,0,2"/>
+                                <TextBlock Text="a little table by the door. she takes gold."
+                                           Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,10"/>
+                                <StackPanel x:Name="HerCornerHost"/>
+                            </StackPanel>
+                        </Border>
+                        <TextBlock x:Name="HdrToys" Text="Toys" Theme="{StaticResource SectionHdr}" FontSize="20" Margin="2,0,0,10"/>
+                        <StackPanel x:Name="BoonHostSkills"/>
+                        <Border x:Name="StubToys" IsVisible="False"
+                                Background="{StaticResource Card2}" BorderThickness="1" CornerRadius="8"
+                                Padding="10" Margin="0,0,0,6" Opacity="0.55">
+                            <Border.BorderBrush><SolidColorBrush Color="#1EE84393"/></Border.BorderBrush>
+                            <TextBlock Text="???" Foreground="{StaticResource TextMut}" FontSize="12" FontWeight="SemiBold"/>
+                        </Border>
+                        <TextBlock x:Name="HdrAccessories" Text="Accessories" Theme="{StaticResource SectionHdr}" FontSize="20" Margin="2,14,0,10"/>
+                        <StackPanel x:Name="BoonHostAccessories"/>
+                        <Border x:Name="StubAccessories" IsVisible="False"
+                                Background="{StaticResource Card2}" BorderThickness="1" CornerRadius="8"
+                                Padding="10" Margin="0,8,0,6" Opacity="0.55">
+                            <Border.BorderBrush><SolidColorBrush Color="#1EE84393"/></Border.BorderBrush>
+                            <TextBlock Text="???" Foreground="{StaticResource TextMut}" FontSize="12" FontWeight="SemiBold"/>
+                        </Border>
+                        <TextBlock Text="Habits" Theme="{StaticResource SectionHdr}" FontSize="20" Margin="2,14,0,2"/>
+                        <TextBlock Text="spend your emotes. once trained they're yours for good. switch them on or off between descents."
+                                   Foreground="{StaticResource TextMut}" FontSize="11" Margin="2,0,0,10"/>
+                        <StackPanel x:Name="HabitsHost"/>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- SETTINGS: run setup -->
+                <ScrollViewer x:Name="PanelRun" VerticalScrollBarVisibility="Auto" IsVisible="False">
+                    <StackPanel>
+                        <StackPanel x:Name="SetupBody">
+                        <Border Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <TextBlock Text="THE DESCENT" Theme="{StaticResource SectionHdr}" Margin="0,0,0,2"/>
+                                <TextBlock Text="dress it up however you like. it ends the same way." Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,10"/>
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="Difficulty" Theme="{StaticResource Lbl}"/>
+                                    <StackPanel x:Name="GrpDifficulty" Orientation="Horizontal">
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="Easy" Content="Gentle" Click="Segment_Click"/>
+                                        <ToggleButton x:Name="SegMedium" Theme="{StaticResource Seg}" Tag="Medium" Content="Teasing" Click="Segment_Click"/>
+                                        <ToggleButton x:Name="SegHard" Theme="{StaticResource Seg}" Tag="Hard" Content="Relentless" Click="Segment_Click"/>
+                                        <ToggleButton x:Name="SegExtreme" Theme="{StaticResource Seg}" Tag="Extreme" Content="Inescapable 🔒" Click="Segment_Click"/>
+                                    </StackPanel>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="Length" Theme="{StaticResource Lbl}"/>
+                                    <StackPanel x:Name="GrpLength" Orientation="Horizontal">
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="120" Content="2 min" Click="Segment_Click"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="180" Content="3 min" Click="Segment_Click"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="300" Content="5 min" Click="Segment_Click"/>
+                                    </StackPanel>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="Motion" Theme="{StaticResource Lbl}"/>
+                                    <StackPanel x:Name="GrpMotion" Orientation="Horizontal">
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="Mixed" Content="Mixed" Click="Segment_Click"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="FloatUp" Content="Float" Click="Segment_Click"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="RainDown" Content="Rain" Click="Segment_Click"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="RoamBounce" Content="Roam" Click="Segment_Click"/>
+                                    </StackPanel>
+                                </StackPanel>
+                                <!-- Resistance stepper removed 2026-06-10: you descend with 0 —
+                                     resistance is TRAINED ("It would never work on me..." charm). -->
+                            </StackPanel>
+                        </Border>
+
+                        <Border Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <TextBlock Text="SENSATION" Theme="{StaticResource SectionHdr}"/>
+                                <CheckBox x:Name="ChkShake" Theme="{StaticResource Chk}" Content="Screen shake"/>
+                                <Slider x:Name="SldShake" Theme="{StaticResource PinkSlider}" Minimum="0" Maximum="1" Margin="0,0,0,6"/>
+                                <CheckBox x:Name="ChkFlashes" Theme="{StaticResource Chk}" Content="Color flashes"/>
+                                <CheckBox x:Name="ChkSkiaFx" Theme="{StaticResource Chk}" Content="Enhanced FX (bloom &amp; bursts)"
+                                          ToolTip.Tip="Additive Skia-rendered glow: rabbit trail, cursor halo, lightning, bubble pop bursts &amp; glassy shine. Off = the classic effects."/>
+                                <CheckBox x:Name="ChkPinTop" Theme="{StaticResource Chk}" Content="Keep on top"
+                                          ToolTip.Tip="Pins the chaos layer above other windows. Off = other apps can come forward over the descent."/>
+                                <CheckBox x:Name="ChkSharedHost" Theme="{StaticResource Chk}" Content="Smooth bubbles (experimental)"
+                                          ToolTip.Tip="Renders all bubbles on one shared layer instead of a window each, so clicks stay responsive when the screen is busy. Experimental — turn off if bubbles misbehave."/>
+                                <TextBlock Text="Effect intensity" Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,6,0,0"/>
+                                <Slider x:Name="SldEffect" Theme="{StaticResource PinkSlider}" Minimum="0.2" Maximum="1.5"/>
+                                <CheckBox x:Name="ChkAnnouncer" Theme="{StaticResource Chk}" Content="Announcements" Margin="0,8,0,0"/>
+                                <TextBlock Text="THE MADAM" Theme="{StaticResource SectionHdr}" Margin="0,12,0,0"/>
+                                <CheckBox x:Name="ChkNarrative" Theme="{StaticResource Chk}" Content="Narrator (voiced reactions)"
+                                          ToolTip.Tip="A reactive narrator speaks voiced + text lines during a descent."/>
+                                <CheckBox x:Name="ChkBackdrop" Theme="{StaticResource Chk}" Content="Zone backdrops" Margin="0,4,0,0"
+                                          ToolTip.Tip="Per-zone backdrop plates under the bubbles. Off = classic Chaos over your live desktop."/>
+                                <TextBlock Text="Backdrop opacity" Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,6,0,0"/>
+                                <Slider x:Name="SldBackdropOpacity" Theme="{StaticResource PinkSlider}" Minimum="0" Maximum="1"/>
+                                <CheckBox x:Name="ChkTunnel" Theme="{StaticResource Chk}" Content="3D rabbit-hole tunnel" Margin="0,10,0,0"
+                                          ToolTip.Tip="An endless procedurally-generated 3D tunnel rendered behind the game. Heavier on the GPU — default off."/>
+                            </StackPanel>
+                        </Border>
+
+                        <Border x:Name="CardKeybinds" Theme="{StaticResource CardStyle}">
+                            <StackPanel>
+                                <TextBlock Text="KEYBINDS" Theme="{StaticResource SectionHdr}" Margin="0,0,0,2"/>
+                                <TextBlock x:Name="TxtKeybindsSub" Text="your equipped toy fires on this, mid-descent. the second pocket isn't sewn yet."
+                                           Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,10"/>
+                                <StackPanel x:Name="RowToyKey1" Orientation="Horizontal" Margin="0,0,0,8">
+                                    <TextBlock Text="Toy 1" Theme="{StaticResource Lbl}"/>
+                                    <ComboBox x:Name="CmbAccKey1" Theme="{StaticResource DarkComboBoxStyle}" Width="70" SelectionChanged="AccKey_Changed"/>
+                                </StackPanel>
+                                <StackPanel x:Name="RowToyKey2" Orientation="Horizontal">
+                                    <TextBlock Text="Toy 2" Theme="{StaticResource Lbl}"/>
+                                    <ComboBox x:Name="CmbAccKey2" Theme="{StaticResource DarkComboBoxStyle}" Width="70" SelectionChanged="AccKey_Changed"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- TESTING OPTIONS: dev/test knobs the descent normally tunes itself
+                             (bubble pool, mantra/sin toggles, loop count). Collapsed by default
+                             so the casual read is just difficulty + length + feel. -->
+                        <ToggleButton x:Name="TglTesting" Theme="{StaticResource Seg}" Content="🧪 testing options ▸"
+                                      Click="TestingToggle_Click" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+                        <StackPanel x:Name="TestingBody" IsVisible="False">
+
+                            <Border Theme="{StaticResource CardStyle}">
+                                <StackPanel>
+                                    <TextBlock Text="BUBBLE POOL — what can drop" Theme="{StaticResource SectionHdr}"/>
+                                    <WrapPanel x:Name="GrpPool">
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="flash" Content="Flash" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="subliminal" Content="Subliminal" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="pink" Content="Pink Filter" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="spiral" Content="Spiral" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="braindrain" Content="BrainDrain" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="bambifreeze" Content="Bambi Freeze" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="video" Content="Video" Margin="0,0,6,6"/>
+                                        <ToggleButton Theme="{StaticResource Seg}" Tag="htlink" Content="Gif Rain" Margin="0,0,6,6"/>
+                                    </WrapPanel>
+                                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="presets:" Foreground="{StaticResource TextMut}" FontSize="12" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                        <Button Content="Balanced" Tag="Balanced" Click="Preset_Click" Theme="{StaticResource Stepper}" Width="NaN" Padding="10,4" Margin="0,0,6,0"/>
+                                        <Button Content="Tease" Tag="Tease" Click="Preset_Click" Theme="{StaticResource Stepper}" Width="NaN" Padding="10,4" Margin="0,0,6,0"/>
+                                        <Button Content="Flash-only" Tag="Flash-only" Click="Preset_Click" Theme="{StaticResource Stepper}" Width="NaN" Padding="10,4"/>
+                                    </StackPanel>
+                                    <CheckBox x:Name="ChkDarters" Theme="{StaticResource Chk}" Content="White rabbits (fast bonus catch targets)" Margin="0,12,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Theme="{StaticResource CardStyle}">
+                                <StackPanel>
+                                    <TextBlock Text="MANTRAS &amp; LOOPS" Theme="{StaticResource SectionHdr}"/>
+                                    <CheckBox x:Name="ChkBoonDraft" Theme="{StaticResource Chk}" Content="Mantra draft between loops"/>
+                                    <CheckBox x:Name="ChkCurses" Theme="{StaticResource Chk}" Content="Allow sins"/>
+                                    <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                        <TextBlock Text="Loops" Foreground="{StaticResource TextDim}" FontSize="12" VerticalAlignment="Center" Width="50"/>
+                                        <Button Theme="{StaticResource Stepper}" Content="−" Tag="waves-" Click="Stepper_Click"/>
+                                        <TextBlock x:Name="TxtWaves" Foreground="White" FontWeight="Bold" FontSize="14" Width="34" TextAlignment="Center" VerticalAlignment="Center"/>
+                                        <Button Theme="{StaticResource Stepper}" Content="+" Tag="waves+" Click="Stepper_Click"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                <Button Content="↻ Randomize" Click="BtnRandomize_Click" Theme="{StaticResource Stepper}" Width="NaN" Height="NaN" Padding="12,8" Margin="0,0,8,0"/>
+                                <Button Content="Defaults" Click="BtnDefaults_Click" Theme="{StaticResource Stepper}" Width="NaN" Height="NaN" Padding="12,8"/>
+                            </StackPanel>
+                        </StackPanel><!-- /TestingBody -->
+                        </StackPanel><!-- /SetupBody -->
+                    </StackPanel>
+                </ScrollViewer>
+
+                <!-- THE LOOKING GLASS: the seamstress's bench (meta unlocks) + mantras + stats & diary -->
+                <Grid x:Name="PanelImprove" IsVisible="False" RowDefinitions="Auto,*">
+                    <Border Grid.Row="0" Theme="{StaticResource CardStyle}">
+                        <StackPanel>
+                            <TextBlock Text="the seamstress's bench" Theme="{StaticResource SectionHdr}" Margin="0,0,0,2"/>
+                            <TextBlock Text="permanent alterations to the dollhouse itself. extra pockets, deeper doors."
+                                       Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,10"/>
+                            <ScrollViewer MaxHeight="190" VerticalScrollBarVisibility="Auto">
+                                <StackPanel x:Name="ImprovementsHost"/>
+                            </ScrollViewer>
+                        </StackPanel>
+                    </Border>
+                    <Grid Grid.Row="1" ColumnDefinitions="*,*">
+                        <Border x:Name="CardMantras" Grid.Column="0" Theme="{StaticResource CardStyle}" Margin="0,0,6,12">
+                            <Grid RowDefinitions="Auto,Auto,*">
+                                <TextBlock Grid.Row="0" Text="MANTRAS" Theme="{StaticResource SectionHdr}" Margin="0,0,0,2"/>
+                                <TextBlock Grid.Row="1" Text="click one to whisper it on the way down. click again for silence."
+                                           Foreground="{StaticResource TextMut}" FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap"/>
+                                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                                    <StackPanel x:Name="MantrasHost"/>
+                                </ScrollViewer>
+                            </Grid>
+                        </Border>
+                        <Border Grid.Column="1" Theme="{StaticResource CardStyle}" Margin="6,0,0,12">
+                            <Grid RowDefinitions="Auto,*">
+                                <TextBlock x:Name="HdrStats" Grid.Row="0" Text="HOW FAR YOU'VE FALLEN" Theme="{StaticResource SectionHdr}"/>
+                                <Grid Grid.Row="1" x:Name="StatsGrid" VerticalAlignment="Top" Margin="0,0,0,8"
+                                      ColumnDefinitions="Auto,*"
+                                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Emotes" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4" Width="175"/>
+                                    <TextBlock Grid.Row="0" Grid.Column="1" x:Name="StSparks" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Descents completed" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="1" x:Name="StRuns" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Time under" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="2" Grid.Column="1" x:Name="StTimeUnder" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Best score" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="3" Grid.Column="1" x:Name="StBestScore" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Best streak" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="4" Grid.Column="1" x:Name="StBestCombo" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="0" Text="Total snapped" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="5" Grid.Column="1" x:Name="StDefused" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Time holding on" Foreground="{StaticResource TextDim}" FontSize="15" Margin="0,4"/>
+                                    <TextBlock Grid.Row="6" Grid.Column="1" x:Name="StTimeHeld" Foreground="White" FontWeight="Bold" FontSize="15" Margin="0,4"/>
+                                </Grid>
+                            </Grid>
+                        </Border>
+                    </Grid>
+                </Grid>
+
+                <!-- the Diary: its own tab so a full stats sheet can't crowd it out.
+                     Revealed only after the player has met something down there. -->
+                <ScrollViewer x:Name="PanelDiary" VerticalScrollBarVisibility="Auto" IsVisible="False">
+                    <Border Theme="{StaticResource CardStyle}">
+                        <StackPanel>
+                            <TextBlock x:Name="HdrDiary" Text="DIARY · what you've met down there · click to pop out ⤢"
+                                       Cursor="Hand" Foreground="{StaticResource Pink}"
+                                       FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="12" Margin="0,0,0,10"/>
+                            <StackPanel x:Name="DiaryHost"/>
+                        </StackPanel>
+                    </Border>
+                </ScrollViewer>
+            </Grid>
+
+            <!-- footer -->
+            <Grid Grid.Row="3" Margin="0,12,0,0">
+                <TextBlock x:Name="TxtHint" Foreground="{StaticResource TextMut}" FontSize="11" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <!-- The play-mode pick moved to the Lab card (ChaosModeService.SelectedPlayMode);
+                         this separate Free Desktop button is retired. Kept (collapsed) so it can be
+                         restored if the pick ever returns to the hub. -->
+                    <Button x:Name="BtnBeginDesktop" Content="🖥 FREE DESKTOP" Tag="FreeDesktop" Click="BtnBegin_Click"
+                            IsVisible="False"
+                            ToolTip.Tip="Pop bubbles over your real desktop — no story or backdrop, and other windows can stay in front. Your companion floats along."
+                            Background="#332A2A4A" Foreground="{StaticResource TextMut}" FontWeight="SemiBold" FontSize="14"
+                            BorderBrush="#55E84393" BorderThickness="1" Padding="22,12" Margin="0,0,12,0" Cursor="Hand"
+                            CornerRadius="14"/>
+                    <!-- Single launcher. Mode is decided on the Lab card, so this is mode-neutral
+                         ("FALL IN — STORY" label + Story tag removed). StartRun resolves the actual
+                         mode from ChaosModeService.SelectedPlayMode. -->
+                    <Button x:Name="BtnBegin" Content="▶ FALL IN" Click="BtnBegin_Click"
+                            ToolTip.Tip="Begin the descent."
+                            Background="{StaticResource Brand}" Foreground="White" FontWeight="Bold" FontSize="16"
+                            BorderThickness="0" Padding="32,13" Cursor="Hand" CornerRadius="14">
+                        <Button.Effect><DropShadowEffect Color="#FFE84393" BlurRadius="18" OffsetX="0" OffsetY="0" Opacity="0.6"/></Button.Effect>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Grid>
+        <!-- ============ MAIN MENU (cinematic split: menu left, art right) ============ -->
+        <Grid x:Name="MenuView" Margin="22" ColumnDefinitions="Auto,*">
+
+            <!-- right: character / banner art fills the right half. Thick pink neon border with
+                 rounded corners + an animated glow (pulsed in code-behind SetupMenuMotion). -->
+            <Border x:Name="MenuArtPanel" Grid.Column="1" CornerRadius="24" Margin="18,52,2,2"
+                    BorderThickness="3">
+                <Border.BorderBrush>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                        <GradientStop Color="#FFFF5FB0" Offset="0"/>
+                        <GradientStop Color="#FFE84393" Offset="0.5"/>
+                        <GradientStop Color="#FF9B6CF6" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.BorderBrush>
+                <Border.Effect>
+                    <DropShadowEffect Color="#FFE84393" OffsetX="0" OffsetY="0" BlurRadius="20" Opacity="0.7"/>
+                </Border.Effect>
+                <Grid x:Name="MenuArtClip" Background="Transparent">
+                    <!-- Every layer rounds itself: a Border clips its own Background/ImageBrush to its
+                         CornerRadius (reliable, unlike UIElement.Clip here). Fog rounds at the canvas. -->
+                    <Border CornerRadius="22">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                <GradientStop Color="#22E84393" Offset="0"/>
+                                <GradientStop Color="#11000000" Offset="1"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                    </Border>
+                    <!-- two stacked image layers (rounded image-brush borders) so frames can crossfade;
+                         both share the breathing motion via the wrapping MenuArtMotion grid.
+                         ponytail: needs ChaosArt for the menu flipbook frames, wired when it moves
+                         to Core — both brushes have no Source on this head, so the gradient shows. -->
+                    <Grid x:Name="MenuArtMotion" RenderTransformOrigin="50%,50%">
+                        <Border CornerRadius="22">
+                            <Border.Background><ImageBrush Stretch="UniformToFill"/></Border.Background>
+                        </Border>
+                        <Border x:Name="MenuArtTopBox" CornerRadius="22" Opacity="0">
+                            <Border.Background><ImageBrush Stretch="UniformToFill"/></Border.Background>
+                        </Border>
+                    </Grid>
+                    <!-- WPF: skia:SKElement MenuFog — animated pink fog drifting IN FRONT of the
+                         character (additive-soft), gated on Enhanced FX. ponytail: needs SkiaSharp,
+                         which this head does not reference and a view layer may not add; the layer
+                         stays as an inert placeholder so the z-order still reads. -->
+                    <Border x:Name="MenuFog" IsHitTestVisible="False" Background="Transparent"/>
+                </Grid>
+            </Border>
+
+            <!-- left: title + menu + chips -->
+            <Grid x:Name="MenuLeftCol" Grid.Column="0" Width="370" RowDefinitions="Auto,*,Auto">
+
+                <!-- title (drag region) — neon logo wordmark, centered above the buttons -->
+                <StackPanel Grid.Row="0" x:Name="MenuTitleBar" Background="Transparent">
+                    <!-- WPF: skia:SKElement MenuLogoFx, the wordmark rendered in Skia so the authored
+                         glint FX is true additive light on the logo's real pixels. ponytail: needs
+                         SkiaSharp; the static frame (the wordmark itself, no glint sweep) is drawn
+                         here at the same 314x224 so the menu keeps its title block. -->
+                    <Border x:Name="MenuLogoFx" IsHitTestVisible="False"
+                            Width="314" Height="224" HorizontalAlignment="Center" Margin="0,48,0,0">
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="DOWN THE" Foreground="White" FontSize="34" FontWeight="Bold"
+                                       HorizontalAlignment="Center">
+                                <TextBlock.Effect><DropShadowEffect Color="#FFE84393" BlurRadius="26" OffsetX="0" OffsetY="0" Opacity="0.9"/></TextBlock.Effect>
+                            </TextBlock>
+                            <TextBlock Text="RABBIT HOLE" Foreground="White" FontSize="40" FontWeight="Bold"
+                                       HorizontalAlignment="Center" Margin="0,2,0,0">
+                                <TextBlock.Effect><DropShadowEffect Color="#FF8B5CF6" BlurRadius="26" OffsetX="0" OffsetY="0" Opacity="0.9"/></TextBlock.Effect>
+                            </TextBlock>
+                            <TextBlock Text="🐇" FontSize="34" HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    <TextBlock Text="· the dollhouse ·" Foreground="{StaticResource Pink}" FontFamily="Consolas, Courier New"
+                               FontWeight="Bold" FontSize="12" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+                </StackPanel>
+
+                <!-- center: the menu list (options now lives full-width — see MenuOptions below) -->
+                <Grid Grid.Row="1" VerticalAlignment="Center" Margin="0,18,0,18">
+                    <StackPanel x:Name="MenuButtons">
+                        <Button x:Name="BtnMenuFallIn" Content="▶  FALL IN" Click="Menu_FallIn_Click"
+                                Height="64" Margin="0,0,0,14" FontSize="22" FontWeight="Bold" Foreground="White"
+                                Background="{StaticResource Brand}" BorderThickness="0" Cursor="Hand"
+                                HorizontalContentAlignment="Left" Padding="22,0" CornerRadius="12"
+                                ToolTip.Tip="you were always going to.">
+                            <Button.Effect><DropShadowEffect Color="#FFE84393" BlurRadius="18" OffsetX="0" OffsetY="0" Opacity="0.6"/></Button.Effect>
+                        </Button>
+                        <Button x:Name="BtnMenuHowTo" Theme="{StaticResource MenuBtn}" Content="📖  HOW TO PLAY"
+                                Click="Menu_HowTo_Click" ToolTip.Tip="new here? thirty seconds and you'll have it."/>
+                        <Button x:Name="BtnMenuDollhouse" Theme="{StaticResource MenuBtn}" Content="🏠  THE DOLL HOUSE"
+                                Click="Menu_Dollhouse_Click" ToolTip.Tip="pockets, toys, the bench — dress the fall."/>
+                        <Button x:Name="BtnMenuStory" Theme="{StaticResource MenuBtn}" Content="📖  STORY MODE  🔒"
+                                Click="Menu_Story_Click" ToolTip.Tip="the Madam's narrated descent — coming soon."/>
+                        <Button x:Name="BtnMenuOptions" Theme="{StaticResource MenuBtn}" Content="⚙  OPTIONS" Click="Menu_Options_Click"/>
+                        <Button x:Name="BtnMenuExit" Theme="{StaticResource MenuBtn}" Content="✕  EXIT" Click="Menu_Exit_Click"/>
+                    </StackPanel>
+                </Grid>
+
+                <!-- bottom: rank / drops / gold -->
+                <StackPanel Grid.Row="2" Orientation="Horizontal">
+                    <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="10,5" Margin="0,0,8,0">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="RANK" Foreground="{StaticResource TextMut}" FontFamily="Consolas, Courier New" FontSize="10" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock x:Name="MenuRank" Text="Curious" Foreground="White" FontWeight="Bold" FontSize="13" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="10,5" Margin="0,0,8,0">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="✦" Foreground="{StaticResource Purple}" FontSize="13" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock x:Name="MenuSparks" Text="0" Foreground="White" FontWeight="Bold" FontSize="14" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="{StaticResource Card2}" CornerRadius="9" Padding="10,5">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="🪙" FontSize="13" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                            <TextBlock x:Name="MenuGold" Text="0" Foreground="White" FontWeight="Bold" FontSize="14" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <!-- soundtrack mute toggle (icon swaps 🔊/🔇 in code-behind) -->
+                    <Button x:Name="BtnMenuMute" Click="BtnMenuMute_Click" Cursor="Hand"
+                            ToolTip.Tip="Mute / unmute the menu music" Background="{StaticResource Card2}"
+                            BorderThickness="0" Padding="10,5" Margin="8,0,0,0" CornerRadius="9">
+                        <TextBlock x:Name="MenuMuteIcon" Text="🔊" FontSize="15" VerticalAlignment="Center"/>
+                    </Button>
+                </StackPanel>
+            </Grid>
+
+            <!-- OPTIONS: full-width sub-screen (art + left column hide while it's up) so the toggles
+                 use the whole window — bigger and spread across two columns. The overlapping ones
+                 two-way bind to the Settings-tab controls so there's a single source of truth. -->
+            <Border x:Name="MenuOptions" Grid.ColumnSpan="2" IsVisible="False"
+                    Background="{StaticResource Card}" BorderBrush="{StaticResource Border1}" BorderThickness="2"
+                    CornerRadius="14" Padding="40,30">
+                <Grid RowDefinitions="Auto,*,Auto">
+
+                    <StackPanel Grid.Row="0">
+                        <TextBlock Text="⚙  OPTIONS" Foreground="{StaticResource Pink}" FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="28"/>
+                        <TextBlock Text="display &amp; comfort — these stick between descents." Foreground="{StaticResource TextMut}" FontSize="13" Margin="2,6,0,0"/>
+                    </StackPanel>
+
+                    <Grid Grid.Row="1" Margin="0,12,0,0" VerticalAlignment="Center" ColumnDefinitions="*,64,*">
+
+                        <!-- left: toggles. WPF scaled each OptChk with a 1.35 LayoutTransform; Avalonia
+                             has no per-control LayoutTransform, so ONE LayoutTransformControl scales
+                             the whole column — same 18px dot at ~24px, same intent. -->
+                        <LayoutTransformControl Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="6,0,0,0">
+                            <LayoutTransformControl.LayoutTransform>
+                                <ScaleTransform ScaleX="1.35" ScaleY="1.35"/>
+                            </LayoutTransformControl.LayoutTransform>
+                            <StackPanel>
+                                <CheckBox x:Name="OptFullscreen" Theme="{StaticResource OptChk}" Content="Fullscreen" Click="OptFullscreen_Click"/>
+                                <CheckBox x:Name="OptKeepTop" Theme="{StaticResource OptChk}" Content="Keep on top"
+                                          IsChecked="{Binding #ChkPinTop.IsChecked, Mode=TwoWay}"/>
+                                <CheckBox x:Name="OptSkiaFx" Theme="{StaticResource OptChk}" Content="Enhanced FX (bloom &amp; bursts)"
+                                          IsChecked="{Binding #ChkSkiaFx.IsChecked, Mode=TwoWay}"/>
+                                <CheckBox x:Name="OptAnnounce" Theme="{StaticResource OptChk}" Content="Announcements"
+                                          IsChecked="{Binding #ChkAnnouncer.IsChecked, Mode=TwoWay}"/>
+                            </StackPanel>
+                        </LayoutTransformControl>
+
+                        <!-- right: intensity slider -->
+                        <StackPanel Grid.Column="2" VerticalAlignment="Center" Margin="0,0,6,0">
+                            <TextBlock Text="EFFECT INTENSITY" Foreground="{StaticResource TextMut}" FontFamily="Consolas, Courier New" FontSize="13" FontWeight="Bold" Margin="0,0,0,10"/>
+                            <Slider Theme="{StaticResource PinkSlider}" Minimum="0.2" Maximum="1.5" Value="{Binding #SldEffect.Value, Mode=TwoWay}" Height="30"/>
+                            <TextBlock Text="lower = gentler bloom &amp; shake." Foreground="{StaticResource TextMut}" FontSize="12" Margin="0,10,0,0"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <Button Grid.Row="2" Content="‹ back" Click="Options_Back_Click" Theme="{StaticResource MenuBtn}"
+                            HorizontalAlignment="Left" Width="170" Height="52" Margin="0,16,0,0"/>
+                </Grid>
+            </Border>
+
+            <!-- HOW TO PLAY: card overlay floating over the menu (art keeps breathing, music keeps
+                 playing underneath). Built one card at a time in code-behind (HowToShow). -->
+            <Border x:Name="MenuHowTo" Grid.ColumnSpan="2" IsVisible="False" Background="#D80B0B16">
+                <Border Width="660" MaxHeight="660" VerticalAlignment="Center" HorizontalAlignment="Center"
+                        Background="{StaticResource Card}" BorderBrush="{StaticResource Border1}" BorderThickness="2"
+                        CornerRadius="18" Margin="0,40,0,0">
+                    <Border.Effect><DropShadowEffect Color="#FFE84393" OffsetX="0" OffsetY="0" BlurRadius="34" Opacity="0.45"/></Border.Effect>
+                    <Grid RowDefinitions="Auto,Auto,*,Auto">
+
+                        <!-- card image (hidden when no screenshot present) -->
+                        <Border x:Name="HowToImageBox" Grid.Row="0" Height="252" CornerRadius="16,16,0,0" ClipToBounds="True">
+                            <Grid>
+                                <Border CornerRadius="16,16,0,0">
+                                    <Border.Background><ImageBrush Stretch="UniformToFill"/></Border.Background>
+                                </Border>
+                                <Border CornerRadius="16,16,0,0">
+                                    <Border.Background>
+                                        <LinearGradientBrush StartPoint="0%,100%" EndPoint="0%,0%">
+                                            <GradientStop Color="#FF1C1A36" Offset="0"/>
+                                            <GradientStop Color="Transparent" Offset="0.85"/>
+                                        </LinearGradientBrush>
+                                    </Border.Background>
+                                </Border>
+                            </Grid>
+                        </Border>
+
+                        <!-- title -->
+                        <StackPanel Grid.Row="1" Margin="32,18,32,0">
+                            <TextBlock x:Name="HowToStep" Text="STEP 1 / 5" Foreground="{StaticResource Pink}"
+                                       FontFamily="Consolas, Courier New" FontWeight="Bold" FontSize="11" Margin="0,0,0,4"/>
+                            <TextBlock x:Name="HowToTitle" Text="" Foreground="White" FontSize="22" FontWeight="Bold" TextWrapping="Wrap"/>
+                        </StackPanel>
+
+                        <!-- body lines (built in code-behind) -->
+                        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" Margin="32,12,32,8">
+                            <StackPanel x:Name="HowToBody"/>
+                        </ScrollViewer>
+
+                        <!-- footer: back · dots · next -->
+                        <Grid Grid.Row="3" Margin="24,8,24,22">
+                            <Button x:Name="HowToBack" Content="‹  BACK" Click="HowTo_Back_Click" Theme="{StaticResource MenuBtn}"
+                                    HorizontalAlignment="Left" Width="140" Height="46"/>
+                            <StackPanel x:Name="HowToDots" Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            <Button x:Name="HowToNext" Content="NEXT  ›" Click="HowTo_Next_Click"
+                                    HorizontalAlignment="Right" Width="140" Height="46" FontWeight="Bold" FontSize="14"
+                                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                                    Foreground="White" Background="{StaticResource Brand}" BorderThickness="0"
+                                    Cursor="Hand" CornerRadius="10"/>
+                        </Grid>
+
+                        <!-- close X -->
+                        <Button x:Name="HowToClose" Grid.Row="0" Content="✕" Click="HowTo_Close_Click"
+                                HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,10,12,0" ZIndex="5"
+                                Width="34" Height="34" Padding="0" FontSize="14" Foreground="White" Cursor="Hand"
+                                HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                                Background="#66000000" BorderThickness="0" CornerRadius="17" ToolTip.Tip="Close"/>
+                    </Grid>
+                </Border>
+            </Border>
+        </Grid>
+
+        <!-- unlock cards float top-center over everything; never blocks clicks (shopping continues under it) -->
+        <Grid x:Name="UnlockCardLayer" IsHitTestVisible="False"/>
+
+        <!-- shared window controls (top-right, above both views) -->
+        <StackPanel x:Name="WinChrome" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Margin="0,10,12,0" ZIndex="50">
+            <Button x:Name="BtnMin" Theme="{StaticResource WinBtn}" Content="—" Click="BtnMin_Click" ToolTip.Tip="Minimize"/>
+            <Button x:Name="BtnFull" Theme="{StaticResource WinBtn}" Content="⛶" Click="BtnFull_Click" ToolTip.Tip="Fullscreen (maximize)"/>
+            <Button x:Name="BtnCloseWin" Theme="{StaticResource WinBtn}" Content="✕" Click="BtnClose_Click" ToolTip.Tip="Close"/>
+        </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Chaos/ChaosHubWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosHubWindow.axaml.cs
@@ -1,0 +1,1995 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Chaos
+{
+    /// <summary>
+    /// The Down the Rabbit Hole hub ("the Dollhouse"): opened from the Lab card. A main menu
+    /// lands first; behind it are four tabs — BAG (pocket slots + the whole collection as
+    /// clickable tiles), THE TOYBOX (unlock/deepen toys, accessories and habits), SETTINGS
+    /// (run setup), and THE LOOKING GLASS (the seamstress's bench, mantras and stats).
+    ///
+    /// PORTED from ConditioningControlPanel/Chaos/ChaosHubWindow.xaml.cs. What changed and why:
+    ///
+    ///  - Every shelf, tile, mantra, diary entry and bench row is built from the sample data at
+    ///    the bottom of this file instead of <c>ChaosMeta</c> / <c>ChaosUpgrades</c> /
+    ///    <c>ChaosLifetimeBoons</c> / <c>ChaosBoonPool</c> / <c>ChaosBubbleVariants</c> /
+    ///    <c>ChaosArt</c>, which are WPF-head services. The samples deliberately hit EVERY visual
+    ///    state each builder branches on (equipped / owned / locked / rank-locked / empty;
+    ///    trained-on / trained-off / untrained; seen / unseen / sin; sewn / for-sale / rank-short
+    ///    / hazy), so the render proves the builders rather than one branch of them.
+    ///    ponytail: needs the Chaos services, wired when they move to Core.
+    ///  - The four partials the WPF class spans (Bench / Reveals / Lessons / Debug) are NOT in
+    ///    this layer. <c>BuildBench</c> is inlined here because <c>ImprovementsHost</c> must not
+    ///    render empty; the reveal framework, the lesson gates and the CCP_CHAOS_DEBUG strip are
+    ///    dropped, so every pill and header renders in its revealed state.
+    ///  - The whole Skia menu scene (fog, per-frame glint masks, blooms, the crossfading
+    ///    flipbook) and the NAudio menu music are gone: no SkiaSharp and no NAudio on this head,
+    ///    and a view layer may not add a package. <c>SetupMenuMotion</c>'s breathing/wobble/glow
+    ///    loop has no faithful Avalonia twin without re-authoring it, so it is a stub and the
+    ///    static frame renders — see the note on that method.
+    ///  - <c>Visibility</c> -> <c>IsVisible</c>; <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>;
+    ///    <c>MouseLeftButtonDown</c> -> <c>PointerPressed</c>; <c>StateChanged</c> ->
+    ///    <c>GetObservable(WindowStateProperty)</c>; <c>ToolTip =</c> -> <c>ToolTip.SetTip</c>;
+    ///    <c>FindResource</c> -> <c>this.FindResource</c>; <c>App.Logger</c> -> Serilog's static
+    ///    <c>Log</c>; <c>FontWeights.X</c> -> <c>FontWeight.X</c>; <c>Cursors.Hand</c> ->
+    ///    <c>new Cursor(StandardCursorType.Hand)</c>.
+    ///  - The constructor is parameterless, as in WPF, which also makes it the constructor
+    ///    <c>--render-all</c> discovers. It lands on the main menu, exactly as the WPF one does.
+    /// </summary>
+    public partial class ChaosHubWindow : Window
+    {
+        private static readonly Random _rng = new();
+        private int _waves = 5;
+
+        // ---- palette (the same literals the WPF code-behind builds brushes from) ----
+        private static readonly Color Gold = Color.FromRgb(0xFF, 0xD7, 0x00);
+        private static readonly Color BoonAccent = Color.FromRgb(0xE8, 0x43, 0x93);
+        private static readonly IBrush White = Brushes.White;
+        private static readonly IBrush BodyText = new SolidColorBrush(Color.FromRgb(0xAA, 0xB8, 0xB8));
+        private static readonly IBrush FlavorText = new SolidColorBrush(Color.FromArgb(0xCC, 0xB0, 0xB0, 0xC8));
+        private static readonly IBrush MutedText = new SolidColorBrush(Color.FromRgb(0x88, 0xA0, 0xC0));
+        private static readonly IBrush DimText = new SolidColorBrush(Color.FromRgb(0x77, 0x77, 0x90));
+        private static readonly IBrush RowBg = new SolidColorBrush(Color.FromRgb(0x22, 0x1F, 0x40));
+        private static readonly IBrush CardBg = new SolidColorBrush(Color.FromRgb(0x1C, 0x1A, 0x36));
+        private static readonly IBrush GoldBrush = new SolidColorBrush(Gold);
+
+        private const double TILE = 96;
+
+        // ---- named parts (WPF got these as generated fields; Avalonia looks them up) ----
+        private readonly Grid _dollhouseView, _menuView, _menuLeftCol, _panelImprove, _titleBar, _menuArtClip;
+        private readonly Border _menuArtPanel, _menuOptions, _menuHowTo, _dragBar, _herCornerCard, _howToImageBox;
+        private readonly StackPanel _menuTitleBar;
+        private readonly ToggleButton _tabLoadout, _tabEnhance, _tabRun, _tabImprove, _tabDiary, _tglTesting;
+        private readonly ToggleButton _segMedium, _segHard, _segExtreme;
+        private readonly Control _panelLoadout, _panelEnhance, _panelRun, _panelDiary;
+        private readonly StackPanel _testingBody, _pocketSlotsHost, _boonHostSkills, _boonHostAccessories;
+        private readonly StackPanel _habitsHost, _herCornerHost, _improvementsHost, _mantrasHost, _diaryHost;
+        private readonly StackPanel _howToBody, _howToDots;
+        private readonly Panel _grpDifficulty, _grpLength, _grpMotion, _grpPool;
+        private readonly UniformGrid _tilesAccessories, _tilesSkills, _tilesHabits;
+        private readonly TextBlock _txtHint, _txtRank, _txtSparks, _txtGold, _menuRank, _menuSparks, _menuGold;
+        private readonly TextBlock _txtAccCount, _txtSkillCount, _txtHabitCount, _txtWaves, _menuMuteIcon;
+        private readonly TextBlock _stSparks, _stRuns, _stTimeUnder, _stBestScore, _stBestCombo, _stDefused, _stTimeHeld;
+        private readonly TextBlock _howToStep, _howToTitle, _hdrDiary;
+        private readonly Button _howToBack, _howToNext, _btnMenuStory;
+        private readonly CheckBox _chkShake, _chkFlashes, _chkSkiaFx, _chkPinTop, _chkSharedHost, _chkAnnouncer;
+        private readonly CheckBox _chkNarrative, _chkBackdrop, _chkTunnel, _chkBoonDraft, _chkCurses, _chkDarters;
+        private readonly CheckBox _optFullscreen;
+        private readonly Slider _sldShake, _sldEffect, _sldBackdropOpacity;
+        private readonly ComboBox _cmbAccKey1, _cmbAccKey2;
+
+        private T Part<T>(string name) where T : Control => this.FindControl<T>(name)
+            ?? throw new InvalidOperationException($"ChaosHubWindow: no '{name}' in the XAML");
+
+        public ChaosHubWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _dollhouseView = Part<Grid>("DollhouseView");
+            _menuView = Part<Grid>("MenuView");
+            _menuLeftCol = Part<Grid>("MenuLeftCol");
+            _panelImprove = Part<Grid>("PanelImprove");
+            _titleBar = Part<Grid>("TitleBar");
+            _menuArtClip = Part<Grid>("MenuArtClip");
+            _menuArtPanel = Part<Border>("MenuArtPanel");
+            _menuOptions = Part<Border>("MenuOptions");
+            _menuHowTo = Part<Border>("MenuHowTo");
+            _dragBar = Part<Border>("DragBar");
+            _herCornerCard = Part<Border>("HerCornerCard");
+            _howToImageBox = Part<Border>("HowToImageBox");
+            _menuTitleBar = Part<StackPanel>("MenuTitleBar");
+            _tabLoadout = Part<ToggleButton>("TabLoadout");
+            _tabEnhance = Part<ToggleButton>("TabEnhance");
+            _tabRun = Part<ToggleButton>("TabRun");
+            _tabImprove = Part<ToggleButton>("TabImprove");
+            _tabDiary = Part<ToggleButton>("TabDiary");
+            _tglTesting = Part<ToggleButton>("TglTesting");
+            _segMedium = Part<ToggleButton>("SegMedium");
+            _segHard = Part<ToggleButton>("SegHard");
+            _segExtreme = Part<ToggleButton>("SegExtreme");
+            _panelLoadout = Part<ScrollViewer>("PanelLoadout");
+            _panelEnhance = Part<ScrollViewer>("PanelEnhance");
+            _panelRun = Part<ScrollViewer>("PanelRun");
+            _panelDiary = Part<ScrollViewer>("PanelDiary");
+            _testingBody = Part<StackPanel>("TestingBody");
+            _pocketSlotsHost = Part<StackPanel>("PocketSlotsHost");
+            _boonHostSkills = Part<StackPanel>("BoonHostSkills");
+            _boonHostAccessories = Part<StackPanel>("BoonHostAccessories");
+            _habitsHost = Part<StackPanel>("HabitsHost");
+            _herCornerHost = Part<StackPanel>("HerCornerHost");
+            _improvementsHost = Part<StackPanel>("ImprovementsHost");
+            _mantrasHost = Part<StackPanel>("MantrasHost");
+            _diaryHost = Part<StackPanel>("DiaryHost");
+            _howToBody = Part<StackPanel>("HowToBody");
+            _howToDots = Part<StackPanel>("HowToDots");
+            _grpDifficulty = Part<StackPanel>("GrpDifficulty");
+            _grpLength = Part<StackPanel>("GrpLength");
+            _grpMotion = Part<StackPanel>("GrpMotion");
+            _grpPool = Part<WrapPanel>("GrpPool");
+            _tilesAccessories = Part<UniformGrid>("TilesAccessories");
+            _tilesSkills = Part<UniformGrid>("TilesSkills");
+            _tilesHabits = Part<UniformGrid>("TilesHabits");
+            _txtHint = Part<TextBlock>("TxtHint");
+            _txtRank = Part<TextBlock>("TxtRank");
+            _txtSparks = Part<TextBlock>("TxtSparks");
+            _txtGold = Part<TextBlock>("TxtGold");
+            _menuRank = Part<TextBlock>("MenuRank");
+            _menuSparks = Part<TextBlock>("MenuSparks");
+            _menuGold = Part<TextBlock>("MenuGold");
+            _txtAccCount = Part<TextBlock>("TxtAccCount");
+            _txtSkillCount = Part<TextBlock>("TxtSkillCount");
+            _txtHabitCount = Part<TextBlock>("TxtHabitCount");
+            _txtWaves = Part<TextBlock>("TxtWaves");
+            _menuMuteIcon = Part<TextBlock>("MenuMuteIcon");
+            _stSparks = Part<TextBlock>("StSparks");
+            _stRuns = Part<TextBlock>("StRuns");
+            _stTimeUnder = Part<TextBlock>("StTimeUnder");
+            _stBestScore = Part<TextBlock>("StBestScore");
+            _stBestCombo = Part<TextBlock>("StBestCombo");
+            _stDefused = Part<TextBlock>("StDefused");
+            _stTimeHeld = Part<TextBlock>("StTimeHeld");
+            _howToStep = Part<TextBlock>("HowToStep");
+            _howToTitle = Part<TextBlock>("HowToTitle");
+            _hdrDiary = Part<TextBlock>("HdrDiary");
+            _howToBack = Part<Button>("HowToBack");
+            _howToNext = Part<Button>("HowToNext");
+            _btnMenuStory = Part<Button>("BtnMenuStory");
+            _chkShake = Part<CheckBox>("ChkShake");
+            _chkFlashes = Part<CheckBox>("ChkFlashes");
+            _chkSkiaFx = Part<CheckBox>("ChkSkiaFx");
+            _chkPinTop = Part<CheckBox>("ChkPinTop");
+            _chkSharedHost = Part<CheckBox>("ChkSharedHost");
+            _chkAnnouncer = Part<CheckBox>("ChkAnnouncer");
+            _chkNarrative = Part<CheckBox>("ChkNarrative");
+            _chkBackdrop = Part<CheckBox>("ChkBackdrop");
+            _chkTunnel = Part<CheckBox>("ChkTunnel");
+            _chkBoonDraft = Part<CheckBox>("ChkBoonDraft");
+            _chkCurses = Part<CheckBox>("ChkCurses");
+            _chkDarters = Part<CheckBox>("ChkDarters");
+            _optFullscreen = Part<CheckBox>("OptFullscreen");
+            _sldShake = Part<Slider>("SldShake");
+            _sldEffect = Part<Slider>("SldEffect");
+            _sldBackdropOpacity = Part<Slider>("SldBackdropOpacity");
+            _cmbAccKey1 = Part<ComboBox>("CmbAccKey1");
+            _cmbAccKey2 = Part<ComboBox>("CmbAccKey2");
+
+            // The three drag strips. WPF hooked MouseLeftButtonDown -> DragMove().
+            foreach (var strip in new Control[] { _titleBar, _menuTitleBar, _dragBar })
+                strip.PointerPressed += DragWindow;
+            _menuArtClip.PointerPressed += MenuArt_Click;
+            _menuHowTo.PointerPressed += HowTo_Backdrop_Click;
+            _hdrDiary.PointerPressed += Diary_PopOut;
+
+            // WPF: StateChanged += OnHubStateChanged. Avalonia has no such event.
+            this.GetObservable(WindowStateProperty).Subscribe(new AnonymousObserver<WindowState>(OnHubStateChanged));
+
+            LoadFromSettings();
+            BuildHabits();
+            BuildLifetimeBoons();
+            BuildLoadoutTiles();
+            BuildBench();
+            BuildHerCorner();
+            BuildMantras();
+            BuildDiary();
+            RefreshTopBar();
+            RefreshStats();
+            ApplyUnlocks();
+            ShowTab("loadout");
+            _btnMenuStory.IsEnabled = StoryModeEnabled;   // greyed until story ships
+            ShowMenuView();      // the main menu is the landing view; the dollhouse waits behind it
+            SetupMenuMotion();   // ponytail stub — see the method
+        }
+
+        /// <summary>Stand-in for <c>Services.Chaos.ChaosModeService.StoryModeEnabled</c>, which is
+        /// hard-false in the head until story content ships.
+        /// ponytail: needs ChaosModeService, wired when it moves to Core.</summary>
+        private const bool StoryModeEnabled = false;
+
+        /// <summary>Avalonia's <c>IObservable.Subscribe</c> wants an observer; this is the
+        /// smallest one that calls back. (Avalonia's own ReactiveUI helpers are not referenced.)</summary>
+        private sealed class AnonymousObserver<T> : IObserver<T>
+        {
+            private readonly Action<T> _onNext;
+            public AnonymousObserver(Action<T> onNext) => _onNext = onNext;
+            public void OnCompleted() { }
+            public void OnError(Exception error) { }
+            public void OnNext(T value) => _onNext(value);
+        }
+
+        // ============================ tabs / gating ============================
+
+        private void ApplyUnlocks()
+        {
+            // All four tabs render from the first visit (the drops cost is the real gate, and
+            // run setup must be reachable before run #1).
+            _tabLoadout.IsEnabled = true;
+            _tabEnhance.IsEnabled = true;
+            _tabRun.IsEnabled = true;
+            _tabImprove.IsEnabled = true;
+            // The Diary tab only appears once there's something in it (met a bubble down there).
+            _tabDiary.IsVisible = DiaryUnlocked;
+        }
+
+        private void Tab_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is ToggleButton { IsEnabled: true } tb) ShowTab(tb.Tag?.ToString() ?? "loadout");
+            else if (sender is ToggleButton tb2) tb2.IsChecked = false;
+        }
+
+        private void ShowTab(string tag)
+        {
+            // The old Habits tab folded into the Toybox; external callers may still ask for it.
+            if (tag == "habits") tag = "enhance";
+            if (tag == "improve" && !_tabImprove.IsEnabled) tag = "loadout";
+            // The diary lives behind its own reveal — nothing met yet, nothing to read.
+            if (tag == "diary" && !DiaryUnlocked) tag = "loadout";
+
+            _panelLoadout.IsVisible = tag == "loadout";
+            _panelEnhance.IsVisible = tag == "enhance";
+            _panelRun.IsVisible     = tag == "run";
+            _panelImprove.IsVisible = tag == "improve";
+            _panelDiary.IsVisible   = tag == "diary";
+
+            _tabLoadout.IsChecked = tag == "loadout";
+            _tabEnhance.IsChecked = tag == "enhance";
+            _tabRun.IsChecked     = tag == "run";
+            _tabImprove.IsChecked = tag == "improve";
+            _tabDiary.IsChecked   = tag == "diary";
+
+            _txtHint.Text = tag switch
+            {
+                "loadout" => "click a tile to slip it into a pocket. + takes you where it's sold.",
+                "enhance" => "spend your emotes. deepen what you like.",
+                "run"     => "dress up the fall, then FALL IN.",
+                "improve" => "the bench, the mantras, how far you've fallen.",
+                "diary"   => "everything you've met down there. click an entry to pop it out.",
+                _ => "",
+            };
+        }
+
+        /// <summary>WPF: <c>RevealService.IsUnlocked(RevealIds.Diary)</c>. The sample save has met
+        /// things down there, so the tab is offered.
+        /// ponytail: needs RevealService, wired when it moves to Core.</summary>
+        private static bool DiaryUnlocked => true;
+
+        /// <summary>Settings tab: fold the dev/test knobs (bubble pool, mantra toggles, loops)
+        /// in and out. Collapsed every open — the casual read stays short.</summary>
+        private void TestingToggle_Click(object? sender, RoutedEventArgs e)
+        {
+            bool open = _tglTesting.IsChecked == true;
+            _testingBody.IsVisible = open;
+            _tglTesting.Content = open ? "🧪 testing options ▾" : "🧪 testing options ▸";
+        }
+
+        /// <summary>A + tile wants to take the player shopping.</summary>
+        private void JumpToTab(string tag) => ShowTab(tag);
+
+        /// <summary>External navigation (the loadout sidebar's empty "+" tiles): switch tab and
+        /// bring the Dollhouse forward.</summary>
+        public void NavigateTo(string tag)
+        {
+            ShowTab(tag);
+            try { Activate(); } catch { /* not shown yet */ }
+        }
+
+        // ============================ top bar / stats ============================
+
+        private int _shownSparks = -1, _shownGold = -1;
+        private readonly Dictionary<TextBlock, DispatcherTimer> _balanceAnims = new();
+
+        private void RefreshTopBar()
+        {
+            AnimateBalance(_txtSparks, _shownSparks, Sample.Sparks);
+            AnimateBalance(_txtGold, _shownGold, Sample.Gold);
+            _shownSparks = Sample.Sparks;
+            _shownGold = Sample.Gold;
+            _txtRank.Text = Sample.Rank;
+            // mirror onto the main-menu chips (plain text; the animated balance lives on the top bar)
+            _menuRank.Text = Sample.Rank;
+            _menuSparks.Text = Sample.Sparks.ToString("N0");
+            _menuGold.Text = Sample.Gold.ToString("N0");
+            RefreshTabBadges();   // every balance change re-counts what the shelves can sell
+        }
+
+        /// <summary>Signposting on the shop tabs: a small count of what's buyable RIGHT NOW
+        /// (drops purchases on the Toybox, gold purchases on the Looking Glass) — the answer
+        /// to "is there anything for me in there?" without scanning four shelves.</summary>
+        private void RefreshTabBadges()
+        {
+            SetTabBadge(_tabEnhance, "the Toybox", CountAffordableToybox());
+            SetTabBadge(_tabImprove, "the Looking Glass", _tabImprove.IsEnabled ? CountAffordableBench() : 0);
+        }
+
+        private static void SetTabBadge(ToggleButton tab, string label, int count)
+        {
+            if (count <= 0)
+            {
+                tab.Content = label;
+                ToolTip.SetTip(tab, null);
+                return;
+            }
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            row.Children.Add(new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center });
+            row.Children.Add(new Border
+            {
+                Background = new SolidColorBrush(BoonAccent),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(6, 1, 6, 1),
+                Margin = new Thickness(7, 0, 0, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = new TextBlock { Text = count.ToString(), Foreground = White, FontSize = 10.5, FontWeight = FontWeight.Bold },
+            });
+            tab.Content = row;
+            ToolTip.SetTip(tab, count == 1 ? "1 thing you can afford right now" : $"{count} things you can afford right now");
+        }
+
+        /// <summary>Drops purchases buyable this instant: untrained habits + boon unlocks +
+        /// boon level-ups — the same gates the shelf buttons enforce.</summary>
+        private static int CountAffordableToybox()
+        {
+            int n = Sample.Habits.Count(u => !u.Owned && Sample.Sparks >= u.Cost);
+            foreach (var b in Sample.Boons)
+            {
+                if (b.RankLocked) continue;
+                if (b.Level <= 0) { if (Sample.Sparks >= b.UnlockCost) n++; }
+                else if (b.Level < b.MaxLevel && Sample.Sparks >= b.UpgradeCost) n++;
+            }
+            return n;
+        }
+
+        /// <summary>Gold purchases buyable this instant at her bench (rank + reveal gated).</summary>
+        private static int CountAffordableBench() =>
+            Sample.Bench.Count(i => !i.Owned && !i.RankShort && !i.Hazy && Sample.Gold >= i.Cost);
+
+        /// <summary>Roll a top-bar balance from its last shown value to the new one (~500ms) so
+        /// spending visibly *costs* — first paint just snaps. WPF layered a soft tick cue under
+        /// it; ChaosSfx is a head service, so the sound is dropped.</summary>
+        private void AnimateBalance(TextBlock tb, int from, int to)
+        {
+            if (_balanceAnims.TryGetValue(tb, out var old))
+            {
+                old.Stop();
+                _balanceAnims.Remove(tb);
+            }
+            if (from < 0 || from == to || !IsLoaded)
+            {
+                tb.Text = to.ToString("N0");
+                return;
+            }
+
+            const int DURATION_MS = 500, FRAME_MS = 33;
+            int elapsed = 0;
+
+            var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(FRAME_MS) };
+            _balanceAnims[tb] = timer;
+            timer.Tick += (_, _) =>
+            {
+                elapsed += FRAME_MS;
+                if (elapsed >= DURATION_MS)
+                {
+                    timer.Stop();
+                    _balanceAnims.Remove(tb);
+                    tb.Text = to.ToString("N0");
+                    return;
+                }
+                double eased = 1 - Math.Pow(1 - elapsed / (double)DURATION_MS, 3);
+                tb.Text = ((int)Math.Round(from + (to - from) * eased)).ToString("N0");
+            };
+            timer.Start();
+        }
+
+        private void RefreshStats()
+        {
+            _stSparks.Text = Sample.Sparks.ToString("N0");
+            _stRuns.Text = Sample.RunsCompleted.ToString("N0");
+            _stTimeUnder.Text = FormatPlaytime(Sample.TotalRunSeconds);
+            _stBestScore.Text = Sample.BestScore.ToString("N0");
+            _stBestCombo.Text = Sample.BestCombo.ToString("N0");
+            _stDefused.Text = Sample.TotalDefused.ToString("N0");
+            _stTimeHeld.Text = FormatPlaytime(Sample.TotalChannelSeconds);
+        }
+
+        private static string FormatPlaytime(double seconds)
+        {
+            var t = TimeSpan.FromSeconds(Math.Max(0, seconds));
+            return t.TotalHours >= 1 ? $"{(int)t.TotalHours}h {t.Minutes}m" : $"{t.Minutes}m {t.Seconds}s";
+        }
+
+        // ============================ habits (the Toybox) ============================
+
+        private static Color BranchColor(string branch) => branch switch
+        {
+            "Control" => Color.FromRgb(0x49, 0xB6, 0xE8),
+            "Greed"   => Color.FromRgb(0xE8, 0xB4, 0x43),
+            "Depth"   => Color.FromRgb(0x8B, 0x5C, 0xF6),
+            _         => Color.FromRgb(0xE8, 0x43, 0x93)
+        };
+
+        private static string BranchLabel(string branch) => branch switch
+        {
+            "Control" => "RESTRAINT",
+            "Greed"   => "CRAVING",
+            _         => "DEPTH",
+        };
+
+        /// <summary>One grouped list of the trainable passives — untrained rows sell, trained
+        /// rows toggle on/off.</summary>
+        private void BuildHabits()
+        {
+            _habitsHost.Children.Clear();
+            foreach (var u in Sample.Habits) _habitsHost.Children.Add(BuildUpgradeRow(u));
+            foreach (var b in Sample.Charms) _habitsHost.Children.Add(BuildLifetimeBoonRow(b, habitVoice: true));
+        }
+
+        /// <summary>One habit card, in the same dress as the boon rows (72px art, big card,
+        /// gold edge while switched on) — the Habits list is one cohesive shelf.</summary>
+        private Border BuildUpgradeRow(SampleHabit u)
+        {
+            bool owned = u.Owned;
+            bool afford = Sample.Sparks >= u.Cost;
+            bool on = owned && u.On;
+            var accent = BranchColor(u.Branch);
+
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+            // ---- icon: a branch-tinted square with the glyph (ChaosArt sprites are head-side) ----
+            var icon = GlyphIcon(u.Glyph, 72, 14, accent, owned ? 1.0 : 0.5);
+            Grid.SetColumn(icon, 0);
+            grid.Children.Add(icon);
+
+            // ---- middle: name + desc + flavor + branch tag ----
+            var mid = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            mid.Children.Add(new TextBlock { Text = u.Name, Foreground = White, FontSize = 14, FontWeight = FontWeight.SemiBold });
+            mid.Children.Add(new TextBlock { Text = u.Desc, Foreground = BodyText, FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 3, 0, 0) });
+            if (!string.IsNullOrEmpty(u.Flavor))
+                mid.Children.Add(new TextBlock
+                {
+                    Text = u.Flavor, FontStyle = FontStyle.Italic, FontSize = 11,
+                    Foreground = FlavorText, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0)
+                });
+            mid.Children.Add(new TextBlock
+            {
+                Text = BranchLabel(u.Branch).ToLowerInvariant(),
+                Foreground = new SolidColorBrush(Color.FromArgb(0xAA, accent.R, accent.G, accent.B)),
+                FontSize = 10.5, FontWeight = FontWeight.Bold,
+                Margin = new Thickness(0, 6, 0, 0)
+            });
+            Grid.SetColumn(mid, 1);
+            grid.Children.Add(mid);
+
+            // ---- right: ON badge + on/off toggle, or the Train buy button ----
+            var right = new StackPanel { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Right, Width = 132 };
+            if (owned)
+            {
+                if (on) right.Children.Add(StateBadge("ON ✓"));
+                var toggle = StepperButton(on ? "switch off" : "switch on", u.Id);
+                ToolTip.SetTip(toggle, on ? "switched on — shapes your next descent." : "switched off — sits out the descent.");
+                toggle.Click += HabitToggle_Click;
+                right.Children.Add(toggle);
+            }
+            else
+            {
+                right.Children.Add(BuyButton($"Train  ✦{u.Cost}", u.Id, afford, Buy_Click));
+            }
+            Grid.SetColumn(right, 2);
+            grid.Children.Add(right);
+
+            return ShelfCard(grid, on, owned, accent);
+        }
+
+        /// <summary>The card every shelf row sits in: gold edge while switched on, pink otherwise,
+        /// dimmed while still locked.</summary>
+        private static Border ShelfCard(Control body, bool on, bool owned, Color accent) => new()
+        {
+            Child = body,
+            Background = CardBg,
+            BorderBrush = on
+                ? new SolidColorBrush(Color.FromArgb(180, Gold.R, Gold.G, Gold.B))
+                : new SolidColorBrush(Color.FromArgb(owned ? (byte)90 : (byte)40, accent.R, accent.G, accent.B)),
+            BorderThickness = new Thickness(on ? 3 : 2),
+            CornerRadius = new CornerRadius(12),
+            Padding = new Thickness(16),
+            Margin = new Thickness(0, 0, 0, 12)
+        };
+
+        private static TextBlock StateBadge(string text) => new()
+        {
+            Text = text,
+            Foreground = GoldBrush,
+            FontSize = 11, FontWeight = FontWeight.Bold,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Margin = new Thickness(0, 0, 0, 4)
+        };
+
+        /// <summary>WPF resolved real art through ChaosArt and fell back to this tinted glyph
+        /// square. Only the fallback exists on this head.
+        /// ponytail: needs ChaosArt, wired when it moves to Core.</summary>
+        private static Border GlyphIcon(string glyph, double size, double radius, Color accent, double opacity) => new()
+        {
+            Width = size, Height = size, CornerRadius = new CornerRadius(radius),
+            Background = new SolidColorBrush(Color.FromArgb(70, accent.R, accent.G, accent.B)),
+            BorderBrush = new SolidColorBrush(accent), BorderThickness = new Thickness(1),
+            VerticalAlignment = VerticalAlignment.Top,
+            Margin = new Thickness(0, 0, 12, 0),
+            Opacity = opacity,
+            Child = new TextBlock
+            {
+                Text = glyph, FontSize = size >= 60 ? 34 : 19, Foreground = White,
+                HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center
+            }
+        };
+
+        // ponytail: needs ChaosMeta.TryPurchase + the unlock-card queue, wired when they move to
+        // Core. Until then a buy is a no-op that says so rather than silently spending nothing.
+        private void Buy_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ChaosHub: train {Id} requested; no ChaosMeta on this head yet", (sender as Button)?.Tag);
+
+        private void HabitToggle_Click(object? sender, RoutedEventArgs e)
+        {
+            var id = (sender as Button)?.Tag?.ToString();
+            if (string.IsNullOrEmpty(id)) return;
+            Sample.ToggleHabit(id!);
+            BuildHabits();
+            BuildLoadoutTiles();
+        }
+
+        // ===================== lifetime boons (toys / accessories / charms) =====================
+
+        private void BuildLifetimeBoons()
+        {
+            BuildBoonShelf(_boonHostSkills, "Skill");
+            BuildBoonShelf(_boonHostAccessories, "Accessory");
+            // Utility charms train on the Habits shelf (BuildHabits) — they're habits in spirit.
+        }
+
+        private void BuildBoonShelf(Panel host, string category)
+        {
+            host.Children.Clear();
+            var boons = Sample.Boons.Where(b => b.Category == category).ToList();
+            if (boons.Count == 0)
+            {
+                host.Children.Add(new Border
+                {
+                    Theme = this.FindResource("CardStyle") as ControlTheme,
+                    Child = new TextBlock
+                    {
+                        Text = "something is being prepared for you.",
+                        Foreground = MutedText, FontSize = 12, TextWrapping = TextWrapping.Wrap
+                    }
+                });
+                return;
+            }
+            foreach (var b in boons) host.Children.Add(BuildLifetimeBoonRow(b, habitVoice: false));
+        }
+
+        private Border BuildLifetimeBoonRow(SampleBoon b, bool habitVoice)
+        {
+            int level = b.Level;
+            bool unlocked = level >= 1;
+            bool active = b.Active;
+            bool maxed = unlocked && level >= b.MaxLevel;
+            // Rank-locked = below your depth tier: a MYSTERY. Hide the art, name and what it does —
+            // only the rank gate shows, so the deeper toys stay a reveal instead of a spoiled preview.
+            bool rankLocked = b.RankLocked;
+
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+            var icon = GlyphIcon(rankLocked ? "?" : b.Glyph, 72, 14, BoonAccent,
+                                 unlocked ? 1.0 : (rankLocked ? 0.6 : 0.5));
+            ToolTip.SetTip(icon, rankLocked ? RankLockedTip : b.Desc);
+            Grid.SetColumn(icon, 0);
+            grid.Children.Add(icon);
+
+            // ---- middle: name + desc + level pips + value ----
+            var mid = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            mid.Children.Add(new TextBlock { Text = rankLocked ? "? ? ?" : b.Name, Foreground = White, FontSize = 14, FontWeight = FontWeight.SemiBold });
+            if (rankLocked)
+            {
+                // No desc, no flavor — only the gate. The reveal is the reward for sinking deeper.
+                mid.Children.Add(new TextBlock
+                {
+                    Text = RankLockedTip + " " + RankSpecifics(b.RankFloor),
+                    Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x80, 0xA8)), FontStyle = FontStyle.Italic,
+                    FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 3, 0, 0)
+                });
+            }
+            else
+            {
+                mid.Children.Add(new TextBlock { Text = b.Desc, Foreground = BodyText, FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 3, 0, 0) });
+                if (!string.IsNullOrEmpty(b.Flavor))
+                    mid.Children.Add(new TextBlock
+                    {
+                        Text = b.Flavor, FontStyle = FontStyle.Italic, FontSize = 11,
+                        Foreground = FlavorText, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0)
+                    });
+            }
+
+            // Active-use toys carry their trigger: the keybind (when equipped) or a generic hint.
+            if (b.IsActiveUse && !rankLocked)
+            {
+                string key = _cmbAccKey1.SelectedItem as string ?? "Q";
+                string useHint = b.UseCooldownSec > 0 ? $"{b.UseCooldownSec:0}s cooldown" : "limited uses";
+                mid.Children.Add(new TextBlock
+                {
+                    Text = active ? $"ACTIVE · fires on {key} mid-descent · {useHint}"
+                                  : $"ACTIVE · fires on your toy key mid-descent · {useHint}",
+                    Foreground = GoldBrush, FontSize = 10.5, FontWeight = FontWeight.Bold,
+                    Margin = new Thickness(0, 3, 0, 0)
+                });
+            }
+
+            // Capstone teaser: dim until the final rank is bought, gold once it's live.
+            if (!string.IsNullOrEmpty(b.CapstoneDesc) && !rankLocked)
+                mid.Children.Add(new TextBlock
+                {
+                    Text = "max: " + b.CapstoneDesc,
+                    Foreground = maxed ? GoldBrush : new SolidColorBrush(Color.FromArgb(0x90, 0x8A, 0x86, 0xB8)),
+                    FontSize = 11,
+                    FontStyle = maxed ? FontStyle.Normal : FontStyle.Italic,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 3, 0, 0)
+                });
+
+            var pips = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 6, 0, 0) };
+            for (int i = 1; i <= b.MaxLevel; i++)
+                pips.Children.Add(new TextBlock
+                {
+                    Text = i <= level ? "●" : "○",
+                    Foreground = new SolidColorBrush(i <= level ? BoonAccent : Color.FromArgb(0x66, 0xB8, 0xB8, 0xD0)),
+                    FontSize = 13, Margin = new Thickness(0, 0, 3, 0)
+                });
+            pips.Children.Add(new TextBlock
+            {
+                Text = "   " + (unlocked ? b.ValueLabel : "locked"),
+                Foreground = new SolidColorBrush(Color.FromRgb(0x8B, 0x5C, 0xF6)),
+                FontSize = 12, FontWeight = FontWeight.SemiBold, VerticalAlignment = VerticalAlignment.Center
+            });
+            mid.Children.Add(pips);
+            Grid.SetColumn(mid, 1);
+            grid.Children.Add(mid);
+
+            // ---- right: on/off toggle + unlock/upgrade ----
+            var right = new StackPanel { VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Right, Width = 132 };
+
+            if (unlocked)
+            {
+                // Equip semantics instead of an ambiguous ON/OFF: the badge shows the STATE,
+                // the button is always the ACTION. Pockets cap Toys/Accessories at 2 each.
+                if (active) right.Children.Add(StateBadge(habitVoice ? "ON ✓" : "EQUIPPED ✓"));
+                bool pocketFree = active || Sample.HasFreePocket(b.Category);
+                var equip = StepperButton(
+                    active ? (habitVoice ? "switch off" : "Unequip")
+                           : pocketFree ? (habitVoice ? "switch on" : "Equip") : "pockets full",
+                    b.Id);
+                equip.IsEnabled = pocketFree;
+                equip.Margin = new Thickness(0, 0, 0, 8);
+                equip.Click += BoonEquip_Click;
+                right.Children.Add(equip);
+            }
+
+            if (!unlocked)
+            {
+                if (rankLocked)
+                {
+                    // Mystery: hide the cost too — show only the depth gate.
+                    var held = BuyButton($"🔒 {b.RankFloor}", b.Id, false, BoonUnlock_Click);
+                    ToolTip.SetTip(held, RankLockedTip + "\n" + RankSpecifics(b.RankFloor));
+                    right.Children.Add(held);
+                }
+                else
+                {
+                    right.Children.Add(BuyButton($"Unlock  ✦{b.UnlockCost}", b.Id, Sample.Sparks >= b.UnlockCost, BoonUnlock_Click));
+                }
+            }
+            else if (maxed)
+                right.Children.Add(new TextBlock { Text = "MAX  ✓", Foreground = new SolidColorBrush(Color.FromRgb(0x5A, 0xE0, 0x96)), FontSize = 13, FontWeight = FontWeight.Bold, HorizontalAlignment = HorizontalAlignment.Right });
+            else
+                right.Children.Add(BuyButton($"deepen  ✦{b.UpgradeCost}", b.Id, Sample.Sparks >= b.UpgradeCost, BoonUpgrade_Click));
+
+            Grid.SetColumn(right, 2);
+            grid.Children.Add(right);
+
+            return ShelfCard(grid, active, unlocked, BoonAccent);
+        }
+
+        private Button BuyButton(string text, string id, bool afford, EventHandler<RoutedEventArgs> onClick)
+        {
+            var btn = new Button
+            {
+                Content = new TextBlock { Text = text },   // TextBlock, not a raw string: Avalonia
+                Tag = id,                                  // reads "_" in Content as an access key
+                Padding = new Thickness(20, 10, 20, 10),
+                HorizontalAlignment = HorizontalAlignment.Right,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
+                Background = afford ? new SolidColorBrush(BoonAccent) : new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)),
+                Foreground = afford ? White : new SolidColorBrush(Color.FromRgb(0x88, 0xA0, 0xA0)),
+                BorderThickness = new Thickness(0),
+                FontSize = 13,
+                FontWeight = FontWeight.Bold,
+                Cursor = new Cursor(afford ? StandardCursorType.Hand : StandardCursorType.Arrow),
+                IsEnabled = afford,
+                CornerRadius = new CornerRadius(11),
+            };
+            btn.Click += onClick;
+            return btn;
+        }
+
+        /// <summary>WPF built these from the keyed "Stepper" style and then rounded them with
+        /// <c>Pillify</c>. Here the theme is applied and the radius set directly.</summary>
+        private Button StepperButton(string text, string id) => new()
+        {
+            Theme = this.FindResource("Stepper") as ControlTheme,
+            Content = new TextBlock { Text = text },
+            Tag = id,
+            Width = double.NaN, Height = double.NaN, MinWidth = 112,
+            FontSize = 12.5,
+            Padding = new Thickness(14, 8, 14, 8),
+            HorizontalAlignment = HorizontalAlignment.Right,
+            HorizontalContentAlignment = HorizontalAlignment.Center,
+            CornerRadius = new CornerRadius(11),
+        };
+
+        private void AccKey_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            // ponytail: needs App.Settings to persist the bind, wired when it moves to Core.
+            // The shelf rows print the chosen key, so they are rebuilt either way.
+            if (IsLoaded) BuildLifetimeBoons();
+        }
+
+        private void BoonEquip_Click(object? sender, RoutedEventArgs e)
+        {
+            var id = (sender as Button)?.Tag?.ToString();
+            if (string.IsNullOrEmpty(id)) return;
+            Sample.ToggleBoon(id!);
+            AfterBoonChange();
+        }
+
+        // ponytail: needs ChaosMeta.TryUnlockBoon / TryUpgradeBoon, wired when they move to Core.
+        private void BoonUnlock_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ChaosHub: unlock {Id} requested; no ChaosMeta on this head yet", (sender as Button)?.Tag);
+
+        private void BoonUpgrade_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ChaosHub: deepen {Id} requested; no ChaosMeta on this head yet", (sender as Button)?.Tag);
+
+        private void AfterBoonChange()
+        {
+            BuildLifetimeBoons();
+            BuildHabits();
+            BuildLoadoutTiles();
+            RefreshTopBar();
+        }
+
+        /// <summary>The loadout sidebar pushes unequips back in through here.</summary>
+        public void RefreshAfterExternalLoadoutChange() => AfterBoonChange();
+
+        // ============================ the BAG (glance page) ============================
+
+        private enum TileState { Equipped, Owned, Locked, Empty }
+
+        /// <summary>The whole glance page: pocket slots + accessory/toy/habit tile grids.</summary>
+        private void BuildLoadoutTiles()
+        {
+            // ---- pocket slots (big tiles, one group per category; unsewn categories don't render) ----
+            _pocketSlotsHost.Children.Clear();
+            var toyGroup = PocketGroup("TOY", "Skill");
+            if (toyGroup != null) _pocketSlotsHost.Children.Add(toyGroup);
+            var accGroup = PocketGroup("ACCESSORY", "Accessory");
+            if (accGroup != null) _pocketSlotsHost.Children.Add(accGroup);
+            if (_pocketSlotsHost.Children.Count == 0)
+                _pocketSlotsHost.Children.Add(new TextBlock
+                {
+                    Text = "no pockets sewn yet.",
+                    Foreground = DimText,
+                    FontSize = 12,
+                    Margin = new Thickness(0, 2, 0, 2),
+                });
+
+            // ---- collections ----
+            FillCategoryTiles(_tilesAccessories, "Accessory", padTo: 8);
+            FillCategoryTiles(_tilesSkills, "Skill", padTo: 8);
+            _txtAccCount.Text = $"{Sample.EquippedCountIn("Accessory")}/{Sample.SlotsFor("Accessory")} equipped";
+            _txtSkillCount.Text = $"{Sample.EquippedCountIn("Skill")}/{Sample.SlotsFor("Skill")} equipped";
+
+            // ---- habits 4x4 (trained = on/off toggle; click an untrained one to go train it) ----
+            _tilesHabits.Children.Clear();
+            int trained = 0, switchedOn = 0;
+            foreach (var u in Sample.Habits)
+            {
+                string id = u.Id;
+                bool owned = u.Owned, on = owned && u.On;
+                if (owned) trained++;
+                if (on) switchedOn++;
+                Action onClick = owned
+                    ? () => { Sample.ToggleHabit(id); BuildHabits(); BuildLoadoutTiles(); }
+                    : () => JumpToTab("enhance");
+                _tilesHabits.Children.Add(LoadoutTile(u.Glyph, u.Name, u.Desc,
+                    on ? "click to switch off" : owned ? "click to switch on" : $"train for ✦{u.Cost} in the Toybox",
+                    BranchColor(u.Branch),
+                    on ? TileState.Equipped : owned ? TileState.Owned : TileState.Locked,
+                    onClick,
+                    cornerBadge: on ? "✓" : null,
+                    flavor: u.Flavor));
+            }
+            // Charms live with the habits: leveled, always-on once worn, toggled like a habit.
+            foreach (var b in Sample.Charms)
+            {
+                string bid = b.Id;
+                bool unlocked = b.Level >= 1, active = b.Active, charmRankLocked = b.RankLocked;
+                if (unlocked) trained++;
+                if (active) switchedOn++;
+                Action onClick = unlocked
+                    ? () => { Sample.ToggleBoon(bid); BuildHabits(); BuildLoadoutTiles(); }
+                    : () => JumpToTab("enhance");
+                _tilesHabits.Children.Add(LoadoutTile(charmRankLocked ? "?" : b.Glyph,
+                    charmRankLocked ? "? ? ?" : unlocked ? $"{b.Name} · L{b.Level}" : b.Name,
+                    charmRankLocked ? RankLockedTip : b.Desc,
+                    active ? "click to switch off" : unlocked ? "click to switch on"
+                        : charmRankLocked ? RankSpecifics(b.RankFloor) : $"unlock for ✦{b.UnlockCost} in the Toybox",
+                    BoonAccent,
+                    active ? TileState.Equipped : unlocked ? TileState.Owned : TileState.Locked,
+                    onClick,
+                    cornerBadge: active ? "✓" : null,
+                    flavor: charmRankLocked ? null : b.Flavor));
+            }
+            int shown = Sample.Habits.Count + Sample.Charms.Count;
+            int target = Math.Max(16, ((shown + 3) / 4) * 4);
+            for (int i = shown; i < target; i++)
+                _tilesHabits.Children.Add(LoadoutTile("+", "a habit not yet formed",
+                    "more training arrives in a later fitting.", null,
+                    Color.FromRgb(0xB8, 0xB8, 0xD0), TileState.Empty, null));
+            _txtHabitCount.Text = $"{switchedOn} on · {trained}/{shown} trained";
+        }
+
+        /// <summary>One labelled pocket column: equipped boon as a big gold tile, plus + tiles for
+        /// free slots. Null when the category has no pockets sewn (and nothing stale equipped).</summary>
+        private Control? PocketGroup(string label, string category)
+        {
+            if (Sample.SlotsFor(category) <= 0 && Sample.EquippedCountIn(category) == 0) return null;
+            var col = new StackPanel { Margin = new Thickness(0, 0, 30, 0) };
+            col.Children.Add(new TextBlock
+            {
+                Text = label, Foreground = new SolidColorBrush(Color.FromRgb(0x8A, 0x86, 0xB8)),
+                FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeight.Bold, FontSize = 11,
+                Margin = new Thickness(0, 0, 0, 6)
+            });
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            var equipped = Sample.Boons.Where(b => b.Category == category && b.Active).ToList();
+            foreach (var b in equipped)
+            {
+                string id = b.Id;
+                var cell = LoadoutTile(b.Glyph, $"{b.Name} · L{b.Level}", b.Desc,
+                    "click to unequip", BoonAccent, TileState.Equipped,
+                    () => { Sample.ToggleBoon(id); AfterBoonChange(); },
+                    size: 114, flavor: b.Flavor);
+                cell.Margin = new Thickness(0, 0, 24, 0);
+                row.Children.Add(cell);
+            }
+            for (int i = equipped.Count; i < Sample.SlotsFor(category); i++)
+            {
+                var cell = LoadoutTile("+", $"empty {label.ToLowerInvariant()} pocket",
+                    "pick one from the shelf below, or go shopping in the Toybox.", null,
+                    BoonAccent, TileState.Empty, () => JumpToTab("enhance"), size: 114, caption: "empty");
+                cell.Margin = new Thickness(0, 0, 24, 0);
+                row.Children.Add(cell);
+            }
+            col.Children.Add(row);
+            return col;
+        }
+
+        /// <summary>A category's collection as tiles: equipped gold, owned pink (click = equip,
+        /// swapping out the current occupant), locked dim (click = go shopping), padded with
+        /// placeholder + tiles to full rows.</summary>
+        private void FillCategoryTiles(Panel host, string category, int padTo)
+        {
+            host.Children.Clear();
+            var boons = Sample.Boons.Where(b => b.Category == category).ToList();
+            foreach (var b in boons)
+            {
+                string id = b.Id;
+                bool unlocked = b.Level >= 1, active = b.Active, rankLocked = b.RankLocked;
+                var state = active ? TileState.Equipped : unlocked ? TileState.Owned : TileState.Locked;
+                Action onClick = active ? () => { Sample.ToggleBoon(id); AfterBoonChange(); }
+                    : unlocked ? () => { Sample.EquipSwapping(id, category); AfterBoonChange(); }
+                    : () => JumpToTab("enhance");
+                // Rank-locked → mystery: "???" everywhere, the depth gate instead of a price.
+                string extra = active ? "click to unequip"
+                    : unlocked ? "click to equip"
+                    : rankLocked ? RankSpecifics(b.RankFloor)
+                    : $"unlock for ✦{b.UnlockCost} in the Toybox";
+                host.Children.Add(LoadoutTile(rankLocked ? "?" : b.Glyph,
+                    rankLocked ? "? ? ?" : unlocked ? $"{b.Name} · L{b.Level}" : b.Name,
+                    rankLocked ? RankLockedTip : b.Desc, extra, BoonAccent, state, onClick,
+                    cornerBadge: active ? "★" : null,
+                    flavor: rankLocked ? null : b.Flavor));
+            }
+            int target = Math.Max(padTo, ((boons.Count + 3) / 4) * 4);
+            for (int i = boons.Count; i < target; i++)
+                host.Children.Add(LoadoutTile("+",
+                    category == "Skill" ? "another toy is being stitched" : "another accessory is being stitched",
+                    "it'll hang here when it's ready.", null,
+                    Color.FromRgb(0xB8, 0xB8, 0xD0), TileState.Empty, null));
+        }
+
+        private Control LoadoutTile(string glyph, string title, string? desc, string? extra, Color accent,
+                                    TileState state, Action? onClick, string? cornerBadge = null,
+                                    double size = TILE, string? caption = null, string? flavor = null)
+        {
+            // Rounded clip so the square art can't poke past the ring corners (Border doesn't
+            // clip children to its CornerRadius; the tile is fixed-size so a geometry works).
+            var content = new Grid
+            {
+                Clip = new RectangleGeometry(new Rect(0, 0, size, size)) { RadiusX = 12, RadiusY = 12 }
+            };
+            content.Children.Add(new TextBlock
+            {
+                Text = glyph,
+                FontSize = size >= 114 ? 46 : 36,
+                Foreground = White,
+                Opacity = state switch { TileState.Locked => 0.35, TileState.Empty => 0.4, _ => 1.0 },
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            });
+            var ringBrush = state switch
+            {
+                TileState.Equipped => new SolidColorBrush(Color.FromArgb(200, Gold.R, Gold.G, Gold.B)),
+                TileState.Owned    => new SolidColorBrush(accent),
+                TileState.Locked   => new SolidColorBrush(Color.FromArgb(60, accent.R, accent.G, accent.B)),
+                _                  => new SolidColorBrush(Color.FromArgb(0x50, 0xB8, 0xB8, 0xD0)),
+            };
+            // The ring rides ABOVE the art and ABOVE the badge — always the tile's topmost layer.
+            content.Children.Add(new Border
+            {
+                CornerRadius = new CornerRadius(12),
+                BorderBrush = ringBrush,
+                BorderThickness = new Thickness(state == TileState.Equipped ? 4 : 3.5),
+                IsHitTestVisible = false,
+            });
+            if (cornerBadge != null)
+                content.Children.Add(new TextBlock
+                {
+                    Text = cornerBadge, FontSize = 15, FontWeight = FontWeight.Bold,
+                    Foreground = GoldBrush,
+                    HorizontalAlignment = HorizontalAlignment.Right, VerticalAlignment = VerticalAlignment.Bottom,
+                    Margin = new Thickness(0, 0, 6, 3)
+                });
+
+            var tile = new Border
+            {
+                Width = size, Height = size,
+                CornerRadius = new CornerRadius(12),
+                Child = content,
+                ClipToBounds = true,
+                Background = state switch
+                {
+                    TileState.Equipped => new SolidColorBrush(Color.FromArgb(80, accent.R, accent.G, accent.B)),
+                    TileState.Owned    => new SolidColorBrush(Color.FromArgb(45, accent.R, accent.G, accent.B)),
+                    TileState.Locked   => new SolidColorBrush(Color.FromRgb(0x22, 0x1F, 0x40)),
+                    _                  => Brushes.Transparent,
+                },
+                BorderBrush = ringBrush,
+                BorderThickness = new Thickness(0),
+            };
+
+            // Name under the tile — locked/placeholder tiles keep their mystery.
+            caption ??= state is TileState.Locked or TileState.Empty ? "???" : title.Split(" · ")[0];
+            var label = new TextBlock
+            {
+                Text = caption,
+                FontSize = 12,
+                FontWeight = state == TileState.Equipped ? FontWeight.SemiBold : FontWeight.Normal,
+                Foreground = state switch
+                {
+                    TileState.Equipped => GoldBrush,
+                    TileState.Owned    => White,
+                    _                  => new SolidColorBrush(Color.FromArgb(0x80, 0xB8, 0xB8, 0xD0)),
+                },
+                TextAlignment = TextAlignment.Center,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                MaxWidth = size + 36,
+                Margin = new Thickness(0, 6, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+
+            var cell = new StackPanel
+            {
+                Margin = new Thickness(0, 0, 0, 22),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Top,
+                Cursor = new Cursor(onClick != null ? StandardCursorType.Hand : StandardCursorType.Arrow),
+                Background = Brushes.Transparent,
+            };
+            cell.Children.Add(tile);
+            cell.Children.Add(label);
+            if (onClick != null)
+                cell.PointerPressed += (_, e) =>
+                {
+                    if (e.GetCurrentPoint(cell).Properties.IsLeftButtonPressed) onClick();
+                };
+            // WPF attached a rich ChaosTips card here; Avalonia gets the same words as a tooltip.
+            ToolTip.SetTip(cell, string.Join("\n", new[] { title, desc, flavor, extra }.Where(s => !string.IsNullOrEmpty(s))));
+            return cell;
+        }
+
+        // ============================ the seamstress's bench ============================
+        // WPF keeps this in ChaosHubWindow.Bench.cs. That partial is not part of this layer, so
+        // the row builder is inlined here rather than splitting the port across two files.
+
+        private void BuildBench()
+        {
+            _improvementsHost.Children.Clear();
+            _improvementsHost.Children.Add(GoldBalanceLine());
+            foreach (var item in Sample.Bench) _improvementsHost.Children.Add(BenchRow(item));
+            foreach (var name in Sample.ReservedRows) _improvementsHost.Children.Add(HazyRow(name, WallTip));
+        }
+
+        /// <summary>Her corner inside the Toybox: just the two first-pocket rows, sold early.</summary>
+        private void BuildHerCorner()
+        {
+            _herCornerHost.Children.Clear();
+            _herCornerHost.Children.Add(GoldBalanceLine());
+            foreach (var item in Sample.Bench.Take(2)) _herCornerHost.Children.Add(BenchRow(item));
+            _herCornerCard.IsVisible = true;   // WPF gates this on RevealIds.HerCorner
+        }
+
+        private const string WallTip = "not yet. she hasn't decided what it costs.";
+        private const string DeeperTip = "she'll sell this to someone deeper.";
+
+        private static TextBlock GoldBalanceLine() => new()
+        {
+            Text = $"you're carrying 🪙 {Sample.Gold:N0}",
+            Foreground = new SolidColorBrush(Color.FromRgb(0xE8, 0xB4, 0x43)),
+            FontSize = 11, FontWeight = FontWeight.SemiBold,
+            Margin = new Thickness(0, 0, 0, 8),
+        };
+
+        /// <summary>One bench row in its current state: hazy (reveal-gated), rank-locked,
+        /// owned, or for sale.</summary>
+        private Border BenchRow(SampleBench item)
+        {
+            if (item.Hazy) return HazyRow("???", WallTip);
+
+            var goldColor = Color.FromRgb(0xE8, 0xB4, 0x43);
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+            var glyph = new TextBlock
+            {
+                Text = item.Glyph, FontSize = 16, VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 10, 0), Opacity = item.Owned ? 1.0 : 0.7,
+            };
+            Grid.SetColumn(glyph, 0);
+            grid.Children.Add(glyph);
+
+            var mid = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            mid.Children.Add(new TextBlock
+            {
+                Text = item.Label,
+                Foreground = item.Owned ? White : new SolidColorBrush(Color.FromRgb(0xC8, 0xC8, 0xE0)),
+                FontSize = 12, FontWeight = FontWeight.SemiBold,
+            });
+            mid.Children.Add(new TextBlock
+            {
+                Text = item.Line,
+                Foreground = new SolidColorBrush(Color.FromRgb(0x9A, 0x9A, 0xB8)),
+                FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0),
+            });
+            Grid.SetColumn(mid, 1);
+            grid.Children.Add(mid);
+
+            Control right;
+            if (item.Owned)
+                right = new TextBlock
+                {
+                    Text = "sewn ✓",
+                    Foreground = new SolidColorBrush(Color.FromRgb(0x5A, 0xE0, 0x96)),
+                    FontSize = 11, FontWeight = FontWeight.Bold,
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+            else if (item.RankShort)
+            {
+                right = new TextBlock { Text = "🔒", FontSize = 13, Opacity = 0.7, VerticalAlignment = VerticalAlignment.Center };
+                ToolTip.SetTip(right, DeeperTip);
+            }
+            else
+            {
+                bool afford = Sample.Gold >= item.Cost;
+                // Stays clickable when short — her one gift rides on a short first-pocket buy.
+                var buy = new Button
+                {
+                    Content = new TextBlock { Text = $"buy  🪙 {item.Cost:N0}" },
+                    Tag = item.Id,
+                    Padding = new Thickness(14, 6, 14, 6),
+                    Background = afford ? new SolidColorBrush(goldColor) : new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)),
+                    Foreground = afford ? Brushes.Black : new SolidColorBrush(Color.FromRgb(0x88, 0xA0, 0xA0)),
+                    BorderThickness = new Thickness(0),
+                    FontSize = 11.5,
+                    FontWeight = FontWeight.Bold,
+                    Cursor = new Cursor(StandardCursorType.Hand),
+                    CornerRadius = new CornerRadius(9),
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                // ponytail: needs ChaosMeta bench purchases, wired when they move to Core.
+                buy.Click += (_, _) => Log.Debug("ChaosHub: bench buy {Id} requested; no ChaosMeta on this head yet", item.Id);
+                right = buy;
+            }
+            Grid.SetColumn(right, 2);
+            grid.Children.Add(right);
+
+            return new Border
+            {
+                Child = grid,
+                Background = RowBg,
+                BorderBrush = new SolidColorBrush(Color.FromArgb(item.Owned ? (byte)70 : (byte)30, 0xE8, 0xB4, 0x43)),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 0, 6),
+            };
+        }
+
+        /// <summary>A name on the bench with nothing behind it yet.</summary>
+        private static Border HazyRow(string name, string tip)
+        {
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            row.Children.Add(new TextBlock { Text = "◌", FontSize = 14, Opacity = 0.5, Margin = new Thickness(0, 0, 10, 0), VerticalAlignment = VerticalAlignment.Center });
+            row.Children.Add(new TextBlock { Text = name, Foreground = DimText, FontSize = 12, VerticalAlignment = VerticalAlignment.Center });
+            var border = new Border
+            {
+                Child = row,
+                Background = RowBg,
+                BorderBrush = new SolidColorBrush(Color.FromArgb(20, 0xE8, 0x43, 0x93)),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(10, 8, 10, 8),
+                Margin = new Thickness(0, 0, 0, 6),
+                Opacity = 0.7,
+            };
+            ToolTip.SetTip(border, tip);
+            return border;
+        }
+
+        // ============================ mantras box ============================
+
+        private void BuildMantras()
+        {
+            _mantrasHost.Children.Clear();
+            foreach (var b in Sample.Mantras) _mantrasHost.Children.Add(MantraRow(b));
+        }
+
+        /// <summary>One mantra/sin row: ??? until met in a draft; discovered mantras are clickable
+        /// to set/clear the start mantra (gold ring + ★ on the whispered one). Sins are listed but
+        /// can only be taken mid-fall, never chosen.</summary>
+        private Border MantraRow(SampleMantra b)
+        {
+            bool seen = b.Seen;
+            bool isStart = Sample.StartMantra == b.Id;
+            bool pickable = seen && !b.IsCurse;
+            var accent = b.IsCurse ? Color.FromRgb(0xFF, 0x8A, 0x8A) : Color.FromRgb(0x9C, 0xE8, 0xA0);
+
+            var row = new Grid();
+            row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+            row.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            row.ColumnDefinitions.Add(new ColumnDefinition(GridLength.Auto));
+
+            var icon = new Border
+            {
+                Width = 39, Height = 39, CornerRadius = new CornerRadius(9),
+                Background = new SolidColorBrush(seen ? Color.FromArgb(60, accent.R, accent.G, accent.B) : Color.FromArgb(40, 120, 120, 140)),
+                BorderBrush = new SolidColorBrush(seen ? accent : Color.FromRgb(90, 90, 110)), BorderThickness = new Thickness(1),
+                Child = new TextBlock
+                {
+                    Text = seen ? (b.IsCurse ? "☠" : "◈") : "?",
+                    Foreground = new SolidColorBrush(seen ? accent : Color.FromRgb(0x88, 0x88, 0xA0)),
+                    FontSize = 19, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center
+                },
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 10, 0)
+            };
+            Grid.SetColumn(icon, 0);
+            row.Children.Add(icon);
+
+            var mid = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            mid.Children.Add(new TextBlock { Text = seen ? b.Name : "???", Foreground = seen ? White : DimText, FontSize = 12, FontWeight = FontWeight.SemiBold });
+            mid.Children.Add(new TextBlock { Text = seen ? b.Desc : "hazy. go back down and look closer.", Foreground = BodyText, FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0) });
+            if (seen && !string.IsNullOrEmpty(b.Flavor))
+                mid.Children.Add(new TextBlock
+                {
+                    Text = b.Flavor, FontStyle = FontStyle.Italic, FontSize = 11,
+                    Foreground = FlavorText, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0)
+                });
+            Grid.SetColumn(mid, 1);
+            row.Children.Add(mid);
+
+            if (seen)
+            {
+                var badge = new TextBlock
+                {
+                    Text = isStart ? "start ★" : b.IsCurse ? "taken, never chosen" : "set start",
+                    Foreground = isStart ? GoldBrush : new SolidColorBrush(Color.FromArgb(0x90, 0xB8, 0xB8, 0xD0)),
+                    FontSize = 10.5, FontWeight = isStart ? FontWeight.Bold : FontWeight.Normal,
+                    VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(8, 0, 0, 0)
+                };
+                Grid.SetColumn(badge, 2);
+                row.Children.Add(badge);
+            }
+
+            var card = new Border
+            {
+                Child = row,
+                Background = RowBg,
+                BorderBrush = isStart
+                    ? new SolidColorBrush(Color.FromArgb(190, Gold.R, Gold.G, Gold.B))
+                    : new SolidColorBrush(Color.FromArgb(seen ? (byte)70 : (byte)25, accent.R, accent.G, accent.B)),
+                BorderThickness = new Thickness(isStart ? 3 : 2),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 0, 6),
+                Cursor = new Cursor(pickable ? StandardCursorType.Hand : StandardCursorType.Arrow)
+            };
+            if (seen)
+                ToolTip.SetTip(card, b.Name + "\n" + b.Desc + "\n" +
+                    (b.IsCurse ? "a sin. it can only be taken mid-fall."
+                               : isStart ? "whispered on the way down. click to fall in bare."
+                                         : "click to whisper it on the way down."));
+            if (pickable)
+                card.PointerPressed += (_, e) =>
+                {
+                    if (!e.GetCurrentPoint(card).Properties.IsLeftButtonPressed) return;
+                    Sample.StartMantra = isStart ? null : b.Id;
+                    BuildMantras();
+                };
+            return card;
+        }
+
+        // ============================ diary (bubbles met) ============================
+
+        private void BuildDiary()
+        {
+            _diaryHost.Children.Clear();
+            FillDiaryRows(_diaryHost, 270);
+        }
+
+        /// <summary>The interaction sheet at the top of the diary: every core verb, always
+        /// readable — the recall surface for all the one-time in-run teaches.</summary>
+        private static readonly (string Glyph, string Name, string Desc)[] DiaryVerbs =
+        {
+            ("✋", "hold to snap", "press and HOLD a live (ringed) bubble about a second to defuse it — costs 30 focus. a quick click, or letting go early, TRIGGERS it instead."),
+            ("○", "click the treats", "a tap pops a treat: its payload plays, the streak climbs, and +10 focus flows back (+15 from heavies and rabbits)."),
+            ("🌊", "right-click · the ripple", "casts a wave from your cursor (near the bubbles): treats pop fully paid, trances snap clean, rabbits get flung. one charge, gathered back over time — READY on the sidebar means it's in your hand."),
+            ("◌", "focus", "the defuse fuel: max 100, you fall in with 50, no regen on its own. when the bar runs red you can't afford a hold — farm treats before touching a live one (pressing one anyway triggers it in your grip)."),
+            ("🔥", "lust", "the orange bar. climbs while you perform and pays up to x2 at full burn; an unblocked trigger cools it to zero."),
+            ("💨", "never let treats rot", "a treat that fades unpopped HALVES your streak. chase the rewards too, not just the threats."),
+            ("🐇", "catch the white rabbit", "everything slows to a crawl for six seconds. with the Spanker worn, you smack it into the field instead."),
+            ("❄", "the pickups", "freeze ❄ holds the whole field 3.5 seconds (still poppable, and snaps cost no focus) · the lucky bubble 🍀 pays gold on the spot."),
+            ("⏸", "your panic key", "one press holds the field mid-fall; pressing it again wakes you up to the recap."),
+        };
+
+        /// <summary>Every diary entry into <paramref name="host"/> — shared by the in-tab box
+        /// (narrow wrap) and the pop-out reader (roomier).</summary>
+        private void FillDiaryRows(Panel host, double maxWidth)
+        {
+            // How to play before what you've met — never discovery-gated.
+            host.Children.Add(SubHeader("VERBS · how to play down there"));
+            foreach (var v in DiaryVerbs) host.Children.Add(VerbRow(v.Glyph, v.Name, v.Desc, maxWidth));
+            host.Children.Add(SubHeader("WHAT YOU'VE MET"));
+            foreach (var c in Sample.Codex)
+                host.Children.Add(CodexRow(c.Name, c.Desc, c.Glyph, c.Accent, c.Seen, maxWidth));
+        }
+
+        private Window? _diaryPopout;
+
+        /// <summary>The diary box is a teaser — clicking it opens the full, scrollable reader.</summary>
+        private void Diary_PopOut(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(_hdrDiary).Properties.IsLeftButtonPressed) return;
+            if (_diaryPopout != null)
+            {
+                try { _diaryPopout.Activate(); } catch { /* already closing */ }
+                return;
+            }
+            var host = new StackPanel { Margin = new Thickness(18, 14, 18, 18) };
+            host.Children.Add(new TextBlock
+            {
+                Text = "DIARY · what you've met down there",
+                Foreground = new SolidColorBrush(BoonAccent),
+                FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeight.Bold, FontSize = 13,
+                Margin = new Thickness(0, 0, 0, 12)
+            });
+            FillDiaryRows(host, 440);
+            _diaryPopout = new Window
+            {
+                Title = "Diary",
+                Width = 580, Height = 680,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                ShowInTaskbar = false,
+                Background = new SolidColorBrush(Color.FromRgb(0x14, 0x11, 0x26)),
+                Content = new ScrollViewer { VerticalScrollBarVisibility = ScrollBarVisibility.Auto, Content = host },
+            };
+            _diaryPopout.Closed += (_, _) => _diaryPopout = null;
+            _diaryPopout.Show(this);
+        }
+
+        private static TextBlock SubHeader(string text) => new()
+        {
+            Text = text, Foreground = new SolidColorBrush(BoonAccent),
+            FontFamily = new FontFamily("Consolas, Courier New"), FontWeight = FontWeight.Bold, FontSize = 11,
+            Margin = new Thickness(0, 12, 0, 6)
+        };
+
+        /// <summary>A diary verb row: the CodexRow look without the discovery gate — the
+        /// how-to-play sheet is always legible.</summary>
+        private static Border VerbRow(string glyph, string name, string desc, double maxWidth)
+        {
+            var accent = Color.FromRgb(0x7A, 0xE0, 0xFF);
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            row.Children.Add(new Border
+            {
+                Width = 39, Height = 39, CornerRadius = new CornerRadius(9),
+                Background = new SolidColorBrush(Color.FromArgb(45, accent.R, accent.G, accent.B)),
+                BorderBrush = new SolidColorBrush(accent), BorderThickness = new Thickness(1),
+                VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 12, 0),
+                Child = new TextBlock { Text = glyph, Foreground = new SolidColorBrush(accent), FontSize = 17, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center },
+            });
+            // MaxWidth keeps descs wrapping inside their box (a StackPanel row otherwise
+            // measures at infinite width and clips); the pop-out reader passes a roomier one.
+            var mid = new StackPanel { VerticalAlignment = VerticalAlignment.Center, MaxWidth = maxWidth };
+            mid.Children.Add(new TextBlock { Text = name, Foreground = White, FontSize = 12, FontWeight = FontWeight.SemiBold });
+            mid.Children.Add(new TextBlock { Text = desc, Foreground = BodyText, FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0) });
+            row.Children.Add(mid);
+            return new Border
+            {
+                Child = row,
+                Background = RowBg,
+                BorderBrush = new SolidColorBrush(Color.FromArgb(55, accent.R, accent.G, accent.B)),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 0, 6),
+            };
+        }
+
+        private static Border CodexRow(string name, string desc, string glyph, Color accent, bool seen, double maxWidth)
+        {
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+            var icon = new Border
+            {
+                Width = 39, Height = 39, CornerRadius = new CornerRadius(9),
+                Background = new SolidColorBrush(seen ? Color.FromArgb(60, accent.R, accent.G, accent.B) : Color.FromArgb(40, 120, 120, 140)),
+                BorderBrush = new SolidColorBrush(seen ? accent : Color.FromRgb(90, 90, 110)), BorderThickness = new Thickness(1),
+                VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 12, 0),
+                Child = new TextBlock
+                {
+                    Text = seen ? glyph : "?",
+                    Foreground = new SolidColorBrush(seen ? accent : Color.FromRgb(0x88, 0x88, 0xA0)),
+                    FontSize = 19, HorizontalAlignment = HorizontalAlignment.Center, VerticalAlignment = VerticalAlignment.Center
+                }
+            };
+            if (seen) ToolTip.SetTip(icon, name + "\n" + desc);
+            row.Children.Add(icon);
+
+            var mid = new StackPanel { VerticalAlignment = VerticalAlignment.Center, MaxWidth = maxWidth };
+            mid.Children.Add(new TextBlock { Text = seen ? name : "???", Foreground = seen ? White : DimText, FontSize = 12, FontWeight = FontWeight.SemiBold });
+            mid.Children.Add(new TextBlock { Text = seen ? desc : "hazy. go back down and look closer.", Foreground = BodyText, FontSize = 11, TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0) });
+            row.Children.Add(mid);
+
+            return new Border
+            {
+                Child = row,
+                Background = RowBg,
+                BorderBrush = new SolidColorBrush(Color.FromArgb(seen ? (byte)70 : (byte)25, accent.R, accent.G, accent.B)),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 0, 6)
+            };
+        }
+
+        // ============================ run-setup load / save ============================
+
+        private static readonly string[] KeyOptions = { "Q", "E", "R", "F", "Z", "X", "C", "V", "1", "2", "3", "4" };
+
+        /// <summary>WPF read every knob off <c>App.Settings.Current</c> and fell back to
+        /// <see cref="LoadDefaults"/> when settings were missing. There is no AppSettings on this
+        /// head yet, so this IS the fallback path — plus the two accessory-key combos, which WPF
+        /// filled only on the settings path and which would otherwise render empty.
+        /// ponytail: needs App.Settings, wired when it moves to Core.</summary>
+        private void LoadFromSettings()
+        {
+            _cmbAccKey1.ItemsSource = KeyOptions;
+            _cmbAccKey2.ItemsSource = KeyOptions;
+            _cmbAccKey1.SelectedItem = "Q";
+            _cmbAccKey2.SelectedItem = "E";
+            LoadDefaults();
+            ApplyExtremeGate();
+        }
+
+        /// <summary>Lock/unlock the Extreme difficulty pill from meta state; fall back off it when locked.</summary>
+        private void ApplyExtremeGate()
+        {
+            bool unlocked = Sample.ExtremeUnlocked;
+            _segExtreme.IsEnabled = unlocked;
+            _segExtreme.Content = unlocked ? "Inescapable" : "Inescapable 🔒";
+            if (!unlocked)
+                // The lock keeps its mystery on the face; the hover gives the exact path.
+                // ponytail: needs ChaosLessons / ChaosRanks for the real thresholds and price.
+                ToolTip.SetTip(_segExtreme,
+                    "a deeper door. she sells the key in the Toybox: finish enough relentless "
+                    + "descents, reach Devoted, then train it.");
+            ApplyDifficultyPillTips(extremeUnlocked: unlocked);
+            if (!unlocked && _segExtreme.IsChecked == true) SetSegment(_grpDifficulty, "Hard");
+        }
+
+        /// <summary>What each pill actually changes, on hover — pay multiplier, spawn pace, field
+        /// size — so picking a difficulty is a choice instead of a mystery. The locked Inescapable
+        /// pill keeps its unlock-path tooltip (set in <see cref="ApplyExtremeGate"/>).</summary>
+        private void ApplyDifficultyPillTips(bool extremeUnlocked)
+        {
+            foreach (var pill in _grpDifficulty.Children.OfType<ToggleButton>())
+            {
+                string? tip = pill.Tag?.ToString() switch
+                {
+                    "Easy" => "x1.0 pay. the calmest fall: baseline spawn pace, the longest trances, and the strange bubbles roll half as often.",
+                    "Medium" => "x1.3 on every payout. bubbles surface ~30% faster and the field holds ~14% more of them at once.",
+                    "Hard" => "x1.7 on every payout. ~70% faster spawns, ~30% more on screen, shorter trances — and the Bound hunts here on any rank.",
+                    "Extreme" => extremeUnlocked
+                        ? "x2.2 on every payout. spawns at more than double pace, ~48% more on screen. the deepest the hole goes."
+                        : null,   // the unlock-path tooltip owns the locked pill
+                    _ => null,
+                };
+                if (tip != null) ToolTip.SetTip(pill, tip);
+            }
+        }
+
+        private void LoadDefaults()
+        {
+            SetSegment(_grpDifficulty, "Easy");
+            SetSegment(_grpLength, "180");
+            SetSegment(_grpMotion, "Mixed");
+            _waves = 5; _txtWaves.Text = "5";
+            foreach (var t in _grpPool.Children.OfType<ToggleButton>()) t.IsChecked = true;
+            _chkShake.IsChecked = true; _sldShake.Value = 0.8;
+            _chkFlashes.IsChecked = true; _sldEffect.Value = 0.85;
+            _chkSkiaFx.IsChecked = true;
+            _chkPinTop.IsChecked = true;
+            _chkSharedHost.IsChecked = false;
+            _chkBoonDraft.IsChecked = true; _chkCurses.IsChecked = true;
+            _chkDarters.IsChecked = true;
+            _chkAnnouncer.IsChecked = true;
+            _chkNarrative.IsChecked = true;
+            _chkBackdrop.IsChecked = true;
+            _sldBackdropOpacity.Value = 0.55;
+            _chkTunnel.IsChecked = false;
+        }
+
+        /// <summary>ponytail: needs App.Settings, wired when it moves to Core. WPF wrote every
+        /// knob back on FALL IN and on leaving the dollhouse; nothing persists on this head.</summary>
+        private void SaveToSettings() =>
+            Log.Debug("ChaosHub: run setup not persisted; no App.Settings on this head yet");
+
+        // ============================ run-setup controls ============================
+
+        private void Segment_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not ToggleButton btn) return;
+            if (!btn.IsEnabled) { btn.IsChecked = false; return; }   // locked (Extreme)
+            if (btn.Parent is not Panel grp) return;
+            foreach (var t in grp.Children.OfType<ToggleButton>()) t.IsChecked = ReferenceEquals(t, btn);
+        }
+
+        private void Stepper_Click(object? sender, RoutedEventArgs e)
+        {
+            switch ((sender as Button)?.Tag?.ToString())
+            {
+                case "waves-": _waves = Math.Max(1, _waves - 1); _txtWaves.Text = _waves.ToString(); break;
+                case "waves+": _waves = Math.Min(12, _waves + 1); _txtWaves.Text = _waves.ToString(); break;
+            }
+        }
+
+        /// <summary>The three bubble-pool presets. WPF read them from
+        /// <c>ChaosBubbleVariants.Presets</c>; the ids and groupings are copied verbatim.
+        /// ponytail: needs ChaosBubbleVariants, wired when it moves to Core.</summary>
+        private static readonly Dictionary<string, string[]> PoolPresets = new()
+        {
+            ["Balanced"] = new[] { "flash", "subliminal", "pink", "spiral", "braindrain", "bambifreeze", "video", "htlink" },
+            ["Tease"] = new[] { "flash", "subliminal", "pink", "spiral" },
+            ["Flash-only"] = new[] { "flash" },
+        };
+
+        private void Preset_Click(object? sender, RoutedEventArgs e)
+        {
+            var name = (sender as Button)?.Tag?.ToString();
+            if (name == null || !PoolPresets.TryGetValue(name, out var ids)) return;
+            foreach (var t in _grpPool.Children.OfType<ToggleButton>())
+                t.IsChecked = ids.Contains(t.Tag?.ToString() ?? "");
+        }
+
+        private void BtnRandomize_Click(object? sender, RoutedEventArgs e)
+        {
+            // Only difficulties whose pills are revealed can roll (the saved setting is untouched).
+            var diffs = new List<string> { "Easy" };
+            if (_segMedium.IsVisible) diffs.Add("Medium");
+            if (_segHard.IsVisible) diffs.Add("Hard");
+            if (Sample.ExtremeUnlocked) diffs.Add("Extreme");
+            SetSegment(_grpDifficulty, diffs[_rng.Next(diffs.Count)]);
+            SetSegment(_grpLength, new[] { "120", "180", "300" }[_rng.Next(3)]);
+            SetSegment(_grpMotion, new[] { "Mixed", "FloatUp", "RainDown", "RoamBounce" }[_rng.Next(4)]);
+            var pool = _grpPool.Children.OfType<ToggleButton>().ToList();
+            foreach (var t in pool) t.IsChecked = _rng.NextDouble() < 0.6;
+            if (!pool.Any(t => t.IsChecked == true)) pool[0].IsChecked = true;
+        }
+
+        private void BtnDefaults_Click(object? sender, RoutedEventArgs e) { LoadDefaults(); ApplyExtremeGate(); }
+
+        /// <summary>WPF saved the setup, closed the hub and handed the config to
+        /// <c>App.Chaos.StartRun</c>. There is no ChaosService on this head, so this closes and
+        /// says so. ponytail: needs ChaosService + ChaosRunConfig, wired when they move to Core.</summary>
+        private void BtnBegin_Click(object? sender, RoutedEventArgs e)
+        {
+            var mode = (sender as Control)?.Tag?.ToString() == "FreeDesktop" ? "FreeDesktop" : "Story";
+            SaveToSettings();
+            Log.Debug("ChaosHub: FALL IN ({Mode}) requested; no ChaosService on this head yet", mode);
+            Close();
+        }
+
+        /// <summary>The loadout sidebar's FALL IN hero button lands here — same path as the
+        /// footer button (no Tag ⇒ Story mode).</summary>
+        public void FallIn() => BtnBegin_Click(this, new RoutedEventArgs());
+
+        private void BtnClose_Click(object? sender, RoutedEventArgs e) => Close();
+
+        // ============================ main menu / view swap ============================
+
+        private void ShowMenuView()
+        {
+            _menuView.IsVisible = true;
+            _dollhouseView.IsVisible = false;
+            _menuLeftCol.IsVisible = true;
+            _menuArtPanel.IsVisible = true;
+            _menuOptions.IsVisible = false;
+            RefreshTopBar();   // keep the menu chips current
+        }
+
+        private void ShowDollhouseView()
+        {
+            _menuView.IsVisible = false;
+            _dollhouseView.IsVisible = true;
+        }
+
+        /// <summary>Straight into a descent. WPF also detached the companion for the handoff.
+        /// ponytail: needs App.AvatarWindow, wired when it moves to Core.</summary>
+        private void Menu_FallIn_Click(object? sender, RoutedEventArgs e) => FallIn();
+
+        private void Menu_Dollhouse_Click(object? sender, RoutedEventArgs e)
+        {
+            // WPF also spawned the loadout sidebar here (App.Chaos.ShowLoadoutSidebar).
+            // ponytail: needs ChaosService, wired when it moves to Core.
+            ShowDollhouseView();
+            ShowTab("loadout");
+        }
+
+        /// <summary>Story is greyed (BtnMenuStory.IsEnabled = StoryModeEnabled); this only ever
+        /// fires if the flag flips true, at which point it would route into the story descent.</summary>
+        private void Menu_Story_Click(object? sender, RoutedEventArgs e) { /* coming soon — disabled */ }
+
+        private void Menu_Options_Click(object? sender, RoutedEventArgs e)
+        {
+            _optFullscreen.IsChecked = WindowState == WindowState.Maximized;
+            _menuLeftCol.IsVisible = false;
+            _menuArtPanel.IsVisible = false;
+            _menuOptions.IsVisible = true;
+        }
+
+        private void Options_Back_Click(object? sender, RoutedEventArgs e)
+        {
+            _menuOptions.IsVisible = false;
+            _menuLeftCol.IsVisible = true;
+            _menuArtPanel.IsVisible = true;
+        }
+
+        private void Menu_Exit_Click(object? sender, RoutedEventArgs e) => Close();
+
+        // ======================= HOW TO PLAY (card tutorial overlay) =======================
+
+        private sealed record HowToLine(string Emoji, string EmojiColor, string Lead, string LeadColor, string Body);
+        private sealed record HowToCard(string Title, string Image, HowToLine[] Lines);
+
+        private static readonly HowToCard[] _howToCards =
+        {
+            new("What the Rabbit Hole is", "howto_1", new[]
+            {
+                new HowToLine("", "", "", "",
+                    "Bubbles drift up the screen carrying flashes, videos and overlays. Pop the good ones, snap the dangerous ones before they go off, and ride it deeper. One descent is about **five minutes** — survive the waves, take what she offers, climb out a little more hers."),
+            }),
+            new("What you do", "howto_2", new[]
+            {
+                new HowToLine("🫧", "#FFFF9FD0", "Left-click", "#FFFF9FD0", "pop the treats — the soft pink bubbles. One click builds your streak and refills your focus."),
+                new HowToLine("◉", "#FFFFD228", "Press & hold", "#FFFFD228", "the glowing bubbles are live. Keep pressing until they snap — let one finish and it goes off (a flash or video fires)."),
+                new HowToLine("🌊", "#FF7AE0FF", "Right-click", "#FF7AE0FF", "the ripple. A wave near the bubbles pops treats, snaps live ones and scatters rabbits. Strong, but slow to gather again."),
+                new HowToLine("🐇", "#FFFF69B4", "The rabbits", "#FFFF69B4", "chase them for little bonuses. Everything else down there is yours to find out."),
+            }),
+            new("The two bars", "howto_3", new[]
+            {
+                new HowToLine("", "", "FOCUS", "#FFFFFFFF", "your nerve. Snapping live bubbles spends it; popping treats refills it. Run dry and you can't snap — so keep feeding."),
+                new HowToLine("", "", "HEAT", "#FFFFFFFF", "the burn. It climbs every time something triggers. Let it run high and the descent gets harder to resist."),
+            }),
+            new("A descent", "howto_4", new[]
+            {
+                new HowToLine("", "", "", "",
+                    "Four waves, then it ends. Between waves she offers you a **mantra** — pick one and it bends the rules for that run only. Finish the whole descent for the full reward; slip out early and you forfeit it."),
+            }),
+            new("What you keep", "howto_5", new[]
+            {
+                new HowToLine("", "", "", "",
+                    "Every descent earns **XP** toward your normal level, plus **Sparks** (gold) you carry back out."),
+                new HowToLine("", "", "", "",
+                    "Spend Sparks in **the dollhouse** — accessories at the table by the door, charms, active toys you trigger mid-descent, and the seamstress's bench for permanent upgrades."),
+                new HowToLine("", "", "", "",
+                    "The more descents you finish, the higher your **RANK** — curious, tempted, slipping, entranced, devoted… — and the more of the Rabbit Hole opens up to you."),
+            }),
+        };
+
+        private int _howToIdx;
+
+        private void Menu_HowTo_Click(object? sender, RoutedEventArgs e)
+        {
+            _howToIdx = 0;
+            HowToShow();
+            _menuHowTo.IsVisible = true;
+        }
+
+        private void HowTo_Close_Click(object? sender, RoutedEventArgs e) => _menuHowTo.IsVisible = false;
+
+        // backdrop dismiss: only when the click lands on the dim backdrop itself, not the card
+        private void HowTo_Backdrop_Click(object? sender, PointerPressedEventArgs e)
+        {
+            if (ReferenceEquals(e.Source, _menuHowTo)) _menuHowTo.IsVisible = false;
+        }
+
+        private void HowTo_Back_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_howToIdx > 0) { _howToIdx--; HowToShow(); }
+        }
+
+        private void HowTo_Next_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_howToIdx < _howToCards.Length - 1) { _howToIdx++; HowToShow(); }
+            else _menuHowTo.IsVisible = false;   // last card: "DONE" closes
+        }
+
+        private void HowToShow()
+        {
+            var card = _howToCards[_howToIdx];
+
+            _howToStep.Text = $"STEP {_howToIdx + 1} / {_howToCards.Length}";
+            _howToTitle.Text = card.Title;
+
+            // Card art comes from ChaosArt.Resolve("howto", …) in the head; with no art the box
+            // collapses, exactly as it does in WPF when no screenshot has been dropped in.
+            // ponytail: needs ChaosArt, wired when it moves to Core.
+            _howToImageBox.IsVisible = false;
+
+            // body lines
+            _howToBody.Children.Clear();
+            foreach (var line in card.Lines) _howToBody.Children.Add(BuildHowToLine(line));
+
+            // dots
+            _howToDots.Children.Clear();
+            for (int i = 0; i < _howToCards.Length; i++)
+                _howToDots.Children.Add(new Ellipse
+                {
+                    Width = 8, Height = 8, Margin = new Thickness(4, 0, 4, 0),
+                    Fill = i == _howToIdx
+                        ? this.FindResource("Pink") as IBrush
+                        : new SolidColorBrush(Color.FromArgb(0x55, 0xFF, 0xFF, 0xFF)),
+                });
+
+            // nav state
+            _howToBack.IsVisible = _howToIdx > 0;
+            _howToNext.Content = _howToIdx < _howToCards.Length - 1 ? "NEXT  ›" : "DONE";
+        }
+
+        private static Control BuildHowToLine(HowToLine line)
+        {
+            var tb = new TextBlock { TextWrapping = TextWrapping.Wrap, FontSize = 13.5, LineHeight = 21, Margin = new Thickness(0, 0, 0, 9) };
+            var inlines = new InlineCollection();
+
+            if (!string.IsNullOrEmpty(line.Lead))
+                inlines.Add(new Run(line.Lead + "  ")
+                {
+                    FontWeight = FontWeight.Bold,
+                    Foreground = BrushFromHex(line.LeadColor),
+                });
+            // body supports inline **bold** spans
+            bool bold = false;
+            foreach (var part in line.Body.Split("**"))
+            {
+                if (part.Length > 0)
+                    inlines.Add(new Run(part)
+                    {
+                        Foreground = bold ? White : new SolidColorBrush(Color.FromRgb(0xC8, 0xC8, 0xDE)),
+                        FontWeight = bold ? FontWeight.Bold : FontWeight.Normal,
+                    });
+                bold = !bold;
+            }
+            tb.Inlines = inlines;
+
+            if (string.IsNullOrEmpty(line.Emoji)) return tb;
+
+            // emoji-led row: glyph in a fixed gutter, text beside it
+            var grid = new Grid();
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(34)));
+            grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            var glyph = new TextBlock { Text = line.Emoji, FontSize = 17, VerticalAlignment = VerticalAlignment.Top, Foreground = BrushFromHex(line.EmojiColor) };
+            Grid.SetColumn(glyph, 0);
+            Grid.SetColumn(tb, 1);
+            grid.Children.Add(glyph);
+            grid.Children.Add(tb);
+            return grid;
+        }
+
+        private static IBrush BrushFromHex(string hex)
+        {
+            if (string.IsNullOrEmpty(hex)) return White;
+            try { return new SolidColorBrush(Color.Parse(hex)); }
+            catch (FormatException) { return White; }
+        }
+
+        private void Back_To_Menu_Click(object? sender, RoutedEventArgs e)
+        {
+            SaveToSettings();    // keep any loadout/setup tweaks made in the dollhouse
+            ShowMenuView();
+        }
+
+        // ============================ menu art motion ============================
+
+        /// <summary>
+        /// WPF put almost-imperceptible life on the menu art: a slow breathing zoom of the
+        /// ImageBrush's RelativeTransform, a tiny rotate, and a pulsing pink glow on the border,
+        /// all as looping WPF <c>DoubleAnimation</c>s started with <c>BeginAnimation</c>.
+        ///
+        /// ponytail: no faithful twin here. Avalonia has no <c>BeginAnimation</c>, animating a
+        /// brush's RelativeTransform needs the whole thing re-authored as Avalonia Animations,
+        /// and the art the motion exists to move (ChaosArt's menu frames) is not on this head
+        /// anyway. The static frame renders instead — 1.02 baseline zoom, no drift, steady glow.
+        /// Restore it together with the Skia menu scene.
+        /// </summary>
+        private void SetupMenuMotion() { }
+
+        /// <summary>WPF advanced the crossfading flipbook on a click and restarted the dwell
+        /// timer. ponytail: needs the ChaosArt frames + the Skia scene, wired with them.</summary>
+        private void MenuArt_Click(object? sender, PointerPressedEventArgs e) { }
+
+        // ============================ menu music ============================
+
+        /// <summary>WPF drove a NAudio loop with fades and a master-volume hook. There is no
+        /// audio stack on this head, so the button only swaps its icon.
+        /// ponytail: needs the audio service, wired when it moves to Core.</summary>
+        private bool _menuMuted;
+
+        private void BtnMenuMute_Click(object? sender, RoutedEventArgs e)
+        {
+            _menuMuted = !_menuMuted;
+            _menuMuteIcon.Text = _menuMuted ? "🔇" : "🔊";
+        }
+
+        // ============================ window chrome (move / fullscreen) ============================
+
+        private void DragWindow(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is not Visual v || !e.GetCurrentPoint(v).Properties.IsLeftButtonPressed) return;
+            try { BeginMoveDrag(e); } catch { /* dragging can throw if not pressed */ }
+        }
+
+        private void BtnMin_Click(object? sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;
+
+        private void BtnFull_Click(object? sender, RoutedEventArgs e) => SetFullscreen(WindowState != WindowState.Maximized);
+
+        private void OptFullscreen_Click(object? sender, RoutedEventArgs e) => SetFullscreen(_optFullscreen.IsChecked == true);
+
+        private void SetFullscreen(bool on) => WindowState = on ? WindowState.Maximized : WindowState.Normal;
+
+        /// <summary>WPF also detached the companion tube while maximized (it is anchored to the
+        /// main window). ponytail: needs App.AvatarWindow, wired when it moves to Core.</summary>
+        private void OnHubStateChanged(WindowState state) => _optFullscreen.IsChecked = state == WindowState.Maximized;
+
+        /// <summary>Re-open the spoiler-free rules card on demand. WPF showed ChaosIntroWindow
+        /// modally OVER the dollhouse; that view is not in this layer, and routing to the menu's
+        /// HOW TO PLAY card instead would kick the player out of the tab they are on.
+        /// ponytail: needs ChaosIntroWindow, wired when that view is ported.</summary>
+        private void BtnGuide_Click(object? sender, RoutedEventArgs e) =>
+            Log.Debug("ChaosHub: guide requested; ChaosIntroWindow is not on this head yet");
+
+        // ============================ helpers ============================
+
+        private static void SetSegment(Panel grp, string? tag)
+        {
+            foreach (var t in grp.Children.OfType<ToggleButton>()) t.IsChecked = t.Tag?.ToString() == tag;
+        }
+
+        /// <summary>WPF: <c>ChaosRanks.RankLockedTip</c> / <c>RankSpecifics(rank)</c>.
+        /// ponytail: needs ChaosRanks, wired when it moves to Core.</summary>
+        private const string RankLockedTip = "she'll show you this one when you've fallen further.";
+
+        private static string RankSpecifics(string rank) => $"reach {rank} to be shown this.";
+
+        // ============================ sample data ============================
+        // Everything below stands in for the Chaos services. It is deliberately shaped to hit
+        // every branch each builder above can take, so the render proves all of them at once.
+
+        private sealed record SampleHabit(string Id, string Glyph, string Name, string Desc, string Flavor,
+                                          string Branch, int Cost, bool Owned, bool On);
+
+        private sealed record SampleBoon(string Id, string Glyph, string Name, string Desc, string Flavor,
+                                         string Category, string ValueLabel, int Level, int MaxLevel,
+                                         bool Active, int UnlockCost, int UpgradeCost, bool RankLocked,
+                                         string RankFloor, string CapstoneDesc, bool IsActiveUse,
+                                         double UseCooldownSec);
+
+        private sealed record SampleMantra(string Id, string Name, string Desc, string Flavor, bool Seen, bool IsCurse);
+
+        private sealed record SampleCodexEntry(string Name, string Desc, string Glyph, Color Accent, bool Seen);
+
+        private sealed record SampleBench(string Id, string Glyph, string Label, string Line, int Cost,
+                                          bool Owned, bool RankShort, bool Hazy);
+
+        /// <summary>A played save partway down: two pockets sewn, one toy worn, one accessory
+        /// still on the shelf, one habit trained and switched on, one trained and off, one
+        /// untrained, and one charm behind the rank wall.</summary>
+        private static class Sample
+        {
+            public const string Rank = "Slipping";
+            public const int Sparks = 1820;
+            public const int Gold = 640;
+            public const int RunsCompleted = 14;
+            public const double TotalRunSeconds = 4_930;
+            public const long BestScore = 12_400;
+            public const int BestCombo = 37;
+            public const int TotalDefused = 268;
+            public const double TotalChannelSeconds = 1_190;
+            public static readonly bool ExtremeUnlocked = false;
+
+            public static string? StartMantra = "soft_focus";
+
+            public static readonly List<SampleHabit> Habits = new()
+            {
+                new("start_resistance", "🛡", "It would never work on me...", "fall in with 20 resistance already spent.", "you said that last time, too.", "Control", 120, true, true),
+                new("blank_eyes", "👁", "Blank Eyes", "trances hold ~15% longer before they let go.", "nobody's home. that's the point.", "Depth", 180, true, false),
+                new("slow_fuses", "🕯", "Slow Fuses", "live bubbles take an extra half second to go off.", "she likes to watch you decide.", "Control", 260, false, false),
+            };
+
+            public static readonly List<SampleBoon> Boons = new()
+            {
+                new("the_spanker", "🪄", "The Spanker", "swat the white rabbit into the field instead of chasing it.",
+                    "she calls it a training aid.", "Skill", "3 uses per descent", 2, 3, true, 400, 750, false, "", "the field flinches when you raise it.", true, 12),
+                new("the_ripple", "🌊", "The Ripple", "your wave reaches a little further from the cursor.",
+                    "one good push and the whole room moves.", "Skill", "+18% radius", 1, 3, false, 500, 900, false, "", "", false, 0),
+                new("deep_pockets", "👛", "Deep Pockets", "treats pay 10% more gold.",
+                    "", "Accessory", "+10% gold", 1, 3, true, 300, 600, false, "", "", false, 0),
+                new("the_collar", "⛓", "The Collar", "focus refunds on a clean snap.",
+                    "it isn't locked. it doesn't need to be.", "Accessory", "+8 focus", 0, 3, false, 850, 0, false, "", "", false, 0),
+                new("porcelain_mask", "🎭", "???", "", "", "Accessory", "", 0, 3, false, 0, 0, true, "Devoted", "", false, 0),
+            };
+
+            /// <summary>Utility charms — they train on the Habits shelf, not the toy shelves.</summary>
+            public static readonly List<SampleBoon> Charms = new()
+            {
+                new("rabbits_foot", "🍀", "Rabbit's Foot", "lucky bubbles surface a little more often.",
+                    "worn smooth already.", "Utility", "+6% lucky rate", 2, 3, true, 250, 500, false, "", "", false, 0),
+                new("the_pact", "🖋", "???", "", "", "Utility", "", 0, 3, false, 0, 0, true, "Entranced", "", false, 0),
+            };
+
+            public static readonly List<SampleMantra> Mantras = new()
+            {
+                new("soft_focus", "Soft Focus", "trances start 20% deeper, and hold.", "you stopped blinking a while ago.", true, false),
+                new("open_hands", "Open Hands", "treats pay double for the first wave.", "", true, false),
+                new("the_slip", "The Slip", "one free snap, no focus spent.", "", false, false),
+                new("greedy_little_thing", "Greedy Little Thing", "gold doubles, focus never refills.", "she wrote this one down.", true, true),
+            };
+
+            public static readonly List<SampleCodexEntry> Codex = new()
+            {
+                new("Flash", "a treat carrying an image. pops clean, pays focus back.", "●", Color.FromRgb(0xFF, 0x9F, 0xD0), true),
+                new("Subliminal", "a treat that whispers on the way past.", "●", Color.FromRgb(0xC9, 0xC4, 0xE8), true),
+                new("Spiral", "live. snap it or it takes the screen for a while.", "●", Color.FromRgb(0x8B, 0x5C, 0xF6), true),
+                new("White Rabbit", "fast, small, and worth chasing — everything slows when you catch one.", "✧", Color.FromRgb(0xFF, 0x4D, 0xC4), true),
+                new("Lucky Bubble", "pays gold on the spot. rare.", "🍀", Color.FromRgb(0xFF, 0xD7, 0x00), true),
+                new("The Echo", "it repeats the last thing that got through.", "◌", Color.FromRgb(0xC9, 0xC4, 0xE8), false),
+                new("The Chaperone", "it wants to help. it does not help.", "💞", Color.FromRgb(0x9C, 0xE8, 0xFF), false),
+                new("The Tease", "it never goes off. that is the whole trick.", "✖", Color.FromRgb(0xB3, 0x0E, 0x2E), false),
+                new("The Bound", "it hunts on relentless.", "⛓", Color.FromRgb(0xFF, 0x69, 0xB4), false),
+                new("The Brittle", "one touch and it shatters into three.", "◇", Color.FromRgb(0xD9, 0xEF, 0xFF), false),
+            };
+
+            public static readonly List<SampleBench> Bench = new()
+            {
+                new("toy_pocket_1", "👝", "first toy pocket", "she sews you a pocket.", 50, true, false, false),
+                new("acc_pocket_1", "👝", "first accessory pocket", "she only has two hands. she found a third.", 150, true, false, false),
+                new("start_mantra", "◈", "the starting mantra", "fall in holding something.", 200, false, false, false),
+                new("diary", "📓", "the diary", "she keeps notes on what you meet down there.", 150, false, false, false),
+                new("stats_panel", "🕰", "the stats panel", "the numbers, if you want them.", 100, false, false, false),
+                new("toy_pocket_2", "👝", "second toy pocket", "she found room for one more.", 2000, false, true, false),
+                new("acc_pocket_2", "👝", "second accessory pocket", "a fourth hand. don't ask.", 2500, false, false, true),
+            };
+
+            /// <summary>Reserved hazy rows: names on the bench, nothing behind them yet.</summary>
+            public static readonly string[] ReservedRows =
+            {
+                "the clocks", "descent ledger", "payout eyes", "the fine print",
+                "fall right in", "held breath", "soft landing", "no countdown",
+            };
+
+            public static int SlotsFor(string category) => category == "Skill" ? 1 : 1;
+
+            public static int EquippedCountIn(string category) => Boons.Count(b => b.Category == category && b.Active);
+
+            public static bool HasFreePocket(string category) => EquippedCountIn(category) < SlotsFor(category);
+
+            public static void ToggleHabit(string id)
+            {
+                for (int i = 0; i < Habits.Count; i++)
+                    if (Habits[i].Id == id) Habits[i] = Habits[i] with { On = !Habits[i].On };
+            }
+
+            public static void ToggleBoon(string id)
+            {
+                for (int i = 0; i < Boons.Count; i++)
+                    if (Boons[i].Id == id) Boons[i] = Boons[i] with { Active = !Boons[i].Active };
+                for (int i = 0; i < Charms.Count; i++)
+                    if (Charms[i].Id == id) Charms[i] = Charms[i] with { Active = !Charms[i].Active };
+            }
+
+            /// <summary>Equip into a full 1-slot pocket by quietly swapping the occupant out.</summary>
+            public static void EquipSwapping(string id, string category)
+            {
+                if (!HasFreePocket(category))
+                    for (int i = 0; i < Boons.Count; i++)
+                        if (Boons[i].Category == category && Boons[i].Active) Boons[i] = Boons[i] with { Active = false };
+                for (int i = 0; i < Boons.Count; i++)
+                    if (Boons[i].Id == id) Boons[i] = Boons[i] with { Active = true };
+            }
+        }
+    }
+}


### PR DESCRIPTION
2,890 lines, the largest single view in the port. Every shelf, tile, mantra, diary and bench row is built from sample data shaped to hit each builder branch. Six other hub tabs were verified with a throwaway probe render and the probe removed before commit.

One large view per layer: an `.axaml` and its `.axaml.cs` are never split, so these exceed the ~1,000-line guideline. Nothing was dropped to hit a budget.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351