### PR TITLE
feat(avalonia): port EnhancementsTabView, CompanionTabView

### DIFF
--- a/CCP.Avalonia/Views/Tabs/CompanionTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/CompanionTabView.axaml
@@ -1,0 +1,54 @@
+<!-- PORTED from ConditioningControlPanel/Views/Tabs/CompanionTabView.xaml.
+     Deviations:
+       Visibility="Collapsed"     ->  IsVisible="False"
+       AutomationProperties.AutomationId -> AutomationProperties.AutomationId (same attached
+                                     property, Avalonia.Controls.Automation namespace)
+       x:FieldModifier="internal" ->  dropped; the MainWindow partials that poke these fields are
+                                     not on this head. The x:Names are kept.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:cmp="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls.Companion"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.CompanionTabView"
+             mc:Ignorable="d"
+             d:DesignHeight="900" d:DesignWidth="1240">
+
+    <!-- ================================================================
+         THE COMPANION TAB — "Her Room".
+
+         This file used to be 880 lines of settings sheet. It is now the
+         host for one control: CompanionRoomView, the composed nine-zone
+         page (design doc 04). Everything that used to be declared here
+         either moved into a zone or into one of the Workshop's
+         re-parented cells; nothing was duplicated, so every control on
+         this page exists exactly once.
+
+         The tab keeps three jobs:
+           1. own the room and its runtime viewmodel;
+           2. re-expose, by their original x:Names, the controls the
+              MainWindow partials still write to (see the code-behind);
+           3. tell MainWindow when it becomes visible, which is what
+              drives the tab-transition choreography.
+
+         Jobs 1 and 3 are stubbed on this head — see the code-behind for
+         what they wait on.
+
+         The tab's own header is gone on purpose: Z0 draws it, from the
+         hero's viewmodel, so there is one title and not two.
+         ================================================================ -->
+
+    <Grid>
+        <cmp:CompanionRoomView x:Name="Room"
+                               AutomationProperties.AutomationId="CompanionTabRoom"/>
+
+        <!-- COMPAT SEAM. MainWindow.Presets.cs hangs the AI help popup on this button by name.
+             Its old home was the AI Brain card's header, and that card is superseded by the
+             Engine Room (design §6) — which is deliberately unglamorous and has no room for a
+             help chip. Collapsed, exactly like the other kept-hidden compat elements, so
+             SetHelpContent keeps working and nothing renders. -->
+        <Button x:Name="HelpBtnAiChat"
+                Tag="AiChat" IsVisible="False" IsHitTestVisible="False"/>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Tabs/CompanionTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/CompanionTabView.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Tabs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Tabs/CompanionTabView.xaml.cs. The tab is a host
+    /// for one control — <see cref="Controls.Companion.CompanionRoomView"/> — plus the hidden
+    /// HelpBtnAiChat compat element. That much crosses verbatim.
+    ///
+    /// <para><b>What is stubbed, and why it is not a dropped feature.</b> The WPF file's other two
+    /// jobs are the runtime viewmodel and the compat seam: it news up a
+    /// <c>CompanionRoomRuntimeVm</c>, hands it to <c>Room.ViewModel</c>, and re-publishes ~110
+    /// control names (<c>TxtDetachStatusCompanion</c>, the sixteen AiPermissionsGrid names,
+    /// <c>_vm.Shelf.Roster.*</c>, <c>_vm.Shelf.Behavior.*</c>, …) so the seven MainWindow partials
+    /// keep the accessor path they always had. None of that has anywhere to land here: the ported
+    /// <see cref="Controls.Companion.CompanionRoomView"/> has no <c>ViewModel</c> property and no
+    /// <c>Shelf</c> zone viewmodels, and the partials that consume the names are WPF-side. Writing
+    /// 110 properties that return null would be a seam in name only — it would compile, satisfy a
+    /// reader, and break at the first use — so they are deliberately absent rather than faked.
+    /// ponytail: needs CompanionRoomRuntimeVm + the zone viewmodels (ICompanionRoomVm's eight zone
+    /// interfaces), wired when they move to Core; each passthrough is then one line.</para>
+    /// </summary>
+    public partial class CompanionTabView : UserControl
+    {
+        public CompanionTabView()
+        {
+            InitializeComponent();
+
+            // ponytail: `_vm = new CompanionRoomRuntimeVm(() => Window.GetWindow(this) as
+            // MainWindow); Room.ViewModel = _vm;` — needs CompanionRoomRuntimeVm, wired when it
+            // moves to Core. The room seats its own per-zone sample data until then.
+
+            // ponytail: WPF hooks IsVisibleChanged here to call
+            // MainWindow.OnCompanionTabVisibilityChanged, which drives the tab-transition
+            // choreography and parks the room's clocks. Avalonia has no IsVisibleChanged event and
+            // the shell method is WPF-side; the room already parks its own clocks on unload.
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Tabs/EnhancementsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/EnhancementsTabView.axaml
@@ -1,0 +1,141 @@
+<!-- PORTED from ConditioningControlPanel/Views/Tabs/EnhancementsTabView.xaml.
+     Structure, order, spacing and every resource key are preserved so the two can be compared
+     directly. Documented deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"  (keyed styles are ControlThemes)
+       Visibility="Collapsed"            ->  IsVisible="False"
+       helpers:EmojiTextBlock            ->  TextBlock                   (Avalonia draws COLR/CPAL natively)
+       Image + EmojiToImageSource        ->  TextBlock Text="&#x1F512;"  (same reason; no SharpVectors, no pack:// URI)
+       x:FieldModifier="internal"        ->  dropped; the MainWindow partials that poke these
+                                             fields are not on this head. The x:Names are kept, so
+                                             the seam re-forms with a one-line change per field.
+       StartPoint="0,0" EndPoint="0.9,0.7" -> "0%,0%" / "90%,70%": Avalonia reads bare gradient
+                                             points as ABSOLUTE pixels, so the WPF fractions would
+                                             have drawn a sub-pixel wash (i.e. nothing).
+       PreviewMouseWheel                 ->  PointerWheelChanged, tunneling, in code-behind.
+-->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:fx="clr-namespace:ConditioningControlPanel.Avalonia.Controls"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.EnhancementsTabView"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+        <!-- Velvet Kit 2 · round 4 — hue identity, LOCAL literals only. Enhancements runs the
+             house pink, so the SOLID hue is taken from {DynamicResource PinkBrush} instead of a
+             literal - mods retint it - and only the alpha'd wash/border, which have no theme
+             siblings, live here. -->
+        <SolidColorBrush x:Key="TabHueBorderBrush" Color="#40FF69B4"/>
+        <LinearGradientBrush x:Key="TabHueWashBrush" StartPoint="0%,0%" EndPoint="90%,70%">
+            <GradientStop Color="#14FF69B4" Offset="0"/>
+            <GradientStop Color="#00000000" Offset="0.55"/>
+        </LinearGradientBrush>
+    </UserControl.Resources>
+
+    <!-- ================================================================
+         NO 72px HERO HERE, ON PURPOSE. Every other round-4 tab opens with one;
+         this tab cannot afford it. The tab's height is a CONSTANT ~620dip that no
+         window resize gives back - and the skill tree already spends ~505 of it
+         (460 canvas + scrollbar + chrome) with vertical scrolling disabled,
+         leaving the secret rail its budgeted ~90. A hero row would squeeze row 0
+         and silently clip the bottom path of the tree. The tree canvas also draws
+         its own 500dip stats header at x=20, so a second header band would
+         duplicate it as well as overflow.
+         ================================================================ -->
+    <Grid RowDefinitions="*,Auto">
+
+        <!-- Hidden container for named elements (used programmatically) -->
+        <StackPanel IsVisible="False">
+            <TextBlock x:Name="TxtSkillPoints" Text="0"/>
+            <TextBlock x:Name="TxtXpMultiplier" Text="1.00x"/>
+            <TextBlock x:Name="TxtPinkRushIndicator" Text="{loc:Str label_rush}"/>
+            <TextBlock x:Name="TxtConditioningTime" Text="{loc:Str label_0h_0m}"/>
+            <WrapPanel x:Name="ActiveBonusesList"/>
+            <Border x:Name="ActiveBonusesPanel"/>
+        </StackPanel>
+
+        <!-- The board. Background stays a literal AND stays local: DrawSkillTree overwrites it
+             with the animated gradient on every rebuild and MainWindow.Animations.cs type-tests
+             it, so it must not become a theme brush. -->
+        <Border x:Name="SkillTreeOuterBorder" Background="#151528" CornerRadius="12"
+                BorderBrush="{StaticResource VelvetCardBorderBrush}" BorderThickness="2"
+                Padding="4" Margin="20,3,20,8">
+            <Grid ClipToBounds="True">
+                <!-- The tab's one ambient particle loop, behind the tree. It sits OUTSIDE the
+                     ScrollViewer on purpose: the tree canvas is 3760dip wide, so a dust field
+                     parented to it would size a surface eight screens wide to draw a viewport's
+                     worth of sparks.
+                     ponytail: StartLayers/RegisterTabFx is MainWindow.EnhancementsFx.cs's job
+                     (DustField at 0.55 intensity, parked on tab switch); wired when that moves to
+                     Core. The canvas parks itself when unloaded either way. -->
+                <fx:AmbientFxCanvas x:Name="SkillTreeFx"/>
+
+                <!-- ponytail: local drop of SkillTreeScrollViewerStyle
+                     (Resources/Theme/MainWindow.xaml:1198). That WPF template exists only to strip
+                     the vertical scrollbar out of the ScrollViewer chrome; Avalonia's stock
+                     ScrollViewer with VerticalScrollBarVisibility="Disabled" already draws exactly
+                     that, and a property-only ControlTheme here would blank the control (CLAUDE.md
+                     trap 4). -->
+                <ScrollViewer x:Name="SkillTreeScroller"
+                              HorizontalScrollBarVisibility="Visible"
+                              VerticalScrollBarVisibility="Disabled">
+                    <Canvas x:Name="SkillTreeCanvas" Width="3760" Height="460" HorizontalAlignment="Left">
+                        <!-- Header and skill nodes are drawn programmatically (see code-behind) -->
+                    </Canvas>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+
+        <!-- ============================================================ -->
+        <!-- Secret skills rail.                                          -->
+        <!--                                                              -->
+        <!-- The three IsSecret nodes are deliberately kept OFF the tree  -->
+        <!-- canvas: a secret that owns a visible slot between two        -->
+        <!-- ordinary nodes stops being one, and it has no prerequisite   -->
+        <!-- to hang a connection line off. They live here instead, one   -->
+        <!-- card per secret, "???" until its requirement is met.         -->
+        <!--                                                              -->
+        <!-- HEIGHT IS BUDGETED: this row must stay under ~90dip end to   -->
+        <!-- end, which is what sizes the cards and why the section title -->
+        <!-- sits beside them, not above.                                 -->
+        <!-- ============================================================ -->
+        <Border Grid.Row="1" Theme="{StaticResource SettingCardStyle}" Margin="20,0,20,8">
+            <Grid>
+                <Border Background="{StaticResource TabHueWashBrush}" CornerRadius="11"/>
+                <Border Width="3" HorizontalAlignment="Left" Margin="0,8" CornerRadius="0,2,2,0"
+                        Background="{DynamicResource PinkBrush}"/>
+                <Grid Margin="16,5,16,6" ColumnDefinitions="Auto,*">
+                    <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <TextBlock Text="{loc:Str label_secret_skills}"
+                                   Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="12" FontWeight="Bold"/>
+                        <TextBlock Text="{loc:Str label_secret_skills_sub}"
+                                   Foreground="{StaticResource TextMutedBrush}" FontSize="9" FontStyle="Italic"
+                                   Margin="0,1,0,0"/>
+                    </StackPanel>
+                    <WrapPanel x:Name="SecretSkills" Grid.Column="1"
+                               Orientation="Horizontal" VerticalAlignment="Center"/>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <!-- Login Required Overlay. Still the LAST sibling of the root Grid and still RowSpan=2,
+             so the gate covers the tree AND the secret rail. -->
+        <Border x:Name="EnhancementsLoginOverlay" Grid.RowSpan="2" Background="#E6151528" CornerRadius="12"
+                BorderBrush="{StaticResource TabHueBorderBrush}" BorderThickness="2"
+                Margin="20,3,20,8" IsVisible="False">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="40">
+                <TextBlock Text="&#x1F512;" FontSize="44" HorizontalAlignment="Center" Margin="0,0,0,15"/>
+                <TextBlock Text="{loc:Str label_login_required}" Foreground="{DynamicResource PinkBrush}" FontSize="22" FontWeight="Bold"
+                           HorizontalAlignment="Center" Margin="0,0,0,10"/>
+                <TextBlock Text="{loc:Str label_log_in_with_discord_or_patreon_to_access_enha}"
+                           Foreground="{StaticResource TextSecondaryBrush}" FontSize="14" HorizontalAlignment="Center"
+                           TextAlignment="Center" TextWrapping="Wrap" MaxWidth="350"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Tabs/EnhancementsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/EnhancementsTabView.axaml.cs
@@ -1,0 +1,248 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Tabs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Tabs/EnhancementsTabView.xaml.cs.
+    ///
+    /// <para>The WPF original is one handler wide: the skill tree's wheel redirect. It ports for
+    /// real - it touches nothing but the ScrollViewer it is attached to.</para>
+    ///
+    /// <para>What is NOT here is the tab's content. Both the tree canvas and the secret rail are
+    /// filled by MainWindow.Enhancements.cs (DrawSkillTree / PopulateSecretSkills) off
+    /// <c>App.SkillTree</c> and <c>Models.SkillDefinition.All</c>, neither of which is on this head.
+    /// This file paints a SAMPLE of each instead, with the real loc keys, so the 460dip board and
+    /// the 90dip rail do not render as two unexplained blanks in the render proof.
+    /// ponytail: needs SkillTreeService + SkillDefinition, wired when they move to Core.</para>
+    /// </summary>
+    public partial class EnhancementsTabView : UserControl
+    {
+        /// <summary>Node box, verbatim from MainWindow.Enhancements.cs (NodeWidth/NodeHeight).</summary>
+        private const double NodeWidth = 156, NodeHeight = 139;
+
+        /// <summary>Rail card box, verbatim from MainWindow.Enhancements.cs.</summary>
+        private const double SecretCardWidth = 180, SecretCardHeight = 56;
+
+        public EnhancementsTabView()
+        {
+            InitializeComponent();
+
+            // Tunneling, like WPF's Preview- pair, so the redirect wins before the ScrollViewer's
+            // own handler consumes the wheel.
+            SkillTreeScroller.AddHandler(PointerWheelChangedEvent, OnSkillTreeWheel, RoutingStrategies.Tunnel);
+
+            PaintSampleTree();
+            PaintSampleSecretRail();
+        }
+
+        /// <summary>
+        /// Redirects vertical wheel to horizontal scrolling for the skill tree — EXCEPT when the
+        /// wheel is over a nested vertically-scrollable region (the tree-header panel with its
+        /// stats/analytics expanders). There we yield so the inner viewer scrolls vertically;
+        /// otherwise its content below the canvas fold would be unreachable.
+        ///
+        /// <para>The step is 60px, not WPF's <c>Delta * 0.5</c>: WPF reports ±120 per notch and
+        /// Avalonia reports ±1, so keeping the multiplier would have scrolled half a pixel.</para>
+        /// </summary>
+        private void OnSkillTreeWheel(object? sender, PointerWheelEventArgs e)
+        {
+            const double stepPerNotch = 60;
+
+            for (var el = e.Source as Visual; el is not null && el != SkillTreeScroller; el = el.GetVisualParent())
+            {
+                if (el is ScrollViewer inner && inner.Extent.Height > inner.Viewport.Height)
+                    return; // let the inner viewer take the wheel (vertical scroll)
+            }
+
+            var offset = SkillTreeScroller.Offset;
+            SkillTreeScroller.Offset = new Vector(offset.X - e.Delta.Y * stepPerNotch, offset.Y);
+            e.Handled = true;
+        }
+
+        // =====================================================================================
+        //  sample content — see the class summary
+        // =====================================================================================
+
+        /// <summary>
+        /// The header block plus the root node and the first node of each of the three paths, at
+        /// the coordinates DrawSkillTree uses (header at x=5, root at 570, columns 270 apart, rows
+        /// 160 apart), with the connection lines drawn behind them.
+        /// </summary>
+        private void PaintSampleTree()
+        {
+            const double startX = 570, colSpacing = 270, rowSpacing = 160;
+            double rootY = rowSpacing;
+
+            var branches = new (string Key, double X, double Y)[]
+            {
+                ("skill_ditzy_data_name",       startX + colSpacing, 0),
+                ("skill_sparkle_boost_1_name",  startX + colSpacing, rowSpacing),
+                ("skill_good_girl_streak_name", startX + colSpacing, rowSpacing * 2),
+            };
+
+            // Lines first, so they sit behind the nodes.
+            foreach (var b in branches)
+                SkillTreeCanvas.Children.Add(Connector(
+                    startX + NodeWidth, rootY + NodeHeight / 2,
+                    b.X, b.Y + NodeHeight / 2));
+
+            SkillTreeCanvas.Children.Add(Place(SampleHeader(), 5, 0));
+            SkillTreeCanvas.Children.Add(Place(SampleNode("skill_pink_hours_name", owned: true), startX, rootY));
+            foreach (var b in branches)
+                SkillTreeCanvas.Children.Add(Place(SampleNode(b.Key, owned: false), b.X, b.Y));
+        }
+
+        private static Control Place(Control c, double left, double top)
+        {
+            Canvas.SetLeft(c, left);
+            Canvas.SetTop(c, top);
+            return c;
+        }
+
+        private static Control Connector(double x1, double y1, double x2, double y2) => new Line
+        {
+            StartPoint = new Point(x1, y1),
+            EndPoint = new Point(x2, y2),
+            Stroke = new SolidColorBrush(Color.FromRgb(0x4A, 0x3A, 0x5C)),
+            StrokeThickness = 2,
+        };
+
+        /// <summary>The 500dip stats header CreateSkillTreeHeader draws at the start of the canvas.</summary>
+        private static Control SampleHeader()
+        {
+            var stack = new StackPanel();
+
+            stack.Children.Add(Text("✨ " + Loc.Get("label_enhancement_tree_title"),
+                Color.FromRgb(0xFF, 0x69, 0xB4), 22, bold: true));
+            stack.Children.Add(Text(Loc.Get("label_enhancement_tree_subtitle"),
+                Color.FromRgb(0xB0, 0xB0, 0xB0), 11, italic: true, top: 4));
+            stack.Children.Add(Text(Loc.Get("label_enhancement_tree_warning"),
+                Color.FromRgb(0x88, 0xAA, 0xCC), 10, italic: true, top: 2));
+
+            var points = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Center };
+            points.Children.Add(new TextBlock
+            {
+                Text = "💎",
+                FontSize = 24,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 10, 0),
+            });
+            var info = new StackPanel();
+            info.Children.Add(Text(Loc.Get("label_sparkle_points"), Color.FromRgb(0xB0, 0xB0, 0xB0), 10));
+            // ponytail: the real count is settings.SkillPoints; needs SettingsService.
+            info.Children.Add(Text("0", Color.FromRgb(0xFF, 0x69, 0xB4), 24, bold: true));
+            points.Children.Add(info);
+
+            stack.Children.Add(new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x4A)),
+                CornerRadius = new CornerRadius(12),
+                Padding = new Thickness(15, 10, 15, 10),
+                Margin = new Thickness(0, 15, 0, 0),
+                Child = points,
+            });
+
+            return new Border
+            {
+                Width = 500,
+                Background = new SolidColorBrush(Color.FromRgb(0x1E, 0x1E, 0x3C)),
+                CornerRadius = new CornerRadius(12),
+                Padding = new Thickness(15, 8, 15, 15),
+                Child = stack,
+            };
+        }
+
+        private static Control SampleNode(string nameKey, bool owned)
+        {
+            var body = new StackPanel { VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(10) };
+            body.Children.Add(new TextBlock
+            {
+                Text = owned ? "⭐" : "💠",
+                FontSize = 28,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 0, 0, 8),
+            });
+            var name = Text(Loc.Get(nameKey), owned ? Color.FromRgb(0x64, 0xFF, 0x96) : Color.FromRgb(0xE6, 0xE6, 0xF0), 12, bold: true);
+            name.HorizontalAlignment = HorizontalAlignment.Center;
+            name.TextAlignment = TextAlignment.Center;
+            name.TextWrapping = TextWrapping.Wrap;
+            body.Children.Add(name);
+
+            return new Border
+            {
+                Width = NodeWidth,
+                Height = NodeHeight,
+                CornerRadius = new CornerRadius(10),
+                ClipToBounds = true,
+                Background = new SolidColorBrush(Color.FromRgb(0x22, 0x1E, 0x36)),
+                BorderThickness = new Thickness(owned ? 2 : 1),
+                BorderBrush = new SolidColorBrush(owned ? Color.FromRgb(0x64, 0xFF, 0x96) : Color.FromRgb(0x3C, 0x32, 0x46)),
+                Child = body,
+            };
+        }
+
+        /// <summary>
+        /// Three hidden secret cards, exactly what PopulateSecretSkills draws while none of the
+        /// three requirements is met: the padlock, the withheld-name label, and the hint.
+        /// </summary>
+        private void PaintSampleSecretRail()
+        {
+            foreach (var id in new[] { "night_shift", "early_bird_bimbo", "eternal_doll" })
+                SecretSkills.Children.Add(HiddenSecretCard(Loc.Get($"rf_skill_{id}_req")));
+        }
+
+        private static Control HiddenSecretCard(string requirement)
+        {
+            var body = new Grid { ColumnDefinitions = new ColumnDefinitions("Auto,*") };
+            body.Children.Add(new TextBlock
+            {
+                Text = "🔒",
+                FontSize = 18,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 0, 8, 0),
+            });
+
+            var text = new StackPanel { VerticalAlignment = VerticalAlignment.Center };
+            Grid.SetColumn(text, 1);
+            text.Children.Add(Text(Loc.Get("label_secret_skill_hidden"), Color.FromRgb(0x99, 0x32, 0xCC), 11, bold: true));
+            var hint = Text(requirement, Color.FromRgb(0x80, 0x80, 0x80), 8, top: 1);
+            hint.TextWrapping = TextWrapping.Wrap;
+            text.Children.Add(hint);
+            body.Children.Add(text);
+
+            return new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(30, 20, 40)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(80, 60, 100)),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(8),
+                Width = SecretCardWidth,
+                Height = SecretCardHeight,
+                Margin = new Thickness(0, 3, 10, 3),
+                Padding = new Thickness(8, 6, 8, 6),
+                Opacity = 0.6,
+                Child = body,
+            };
+        }
+
+        private static TextBlock Text(string text, Color colour, double size,
+                                      bool bold = false, bool italic = false, double top = 0) => new()
+        {
+            Text = text,
+            Foreground = new SolidColorBrush(colour),
+            FontSize = size,
+            FontWeight = bold ? FontWeight.Bold : FontWeight.Normal,
+            FontStyle = italic ? FontStyle.Italic : FontStyle.Normal,
+            Margin = new Thickness(0, top, 0, 0),
+        };
+    }
+}


### PR DESCRIPTION
482 lines. Found that Avalonia's wheel Delta is ±1, not WPF's ±120, so the skill-tree scroll needed a real step. The 110 compat passthroughs the WPF tab exposes are deliberately absent rather than stubbed: null-returning properties would be a fake seam.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the render. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351