### PR TITLE
feat(avalonia): port AvailableSubjectsTabView, ExclusivesTabView

### DIFF
--- a/CCP.Avalonia/Views/Tabs/AvailableSubjectsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/AvailableSubjectsTabView.axaml
@@ -1,0 +1,253 @@
+<!-- PORTED from ConditioningControlPanel/Views/Tabs/AvailableSubjectsTabView.xaml.
+     Structure, ordering, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       <Style x:Key TargetType>          ->  <ControlTheme x:Key TargetType>, applied with Theme=
+       ControlTemplate.Triggers          ->  ^:pointerover / ^:disabled nested selectors
+       <ContentPresenter/>               ->  Content="{TemplateBinding Content}" (trap 6: a bare
+                                             presenter draws NOTHING in Avalonia)
+       Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1: "_" is an access key and
+                                             every loc key here is snake_case)
+       Image + EmojiToImageSource        ->  TextBlock (Avalonia renders colour emoji natively)
+       Visibility="Collapsed"            ->  IsVisible="False"
+       BoolToVisibility                  ->  IsVisible="{Binding HasStatusText}" / "{Binding HasTags}"
+       ToolTip="..."                     ->  ToolTip.Tip="..."
+       x:FieldModifier="internal"        ->  dropped; the x:Names are kept and reached with FindControl
+       <Run Text="{Binding Level}"/>     ->  {Binding LevelDisplay}, the int pre-formatted on the row,
+                                             so the "Lv " Run pair needs no converter
+
+     Dropped, each for a reason that is not a shortcut:
+       PreviewMouseWheel on the scroller - it forwarded to MainWindow only to turn a vertical
+         wheel notch into horizontal scrolling. Avalonia's ScrollViewer already scrolls
+         horizontally when it cannot scroll vertically, so there is nothing to undo.
+       PreviewMouseLeftButtonDown/Up + MouseLeave on Connect - MotionFx.PressSquish, which lives
+         in the WPF head. See the code-behind.
+
+     The roster is placeholder data built in the code-behind (App.AvailableSubjects is a WPF-head
+     service): four rows covering every branch the template carries - status text, tags, a claimed
+     row (dimmed + disabled Connect) and a bare one. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:fx="clr-namespace:ConditioningControlPanel.Avalonia.Controls"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:tabs="clr-namespace:ConditioningControlPanel.Avalonia.Views.Tabs"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.AvailableSubjectsTabView"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+
+        <!-- The CTA's WPF Button.Style, verbatim: purple plate, white text, 8px radius,
+             hover dims the plate to 0.9. -->
+        <ControlTheme x:Key="SubjectsCtaButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource NeonPurpleBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" CornerRadius="8"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Opacity" Value="0.9"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The card's Connect button. Same plate; disabled repaints it to the muted violet
+             the "Taken" state wears. -->
+        <ControlTheme x:Key="SubjectsConnectButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource NeonPurpleBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" CornerRadius="8"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:disabled /template/ Border#border">
+                <Setter Property="Background" Value="#3A2E5A"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Foreground" Value="White"/>
+            </Style>
+        </ControlTheme>
+
+    </UserControl.Resources>
+
+    <Grid Margin="36,28,36,28" RowDefinitions="Auto,Auto,*">
+
+        <!-- ============================================================ -->
+        <!-- AMBIENT LAYER - the one looping FX on this tab: a very sparse -->
+        <!-- fog drift behind the roster. Declared FIRST so it is the      -->
+        <!-- bottom of the grid's z-order; the cards paint their own opaque-->
+        <!-- surfaces on top, so the mist only reads through the gutters.  -->
+        <!--                                                              -->
+        <!-- Two puffs at low intensity, not the default three: this tab is-->
+        <!-- a roster you scan, and the air behind it must never compete   -->
+        <!-- with a name. The tint comes from FxTheme (the mod's mist      -->
+        <!-- colour), so it follows the active mod instead of being nailed -->
+        <!-- to one hex - see MainWindow.SubjectsFx for why that is not    -->
+        <!-- literally NeonPurple.                                        -->
+        <!--                                                              -->
+        <!-- AmbientFxCanvas is hit-test invisible by construction and runs -->
+        <!-- a self-stopping clock. MainWindow.SubjectsFx starts it and     -->
+        <!-- registers it with RegisterTabFx; on this head the code-behind  -->
+        <!-- starts it with the same tuning and stops it on unload.         -->
+        <!-- ============================================================ -->
+        <fx:AmbientFxCanvas x:Name="SubjectsAmbientFx" Grid.Row="0" Grid.RowSpan="3"/>
+
+        <!-- Header -->
+        <Grid Grid.Row="0" Margin="0,0,0,18" ColumnDefinitions="Auto,*,Auto">
+            <TextBlock Grid.Column="0" Text="🛰️" FontSize="30" Width="44"
+                       TextAlignment="Center" VerticalAlignment="Center" Margin="0,0,16,0"/>
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <TextBlock Text="{loc:Str tab_available_subjects}"
+                           Foreground="{DynamicResource NeonPurpleBrush}"
+                           FontSize="26" FontWeight="Bold"/>
+                <TextBlock Text="{loc:Str desc_available_subjects}"
+                           Foreground="{DynamicResource TextMutedBrush}"
+                           FontSize="13" Margin="0,4,0,0" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- "Become a subject!" CTA. Free users get the button +
+                 italic subtitle pointing to Patreon; premium users get
+                 the button alone, opening the Remote Control tab. -->
+            <StackPanel Grid.Column="2" VerticalAlignment="Center"
+                        HorizontalAlignment="Right" MaxWidth="260" Margin="16,0,0,0">
+                <Button x:Name="BtnBecomeASubject"
+                        Theme="{StaticResource SubjectsCtaButton}"
+                        Click="BtnBecomeASubject_Click"
+                        ToolTip.Tip="{loc:Str tooltip_become_a_subject}"
+                        FontSize="13" FontWeight="Bold"
+                        Padding="16,9" BorderThickness="0" Cursor="Hand"
+                        HorizontalAlignment="Right">
+                    <TextBlock Text="{loc:Str btn_become_a_subject}"/>
+                </Button>
+                <TextBlock x:Name="TxtBecomeASubjectSubtitle"
+                           Text="{loc:Str desc_become_a_subject_locked}"
+                           Foreground="{DynamicResource TextMutedBrush}"
+                           FontSize="11" FontStyle="Italic"
+                           Margin="0,6,0,0" TextWrapping="Wrap"
+                           TextAlignment="Right"
+                           IsVisible="False"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Empty state (visible iff service.IsEmpty + !HasError) -->
+        <Border Grid.Row="1" x:Name="AvailableSubjectsEmptyPanel"
+                Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{DynamicResource NeonPurpleBrush}" BorderThickness="1"
+                CornerRadius="10" Padding="24,18" Margin="0,0,0,12"
+                IsVisible="False">
+            <TextBlock Text="{loc:Str empty_available_subjects}"
+                       Foreground="{DynamicResource TextMutedBrush}"
+                       FontSize="13" TextWrapping="Wrap" LineHeight="20"/>
+        </Border>
+
+        <!-- Error state (visible iff service.HasError) -->
+        <Border Grid.Row="1" x:Name="AvailableSubjectsErrorPanel"
+                Background="{DynamicResource SurfaceBgBrush}"
+                BorderBrush="{DynamicResource DangerBrush}" BorderThickness="1"
+                CornerRadius="10" Padding="24,18" Margin="0,0,0,12"
+                IsVisible="False">
+            <TextBlock Text="{loc:Str error_available_subjects}"
+                       Foreground="{DynamicResource TextMutedBrush}"
+                       FontSize="13" TextWrapping="Wrap" LineHeight="20"/>
+        </Border>
+
+        <!-- Side-scrollable horizontal card list. ItemsSource is bound
+             in code-behind to App.AvailableSubjects.Entries. Each card
+             gets a fixed 260px width to keep horizontal scrolling
+             intentional rather than incidental. -->
+        <ScrollViewer Grid.Row="2" x:Name="AvailableSubjectsScroller"
+                      HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Disabled">
+            <ItemsControl x:Name="AvailableSubjectsList">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="tabs:SubjectRow">
+                        <Border Width="260" Margin="0,0,12,4" Opacity="{Binding CardOpacity}"
+                                Background="{DynamicResource SurfaceBgBrush}"
+                                BorderBrush="{DynamicResource NeonPurpleBrush}"
+                                BorderThickness="1" CornerRadius="10" Padding="18,14">
+                            <StackPanel>
+                                <!-- Top row: name + level + tier badge -->
+                                <Grid Margin="0,0,0,8" ColumnDefinitions="*,Auto">
+                                    <StackPanel Grid.Column="0">
+                                        <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                   FontSize="15" FontWeight="Bold" TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="11" Margin="0,2,0,0">
+                                            <Run Text="Lv "/><Run Text="{Binding LevelDisplay}"/>
+                                        </TextBlock>
+                                    </StackPanel>
+                                    <Border Grid.Column="1" Background="{DynamicResource NeonPurpleTransparent20Brush}"
+                                            CornerRadius="9999" Padding="8,3" VerticalAlignment="Top">
+                                        <TextBlock Text="{Binding TierLabel}"
+                                                   Foreground="{DynamicResource NeonPurpleBrush}"
+                                                   FontSize="10" FontWeight="Bold"/>
+                                    </Border>
+                                </Grid>
+
+                                <!-- Status text (only when present) -->
+                                <TextBlock Text="{Binding StatusText}" Foreground="{DynamicResource TextMutedBrush}"
+                                           FontSize="12" TextWrapping="Wrap" Margin="0,0,0,8"
+                                           IsVisible="{Binding HasStatusText}"/>
+
+                                <!-- Tags as pill badges (mirrors cclabs-web /dashboard/subjects) -->
+                                <ItemsControl ItemsSource="{Binding Tags}" Margin="0,0,0,12"
+                                              IsVisible="{Binding HasTags}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel Orientation="Horizontal"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="x:String">
+                                            <Border Background="{DynamicResource NeonPurpleTransparent20Brush}"
+                                                    CornerRadius="9999" Padding="7,2" Margin="0,0,5,5">
+                                                <TextBlock Text="{Binding}"
+                                                           Foreground="{DynamicResource NeonPurpleBrush}"
+                                                           FontSize="10" FontWeight="SemiBold"/>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+
+                                <!-- Connect button (or Taken disabled) -->
+                                <Button Theme="{StaticResource SubjectsConnectButton}"
+                                        Tag="{Binding UnifiedId}"
+                                        IsEnabled="{Binding IsConnectEnabled}"
+                                        Click="BtnConnectSubject_Click"
+                                        FontSize="13" FontWeight="Bold"
+                                        Padding="0,8" BorderThickness="0" Cursor="Hand"
+                                        HorizontalAlignment="Stretch"
+                                        HorizontalContentAlignment="Center">
+                                    <TextBlock Text="{Binding ConnectButtonText}"/>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Tabs/AvailableSubjectsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AvailableSubjectsTabView.axaml.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using ConditioningControlPanel.Avalonia.Controls;
+
+namespace ConditioningControlPanel.Avalonia.Views.Tabs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Tabs/AvailableSubjectsTabView.xaml.cs.
+    ///
+    /// <para>The WPF code-behind owns no logic of its own: every handler looks up the hosting
+    /// MainWindow and forwards. Two of those forwards ARE ported, because what they forwarded to
+    /// is canvas tuning rather than a service - the ambient fog's layers and intensity, copied
+    /// from MainWindow.SubjectsFx (two puffs, 0.40). The rest are stubs.</para>
+    ///
+    /// <para>Dropped: AvailableSubjectsScroller_PreviewMouseWheel. It existed only to turn a
+    /// vertical wheel notch into horizontal scrolling on a scroller whose vertical axis is
+    /// disabled; Avalonia's ScrollViewer already does that, so there is nothing to undo.</para>
+    /// </summary>
+    public partial class AvailableSubjectsTabView : UserControl
+    {
+        /// <summary>Sparse on purpose - MainWindow.SubjectsFx: the air behind a roster you read
+        /// must never compete with a name.</summary>
+        private const int SubjectsFogPuffs = 2;
+        private const double SubjectsFogIntensity = 0.40;
+
+        private readonly AmbientFxCanvas _ambientFx;
+
+        public AvailableSubjectsTabView()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _ambientFx = this.FindControl<AmbientFxCanvas>("SubjectsAmbientFx")!;
+
+            LoadPlaceholderRoster();
+
+            // WPF hooked IsVisibleChanged and let MainWindow start/park the canvas through
+            // RegisterTabFx. There is no tab host on this head, so the view starts its own fog
+            // and stops it on unload - the canvas self-gates on motion and window focus anyway.
+            Loaded += OnTabLoaded;
+            Unloaded += OnTabUnloaded;
+        }
+
+        private void OnTabLoaded(object? sender, RoutedEventArgs e)
+            => _ambientFx.StartLayers(new AmbientFxConfig
+            {
+                Layers = AmbientFxLayers.FogDrift,
+                FogPuffs = SubjectsFogPuffs,
+                Intensity = SubjectsFogIntensity,
+            });
+
+        private void OnTabUnloaded(object? sender, RoutedEventArgs e) => _ambientFx.Stop();
+
+        // ------------------------------------------------------------------
+        // Placeholder roster
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Four sample subjects, one per branch the card template carries: a plain row, one with
+        /// status text, one with tags, and a claimed row (dimmed to 0.6 with a disabled "Taken"
+        /// button) - so the render proof exercises the markup rather than one happy path.
+        ///
+        /// ponytail: needs AvailableSubjectsService + DirectoryEntry, both pinned to the WPF head
+        /// (the service polls over App.Http and marshals onto System.Windows.Application).
+        /// Wired when they move to Core; SubjectRow mirrors DirectoryEntry's shape so the swap is
+        /// a rename.
+        /// </summary>
+        private void LoadPlaceholderRoster()
+        {
+            var rows = new List<SubjectRow>
+            {
+                new() { UnifiedId = "u1", DisplayName = "velvet_hush", Level = 41, Tier = "full",
+                        StatusText = "Deep in a spiral session. Say hello.",
+                        Tags = new List<string> { "obedient", "voice", "long sessions" } },
+                new() { UnifiedId = "u2", DisplayName = "Nyx", Level = 27, Tier = "standard",
+                        Tags = new List<string> { "haptics", "mantras" } },
+                new() { UnifiedId = "u3", DisplayName = "spiral.doll", Level = 19, Tier = "light",
+                        StatusText = "Taking it slow today.", Claimed = true },
+                new() { UnifiedId = "u4", DisplayName = "blink", Level = 8, Tier = "light" },
+            };
+
+            this.FindControl<ItemsControl>("AvailableSubjectsList")!.ItemsSource = rows;
+        }
+
+        // ------------------------------------------------------------------
+        // Stubs for what MainWindow owned
+        // ------------------------------------------------------------------
+        // ponytail: BtnBecomeASubject_Click needs App.Patreon (free users go to Patreon, premium
+        // users to the Remote Control tab) and BtnConnectSubject_Click needs
+        // AvailableSubjectsService.TryClaimAsync plus MainWindow.ShowTab. Both are WPF-head
+        // services; wired when they move to Core, so the buttons are inert rather than wrong.
+
+        private void BtnBecomeASubject_Click(object? sender, RoutedEventArgs e) { }
+
+        private void BtnConnectSubject_Click(object? sender, RoutedEventArgs e) { }
+    }
+
+    /// <summary>
+    /// One roster card's data. The Avalonia-side stand-in for
+    /// Services.AvailableSubjectsService.DirectoryEntry, whose derived members - TierLabel,
+    /// HasTags, HasStatusText, IsConnectEnabled, ConnectButtonText, CardOpacity - are copied
+    /// verbatim, including the two hard-coded English strings ("Connect"/"Taken"): they are
+    /// literals in the original, not loc keys, and inventing keys for them here would put a
+    /// string in the catalogue that the real model cannot use.
+    /// </summary>
+    public sealed class SubjectRow
+    {
+        public string UnifiedId { get; set; } = "";
+        public string DisplayName { get; set; } = "Anonymous";
+        public int Level { get; set; }
+        public List<string> Tags { get; set; } = new();
+        public string StatusText { get; set; } = "";
+        public string Tier { get; set; } = "light";
+        public bool Claimed { get; set; }
+
+        /// <summary>The level as text, so the "Lv " Run pair needs no converter.</summary>
+        public string LevelDisplay => Level.ToString(CultureInfo.CurrentCulture);
+
+        public string TierLabel => Tier switch
+        {
+            "light" => "LIGHT",
+            "standard" => "STANDARD",
+            "full" => "FULL",
+            _ => Tier.ToUpperInvariant()
+        };
+
+        public bool HasTags => Tags != null && Tags.Count > 0;
+        public bool HasStatusText => !string.IsNullOrEmpty(StatusText);
+        public bool IsConnectEnabled => !Claimed;
+        public string ConnectButtonText => Claimed ? "Taken" : "Connect";
+        public double CardOpacity => Claimed ? 0.6 : 1.0;
+    }
+}

--- a/CCP.Avalonia/Views/Tabs/ExclusivesTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/ExclusivesTabView.axaml
@@ -1,0 +1,440 @@
+<!-- PORTED from ConditioningControlPanel/Views/Tabs/ExclusivesTabView.xaml.
+     Structure, ordering, spacing, every x:Name and every loc key are preserved so the two diff
+     directly. Deviations, all forced by real WPF/Avalonia differences:
+
+       Style="{StaticResource X}"        ->  Theme="{StaticResource X}"  (keyed styles are ControlThemes)
+       Visibility="Collapsed"            ->  IsVisible="False"
+       Panel.ZIndex                      ->  ZIndex
+       MouseLeftButtonUp                 ->  PointerReleased  (house precedent)
+       Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1: "_" is an access key)
+       DropShadowEffect ShadowDepth="0"  ->  OffsetX="0" OffsetY="0" (Avalonia defaults to 3.5)
+       LinearGradientBrush "0,0"/"1,0"   ->  "0%,0%"/"100%,0%": Avalonia gradient points are
+                                             absolute pixels unless a percentage is written, so
+                                             the WPF form would draw a one-pixel gradient
+       RenderTransformOrigin="0.5,0.5"   ->  "50%,50%"  (same reason)
+       x:FieldModifier="internal"        ->  dropped; the x:Names are kept and reached with FindControl
+       x:Name on a Brush / Transform     ->  dropped (AVLN2000: only a StyledElement can be named).
+                                             VaultHeroBrush, SpotBadgeFill, SpotVeilPillFill and
+                                             SpotArtScale are gone; the Borders around them keep theirs.
+       FontFamily="/Fonts/#Fredoka, …"   ->  dropped; the head ships Inter (Leaderboard precedent)
+
+     Dropped, each for a reason that is not a shortcut:
+       every pack:// image - the vault backdrop, the hero's vault.png plate, the spotlight art and
+         the two Patreon tier plates. This head ships no Resources/ art (DeeperTabView precedent).
+         The room keeps its scrim and its ambient canvas, the hero and the spotlight get the page's
+         own glyph huge and nearly transparent (SystemFeatureControl:221 idiom), and the tier plates
+         become the small vector plates TierBadge already uses in place of its own PNGs. Re-add as
+         avares:// bitmaps when the art moves.
+       Border.OpacityMask on the hero plate - moot once the art under it is gone.
+       RoundClipOnResize(SpotArtHost, 12) - WPF's ClipToBounds is rectangular, so a rounded host
+         needed clip geometry tracked against every resize. An Avalonia Border clips its child to
+         its own CornerRadius, so the helper has nothing left to do and is not ported.
+       the Ken Burns ScaleTransform on the spotlight art - the drift is started by
+         MainWindow.Exclusives.cs and there is no art to drift.
+
+     The shelf: WPF leaves the WrapPanel empty and MainWindow.Exclusives.cs builds every card in
+     code from ExclusiveFeature.All. That builder is MainWindow's, not the view's, so the panel is
+     an ItemsControl over a WrapPanel here and the cards are a DataTemplate fed placeholder rows
+     from the code-behind - six features covering tier 1, tier 2, untiered, a NEW badge, a BETA
+     badge, no badge, a locked veil and both entitlement chips. The three "coming soon" teaser
+     silhouettes (BuildComingSoonCard) are likewise MainWindow's and are not reproduced. -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:fx="clr-namespace:ConditioningControlPanel.Avalonia.Controls"
+             xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+             xmlns:tabs="clr-namespace:ConditioningControlPanel.Avalonia.Views.Tabs"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.ExclusivesTabView"
+             mc:Ignorable="d"
+             d:DesignHeight="620" d:DesignWidth="1460">
+
+    <UserControl.Resources>
+        <!-- Velvet Kit 2 · round 4 — the vault's hue identity. LOCAL literals only:
+             a Theme dictionary may not resolve a StaticResource from another dictionary
+             (deferred-BAML EndOfStreamException), and these three keys are wanted by
+             exactly one tab. Vault gold #FFC94E is the tier livery, kept at the house
+             alphas: full / 0x40 border / 0x14 wash. -->
+        <SolidColorBrush x:Key="TabHueBrush" Color="#FFC94E"/>
+        <SolidColorBrush x:Key="TabHueBorderBrush" Color="#40FFC94E"/>
+        <LinearGradientBrush x:Key="TabHueWashBrush" StartPoint="0%,0%" EndPoint="90%,70%">
+            <GradientStop Color="#14FFC94E" Offset="0"/>
+            <GradientStop Color="#00000000" Offset="0.55"/>
+        </LinearGradientBrush>
+    </UserControl.Resources>
+
+    <!-- ================================================================
+         EXCLUSIVES — "The Velvet Vault"
+         A living gallery replacing the old launcher popup. Three strata:
+           1. The room  — a dark scrim with an AmbientFxCanvas (fog + dust
+                          + aurora) breathing over it. The painted backdrop
+                          under it is WPF-head art; see the header note.
+           2. The header — the 72px Velvet hero (vault art + gold edge,
+                          title/subtitle left, tier plates in the pill).
+           3. The shelf  — spotlight hero (newest exclusive) + the card
+                          grid, built from ExclusiveFeature.All by
+                          MainWindow.Exclusives.cs. Cards never block
+                          navigation; destination tabs own the real gates.
+         Round 4 deliberately does NOT take the capped-column + side-art
+         layout the settings pages got: this tab is already all art, and a
+         2:3 art plate on the right would cost the shelf one 336px card per
+         row for a picture the room is already showing.
+         ================================================================ -->
+    <Border CornerRadius="12" ClipToBounds="True" Background="#12101F"
+            BorderBrush="{StaticResource TabHueBorderBrush}" BorderThickness="1">
+        <Grid>
+            <!-- 1. The room. scrim so content always reads over the painting -->
+            <Border>
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                        <GradientStop Color="#D912101F" Offset="0"/>
+                        <GradientStop Color="#9912101F" Offset="0.25"/>
+                        <GradientStop Color="#C41A1430" Offset="0.62"/>
+                        <GradientStop Color="#F012101F" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+            </Border>
+            <fx:AmbientFxCanvas x:Name="ExclusivesAmbientFx"/>
+
+            <!-- 2 + 3. Content -->
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <StackPanel Margin="26,20,26,22">
+
+                    <!-- HERO. Round-4 parity: the 72px plate every treated page wears
+                         (SpiralFeatureControl is the reference), in vault gold. The old
+                         58px "nebula ribbon" band with banner_default.png is gone — the
+                         room already supplies the painting, so the header only needed the
+                         house geometry: art right under a left fade, title + subtitle
+                         left, and the pill on top of the art. The pill has no master
+                         toggle to hold on this tab (the Vault gates nothing itself), so
+                         it carries the tier plates instead — same names, same opacities,
+                         still repainted by RefreshExclusiveTierPlates. -->
+                    <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
+                            BorderBrush="{StaticResource TabHueBorderBrush}" BorderThickness="2"
+                            Margin="0,0,0,20">
+                        <Grid>
+                            <Border Background="{StaticResource TabHueWashBrush}" CornerRadius="14"/>
+                            <!-- The hero's face. vault.png is WPF-head art, so the plate carries the
+                                 vault's own glyph instead, huge and nearly transparent. -->
+                            <Border CornerRadius="0,14,14,0" Width="240" HorizontalAlignment="Right">
+                                <TextBlock Text="💎" FontSize="46" Opacity="0.16"
+                                           HorizontalAlignment="Right" VerticalAlignment="Center"
+                                           Margin="0,0,18,0"/>
+                            </Border>
+                            <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
+                                <TextBlock Text="{loc:Str exclusives_vault_title}"
+                                           FontWeight="Bold"
+                                           FontSize="17" Foreground="{StaticResource TextLightBrush}"/>
+                                <TextBlock Text="{loc:Str exclusives_vault_sub}"
+                                           FontSize="11.5" Foreground="{StaticResource TextMutedBrush}"
+                                           Margin="0,1,0,0" MaxWidth="620" HorizontalAlignment="Left"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </StackPanel>
+                            <!-- Tier plates (previously unused art). The one matching the
+                                 user's entitlement gets full opacity + a breathing glow;
+                                 see RefreshExclusivesTab. Patreon tier1/tier2.png are WPF-head
+                                 art, so each plate is the vector stand-in TierBadge uses for its
+                                 own signs: a plate in the tier's livery carrying its numeral. -->
+                            <Border HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0"
+                                    CornerRadius="99" Background="#8C131320"
+                                    BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"
+                                    Padding="12,5,12,5">
+                                <StackPanel Orientation="Horizontal">
+                                    <Border x:Name="TierPlate1" Height="30" Width="52" Margin="0,0,8,0"
+                                            Opacity="0.3" CornerRadius="6" Background="#26FFC94E"
+                                            BorderBrush="#99FFC94E" BorderThickness="1">
+                                        <TextBlock Text="I" Foreground="#FFC94E" FontSize="13"
+                                                   FontWeight="Bold"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                    <Border x:Name="TierPlate2" Height="30" Width="52"
+                                            Opacity="0.3" CornerRadius="6" Background="#268FE8FF"
+                                            BorderBrush="#998FE8FF" BorderThickness="1">
+                                        <TextBlock Text="II" Foreground="#8FE8FF" FontSize="13"
+                                                   FontWeight="Bold"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </Border>
+
+                    <!-- Spotlight: the newest exclusive, hero-sized -->
+                    <Border x:Name="SpotlightCard"
+                            Height="250" CornerRadius="14" Margin="0,0,0,22"
+                            Background="#EE1A1A2E" BorderBrush="{StaticResource TabHueBorderBrush}"
+                            BorderThickness="2"
+                            Cursor="Hand" PointerReleased="Spotlight_PointerReleased">
+                        <Grid ColumnDefinitions="1.35*,1*">
+
+                            <!-- Art. The band is ~5:1, so the source is cropped, never
+                                 stretched: on WPF the source (wide BannerArtResource, else the
+                                 card art) and the zoom origin are set by ApplySpotlightArt.
+                                 No art on this head, so the host carries the spotlight
+                                 feature's glyph instead. -->
+                            <Border x:Name="SpotArtHost"
+                                    Grid.Column="0" Grid.ColumnSpan="2" ClipToBounds="True"
+                                    CornerRadius="12">
+                                <TextBlock x:Name="TxtSpotArtGlyph" FontSize="120" Opacity="0.14"
+                                           HorizontalAlignment="Left" VerticalAlignment="Center"
+                                           Margin="60,0,0,0"/>
+                            </Border>
+                            <!-- fade the art into the copy column -->
+                            <Border Grid.Column="0" Grid.ColumnSpan="2">
+                                <Border.Background>
+                                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                        <GradientStop Color="#001D1B33" Offset="0.42"/>
+                                        <GradientStop Color="#D91D1B33" Offset="0.68"/>
+                                        <GradientStop Color="#FA1D1B33" Offset="1"/>
+                                    </LinearGradientBrush>
+                                </Border.Background>
+                            </Border>
+
+                            <!-- The hero's tier sign, painted by RefreshExclusivesTab from the
+                                 spotlight feature's Tier (collapsed when it has none). LEFT, over
+                                 the art column, not right: the right column is the copy, and its
+                                 own badge row (JUST SHIPPED / NEW / FREE TODAY) already owns that
+                                 side. The card badges are top-right; hero bands put the sign on
+                                 the art side, same call as the Play door's DTRH hero. -->
+                            <fx:TierBadge x:Name="SpotTierBadge"
+                                          Grid.Column="0"
+                                          HorizontalAlignment="Left" VerticalAlignment="Top"
+                                          Margin="-4,-4,0,0" ZIndex="9"/>
+
+                            <!-- copy -->
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center"
+                                        Margin="26,0,30,0">
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,9">
+                                    <TextBlock Text="{loc:Str exclusives_just_shipped}"
+                                               Foreground="{StaticResource TabHueBrush}" FontSize="11"
+                                               FontWeight="Bold" VerticalAlignment="Center"/>
+                                    <Border x:Name="SpotBadge"
+                                            CornerRadius="10" Padding="8,2" Margin="10,0,0,0"
+                                            VerticalAlignment="Center">
+                                        <Border.Background>
+                                            <!-- Authored in the Bambi accent pair; re-tinted from
+                                                 the active mod's accent by RefreshExclusivesTab. -->
+                                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                <GradientStop Color="#FF69B4" Offset="0"/>
+                                                <GradientStop Color="#B478FF" Offset="1"/>
+                                            </LinearGradientBrush>
+                                        </Border.Background>
+                                        <TextBlock x:Name="TxtSpotBadge"
+                                                   Foreground="White" FontSize="10" FontWeight="Bold"/>
+                                    </Border>
+                                    <!-- FREE TODAY: shown only on the day DailyFreeService
+                                         rotates the spotlight's feature in, for accounts that
+                                         don't already own it. Painted + pulsed by
+                                         RefreshExclusivesTab; literal colours on purpose (no
+                                         cross-dictionary StaticResource in a view). -->
+                                    <Border x:Name="SpotFreeToday"
+                                            CornerRadius="10" Padding="9,2" Margin="10,0,0,0"
+                                            VerticalAlignment="Center" IsVisible="False"
+                                            BorderThickness="1" BorderBrush="#CCFFF0C2"
+                                            RenderTransformOrigin="50%,50%">
+                                        <Border.RenderTransform>
+                                            <ScaleTransform ScaleX="1" ScaleY="1"/>
+                                        </Border.RenderTransform>
+                                        <Border.Background>
+                                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                <GradientStop Color="#FFD27A" Offset="0"/>
+                                                <GradientStop Color="#FF9C4A" Offset="1"/>
+                                            </LinearGradientBrush>
+                                        </Border.Background>
+                                        <TextBlock x:Name="TxtSpotFreeToday"
+                                                   Foreground="#2A1A05" FontSize="10" FontWeight="Bold"/>
+                                    </Border>
+                                </StackPanel>
+                                <TextBlock x:Name="TxtSpotTitle"
+                                           FontWeight="SemiBold"
+                                           FontSize="30" Foreground="White">
+                                    <TextBlock.Effect>
+                                        <DropShadowEffect Color="#FF69B4" BlurRadius="20"
+                                                          OffsetX="0" OffsetY="0" Opacity="0.5"/>
+                                    </TextBlock.Effect>
+                                </TextBlock>
+                                <TextBlock x:Name="TxtSpotTagline"
+                                           Foreground="{StaticResource TextSecondaryBrush}" FontSize="14" TextWrapping="Wrap"
+                                           Margin="0,8,0,0" LineHeight="21"/>
+                                <Button x:Name="BtnSpotOpen"
+                                        Theme="{StaticResource ActionButton}"
+                                        HorizontalAlignment="Left" Margin="0,16,0,0"
+                                        Padding="24,8" Click="Spotlight_Click">
+                                    <TextBlock Text="{loc:Str exclusives_enter}"/>
+                                </Button>
+                            </StackPanel>
+
+                            <!-- locked veil (decoration only; navigation stays live) -->
+                            <Border x:Name="SpotVeil"
+                                    Grid.Column="0" Grid.ColumnSpan="2" CornerRadius="12"
+                                    IsVisible="False" IsHitTestVisible="False">
+                                <Border.Background>
+                                    <RadialGradientBrush GradientOrigin="40%,50%" Center="40%,50%"
+                                                         RadiusX="80%" RadiusY="90%">
+                                        <GradientStop Color="#801E1632" Offset="0"/>
+                                        <GradientStop Color="#D20C0A18" Offset="1"/>
+                                    </RadialGradientBrush>
+                                </Border.Background>
+                                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <TextBlock x:Name="SpotVeilLock"
+                                               Text="🔒" FontSize="44" HorizontalAlignment="Center"/>
+                                    <Border CornerRadius="12" Padding="14,5" Margin="0,10,0,0">
+                                        <Border.Background>
+                                            <!-- Same accent pair as the shelf cards' unlock pill;
+                                                 re-tinted by RefreshExclusivesTab on a mod switch. -->
+                                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                <GradientStop Color="#E6FF69B4" Offset="0"/>
+                                                <GradientStop Color="#D9B478FF" Offset="1"/>
+                                            </LinearGradientBrush>
+                                        </Border.Background>
+                                        <TextBlock FontSize="11" FontWeight="Bold" Foreground="White"
+                                                   Text="{loc:Str exclusives_chip_lab}"/>
+                                    </Border>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </Border>
+
+                    <!-- Collection label -->
+                    <Grid Margin="2,0,2,12" ColumnDefinitions="Auto,*,Auto">
+                        <TextBlock Grid.Column="0" Text="{loc:Str exclusives_collection}"
+                                   FontWeight="Medium"
+                                   FontSize="16" Foreground="{StaticResource TextLightBrush}"/>
+                        <Rectangle Grid.Column="1" Height="1" Margin="14,0"
+                                   VerticalAlignment="Center">
+                            <Rectangle.Fill>
+                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                    <GradientStop Color="#80FFC94E" Offset="0"/>
+                                    <GradientStop Color="#00FFC94E" Offset="1"/>
+                                </LinearGradientBrush>
+                            </Rectangle.Fill>
+                        </Rectangle>
+                        <TextBlock Grid.Column="2" Text="{loc:Str exclusives_more_soon}"
+                                   Foreground="{StaticResource TextMutedBrush}" FontSize="11"
+                                   VerticalAlignment="Center"/>
+                    </Grid>
+
+                    <!-- The shelf. WPF builds these children in MainWindow.Exclusives.cs from
+                         ExclusiveFeature.All; here the same WrapPanel is an ItemsControl's panel
+                         and the card lives in the template. Geometry is BuildExclusiveCard's:
+                         336x200, 12px radius, bottom scrim plate, chip top-right, badge top-left,
+                         veil over the lot, tier sign pinned over the corner. -->
+                    <ItemsControl x:Name="ExclusivesShelf">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="tabs:ExclusiveCardRow">
+                                <Border Width="336" Height="200" Margin="0,0,16,16"
+                                        CornerRadius="12"
+                                        Background="#1A1A2E"
+                                        BorderBrush="{Binding EdgeBrush}" BorderThickness="1"
+                                        Cursor="Hand">
+                                  <Grid>
+                                    <!-- Everything that must respect the card's corners lives in
+                                         this inner clip. The card itself does NOT clip: the tier
+                                         sign hangs over the corner (WPF clipped only artHost and
+                                         the veil, each on its own). -->
+                                    <Border ClipToBounds="True" CornerRadius="12">
+                                    <Grid>
+                                        <!-- art -->
+                                        <TextBlock Text="{Binding Emoji}" FontSize="76" Opacity="{Binding ArtOpacity}"
+                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                   Margin="0,0,0,34"/>
+
+                                        <!-- bottom plate: gradient scrim + title + tagline -->
+                                        <Border VerticalAlignment="Bottom" Padding="12,26,12,10">
+                                            <Border.Background>
+                                                <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                                                    <GradientStop Color="#000C0A18" Offset="0"/>
+                                                    <GradientStop Color="#E00C0A18" Offset="0.55"/>
+                                                    <GradientStop Color="#F20C0A18" Offset="1"/>
+                                                </LinearGradientBrush>
+                                            </Border.Background>
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                                                           FontSize="15" Foreground="White">
+                                                    <TextBlock.Effect>
+                                                        <DropShadowEffect Color="#FF69B4" BlurRadius="10"
+                                                                          OffsetX="0" OffsetY="0" Opacity="0.7"/>
+                                                    </TextBlock.Effect>
+                                                </TextBlock>
+                                                <TextBlock Text="{Binding Tagline}" Foreground="#9A93B8"
+                                                           FontSize="11" TextWrapping="Wrap"
+                                                           TextTrimming="CharacterEllipsis" MaxHeight="30"
+                                                           Margin="0,2,0,0"/>
+                                            </StackPanel>
+                                        </Border>
+
+                                        <!-- entitlement chip (top-right; colours per gate state) -->
+                                        <Border IsVisible="{Binding HasChip}"
+                                                HorizontalAlignment="Right" VerticalAlignment="Top"
+                                                Margin="{Binding ChipMargin}"
+                                                CornerRadius="10" Padding="8,3" BorderThickness="1"
+                                                Background="{Binding ChipBackground}"
+                                                BorderBrush="{Binding ChipBorderBrush}">
+                                            <TextBlock Text="{Binding ChipText}" FontSize="10" FontWeight="Bold"
+                                                       Foreground="{Binding ChipForeground}"/>
+                                        </Border>
+
+                                        <!-- optional NEW/BETA badge, top-left, in the brand gradient -->
+                                        <Border IsVisible="{Binding HasBadge}"
+                                                HorizontalAlignment="Left" VerticalAlignment="Top"
+                                                Margin="8,8,0,0" CornerRadius="10" Padding="8,2">
+                                            <Border.Background>
+                                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                    <GradientStop Color="#FF69B4" Offset="0"/>
+                                                    <GradientStop Color="#B478FF" Offset="1"/>
+                                                </LinearGradientBrush>
+                                            </Border.Background>
+                                            <TextBlock Text="{Binding BadgeText}" Foreground="White"
+                                                       FontSize="9" FontWeight="Bold"/>
+                                        </Border>
+
+                                        <!-- locked veil: fog scrim + padlock + unlock pill.
+                                             Decoration only - the card still navigates. -->
+                                        <Border IsVisible="{Binding IsLocked}" IsHitTestVisible="False"
+                                                CornerRadius="12">
+                                            <Border.Background>
+                                                <RadialGradientBrush>
+                                                    <GradientStop Color="#861E1632" Offset="0"/>
+                                                    <GradientStop Color="#D60C0A18" Offset="1"/>
+                                                </RadialGradientBrush>
+                                            </Border.Background>
+                                            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <TextBlock Text="🔒" FontSize="34" HorizontalAlignment="Center"/>
+                                                <Border Margin="0,8,0,0" CornerRadius="10" Padding="10,4"
+                                                        HorizontalAlignment="Center">
+                                                    <Border.Background>
+                                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                                                            <GradientStop Color="#E6FF69B4" Offset="0"/>
+                                                            <GradientStop Color="#D9B478FF" Offset="1"/>
+                                                        </LinearGradientBrush>
+                                                    </Border.Background>
+                                                    <TextBlock Text="{loc:Str exclusives_chip_lab}"
+                                                               Foreground="White" FontSize="10" FontWeight="Bold"/>
+                                                </Border>
+                                            </StackPanel>
+                                        </Border>
+                                    </Grid>
+                                    </Border>
+
+                                    <!-- the tier sign, pinned over the art's top-right corner and
+                                         ABOVE the veil: a locked card must still advertise what it
+                                         costs. Hides itself when Tier is 0. -->
+                                    <fx:TierBadge Tier="{Binding Tier}"
+                                                  HorizontalAlignment="Right" VerticalAlignment="Top"
+                                                  Margin="0,-6,-6,0"/>
+                                  </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Border>
+</UserControl>

--- a/CCP.Avalonia/Views/Tabs/ExclusivesTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/ExclusivesTabView.axaml.cs
@@ -1,0 +1,183 @@
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Avalonia.Controls;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Tabs
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Tabs/ExclusivesTabView.xaml.cs.
+    ///
+    /// <para>The WPF shell owns only the backdrop and geometry chores; all roster/card logic lives
+    /// in MainWindow.Exclusives.cs. What survived here is the ambient canvas tuning (fog + dust +
+    /// aurora at 0.55, copied from StartExclusivesMotion - canvas composition, not service logic).
+    /// Everything else is a stub or a placeholder.</para>
+    ///
+    /// <para>Dropped outright: <c>LoadBackdrop</c> (needs ModResourceResolver and a Resources/ PNG
+    /// this head does not ship), the <c>ModChanged</c> subscription that re-ran it, and
+    /// <c>RoundClipOnResize</c> - WPF's ClipToBounds is rectangular, so a rounded host needed clip
+    /// geometry tracked against every resize; an Avalonia Border clips its child to its own
+    /// CornerRadius, so the helper has no work left. Its two other callers were MainWindow's card
+    /// builder, which is not ported either.</para>
+    /// </summary>
+    public partial class ExclusivesTabView : UserControl
+    {
+        private readonly AmbientFxCanvas _ambientFx;
+
+        public ExclusivesTabView()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _ambientFx = this.FindControl<AmbientFxCanvas>("ExclusivesAmbientFx")!;
+
+            LoadPlaceholderVault();
+
+            // The tab is permanently mounted on WPF and MainWindow parks its canvas through
+            // RegisterTabFx. No tab host on this head: the view runs its own room and stops it on
+            // unload. The canvas self-gates on motion, tier and window focus regardless.
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
+        }
+
+        private void OnLoaded(object? sender, RoutedEventArgs e)
+            => _ambientFx.StartLayers(new AmbientFxConfig
+            {
+                Layers = AmbientFxLayers.FogDrift | AmbientFxLayers.DustField | AmbientFxLayers.AuroraWash,
+                Intensity = 0.55,
+                FogPuffs = 3,
+            });
+
+        private void OnUnloaded(object? sender, RoutedEventArgs e) => _ambientFx.Stop();
+
+        // ------------------------------------------------------------------
+        // Placeholder vault
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Paints the spotlight and fills the shelf with sample cards.
+        ///
+        /// ponytail: needs ExclusiveFeature.All, DailyFreeService, VaultLivery and FxTheme, all
+        /// pinned to the WPF head (the registry's gate probe reads App.Patreon). Wired when they
+        /// move to Core. The rows are the real registry's first six entries with their real loc
+        /// keys, spread across every branch the card template carries - tier 1, tier 2, untiered,
+        /// NEW, BETA, no badge, a locked veil and both entitlement chips - so the render proof
+        /// exercises the markup rather than one happy path.
+        /// </summary>
+        private void LoadPlaceholderVault()
+        {
+            // The spotlight is ExclusiveFeature.All[0] - "fyp", tier 1, badged NEW. Keys and the
+            // "emoji + title" shape are EnsureExclusivesBuilt's.
+            this.FindControl<TextBlock>("TxtSpotArtGlyph")!.Text = "📱";
+            this.FindControl<TextBlock>("TxtSpotTitle")!.Text = "📱 " + Loc.Get("tab_fyp");
+            this.FindControl<TextBlock>("TxtSpotTagline")!.Text = Loc.Get("exclusives_tag_fyp");
+            this.FindControl<TextBlock>("TxtSpotBadge")!.Text = Loc.Get("exclusives_badge_new");
+            this.FindControl<TextBlock>("TxtSpotFreeToday")!.Text = Loc.Get("mosaic_free_today");
+            this.FindControl<TierBadge>("SpotTierBadge")!.Tier = 1;
+
+            this.FindControl<ItemsControl>("ExclusivesShelf")!.ItemsSource = new List<ExclusiveCardRow>
+            {
+                new() { Emoji = "📱", TitleKey = "tab_fyp", TaglineKey = "exclusives_tag_fyp",
+                        Tier = 1, BadgeKey = "exclusives_badge_new", State = ExclusiveCardState.Unlocked },
+                new() { Emoji = "🎚", TitleKey = "jd_door_title", TaglineKey = "exclusives_tag_justdrop",
+                        Tier = 2, State = ExclusiveCardState.Locked },
+                new() { Emoji = "💫", TitleKey = "tab_blink_trainer", TaglineKey = "exclusives_tag_blinktrainer",
+                        Tier = 1, State = ExclusiveCardState.PassReady },
+                new() { Emoji = "🎙️", TitleKey = "tab_shelistening", TaglineKey = "exclusives_tag_shelistening",
+                        Tier = 1, BadgeKey = "exclusives_badge_beta", State = ExclusiveCardState.Locked },
+                new() { Emoji = "❓", TitleKey = "tab_gradedintake", TaglineKey = "exclusives_tag_gradedintake",
+                        State = ExclusiveCardState.Unlocked },
+                new() { Emoji = "💜", TitleKey = "tab_haptics", TaglineKey = "exclusives_tag_haptics",
+                        Tier = 1, State = ExclusiveCardState.Unlocked },
+            };
+        }
+
+        // ------------------------------------------------------------------
+        // Stubs for what MainWindow owned
+        // ------------------------------------------------------------------
+
+        private void Spotlight_Click(object? sender, RoutedEventArgs e) => OpenSpotlight();
+
+        private void Spotlight_PointerReleased(object? sender, global::Avalonia.Input.PointerReleasedEventArgs e)
+            => OpenSpotlight();
+
+        /// <summary>
+        /// WPF: <c>MainWindow.OpenExclusiveSpotlight()</c>, i.e. ShowTab(ExclusiveFeature.All[0].Key).
+        /// ponytail: needs the tab host and the ExclusiveFeature registry, wired when they move to
+        /// Core - so the hero is inert here rather than navigating somewhere wrong.
+        /// </summary>
+        private static void OpenSpotlight() { }
+    }
+
+    /// <summary>Gate state of a vault card, mirroring Models.ExclusiveGateState.</summary>
+    public enum ExclusiveCardState
+    {
+        Locked,
+        PassReady,
+        Unlocked,
+    }
+
+    /// <summary>
+    /// One shelf card. The Avalonia-side stand-in for an ExclusiveFeature plus the state
+    /// MainWindow.Exclusives.cs paints onto it (ApplyExclusiveCardState / VaultLivery.Apply): the
+    /// chip's three colours and its offset under a tier sign, the veil, the resting edge. Every
+    /// literal below is copied from that file so the port is a rename away from the real model.
+    /// </summary>
+    public sealed class ExclusiveCardRow
+    {
+        public string Emoji { get; set; } = "";
+        public string TitleKey { get; set; } = "";
+        public string TaglineKey { get; set; } = "";
+        public string? BadgeKey { get; set; }
+        public int Tier { get; set; }
+        public ExclusiveCardState State { get; set; }
+
+        /// <summary>"emoji + title", the shape BuildExclusiveCard gives every card.</summary>
+        public string Title => $"{Emoji} {Loc.Get(TitleKey)}";
+        public string Tagline => Loc.Get(TaglineKey);
+
+        public bool HasBadge => BadgeKey != null;
+        public string BadgeText => BadgeKey == null ? "" : Loc.Get(BadgeKey);
+
+        public bool IsLocked => State == ExclusiveCardState.Locked;
+
+        /// <summary>The WPF card dims its ART to 0.75 under the veil; the glyph stand-in carries
+        /// that as the same proportional dim of its own resting opacity.</summary>
+        public double ArtOpacity => IsLocked ? 0.13 : 0.18;
+
+        /// <summary>A veiled card shows the padlock, not a price chip.</summary>
+        public bool HasChip => !IsLocked;
+
+        /// <summary>On a tiered card the badge owns the top-right corner, so the chip drops below
+        /// it (VaultLivery.ChipTopWhenTiered = 84) rather than fighting it.</summary>
+        public Thickness ChipMargin => Tier > 0 ? new Thickness(0, 84, 8, 0) : new Thickness(0, 8, 8, 0);
+
+        public string ChipText => Loc.Get(State == ExclusiveCardState.PassReady
+            ? "exclusives_chip_pass_ready"
+            : "exclusives_chip_unlocked");
+
+        // Teal for owned, gold for a pass that is ready to burn - ApplyExclusiveCardState's own
+        // three-brush recipe per state, alphas included.
+        public IBrush ChipForeground => State == ExclusiveCardState.PassReady
+            ? Brush("#FFD27A") : Brush("#7FE7E0");
+
+        public IBrush ChipBackground => State == ExclusiveCardState.PassReady
+            ? Brush("#33FFD27A") : Brush("#2E7FE7E0");
+
+        public IBrush ChipBorderBrush => State == ExclusiveCardState.PassReady
+            ? Brush("#73FFD27A") : Brush("#667FE7E0");
+
+        /// <summary>
+        /// The card's resting rim. WPF takes the untiered one from the active mod's accent
+        /// (ExclusiveEdgeDefault) and overwrites a tiered card's with the constant vault livery.
+        /// ponytail: needs FxTheme + VaultLivery for the mod-aware half; the literals here are the
+        /// Bambi accent and the vault gold those two produce by default.
+        /// </summary>
+        public IBrush EdgeBrush => Tier > 0 ? Brush("#66FFC94E") : Brush("#4DB478FF");
+
+        private static IBrush Brush(string hex) => new SolidColorBrush(Color.Parse(hex));
+    }
+}


### PR DESCRIPTION
1,011 lines. The render caught the shelf cards clipping their tier signs; an inner clip Border lets the sign overhang the corner as authored.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the render. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351