### PR TITLE
feat(avalonia): add the Avalonia WebView package and a WebHost control

### DIFF
--- a/CCP.Avalonia/CCP.Avalonia.csproj
+++ b/CCP.Avalonia/CCP.Avalonia.csproj
@@ -28,6 +28,10 @@
          A desktop screenshot cannot run on a headless runner; this can. -->
     <PackageReference Include="Avalonia.Headless" Version="12.1.1" />
     <PackageReference Include="Avalonia.Skia" Version="12.1.1" />
+    <!-- The Linux/Windows web view. Wraps WebKitGTK on Linux and WebView2 on Windows, so the
+         WPF head's Microsoft.Web.WebView2 dependency does not follow us across. Only Views/Controls/WebHost
+         touches it, and that control draws a fallback panel wherever no web view exists. -->
+    <PackageReference Include="Avalonia.Controls.WebView" Version="12.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CCP.Avalonia/Views/Controls/WebHost.axaml
+++ b/CCP.Avalonia/Views/Controls/WebHost.axaml
@@ -1,0 +1,67 @@
+<!-- NOT a port. There is no WPF twin: the WPF head embeds Microsoft.Web.WebView2 directly
+     (ChaosWebViewHost, MainWindow.Browser, SpiralEmbedView), which is Windows-only. This is the
+     cross-platform seam those hosts will move onto - Avalonia.Controls.WebView wraps WebView2 on
+     Windows and WebKitGTK/WPE on Linux behind one control.
+
+     The fallback panel is the reason this control exists rather than a bare <NativeWebView/>:
+     "WebKitGtk library is not installed" is the DEFAULT state of a fresh Linux box (and of the CI
+     runner), and a web view with no engine behind it draws nothing at all - an empty rectangle
+     that looks exactly like a broken layout. The panel says which engine is missing instead.
+
+     Strings here are literals, not {loc:Str}: there is no WPF original to copy a key from, and
+     inventing one would put a key in the XAML that no .resx defines.
+     ponytail: hardcoded English; give it loc keys when the WebView2 hosts actually move over -->
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="ConditioningControlPanel.Avalonia.Views.Controls.WebHost"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignHeight="360" d:DesignWidth="640">
+
+    <Grid x:Name="Root">
+        <!-- The real thing. Created in the code-behind, NOT declared here, so a platform with no
+             engine never attaches it: NativeWebView builds its adapter on attach, and an adapter
+             that cannot be built is an exception on the render thread rather than a blank box. -->
+        <Panel x:Name="WebSlot"/>
+
+        <!-- Fallback. Visible whenever no adapter reports itself installed AND able to host a
+             native control. That is every headless render, so the render proof always shows it. -->
+        <Border x:Name="Fallback"
+                Background="{DynamicResource ElevatedSurfaceBrush}"
+                BorderBrush="{DynamicResource GlassBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="10"
+                Padding="24">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="8">
+                <TextBlock Text="🌐"
+                           FontSize="40"
+                           Opacity="0.75"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Text="Web view unavailable"
+                           FontSize="15"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource TextLightBrush}"
+                           HorizontalAlignment="Center"/>
+                <!-- Filled from the adapter's own UnavailableReason ("WebKitGtk library is not
+                     installed. Install webkit2gtk 4.0+ package."), so the panel names the fix. -->
+                <TextBlock x:Name="TxtReason"
+                           Text="No native web view on this platform."
+                           FontSize="12"
+                           MaxWidth="380"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center"/>
+                <!-- The page that would have loaded. Hidden until Source is set. -->
+                <TextBlock x:Name="TxtSource"
+                           FontSize="11"
+                           MaxWidth="380"
+                           TextTrimming="CharacterEllipsis"
+                           TextAlignment="Center"
+                           Foreground="{DynamicResource TextDimBrush}"
+                           HorizontalAlignment="Center"
+                           IsVisible="False"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/CCP.Avalonia/Views/Controls/WebHost.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/WebHost.axaml.cs
@@ -1,0 +1,135 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls
+{
+    /// <summary>
+    /// A <see cref="NativeWebView"/> that degrades to a legible panel instead of an empty
+    /// rectangle when the machine has no web engine.
+    ///
+    /// This is NOT a ported view. The WPF head talks to Microsoft.Web.WebView2 directly
+    /// (ChaosWebViewHost, MainWindow.Browser, SpiralEmbedView) and that package is Windows-only;
+    /// Avalonia.Controls.WebView is the cross-platform replacement - WebView2 on Windows,
+    /// WebKitGTK or WPE WebKit on Linux - and this control is the single place the head touches
+    /// it, so those three hosts have one seam to move onto rather than three.
+    ///
+    /// The whole point is the fallback. A Linux box without webkit2gtk installed is the DEFAULT,
+    /// not the exception, and a web view with no engine paints nothing: the render proof would
+    /// show a blank region and pass. So availability is probed BEFORE anything is constructed, and
+    /// the real control is only ever added to the tree when an engine can actually host it.
+    /// </summary>
+    public partial class WebHost : UserControl
+    {
+        /// <summary>Page to load. Mirrors <see cref="NativeWebView.SourceProperty"/>.</summary>
+        public static readonly StyledProperty<Uri?> SourceProperty =
+            AvaloniaProperty.Register<WebHost, Uri?>(nameof(Source));
+
+        public Uri? Source { get => GetValue(SourceProperty); set => SetValue(SourceProperty, value); }
+
+        /// <summary>
+        /// True when some adapter is both installed and able to host a native control. Probed once
+        /// per process: <see cref="WebViewAdapterInfo.GetAdapterInfo"/> shells out to the platform
+        /// (dlopen of libwebkit2gtk, a WebView2 registry lookup) and the answer cannot change while
+        /// the app runs.
+        /// </summary>
+        public static bool IsAvailable => UnavailableReason is null;
+
+        private static readonly Lazy<string?> _reason = new(ProbeUnavailableReason);
+
+        /// <summary>Null when a web view can be hosted; otherwise the platform's own explanation.</summary>
+        public static string? UnavailableReason => _reason.Value;
+
+        private readonly Panel _webSlot;
+        private readonly Border _fallback;
+        private readonly TextBlock _txtReason, _txtSource;
+        private readonly NativeWebView? _web;
+
+        public WebHost()
+        {
+            AvaloniaXamlLoader.Load(this);
+            _webSlot = this.FindControl<Panel>("WebSlot")!;
+            _fallback = this.FindControl<Border>("Fallback")!;
+            _txtReason = this.FindControl<TextBlock>("TxtReason")!;
+            _txtSource = this.FindControl<TextBlock>("TxtSource")!;
+
+            if (IsAvailable)
+            {
+                // try/catch, not a bare new: the probe says an engine is installed, it does not
+                // promise the adapter builds. A throw here must show the panel, not kill the host.
+                try
+                {
+                    _web = new NativeWebView();
+                    _webSlot.Children.Add(_web);
+                }
+                catch (Exception ex)
+                {
+                    _web = null;
+                    _txtReason.Text = ex.Message;
+                }
+            }
+            else
+            {
+                _txtReason.Text = UnavailableReason!;
+            }
+
+            _fallback.IsVisible = _web is null;
+            ApplySource();
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (change.Property == SourceProperty) ApplySource();
+        }
+
+        private void ApplySource()
+        {
+            if (_txtSource is null) return; // fired before the XAML loaded
+            var src = Source;
+            // src! because NativeWebView.Source is annotated non-nullable while its StyledProperty's
+            // own default IS null - clearing the page back to null is a real state, not a bug.
+            if (_web is not null) { _web.Source = src!; return; }
+            // No engine: the panel at least names the page that was meant to load.
+            _txtSource.Text = src?.ToString() ?? "";
+            _txtSource.IsVisible = src is not null;
+        }
+
+        /// <summary>
+        /// Walks every adapter the package knows about and returns null as soon as one is installed
+        /// and advertises <see cref="WebViewEmbeddingScenario.NativeControlHost"/>. The scenario
+        /// check is what keeps a headless render honest: the Headless adapter reports itself
+        /// installed but offers only <c>OffscreenRenderer</c>, so it never passes for an embedded
+        /// control and <c>--render-all</c> always draws the fallback.
+        /// </summary>
+        private static string? ProbeUnavailableReason()
+        {
+            string? firstReason = null;
+            foreach (WebViewAdapterType type in Enum.GetValues(typeof(WebViewAdapterType)))
+            {
+                if (type == WebViewAdapterType.Unknown) continue;
+                DetailedWebViewAdapterInfo info;
+                try
+                {
+                    info = WebViewAdapterInfo.GetAdapterInfo(type);
+                }
+                catch (Exception)
+                {
+                    // The macOS adapter's static constructor throws off macOS. An adapter that
+                    // cannot even be asked about is, for our purposes, not there.
+                    continue;
+                }
+                if (!info.IsSupported) continue;
+                if (info.IsInstalled && info.SupportedScenarios.HasFlag(WebViewEmbeddingScenario.NativeControlHost))
+                    return null;
+                // Prefer the first supported-but-missing engine's message: on Linux that is the
+                // actionable "Install webkit2gtk 4.0+ package", not "not supported on this platform".
+                if (firstReason is null && !string.IsNullOrWhiteSpace(info.UnavailableReason))
+                    firstReason = info.UnavailableReason;
+            }
+            return firstReason ?? "No native web view on this platform.";
+        }
+    }
+}


### PR DESCRIPTION
206 lines. `Avalonia.Controls.WebView` 12.1.0 restores and builds on Linux, which is what the Avalonia-12 decision was made for. WebHost wraps NativeWebView with a Source property and a visible fallback panel, so a headless render never draws an empty box. This is the only layer permitted to edit the head's csproj; bucket D's six views build on it.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs; placeholder data drives the render. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351