### PR TITLE
feat(avalonia): port AnnouncementPopup

### DIFF
--- a/CCP.Avalonia/Views/Windows/AnnouncementPopup.axaml
+++ b/CCP.Avalonia/Views/Windows/AnnouncementPopup.axaml
@@ -1,0 +1,217 @@
+<!-- PORTED from ConditioningControlPanel/Windows/AnnouncementPopup.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"              -> SystemDecorations="None"
+       AllowsTransparency="True"       -> TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"           -> CanResize="False"
+       Visibility="Collapsed"          -> IsVisible="False"
+       Panel.ZIndex                    -> ZIndex
+       ShadowDepth="0"                 -> OffsetX="0" OffsetY="0"  (Avalonia's DropShadowEffect
+                                          takes a vector, not depth+direction)
+       StartPoint/EndPoint "0,0"/"0.3,1" -> "0%,0%"/"30%,100%". Avalonia reads a bare pair as
+                                          ABSOLUTE pixels, so the rail gradient would have run its
+                                          whole ramp inside the first 0.3px and painted solid.
+       RenderTransformOrigin="0.5,0.5" -> dropped; Avalonia's default origin is already the centre
+                                          (and a bare "0.5,0.5" would be read as pixels here too).
+       MouseLeftButtonDown="..."       -> not wired: the WPF handler is an empty no-op by design
+                                          ("don't dismiss on click"), and not wiring it is the
+                                          same behaviour with less code.
+       Two inline <Button.Style>s      -> one keyed ControlTheme, below. They were byte-identical.
+
+     The close button carries a TextBlock child rather than Content: Avalonia parses "_" in a
+     Button's Content as an access key (CLAUDE.md trap 1). The two pill buttons keep Content
+     because code assigns it (actionText / dismissText) - their template's plain ContentPresenter
+     has RecognizesAccessKey false, so an underscore in a caller's label survives. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.AnnouncementPopup"
+        Title="Announcement"
+        Width="440" SizeToContent="Height" MaxHeight="600"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        Focusable="False"
+        CanResize="False"
+        WindowStartupLocation="CenterScreen">
+
+    <Window.Styles>
+        <!-- ponytail: local copy of AnnouncementPopup.xaml:BtnClose inline <Button.Style>, same
+             shape AchievementPopup uses. Hoist when a third popup needs it. -->
+        <Style Selector="Button.closeGlyph:pointerover">
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Window.Resources>
+        <!-- ponytail: local copy of AnnouncementPopup.xaml:BtnDownload/BtnDismiss inline
+             <Button.Style> (both were identical), setters verbatim. Same pill FeatureIntroPopup
+             keeps locally; hoist the pair into Theme/Styles.xaml when a third view wants it. -->
+        <ControlTheme x:Key="AnnouncementPillButton" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}"
+                            CornerRadius="18" Padding="16,6">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="{DynamicResource PinkButtonHoveredBrush}"/>
+            </Style>
+            <Style Selector="^:pressed /template/ Border#border">
+                <Setter Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The matrix skin. In WPF this was built at runtime out of FrameworkElementFactory
+             (ApplyMatrixButtonStyle); Avalonia has no such factory, and a declared ControlTheme
+             the code-behind assigns to Button.Theme is the same thing with none of the plumbing.
+             Colours copied from the code-behind: #00FF41 fill, #39FF14 hover, #00CC33 pressed. -->
+        <ControlTheme x:Key="AnnouncementMatrixPillButton" TargetType="Button">
+            <Setter Property="Background" Value="#00FF41"/>
+            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border" Background="{TemplateBinding Background}"
+                            CornerRadius="18" Padding="16,6">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#border">
+                <Setter Property="Background" Value="#39FF14"/>
+            </Style>
+            <Style Selector="^:pressed /template/ Border#border">
+                <Setter Property="Background" Value="#00CC33"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border x:Name="OuterBorder"
+            Background="#F0151530" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <!--
+            Two column shapes share this window.
+
+            Column 0 is the CARD ART RAIL, used only by local callers that hand in an image
+            (the weekly intake nudge). It is hidden by default, and a hidden child in an
+            Auto column measures to zero width - so for every server announcement this Grid is
+            byte-for-byte the single-column layout it has always been. Server announcements keep
+            using the stacked ImageContainer inside the StackPanel instead; do not merge the two.
+        -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Card art rail (local image only) -->
+            <Border x:Name="CardArtPanel" Grid.Column="0" IsVisible="False"
+                    Width="210" CornerRadius="10,0,0,10" ClipToBounds="True">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0%,0%" EndPoint="30%,100%">
+                        <GradientStop Color="#3C2159" Offset="0"/>
+                        <GradientStop Color="#252542" Offset="0.55"/>
+                        <GradientStop Color="#1A1A2E" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+                <Grid>
+                    <!-- Square (1:1) source, shown whole. Uniform, never UniformToFill: the art is
+                         a card face, and cropping its edges to fill a taller rail would eat the
+                         framing that makes it read as a card. -->
+                    <!-- MaxHeight is a measure guard, not styling: SizeToContent=Height measures
+                         this cell with infinite height, so an unconstrained Uniform Image would
+                         ask for its natural 1024px and shove the window straight to MaxHeight. -->
+                    <Image x:Name="CardArtImage" Stretch="Uniform"
+                           Margin="18" MaxHeight="240"
+                           HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Image.Effect>
+                            <DropShadowEffect Color="#FF69B4" BlurRadius="26" OffsetX="0" OffsetY="0" Opacity="0.55"/>
+                        </Image.Effect>
+                    </Image>
+
+                    <!-- Hairline seam so the rail reads as part of the card, not a pasted panel -->
+                    <Rectangle Width="1" HorizontalAlignment="Right" Fill="#55FF69B4"/>
+                </Grid>
+            </Border>
+
+            <!-- Close Button -->
+            <Button x:Name="BtnClose"
+                    Grid.Column="1" Classes="closeGlyph"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="28" Height="28" Margin="0,8,12,0" Padding="0"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand"
+                    ZIndex="1">
+                <TextBlock Text="✕"/>
+            </Button>
+
+            <StackPanel Grid.Column="1" Margin="20" VerticalAlignment="Center">
+                <!-- Optional Image (server announcements: downloaded from image_url) -->
+                <Border x:Name="ImageContainer" IsVisible="False"
+                        CornerRadius="8" ClipToBounds="True" Margin="0,0,0,14"
+                        MaxHeight="200" HorizontalAlignment="Center">
+                    <Image x:Name="AnnouncementImage" Stretch="Uniform"/>
+                </Border>
+
+                <!-- Title -->
+                <TextBlock x:Name="TxtTitle"
+                           Foreground="{DynamicResource PinkBrush}" FontWeight="Bold" FontSize="20"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,0,0,10"/>
+
+                <!-- Message -->
+                <TextBlock x:Name="TxtMessage"
+                           Foreground="White" FontSize="14"
+                           TextWrapping="Wrap" TextAlignment="Center"
+                           LineHeight="22"
+                           Margin="0,0,0,16"/>
+
+                <!--
+                    Button rail. Vertical by default, which is exactly how the two buttons stacked
+                    before this wrapper existed (both are HorizontalAlignment=Center, so a
+                    stretch-wide vertical StackPanel changes nothing). Card layout flips it to
+                    Horizontal in code so the CTA and the dismiss sit side by side under the copy.
+                -->
+                <StackPanel x:Name="ButtonRow">
+                    <!-- Action / Download button (visible when link_url or an onAction is supplied) -->
+                    <Button x:Name="BtnDownload" Content="▶ Download Mod"
+                            Theme="{StaticResource AnnouncementPillButton}"
+                            HorizontalAlignment="Center"
+                            Width="180" Height="38"
+                            Cursor="Hand"
+                            FontSize="14" FontWeight="Bold"
+                            IsVisible="False"
+                            Margin="0,0,0,8"/>
+
+                    <!-- Got it Button -->
+                    <Button x:Name="BtnDismiss" Content="Got it!"
+                            Theme="{StaticResource AnnouncementPillButton}"
+                            HorizontalAlignment="Center"
+                            Width="120" Height="36"
+                            Cursor="Hand"
+                            FontSize="14" FontWeight="SemiBold"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/AnnouncementPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/AnnouncementPopup.axaml.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Popup window for server-triggered announcements with optional image, link, and theme support.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/AnnouncementPopup.xaml.cs. Deviations:
+    ///  - <c>ImageSource</c> is a WPF type; the card-art parameter takes Avalonia's
+    ///    <see cref="IImage"/> instead. Call shape is otherwise unchanged.
+    ///  - The <c>DoubleAnimation</c>s (window fade in/out, card-art pop) become
+    ///    <see cref="Transitions"/> plus a plain property assignment - Avalonia animates through
+    ///    the property system, not a Storyboard, so there is no clock to tear down and the WPF
+    ///    <c>Closed</c> handler that unpinned one has nothing to do here.
+    ///  - <c>ApplyMatrixButtonStyle</c>'s runtime <c>FrameworkElementFactory</c> template becomes
+    ///    the declared <c>AnnouncementMatrixPillButton</c> ControlTheme in the XAML, assigned to
+    ///    <c>Button.Theme</c>. Same three colours, none of the factory plumbing. <c>Freeze()</c>
+    ///    has no Avalonia twin and is dropped (Avalonia brushes are not thread-affine here).
+    ///  - <c>Dispatcher.BeginInvoke</c> -&gt; <c>Dispatcher.UIThread.Post</c>.
+    ///  - <c>App.Logger</c> has no twin on this head yet, so the guarded catches simply swallow,
+    ///    as AchievementPopup's port does.
+    ///  - The default dismissal bookkeeping (<c>App.Settings.Current.DismissedAnnouncementId</c>)
+    ///    is stubbed; see DismissAndClose.
+    /// </summary>
+    public partial class AnnouncementPopup : Window
+    {
+        /// <summary>Window width once the card-art rail is showing. The default 440 is sized for the
+        /// stacked, text-only server announcement; the rail eats 210 of it, so the copy column would
+        /// be unreadably narrow without this. At 620 the copy column lands near 346px, which holds a
+        /// ~130-character body in three lines - the ceiling the nudge copy is written to.</summary>
+        private const double CardLayoutWidth = 620;
+
+        private const double FadeMs = 300;
+
+        private readonly string _announcementId;
+        private readonly string? _linkUrl;
+        private readonly Action? _onDismiss;
+        private readonly Action? _onAction;
+
+        private readonly TextBlock _txtTitle, _txtMessage;
+        private readonly Button _btnDownload, _btnDismiss, _btnClose;
+        private readonly Border _cardArtPanel, _imageContainer;
+        private readonly Image _cardArtImage, _announcementImage;
+        private readonly StackPanel _buttonRow;
+
+        /// <summary>Only non-null in card layout.</summary>
+        private ScaleTransform? _cardArtScale;
+
+        /// <summary>Render constructor: the card layout, which is the strict superset - art rail,
+        /// its gradient and seam, the horizontal button row and both templated pill buttons. The
+        /// stacked server layout is the same window with column 0 collapsed.</summary>
+        internal AnnouncementPopup() : this(
+            id: "render-sample",
+            title: "Weekly Intake",
+            message: "Two minutes of questions keeps the program tuned to where you actually are.",
+            imageUrl: null,
+            linkUrl: null,
+            theme: null,
+            onDismiss: () => { },
+            cardImage: SampleCardArt(),
+            actionText: "Start intake",
+            onAction: () => { },
+            dismissText: "Not now")
+        {
+            // A transition cannot complete inside a headless render's two dispatcher passes, so the
+            // PNG would capture a transparent window and a 0.94-scaled card. Land both immediately.
+            Transitions = null;
+            Opacity = 1;
+            if (_cardArtScale is not null)
+            {
+                _cardArtScale.Transitions = null;
+                _cardArtScale.ScaleX = _cardArtScale.ScaleY = 1;
+            }
+
+            // RenderProof forces a NaN Height to 780, which SizeToContent would then fight and
+            // MaxHeight=600 would clamp - a tall frame with a dead band under the card. Pin it.
+            SizeToContent = SizeToContent.Manual;
+            Height = 320;
+        }
+
+        /// <summary>Flat swatch standing in for real card art, so the render proves the rail,
+        /// its Uniform stretch and the drop shadow without shipping a bitmap in the repo.</summary>
+        private static IImage SampleCardArt() => new DrawingImage
+        {
+            Drawing = new GeometryDrawing
+            {
+                Brush = new SolidColorBrush(Color.Parse("#FF69B4")),
+                Geometry = new RectangleGeometry(new Rect(0, 0, 240, 240))
+            }
+        };
+
+        /// <param name="onDismiss">Optional replacement for the default dismissal bookkeeping. The
+        /// popup normally records <c>AppSettings.DismissedAnnouncementId</c>, which is a SINGLE slot
+        /// owned by server-triggered announcements. Any local, recurring popup that reuses this
+        /// window must pass its own handler, or dismissing it would silently consume the slot and
+        /// suppress the next real server announcement.</param>
+        /// <param name="cardImage">Optional LOCAL art (a resolved <see cref="IImage"/>, not a
+        /// URL). Supplying it switches the window to the wider card layout: art rail on the left,
+        /// copy and buttons beside it. Server announcements pass <paramref name="imageUrl"/> instead
+        /// and keep the original stacked 440px layout untouched - the two paths are deliberately
+        /// separate so a local card can never restyle a server announcement. Null (the resource was
+        /// missing) simply leaves the text-only layout in place; it never renders an empty box.</param>
+        /// <param name="actionText">Label for the primary button when <paramref name="onAction"/> is
+        /// supplied. Ignored otherwise.</param>
+        /// <param name="onAction">Optional primary action. When set, the primary button runs this
+        /// instead of opening <paramref name="linkUrl"/>, and the popup dismisses itself through the
+        /// normal path first - so the caller's <paramref name="onDismiss"/> bookkeeping still runs.</param>
+        /// <param name="dismissText">Optional replacement label for the secondary button.</param>
+        public AnnouncementPopup(string id, string title, string message, string? imageUrl,
+            string? linkUrl = null, string? theme = null, Action? onDismiss = null,
+            IImage? cardImage = null, string? actionText = null, Action? onAction = null,
+            string? dismissText = null)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtTitle = this.FindControl<TextBlock>("TxtTitle")!;
+            _txtMessage = this.FindControl<TextBlock>("TxtMessage")!;
+            _btnDownload = this.FindControl<Button>("BtnDownload")!;
+            _btnDismiss = this.FindControl<Button>("BtnDismiss")!;
+            _btnClose = this.FindControl<Button>("BtnClose")!;
+            _cardArtPanel = this.FindControl<Border>("CardArtPanel")!;
+            _imageContainer = this.FindControl<Border>("ImageContainer")!;
+            _cardArtImage = this.FindControl<Image>("CardArtImage")!;
+            _announcementImage = this.FindControl<Image>("AnnouncementImage")!;
+            _buttonRow = this.FindControl<StackPanel>("ButtonRow")!;
+
+            _announcementId = id;
+            _linkUrl = linkUrl;
+            _onDismiss = onDismiss;
+            _onAction = onAction;
+            _txtTitle.Text = title;
+            _txtMessage.Text = message;
+
+            _btnDownload.Click += BtnDownload_Click;
+            _btnDismiss.Click += BtnDismiss_Click;
+            _btnClose.Click += BtnClose_Click;
+
+            // Primary button: a caller-supplied action wins over the server's link_url. The
+            // link_url branch below is byte-identical to the original behaviour when onAction is null.
+            if (onAction != null && !string.IsNullOrWhiteSpace(actionText))
+            {
+                _btnDownload.Content = actionText;
+                _btnDownload.IsVisible = true;
+            }
+            else if (!string.IsNullOrWhiteSpace(linkUrl))
+            {
+                _btnDownload.IsVisible = true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(dismissText))
+            {
+                _btnDismiss.Content = dismissText;
+            }
+
+            if (cardImage != null)
+            {
+                ApplyCardLayout(cardImage);
+            }
+
+            // Apply theme
+            if (string.Equals(theme, "matrix", StringComparison.OrdinalIgnoreCase))
+            {
+                ApplyMatrixTheme();
+            }
+
+            // Fade in
+            Transitions = new Transitions
+            {
+                new DoubleTransition { Property = OpacityProperty, Duration = TimeSpan.FromMilliseconds(FadeMs) }
+            };
+            Opacity = 0;
+            Loaded += (_, _) =>
+            {
+                Opacity = 1;
+                if (_cardArtScale != null)
+                {
+                    _cardArtScale.ScaleX = 1.0;
+                    _cardArtScale.ScaleY = 1.0;
+                }
+            };
+
+            // Load image asynchronously if URL provided
+            if (!string.IsNullOrWhiteSpace(imageUrl))
+            {
+                _ = LoadImageAsync(imageUrl);
+            }
+        }
+
+        /// <summary>
+        /// Switch from the stacked announcement layout to the two-column card: art rail left, copy
+        /// and buttons right. Every change here is a local set on an element the server path leaves
+        /// alone, so nothing about this can leak into an announcement that did not ask for it.
+        /// </summary>
+        private void ApplyCardLayout(IImage art)
+        {
+            try
+            {
+                Width = CardLayoutWidth;
+
+                _cardArtImage.Source = art;
+                _cardArtPanel.IsVisible = true;
+
+                // Centred copy reads as a notice; ranged against art it reads as a card face.
+                _txtTitle.TextAlignment = TextAlignment.Left;
+                _txtMessage.TextAlignment = TextAlignment.Left;
+                _txtMessage.Margin = new Thickness(0, 0, 0, 18);
+
+                // Buttons go side by side under the copy instead of stacking down the middle.
+                _buttonRow.Orientation = Orientation.Horizontal;
+                _buttonRow.HorizontalAlignment = HorizontalAlignment.Left;
+
+                _btnDownload.Width = 176;
+                _btnDownload.Height = 38;
+                _btnDownload.Margin = new Thickness(0, 0, 10, 0);
+
+                _btnDismiss.Width = 116;
+                _btnDismiss.Height = 38;
+
+                // The WPF original ran the pop off the transform with BeginAnimation; a transition
+                // on the same transform is the Avalonia twin - Loaded pushes it to 1.0.
+                _cardArtScale = new ScaleTransform(0.94, 0.94)
+                {
+                    Transitions = new Transitions
+                    {
+                        new DoubleTransition
+                        {
+                            Property = ScaleTransform.ScaleXProperty,
+                            Duration = TimeSpan.FromMilliseconds(420),
+                            Easing = new CubicEaseOut()
+                        },
+                        new DoubleTransition
+                        {
+                            Property = ScaleTransform.ScaleYProperty,
+                            Duration = TimeSpan.FromMilliseconds(420),
+                            Easing = new CubicEaseOut()
+                        }
+                    }
+                };
+                _cardArtImage.RenderTransform = _cardArtScale;
+            }
+            catch
+            {
+                // A layout failure must not cost the user the message itself.
+                // ponytail: needs App.Logger, wired when it moves to Core.
+            }
+        }
+
+        private void ApplyMatrixTheme()
+        {
+            var matrixGreen = Color.Parse("#00FF41");
+            var matrixGreenBrush = new SolidColorBrush(matrixGreen);
+            var matrixLightGreenBrush = new SolidColorBrush(Color.Parse("#39FF14"));
+
+            var matrixBg = Color.Parse("#0D0D0D");
+            var matrixBgBrush = new SolidColorBrush(Color.FromArgb(0xF0, matrixBg.R, matrixBg.G, matrixBg.B));
+
+            var consolasFont = new FontFamily("Consolas, Courier New");
+
+            // Find the outer border (first child of the window)
+            if (Content is Border outerBorder)
+            {
+                outerBorder.Background = matrixBgBrush;
+                outerBorder.BorderBrush = matrixGreenBrush;
+                outerBorder.Effect = new DropShadowEffect
+                {
+                    Color = matrixGreen,
+                    BlurRadius = 20,
+                    OffsetX = 0,
+                    OffsetY = 0,
+                    Opacity = 0.6
+                };
+            }
+
+            // Title
+            _txtTitle.Foreground = matrixGreenBrush;
+            _txtTitle.FontFamily = consolasFont;
+
+            // Message
+            _txtMessage.Foreground = matrixLightGreenBrush;
+            _txtMessage.FontFamily = consolasFont;
+
+            // Download button — matrix style
+            if (_btnDownload.IsVisible)
+            {
+                ApplyMatrixButtonStyle(_btnDownload, consolasFont);
+            }
+
+            // Dismiss button — matrix style
+            ApplyMatrixButtonStyle(_btnDismiss, consolasFont);
+        }
+
+        /// <summary>
+        /// Swap the pill theme for its green twin. WPF assembled the same template from
+        /// FrameworkElementFactory at runtime; the ControlTheme is declared in the XAML instead,
+        /// so the hover and pressed colours are selectors rather than Trigger objects.
+        /// </summary>
+        private void ApplyMatrixButtonStyle(Button button, FontFamily font)
+        {
+            button.FontFamily = font;
+            if (Resources.TryGetResource("AnnouncementMatrixPillButton", ActualThemeVariant, out var theme)
+                && theme is ControlTheme matrixTheme)
+            {
+                button.Theme = matrixTheme;
+            }
+        }
+
+        private async Task LoadImageAsync(string imageUrl)
+        {
+            try
+            {
+                using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+                var bytes = await httpClient.GetByteArrayAsync(imageUrl);
+
+                using var stream = new MemoryStream(bytes);
+                var bitmap = new Bitmap(stream);
+
+                Dispatcher.UIThread.Post(() =>
+                {
+                    _announcementImage.Source = bitmap;
+                    _imageContainer.IsVisible = true;
+                });
+            }
+            catch
+            {
+                // ponytail: needs App.Logger ("Failed to load announcement image"), wired when it
+                // moves to Core. A missing image leaves the text-only layout, as before.
+            }
+        }
+
+        private void BtnDownload_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (_onAction != null)
+            {
+                // Dismiss FIRST, through the normal path, so the caller's onDismiss bookkeeping runs
+                // (acting on a weekly nudge has to count as answering it, or it fires again next
+                // launch). The action itself is then queued behind the fade: it can be heavy - the
+                // intake boots a web view window - and running it inline would stall the animation.
+                DismissAndClose();
+
+                var act = _onAction;
+                Dispatcher.UIThread.Post(() =>
+                {
+                    try { act(); }
+                    catch { /* ponytail: needs App.Logger ("Announcement action failed") */ }
+                }, DispatcherPriority.Background);
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_linkUrl) &&
+                Uri.TryCreate(_linkUrl, UriKind.Absolute, out var uri) &&
+                uri.Scheme == Uri.UriSchemeHttps)
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+                }
+                catch
+                {
+                    // ponytail: needs App.Logger ("Failed to open announcement link").
+                }
+            }
+        }
+
+        private void DismissAndClose()
+        {
+            if (_onDismiss != null)
+            {
+                // Caller owns its own dismissal record - do NOT touch the shared server-announcement slot.
+                try { _onDismiss(); }
+                catch { /* ponytail: needs App.Logger ("Announcement dismiss handler failed") */ }
+            }
+            else
+            {
+                // ponytail: needs App.Settings (the single DismissedAnnouncementId slot), wired when
+                // it moves to Core. Until then a server announcement re-shows on the next launch
+                // rather than being recorded as seen.
+                _ = _announcementId;
+            }
+
+            try
+            {
+                Opacity = 0;
+                DispatcherTimer.RunOnce(() => { try { Close(); } catch { /* already closed */ } },
+                    TimeSpan.FromMilliseconds(FadeMs));
+            }
+            catch
+            {
+                try { Close(); } catch { }
+            }
+        }
+
+        private void BtnDismiss_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            DismissAndClose();
+        }
+
+        private void BtnClose_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            DismissAndClose();
+        }
+
+        // Window_MouseLeftButtonDown is not ported: the WPF handler is deliberately empty
+        // ("Don't dismiss on click — announcement has action buttons, use close button or Got it"),
+        // and not attaching a handler is the same behaviour.
+    }
+}


### PR DESCRIPTION
637 lines. No WebView2: the only mention in the WPF source is a comment about the caller's intake window. A runtime-built WPF style factory becomes a declared ControlTheme.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read (real strings, no blank templated controls, no binding errors), `--render-all` N/N, core guards. Service, device and Win32 reaches are `ponytail:` stubs. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351