### PR TITLE
feat(avalonia): port QuestCompletePopup

### DIFF
--- a/CCP.Avalonia/Views/Windows/QuestCompletePopup.axaml
+++ b/CCP.Avalonia/Views/Windows/QuestCompletePopup.axaml
@@ -1,0 +1,89 @@
+<!-- PORTED from ConditioningControlPanel/Windows/QuestCompletePopup.xaml.
+     Structure, ordering, spacing and every colour literal preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None"              -> SystemDecorations="None"
+       AllowsTransparency="True"       -> TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"           -> CanResize="False"
+       MouseLeftButtonDown="..."       -> PointerPressed, wired in the constructor
+       Click="BtnClose_Click"          -> wired in the constructor (BtnClose gained an x:Name)
+       ShadowDepth="0"                 -> OffsetX="0" OffsetY="0"  (Avalonia's DropShadowEffect
+                                          takes a vector, not depth+direction)
+       Button.Style + IsMouseOver      -> the Button.popupclose selectors below
+
+     Every string here is a literal in the WPF original too - this view has no {loc:Str} keys and
+     none are invented for it.
+
+     The close button carries a TextBlock child rather than Content: Avalonia parses "_" in
+     Content as an access key. See the porting notes in CLAUDE.md. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.QuestCompletePopup"
+        Title="Quest Complete!"
+        Width="350" Height="130"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        Focusable="False"
+        CanResize="False"
+        WindowStartupLocation="Manual">
+
+    <Window.Styles>
+        <!-- The WPF <Button.Style> IsMouseOver trigger. The Fluent theme paints its own hover
+             plate, so the rest state has to be pinned too or this borderless glyph grows a grey
+             background on hover - which the WPF Background="Transparent" got for free.
+             ponytail: byte-identical to RoadmapStepPopup.axaml:popupclose; hoist both to
+             Theme/Styles.xaml when a third popup wants it (this layer may not edit Theme). -->
+        <Style Selector="Button.popupclose /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+        </Style>
+        <Style Selector="Button.popupclose:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+    </Window.Styles>
+
+    <Border Background="#E0151530" CornerRadius="12" BorderBrush="#00E676" BorderThickness="2"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect Color="#00E676" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <Grid Margin="15">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Checkmark Icon -->
+            <Border Grid.Column="0" Width="60" Height="60" Background="#2D4A2D" CornerRadius="30" Margin="0,0,15,0">
+                <TextBlock Text="✓" Foreground="#00E676" FontSize="32" FontWeight="Bold"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+
+            <!-- Text Content -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <TextBlock Text="QUEST COMPLETE!" Foreground="#00E676"
+                           FontWeight="Bold" FontSize="16" Margin="0,0,0,4"/>
+                <TextBlock x:Name="TxtQuestName" Text="Quest Name"
+                           Foreground="White" FontSize="14" FontWeight="SemiBold"
+                           TextWrapping="Wrap" Margin="0,0,0,4"/>
+                <TextBlock x:Name="TxtXPAwarded" Text="+0 XP"
+                           Foreground="#FFD700" FontSize="13" FontWeight="Bold"/>
+            </StackPanel>
+
+            <!-- Close Button -->
+            <Button x:Name="BtnClose" Grid.Column="1" Classes="popupclose"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="24" Height="24" Margin="0,-5,-5,0" Padding="0"
+                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                    Background="Transparent" Foreground="{DynamicResource TextMutedBrush}"
+                    BorderThickness="0" Cursor="Hand">
+                <TextBlock Text="✕"/>
+            </Button>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/QuestCompletePopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuestCompletePopup.axaml.cs
@@ -1,0 +1,152 @@
+using System;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Popup window shown when a quest is completed.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/QuestCompletePopup.xaml.cs. Deviations:
+    ///  - <c>BeginAnimation(OpacityProperty, DoubleAnimation)</c> has no Avalonia equivalent: a
+    ///    <see cref="DoubleTransition"/> on Opacity gives the same 300ms fade for a plain
+    ///    assignment, and the close is deferred by one timer tick so the fade-out is seen.
+    ///  - <c>SystemParameters.WorkArea</c> becomes <c>Screens.Primary.WorkingArea</c>, which is
+    ///    only populated once the window has a platform handle, so placement moves to OnOpened.
+    ///  - <c>MouseLeftButtonDown</c> / <c>Click</c> become PointerPressed / Click wired here.
+    ///  - <c>App.Logger</c> calls are dropped; there is no logger on this head yet.
+    ///  - <see cref="ForceToTopMost"/>'s Win32 body is stubbed; see the note on it.
+    /// </summary>
+    public partial class QuestCompletePopup : Window
+    {
+        private const double FadeMs = 300;
+
+        private readonly DispatcherTimer _autoCloseTimer;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the popup.</summary>
+        internal QuestCompletePopup() : this("Wear the plug for one hour", 250)
+        {
+            // The fade-in cannot complete inside a headless render's two dispatcher passes, so the
+            // PNG would capture a fully transparent window. Skip the animation for the render.
+            Transitions = null;
+            Opacity = 1;
+        }
+
+        public QuestCompletePopup(string questName, int xpAwarded)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            this.FindControl<TextBlock>("TxtQuestName")!.Text = questName;
+            this.FindControl<TextBlock>("TxtXPAwarded")!.Text = $"+{xpAwarded} XP";
+
+            // Auto-close after 5 seconds
+            _autoCloseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+            _autoCloseTimer.Tick += (_, _) =>
+            {
+                _autoCloseTimer.Stop();
+                FadeOutAndClose();
+            };
+            _autoCloseTimer.Start();
+
+            // Fade in
+            Transitions = new Transitions
+            {
+                new DoubleTransition { Property = OpacityProperty, Duration = TimeSpan.FromMilliseconds(FadeMs) }
+            };
+            Opacity = 0;
+            Loaded += (_, _) =>
+            {
+                // Re-assert to the top of the topmost band WITHOUT activating, so the popup is
+                // visible over an in-app fullscreen video and playback keeps focus (#332).
+                ForceToTopMost();
+                Opacity = 1;
+            };
+
+            // Handlers live here rather than in markup, per the porting convention. After the
+            // timer exists, because the close button stops it.
+            this.FindControl<Button>("BtnClose")!.Click += (_, _) =>
+            {
+                _autoCloseTimer.Stop();
+                FadeOutAndClose();
+            };
+            AddHandler(InputElement.PointerPressedEvent, Window_PointerPressed, handledEventsToo: false);
+        }
+
+        /// <summary>
+        /// WPF re-asserted <c>SetWindowPos(HWND_TOPMOST, SWP_NOACTIVATE)</c> here so the toast rose
+        /// to the TOP of the topmost band without stealing focus, beating the app's own fullscreen
+        /// video surface - which is also Topmost but was activated more recently (#332).
+        ///
+        /// ponytail: only the portable half survives. Re-assigning Topmost re-issues
+        /// <c>_NET_WM_STATE_ABOVE</c>, which puts the window in the keep-above layer but does NOT
+        /// reorder it against a sibling already in that layer, so an in-app fullscreen video can
+        /// still cover this popup. <c>X11Overlay.RestackAbove</c> is the right primitive and is
+        /// already on this head, but it needs the sibling TopLevel and this popup has no handle to
+        /// the video window - so wiring it needs whoever owns that surface, in its own layer.
+        /// </summary>
+        private void ForceToTopMost()
+        {
+            try { Topmost = true; }
+            catch { /* the WPF original swallowed the same failure */ }
+        }
+
+        /// <summary>
+        /// Position the window in the bottom-right corner of the primary screen.
+        /// Screens is null until the window has a handle, so this runs on open rather than in the
+        /// constructor as WPF's SystemParameters.WorkArea allowed.
+        /// </summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            try
+            {
+                var screen = Screens.Primary
+                    ?? throw new InvalidOperationException("no primary screen");
+
+                // WorkingArea is physical pixels; Width/Height and the 20px margin are DIPs.
+                var scale = screen.Scaling;
+                var area = screen.WorkingArea;
+
+                // Position in bottom-right corner with 20px margin
+                Position = new PixelPoint(
+                    area.Right - (int)((Width + 20) * scale),
+                    area.Bottom - (int)((Height + 20) * scale));
+            }
+            catch
+            {
+                // Fallback: centre on screen, as the WPF original did.
+                WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            }
+        }
+
+        private void FadeOutAndClose()
+        {
+            try
+            {
+                Opacity = 0;
+                DispatcherTimer.RunOnce(() => { try { Close(); } catch { /* already closed */ } },
+                    TimeSpan.FromMilliseconds(FadeMs));
+            }
+            catch
+            {
+                try { Close(); } catch { /* Ignore close errors */ }
+            }
+        }
+
+        private void Window_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            FadeOutAndClose();   // the original does not stop the timer here either; OnClosed does
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _autoCloseTimer.Stop();
+            base.OnClosed(e);
+        }
+    }
+}


### PR DESCRIPTION
241 lines. The topmost re-assert reissues _NET_WM_STATE_ABOVE but cannot reorder against a sibling already keep-above, so the app's own fullscreen video can still cover it; RestackAbove needs a sibling handle this popup does not own, so that wiring belongs to whoever owns the video surface.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351