### PR TITLE
feat(avalonia): port PopQuizWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml
@@ -1,0 +1,134 @@
+<!-- PORTED from ConditioningControlPanel/Windows/PopQuizWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                      -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       LinearGradientBrush 0,0 -> 1,1 -> "0%,0%" -> "100%,100%". A bare pair is ABSOLUTE pixels in
+                                         Avalonia, which collapses the border ramp to one pixel.
+       <Border.BorderThickness><Thickness>
+                                      -> the attribute form; element-form Thickness is not what
+                                         Avalonia's XAML compiler expects here.
+       DropShadowEffect ShadowDepth   -> OffsetX="0" OffsetY="0"
+       {DynamicResource PinkColor}
+         inside an Effect             -> {StaticResource PinkColor}. An Effect is not in the
+                                         logical tree, so DynamicResource has no scope to resolve.
+       Visibility="Collapsed"         -> IsVisible="False"
+       KeyDown= / MouseLeftButtonDown= / MouseEnter= / MouseLeave=
+                                      -> KeyDown / PointerPressed / PointerEntered / PointerExited,
+                                         wired in the constructor.
+
+     Tag="0..3" and Cursor="Hand" stay on the answer Borders: both exist on Avalonia's Control,
+     and the constructor overwrites Tag with the shuffled index exactly as WPF did.
+     Focusable="True" is new: the window has no focusable child and Avalonia only delivers KeyDown
+     to a focused element, so without it ESC would silently do nothing. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.PopQuizWindow"
+        Title="{loc:Str label_pop_quiz}"
+        Width="500" Height="420"
+        WindowStartupLocation="CenterScreen"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        Focusable="True"
+        Topmost="True">
+
+    <Border CornerRadius="16" Margin="10" BorderThickness="1.5">
+        <Border.Background>
+            <SolidColorBrush Color="#F0151530"/>
+        </Border.Background>
+        <Border.BorderBrush>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,100%">
+                <GradientStop Color="#60FF69B4" Offset="0"/>
+                <GradientStop Color="#609B59B6" Offset="1"/>
+            </LinearGradientBrush>
+        </Border.BorderBrush>
+        <Border.Effect>
+            <DropShadowEffect Color="Black" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+        </Border.Effect>
+
+        <Grid Margin="24,20">
+            <!-- Question Panel -->
+            <StackPanel x:Name="QuestionPanel" VerticalAlignment="Center">
+                <!-- Question text -->
+                <TextBlock x:Name="TxtQuestion" FontSize="24" FontWeight="Bold"
+                           Foreground="White" TextWrapping="Wrap" TextAlignment="Center"
+                           Margin="0,0,0,24">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="15" OffsetX="0" OffsetY="0" Opacity="0.3"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+
+                <!-- Answer buttons -->
+                <StackPanel x:Name="AnswersPanel">
+                    <Border x:Name="AnswerA" Cursor="Hand" CornerRadius="8" Margin="0,0,0,8" Padding="14,10"
+                            Tag="0" BorderThickness="1">
+                        <Border.Background>
+                            <SolidColorBrush Color="#15FFFFFF"/>
+                        </Border.Background>
+                        <Border.BorderBrush>
+                            <SolidColorBrush Color="#20FFFFFF"/>
+                        </Border.BorderBrush>
+                        <TextBlock x:Name="TxtAnswerA" FontSize="15" Foreground="#D0D0E0"
+                                   TextWrapping="Wrap" TextAlignment="Center"/>
+                    </Border>
+
+                    <Border x:Name="AnswerB" Cursor="Hand" CornerRadius="8" Margin="0,0,0,8" Padding="14,10"
+                            Tag="1" BorderThickness="1">
+                        <Border.Background>
+                            <SolidColorBrush Color="#15FFFFFF"/>
+                        </Border.Background>
+                        <Border.BorderBrush>
+                            <SolidColorBrush Color="#20FFFFFF"/>
+                        </Border.BorderBrush>
+                        <TextBlock x:Name="TxtAnswerB" FontSize="15" Foreground="#D0D0E0"
+                                   TextWrapping="Wrap" TextAlignment="Center"/>
+                    </Border>
+
+                    <Border x:Name="AnswerC" Cursor="Hand" CornerRadius="8" Margin="0,0,0,8" Padding="14,10"
+                            Tag="2" BorderThickness="1">
+                        <Border.Background>
+                            <SolidColorBrush Color="#15FFFFFF"/>
+                        </Border.Background>
+                        <Border.BorderBrush>
+                            <SolidColorBrush Color="#20FFFFFF"/>
+                        </Border.BorderBrush>
+                        <TextBlock x:Name="TxtAnswerC" FontSize="15" Foreground="#D0D0E0"
+                                   TextWrapping="Wrap" TextAlignment="Center"/>
+                    </Border>
+
+                    <Border x:Name="AnswerD" Cursor="Hand" CornerRadius="8" Margin="0,0,0,8" Padding="14,10"
+                            Tag="3" BorderThickness="1">
+                        <Border.Background>
+                            <SolidColorBrush Color="#15FFFFFF"/>
+                        </Border.Background>
+                        <Border.BorderBrush>
+                            <SolidColorBrush Color="#20FFFFFF"/>
+                        </Border.BorderBrush>
+                        <TextBlock x:Name="TxtAnswerD" FontSize="15" Foreground="#D0D0E0"
+                                   TextWrapping="Wrap" TextAlignment="Center"/>
+                    </Border>
+                </StackPanel>
+
+                <!-- ESC hint -->
+                <TextBlock Text="{loc:Str label_esc_to_skip}" Foreground="#303050" FontSize="11"
+                           HorizontalAlignment="Center" Margin="0,8,0,0"/>
+            </StackPanel>
+
+            <!-- Affirmation Panel (shown after answering) -->
+            <StackPanel x:Name="AffirmationPanel" IsVisible="False"
+                        VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock x:Name="TxtAffirmation" FontSize="22" FontWeight="SemiBold"
+                           Foreground="{DynamicResource PinkBrush}" TextWrapping="Wrap" TextAlignment="Center">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+                <TextBlock Text="{loc:Str label_25_xp}" Foreground="{DynamicResource SecondaryBrush}" FontSize="14" FontWeight="Bold"
+                           HorizontalAlignment="Center" Margin="0,10,0,0"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// The pop quiz: one question, four shuffled answers, every one of them "correct", and an
+    /// affirmation plus 25 XP whichever is picked.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/PopQuizWindow.xaml.cs. Deviations:
+    ///  - The two Win32 calls are gone. <c>SetWindowPos(HWND_TOPMOST)</c> is <c>Topmost="True"</c>
+    ///    in the markup — Avalonia maps it to <c>_NET_WM_STATE_ABOVE</c>, which is the correct X11
+    ///    mechanism (see <c>Platform/X11Overlay</c>'s header) — and <c>SetForegroundWindow</c> is
+    ///    <see cref="Window.Activate"/> in the Deactivated handler.
+    ///  - The 200ms <c>_keepOnTopTimer</c> is dropped entirely. Both halves of it are gone: the
+    ///    topmost re-assert is covered by the property above, and the "self-close once the main
+    ///    window is genuinely gone" watchdog reads <c>App.MainWindowRef</c>.
+    ///    ponytail: needs App.MainWindowRef, wired when the shell moves to Core. Dropping it also
+    ///    means nothing here can outlive the window during --render-all.
+    ///  - <c>PopQuizQuestion</c> is copied to the bottom of this file: it lives in the WPF head's
+    ///    PopQuizService and this project may not reference that, same as TextEditorDialog's
+    ///    TextItem.
+    ///  - <c>MouseLeftButtonDown</c>/<c>MouseEnter</c>/<c>MouseLeave</c>/<c>KeyDown</c> are wired
+    ///    in the constructor as PointerPressed / PointerEntered / PointerExited / KeyDown.
+    ///  - <c>Application.Current.Windows</c> becomes the desktop lifetime's window list; that
+    ///    lifetime is null under a headless render, which the existing try/catch already covers.
+    /// </summary>
+    public partial class PopQuizWindow : Window
+    {
+        public static bool IsOpen { get; private set; }
+
+        private readonly PopQuizQuestion _question;
+        private readonly bool _isTest;
+        private bool _answered;
+        private static readonly Random _random = new();
+
+        private readonly TextBlock _txtQuestion, _txtAffirmation;
+        private readonly StackPanel _questionPanel, _affirmationPanel;
+        private readonly Border[] _answers;
+
+        /// <summary>Render/design constructor: the first question of the WPF pool, whose strings are
+        /// hardcoded English there too, so the sample is faithful rather than invented.</summary>
+        internal PopQuizWindow() : this(
+            new PopQuizQuestion("How does obedience feel?",
+                new[] { "Natural", "Peaceful", "Exciting", "Like coming home" },
+                new[] { "That's right — it's always been natural.", "Peace comes from letting go.", "The thrill never fades.", "Welcome home." }),
+            isTest: true)
+        {
+        }
+
+        public PopQuizWindow(PopQuizQuestion question, bool isTest = false)
+        {
+            IsOpen = true;
+
+            // ponytail: needs App.AvatarWindow (SetMuteAvatar). WPF muted the avatar for the whole
+            // quiz so her z-order work could not cover this window, and restored it in OnClosed.
+
+            AvaloniaXamlLoader.Load(this);
+            _question = question;
+            _isTest = isTest;
+
+            _txtQuestion = this.FindControl<TextBlock>("TxtQuestion")!;
+            _txtAffirmation = this.FindControl<TextBlock>("TxtAffirmation")!;
+            _questionPanel = this.FindControl<StackPanel>("QuestionPanel")!;
+            _affirmationPanel = this.FindControl<StackPanel>("AffirmationPanel")!;
+            _answers = new[] { "AnswerA", "AnswerB", "AnswerC", "AnswerD" }
+                .Select(n => this.FindControl<Border>(n)!).ToArray();
+
+            // Shuffle answer order
+            var indices = new[] { 0, 1, 2, 3 };
+            for (int i = 3; i > 0; i--)
+            {
+                int j = _random.Next(i + 1);
+                (indices[i], indices[j]) = (indices[j], indices[i]);
+            }
+
+            // When something steals focus from us, grab it right back. WPF did this with
+            // SetWindowPos(HWND_TOPMOST) + SetForegroundWindow; Topmost is declarative now and
+            // Activate() is the rest. The !IsVisible guard matters under --render-all, which
+            // closes each window before showing the next.
+            Deactivated += (_, _) =>
+            {
+                if (_answered) return;
+                Dispatcher.UIThread.Post(() =>
+                {
+                    if (_answered || !IsVisible) return;
+                    Activate();
+                }, DispatcherPriority.Input);
+            };
+
+            KeyDown += Window_KeyDown;
+            // No focusable child, and Avalonia only routes KeyDown to the focused element, so
+            // without this ESC does nothing on a real desktop.
+            Opened += (_, _) => Focus();
+
+            var texts = new[] { "TxtAnswerA", "TxtAnswerB", "TxtAnswerC", "TxtAnswerD" };
+            for (int slot = 0; slot < 4; slot++)
+            {
+                var border = _answers[slot];
+                this.FindControl<TextBlock>(texts[slot])!.Text = question.Answers[indices[slot]];
+
+                // Store the mapped indices so we can look up the correct affirmation
+                border.Tag = indices[slot];
+
+                border.PointerPressed += Answer_Click;
+                border.PointerEntered += Answer_MouseEnter;
+                border.PointerExited += Answer_MouseLeave;
+            }
+
+            _txtQuestion.Text = question.QuestionText;
+        }
+
+        private void Window_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && !_answered)
+            {
+                CleanupAndClose();
+            }
+        }
+
+        private async void Answer_Click(object? sender, PointerPressedEventArgs e)
+        {
+            if (_answered) return;
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+            _answered = true;
+
+            if (sender is not Border b || b.Tag is not int answerIndex) return;
+
+            // Highlight selected answer pink
+            b.Background = new SolidColorBrush(Color.FromArgb(0x40, 0xFF, 0x69, 0xB4));
+            b.BorderBrush = new SolidColorBrush(Color.FromArgb(0x60, 0xFF, 0x69, 0xB4));
+
+            // Play chime
+            PlayChime();
+
+            // Award XP
+            if (!_isTest)
+            {
+                // ponytail: needs App.Progression.AddXP(25, XPSource.Other), wired when the
+                // progression service moves to Core.
+            }
+
+            // Show affirmation
+            await Task.Delay(300);
+            _txtAffirmation.Text = _question.Affirmations[answerIndex];
+            _questionPanel.IsVisible = false;
+            _affirmationPanel.IsVisible = true;
+
+            // Auto-dismiss after 1.5s
+            await Task.Delay(1500);
+            CleanupAndClose();
+        }
+
+        private void CleanupAndClose()
+        {
+            // Mark answered BEFORE completing: OnClosed re-Completes when !_answered as a
+            // safety net, and the ESC path (still unanswered) would otherwise double-Complete —
+            // the second call hits the mismatch branch and clears whatever interaction the
+            // first Complete just dequeued (same #462 class as the lock-card fix).
+            _answered = true;
+            // ponytail: needs App.InteractionQueue.Complete(InteractionType.PopQuiz).
+            Close();
+        }
+
+        /// <summary>ponytail: needs App.Audio (PlayOneShot), App.Settings.MasterVolume and the
+        /// Resources/sounds chimes. The whole body of the WPF original was those three.</summary>
+        private static void PlayChime()
+        {
+        }
+
+        // Hover effects
+        private void Answer_MouseEnter(object? sender, PointerEventArgs e)
+        {
+            if (!_answered && sender is Border border)
+            {
+                border.Background = new SolidColorBrush(Color.FromArgb(0x25, 0xFF, 0xFF, 0xFF));
+                border.BorderBrush = new SolidColorBrush(Color.FromArgb(0x40, 0xFF, 0x69, 0xB4));
+            }
+        }
+
+        private void Answer_MouseLeave(object? sender, PointerEventArgs e)
+        {
+            if (!_answered && sender is Border border)
+            {
+                border.Background = new SolidColorBrush(Color.FromArgb(0x15, 0xFF, 0xFF, 0xFF));
+                border.BorderBrush = new SolidColorBrush(Color.FromArgb(0x20, 0xFF, 0xFF, 0xFF));
+            }
+        }
+
+        /// <summary>
+        /// Whether a pop quiz is actually on screen right now. Gates on the visible set rather than the
+        /// <see cref="IsOpen"/> flag: that flag is raised in the constructor and only lowered in
+        /// OnClosed, so a quiz that failed between construction and Show() would leave it stuck true
+        /// and block every later interaction.
+        /// </summary>
+        public static bool IsAnyOpen()
+        {
+            try
+            {
+                return DesktopWindows().Any(w => w.IsVisible);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Force close all pop quiz windows (used by panic button)
+        /// </summary>
+        public static void ForceCloseAll()
+        {
+            try
+            {
+                foreach (var window in DesktopWindows().ToList())
+                {
+                    try { window.Close(); } catch { }
+                }
+            }
+            catch { }
+        }
+
+        private static System.Collections.Generic.IEnumerable<PopQuizWindow> DesktopWindows() =>
+            (global::Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)
+                ?.Windows.OfType<PopQuizWindow>()
+            ?? Enumerable.Empty<PopQuizWindow>();
+
+        protected override void OnClosed(EventArgs e)
+        {
+            IsOpen = false;
+
+            // ponytail: restoring App.AvatarWindow's mute state, and the safety-net
+            // `if (!_answered) App.InteractionQueue.Complete(...)`, both go here, wired with the
+            // services above. _answered is deliberately NOT set here — that flag is what tells the
+            // safety net an unanswered quiz still owes a Complete.
+
+            base.OnClosed(e);
+        }
+    }
+
+    /// <summary>
+    /// One quiz question and its four answer/affirmation pairs.
+    /// Copied from ConditioningControlPanel/Services/Quiz/PopQuizService.cs: the type lives in the
+    /// WPF head, not in CCP.Core, and neither may be touched by this port.
+    /// </summary>
+    public class PopQuizQuestion
+    {
+        public string QuestionText { get; }
+        public string[] Answers { get; }
+        public string[] Affirmations { get; }
+
+        public PopQuizQuestion(string questionText, string[] answers, string[] affirmations)
+        {
+            QuestionText = questionText;
+            Answers = answers;
+            Affirmations = affirmations;
+        }
+    }
+}


### PR DESCRIPTION
400 lines. Two Win32 calls only, both mapped. Adds Focusable and an explicit focus on open: the window has no focusable child and Avalonia routes keys only to the focused element, so Escape would otherwise do nothing on a real desktop.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351