### PR TITLE
feat(avalonia): port BubbleCountResultWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml
@@ -1,0 +1,183 @@
+<!-- PORTED from ConditioningControlPanel/Windows/BubbleCountResultWindow.xaml.
+     Structure, ordering, spacing and every resource key preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True"
+                                      -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"          -> CanResize="False"
+       Visibility="Collapsed"         -> IsVisible="False"
+       {DynamicResource PinkColor}    -> {StaticResource PinkColor}. An Effect is not in the
+                                         logical tree, so DynamicResource has no scope to resolve
+                                         through (same as MantraWindow).
+       DropShadowEffect ShadowDepth="0"
+                                      -> OffsetX="0" OffsetY="0"
+       <Button.Style> ControlTemplate -> a keyed ControlTheme in Window.Resources. The
+                                         ContentPresenter gained Content="{TemplateBinding Content}":
+                                         a bare presenter draws nothing in Avalonia (CLAUDE.md #6).
+       Content="{loc:Str btn_submit}" -> a TextBlock child. Avalonia parses "_" in Content as an
+                                         access key and every loc key here is snake_case.
+       Click="BtnSubmit_Click"        -> wired in the constructor, with the KeyDown / TextChanged /
+                                         PreviewTextInput handlers the WPF code-behind wired there.
+       WS_EX_TOOLWINDOW (code-behind) -> ShowInTaskbar="False", already on this window.
+       TextWrapping/TextAlignment     -> ADDED to the title, instruction and feedback blocks. The
+                                         head renders in Inter, which is wider than the original's
+                                         Comic Sans, and "🫧 How Many Bubbles? 🫧" at 40px overran
+                                         the card's MaxWidth="600" - the trailing emoji was cut off
+                                         in the first render. Wrapping keeps every glyph on screen
+                                         without changing the card geometry. -->
+
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.BubbleCountResultWindow"
+        Title="{loc:Str dialog_how_many_bubbles}"
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        WindowState="Maximized"
+        Topmost="True"
+        ShowInTaskbar="False"
+        CanResize="False"
+        FontFamily="Comic Sans MS, Segoe UI">
+
+    <Window.Styles>
+        <!-- Fluent paints PART_BorderElement itself, and that setter sits on the template child, so
+             it outranks the TextBox's own Background/BorderBrush/BorderThickness in every state.
+             The values below are the WPF original's, verbatim.
+             ponytail: local copy, hoist to Theme/Styles.xaml when a second view needs it. -->
+        <Style Selector="TextBox.answer /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="#40FFFFFF"/>
+            <Setter Property="BorderBrush" Value="{StaticResource PinkBrush}"/>
+            <Setter Property="BorderThickness" Value="3"/>
+            <Setter Property="CornerRadius" Value="0"/>
+        </Style>
+    </Window.Styles>
+
+    <Window.Resources>
+        <!-- The WPF <Button.Style> inline ControlTemplate, setter for setter.
+             ponytail: local copy of ConditioningControlPanel/Windows/BubbleCountResultWindow.xaml's
+             inline Button style, hoist when a second view needs it. -->
+        <ControlTheme x:Key="SubmitButton" TargetType="Button">
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="10"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid>
+        <!-- Semi-transparent background -->
+        <Rectangle Fill="#E0000000"/>
+
+        <!-- Content Card -->
+        <Border Background="#FF2D2D3A"
+                CornerRadius="20"
+                Padding="50"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                MinWidth="500"
+                MaxWidth="600">
+            <Border.Effect>
+                <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="30" OffsetX="0" OffsetY="0" Opacity="0.5"/>
+            </Border.Effect>
+
+            <StackPanel>
+                <!-- Title -->
+                <TextBlock Text="{loc:Str label_how_many_bubbles}"
+                           FontSize="40"
+                           FontWeight="Bold"
+                           Foreground="{DynamicResource PinkBrush}"
+                           HorizontalAlignment="Center"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Margin="0,0,0,20">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="12" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+
+                <!-- Instruction -->
+                <TextBlock Text="{loc:Str label_enter_the_number_of_bubbles_you_counted}"
+                           FontSize="18"
+                           Foreground="{DynamicResource PinkBrush}"
+                           HorizontalAlignment="Center"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Margin="0,0,0,30"/>
+
+                <!-- Number Input -->
+                <TextBox x:Name="TxtAnswer"
+                         Classes="answer"
+                         FontSize="48"
+                         FontWeight="Bold"
+                         Foreground="White"
+                         Background="#40FFFFFF"
+                         BorderBrush="{DynamicResource PinkBrush}"
+                         BorderThickness="3"
+                         Padding="20,10"
+                         HorizontalAlignment="Center"
+                         MinWidth="200"
+                         TextAlignment="Center"
+                         MaxLength="3"/>
+
+                <!-- Attempts remaining -->
+                <TextBlock x:Name="TxtAttempts"
+                           Text="{loc:Str label_attempts_remaining_3}"
+                           FontSize="16"
+                           Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center"
+                           Margin="0,20,0,0"/>
+
+                <!-- Feedback -->
+                <TextBlock x:Name="TxtFeedback"
+                           Text=""
+                           FontSize="20"
+                           FontWeight="Bold"
+                           HorizontalAlignment="Center"
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Margin="0,15,0,0"
+                           IsVisible="False"/>
+
+                <!-- Submit Button -->
+                <Button x:Name="BtnSubmit"
+                        Theme="{StaticResource SubmitButton}"
+                        FontSize="24"
+                        FontWeight="Bold"
+                        Foreground="White"
+                        Background="{DynamicResource PinkBrush}"
+                        BorderThickness="0"
+                        Padding="40,15"
+                        Margin="0,30,0,0"
+                        Cursor="Hand"
+                        HorizontalAlignment="Center">
+                    <TextBlock Text="{loc:Str btn_submit}"/>
+                </Button>
+
+                <!-- Strict Mode Indicator -->
+                <TextBlock x:Name="TxtStrict"
+                           Text="{loc:Str label_strict_mode_must_answer_correctly}"
+                           FontSize="14"
+                           Foreground="#FF6B6B"
+                           HorizontalAlignment="Center"
+                           Margin="0,20,0,0"
+                           IsVisible="False"/>
+
+                <!-- ESC Hint -->
+                <TextBlock x:Name="TxtEscHint"
+                           Text="{loc:Str label_press_esc_to_skip_won_t_earn_xp}"
+                           FontSize="12"
+                           Foreground="{DynamicResource TextMutedBrush}"
+                           HorizontalAlignment="Center"
+                           Margin="0,15,0,0"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Result window for bubble counting - enter the number, 3 attempts, then mercy card.
+    /// Multi-monitor support.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/BubbleCountResultWindow.xaml.cs. Deviations:
+    ///
+    ///  - <b>Win32 is gone.</b> The only P/Invoke here was
+    ///    <c>SetWindowLong(GWL_EXSTYLE, WS_EX_TOOLWINDOW)</c> in <c>SourceInitialized</c>, to keep
+    ///    the window out of Alt+Tab. That is <c>ShowInTaskbar="False"</c> in the .axaml, so nothing
+    ///    is lost and no <c>user32</c> reference reaches this net8.0 head.
+    ///  - <b>Screens.</b> <c>System.Windows.Forms.Screen</c> + <c>BubbleCountWindow.GetDpiForScreen</c>
+    ///    become <see cref="Screen"/> from <c>Window.Screens</c>. The DPI division drops out with
+    ///    them: WPF's Left/Top are DIPs, Avalonia's <c>Position</c> is physical pixels, which is
+    ///    what <c>Screen.Bounds</c> is already in.
+    ///  - <b>Width=400/Height=300 in the ctor are dropped.</b> They were dead in WPF too - the XAML
+    ///    already carries <c>WindowState="Maximized"</c> and Loaded re-asserts it, so the 400x300
+    ///    box was never on screen.
+    ///  - <b>Services are stubbed</b> (see the ponytail comments): App.Settings.DualMonitorEnabled,
+    ///    App.GetAllScreensCached, App.Progression.AddXP, App.Achievements.TrackBubbleCountResult,
+    ///    App.Mods.GetPhrases, App.Logger, BubbleCountService.ScaleXpByDuration and LockCardWindow.
+    ///    Everything that only touches the view - the 3-attempt loop, the too-high/too-low hints,
+    ///    the cross-window input mirroring, the inactivity watchdog - is ported verbatim.
+    ///  - <c>PreviewTextInput</c> -> a tunnelling <c>TextInputEvent</c> handler; <c>Visibility</c>
+    ///    -> <c>IsVisible</c>; <c>SourceInitialized</c>/<c>Loaded</c> -> <c>Opened</c>/<c>Loaded</c>.
+    ///  - The feedback and attempt strings stay the hardcoded English of the WPF original: there is
+    ///    no loc key with a count placeholder for either, so inventing one would be worse than
+    ///    keeping the two heads identical.
+    /// </summary>
+    public partial class BubbleCountResultWindow : Window
+    {
+        private readonly int _correctAnswer;
+        private readonly bool _strictMode;
+        private readonly Action<bool> _onComplete;
+        private readonly Screen? _screen;
+        private readonly bool _isPrimary;
+
+        private int _attemptsRemaining = 3;
+        private bool _isCompleted = false;
+
+        // #633: hard inactivity watchdog (primary only). If an idle user is stranded on the
+        // fullscreen/topmost result window (strict mode has no Esc), auto-complete after
+        // this timeout. Reset on every keystroke/text change so an active typist is never cut off.
+        private DispatcherTimer? _watchdogTimer;
+        private static readonly TimeSpan WatchdogTimeout = TimeSpan.FromSeconds(120);
+
+        // Multi-monitor support
+        private static List<BubbleCountResultWindow> _allWindows = new();
+        private static string _sharedInput = "";
+
+        private readonly TextBox _txtAnswer;
+        private readonly TextBlock _txtAttempts, _txtFeedback, _txtStrict, _txtEscHint;
+        private readonly Button _btnSubmit;
+
+        /// <summary>Render/design constructor: sample data so --render-view can draw the window.</summary>
+        internal BubbleCountResultWindow() : this(42, false, _ => { }) { }
+
+        public BubbleCountResultWindow(int correctAnswer, bool strictMode, Action<bool> onComplete,
+            Screen? screen = null, bool isPrimary = true)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _txtAnswer = this.FindControl<TextBox>("TxtAnswer")!;
+            _txtAttempts = this.FindControl<TextBlock>("TxtAttempts")!;
+            _txtFeedback = this.FindControl<TextBlock>("TxtFeedback")!;
+            _txtStrict = this.FindControl<TextBlock>("TxtStrict")!;
+            _txtEscHint = this.FindControl<TextBlock>("TxtEscHint")!;
+            _btnSubmit = this.FindControl<Button>("BtnSubmit")!;
+
+            _correctAnswer = correctAnswer;
+            _strictMode = strictMode;
+            _onComplete = onComplete;
+            _screen = screen;
+            _isPrimary = isPrimary;
+
+            // Setup UI
+            UpdateAttemptsDisplay();
+
+            if (_strictMode)
+            {
+                _txtStrict.IsVisible = true;
+                _txtEscHint.IsVisible = false;
+            }
+
+            // Non-primary windows are read-only
+            if (!_isPrimary)
+            {
+                _txtAnswer.IsReadOnly = true;
+                _txtAnswer.Focusable = false;
+                _btnSubmit.IsEnabled = false;
+            }
+
+            // Register window
+            _allWindows.Add(this);
+
+            // Position on screen. WPF divided by the per-screen DPI because Left/Top are DIPs;
+            // Avalonia's Position is in the same physical pixels Screen.Bounds reports, so the
+            // conversion - and BubbleCountWindow.GetDpiForScreen with it - disappears. Screens is
+            // only populated once the window has a platform impl, hence Opened rather than the ctor.
+            Opened += (_, _) =>
+            {
+                var target = _screen ?? Screens?.Primary;
+                if (target is not null)
+                    Position = new PixelPoint(target.Bounds.X + 100, target.Bounds.Y + 100);
+            };
+
+            // Focus input on primary
+            Loaded += (_, _) =>
+            {
+                WindowState = WindowState.Maximized;
+                if (_isPrimary)
+                {
+                    _txtAnswer.Focus();
+                    StartWatchdog();
+                }
+            };
+
+            // Key handlers
+            _btnSubmit.Click += (_, _) => BtnSubmit_Click();
+            KeyDown += OnKeyDown;
+            _txtAnswer.KeyDown += OnInputKeyDown;
+            _txtAnswer.TextChanged += OnTextChanged;
+
+            // Only allow numbers. WPF's PreviewTextInput is a tunnelling TextInput here; handling
+            // it in the bubble phase would be too late, the character is already in the box.
+            _txtAnswer.AddHandler(TextInputEvent, (object? _, TextInputEventArgs e) =>
+            {
+                e.Handled = string.IsNullOrEmpty(e.Text) || !char.IsDigit(e.Text, 0);
+            }, RoutingStrategies.Tunnel);
+        }
+
+        /// <summary>
+        /// Show result window on all monitors.
+        ///
+        /// ponytail: needs App.Settings.Current.DualMonitorEnabled and App.GetAllScreensCached() to
+        /// pick the screen set, wired when those move to Core. Until then this shows one window on
+        /// the primary screen, which is the single-monitor path the setting defaults to.
+        /// </summary>
+        public static void ShowOnAllMonitors(int correctAnswer, bool strictMode, Action<bool> onComplete)
+        {
+            _allWindows.Clear();
+            _sharedInput = "";
+
+            var primaryWindow = new BubbleCountResultWindow(correctAnswer, strictMode, onComplete, null, true);
+            primaryWindow.Show();
+            primaryWindow.Activate();   // WPF SetForegroundWindow equivalent
+        }
+
+        private void OnTextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (!_isPrimary) return;
+
+            // Active typist: keep the inactivity watchdog from firing.
+            ResetWatchdog();
+
+            _sharedInput = _txtAnswer.Text ?? "";
+
+            // Sync to all windows
+            foreach (var window in _allWindows.Where(w => w != this))
+            {
+                window._txtAnswer.Text = _sharedInput;
+            }
+        }
+
+        private void OnInputKeyDown(object? sender, KeyEventArgs e)
+        {
+            // Any keystroke counts as activity (covers keys that don't change the text,
+            // e.g. Enter/backspace on an empty field).
+            if (_isPrimary) ResetWatchdog();
+
+            if (e.Key == Key.Enter && _isPrimary)
+            {
+                CheckAnswer();
+                e.Handled = true;
+            }
+        }
+
+        private void OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && !_strictMode && !_isCompleted)
+            {
+                CompleteAll(false);
+            }
+        }
+
+        private void BtnSubmit_Click()
+        {
+            if (_isPrimary) CheckAnswer();
+        }
+
+        private void CheckAnswer()
+        {
+            if (_isCompleted) return;
+
+            if (!int.TryParse((_txtAnswer.Text ?? "").Trim(), out int answer))
+            {
+                ShowFeedbackOnAll("Please enter a number!", Colors.Orange);
+                _txtAnswer.Clear();
+                _txtAnswer.Focus();
+                return;
+            }
+
+            if (answer == _correctAnswer)
+            {
+                // Correct! XP scaled by video duration.
+                // ponytail: needs BubbleCountService.ScaleXpByDuration(250), App.Progression.AddXP
+                // and App.Achievements.TrackBubbleCountResult(true); wired when they move to Core.
+                var xp = 250;
+                ShowFeedbackOnAll($"🎉 CORRECT! +{xp} XP 🎉", Color.FromRgb(50, 205, 50));
+                DisableInputOnAll();
+                StopWatchdog(); // terminal success: no more input expected
+
+                // Delay then complete
+                var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
+                timer.Tick += (_, _) =>
+                {
+                    timer.Stop();
+                    CompleteAll(true);
+                };
+                timer.Start();
+            }
+            else
+            {
+                // Wrong answer
+                _attemptsRemaining--;
+                UpdateAttemptsOnAll();
+
+                // ponytail: needs App.Achievements.TrackBubbleCountResult(false) - a wrong answer
+                // breaks the streak; wired when the service moves to Core.
+
+                if (_attemptsRemaining <= 0)
+                {
+                    if (_strictMode)
+                    {
+                        // Strict mode: signal failure - service handles retry/mercy
+                        CompleteAll(false);
+                    }
+                    else
+                    {
+                        // Non-strict: show mercy lock card
+                        ShowMercyCard();
+                    }
+                }
+                else
+                {
+                    // Give hint
+                    string hint = answer < _correctAnswer ? "Too low! Try higher." : "Too high! Try lower.";
+                    ShowFeedbackOnAll($"❌ {hint}", Color.FromRgb(255, 107, 107));
+                    _txtAnswer.Clear();
+                    _txtAnswer.Focus();
+                }
+            }
+        }
+
+        private void ShowFeedbackOnAll(string message, Color color)
+        {
+            foreach (var window in _allWindows)
+            {
+                window._txtFeedback.Text = message;
+                window._txtFeedback.Foreground = new SolidColorBrush(color);
+                window._txtFeedback.IsVisible = true;
+            }
+        }
+
+        private void UpdateAttemptsOnAll()
+        {
+            foreach (var window in _allWindows)
+            {
+                window._attemptsRemaining = _attemptsRemaining;
+                window.UpdateAttemptsDisplay();
+            }
+        }
+
+        private void DisableInputOnAll()
+        {
+            foreach (var window in _allWindows)
+            {
+                window._btnSubmit.IsEnabled = false;
+                window._txtAnswer.IsEnabled = false;
+            }
+        }
+
+        /// <summary>
+        /// ponytail: the count has no loc key with a placeholder, so this stays the WPF original's
+        /// hardcoded English. It also writes over the {loc:Str label_attempts_remaining_3} binding
+        /// the .axaml puts on TxtAttempts, which Avalonia keeps alive under the local value - a
+        /// language change mid-game would snap the label back to "3". Add an
+        /// `label_attempts_remaining` format key and use Loc.GetF to fix both at once.
+        /// </summary>
+        private void UpdateAttemptsDisplay()
+        {
+            _txtAttempts.Text = $"Attempts remaining: {_attemptsRemaining}";
+
+            // Color based on attempts
+            if (_attemptsRemaining == 1)
+            {
+                _txtAttempts.Foreground = new SolidColorBrush(Color.FromRgb(255, 107, 107));
+            }
+            else if (_attemptsRemaining == 2)
+            {
+                _txtAttempts.Foreground = new SolidColorBrush(Color.FromRgb(255, 165, 0));
+            }
+        }
+
+        private void ShowMercyCard()
+        {
+            _isCompleted = true;
+            StopWatchdog();
+
+            // Hide all result windows
+            foreach (var window in _allWindows)
+            {
+                window._isCompleted = true;
+                window.StopWatchdog();
+                window.Hide();
+            }
+
+            // ponytail: needs App.Mods.GetPhrases("BubbleCountMercy") and LockCardWindow
+            // (not ported yet). The WPF original picks a mod-aware mercy phrase - never one that
+            // contains the answer - and makes the user type it twice on a lock card, then polls
+            // LockCardWindow.IsAnyOpen() before completing. Without the card there is nothing to
+            // wait for, so this completes straight away, as the poll would have.
+            CompleteAll(false);
+        }
+
+        /// <summary>
+        /// Force close all result windows (used by panic button)
+        /// </summary>
+        public static void ForceCloseAll()
+        {
+            foreach (var window in _allWindows.ToArray())
+            {
+                window._isCompleted = true;
+                try { window.Close(); } catch { }
+            }
+            _allWindows.Clear();
+        }
+
+        private void CompleteAll(bool success)
+        {
+            StopWatchdog();
+            foreach (var window in _allWindows.ToArray())
+            {
+                window._isCompleted = true;
+                window.StopWatchdog();
+                try { window.Close(); } catch { }
+            }
+            _allWindows.Clear();
+
+            _onComplete?.Invoke(success);
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            StopWatchdog();
+            _allWindows.Remove(this);
+
+            if (!_isCompleted && _isPrimary)
+            {
+                _onComplete?.Invoke(false);
+            }
+            base.OnClosed(e);
+        }
+
+        #region Inactivity watchdog (#633)
+
+        /// <summary>
+        /// Start the primary window's inactivity watchdog. Fires <see cref="WatchdogTimeout"/>
+        /// after the last activity, auto-completing so an idle user is never stranded on the
+        /// fullscreen/topmost result window (strict mode offers no Esc).
+        /// </summary>
+        private void StartWatchdog()
+        {
+            if (!_isPrimary) return;
+            _watchdogTimer?.Stop();
+            _watchdogTimer = new DispatcherTimer { Interval = WatchdogTimeout };
+            _watchdogTimer.Tick += (_, _) =>
+            {
+                _watchdogTimer?.Stop();
+                if (_isCompleted) return;
+                Serilog.Log.Warning("BubbleCountResultWindow: Inactivity watchdog fired after {Seconds}s - auto-completing to prevent lockout",
+                    WatchdogTimeout.TotalSeconds);
+                CompleteAll(false);
+            };
+            _watchdogTimer.Start();
+        }
+
+        /// <summary>Reset the inactivity countdown on user activity (keystroke / text change).</summary>
+        private void ResetWatchdog()
+        {
+            if (_watchdogTimer == null) return;
+            _watchdogTimer.Stop();
+            _watchdogTimer.Start();
+        }
+
+        private void StopWatchdog()
+        {
+            _watchdogTimer?.Stop();
+            _watchdogTimer = null;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
600 lines. One Win32 call, the Alt+Tab hide, which maps exactly to ShowInTaskbar. Inter is wider than the original's face, so the title needed wrapping to stop the trailing glyph clipping.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351