### PR TITLE
feat(avalonia): port EmiOptionsWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml
@@ -1,0 +1,369 @@
+<!-- PORTED from ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml.
+     Structure, ordering, spacing, x:Names and every colour literal preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" +
+                                                   TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                    -> CanResize="False"
+       Visibility="Hidden"                      -> dropped. A WPF Window declared Hidden is still
+                                                   constructed and realised; an Avalonia Window is
+                                                   simply not on screen until Show(), which is the
+                                                   same "created folded" the panel relies on.
+       WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE      -> ShowInTaskbar="False" + ShowActivated="False".
+         (stamped in OnSourceInitialized)          See the code-behind for what that does and does
+                                                   NOT buy back.
+       <Style x:Key TargetType>                 -> <ControlTheme x:Key TargetType> with the SAME
+                                                   Template; ControlTemplate.Triggers become
+                                                   ^:pointerover / ^:checked / ^:disabled selectors
+       <ContentPresenter/>                      -> ContentPresenter Content="{TemplateBinding Content}"
+                                                   (CLAUDE.md trap 6 - a bare presenter draws nothing)
+       StrokeStartLineCap + StrokeEndLineCap    -> StrokeLineCap (Avalonia has the one property)
+       ToolTip="..."                            -> ToolTip.Tip="..."
+       English literal Text/Content             -> {loc:Str <the key the WPF Localize() used>}. The
+                                                   WPF original writes the literal in markup and
+                                                   overwrites it from Localize() with Loc.Get; on
+                                                   Avalonia a local .Text assignment survives a
+                                                   language change and the binding does not, so the
+                                                   sixteen keys move into the markup verbatim.
+
+     Buttons and radio segments carry a TextBlock rather than a string Content: Avalonia parses "_"
+     in Content as an access key and every loc key here is snake_case. See CLAUDE.md.
+     The root Border is Top-aligned so SizeToContent="Height" still reads as a compact card under
+     the render harness, which forces a Height onto any window that declares none. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:ctl="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk.EmiOptionsWindow"
+        Title="EMI"
+
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowActivated="False"
+        ShowInTaskbar="False"
+        CanResize="False"
+        SizeToContent="Height"
+        WindowStartupLocation="Manual"
+        UseLayoutRounding="True"
+        Topmost="True"
+        Width="392">
+
+    <!--
+        HER OPTIONS.
+
+        The gear top-left opens this. It is the third sibling window in the feature and it follows
+        the same recipe as the other two, none of which is optional: SystemDecorations None +
+        TransparencyLevelHint Transparent + ShowActivated False + ShowInTaskbar False + Topmost.
+        That combination is what makes her a desktop ornament rather than a window - she never
+        steals focus and never appears in the task switcher.
+
+        THE CONSEQUENCE, and it shapes what can be in here: this window is not meant to hold
+        keyboard focus. Everything is therefore mouse-driven. There is no text box, and the summon
+        chord is SHOWN rather than captured (a capture needs key events this window can never
+        receive) with a pointer to the settings tab, which can.
+
+        EVERY BRUSH IS A LITERAL. This window has no resource dictionary behind it, so a
+        StaticResource reaching for MainWindow's palette would be the cross-dictionary lookup the
+        Velvet Kit work was bitten by.
+
+        The forbidden word is on EMI's fence and a checker rejects it: the ring is her CARDS,
+        everywhere a user can read it.
+    -->
+
+    <Window.Resources>
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml:EmiPanelButton, hoist when a second view needs it -->
+        <ControlTheme x:Key="EmiPanelButton" TargetType="Button">
+            <Setter Property="Foreground" Value="#FFF2FA"/>
+            <Setter Property="Background" Value="#252542"/>
+            <Setter Property="BorderBrush" Value="#4A3A63"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="12,7"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chrome"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Chrome">
+                <Setter Property="Background" Value="#33294F"/>
+                <Setter Property="BorderBrush" Value="#FF69B4"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Opacity" Value="0.42"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- A switch, drawn as a pill. A CheckBox rather than a ToggleButton so the automation
+             peers and the keyboard semantics stay honest even though this window has no keyboard. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml:EmiPanelSwitch, hoist when a second view needs it -->
+        <ControlTheme x:Key="EmiPanelSwitch" TargetType="CheckBox">
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="CheckBox">
+                    <Border x:Name="Track" Width="40" Height="20" CornerRadius="10"
+                            Background="#22203A" BorderBrush="#4A3A63" BorderThickness="1">
+                        <Ellipse x:Name="Knob" Width="14" Height="14"
+                                 HorizontalAlignment="Left" Margin="2,0,0,0"
+                                 Fill="#7C7396"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <!-- checked before hover, the order the WPF triggers ran in: the other way round,
+                 moving the pointer onto a switch that is already on takes its pink edge off. -->
+            <Style Selector="^:checked /template/ Border#Track">
+                <Setter Property="Background" Value="#4A2A55"/>
+                <Setter Property="BorderBrush" Value="#FF69B4"/>
+            </Style>
+            <Style Selector="^:checked /template/ Ellipse#Knob">
+                <Setter Property="Fill" Value="#FF69B4"/>
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="Margin" Value="0,0,2,0"/>
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#Track">
+                <Setter Property="BorderBrush" Value="#8CFF69B4"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- One notch of the spice scale. Three of them are the 0..2 the lines file filters on;
+             a segmented row rather than a ComboBox because a ComboBox drops a Popup, and a popup
+             in a click-away window is a click the dismissal hook has to be taught to forgive. -->
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml:EmiPanelSegment, hoist when a second view needs it -->
+        <ControlTheme x:Key="EmiPanelSegment" TargetType="RadioButton">
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Foreground" Value="#C6BEDC"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="RadioButton">
+                    <Border x:Name="Seg" CornerRadius="5" Margin="0,0,4,0"
+                            Background="#22203A" BorderBrush="#4A3A63" BorderThickness="1"
+                            Padding="9,4">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Seg">
+                <Setter Property="BorderBrush" Value="#8CFF69B4"/>
+            </Style>
+            <Style Selector="^:checked /template/ Border#Seg">
+                <Setter Property="Background" Value="#4A2A55"/>
+                <Setter Property="BorderBrush" Value="#FF69B4"/>
+            </Style>
+            <Style Selector="^:checked">
+                <Setter Property="Foreground" Value="#FFF2FA"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml:EmiPanelLabel, hoist when a second view needs it -->
+        <ControlTheme x:Key="EmiPanelLabel" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#E7E1F5"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="TextTrimming" Value="CharacterEllipsis"/>
+        </ControlTheme>
+
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml:EmiPanelSectionHeader, hoist when a second view needs it -->
+        <ControlTheme x:Key="EmiPanelSectionHeader" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#FF69B4"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0,14,0,6"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Border Background="#F21A1A2E" BorderBrush="#FF69B4" BorderThickness="1" CornerRadius="10"
+            VerticalAlignment="Top">
+        <Grid Margin="16,13,16,14">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <!-- Title bar. The x here dismisses the PANEL, never her: sending her away is the x on
+                 her body, and one click that could mean either would be the wrong one half the time. -->
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock x:Name="TxtTitle" Grid.Column="0"
+                           Text="{loc:Str emi_desk_opt_title}"
+                           Foreground="#FF69B4" FontSize="14" FontWeight="SemiBold"
+                           VerticalAlignment="Center"/>
+                <Button x:Name="BtnPanelClose" Grid.Column="1"
+                        Width="22" Height="22" Padding="0"
+                        Cursor="Hand" Focusable="False"
+                        ToolTip.Tip="{loc:Str emi_desk_opt_close}">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Grid Background="Transparent">
+                                <Ellipse x:Name="Disc" Fill="#00000000" Stroke="#4A3A63" StrokeThickness="1"/>
+                                <Path Data="M 7,7 L 15,15 M 15,7 L 7,15"
+                                      Stroke="#C6BEDC" StrokeThickness="1.6"
+                                      StrokeLineCap="Round"/>
+                            </Grid>
+                        </ControlTemplate>
+                    </Button.Template>
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ Ellipse#Disc">
+                            <Setter Property="Stroke" Value="#FF69B4"/>
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
+
+            <ScrollViewer Grid.Row="1" x:Name="Scroller"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Margin="0,10,0,0">
+                <StackPanel>
+
+                    <!-- 1. THE CARDS. First, and a whole-width button, because the six-dot glyph
+                            that used to sit where the gear now is was the ring's only visible way
+                            in. A right click on her body still opens it; this is the one you can
+                            find without being told. -->
+                    <Button x:Name="BtnOpenCards"
+                            Theme="{StaticResource EmiPanelButton}"
+                            HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                            Background="#3A2350" BorderBrush="#FF69B4">
+                        <TextBlock Text="{loc:Str emi_desk_tip_cards}"/>
+                    </Button>
+                    <TextBlock x:Name="TxtCardsHint"
+                               Text="{loc:Str emi_desk_opt_cards_hint}"
+                               Foreground="#9C93B8" FontSize="11"
+                               TextWrapping="Wrap" Margin="0,5,0,0"/>
+
+                    <!-- 2. HER OPTIONS. Every row here is an AppSettings key that already exists
+                            and is already read at the moment it matters. Nothing in this panel
+                            invents a setting with no behaviour behind it. -->
+                    <TextBlock x:Name="TxtHeadOptions" Text="{loc:Str emi_desk_opt_head_options}"
+                               Theme="{StaticResource EmiPanelSectionHeader}"/>
+
+                    <!-- the summon chord: shown, not captured. See the header comment. -->
+                    <Grid MinHeight="30">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="LblHotkey" Grid.Column="0" Text="{loc:Str emi_desk_opt_hotkey}"
+                                   Theme="{StaticResource EmiPanelLabel}" Margin="0,0,10,0"/>
+                        <Border Grid.Column="1" CornerRadius="5" Padding="9,3"
+                                Background="#22203A" BorderBrush="#4A3A63" BorderThickness="1">
+                            <TextBlock x:Name="TxtHotkey" Text="Ctrl+Alt+E"
+                                       Foreground="#FFF2FA" FontSize="11"/>
+                        </Border>
+                    </Grid>
+                    <TextBlock x:Name="TxtHotkeyHint"
+                               Text="{loc:Str emi_desk_opt_hotkey_hint}"
+                               Foreground="#9C93B8" FontSize="10.5"
+                               TextWrapping="Wrap" Margin="0,3,0,0"/>
+
+                    <!-- her size: the same DIP width the corner grip writes -->
+                    <Grid MinHeight="30" Margin="0,9,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="LblWidth" Grid.Column="0" Text="{loc:Str emi_desk_opt_width}"
+                                   Theme="{StaticResource EmiPanelLabel}" Margin="0,0,10,0"/>
+                        <Slider x:Name="SldWidth" Grid.Column="1"
+                                Minimum="152" Maximum="420"
+                                IsSnapToTickEnabled="True" TickFrequency="4"
+                                Focusable="False" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="TxtWidth" Grid.Column="2" Text="220"
+                                   Foreground="#9C93B8" FontSize="11"
+                                   VerticalAlignment="Center" Margin="8,0,0,0"
+                                   MinWidth="26" TextAlignment="Right"/>
+                    </Grid>
+
+                    <!-- the mute arbiter -->
+                    <Grid MinHeight="30" Margin="0,9,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="LblMute" Grid.Column="0" Text="{loc:Str emi_desk_opt_mute}"
+                                   Theme="{StaticResource EmiPanelLabel}" Margin="0,0,10,0"/>
+                        <CheckBox x:Name="ChkMute" Grid.Column="1"
+                                  Theme="{StaticResource EmiPanelSwitch}"/>
+                    </Grid>
+
+                    <!-- the spice ceiling, 0..2 -->
+                    <Grid MinHeight="30" Margin="0,9,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="LblSpice" Grid.Column="0" Text="{loc:Str emi_desk_opt_spice}"
+                                   Theme="{StaticResource EmiPanelLabel}" Margin="0,0,10,0"/>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                    HorizontalAlignment="Right">
+                            <RadioButton x:Name="SpiceInnocent" GroupName="Spice"
+                                         Theme="{StaticResource EmiPanelSegment}">
+                                <TextBlock Text="{loc:Str emi_desk_spice_innocent}"/>
+                            </RadioButton>
+                            <RadioButton x:Name="SpiceSuggestive" GroupName="Spice"
+                                         Theme="{StaticResource EmiPanelSegment}">
+                                <TextBlock Text="{loc:Str emi_desk_spice_suggestive}"/>
+                            </RadioButton>
+                            <RadioButton x:Name="SpiceAnything" GroupName="Spice" Margin="0"
+                                         Theme="{StaticResource EmiPanelSegment}">
+                                <TextBlock Text="{loc:Str emi_desk_spice_anything}"/>
+                            </RadioButton>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- may she ask -->
+                    <Grid MinHeight="30" Margin="0,9,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="LblOffers" Grid.Column="0" Text="{loc:Str emi_desk_opt_offers}"
+                                   Theme="{StaticResource EmiPanelLabel}" Margin="0,0,10,0"/>
+                        <CheckBox x:Name="ChkOffers" Grid.Column="1"
+                                  Theme="{StaticResource EmiPanelSwitch}"/>
+                    </Grid>
+
+                    <!-- the glass -->
+                    <Grid MinHeight="30" Margin="0,9,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="LblGlass" Grid.Column="0" Text="{loc:Str emi_desk_opt_glass}"
+                                   Theme="{StaticResource EmiPanelLabel}" Margin="0,0,10,0"/>
+                        <CheckBox x:Name="ChkGlass" Grid.Column="1"
+                                  Theme="{StaticResource EmiPanelSwitch}"/>
+                    </Grid>
+
+                    <!-- 3. HER RING. The same control the settings tab hosts, writing the same
+                            EmiState.Pins through the same EmiSuggester. Header shown here: this
+                            panel has no other place to put the count or the reset. -->
+                    <TextBlock x:Name="TxtHeadRing" Text="{loc:Str emi_desk_opt_head_ring}"
+                               Theme="{StaticResource EmiPanelSectionHeader}"/>
+                    <ctl:EmiRingPicker x:Name="RingPicker"/>
+
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Border>
+</Window>

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml.cs
@@ -1,0 +1,605 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Views.Controls;
+using ConditioningControlPanel.Localization;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
+{
+    /// <summary>
+    /// HER OPTIONS: the little panel the gear opens beside her.
+    ///
+    /// <para><b>Why it exists.</b> Wave 3 put a six-pixel-dot glyph top-left that opened her ring.
+    /// The owner read it as a move handle - "the three dots to move emi, not needed, we drag her" -
+    /// and asked for a gear that opens her options instead (2026-08-30). Since those dots were the
+    /// ring's only VISIBLE way in (nothing on a desktop advertises a right click), the first thing
+    /// in this panel is "Open her cards".</para>
+    ///
+    /// <para><b>The window recipe is not optional</b> and is copied from her other two windows:
+    /// SystemDecorations None, TransparencyLevelHint Transparent, ShowActivated false,
+    /// ShowInTaskbar false, Topmost. She is a desktop ornament, not an application window: no focus
+    /// theft, nothing in the task switcher, and no click that costs the user the window they were
+    /// actually working in.</para>
+    ///
+    /// <para><b>And it is not modal, deliberately.</b> §10.8b of the primer: anything modal on a
+    /// summon path needs the <c>_summonGen</c> generation guard, because the dismiss that happens
+    /// while the dialog is up desyncs <c>IsOut</c> and strands her on screen. A non-modal panel that
+    /// closes itself on a click outside has none of that surface.</para>
+    ///
+    /// <para><b>Every editor in here is mouse-only</b>, which is what the WPF original's
+    /// WS_EX_NOACTIVATE forced and what this port keeps. The summon chord is SHOWN rather than
+    /// captured and points at the settings tab, which does own the rebind.</para>
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/EmiDesk/EmiOptionsWindow.xaml.cs. What changed,
+    /// and why:
+    ///
+    /// <list type="bullet">
+    ///   <item><b>The four Win32 entry points are gone.</b> <c>GetWindowLong</c>/<c>SetWindowLong</c>
+    ///         stamping <c>WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE</c> in <c>OnSourceInitialized</c> map
+    ///         one-for-one onto <c>ShowInTaskbar="False"</c> and <c>ShowActivated="False"</c> in the
+    ///         markup, so <c>OnSourceInitialized</c> and the two DllImports go with them. NOT
+    ///         equivalent in one respect worth naming: WS_EX_NOACTIVATE makes activation
+    ///         *impossible*, where <c>ShowActivated="False"</c> only declines it at show time - a
+    ///         click on this panel can still focus it on X11.</item>
+    ///   <item><b>The two global hooks have no equivalent on this head</b> and are stubbed. See
+    ///         <see cref="InstallHooks"/> for exactly which two behaviours that costs.</item>
+    ///   <item><b>The owner is not ported yet.</b> <c>EmiDeskWindow</c> is the widget this panel
+    ///         hangs off, and it does not exist on this head, so the constructor takes no owner and
+    ///         every <c>_owner.*</c> call is a stub. That also makes this its own render
+    ///         constructor - there is no argument left to supply sample data for.</item>
+    ///   <item><b>Localize() is gone.</b> Its sixteen <c>Loc.Get</c> assignments are
+    ///         <c>{loc:Str}</c> in the markup, so a language change re-renders them (CLAUDE.md).
+    ///         The one string it set that is NOT static - the summon chord, which is either the
+    ///         bound chord or <c>emi_desk_hotkey_unbound</c> - is still chosen in code, in
+    ///         <see cref="LoadValues"/>.</item>
+    ///   <item><b>WPF DIPs become physical pixels.</b> <c>Left</c>/<c>Top</c> are DIPs and
+    ///         <c>BodyScreenRect</c> was physical, which is why the original divides by
+    ///         <c>DipScale</c> on both sides of every sum. Avalonia's <c>Position</c> is already a
+    ///         <c>PixelPoint</c> and <c>Screens.WorkingArea</c> a <c>PixelRect</c>, so the placement
+    ///         arithmetic works in physical pixels throughout and scales only the window's own
+    ///         DIP size. Same result, one conversion instead of six.</item>
+    ///   <item><b>The namespace is no longer the flat WPF one.</b> The WinRT <c>Windows</c>-shadowing
+    ///         trap the original's header describes is a WPF-head problem; this head has no OCR
+    ///         service and no WinRT.</item>
+    /// </list>
+    /// </summary>
+    public partial class EmiOptionsWindow : Window
+    {
+        /// <summary>Air between her silhouette and the panel's near edge, in DIPs.</summary>
+        private const double BodyGap = 12.0;
+
+        /// <summary>How long a width drag rests before the number is written to settings.</summary>
+        private const int WidthPersistMs = 400;
+
+        // ponytail: needs EmiDeskWindow.MinBodyWidth / MaxBodyWidth, wired when the widget is
+        // ported. The two literals below are the ones the WPF markup already declared on the
+        // slider; WireControls() then overwrote them with the same pair from the owner.
+        private const double MinBodyWidth = 152.0;
+        private const double MaxBodyWidth = 420.0;
+
+        private readonly Button _btnPanelClose;
+        private readonly Button _btnOpenCards;
+        private readonly Slider _sldWidth;
+        private readonly TextBlock _txtWidth;
+        private readonly TextBlock _txtHotkey;
+        private readonly CheckBox _chkMute;
+        private readonly CheckBox _chkOffers;
+        private readonly CheckBox _chkGlass;
+        private readonly RadioButton _spiceInnocent;
+        private readonly RadioButton _spiceSuggestive;
+        private readonly RadioButton _spiceAnything;
+        private readonly EmiRingPicker _ringPicker;
+
+        private bool _open;
+        private bool _closingForGood;
+
+        /// <summary>Suppresses the change handlers while the code is filling the controls in.</summary>
+        private bool _loading;
+
+        private DispatcherTimer? _widthPersist;
+
+        // ---------------------------------------------------------------- ctor
+
+        /// <summary>
+        /// Builds the panel. Created folded; <see cref="OpenPanel"/> shows it.
+        ///
+        /// <para>Parameterless where WPF took an <c>EmiDeskWindow</c>: that widget is not on this
+        /// head yet, so there is nothing to hold and nothing to null-check. It doubles as the
+        /// render constructor for that reason.</para>
+        /// </summary>
+        public EmiOptionsWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _btnPanelClose = this.FindControl<Button>("BtnPanelClose")!;
+            _btnOpenCards = this.FindControl<Button>("BtnOpenCards")!;
+            _sldWidth = this.FindControl<Slider>("SldWidth")!;
+            _txtWidth = this.FindControl<TextBlock>("TxtWidth")!;
+            _txtHotkey = this.FindControl<TextBlock>("TxtHotkey")!;
+            _chkMute = this.FindControl<CheckBox>("ChkMute")!;
+            _chkOffers = this.FindControl<CheckBox>("ChkOffers")!;
+            _chkGlass = this.FindControl<CheckBox>("ChkGlass")!;
+            _spiceInnocent = this.FindControl<RadioButton>("SpiceInnocent")!;
+            _spiceSuggestive = this.FindControl<RadioButton>("SpiceSuggestive")!;
+            _spiceAnything = this.FindControl<RadioButton>("SpiceAnything")!;
+            _ringPicker = this.FindControl<EmiRingPicker>("RingPicker")!;
+
+            WireControls();
+
+            // Filled here rather than only in OpenPanel: a headless render never opens the panel,
+            // and an unfilled panel would prove nothing about the switches or the segments.
+            LoadValues();
+
+            // The chrome on her body stays lit while the pointer is in here, so the gear that
+            // opened this is still on screen to close it again after the round trip.
+            PointerEntered += (_, _) => Hold(true);
+            PointerExited += (_, _) => Hold(false);
+
+            // WPF also subscribed _owner.Moved / _owner.Resized here. See NotifyOwnerMoved and
+            // NotifyOwnerResized: with no owner type on this head the widget calls in instead.
+        }
+
+        /// <summary>The panel folded. The desk window drops its chrome hold on this.</summary>
+        public event EventHandler? PanelClosed;
+
+        /// <summary>"Open her cards" was clicked. The desk window owns what a ring is; this only asks.</summary>
+        public event EventHandler? CardsRequested;
+
+        /// <summary>True while the panel is on screen.</summary>
+        public bool IsOpen => _open;
+
+        /// <summary>This window's own scale. Never assume 1.0 on a multi-monitor desk.</summary>
+        private double DipScale
+        {
+            get
+            {
+                try
+                {
+                    if (RenderScaling > 0) return RenderScaling;
+                }
+                catch { /* no toplevel yet */ }
+                try
+                {
+                    var s = Screens?.Primary;
+                    if (s != null && s.Scaling > 0) return s.Scaling;
+                }
+                catch { /* no screens under a headless backend */ }
+                return 1.0;
+            }
+        }
+
+        // ---------------------------------------------------------------- wiring
+
+        private void WireControls()
+        {
+            _btnPanelClose.Click += (_, _) => ClosePanel();
+
+            _btnOpenCards.Click += (_, _) =>
+            {
+                try
+                {
+                    // Fold first: the fan is anchored on the same body and would open underneath this.
+                    ClosePanel();
+                    CardsRequested?.Invoke(this, EventArgs.Empty);
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug(ex, "[EmiDesk] options cards request failed");
+                }
+            };
+
+            _sldWidth.Minimum = MinBodyWidth;
+            _sldWidth.Maximum = MaxBodyWidth;
+            _sldWidth.ValueChanged += OnWidthChanged;
+            // A track click is not a drag, so the debounce is what actually persists both. Kept
+            // anyway: it is what makes the write land the instant the thumb is let go.
+            _sldWidth.AddHandler(Thumb.DragCompletedEvent, (EventHandler<VectorEventArgs>)((_, _) => PersistWidth()));
+
+            _chkMute.IsCheckedChanged += OnMuteChanged;
+            _chkOffers.IsCheckedChanged += OnOffersChanged;
+            _chkGlass.IsCheckedChanged += OnGlassChanged;
+
+            // WPF wired Checked only. Avalonia has the one event for both edges, and a radio group
+            // raises it on the segment being cleared too, so the guard is on IsChecked here.
+            _spiceInnocent.IsCheckedChanged += (_, _) => { if (_spiceInnocent.IsChecked == true) OnSpicePicked(0); };
+            _spiceSuggestive.IsCheckedChanged += (_, _) => { if (_spiceSuggestive.IsChecked == true) OnSpicePicked(1); };
+            _spiceAnything.IsCheckedChanged += (_, _) => { if (_spiceAnything.IsChecked == true) OnSpicePicked(2); };
+        }
+
+        // ponytail: needs EmiDeskWindow.HoldChromeForPanel, wired when the widget is ported.
+        private void Hold(bool on) { _ = on; }
+
+        // ---------------------------------------------------------------- open / close
+
+        /// <summary>Fill the controls from settings, place the panel beside her and start listening.</summary>
+        public void OpenPanel()
+        {
+            if (_closingForGood) return;
+            try
+            {
+                LoadValues();
+                // Rebuilt rather than refreshed: availability and lock are DELEGATES on a target,
+                // and both can have changed since the last time this was opened.
+                _ringPicker.Rebuild();
+
+                PlaceWindow();
+                if (!IsVisible)
+                {
+                    Show();
+                    // The window has no scale of its own until it is mapped, so the first placement
+                    // is always done twice: once to get it on screen, once with its real scale and
+                    // its real measured height.
+                    PlaceWindow();
+                }
+
+                _open = true;
+                UpdateHotRects();
+                InstallHooks();
+
+                Log.Information("[EmiDesk] options panel open");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] options panel failed to open");
+                try { ClosePanel(); } catch { /* nothing else to try */ }
+            }
+        }
+
+        /// <summary>Fold the panel. Idempotent, and safe to call from a posted continuation.</summary>
+        public void ClosePanel()
+        {
+            try
+            {
+                RemoveHooks();
+                StopWidthPersist();
+                if (!_open && !IsVisible) return;
+                _open = false;
+                Hide();
+
+                Log.Debug("[EmiDesk] options panel closed");
+                try { PanelClosed?.Invoke(this, EventArgs.Empty); }
+                catch (Exception ex) { Log.Debug(ex, "[EmiDesk] PanelClosed handler threw"); }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options panel close failed");
+            }
+        }
+
+        /// <summary>Let the panel go for good: app shutdown, or the widget closing.</summary>
+        public void Kill()
+        {
+            try
+            {
+                _closingForGood = true;
+                ClosePanel();
+                Close();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options kill failed");
+            }
+        }
+
+        // ---------------------------------------------------------------- values
+
+        /// <summary>
+        /// Fill the controls in.
+        ///
+        /// <para>ponytail: needs App.Settings and EmiDeskWindow.BodyWidth, wired when they move to
+        /// Core. The placeholders below are chosen to prove the templates rather than to look
+        /// tidy: one switch off and two on, and a checked middle segment, so a render shows both
+        /// states of the pill and both states of the segment.</para>
+        /// </summary>
+        private void LoadValues()
+        {
+            try
+            {
+                _loading = true;
+
+                _chkMute.IsChecked = false;
+                _chkOffers.IsChecked = true;
+                _chkGlass.IsChecked = true;
+
+                // The three segments ARE the 0..2 scale the lines file carries. No translation.
+                int spice = Math.Max(0, Math.Min(2, 1));
+                _spiceInnocent.IsChecked = spice == 0;
+                _spiceSuggestive.IsChecked = spice == 1;
+                _spiceAnything.IsChecked = spice == 2;
+
+                var chord = "Ctrl+Alt+E";
+                // Chosen in code, not markup: which of the two strings applies depends on whether
+                // a chord is bound. Bind the key rather than assign .Text once App.Settings is
+                // here - an assignment is undone by the next language change (CLAUDE.md).
+                _txtHotkey.Text = string.IsNullOrWhiteSpace(chord)
+                    ? Loc.Get("emi_desk_hotkey_unbound")
+                    : chord;
+
+                // Her CURRENT width, not the stored one: the grip writes settings on mouse-up, so
+                // mid-drag the window is the truth and the file is one drag behind.
+                double w = 220.0;
+                _sldWidth.Value = Math.Max(_sldWidth.Minimum, Math.Min(_sldWidth.Maximum, w));
+                _txtWidth.Text = ((int)Math.Round(_sldWidth.Value)).ToString();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] options load failed");
+            }
+            finally
+            {
+                _loading = false;
+            }
+        }
+
+        // ponytail: needs App.Settings, wired when it moves to Core. WPF read Current, ran the
+        // write and called Save(); with no settings service on this head there is nothing to write.
+        private static void Persist(Action write) { _ = write; }
+
+        private void OnMuteChanged(object? sender, RoutedEventArgs e)
+        {
+            if (_loading) return;
+            bool on = _chkMute.IsChecked == true;
+            Persist(() =>
+            {
+                // ponytail: needs App.Settings.EmiDeskMuteAvatar = on, and the same rule as the
+                // settings tab - flipping the switch clears EmiDeskMuteDontAsk, because the user
+                // has just changed their mind about the whole arrangement.
+                _ = on;
+            });
+        }
+
+        private void OnOffersChanged(object? sender, RoutedEventArgs e)
+        {
+            if (_loading) return;
+            bool on = _chkOffers.IsChecked == true;
+            // ponytail: needs App.Settings.EmiDeskOffers = on
+            Persist(() => { _ = on; });
+        }
+
+        private void OnGlassChanged(object? sender, RoutedEventArgs e)
+        {
+            if (_loading) return;
+            bool on = _chkGlass.IsChecked == true;
+            // ponytail: needs App.Settings.EmiDeskGlass = on
+            Persist(() => { _ = on; });
+        }
+
+        private void OnSpicePicked(int spice)
+        {
+            if (_loading) return;
+            int v = Math.Max(0, Math.Min(2, spice));
+            // ponytail: needs App.Settings.EmiDeskSpice = v
+            Persist(() => { _ = v; });
+        }
+
+        /// <summary>
+        /// The size slider is LIVE: she resizes under the pointer, exactly as she does on the grip.
+        /// Settings are written on a short rest instead, because a drag across the band is a hundred
+        /// value changes and a hundred writes of the whole settings file.
+        /// </summary>
+        private void OnWidthChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_loading) return;
+            try
+            {
+                _txtWidth.Text = ((int)Math.Round(e.NewValue)).ToString();
+                // ponytail: needs EmiDeskWindow.ApplyBodyWidth + ClampIntoWorkArea, wired when the
+                // widget is ported. Without them the number moves and she does not.
+                ArmWidthPersist();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options width change failed");
+            }
+        }
+
+        private void ArmWidthPersist()
+        {
+            try
+            {
+                if (_widthPersist == null)
+                {
+                    _widthPersist = new DispatcherTimer(DispatcherPriority.Background)
+                    {
+                        Interval = TimeSpan.FromMilliseconds(WidthPersistMs),
+                    };
+                    _widthPersist.Tick += (_, _) => PersistWidth();
+                }
+                _widthPersist.Stop();
+                _widthPersist.Start();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options width debounce failed");
+            }
+        }
+
+        private void StopWidthPersist()
+        {
+            try { _widthPersist?.Stop(); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] options width debounce stop failed"); }
+        }
+
+        private void PersistWidth()
+        {
+            StopWidthPersist();
+            // ponytail: needs App.Settings.EmiDeskWidth and EmiDeskWindow.BodyWidth /
+            // SavePlacement, wired when both move to Core. WPF wrote the width only when it had
+            // moved by more than half a pixel, then saved her placement alongside it.
+        }
+
+        // ---------------------------------------------------------------- placement
+
+        /// <summary>
+        /// The work area of the monitor she is standing on, in PHYSICAL pixels.
+        ///
+        /// <para>WPF asked WinForms' <c>Screen.FromPoint</c>. Avalonia's <c>Screens</c> answers the
+        /// same question with the same units, so the only thing lost is the WinForms reference.</para>
+        /// </summary>
+        private PixelRect WorkArea()
+        {
+            try
+            {
+                var screens = Screens;
+                if (screens == null || screens.ScreenCount == 0)
+                    return new PixelRect(0, 0, 1920, 1080);
+
+                // ponytail: needs EmiDeskWindow.BodyScreenRect for the centre of her body, wired
+                // when the widget is ported. Until then the panel's own screen is the best guess,
+                // and it is the right one whenever she and the panel share a monitor.
+                var screen = screens.ScreenFromWindow(this) ?? screens.Primary;
+                return screen?.WorkingArea ?? new PixelRect(0, 0, 1920, 1080);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options work-area probe failed");
+                return new PixelRect(0, 0, 1920, 1080);
+            }
+        }
+
+        /// <summary>
+        /// Put the panel beside her, on the side that has room, clamped into the work area of the
+        /// monitor she is standing on.
+        ///
+        /// <para>PHYSICAL PIXELS throughout, which is the one simplification the port buys: WPF's
+        /// <c>Left</c>/<c>Top</c>/<c>Width</c> were DIPs while <c>BodyScreenRect</c> was physical,
+        /// and mixing the two is the documented trap that ate the gaze work. Avalonia's
+        /// <c>Position</c> is already a <c>PixelPoint</c>, so only this window's own DIP size is
+        /// scaled and nothing else has to be.</para>
+        ///
+        /// <para>The gear is on her LEFT, so the panel goes left of her by preference and the
+        /// pointer travels the shortest way to what it just opened. It flips to her right when the
+        /// left side has no room, and only then falls back to overlapping her.</para>
+        /// </summary>
+        private void PlaceWindow()
+        {
+            try
+            {
+                var work = WorkArea();
+                double s = DipScale;
+                if (s <= 0) s = 1.0;
+
+                // Never taller than the desk. SizeToContent grows the window to its content, so
+                // without this cap a long pin wall would run off the bottom instead of scrolling.
+                MaxHeight = Math.Max(220, work.Height / s - 24);
+
+                // Measure with the cap applied: the height is content-driven and not known until now.
+                UpdateLayout();
+
+                // ponytail: needs EmiDeskWindow.BodyScreenRect, wired when the widget is ported.
+                // With no body to hang off, the panel sits at the work area's top-left corner - the
+                // same fallback the clamp below would produce for a body pinned there.
+                var bodyPx = new PixelRect(work.X, work.Y, 1, 1);
+
+                double w = (Bounds.Width > 1 ? Bounds.Width : Width) * s;
+                double h = (Bounds.Height > 1 ? Bounds.Height : MinHeight) * s;
+                double gap = BodyGap * s;
+
+                double left = bodyPx.X - gap - w;
+                if (left < work.X)
+                {
+                    double right = bodyPx.Right + gap;
+                    if (right + w <= work.Right) left = right;
+                }
+
+                // Top-aligned with her head, because that is where the gear is.
+                double top = bodyPx.Y;
+
+                Position = new PixelPoint(
+                    (int)Math.Round(Math.Max(work.X, Math.Min(work.Right - w, left))),
+                    (int)Math.Round(Math.Max(work.Y, Math.Min(work.Bottom - h, top))));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] options placement failed");
+            }
+        }
+
+        /// <summary>She moved. The panel is anchored to her edge and has to come along.</summary>
+        /// <remarks>WPF subscribed <c>EmiDeskWindow.Moved</c> in the constructor. With no owner type
+        /// on this head the widget calls in here instead; the body is unchanged.</remarks>
+        public void NotifyOwnerMoved()
+        {
+            if (!_open) return;
+            try
+            {
+                PlaceWindow();
+                UpdateHotRects();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options follow-move failed");
+            }
+        }
+
+        /// <summary>She was resized, by the grip or by this panel's own slider.</summary>
+        /// <remarks>The WPF twin of <c>EmiDeskWindow.Resized</c>. The grip can drive this too, so
+        /// the slider follows her rather than the other way round; <c>_loading</c> keeps that from
+        /// bouncing straight back into <c>ApplyBodyWidth</c>.</remarks>
+        public void NotifyOwnerResized(double width)
+        {
+            if (!_open) return;
+            try
+            {
+                _loading = true;
+                try
+                {
+                    _sldWidth.Value = Math.Max(_sldWidth.Minimum, Math.Min(_sldWidth.Maximum, width));
+                    _txtWidth.Text = ((int)Math.Round(width)).ToString();
+                }
+                finally { _loading = false; }
+
+                PlaceWindow();
+                UpdateHotRects();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options follow-resize failed");
+            }
+        }
+
+        /// <summary>
+        /// Freeze the rectangles a click-away hook is allowed to read - the panel itself and her
+        /// body - so the hook never walks a live visual tree.
+        /// </summary>
+        // ponytail: dead until InstallHooks has something to install. The snapshot exists only to
+        // be read on a hook thread, and there is no hook thread on this head; rebuilding it here
+        // would be arithmetic nobody reads. Restore the WPF body with the hook.
+        private void UpdateHotRects() { }
+
+        // ---------------------------------------------------------------- the hooks
+
+        /// <summary>
+        /// WPF installed a low-level mouse hook and a low-level keyboard hook here, both
+        /// <c>SetWindowsHookEx</c> in <c>Services.GlobalMouseHook</c> / <c>GlobalKeyboardHook</c>.
+        ///
+        /// <para>ponytail: no equivalent on this head. X11 has no supported desktop-wide input hook
+        /// (XRecord is a debugging extension, not something to ship, and Wayland forbids it
+        /// outright), so BOTH behaviours the hooks bought are lost for now:</para>
+        /// <list type="bullet">
+        ///   <item><b>Click-away no longer folds the panel.</b> A click anywhere off the panel and
+        ///         off her body closed it; now only the x, "Open her cards", or the caller does.</item>
+        ///   <item><b>Escape no longer folds the panel.</b> It was a GLOBAL Escape, deliberately:
+        ///         the window can never hold the keyboard, so a local <c>KeyDown</c> here would not
+        ///         be the same feature and is not offered as one.</item>
+        /// </list>
+        /// <para>The honest replacement is a compositor-side dismissal (an X11 pointer grab, or a
+        /// layer-shell surface on Wayland), which is its own layer.</para>
+        ///
+        /// <para>WPF's <c>OnGlobalDown</c>, <c>OnGlobalKey</c> and the <c>Post</c> helper that
+        /// marshalled them back onto the UI thread go with the hooks: they existed only to be
+        /// called from a hook thread. On Avalonia that marshalling is one
+        /// <c>Dispatcher.UIThread.Post</c> when there is finally something to marshal.</para>
+        /// </summary>
+        private void InstallHooks() { }
+
+        /// <summary>Symmetrical stub. See <see cref="InstallHooks"/>.</summary>
+        private void RemoveHooks() { }
+    }
+}


### PR DESCRIPTION
974 lines. Both DllImports are gone rather than shimmed: the tool-window and no-activate styles map to markup. Not equivalent in one respect, documented in the file: the Win32 style makes activation impossible where the Avalonia one only declines it at show time. The two global hooks have no shippable X11 equivalent, so click-away dismissal and global Escape are stubbed and named.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351