### PR TITLE
feat(avalonia): port EmiBookWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml
@@ -1,0 +1,310 @@
+<!-- PORTED from ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml.
+     Structure, ordering, spacing, geometry and every colour literal preserved so the two diff
+     cleanly. The original's design notes live in that file and are not copied here; only the
+     deviations are, and every one of them is forced:
+
+       WindowStyle="None" + AllowsTransparency  -> SystemDecorations="None" +
+                                                   TransparencyLevelHint="Transparent"
+       ResizeMode="NoResize"                    -> CanResize="False"
+       SnapsToDevicePixels / RenderOptions.
+         BitmapScalingMode="NearestNeighbor"    -> RenderOptions.BitmapInterpolationMode="None"
+       PanningMode="VerticalOnly"               -> dropped (Avalonia scrolls by touch already)
+       Visibility="Collapsed"                   -> IsVisible="False"
+       RenderTransformOrigin="0,0.5"            -> "0%,50%".  A BARE PAIR IS ABSOLUTE PIXELS in
+                                                   Avalonia, so "0,0.5" would hinge the unfurl on
+                                                   half a pixel and the panel would slide, not open.
+       <Style x:Key TargetType="Button">        -> <ControlTheme> with the SAME Template
+       Trigger Property="IsMouseOver"           -> ^:pointerover selector
+       Trigger Property="IsEnabled" False       -> ^:disabled selector
+       Trigger Property="Tag" Value="on"        -> an "on" style CLASS and a ^.on selector. Avalonia
+                                                   has no property trigger; Classes is the
+                                                   guaranteed equivalent and the code-behind sets it
+                                                   where the WPF original set Tag.
+       <ContentPresenter/>                      -> ContentPresenter Content="{TemplateBinding Content}"
+                                                   (CLAUDE.md trap 6 - a bare presenter draws nothing)
+       ScrollChanged="OnNudgeScrollChanged"     -> wired in the constructor, per the repo convention.
+
+     The two ScaleTransforms the unfurl drives are BUILT IN CODE rather than named here: only
+     Controls come back from FindControl, and this head does not lean on generated x:Name fields.
+
+     THE WINDOW RECIPE, in this head's terms. WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE was stamped in
+     OnSourceInitialized; ShowInTaskbar="False" covers the first and ShowActivated="False" covers
+     as much of the second as Avalonia exposes. See the code-behind for what that loses.
+
+     NO Visibility="Hidden" HERE, exactly as in the original, and for a reason that survives the
+     port: the book is built and shown in the same turn. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk.EmiBookWindow"
+        Title="EMI"
+
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowActivated="False"
+        ShowInTaskbar="False"
+        CanResize="False"
+        SizeToContent="Manual"
+        WindowStartupLocation="Manual"
+        UseLayoutRounding="True"
+        Topmost="True"
+        Width="364" Height="728">
+
+    <Window.Resources>
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml:TabChip,
+             hoist when a second view needs it. One tab chip. Lit chip is her pink with ink text; the
+             rest are ink with a dull label. -->
+        <ControlTheme x:Key="TabChip" TargetType="Button">
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Foreground" Value="#FF6B6890"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd" Background="#FF0E0E1C" BorderBrush="#FF1C1C31" BorderThickness="0,0,2,0">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^.on /template/ Border#Bd">
+                <Setter Property="Background" Value="#FFFF69B4"/>
+            </Style>
+            <Style Selector="^.on">
+                <Setter Property="Foreground" Value="#FF0E0E1C"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Foreground" Value="#FF3A3856"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml:ChromeChip,
+             hoist when a second view needs it. The pager arrows, and the close x. -->
+        <ControlTheme x:Key="ChromeChip" TargetType="Button">
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Foreground" Value="#FFF5F0E1"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd" Background="#FF0E0E1C">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Bd">
+                <Setter Property="Background" Value="#FFFF69B4"/>
+            </Style>
+            <Style Selector="^:pointerover">
+                <Setter Property="Foreground" Value="#FF0E0E1C"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Foreground" Value="#FF3A3856"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml:RailChip,
+             hoist when a second view needs it. ONE RAIL CHIP. The lit one wears her pink down its
+             left edge and a raised ground; the rest are flat and their icon is dimmed in code. -->
+        <ControlTheme x:Key="RailChip" TargetType="Button">
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd" Background="Transparent" BorderBrush="Transparent"
+                            BorderThickness="3,0,0,0">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Bd">
+                <Setter Property="Background" Value="#FF2E2A45"/>
+            </Style>
+            <Style Selector="^.on /template/ Border#Bd">
+                <Setter Property="Background" Value="#FF2E2A45"/>
+                <Setter Property="BorderBrush" Value="#FFFF69B4"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- ponytail: local copy of ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml:GoChip,
+             hoist when a second view needs it. TAKE ME THERE. Ghosted when the card has no detour,
+             or when the door is locked. -->
+        <ControlTheme x:Key="GoChip" TargetType="Button">
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Foreground" Value="#FF0E0E1C"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd" Background="#FFFF69B4" BorderBrush="#FFA8386F" BorderThickness="0,0,0,3">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#Bd">
+                <Setter Property="Background" Value="#FFFF87C4"/>
+            </Style>
+            <Style Selector="^:disabled /template/ Border#Bd">
+                <Setter Property="Background" Value="#FF34314F"/>
+                <Setter Property="BorderBrush" Value="#FF242239"/>
+            </Style>
+            <Style Selector="^:disabled">
+                <Setter Property="Foreground" Value="#FF7E7BA4"/>
+                <Setter Property="Cursor" Value="Arrow"/>
+            </Style>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid>
+        <!--
+            Two nested scale transforms, because the unfurl is two moves and they have different
+            origins: a flat line shoots out FROM HER EDGE (ScaleX about the near edge), then it
+            opens like a CRT coming on (ScaleY about the middle). SweepHost's origin is flipped to
+            the right edge in code when the panel sits on her left.
+        -->
+        <Border x:Name="SweepHost" RenderTransformOrigin="0%,50%">
+            <Grid x:Name="OpenHost" RenderTransformOrigin="50%,50%">
+
+                <!-- THE SHADOW IS A HARD OFFSET BLOCK, not a blur: the right shadow for an 8-bit
+                     panel, and the cheap one. -->
+                <Border Background="#B3000000" Margin="7,7,-7,-7" IsHitTestVisible="False"/>
+
+                <Border x:Name="Panel"
+                        Background="#FF252542"
+                        BorderBrush="#FFFF69B4"
+                        BorderThickness="2">
+
+                    <Grid>
+                    <DockPanel LastChildFill="True">
+
+                    <!-- the three tab chips, and the way out -->
+                    <Grid DockPanel.Dock="Top" Height="34" Background="#FF0E0E1C">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="34"/>
+                        </Grid.ColumnDefinitions>
+                        <Button x:Name="Tab0" Grid.Column="0" Theme="{StaticResource TabChip}"/>
+                        <Button x:Name="Tab1" Grid.Column="1" Theme="{StaticResource TabChip}"/>
+                        <Button x:Name="Tab2" Grid.Column="2" Theme="{StaticResource TabChip}"/>
+                        <Button x:Name="BtnClose" Grid.Column="3" Theme="{StaticResource ChromeChip}"
+                                Content="x" ToolTip.Tip="{loc:Str emi_book_close}"/>
+                        <Border Grid.ColumnSpan="4" VerticalAlignment="Bottom" Height="2"
+                                Background="#FF0E0E1C"/>
+                    </Grid>
+
+                    <!-- the pager -->
+                    <Grid DockPanel.Dock="Bottom" Height="44" Background="#FF1E1D34">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="44"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="44"/>
+                        </Grid.ColumnDefinitions>
+                        <Border Grid.ColumnSpan="3" VerticalAlignment="Top" Height="2" Background="#FF0E0E1C"/>
+                        <Button x:Name="BtnPrev" Grid.Column="0" Margin="6,8,2,8"
+                                Theme="{StaticResource ChromeChip}" Content="&lt;"/>
+                        <WrapPanel x:Name="Dots" Grid.Column="1" Orientation="Horizontal"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <Button x:Name="BtnNext" Grid.Column="2" Margin="2,8,6,8"
+                                Theme="{StaticResource ChromeChip}" Content="&gt;"/>
+                    </Grid>
+
+                    <!-- THE RAIL: one icon per card ON THIS TAB, docked left BEFORE the card so the
+                         card keeps the whole remaining width. Never more than eight. -->
+                    <Border DockPanel.Dock="Left" Width="44" Background="#FF1E1D34"
+                            BorderBrush="#FF0E0E1C" BorderThickness="0,0,2,0">
+                        <ScrollViewer VerticalScrollBarVisibility="Hidden"
+                                      HorizontalScrollBarVisibility="Disabled">
+                            <StackPanel x:Name="Rail" VerticalAlignment="Center"/>
+                        </ScrollViewer>
+                    </Border>
+
+                    <!-- THE CARD. The nudge row is the STRETCHY one and everything else is Auto, so
+                         the bullets take the slack and the catch and the button sit against the foot
+                         of the panel where the chrome belongs. -->
+                    <Grid Margin="12">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>  <!-- the demo stage -->
+                            <RowDefinition Height="Auto"/>  <!-- title          -->
+                            <RowDefinition Height="Auto"/>  <!-- gist           -->
+                            <RowDefinition Height="*"/>     <!-- the four nudges, and the slack -->
+                            <RowDefinition Height="Auto"/>  <!-- the catch strip -->
+                            <RowDefinition Height="Auto"/>  <!-- the one button  -->
+                        </Grid.RowDefinitions>
+
+                        <Border Grid.Row="0" x:Name="StageFrame" BorderBrush="#FF3B3962" BorderThickness="2"
+                                Background="#FF0E0E1C" HorizontalAlignment="Left">
+                            <Grid>
+                                <Image x:Name="Stage" Width="288" Height="216"
+                                       RenderOptions.BitmapInterpolationMode="None"/>
+                                <Border Background="#FF3B3962" HorizontalAlignment="Right"
+                                        VerticalAlignment="Top" Padding="4,3">
+                                    <TextBlock x:Name="StageLabel" Foreground="#FF0E0E1C"
+                                               Text="{loc:Str emi_book_stage}"/>
+                                </Border>
+                            </Grid>
+                        </Border>
+
+                        <TextBlock Grid.Row="1" x:Name="CardTitle" Margin="0,12,0,0"
+                                   Foreground="#FFF5F0E1" TextWrapping="Wrap" LineHeight="22"/>
+
+                        <TextBlock Grid.Row="2" x:Name="CardGist" Margin="0,10,0,0"
+                                   Foreground="#FFFF69B4" TextWrapping="Wrap" LineHeight="16"/>
+
+                        <!-- The bullets scroll rather than clip, with the scrollbar hidden and the
+                             cue drawn by us: a chevron that shows only while there is something
+                             below, in its own band so it never sits on the words. -->
+                        <Grid Grid.Row="3" Margin="0,12,0,0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <ScrollViewer Grid.Row="0" x:Name="NudgeScroll"
+                                          VerticalScrollBarVisibility="Hidden"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <StackPanel x:Name="Nudges" VerticalAlignment="Top"/>
+                            </ScrollViewer>
+
+                            <Border Grid.Row="1" x:Name="MoreBelow" IsVisible="False"
+                                    IsHitTestVisible="False" HorizontalAlignment="Right"
+                                    Margin="0,3,0,0" Padding="6,2">
+                                <Polygon Points="0,0 10,0 5,6" Fill="#FFFF69B4"/>
+                            </Border>
+                        </Grid>
+
+                        <!-- The honest bit, in gold, with a rule down its left edge instead of a
+                             bullet. Same fixed place on every card. -->
+                        <Border Grid.Row="4" x:Name="CatchStrip" Margin="0,10,0,0"
+                                Background="#FF2E2A45" BorderBrush="#FFF0C050"
+                                BorderThickness="3,0,0,0" Padding="8,6,8,7">
+                            <TextBlock x:Name="CardCatch" TextWrapping="Wrap" LineHeight="15"
+                                       Foreground="#FFE8C46A"/>
+                        </Border>
+
+                        <Button Grid.Row="5" x:Name="BtnGo" Height="36" Margin="0,12,0,0"
+                                Theme="{StaticResource GoChip}"/>
+                    </Grid>
+
+                    </DockPanel>
+
+                    <!-- The CRT flash on the unfurl. Never hit-testable, and INSIDE the panel
+                         border: as a sibling it would paint over the transparent air the unfurl
+                         scales through. -->
+                    <Border x:Name="Flash" Background="#FFF5F0E1" Opacity="0" IsHitTestVisible="False"/>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
@@ -1,0 +1,1173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services.EmiDesk;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
+{
+    /// <summary>
+    /// HER BOOK: the flipbook that unfurls beside her.
+    ///
+    /// <para><b>What it is.</b> One card per feature. The top of the card is a little 8-bit loop
+    /// that SHOWS the feature happening, and under it sit a title, one pink line, up to four
+    /// nudges, the catch on its own strip, and at most one button. Roughly forty words.</para>
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Windows/EmiDesk/EmiBookWindow.xaml.cs. The XAML's
+    /// header lists the markup deviations; these are the code ones, and every one is forced:</para>
+    ///
+    /// <list type="bullet">
+    ///   <item><b>The Win32 goes, and one behaviour goes with it.</b>
+    ///     <c>SetWindowLong(GWL_EXSTYLE, WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE)</c> becomes
+    ///     <c>ShowInTaskbar="False"</c> plus <c>ShowActivated="False"</c> in the markup.
+    ///     <b>WS_EX_NOACTIVATE is only half covered.</b> On Windows it meant the book could NEVER
+    ///     take the keyboard, at any point in its life - which is why the original has no key
+    ///     handling at all. <c>ShowActivated="False"</c> only governs the first Show, so on X11 a
+    ///     click on a chip WILL focus this window and pull focus off whatever the reader was doing.
+    ///     There is no property for the permanent form; it needs
+    ///     <c>_NET_WM_STATE_SKIP_TASKBAR</c>/input-hint work on the X11 shim, which is its own
+    ///     layer. Nothing here fakes it.
+    ///     <c>NativeStyle()</c> (<c>GWL_STYLE</c>/<c>WS_VISIBLE</c>) is dropped outright: it existed
+    ///     to catch a WPF-specific bug where <c>Window.IsVisible</c> lied, and the native style word
+    ///     it printed has no X11 twin worth inventing. The log line keeps the geometry.</item>
+    ///   <item><b>No web view anywhere.</b> This window never hosted one - the original's header
+    ///     explains at length why it could not - so nothing here touches <c>controls:WebHost</c>.</item>
+    ///   <item><b>No X11Overlay call.</b> Nothing in this window was click-through or restacked
+    ///     against a sibling; <c>Topmost</c> in the markup is the whole z-order story.</item>
+    ///   <item><b>The deck, the demos, the glyphs and the fonts are stubs</b>, each marked
+    ///     <c>ponytail:</c> below. <see cref="Book"/> carries six real cards' worth of placeholder
+    ///     data keyed on the REAL loc stems, so every string on screen is the shipped English (or
+    ///     the reader's language), never a raw key.</item>
+    ///   <item><b>The emphasis parser is the real one.</b> <c>EmiBookText.Parse</c> is already in
+    ///     Core, so the <c>*asterisk*</c> runs are ported rather than approximated.
+    ///     <c>EmiBookLayout</c> is NOT: it is <c>internal</c> to CCP.Core and this assembly is not
+    ///     in Core's <c>InternalsVisibleTo</c>, so the side/width decision is stubbed rather than
+    ///     copied - a second copy of that arithmetic is the exact thing it was extracted to
+    ///     prevent.</item>
+    ///   <item><c>Left</c>/<c>Top</c> (DIPs) -&gt; <c>Position</c>, which is PHYSICAL pixels: the
+    ///     conversion the original does in one direction now runs in both.
+    ///     <c>PresentationSource...TransformToDevice.M11</c> -&gt; <c>RenderScaling</c>;
+    ///     <c>Forms.Screen.FromPoint</c> -&gt; <c>Screens.ScreenFromPoint</c>.</item>
+    ///   <item><c>ScrollableHeight</c> does not exist: the overflow test is
+    ///     <c>Extent.Height - Viewport.Height - Offset.Y</c>. <c>ScrollToTop</c> -&gt;
+    ///     <c>ScrollToHome</c>.</item>
+    ///   <item><c>DoubleAnimation</c>/<c>BeginAnimation</c> -&gt; <c>Animation.RunAsync</c> on the
+    ///     <c>ScaleTransform</c> itself (a <c>Transform</c> is an <c>Animatable</c>);
+    ///     <c>BeginTime</c> -&gt; <c>Delay</c>. The fold closes on the awaited sweep, which is the
+    ///     same "close on the LAST animation, never on a timer" rule the original states.</item>
+    ///   <item><c>Tag = "on"</c> -&gt; the <c>on</c> style class, because Avalonia has no property
+    ///     trigger. <c>MouseEnter/Leave</c> -&gt; <c>PointerEntered/Exited</c>;
+    ///     <c>MouseLeftButtonUp</c> -&gt; <c>PointerReleased</c>.</item>
+    ///   <item>The constructor is parameterless. The WPF one takes the desk window that owns the
+    ///     book and that type does not exist on this head yet, so the owner hooks are stubs - and
+    ///     the same constructor is what <c>--render-all</c> discovers. It selects the first card,
+    ///     which the WPF constructor left to <see cref="OpenBook"/>: a window that draws nothing
+    ///     until a service calls it renders as an empty panel.</item>
+    /// </list>
+    /// </summary>
+    public partial class EmiBookWindow : Window
+    {
+        /// <summary>The book at its full drawn height, in DIPs. Matches the XAML.</summary>
+        private const double FullHeight = 728.0;
+
+        /// <summary>The floor the book will not shrink under, even on a very short desk.</summary>
+        private const double MinPanelHeight = 430.0;
+
+        /// <summary>Panel height at or above which the demo stage gets its 3x, 288 x 216 pixels.</summary>
+        private const double BigStageFloor = 640.0;
+
+        /// <summary>The demo buffer, in cells. 288 = 3 x 96 exactly, which is why the stage is 288 wide.</summary>
+        private const int BufW = 96;
+
+        /// <inheritdoc cref="BufW"/>
+        private const int BufH = 72;
+
+        /// <summary>How many bullets a card may show, whatever the deck hands over.</summary>
+        private const int MaxNudges = 4;
+
+        // ponytail: needs MotionFx (WPF head, Services/MotionFx.cs), wired when it moves to Core.
+        // Both gates read "allowed" here, which is the shipped default; a reduced-motion desk gets
+        // the animation it asked not to have until the gate lands.
+        private const bool AllowTransitions = true;
+        private const bool AllowAmbientLoops = true;
+
+        private readonly List<Border> _dots = new();
+
+        private readonly Button _tab0;
+        private readonly Button _tab1;
+        private readonly Button _tab2;
+        private readonly Button _btnClose;
+        private readonly Button _btnPrev;
+        private readonly Button _btnNext;
+        private readonly Button _btnGo;
+        private readonly Border _sweepHost;
+        private readonly Grid _openHost;
+        private readonly Border _flash;
+        private readonly Border _moreBelow;
+        private readonly Image _stage;
+        private readonly TextBlock _stageLabel;
+        private readonly TextBlock _cardTitle;
+        private readonly TextBlock _cardGist;
+        private readonly TextBlock _cardCatch;
+        private readonly StackPanel _nudges;
+        private readonly StackPanel _rail;
+        private readonly WrapPanel _dotsPanel;
+        private readonly ScrollViewer _nudgeScroll;
+
+        private readonly ScaleTransform _sweepScale = new(1, 1);
+        private readonly ScaleTransform _openScale = new(1, 1);
+
+        /// <summary>One log line per book, not one per move: <c>PlaceWindow</c> runs on every drag tick.</summary>
+        private bool _notedCover;
+
+        /// <summary>
+        /// QA ONLY: pretend there is no room, so the narrow book can be reviewed on a desk that has
+        /// plenty. Nothing in a normal launch sets this.
+        /// </summary>
+        internal static bool ForceNarrow;
+
+        private int _index;
+        private int _tab;
+        private bool _closingForGood;
+        private bool _folding;
+
+        /// <summary>True while the panel sits to her LEFT, which flips the unfurl's origin.</summary>
+        private bool _onHerLeft;
+
+        /// <summary>
+        /// Which side of her this panel took: <c>-1</c> her LEFT, <c>+1</c> her RIGHT. Read through
+        /// the book service, never off this window.
+        /// </summary>
+        internal int SideOfHer => _onHerLeft ? -1 : 1;
+
+        // ---------------------------------------------------------------- ctor
+
+        /// <summary>
+        /// Builds the book. The WPF constructor takes the desk widget that owns it; that window is
+        /// not on this head yet, so the owner is a stub and this doubles as the render constructor.
+        /// </summary>
+        // ponytail: needs EmiDeskWindow (owner: Moved, Resized, HoldChromeForPanel, SpeakLine,
+        // BodyScreenRect), wired when the desk moves to Core.
+        public EmiBookWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _tab0 = this.FindControl<Button>("Tab0")!;
+            _tab1 = this.FindControl<Button>("Tab1")!;
+            _tab2 = this.FindControl<Button>("Tab2")!;
+            _btnClose = this.FindControl<Button>("BtnClose")!;
+            _btnPrev = this.FindControl<Button>("BtnPrev")!;
+            _btnNext = this.FindControl<Button>("BtnNext")!;
+            _btnGo = this.FindControl<Button>("BtnGo")!;
+            _sweepHost = this.FindControl<Border>("SweepHost")!;
+            _openHost = this.FindControl<Grid>("OpenHost")!;
+            _flash = this.FindControl<Border>("Flash")!;
+            _moreBelow = this.FindControl<Border>("MoreBelow")!;
+            _stage = this.FindControl<Image>("Stage")!;
+            _stageLabel = this.FindControl<TextBlock>("StageLabel")!;
+            _cardTitle = this.FindControl<TextBlock>("CardTitle")!;
+            _cardGist = this.FindControl<TextBlock>("CardGist")!;
+            _cardCatch = this.FindControl<TextBlock>("CardCatch")!;
+            _nudges = this.FindControl<StackPanel>("Nudges")!;
+            _rail = this.FindControl<StackPanel>("Rail")!;
+            _dotsPanel = this.FindControl<WrapPanel>("Dots")!;
+            _nudgeScroll = this.FindControl<ScrollViewer>("NudgeScroll")!;
+
+            // The transforms are built here rather than named in markup: FindControl only returns
+            // Controls, and a ScaleTransform is not one.
+            _sweepHost.RenderTransform = _sweepScale;
+            _openHost.RenderTransform = _openScale;
+
+            ApplyFonts();
+            WireControls();
+
+            // The chrome on her body stays lit while the pointer is in here, so the ? chip that
+            // opened this is still on screen after the round trip.
+            PointerEntered += (_, _) => Hold(true);
+            PointerExited += (_, _) => Hold(false);
+
+            // NOT in the WPF original, where OpenBook is always what fills the panel. Here the
+            // render harness constructs the window and screenshots it, so an unpopulated book is an
+            // empty pink box that passes.
+            SelectCard(0, speak: false);
+            PaintStill();
+        }
+
+        // ---------------------------------------------------------------- wiring
+
+        /// <summary>
+        /// ponytail: needs EmiFace (WPF head, Services/EmiDesk/EmiFace.cs) for Press Start 2P and
+        /// the body face, wired when the shipped fonts land as AvaloniaResource on this head. The
+        /// SIZES are ported verbatim because they are the layout - 16 for the title, 8 for the
+        /// chrome, one whole number of pixels per 8x8 cell - but at those sizes the default UI face
+        /// reads much smaller than the pixel font does, so the chrome is small until the face lands.
+        /// </summary>
+        private void ApplyFonts()
+        {
+            try
+            {
+                foreach (var b in new[] { _tab0, _tab1, _tab2 }) b.FontSize = 8;
+
+                _btnClose.FontSize = 8;
+                _btnPrev.FontSize = 10;
+                _btnNext.FontSize = 10;
+                _btnGo.FontSize = 8;
+
+                _stageLabel.FontSize = 6;
+                _cardTitle.FontSize = 16;
+                _cardGist.FontSize = 13;
+                _cardCatch.FontSize = 11.5;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] book fonts failed");
+            }
+        }
+
+        private void WireControls()
+        {
+            _btnClose.Click += (_, _) => CloseBook();
+            _btnPrev.Click += (_, _) => Step(-1);
+            _btnNext.Click += (_, _) => Step(+1);
+            _btnGo.Click += (_, _) => Go();
+
+            _tab0.Click += (_, _) => PickTab(0);
+            _tab1.Click += (_, _) => PickTab(1);
+            _tab2.Click += (_, _) => PickTab(2);
+
+            // Markup in this head, not a code assignment: a local .Text set here would survive a
+            // language change and the binding would not. The close tooltip and the stage label are
+            // both {loc:Str} in the XAML for the same reason.
+            _nudgeScroll.ScrollChanged += (_, _) => UpdateMoreCue();
+        }
+
+        // ponytail: needs EmiDeskWindow.HoldChromeForPanel, wired when the desk moves to Core.
+        private void Hold(bool on) { _ = on; }
+
+        // ponytail: needs the EmiBook service (WPF head, Services/EmiDesk/EmiBook.cs) for Close,
+        // NoteCard and NoteSideChanged, wired when it moves to Core. Closing the window itself is
+        // the honest local half of it.
+        private void CloseBook() => Kill();
+
+        // ---------------------------------------------------------------- open / close
+
+        /// <summary>Unfurl the book beside her, at <paramref name="cardId"/> or at the first card.</summary>
+        public void OpenBook(string? cardId)
+        {
+            if (_closingForGood) return;
+            try
+            {
+                SelectCard(Book.IndexOf(cardId) is var i and >= 0 ? i : 0, speak: false);
+
+                PlaceWindow();
+                if (!IsVisible)
+                {
+                    Show();
+                    // The window has no scaling of its own until it is up, so the first placement is
+                    // always done twice: once to get it on screen, once with its real scale.
+                    PlaceWindow();
+                }
+
+                Log.Information("[EmiDesk] book shown at {P} {W}x{H}", Position, Bounds.Width, Bounds.Height);
+
+                Unfurl();
+                StartClock();
+                SpeakMargin();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] book failed to open");
+                try { Kill(); } catch { /* nothing else to try */ }
+            }
+        }
+
+        /// <summary>Navigate a book that is already up. Used when a second Open arrives.</summary>
+        public void GoTo(string? cardId)
+        {
+            try
+            {
+                int i = Book.IndexOf(cardId);
+                if (i < 0) return;
+                SelectCard(i, speak: true);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book navigate failed");
+            }
+        }
+
+        /// <summary>Fold the book and let it go: her dismissal, or app shutdown.</summary>
+        public void Kill()
+        {
+            try
+            {
+                _closingForGood = true;
+                StopClock();
+                Hold(false);
+
+                if (!IsVisible)
+                {
+                    Close();
+                    return;
+                }
+                Fold();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book kill failed");
+                try { Close(); } catch { /* it is going away either way */ }
+            }
+        }
+
+        // ---------------------------------------------------------------- the unfurl
+
+        /// <summary>
+        /// Two moves with two origins, which is why there are two transforms.
+        ///
+        /// <para>A flat line shoots out FROM HER EDGE (ScaleX about the near edge), then it opens
+        /// like a CRT coming on (ScaleY about the middle) with a single bright frame at the seam.
+        /// One transform cannot do both.</para>
+        ///
+        /// <para>Under reduced motion the book is simply there. The panel is not a decoration that
+        /// can be slowed down; it is the content.</para>
+        /// </summary>
+        private void Unfurl()
+        {
+            try
+            {
+                _sweepHost.RenderTransformOrigin = new RelativePoint(_onHerLeft ? 1 : 0, 0.5, RelativeUnit.Relative);
+
+                if (!AllowTransitions)
+                {
+                    _sweepScale.ScaleX = 1;
+                    _openScale.ScaleY = 1;
+                    _flash.Opacity = 0;
+                    return;
+                }
+
+                _sweepScale.ScaleX = 0;
+                _openScale.ScaleY = 0.04;
+                _flash.Opacity = 0;
+
+                _ = Scale(ScaleTransform.ScaleXProperty, 0, 1, 170, 0, new CubicEaseOut()).RunAsync(_sweepScale);
+                _ = Scale(ScaleTransform.ScaleYProperty, 0.04, 1, 200, 160, new CubicEaseOut()).RunAsync(_openScale);
+
+                var flash = new Animation
+                {
+                    Duration = TimeSpan.FromMilliseconds(280),
+                    Delay = TimeSpan.FromMilliseconds(160),
+                    FillMode = FillMode.Forward,
+                    Children =
+                    {
+                        new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(OpacityProperty, 0d) } },
+                        new KeyFrame { Cue = new Cue(60d / 280d), Setters = { new Setter(OpacityProperty, 0.72d) } },
+                        new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(OpacityProperty, 0d) } },
+                    },
+                };
+                _ = flash.RunAsync(_flash);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book unfurl failed");
+                try { _sweepScale.ScaleX = 1; _openScale.ScaleY = 1; } catch { /* nothing left to try */ }
+            }
+        }
+
+        /// <summary>One scale ramp, which is the only shape of animation this window has.</summary>
+        private static Animation Scale(
+            AvaloniaProperty prop, double from, double to, double ms, double delayMs, Easing easing)
+        {
+            return new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(ms),
+                Delay = TimeSpan.FromMilliseconds(delayMs),
+                Easing = easing,
+                FillMode = FillMode.Forward,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(prop, from) } },
+                    new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(prop, to) } },
+                },
+            };
+        }
+
+        /// <summary>The unfurl backwards, and then the window is gone.</summary>
+        private async void Fold()
+        {
+            if (_folding) return;
+            _folding = true;
+            try
+            {
+                if (!AllowTransitions)
+                {
+                    Close();
+                    return;
+                }
+
+                _ = Scale(ScaleTransform.ScaleYProperty, 1, 0.04, 130, 0, new CubicEaseIn()).RunAsync(_openScale);
+
+                // Awaited rather than fired on a timer, which is the same rule the original states:
+                // the close hangs off the LAST animation, so a slow frame cannot leave the window on
+                // screen at zero width with nothing coming to close it.
+                await Scale(ScaleTransform.ScaleXProperty, 1, 0, 140, 120, new CubicEaseIn()).RunAsync(_sweepScale);
+                Close();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book fold failed");
+                try { Close(); } catch { /* already gone */ }
+            }
+        }
+
+        // ---------------------------------------------------------------- the clock
+
+        /// <summary>
+        /// ponytail: needs EmiBookDemos / EmiDemoPainter / EmiPixelCanvas (WPF head,
+        /// Services/EmiDesk/), wired when they move to Core. The original owns ONE 30 fps
+        /// DispatcherTimer driving whichever painter the current card holds; with no painter on
+        /// this head there is nothing for a clock to drive, so the stage gets the one placeholder
+        /// still frame <see cref="PaintStill"/> draws and no timer is created at all.
+        /// </summary>
+        private void StartClock()
+        {
+            if (!AllowAmbientLoops)
+            {
+                PaintStill();
+                return;
+            }
+            PaintStill();
+        }
+
+        /// <inheritdoc cref="StartClock"/>
+        private void StopClock() { }
+
+        /// <summary>
+        /// The stage's still frame. ponytail: needs EmiPixelCanvas plus the card's own
+        /// EmiDemoPainter; until then this is a deterministic 96 x 72 stand-in in the panel's own
+        /// palette, which is what the demo buffer is, and it proves the integer blow-up - 288 = 3 x
+        /// 96 with BitmapInterpolationMode None - lands with no seam and no filtering.
+        /// </summary>
+        private void PaintStill()
+        {
+            try
+            {
+                var bmp = new WriteableBitmap(new PixelSize(BufW, BufH), new Vector(96, 96), PixelFormats.Bgra8888, AlphaFormat.Opaque);
+                using (var fb = bmp.Lock())
+                {
+                    var row = new byte[fb.RowBytes];
+                    for (var y = 0; y < BufH; y++)
+                    {
+                        for (var x = 0; x < BufW; x++)
+                        {
+                            // A framed field with a scanline wash and a pink bar across the middle:
+                            // enough shape that a blank stage is obvious, seeded off the card index
+                            // so flipping a page visibly changes the picture.
+                            bool edge = x < 2 || y < 2 || x >= BufW - 2 || y >= BufH - 2;
+                            bool bar = y >= 33 && y < 39 && x >= 8 + _index * 4 && x < BufW - 8;
+                            bool wash = (y % 4) == 0;
+                            row[x * 4 + 0] = edge ? (byte)0x62 : bar ? (byte)0xB4 : wash ? (byte)0x2A : (byte)0x1C; // B
+                            row[x * 4 + 1] = edge ? (byte)0x39 : bar ? (byte)0x69 : wash ? (byte)0x1E : (byte)0x0E; // G
+                            row[x * 4 + 2] = edge ? (byte)0x3B : bar ? (byte)0xFF : wash ? (byte)0x1E : (byte)0x0E; // R
+                            row[x * 4 + 3] = 0xFF;
+                        }
+                        Marshal.Copy(row, 0, fb.Address + y * fb.RowBytes, fb.RowBytes);
+                    }
+                }
+                _stage.Source = bmp;
+            }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book still frame failed"); }
+        }
+
+        /// <summary>
+        /// Freeze the stage on one exact frame. FOR THE OFFSCREEN SHOT RIG ONLY: a review of a 30
+        /// fps loop needs a determinate frame.
+        ///
+        /// <para>ponytail: needs EmiDemoPainter for <paramref name="tMs"/> to mean anything. The
+        /// card selection half is real, so a rig that walks the deck already works.</para>
+        /// </summary>
+        internal void ShootFrame(string? cardId, double tMs)
+        {
+            try
+            {
+                _ = tMs;
+                StopClock();
+                int i = Book.IndexOf(cardId);
+                if (i >= 0) SelectCard(i, speak: false);
+                PaintStill();
+            }
+            catch (Exception ex) { Log.Warning(ex, "[EmiDesk] book shot frame failed"); }
+        }
+
+        // ---------------------------------------------------------------- the cards
+
+        /// <summary>Move to a card by index, redraw everything, and remember where we are.</summary>
+        private void SelectCard(int index, bool speak)
+        {
+            var cards = Book.All;
+            if (cards.Count == 0) return;
+
+            _index = Math.Max(0, Math.Min(cards.Count - 1, index));
+            var card = cards[_index];
+            _tab = card.Tab;
+
+            PaintStill();
+
+            RenderCard(card);
+            RenderTabs();
+            RenderRail();
+            RenderDots();
+
+            // ponytail: needs EmiBook.NoteCard (the read ledger), wired when it moves to Core.
+            if (speak) SpeakMargin();
+        }
+
+        private void Step(int delta)
+        {
+            var cards = Book.All;
+            if (cards.Count == 0) return;
+            int next = _index + delta;
+            if (next < 0 || next >= cards.Count) return;
+            SelectCard(next, speak: true);
+        }
+
+        private void PickTab(int tab)
+        {
+            int first = Book.FirstOnTab(tab);
+            if (first < 0) return;
+            if (first == _index && _tab == tab) return;
+            SelectCard(first, speak: true);
+        }
+
+        /// <summary>The bullets' body text.</summary>
+        private static readonly IBrush NudgePlain = Frozen(0xC9, 0xC3, 0xE2);
+
+        /// <summary>
+        /// The key words, in every row that has any. Pink, and NOT a third hue: the panel already
+        /// spends pink on the gist and gold on the catch.
+        /// </summary>
+        private static readonly IBrush NudgeHot = Frozen(0xFF, 0x69, 0xB4);
+
+        /// <summary>The gist line, and its key words a shade up from it.</summary>
+        private static readonly IBrush GistPlain = Frozen(0xFF, 0x69, 0xB4);
+
+        /// <inheritdoc cref="GistPlain"/>
+        private static readonly IBrush GistHot = Frozen(0xFF, 0xD2, 0xEE);
+
+        /// <summary>The catch strip, and its key words a shade up from it.</summary>
+        private static readonly IBrush CatchPlain = Frozen(0xE8, 0xC4, 0x6A);
+
+        /// <inheritdoc cref="CatchPlain"/>
+        private static readonly IBrush CatchHot = Frozen(0xF9, 0xE2, 0xAC);
+
+        /// <summary>WPF's <c>Freeze()</c> has no Avalonia twin; an immutable brush is the twin.</summary>
+        private static IBrush Frozen(byte r, byte g, byte b) =>
+            new ImmutableSolidColorBrush(Color.FromRgb(r, g, b));
+
+        private void RenderCard(BookCard card)
+        {
+            try
+            {
+                _cardTitle.Text = card.Title;
+                Emphasize(_cardGist, card.Gist, GistPlain, GistHot);
+                Emphasize(_cardCatch, card.Catch, CatchPlain, CatchHot);
+
+                _nudges.Children.Clear();
+                int n = 0;
+                foreach (var nudge in card.Nudges)
+                {
+                    if (n++ >= MaxNudges) break;
+                    _nudges.Children.Add(NudgeRow(nudge));
+                }
+
+                RenderButton(card);
+
+                // The card just changed height under the scroller. Ask at Loaded rather than now:
+                // the extent is zero until this content has been arranged, so reading it here says
+                // "nothing to scroll" on every card - the failure that looks like success.
+                _nudgeScroll.ScrollToHome();
+                Dispatcher.UIThread.Post(UpdateMoreCue, DispatcherPriority.Loaded);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] book card render failed for {Card}", card.Id);
+            }
+        }
+
+        /// <summary>
+        /// Show the chevron exactly while there is unread copy under the fold. It appears when a
+        /// card overflows and goes away at the bottom, so it is a statement about THIS card rather
+        /// than a decoration that trains the reader to ignore it.
+        /// </summary>
+        private void UpdateMoreCue()
+        {
+            try
+            {
+                // WPF's ScrollableHeight, spelled out: Avalonia exposes the extent and the viewport
+                // and leaves the subtraction to the caller.
+                double left = _nudgeScroll.Extent.Height - _nudgeScroll.Viewport.Height - _nudgeScroll.Offset.Y;
+                _moreBelow.IsVisible = left > 1.0;
+            }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book more-cue failed"); }
+        }
+
+        /// <summary>
+        /// Lay a line of card copy into a TextBlock as runs, with the <c>*asterisk*</c> key words
+        /// drawn loud. Falls all the way back to the plain string if anything at all goes wrong: a
+        /// card that lost its emphasis is a card, a card that lost its text is a blank panel.
+        /// </summary>
+        private static void Emphasize(TextBlock target, string? line, IBrush plain, IBrush hot)
+        {
+            try
+            {
+                target.Inlines ??= new InlineCollection();
+                target.Inlines.Clear();
+                foreach (var run in EmiBookText.Parse(line))
+                {
+                    target.Inlines.Add(new Run(run.Text)
+                    {
+                        Foreground = run.Hot ? hot : plain,
+                        FontWeight = run.Hot ? FontWeight.Bold : FontWeight.Normal,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book emphasis failed, falling back to plain text");
+                try { target.Inlines?.Clear(); target.Text = EmiBookText.Strip(line); } catch { /* nothing left */ }
+            }
+        }
+
+        /// <summary>
+        /// One nudge: a hard little square and a wrapped line, with its key words bold and pink.
+        /// Nine of bottom margin, not six: four bullets that each wrap to two lines ran together
+        /// into one block at six.
+        /// </summary>
+        private DockPanel NudgeRow(string text)
+        {
+            var row = new DockPanel { Margin = new Thickness(0, 0, 0, 9), LastChildFill = true };
+
+            var bullet = new Border
+            {
+                Width = 6,
+                Height = 6,
+                Margin = new Thickness(0, 5, 8, 0),
+                VerticalAlignment = VerticalAlignment.Top,
+                Background = NudgeHot,
+            };
+            DockPanel.SetDock(bullet, Dock.Left);
+            row.Children.Add(bullet);
+
+            var tb = new TextBlock
+            {
+                TextWrapping = TextWrapping.Wrap,
+                LineHeight = 16,
+                FontSize = 12.5,
+                Foreground = NudgePlain,
+            };
+            // ponytail: needs EmiFace.FaceFont, as in ApplyFonts.
+            Emphasize(tb, text, NudgePlain, NudgeHot);
+            row.Children.Add(tb);
+
+            return row;
+        }
+
+        /// <summary>
+        /// The one button. A card with no detour has no button at all rather than a dead one, and a
+        /// card whose detour cannot run right now keeps the button but ghosts it, so the shape of
+        /// the card does not change under the reader between one launch and the next.
+        /// </summary>
+        private void RenderButton(BookCard card)
+        {
+            if (card.Target == null && card.Tour == null)
+            {
+                _btnGo.IsVisible = false;
+                return;
+            }
+
+            _btnGo.IsVisible = true;
+
+            if (card.Target != null)
+            {
+                // ponytail: needs EmiTargets.Find (WPF head, Services/EmiDesk) for the door's
+                // Available flag, wired when it moves to Core. Enabled here, so the card's full
+                // shape is what renders.
+                _btnGo.Content = new TextBlock { Text = Book.L("emi_book_go", "TAKE ME THERE") };
+                _btnGo.IsEnabled = true;
+                return;
+            }
+
+            _btnGo.Content = new TextBlock { Text = Book.L("emi_book_walk", "WALK ME THROUGH IT") };
+            _btnGo.IsEnabled = TourReady();
+        }
+
+        /// <summary>
+        /// ponytail: needs MainWindow, SessionEngine.Active and App.Tutorial - the same three
+        /// conditions EmiOffers.TourFeasible checks, minus the "already done" latch - wired when
+        /// they move to Core. True here, so a tour card renders lit rather than permanently ghosted.
+        /// </summary>
+        private static bool TourReady() => true;
+
+        // ponytail: needs EmiTargets.Open and MainWindow.StartTutorial (both WPF head), wired when
+        // they move to Core. Everything the button does is a detour into the app, so there is
+        // nothing view-local left to port here.
+        private void Go()
+        {
+            var cards = Book.All;
+            if (_index < 0 || _index >= cards.Count) return;
+            Log.Debug("[EmiDesk] book detour for {Card} is not wired on this head", cards[_index].Id);
+        }
+
+        private void RenderTabs()
+        {
+            var tabs = new[] { _tab0, _tab1, _tab2 };
+            for (int i = 0; i < tabs.Length; i++)
+            {
+                try
+                {
+                    // A TextBlock rather than a bare string: Avalonia reads "_" in Content as an
+                    // access key, and a localized label is not ours to guarantee is free of one.
+                    tabs[i].Content = new TextBlock { Text = Book.TabName(i) };
+                    // A tab with nothing behind it is drawn and dead, not hidden: the shape of the
+                    // book is honest from day one.
+                    tabs[i].IsEnabled = Book.TabHasCards(i);
+                    tabs[i].Classes.Set("on", i == _tab);
+                }
+                catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book tab {Tab} render failed", i); }
+            }
+        }
+
+        /// <summary>
+        /// THE SIDE RAIL: one icon per card on this tab, and clicking one goes straight there.
+        /// Rebuilt on every card change rather than built once and re-tagged - it is at most eight
+        /// buttons, and a rail rebuilt from the deck cannot drift out of step with it.
+        /// </summary>
+        private void RenderRail()
+        {
+            try
+            {
+                _rail.Children.Clear();
+
+                Resources.TryGetResource("RailChip", null, out var themeRes);
+                var chipTheme = themeRes as ControlTheme;
+                var cards = Book.All;
+                for (int i = 0; i < cards.Count; i++)
+                {
+                    if (cards[i].Tab != _tab) continue;
+
+                    int target = i;
+                    var card = cards[i];
+                    bool here = i == _index;
+
+                    var chip = new Button { Theme = chipTheme };
+                    chip.Classes.Set("on", here);
+                    ToolTip.SetTip(chip, card.Title);
+
+                    // ponytail: needs EmiBookGlyphs.For (WPF head; 16-cell glyphs blown up 2x with
+                    // nearest neighbour), wired when it moves to Core. With no glyph the original's
+                    // OWN fallback runs - a card with no glyph still gets a chip, because skipping
+                    // it would silently drop a page out of the only navigation that names its
+                    // destinations.
+                    chip.Content = new Border { Width = 10, Height = 10, Background = here ? NudgeHot : NudgePlain };
+
+                    chip.Click += (_, _) => SelectCard(target, speak: true);
+                    _rail.Children.Add(chip);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book rail render failed");
+            }
+        }
+
+        /// <summary>
+        /// One dot per card ON THIS TAB, not per card in the book. The dots are a "where am I in
+        /// this chapter" reading.
+        /// </summary>
+        private void RenderDots()
+        {
+            try
+            {
+                _dotsPanel.Children.Clear();
+                _dots.Clear();
+
+                var cards = Book.All;
+                for (int i = 0; i < cards.Count; i++)
+                {
+                    if (cards[i].Tab != _tab) continue;
+
+                    int target = i;
+                    bool here = i == _index;
+                    var dot = new Border
+                    {
+                        Width = 8,
+                        Height = 8,
+                        Margin = new Thickness(4, 0, 4, 0),
+                        Cursor = new Cursor(StandardCursorType.Hand),
+                        Background = new ImmutableSolidColorBrush(here
+                            ? Color.FromRgb(0xFF, 0x69, 0xB4)
+                            : Color.FromRgb(0x46, 0x43, 0x6D)),
+                    };
+                    dot.PointerReleased += (_, _) => SelectCard(target, speak: true);
+                    _dotsPanel.Children.Add(dot);
+                    _dots.Add(dot);
+                }
+
+                _btnPrev.IsEnabled = _index > 0;
+                _btnNext.IsEnabled = _index < cards.Count - 1;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book dots render failed");
+            }
+        }
+
+        /// <summary>
+        /// Her line in the margin: a comment ON the card, not a reading of it.
+        ///
+        /// <para>ponytail: needs EmiDeskWindow.SpeakLine and the LineDraw record (WPF head), wired
+        /// when the desk moves to Core. Priority 2, keyed "book.margin.&lt;id&gt;", face from the
+        /// card - all of that is data this stub already carries, so only the delivery is missing.</para>
+        /// </summary>
+        private void SpeakMargin()
+        {
+            try
+            {
+                var cards = Book.All;
+                if (_index < 0 || _index >= cards.Count) return;
+                var card = cards[_index];
+                if (string.IsNullOrWhiteSpace(card.MarginEn)) return;
+                Log.Verbose("[EmiDesk] book margin {Id}: {Line} {Face}", card.Id, card.MarginEn, card.MarginFace);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book margin line failed");
+            }
+        }
+
+        // ---------------------------------------------------------------- placement
+
+        /// <summary>
+        /// Her body box on the desk, in PHYSICAL pixels.
+        ///
+        /// <para>ponytail: needs EmiDeskWindow.BodyScreenRect, wired when the desk moves to Core. A
+        /// fixed box on the right of a 1920 desk until then, which is where she usually stands and
+        /// therefore exercises the same branch the real one does.</para>
+        /// </summary>
+        private PixelRect BodyScreenRect => new(1480, 360, 220, 420);
+
+        private PixelRect WorkArea()
+        {
+            try
+            {
+                var body = BodyScreenRect;
+                var centre = new PixelPoint(body.X + body.Width / 2, body.Y + body.Height / 2);
+                var screen = Screens?.ScreenFromPoint(centre) ?? Screens?.Primary;
+                if (screen != null) return screen.WorkingArea;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book work-area probe failed");
+            }
+            return new PixelRect(0, 0, 1920, 1080);
+        }
+
+        /// <summary>
+        /// Put the book beside her, on the side with room, vertically centred on her and clamped
+        /// into the work area of the monitor she is standing on.
+        ///
+        /// <para>PHYSICAL PIXELS over this window's own scale, both sides of the sum. Avalonia makes
+        /// that explicit where WPF did not: <c>Width</c>/<c>Height</c> are DIPs and
+        /// <c>Position</c> is device pixels, so the conversion runs in both directions here.</para>
+        ///
+        /// <para>On a short desk the stage drops from 3x to 2x rather than the book scrolling. Nine
+        /// screen pixels per cell down to four keeps the integer multiple, and a demo with a
+        /// half-pixel seam in it is worse than a smaller demo.</para>
+        /// </summary>
+        private void PlaceWindow()
+        {
+            try
+            {
+                var work = WorkArea();
+                double s = RenderScaling;
+                if (s <= 0) s = 1.0;
+
+                double workL = work.X / s;
+                double workT = work.Y / s;
+                double workW = work.Width / s;
+                double workH = work.Height / s;
+
+                var bodyPx = BodyScreenRect;
+                double bodyL = bodyPx.X / s;
+                double bodyT = bodyPx.Y / s;
+                double bodyR = bodyPx.Right / s;
+                double bodyH = bodyPx.Height / s;
+
+                var place = Place(workL, workW, bodyL, bodyR);
+                if (ForceNarrow) place = place with { Width = NarrowWidth, Narrow = true };
+                if (Math.Abs(Width - place.Width) > 0.5) Width = place.Width;
+
+                double h = Math.Min(FullHeight, Math.Max(MinPanelHeight, workH - 24));
+                if (Math.Abs(Height - h) > 0.5) Height = h;
+
+                // The test is ROOM rather than "did we get the full height": a 1366 x 768 laptop
+                // lands a hair under FullHeight with ample room for the big stage, and measuring
+                // against FullHeight sent those machines to the small stage for an 8 pixel shortfall.
+                // The narrow book overrides it outright: a 288 wide stage does not fit a 196 column.
+                ApplyStageScale(!place.Narrow && h >= BigStageFloor ? 3 : 2);
+
+                bool wasOnHerLeft = _onHerLeft;
+                _onHerLeft = place.OnHerLeft;
+
+                if (place.CoversHer && !_notedCover)
+                {
+                    _notedCover = true;
+                    Log.Information(
+                        "[EmiDesk] book has no room beside her (work {WorkW:F0}, body {BodyW:F0}); it overlaps",
+                        workW, bodyR - bodyL);
+                }
+
+                // Centred on her, not aligned to her head: the book is nearly three of her tall.
+                double top = bodyT + bodyH / 2 - h / 2;
+                top = Math.Max(workT, Math.Min(workT + workH - h, top));
+
+                Position = new PixelPoint(
+                    (int)Math.Round(place.Left * s),
+                    (int)Math.Round(top * s));
+
+                _sweepHost.RenderTransformOrigin = new RelativePoint(_onHerLeft ? 1 : 0, 0.5, RelativeUnit.Relative);
+
+                // ponytail: needs EmiBook.NoteSideChanged (her bubble dodges to the side the panel
+                // is NOT on), wired when it moves to Core.
+                if (wasOnHerLeft != _onHerLeft)
+                    Log.Debug("[EmiDesk] book changed side, now {Side}", SideOfHer);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] book placement failed");
+            }
+        }
+
+        /// <summary>Integer stage scale only. 3 gives 288 x 216, 2 gives 192 x 144.</summary>
+        private void ApplyStageScale(int mult)
+        {
+            try
+            {
+                int m = Math.Max(2, Math.Min(3, mult));
+                double w = BufW * m;
+                double hh = BufH * m;
+                if (Math.Abs(_stage.Width - w) < 0.5) return;
+                _stage.Width = w;
+                _stage.Height = hh;
+            }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book stage scale failed"); }
+        }
+
+        // ---- the side/width decision -------------------------------------------------
+        //
+        // ponytail: needs CCP.Core's EmiBookLayout.Place, which is `internal` to CCP.Core and this
+        // assembly is NOT in Core's InternalsVisibleTo - so it cannot be called from here and must
+        // not be re-derived: geometry that only misbehaves at desk sizes nobody owns is exactly what
+        // was extracted into that class, and a second copy would put the bug back. Widening Core's
+        // InternalsVisibleTo (or making the type public) is its own one-line layer; until then this
+        // is the crudest honest stand-in - full width, her right, never narrow.
+
+        /// <summary>The narrow book's width, mirroring Core's <c>EmiBookLayout.NarrowWidth</c>.</summary>
+        private const double NarrowWidth = 270.0;
+
+        private readonly record struct Placement(double Left, double Width, bool OnHerLeft, bool Narrow, bool CoversHer);
+
+        private static Placement Place(double workLeft, double workWidth, double bodyLeft, double bodyRight)
+        {
+            _ = workLeft;
+            _ = workWidth;
+            _ = bodyLeft;
+            return new Placement(bodyRight + 12.0, 364.0, false, false, false);
+        }
+
+        // ---------------------------------------------------------------- the stub deck
+
+        /// <summary>One card, exactly as the WPF <c>EmiBookCard</c> record shapes it.</summary>
+        internal sealed record BookCard(
+            string Id,
+            int Tab,
+            string KeyStem,
+            string TitleEn,
+            string GistEn,
+            IReadOnlyList<string> NudgesEn,
+            string CatchEn,
+            string? Target,
+            string? Tour,
+            string MarginEn,
+            string MarginFace)
+        {
+            /// <summary>The card's visible title.</summary>
+            public string Title => Book.L(KeyStem + "_title", TitleEn);
+
+            /// <summary>The pink line.</summary>
+            public string Gist => Book.L(KeyStem + "_gist", GistEn);
+
+            /// <summary>The catch, already carrying its label.</summary>
+            public string Catch =>
+                Book.L("emi_book_catch_label", "the catch:") + " " + Book.L(KeyStem + "_catch", CatchEn);
+
+            /// <summary>The plain nudges, localized, in order.</summary>
+            public IReadOnlyList<string> Nudges =>
+                NudgesEn.Select((n, i) => Book.L($"{KeyStem}_nudge{i + 1}", n)).ToList();
+        }
+
+        /// <summary>
+        /// ponytail: needs EmiBookCards and the six EmiBookDeck.* partials (WPF head,
+        /// Services/EmiDesk/), wired when they move to Core - they are pure data and pure
+        /// localization, so nothing but the move is in the way.
+        ///
+        /// <para>Six of the shipped cards, copied verbatim including their real key stems, so every
+        /// string on screen is the shipped English or the reader's own language rather than a
+        /// placeholder sentence. Tab 2 (DEEPER) is left empty on purpose: that is the shipped state
+        /// in wave A, and it is what draws the greyed, dead-but-visible tab chip.</para>
+        /// </summary>
+        internal static class Book
+        {
+            /// <summary>Tab labels, left to right. Index matches <see cref="BookCard.Tab"/>.</summary>
+            private static readonly string[] TabKeys = { "start", "tools", "deeper" };
+
+            /// <summary>English tab labels, and the fallback when a key is missing.</summary>
+            private static readonly string[] TabNamesEn = { "START", "TOOLS", "DEEPER" };
+
+            /// <summary>Localized tab label for a tab index.</summary>
+            internal static string TabName(int tab)
+            {
+                if (tab < 0 || tab >= TabKeys.Length) return string.Empty;
+                return L("emi_book_tab_" + TabKeys[tab], TabNamesEn[tab]);
+            }
+
+            /// <summary>The cards, in reading order, grouped by tab.</summary>
+            internal static readonly IReadOnlyList<BookCard> All = new[]
+            {
+                new BookCard(
+                    "the-ccp", 0, "emi_book_the_ccp",
+                    "THE CCP",
+                    "*flashes*, *videos*, whispers and overlays, over your normal desktop.",
+                    new[] { "every tool gets its own *tab* and its own switches",
+                            "press *Start* and it runs over whatever you are doing",
+                            "a *session* drives the whole set and ramps it over time",
+                            "using it pays *XP*, and every *level* pays a *skill point*" },
+                    "with an empty assets folder nothing shows. add media, or go online.",
+                    null, "GettingStarted",
+                    "my desk, your switches. flip something.", "(¬‿¬)"),
+
+                new BookCard(
+                    "the-panic-key", 0, "emi_book_the_panic_key",
+                    "THE PANIC KEY",
+                    "one press and *everything on screen stops* at once.",
+                    new[] { "it is *Esc* until you click the box and *rebind* it",
+                            "one press kills *flashes, videos, overlays, games*",
+                            "during a *strict lock* video it is the only way out",
+                            "press it again with *nothing running* and the app quits" },
+                    "No Panic and Lockdown can switch it off. you choose those yourself.",
+                    "settings", null,
+                    "the one key i never joke about.", "._."),
+
+                new BookCard(
+                    "the-desk", 0, "emi_book_the_desk",
+                    "THE DESK",
+                    "your *desktop companion*, and the one holding *this book*.",
+                    new[] { "the *chip* in the rail calls her out, and *Ctrl+Alt+E*",
+                            "*right-click* her for *her cards*: six shortcuts you can *pin*",
+                            "the *gear* holds *her size*, *how daring*, *let her ask*",
+                            "*drag* her anywhere. the *x* on her sends her away" },
+                    "every line she says is dealt from a written file, not an AI.",
+                    null, null,
+                    "a whole card about me. i had nothing to do with it.", "^_~"),
+
+                new BookCard(
+                    "flashes", 1, "emi_book_flashes",
+                    "FLASHES",
+                    "your *gifs and images*, thrown at the screen on a timer.",
+                    new[] { "pick *how often* they land, up to 180 an hour",
+                            "sliders for *size*, *opacity* and how long each one stays",
+                            "*click* one to pop it. *hydra* mode spawns two more",
+                            "*online* mode pulls fresh stills from your *subreddits*" },
+                    "they show up in a screen recording or a stream.",
+                    "flashes", null,
+                    "i get the best seat in the house for these.", "(｡♥‿♥｡)"),
+
+                new BookCard(
+                    "subliminals", 1, "emi_book_subliminals",
+                    "SUBLIMINALS",
+                    "your *trigger phrases*, flashed a couple of frames at a time.",
+                    new[] { "a stock pool ships. open the *editor* to write your own",
+                            "tune the *rate*, the *frame count* and the opacity",
+                            "pick your *colors* in the visual settings",
+                            "a *whisper* can speak each phrase as it flashes" },
+                    "they show up in a screen recording, same as flashes.",
+                    "subliminals", null,
+                    "two frames is plenty when you read as fast as me.", "(⌐■_■)"),
+
+                new BookCard(
+                    "videos", 1, "emi_book_videos",
+                    "MANDATORY VIDEOS",
+                    "*full screen* video, on its own *schedule*, over everything else.",
+                    new[] { "*1 to 20* an hour, pulled from your *videos* folder",
+                            "*strict lock* removes *skip* and *close* until the clip ends",
+                            "*attention checks* drop up to *10* targets you must *click*",
+                            "*miss one* and it makes you watch a *different video*" },
+                    "even a clean pass has a one in ten chance of a replay.",
+                    "videos", null,
+                    "click the little words. i am counting.", "0_0"),
+            };
+
+            /// <summary>Index of a card id, or -1.</summary>
+            internal static int IndexOf(string? id)
+            {
+                if (string.IsNullOrWhiteSpace(id)) return -1;
+                for (int i = 0; i < All.Count; i++)
+                    if (string.Equals(All[i].Id, id, StringComparison.Ordinal)) return i;
+                return -1;
+            }
+
+            /// <summary>The first card on a tab, or -1 when that tab is empty (DEEPER, in wave A).</summary>
+            internal static int FirstOnTab(int tab)
+            {
+                for (int i = 0; i < All.Count; i++)
+                    if (All[i].Tab == tab) return i;
+                return -1;
+            }
+
+            /// <summary>True when a tab has at least one card behind it.</summary>
+            internal static bool TabHasCards(int tab) => FirstOnTab(tab) >= 0;
+
+            /// <summary>
+            /// Localization with an English fallback baked in, copied from <c>EmiBookCards.L</c>:
+            /// the book must render on a build whose language file predates it, so a missing key
+            /// shows the English string and never the raw key.
+            /// </summary>
+            internal static string L(string key, string fallback)
+            {
+                try
+                {
+                    var s = Loc.Get(key);
+                    if (string.IsNullOrWhiteSpace(s) || string.Equals(s, key, StringComparison.Ordinal))
+                        return fallback;
+                    return s;
+                }
+                catch { return fallback; }
+            }
+        }
+    }
+}


### PR DESCRIPTION
1,483 lines.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351