### PR TITLE
feat(avalonia): port AvatarTubeWindow

### DIFF
--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml
@@ -1,0 +1,628 @@
+<!-- PORTED from ConditioningControlPanel/AvatarTube/AvatarTubeWindow.xaml.
+     Structure, ordering, margins, ZIndexes and every colour preserved so the two diff cleanly.
+     Deviations, all forced:
+
+       WindowStyle="None" + AllowsTransparency="True" + Background="Transparent"
+                                      -> SystemDecorations="None" + TransparencyLevelHint="Transparent"
+                                         + Background="Transparent"
+       ShowActivated / ShowInTaskbar   -> kept as-is; together they are the Avalonia twin of the
+                                         WS_EX_NOACTIVATE + WS_EX_TOOLWINDOW that OnLoaded set by
+                                         P/Invoke in the WPF head. No user32 crosses over.
+       ResizeMode="NoResize"           -> CanResize="False"
+       SizeToContent="WidthAndHeight"  -> explicit Width/Height at the design canvas size. Faithful:
+                                         the WPF window flips to SizeToContent.Manual with an
+                                         explicit size after first paint (OnFirstContentRendered),
+                                         precisely to avoid the layered-window CompleteRender hang.
+       Panel.ZIndex                    -> ZIndex
+       Visibility="Collapsed"          -> IsVisible="False"
+       MouseEnter / MouseLeave         -> PointerEntered / PointerExited (wired in code-behind)
+       MouseLeftButtonDown             -> PointerPressed (wired in code-behind)
+       ToolTip="..."                   -> ToolTip.Tip="..."
+       DropShadowEffect ShadowDepth=0  -> OffsetX="0" OffsetY="0"; ShadowDepth="1.5" Direction="315"
+                                          -> OffsetX="1" OffsetY="1" (Avalonia has no polar offset)
+       {DynamicResource PinkColor} etc.
+         inside an Effect / GradientStop
+                                       -> {StaticResource ...}. Neither is in the logical tree, so a
+                                          DynamicResource has no scope to resolve through and the
+                                          shadow silently renders black. Measured on MantraWindow.
+       StartPoint="0,0" EndPoint="1,1" -> "0%,0%" / "100%,100%", and RadialGradientBrush
+       RenderTransformOrigin="0.5,0.5"    Center/GradientOrigin/Radius likewise, and
+                                          RenderTransformOrigin -> "50%,50%". A bare pair is
+                                          ABSOLUTE PIXELS in Avalonia; WPF's was relative.
+       x:Name on a Transform            -> dropped (AVLN2000: Avalonia only name-scopes
+                                           StyledElements). See the ponytail notes below for the
+                                           animations that hung off each one.
+       TinyPinkScrollBar / TinyPinkScrollViewer
+                                       -> dropped. A WPF keyed <Style> keeps the control's default
+                                          template; an Avalonia ControlTheme REPLACES it, so a
+                                          half-ported one draws nothing at all (CLAUDE.md trap 4).
+                                          The default ScrollViewer is used instead.
+                                          ponytail: 6px pink scrollbar is cosmetic; restore with a
+                                          `ScrollBar /template/ Thumb` Style if it is missed.
+       ContextMenu ControlTemplate /
+       MenuItem ControlTemplate /
+       ItemContainerStyle              -> dropped for the same reason; the dark palette is applied
+                                          with property Styles below, which keep the default
+                                          template. A ContextMenu is never in the render frame.
+       ItemsControl DataTrigger IsUser -> Classes.user="{Binding IsUser}" + a Style selector.
+                                          Avalonia has no DataTriggers.
+       Tag="{Binding Text}" +
+       Loaded="ChatHistoryText_Loaded" -> Text="{Binding Text}".
+                                          ponytail: the WPF loader re-rendered each history line as
+                                          Inlines with clickable video links; link detection is lost.
+       Window.CommandBindings          -> dropped. Avalonia has no CommandBindings.
+                                          ponytail: AvatarTubeWindow.OpenChatCommand (the user's
+                                          Ctrl+T chat shortcut) has no host here; needs a KeyBinding
+                                          once ApplyChatShortcutTo moves to Core.
+       gif: xmlns                      -> dropped; the WPF XAML declares it and never uses it.
+       FontFamily="Segoe UI"           -> dropped; the head ships Inter and picks it in App.axaml. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:at="clr-namespace:ConditioningControlPanel.Avalonia.Views.AvatarTube"
+        x:Class="ConditioningControlPanel.Avalonia.Views.AvatarTube.AvatarTubeWindow"
+        Title="{loc:Str dialog_avatar_tube}"
+
+        SystemDecorations="None"
+        TransparencyLevelHint="Transparent"
+        Background="Transparent"
+        ShowActivated="False"
+        ShowInTaskbar="False"
+        CanResize="False"
+        Width="780" Height="1080"
+        UseLayoutRounding="True">
+
+    <Window.Resources>
+        <!-- Purplish gradient background for speech bubble -->
+        <LinearGradientBrush x:Key="BubbleGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+            <GradientStop Color="{StaticResource PatreonDarkPurple}" Offset="0"/>
+            <GradientStop Color="{StaticResource DarkerBg}" Offset="1"/>
+        </LinearGradientBrush>
+    </Window.Resources>
+
+    <Window.Styles>
+        <!-- ponytail: local copy of AvatarTubeWindow.xaml:ContextMenu.Style / MenuItem Style,
+             reduced to the property setters that survive without a template. Hoist when a second
+             view needs a dark context menu. -->
+        <Style Selector="ContextMenu">
+            <Setter Property="Background" Value="{DynamicResource DarkerBgBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="Padding" Value="4"/>
+        </Style>
+        <Style Selector="ContextMenu MenuItem">
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="10,6"/>
+        </Style>
+        <Style Selector="ContextMenu Separator">
+            <Setter Property="Height" Value="1"/>
+            <Setter Property="Margin" Value="8,4"/>
+            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+        </Style>
+
+        <!-- Chat-history bubble. Replaces the WPF DataTrigger on ChatMessage.IsUser: the companion's
+             lines sit left on plum, the user's right on pink. -->
+        <Style Selector="Border.chatBubble">
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="Background" Value="#3D2A55"/>
+        </Style>
+        <Style Selector="Border.chatBubble.user">
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Background" Value="#FF69B4"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid>
+        <!-- Viewbox scales content uniformly to fit any screen size -->
+        <Viewbox x:Name="ContentViewbox" Stretch="Uniform" ClipToBounds="False">
+            <!-- Design canvas at fixed reference size - will be scaled -->
+            <Grid Width="780" Height="1080" ClipToBounds="False">
+            <!-- Tube frame FIRST (behind) - Z-Index 0 implicit.
+                 ponytail: WPF loaded pack://application:,,,/Resources/tube.png. This head ships no
+                 image assets and SetTubeStyle (mod-aware tube art) lives in the Windowing partial,
+                 so the frame is left sourceless and the tube reads as empty in the render. -->
+            <Image x:Name="ImgTubeFrame"
+                   Stretch="Uniform"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   IsHitTestVisible="False"/>
+
+            <!-- Speech Bubble - Z-Index 10, positioned next to avatar -->
+            <!-- Dynamic bubble that sizes to content, grows UPWARD, scrolls when exceeding max -->
+            <Border x:Name="SpeechBubble"
+                    ZIndex="10"
+                    IsVisible="False"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Opacity="0.92"
+                    Margin="0,0,125,550"
+                    MinWidth="120" MaxWidth="380"
+                    Background="{StaticResource BubbleGradient}"
+                    CornerRadius="20"
+                    BorderBrush="{DynamicResource PinkBrush}"
+                    BorderThickness="3"
+                    Padding="15,12">
+
+                <Grid>
+                    <!-- Single-message mode: existing bubble content -->
+                    <ScrollViewer x:Name="SpeechScroller"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  MaxHeight="280">
+
+                        <!-- Speech text with bubbly pink font -->
+                        <TextBlock x:Name="TxtSpeech"
+                                   Text=""
+                                   Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="20"
+                                   FontWeight="Bold"
+                                   TextWrapping="Wrap"
+                                   TextAlignment="Left"
+                                   Padding="0,0,8,0">
+                            <TextBlock.Effect>
+                                <DropShadowEffect Color="Black" BlurRadius="2" OffsetX="1" OffsetY="1" Opacity="0.8"/>
+                            </TextBlock.Effect>
+                        </TextBlock>
+                    </ScrollViewer>
+
+                    <!-- AI-generated content badge (top-left). Visibility is controlled in code-behind
+                         based on whether the current bubble text came from an AI inference vs. a canned
+                         phrase. Required for CCBill AI Content Merchant Addendum visible-labeling. -->
+                    <Border x:Name="AiBadge"
+                            IsVisible="False"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            Margin="-6,-6,0,0"
+                            Width="22" Height="14"
+                            CornerRadius="4"
+                            Background="{DynamicResource PinkBrush}"
+                            ZIndex="20"
+                            IsHitTestVisible="False">
+                        <TextBlock Text="{loc:Str label_ai_badge}"
+                                   Foreground="White"
+                                   FontSize="9"
+                                   FontWeight="Bold"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+
+                    <!-- Moderation-refusal POLICY badge (same slot as AiBadge). Shown by code-behind
+                         when ModerationGuard blocks an input or output. Mutually exclusive with the
+                         AI badge - they share the corner slot but visibility is managed in one place
+                         (ShowGiggle / ShowModerationRefusalBubble). Amber to distinguish from the pink
+                         AI badge. Part of P1.1 (CCBill substantive moderation). -->
+                    <Border x:Name="PolicyBadge"
+                            IsVisible="False"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            Margin="-6,-6,0,0"
+                            Width="44" Height="14"
+                            CornerRadius="4"
+                            Background="#FFC107"
+                            ZIndex="20"
+                            IsHitTestVisible="False">
+                        <TextBlock Text="{loc:Str label_policy_badge}"
+                                   Foreground="Black"
+                                   FontSize="9"
+                                   FontWeight="Bold"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Border>
+
+                    <!-- Chat history mode: scrollable WhatsApp-style log -->
+                    <Grid x:Name="ChatHistoryView" IsVisible="False">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <DockPanel Grid.Row="0" Margin="0,0,0,6" LastChildFill="True">
+                            <Button x:Name="BtnCloseChatHistory"
+                                    DockPanel.Dock="Right"
+                                    Width="24" Height="24"
+                                    Padding="0"
+                                    Background="Transparent"
+                                    Foreground="{DynamicResource PinkBrush}"
+                                    BorderThickness="0"
+                                    Cursor="Hand"
+                                    ToolTip.Tip="{loc:Str tooltip_close_chat_history}">
+                                <!-- A TextBlock, not a string Content: Avalonia parses "_" in Content
+                                     as an access key (CLAUDE.md trap 1). -->
+                                <TextBlock Text="✕"
+                                           FontSize="14"
+                                           FontWeight="Bold"
+                                           HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"/>
+                            </Button>
+                            <TextBlock Text="{loc:Str label_chat_history_title}"
+                                       Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="16"
+                                       FontWeight="Bold"
+                                       VerticalAlignment="Center"/>
+                        </DockPanel>
+
+                        <ScrollViewer x:Name="ChatHistoryScroller"
+                                      Grid.Row="1"
+                                      VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      MaxHeight="420">
+                            <Grid>
+                                <!-- Empty-state hint when no chat history yet -->
+                                <TextBlock x:Name="TxtChatHistoryEmpty"
+                                           Text="{loc:Str label_chat_history_empty}"
+                                           Foreground="#AAAAAA"
+                                           FontSize="14"
+                                           FontStyle="Italic"
+                                           HorizontalAlignment="Center"
+                                           Margin="0,20,0,20"
+                                           IsVisible="False"/>
+
+                                <ItemsControl x:Name="ChatHistoryList">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="at:ChatMessage">
+                                            <Border Classes="chatBubble"
+                                                    Classes.user="{Binding IsUser}"
+                                                    CornerRadius="10" Padding="9,6" Margin="2,3" MaxWidth="380">
+                                                <StackPanel>
+                                                    <TextBlock Text="{Binding Text}"
+                                                               Foreground="White"
+                                                               FontSize="14"
+                                                               TextWrapping="Wrap"/>
+                                                    <TextBlock Text="{Binding TimeLabel}"
+                                                               Foreground="#DDDDDD"
+                                                               FontSize="10"
+                                                               HorizontalAlignment="Right"
+                                                               Margin="0,2,0,0"/>
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Grid>
+                        </ScrollViewer>
+                    </Grid>
+                </Grid>
+            </Border>
+
+            <!-- Text Input Panel (hidden by default) - Z-Index 3, positioned near avatar -->
+            <Border x:Name="InputPanel"
+                    ZIndex="3"
+                    IsVisible="False"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Margin="0,0,126,520"
+                    Background="{DynamicResource PanelBgBrush}"
+                    CornerRadius="10"
+                    Padding="10"
+                    BorderBrush="{DynamicResource PinkBrush}"
+                    BorderThickness="2">
+                <StackPanel Orientation="Horizontal">
+                    <TextBox x:Name="TxtUserInput"
+                             Width="180"
+                             Height="30"
+                             FontSize="14"
+                             Background="{DynamicResource DarkerBgBrush}"
+                             Foreground="White"
+                             BorderBrush="{DynamicResource PinkBrush}"
+                             BorderThickness="1"
+                             Padding="5,3"
+                             VerticalContentAlignment="Center"/>
+                    <Button x:Name="BtnSendChat"
+                            Width="50"
+                            Height="30"
+                            Padding="0"
+                            Margin="5,0,0,0"
+                            Background="{DynamicResource PinkBrush}"
+                            Foreground="White"
+                            BorderThickness="0"
+                            Cursor="Hand">
+                        <TextBlock Text="{loc:Str btn_send}"
+                                   FontWeight="Bold"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"/>
+                    </Button>
+                </StackPanel>
+            </Border>
+
+            <!-- Avatar/Sprite - Z-Index 1 implicit, with floating animation -->
+            <Border x:Name="AvatarBorder"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Margin="5,100,126,210"
+                    Cursor="Hand"
+                    ClipToBounds="False">
+                <Border.ContextMenu>
+                    <ContextMenu x:Name="AvatarContextMenu">
+                        <MenuItem x:Name="MenuItemTalkToBambi" Header="{loc:Str section_talk_to_companion}" Foreground="{DynamicResource PinkBrush}" FontWeight="Bold"/>
+                        <Separator/>
+                        <MenuItem x:Name="MenuItemDetach" Header="{loc:Str section_detach}"/>
+                        <MenuItem x:Name="MenuItemAttach" Header="{loc:Str section_attach_to_main_window}" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemShrink" Header="{loc:Str section_shrink}" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemGrow" Header="{loc:Str section_grow}" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemDismiss" Header="{loc:Str section_dismiss}" IsVisible="False"/>
+                        <Separator/>
+                        <MenuItem x:Name="MenuItemEngine" Header="{loc:Str section_start_engine}" Foreground="#90EE90"/>
+                        <MenuItem x:Name="MenuItemTriggerMode" Header="{loc:Str section_trigger_mode}"/>
+                        <MenuItem x:Name="MenuItemBambiTakeover" Header="{loc:Str section_takeover}"/>
+                        <MenuItem x:Name="MenuItemPersonality" Header="{loc:Str section_personality}" Foreground="{DynamicResource PinkBrush}"/>
+                        <MenuItem x:Name="MenuItemMute" Header="{loc:Str section_mute_avatar}"/>
+                        <!-- Emote MenuItems replace the 5 items above (Engine, TriggerMode, BambiTakeover,
+                             Personality, Mute) whenever a remote controller is connected. Header strings
+                             and Tag references are populated in AvatarContextMenu_Opened from
+                             App.Settings.Current.RemoteEmotePresets. -->
+                        <MenuItem x:Name="MenuItemEmote1" Header="" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemEmote2" Header="" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemEmote3" Header="" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemEmote4" Header="" IsVisible="False"/>
+                        <MenuItem x:Name="MenuItemEmote5" Header="" IsVisible="False"/>
+                        <Separator/>
+                        <MenuItem x:Name="MenuItemShowChatHistory" Header="{loc:Str section_show_chat_history}"/>
+                        <MenuItem x:Name="MenuItemMuteWhispers" Header="{loc:Str section_mute_whispers}"/>
+                        <MenuItem x:Name="MenuItemPauseBrowser" Header="{loc:Str section_pause_browser}"/>
+                    </ContextMenu>
+                </Border.ContextMenu>
+                <!-- ponytail: AvatarBounceScale (click-squash), AvatarScale/AvatarRotate/AvatarTranslate
+                     and the B pair (60fps breathing / wobble / bob), MistScale (mist drift) and
+                     AvatarAnimatedTranslate (GIF bob) were all x:Named transforms driven from
+                     AvatarTubeWindow.Avatar.cs. Avalonia only name-scopes StyledElements (AVLN2000),
+                     and every driver lives in a partial this layer does not port, so the identity
+                     transforms are dropped and the avatar renders as a static frame. -->
+                <Grid x:Name="AvatarBounceHost" RenderTransformOrigin="50%,100%">
+                    <!-- Static PNG avatar (default) / emotive-portrait crossfade layer A -->
+                    <Image x:Name="ImgAvatar"
+                           Stretch="Uniform"
+                           MaxHeight="306"
+                           MaxWidth="198"
+                           RenderTransformOrigin="50%,50%">
+                        <Image.Effect>
+                            <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                        </Image.Effect>
+                    </Image>
+                    <!-- Emotive-portrait crossfade layer B (hidden unless portrait mode is active) -->
+                    <Image x:Name="ImgAvatarB"
+                           Stretch="Uniform"
+                           MaxHeight="306"
+                           MaxWidth="198"
+                           Opacity="0"
+                           IsVisible="False"
+                           RenderTransformOrigin="50%,50%">
+                        <Image.Effect>
+                            <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                        </Image.Effect>
+                    </Image>
+                    <!-- Pink mist overlay (emotive-portrait mode only): soft drifting pink glow over the avatar -->
+                    <Ellipse x:Name="MistOverlay"
+                             IsHitTestVisible="False"
+                             IsVisible="False"
+                             Opacity="0.12"
+                             RenderTransformOrigin="50%,50%">
+                        <Ellipse.Fill>
+                            <RadialGradientBrush GradientOrigin="50%,45%" Center="50%,45%" RadiusX="60%" RadiusY="72%">
+                                <GradientStop Color="#FFFF8FCF" Offset="0.0"/>
+                                <GradientStop Color="#66FF69B4" Offset="0.45"/>
+                                <GradientStop Color="#00FF69B4" Offset="1.0"/>
+                            </RadialGradientBrush>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <!-- Animated GIF avatar (for level 20+).
+                         ponytail: WPF drove this through XamlAnimatedGif (gif:AnimationBehavior),
+                         a WPF-only package. Avalonia needs its own GIF decoder; the layer is kept
+                         so the crossfade code has its slot, but nothing animates it. -->
+                    <Image x:Name="ImgAvatarAnimated"
+                           Stretch="Uniform"
+                           MaxHeight="306"
+                           MaxWidth="198"
+                           IsVisible="False"
+                           RenderTransformOrigin="50%,50%">
+                        <Image.Effect>
+                            <!-- BlurRadius 20->10 (2026-07-05): during a crossfade BOTH animated layers
+                                 composite a full-size blur shader every frame; Gaussian cost scales ~radius^2,
+                                 so halving the radius is ~4x cheaper per layer. -->
+                            <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="10" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                        </Image.Effect>
+                    </Image>
+                    <!-- Second animated layer: crossfade target for Circe WebP emotes
+                         (AvatarTubeWindow.CirceEmotes.cs). Mirrors ImgAvatarAnimated. -->
+                    <Image x:Name="ImgAvatarAnimatedB"
+                           Stretch="Uniform"
+                           MaxHeight="306"
+                           MaxWidth="198"
+                           Opacity="0"
+                           IsVisible="False"
+                           RenderTransformOrigin="50%,50%">
+                        <Image.Effect>
+                            <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="10" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                        </Image.Effect>
+                    </Image>
+                    <!-- Possession (Lockdown R4, "glitchportrait"): the corrupted-portrait layer.
+                         A SIBLING of the avatar images inside AvatarBounceHost on purpose - a copy
+                         placed here inherits the exact same layout slot, so a sliced duplicate lines
+                         up with the real portrait pixel for pixel without measuring anything.
+                         Filled and emptied entirely by GlitchPortrait below. -->
+                    <Grid x:Name="PossessionGlitchLayer"
+                          IsHitTestVisible="False"
+                          IsVisible="False"
+                          ClipToBounds="False"/>
+                </Grid>
+            </Border>
+
+            <!-- Possession (Lockdown R4): the warden's note, left in the tube while the companion is
+                 away (Warden.LeaveAsync) and taken down by ReturnAsync. Crimson - the Lockdown THEME
+                 colour, never ember: ember means something is happening RIGHT NOW, and a note is the
+                 opposite of that. Same margin as AvatarBorder so it sits where she was standing. -->
+            <Border x:Name="PossessionNoteCard"
+                    ZIndex="6"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                    Margin="5,100,126,210"
+                    MaxWidth="210"
+                    Padding="16,12"
+                    CornerRadius="10"
+                    Background="#F21A0A0E"
+                    BorderBrush="#DC143C" BorderThickness="1.5"
+                    RenderTransformOrigin="50%,50%">
+                <Border.RenderTransform>
+                    <!-- Unnamed: ShowPossessionNote reaches it through PossessionNoteCard.RenderTransform -->
+                    <RotateTransform Angle="-3"/>
+                </Border.RenderTransform>
+                <Border.Effect>
+                    <DropShadowEffect Color="#DC143C" BlurRadius="18" OffsetX="0" OffsetY="0" Opacity="0.55"/>
+                </Border.Effect>
+                <TextBlock x:Name="TxtPossessionNote"
+                           Foreground="#FFE3E8" FontSize="15" FontWeight="SemiBold"
+                           TextWrapping="Wrap" TextAlignment="Center" LineHeight="20"/>
+            </Border>
+
+            <!-- Takeover countdown bar - thin pink bar under the avatar, drains toward the next
+                 random Takeover action. Shown only while Takeover is running (driven in code-behind).
+                 ponytail: the WPF fill was horizontally scaled by the x:Named TakeoverCountdownScale
+                 (1.0 full -> 0 about to fire) from InitTakeoverCountdownBar, which lives in a partial
+                 this layer does not port. The transform is dropped, so the bar renders full. -->
+            <Border x:Name="TakeoverCountdownBar"
+                    ZIndex="5"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Margin="0,0,116,246"
+                    Width="120" Height="9"
+                    CornerRadius="4"
+                    Background="#EE14141C"
+                    BorderBrush="#FFFF1493"
+                    BorderThickness="1"
+                    IsVisible="False"
+                    IsHitTestVisible="False">
+                <Border x:Name="TakeoverCountdownFill"
+                        HorizontalAlignment="Left"
+                        Width="116" Height="5"
+                        CornerRadius="2"
+                        Background="#FFF7A8D8"
+                        RenderTransformOrigin="0%,50%">
+                    <Border.Effect>
+                        <DropShadowEffect Color="{StaticResource PinkColor}" BlurRadius="6" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                    </Border.Effect>
+                </Border>
+            </Border>
+
+            <!-- THE FUSE's candle (CONTRACT-FUSE-0816 2.2). From twelve hours out, a small flame
+                 stands beside the tube. It says nothing and does nothing; it is company.
+
+                 Decorative-element recipe, same as ImgTubeFrame / MistOverlay / TakeoverCountdownBar:
+                 a sibling of the 780x1080 design grid with an explicit ZIndex and
+                 IsHitTestVisible="False", so AvatarBorder's click, right-click and context menu are
+                 untouched. Collapsed here and shown only by AvatarTubeWindow.DescentFuse.cs, which
+                 does nothing without a cached ceremony timestamp.
+
+                 Two layers: a soft radial halo and the flame body.
+                 ponytail: the flicker animated the halo's opacity and the body's x:Named
+                 FuseCandleFlameScale. Both drivers are in the DescentFuse partial, so the candle is
+                 the STATIC rest frame the WPF original falls back to when ambient loops are off -
+                 which is the same picture, and the intended one. -->
+            <Grid x:Name="FuseCandleHost"
+                  ZIndex="2"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Bottom"
+                  Margin="96,0,0,214"
+                  Width="54" Height="74"
+                  IsVisible="False"
+                  IsHitTestVisible="False">
+                <Ellipse x:Name="FuseCandleHalo" Width="54" Height="54"
+                         VerticalAlignment="Top" Opacity="0.5">
+                    <Ellipse.Fill>
+                        <RadialGradientBrush GradientOrigin="50%,50%" Center="50%,50%" RadiusX="50%" RadiusY="50%">
+                            <GradientStop Offset="0" Color="#90FFC864"/>
+                            <GradientStop Offset="0.55" Color="#30E0B052"/>
+                            <GradientStop Offset="1" Color="#00E0B052"/>
+                        </RadialGradientBrush>
+                    </Ellipse.Fill>
+                </Ellipse>
+                <!-- The flame body. Teardrop, origin at its base so the flicker's scale reads as a
+                     flame stretching upward rather than a shape growing in place. -->
+                <Path x:Name="FuseCandleFlame" Width="18" Height="30" Stretch="Fill"
+                      HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,10,0,0"
+                      RenderTransformOrigin="50%,100%"
+                      Data="M 9,0 C 15,10 18,16 18,21 C 18,26 14,30 9,30 C 4,30 0,26 0,21 C 0,16 3,10 9,0 Z">
+                    <Path.Fill>
+                        <LinearGradientBrush StartPoint="50%,0%" EndPoint="50%,100%">
+                            <GradientStop Offset="0" Color="#FFFFE9B0"/>
+                            <GradientStop Offset="0.5" Color="#FFE0B052"/>
+                            <GradientStop Offset="1" Color="#FFB4642A"/>
+                        </LinearGradientBrush>
+                    </Path.Fill>
+                </Path>
+                <!-- The stub it burns on. Static, always. -->
+                <Border Width="14" Height="26" CornerRadius="3,3,1,1"
+                        HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                        Background="#FF2A2440" BorderBrush="#40E0B052" BorderThickness="1"/>
+            </Grid>
+
+            <!-- Title/Level Box with Avatar Selection - Z-Index 4 to be above everything -->
+            <Border x:Name="TitleBox"
+                    ZIndex="4"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Margin="0,0,121,180"
+                    Background="#CC1A1A2E"
+                    CornerRadius="12"
+                    BorderBrush="{DynamicResource PinkBrush}"
+                    BorderThickness="2"
+                    Padding="8,6">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Left Arrow (Previous Avatar) - 50% bigger -->
+                    <Border x:Name="BtnPrevAvatar" Grid.Column="0"
+                            Background="Transparent" Cursor="Hand"
+                            IsVisible="False"
+                            VerticalAlignment="Center" Margin="0,0,10,0">
+                        <TextBlock Text="◀" FontSize="27" Foreground="{DynamicResource SecondaryBrush}" FontWeight="Bold">
+                            <TextBlock.Effect>
+                                <DropShadowEffect Color="{StaticResource PatreonPurple}" BlurRadius="10" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                            </TextBlock.Effect>
+                        </TextBlock>
+                    </Border>
+
+                    <!-- Title and Level -->
+                    <StackPanel Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock x:Name="TxtAvatarTitle"
+                                   Text="{loc:Str label_basic_subject_2}"
+                                   FontSize="16"
+                                   FontWeight="Bold"
+                                   Foreground="{DynamicResource PinkBrush}"
+                                   TextAlignment="Center"
+                                   HorizontalAlignment="Center">
+                            <TextBlock.Effect>
+                                <DropShadowEffect Color="Black" BlurRadius="2" OffsetX="1" OffsetY="1" Opacity="0.8"/>
+                            </TextBlock.Effect>
+                        </TextBlock>
+                        <TextBlock x:Name="TxtAvatarLevel"
+                                   Text="{loc:Str label_lv_1_2}"
+                                   FontSize="13"
+                                   Foreground="#B0B0B0"
+                                   TextAlignment="Center"
+                                   HorizontalAlignment="Center"
+                                   Margin="0,-2,0,0"/>
+                    </StackPanel>
+
+                    <!-- Right Arrow (Next Avatar) - 50% bigger -->
+                    <Border x:Name="BtnNextAvatar" Grid.Column="2"
+                            Background="Transparent" Cursor="Hand"
+                            IsVisible="False"
+                            VerticalAlignment="Center" Margin="10,0,0,0">
+                        <TextBlock Text="▶" FontSize="27" Foreground="{DynamicResource SecondaryBrush}" FontWeight="Bold">
+                            <TextBlock.Effect>
+                                <DropShadowEffect Color="{StaticResource PatreonPurple}" BlurRadius="10" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                            </TextBlock.Effect>
+                        </TextBlock>
+                    </Border>
+                </Grid>
+            </Border>
+
+        </Grid>
+        </Viewbox>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -1,0 +1,627 @@
+using System;
+using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Platform;
+using ConditioningControlPanel.Localization;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
+{
+    /// <summary>
+    /// One conversational line in the tube's chat-history view.
+    ///
+    /// PORTED from AvatarTubeWindow.ChatMessage (AvatarTubeWindow.Speech.cs), where it is a nested
+    /// public class. Top-level here so the compiled-binding <c>x:DataType</c> in the DataTemplate
+    /// can name it without the nested-type syntax; it deletes and re-points at the Core type the
+    /// moment the speech pipeline moves.
+    /// </summary>
+    public sealed class ChatMessage
+    {
+        public string Text { get; set; } = string.Empty;
+        public bool IsUser { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+        public string TimeLabel => Timestamp.ToString("HH:mm");
+    }
+
+    /// <summary>
+    /// The companion's tube: a frameless, click-through-adjacent overlay that rides beside the main
+    /// window and holds the avatar, her speech bubble, the chat input, the chat log, the Takeover
+    /// countdown, THE FUSE's candle and the Possession note card.
+    ///
+    /// PORTED from ConditioningControlPanel/AvatarTube/AvatarTubeWindow.xaml.cs. What crossed, and
+    /// what did not:
+    ///
+    /// <para><b>Win32.</b> The WPF file P/Invokes user32 in three places and every one of them maps
+    /// or drops:</para>
+    /// <list type="bullet">
+    ///   <item><c>SetWindowLong(GWL_EXSTYLE, WS_EX_TOOLWINDOW)</c> (hide from Alt+Tab) ->
+    ///         <c>ShowInTaskbar="False"</c> in the XAML, plus <c>ShowActivated="False"</c> for the
+    ///         WS_EX_NOACTIVATE half. Declarative, so nothing to call.</item>
+    ///   <item><c>SetWindowLongPtr(GWL_HWNDPARENT)</c> - native ownership, which is what glued the
+    ///         tube directly above main in z-order - -> <see cref="X11Overlay.RestackAbove"/> in
+    ///         <c>OnOpened</c>. Called unconditionally: the shim returns false off X11.</item>
+    ///   <item><c>SetWindowPos(SWP_FRAMECHANGED)</c>, <c>HwndSource.AddHook(WndProc)</c>,
+    ///         <c>WindowInteropHelper</c>, <c>DisableProcessWindowsGhosting</c> - all dropped. They
+    ///         exist to flush a LAYERED window's cached frame and to intercept WM_ messages; X11 has
+    ///         neither the cache nor the message pump, so there is nothing to work around.</item>
+    /// </list>
+    ///
+    /// <para><b>ponytail: the restack is a one-shot.</b> Win32 ownership is PERSISTENT - the window
+    /// manager re-applies it every time main is raised. <c>_NET_RESTACK_WINDOW</c> is a single
+    /// request, so the tube can fall behind main after the user raises main again. Fixing that needs
+    /// the shim to grow a "follow this window" mode, which is its own layer.</para>
+    ///
+    /// <para><b>ponytail: no own-thread mode.</b> WPF ran this window on its own STA thread behind
+    /// <c>AppSettings.AvatarOwnThread</c>, which is why every public method starts with a
+    /// <c>Dispatcher.CheckAccess()</c> self-marshal. Avalonia has one UI thread per process, so
+    /// <see cref="RunOnAvatar"/> marshals to <c>Dispatcher.UIThread</c> and the setting has no
+    /// meaning here. The guards are kept so callers from a worker thread still behave.</para>
+    ///
+    /// <para><b>ponytail: the eight partials did not come.</b> This layer ports the .xaml.cs only.
+    /// Avatar loading and the 60fps float loop (Avatar.cs), speech and barks (Speech.cs), chat and
+    /// the AI pipeline (ChatInput.cs), Circe emotes (CirceEmotes.cs), reactions (Reactions.cs), the
+    /// candle (DescentFuse.cs) and ALL of the attach/detach/scale/position/fullscreen windowing
+    /// (Windowing.cs) stay in the WPF head. Everything the WPF constructor called into them is a
+    /// stub below, and the whole <c>App.*</c> service-subscription block (Video, BubbleCount, Flash,
+    /// Subliminal, Bubbles, Achievements, Progression, Companion, WindowAwareness, MindWipe,
+    /// BrainDrain, ModerationCounter, Mods) is one stub: none of those services are in Core yet.</para>
+    /// </summary>
+    public partial class AvatarTubeWindow : Window
+    {
+        private readonly Window? _parentWindow;
+        private readonly Random _random = new();
+
+        // Chat history: only the conversational pair (user prompts + AI replies), not random
+        // preset/trigger chatter. Capped at MaxChatHistorySize entries.
+        private const int MaxChatHistorySize = 100;
+        public ObservableCollection<ChatMessage> ChatHistory { get; } = new();
+
+        // Bubble-state flags. In WPF these are written across Speech.cs / ChatInput.cs; here they
+        // only back IsSpeaking / HasBubbleUp, which EMI Desk and the bark system ask about.
+        private bool _isGiggling;
+        private bool _isListeningBubble;
+        private bool _isShowingChatHistory;
+        private bool _isShowingAiBubble;
+        private bool _isPlayingUninterruptibleClip;
+
+        // Pose cycling (static avatars only). The poses themselves load in Avatar.cs.
+        private readonly DispatcherTimer _poseTimer;
+        private int _currentPoseIndex;
+        private readonly int _currentAvatarSet = 1;
+
+        // Moderation cooldown (P1.4).
+        private DateTime? _cooldownEndsAt;
+        private DispatcherTimer? _cooldownTickTimer;
+
+        private readonly Border _speechBubble;
+        private readonly ScrollViewer _speechScroller;
+        private readonly Grid _chatHistoryView;
+        private readonly ScrollViewer _chatHistoryScroller;
+        private readonly Border _aiBadge;
+        private readonly TextBlock _txtChatHistoryEmpty;
+        private readonly ItemsControl _chatHistoryList;
+        private readonly Border _inputPanel;
+        private readonly TextBox _txtUserInput;
+        private readonly Button _btnSendChat;
+        private readonly Grid _possessionGlitchLayer;
+        private readonly Border _possessionNoteCard;
+        private readonly TextBlock _txtPossessionNote;
+
+        /// <summary>Render-proof constructor: no parent window, and the states a reviewer cannot
+        /// otherwise see (chat log, input panel, candle, Takeover bar) turned on with
+        /// sample data. <c>internal</c> so no production caller can ship the sample.</summary>
+        internal AvatarTubeWindow() : this(null)
+        {
+            ChatHistory.Add(new ChatMessage { Text = "hi bambi, are you there?", IsUser = true });
+            ChatHistory.Add(new ChatMessage { Text = "always, sweetie. i've been waiting for you to say something.", IsUser = false });
+            ChatHistory.Add(new ChatMessage { Text = "what should we do tonight?", IsUser = true });
+
+            ShowChatHistory();
+            _inputPanel.IsVisible = true;
+            _txtUserInput.Text = "type something…";
+            this.FindControl<Grid>("FuseCandleHost")!.IsVisible = true;
+            this.FindControl<Border>("TakeoverCountdownBar")!.IsVisible = true;
+            // Note: the AI and POLICY badges are single-message-mode only (ShowChatHistory hides the
+            // AI one, exactly as the WPF original does), so they are not in this frame. Both were
+            // rendered separately during the port to confirm they draw with real strings.
+        }
+
+        public AvatarTubeWindow(Window? parentWindow)
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _parentWindow = parentWindow;
+            // Don't set Owner - in WPF it caused black window artifacts during minimize, and the
+            // z-order pairing is done natively instead (see OnOpened).
+
+            _speechBubble = this.FindControl<Border>("SpeechBubble")!;
+            _speechScroller = this.FindControl<ScrollViewer>("SpeechScroller")!;
+            _chatHistoryView = this.FindControl<Grid>("ChatHistoryView")!;
+            _chatHistoryScroller = this.FindControl<ScrollViewer>("ChatHistoryScroller")!;
+            _aiBadge = this.FindControl<Border>("AiBadge")!;
+            _txtChatHistoryEmpty = this.FindControl<TextBlock>("TxtChatHistoryEmpty")!;
+            _chatHistoryList = this.FindControl<ItemsControl>("ChatHistoryList")!;
+            _inputPanel = this.FindControl<Border>("InputPanel")!;
+            _txtUserInput = this.FindControl<TextBox>("TxtUserInput")!;
+            _btnSendChat = this.FindControl<Button>("BtnSendChat")!;
+            _possessionGlitchLayer = this.FindControl<Grid>("PossessionGlitchLayer")!;
+            _possessionNoteCard = this.FindControl<Border>("PossessionNoteCard")!;
+            _txtPossessionNote = this.FindControl<TextBlock>("TxtPossessionNote")!;
+
+            // Bind chat history list to the rolling collection of conversational messages.
+            _chatHistoryList.ItemsSource = ChatHistory;
+
+            // Esc closes chat history mode if open. (WPF: PreviewKeyDown; Avalonia tunnels with
+            // AddHandler(..., RoutingStrategies.Tunnel), but a window-level KeyDown is enough here.)
+            KeyDown += OnWindowKeyDown;
+
+            // Handlers the WPF XAML wired inline. Every one either only touches this view or is a
+            // stub below; none reaches a service.
+            _speechBubble.PointerEntered += (_, _) => _isMouseOverSpeechBubble = true;
+            _speechBubble.PointerExited += (_, _) => _isMouseOverSpeechBubble = false;
+            this.FindControl<Button>("BtnCloseChatHistory")!.Click += (_, _) => HideChatHistory();
+            _btnSendChat.Click += (_, _) => SendChat();
+            _txtUserInput.KeyDown += (_, e) => { if (e.Key == Key.Enter) SendChat(); };
+
+            var avatarBorder = this.FindControl<Border>("AvatarBorder")!;
+            avatarBorder.PointerPressed += OnAvatarPointerPressed;
+            this.FindControl<Border>("BtnPrevAvatar")!.PointerPressed += (_, _) => SelectAvatarSet(-1);
+            this.FindControl<Border>("BtnNextAvatar")!.PointerPressed += (_, _) => SelectAvatarSet(+1);
+            this.FindControl<ContextMenu>("AvatarContextMenu")!.Opened += (_, _) => UpdateQuickMenuState();
+
+            // Setup pose switching timer (only for static avatars). Created, never started: the
+            // poses it would cycle load in AvatarTubeWindow.Avatar.cs.
+            _poseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+            _poseTimer.Tick += (_, _) => AdvancePose();
+
+            // ponytail: needs App.Settings / App.Mods / App.Companion and AvatarTubeWindow.Avatar.cs.
+            // WPF read PlayerLevel here, picked the avatar set, loaded the poses (static or animated),
+            // applied the per-set transform, entered emotive-portrait or Circe-emote mode, refreshed
+            // the tube art from the active mod and reloaded the mod's video links. None of that is in
+            // Core, so the avatar layers render empty and the title box keeps its XAML defaults.
+
+            // ponytail: needs the ~14 App.* services the WPF constructor subscribed to (Video,
+            // BubbleCount, Flash, Subliminal, Bubbles, Achievements, Progression, Companion,
+            // WindowAwareness, MindWipe, BrainDrain, ModerationCounter, Mods, MainWindow.EngineStopped),
+            // wired when they move to Core. Their handlers all live in the Reactions/Speech partials.
+
+            // ponytail: the WPF ctor also started four timers here - a 2s greeting, the idle-giggle,
+            // the trigger and the random-bubble loops. Deliberately NOT started: every one of them
+            // calls into a partial this layer does not have, and --render-all constructs ~180 windows
+            // in one process, where a stray timer firing at a closed window is a flaky failure.
+
+            Log.Information("AvatarTubeWindow initialized with avatar set {Set}", _currentAvatarSet);
+        }
+
+        private bool _isMouseOverSpeechBubble;
+
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+
+            // Ensure NOT topmost when attached (starts attached). Window.Topmost is Avalonia's
+            // _NET_WM_STATE_ABOVE, which is the correct replacement for HWND_TOPMOST.
+            Topmost = false;
+
+            // The z-order pairing the WPF head got from native (GWL_HWNDPARENT) ownership. Safe to
+            // call unconditionally - the shim returns false off X11 and on the headless render.
+            if (_parentWindow is not null)
+                X11Overlay.RestackAbove(this, _parentWindow);
+
+            // ponytail: needs AvatarTubeWindow.Windowing.cs. WPF's OnLoaded also ran
+            // CalculateScaleFactor / UpdatePosition / StartFloatingAnimation /
+            // ApplySpeechBubblePlacement / RestoreSavedPlacement / StartFullscreenDetection and
+            // InitTakeoverCountdownBar. Screens.ScreenFromPoint + screen.WorkingArea/Scaling are the
+            // replacements for GetDpiForMonitor / MonitorFromPoint / SystemParameters.WorkArea when
+            // that partial ports; nothing here needs them yet.
+        }
+
+        // =========================================================================================
+        //  Thread marshalling. WPF's own-thread mode (AppSettings.AvatarOwnThread) has no Avalonia
+        //  twin - one UI thread per process - so these all target Dispatcher.UIThread.
+        // =========================================================================================
+
+        internal void RunOnAvatar(Action action, DispatcherPriority priority = default)
+        {
+            if (Dispatcher.UIThread.CheckAccess()) action();
+            else Dispatcher.UIThread.Post(action, priority);
+        }
+
+        public void ShowSafe() => RunOnAvatar(() =>
+        {
+            try { Show(); } catch (Exception ex) { Log.Debug("AvatarTube ShowSafe failed: {Error}", ex.Message); }
+        });
+
+        public void CloseSafe() => RunOnAvatar(() =>
+        {
+            try { Close(); } catch (Exception ex) { Log.Debug("AvatarTube CloseSafe failed: {Error}", ex.Message); }
+        });
+
+        // =========================================================================================
+        //  Chat history view
+        // =========================================================================================
+
+        /// <summary>Swap the bubble into chat-log mode. Ported from ChatInput.cs's ShowChatHistory
+        /// (the only part of that partial the XAML's own controls need).</summary>
+        public void ShowChatHistory()
+        {
+            _isShowingChatHistory = true;
+
+            // Show empty-state hint when there are no captured messages yet.
+            _txtChatHistoryEmpty.IsVisible = ChatHistory.Count == 0;
+
+            // Swap bubble content: hide single-message view, show chat history.
+            _speechScroller.IsVisible = false;
+            _chatHistoryView.IsVisible = true;
+            // Hide the per-message AI badge when showing the chat history list (mixed AI + user lines).
+            _aiBadge.IsVisible = false;
+
+            // Enlarge bubble for the chat history layout.
+            // ponytail: WPF followed this with ApplySpeechBubblePlacement(), which recomputes the
+            // margin from MaxWidth so a 600px bubble does not hang off the canvas. That method is in
+            // AvatarTubeWindow.Windowing.cs, so the bubble keeps its XAML margin here.
+            _speechBubble.MaxWidth = 600;
+            _speechBubble.IsVisible = true;
+
+            // Auto-scroll to most recent message.
+            Dispatcher.UIThread.Post(() => _chatHistoryScroller.ScrollToEnd(), DispatcherPriority.Background);
+        }
+
+        /// <summary>Back to single-message mode, and take the bubble down with it.</summary>
+        public void HideChatHistory()
+        {
+            _isShowingChatHistory = false;
+            _chatHistoryView.IsVisible = false;
+            _speechScroller.IsVisible = true;
+            _speechBubble.MaxWidth = 380; // Restore default bubble width.
+            _speechBubble.IsVisible = false;
+        }
+
+        private void AddToChatHistory(string text, bool isUser)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return;
+            ChatHistory.Add(new ChatMessage { Text = text, IsUser = isUser });
+            while (ChatHistory.Count > MaxChatHistorySize) ChatHistory.RemoveAt(0);
+        }
+
+        private void OnWindowKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape && _isShowingChatHistory)
+            {
+                HideChatHistory();
+                e.Handled = true;
+            }
+        }
+
+        // =========================================================================================
+        //  Moderation cooldown (P1.4). Fully portable: it only enables/disables two controls and
+        //  paints a countdown into the input box.
+        // =========================================================================================
+
+        private void OnCooldownStarted(DateTime endsAt)
+        {
+            _cooldownEndsAt = endsAt;
+            try
+            {
+                _txtUserInput.IsEnabled = false;
+                _txtUserInput.Opacity = 0.5;
+                _txtUserInput.Text = string.Empty;
+                _btnSendChat.IsEnabled = false;
+                _btnSendChat.Opacity = 0.5;
+
+                _cooldownTickTimer ??= new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                _cooldownTickTimer.Tick -= CooldownTick;
+                _cooldownTickTimer.Tick += CooldownTick;
+                _cooldownTickTimer.Start();
+                CooldownTick(null, EventArgs.Empty); // initial paint
+                Log.Information("AvatarTubeWindow: chat cooldown engaged until {End}", endsAt);
+            }
+            catch (Exception ex) { Log.Warning(ex, "AvatarTubeWindow: OnCooldownStarted failed"); }
+        }
+
+        private void CooldownTick(object? sender, EventArgs e)
+        {
+            if (!_cooldownEndsAt.HasValue) { _cooldownTickTimer?.Stop(); return; }
+            var remaining = _cooldownEndsAt.Value - DateTime.UtcNow;
+            if (remaining.TotalSeconds <= 0)
+            {
+                // ponytail: needs App.ModerationCounter - WPF probed GetState() here so the counter
+                // itself raised CooldownEnded. Without it, end the cooldown locally.
+                OnCooldownEnded();
+                return;
+            }
+            try
+            {
+                _txtUserInput.Text = Loc.GetF("chat_cooldown_active", (int)Math.Ceiling(remaining.TotalSeconds));
+            }
+            catch { /* best-effort painter */ }
+        }
+
+        private void OnCooldownEnded()
+        {
+            _cooldownEndsAt = null;
+            _cooldownTickTimer?.Stop();
+            try
+            {
+                _txtUserInput.IsEnabled = true;
+                _txtUserInput.Opacity = 1.0;
+                _txtUserInput.Text = string.Empty;
+                _btnSendChat.IsEnabled = true;
+                _btnSendChat.Opacity = 1.0;
+                Log.Information("AvatarTubeWindow: chat cooldown ended");
+            }
+            catch (Exception ex) { Log.Warning(ex, "AvatarTubeWindow: OnCooldownEnded failed"); }
+        }
+
+        // =========================================================================================
+        //  Pose animation
+        // =========================================================================================
+
+        public void StartPoseAnimation() => RunOnAvatar(() => _poseTimer.Start());
+        public void StopPoseAnimation() => RunOnAvatar(() => _poseTimer.Stop());
+        public void SetPoseInterval(TimeSpan interval) => _poseTimer.Interval = interval;
+
+        public void SetPose(int poseNumber) => RunOnAvatar(() =>
+        {
+            if (poseNumber < 1 || poseNumber > 4) return;
+            _currentPoseIndex = poseNumber - 1;
+            // ponytail: needs _avatarPoses from AvatarTubeWindow.Avatar.cs (LoadAvatarPoses reads
+            // the active mod's PNG set). Without it there is no Bitmap to assign to ImgAvatar.
+        });
+
+        private void AdvancePose()
+        {
+            // ponytail: needs AvatarTubeWindow.Avatar.cs's PoseTimer_Tick, which also drives the
+            // talking/idle pose choice off the speech state.
+            _currentPoseIndex = (_currentPoseIndex + 1) % 4;
+        }
+
+        /// <summary>Gets the current avatar set number</summary>
+        public int CurrentAvatarSet => _currentAvatarSet;
+
+        /// <summary>
+        /// True while ANY speech bubble (AI or ordinary "Preset" bark/chatter) is currently being
+        /// displayed. Unlike <see cref="HasBubbleUp"/> this also covers non-AI bubbles, so the bark
+        /// system can avoid stacking ordinary barks behind one that's already on screen.
+        /// </summary>
+        public bool IsSpeaking => _isGiggling;
+
+        /// <summary>
+        /// True while ANYTHING is in the tube's bubble slot: a spoken line, the listening dots, the
+        /// chat history view or an uninterruptible recorded clip. Broader than
+        /// <see cref="IsSpeaking"/> on purpose - EMI Desk asks this (via
+        /// <c>EmiDeskService.TubeBubbleLive</c>) to decide whether the tube is visually busy, and
+        /// the listening indicator counts as busy even though it is not speech.
+        /// </summary>
+        internal bool HasBubbleUp =>
+            _isGiggling || _isListeningBubble || _isShowingChatHistory
+            || _isShowingAiBubble || _isPlayingUninterruptibleClip;
+
+        // =========================================================================================
+        //  POSSESSION - the two things the haunted-UI layer is allowed to do to the tube.
+        //  Read Services/Possession/POSSESSION.md ("Companion wave") first.
+        //
+        //  Both are deliberately dumb: they draw into their OWN overlay elements and never touch
+        //  ImgAvatar / ImgAvatarB / the animated pair, the pose timer, the emote crossfade or the
+        //  portrait float loop. The haunt must never be able to leave the companion looking wrong
+        //  after a lockdown ends, and the only way to guarantee that is to never write to the real
+        //  pipeline in the first place.
+        // =========================================================================================
+
+        /// <summary>Possession ember (#FF8A5C). Ember means Possession, only - crimson is the theme.</summary>
+        private static readonly IBrush PossessionEmberBrush =
+            new ImmutableSolidColorBrush(Color.FromRgb(0xFF, 0x8A, 0x5C));
+
+        private DispatcherTimer? _possessionGlitchTimer;
+
+        /// <summary>
+        /// R4 "glitchportrait": for <paramref name="ms"/> milliseconds the portrait tears into three
+        /// horizontal bands that slip a few pixels sideways, ember-tinted, then snaps back.
+        ///
+        /// <para>The copies live in PossessionGlitchLayer, a sibling of the avatar images inside
+        /// AvatarBounceHost, so each one inherits the SAME layout slot as the real portrait and lines
+        /// up with it without any measuring. The bands are clipped before they are translated
+        /// (Clip is applied in local space, ahead of RenderTransform), which is what makes them read
+        /// as a tear rather than three ghosts.</para>
+        ///
+        /// <para>No-op when no portrait is loaded, when the tube has not laid out yet, or when the
+        /// window is on its way down. Safe to call again while one is still running.</para>
+        /// </summary>
+        public void GlitchPortrait(int ms) => RunOnAvatar(() =>
+        {
+            try
+            {
+                var layer = _possessionGlitchLayer;
+                if (layer == null) return;
+
+                var src = CurrentPortraitImage();
+                var source = src?.Source;
+                if (src == null || source == null) return;
+
+                double w = src.Bounds.Width, h = src.Bounds.Height;
+                if (w < 8 || h < 8) return;
+
+                ClearGlitchPortrait();
+
+                const int slices = 3;
+                double band = h / slices;
+                for (int i = 0; i < slices; i++)
+                {
+                    // Alternating, so the tear reads as a horizontal SLIP and not as a lean.
+                    double dx = (i % 2 == 0) ? 6 : -6;
+                    double dy = (i % 2 == 0) ? -1 : 1;
+
+                    var cell = new Grid
+                    {
+                        Width = w,
+                        Height = h,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        IsHitTestVisible = false,
+                        Clip = new RectangleGeometry(new Rect(0, i * band, w, band)),
+                        RenderTransform = new TranslateTransform(dx, dy)
+                    };
+                    cell.Children.Add(new Image
+                    {
+                        Source = source,
+                        Stretch = src.Stretch,
+                        Width = w,
+                        Height = h,
+                        IsHitTestVisible = false
+                    });
+                    cell.Children.Add(new Rectangle
+                    {
+                        Fill = PossessionEmberBrush,
+                        Opacity = 0.20,
+                        Width = w,
+                        Height = h,
+                        IsHitTestVisible = false
+                    });
+                    layer.Children.Add(cell);
+                }
+
+                layer.IsVisible = true;
+
+                _possessionGlitchTimer = new DispatcherTimer
+                {
+                    Interval = TimeSpan.FromMilliseconds(Math.Clamp(ms, 60, 1000))
+                };
+                _possessionGlitchTimer.Tick += (_, _) => ClearGlitchPortrait();
+                _possessionGlitchTimer.Start();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("AvatarTube GlitchPortrait failed: {Error}", ex.Message);
+                ClearGlitchPortrait();
+            }
+        });
+
+        /// <summary>Take the glitch down. Safe any number of times, from any thread.</summary>
+        public void ClearGlitchPortrait() => RunOnAvatar(() =>
+        {
+            try
+            {
+                if (_possessionGlitchTimer != null)
+                {
+                    _possessionGlitchTimer.Stop();
+                    _possessionGlitchTimer = null;
+                }
+                var layer = _possessionGlitchLayer;
+                if (layer == null) return;
+                layer.Children.Clear();
+                layer.IsVisible = false;
+            }
+            catch (Exception ex) { Log.Debug("AvatarTube ClearGlitchPortrait failed: {Error}", ex.Message); }
+        });
+
+        /// <summary>
+        /// Whichever avatar Image is actually on screen right now, topmost first: the two animated
+        /// layers (Circe webp / GIF sets), then the emotive-portrait crossfade layer, then the plain
+        /// pose image. Opacity is checked as well as visibility because the crossfade layers stay
+        /// visible at Opacity 0 between emotes.
+        /// </summary>
+        private Image? CurrentPortraitImage()
+        {
+            foreach (var name in new[] { "ImgAvatarAnimatedB", "ImgAvatarAnimated", "ImgAvatarB", "ImgAvatar" })
+            {
+                try
+                {
+                    var img = this.FindControl<Image>(name);
+                    if (img == null) continue;
+                    if (!img.IsVisible) continue;
+                    if (img.Opacity < 0.5) continue;
+                    if (img.Source == null) continue;
+                    return img;
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// R4 "leave": the warden puts a note where she was standing. Idempotent - calling it twice
+        /// just rewrites the card - and a no-op when the card never made it into the tree.
+        /// </summary>
+        public void ShowPossessionNote(string text) => RunOnAvatar(() =>
+        {
+            try
+            {
+                var card = _possessionNoteCard;
+                if (card == null || string.IsNullOrWhiteSpace(text)) return;
+
+                _txtPossessionNote.Text = text;
+                // A small random lean, so it reads as something that was PUT there.
+                if (card.RenderTransform is RotateTransform rot) rot.Angle = _random.Next(2) == 0 ? -3 : 3;
+
+                // ponytail: WPF ran a 260ms cubic-ease opacity Storyboard here. Avalonia's twin is a
+                // Transitions entry, which would also animate the hide below; the note is set
+                // straight to full instead, which is the same end state without a second code path.
+                card.Opacity = 1;
+                card.IsVisible = true;
+            }
+            catch (Exception ex) { Log.Debug("AvatarTube ShowPossessionNote failed: {Error}", ex.Message); }
+        });
+
+        /// <summary>Take the note down. Safe when there never was one, and safe to call twice.</summary>
+        public void HidePossessionNote() => RunOnAvatar(() =>
+        {
+            try
+            {
+                var card = _possessionNoteCard;
+                if (card == null || !card.IsVisible) return;
+                card.Opacity = 0;
+                card.IsVisible = false;
+            }
+            catch (Exception ex) { Log.Debug("AvatarTube HidePossessionNote failed: {Error}", ex.Message); }
+        });
+
+        // =========================================================================================
+        //  Stubs. Each one is a handler the WPF XAML wired inline whose body lives in a partial
+        //  this layer does not port, or reaches a service that is not in Core.
+        // =========================================================================================
+
+        /// <summary>Left click bounces her and fires a reaction bark; right click opens the menu.</summary>
+        private void OnAvatarPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            var point = e.GetCurrentPoint(this);
+            if (point.Properties.IsRightButtonPressed) return; // Avalonia opens the ContextMenu itself
+            // ponytail: needs AvatarTubeWindow.Avatar.cs (BounceAvatar) and Reactions.cs
+            // (ImgAvatar_MouseLeftButtonDown -> click bark + pose change), wired when they move to Core.
+        }
+
+        /// <summary>Send whatever is in the input box to the companion.</summary>
+        private void SendChat()
+        {
+            var input = _txtUserInput.Text;
+            if (string.IsNullOrWhiteSpace(input)) return;
+            AddToChatHistory(input, isUser: true);
+            _txtUserInput.Text = string.Empty;
+            // ponytail: needs AvatarTubeWindow.ChatInput.cs (moderation guard, AI inference,
+            // typewriter reply, TTS) and App.ModerationCounter, wired when they move to Core. The
+            // user's line still lands in the log so the view is honest about what it did.
+        }
+
+        /// <summary>Step through the unlocked avatar sets with the title-box arrows.</summary>
+        private void SelectAvatarSet(int delta)
+        {
+            // ponytail: needs App.Settings (SelectedAvatarSet) and AvatarTubeWindow.Avatar.cs
+            // (GetUnlockedAvatarSets / LoadAvatarPoses / ApplyAvatarTransform / UpdateTitleDisplay).
+        }
+
+        /// <summary>Refresh the context menu's checkmarks and the remote-emote item swap.</summary>
+        private void UpdateQuickMenuState()
+        {
+            // ponytail: needs App.Settings.Current.RemoteEmotePresets, App.Engine, App.Companion and
+            // AvatarTubeWindow.Reactions.cs's AvatarContextMenu_Opened, which retitles every item
+            // from live state on each open.
+        }
+    }
+}


### PR DESCRIPTION
1,255 lines.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351