### PR TITLE
feat(avalonia): port WebcamCalibrationWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml
@@ -1,0 +1,323 @@
+<!-- PORTED from ConditioningControlPanel/Windows/WebcamCalibrationWindow.xaml.
+     Structure, ordering, spacing, colours and every element name preserved so the two diff
+     cleanly. Deviations, all forced:
+
+       WindowStyle="None"                 -> SystemDecorations="None"
+       ResizeMode="NoResize"              -> CanResize="False"
+       Visibility="Collapsed"             -> IsVisible="False"
+       Panel.ZIndex                       -> ZIndex
+       KeyDown / Loaded / Closed=         -> wired in the constructor, per the porting convention
+       ToolTip="…"                        -> ToolTip.Tip="…"
+       StrokeDashCap="Round"              -> StrokeLineCap="Round"  (Avalonia's Shape has no
+                                             StrokeDashCap; StrokeLineCap caps the dashes)
+       StrokeDashArray="0 10000"          -> "0,10000"              (comma form, unambiguous)
+       DropShadowEffect ShadowDepth="0"   -> OffsetX="0" OffsetY="0" (Avalonia's ShadowDepth lives
+                                             on DropShadowDirectionEffect, not this effect)
+       RenderTransformOrigin="0.5,0.5"    -> dropped; Avalonia's default IS RelativePoint.Center,
+                                             and "0.5,0.5" would parse as an ABSOLUTE point
+       x:Name on the two ScaleTransforms  -> dropped; Avalonia's XAML compiler rejects a name on a
+                                             non-Control (AVLN2000). The code-behind reaches them
+                                             through the owning shape's RenderTransform instead.
+       ControlTemplate.Triggers           -> a :pointerover selector in Window.Styles
+       <ContentPresenter/>                -> Content="{TemplateBinding Content}" (CLAUDE.md trap 6)
+       TextBlock inner text               -> Text="…" so the XAML indentation is not rendered
+
+     Buttons carry a TextBlock child rather than Content wherever the label is a word, per the
+     access-key note in CLAUDE.md. The "?" help button keeps Content because its inline template
+     needs a ContentPresenter anyway and "?" has no underscore.
+
+     There is NO Win32 P/Invoke and NO WebView2 in this view - see the code-behind header. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.WebcamCalibrationWindow"
+        Title="Webcam Calibration"
+        Background="#000000"
+        SystemDecorations="None"
+        WindowState="Maximized"
+        CanResize="False"
+        Topmost="True"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterScreen">
+
+    <Window.Styles>
+        <!-- The WPF Button.Template's IsMouseOver trigger, setter verbatim. -->
+        <Style Selector="Button#BtnCalibrationHelp:pointerover /template/ Border#bd">
+            <Setter Property="Background" Value="#FF69B4"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid>
+        <Canvas x:Name="DotCanvas">
+            <!-- Background ring: faint full circle so the user always sees the
+                 progress track. -->
+            <Ellipse x:Name="DotRingBg" Width="84" Height="84"
+                     Stroke="#33FFFFFF" StrokeThickness="3"/>
+            <!-- Foreground ring: fills clockwise from 12 o'clock as samples
+                 accumulate. Drawn via StrokeDashArray (visible/gap) so we can
+                 update the fill amount per-frame from code-behind. -->
+            <Ellipse x:Name="DotRingFg" Width="84" Height="84"
+                     Stroke="#FFFF69B4" StrokeThickness="4"
+                     StrokeDashArray="0,10000" StrokeLineCap="Round">
+                <Ellipse.RenderTransform>
+                    <TransformGroup>
+                        <RotateTransform Angle="-90"/>
+                        <ScaleTransform ScaleX="1" ScaleY="1"/>
+                    </TransformGroup>
+                </Ellipse.RenderTransform>
+                <Ellipse.Effect>
+                    <DropShadowEffect Color="#FF69B4" BlurRadius="14" OffsetX="0" OffsetY="0" Opacity="0.7"/>
+                </Ellipse.Effect>
+            </Ellipse>
+            <Ellipse x:Name="Dot" Width="44" Height="44">
+                <Ellipse.Fill>
+                    <RadialGradientBrush>
+                        <GradientStop Color="#FFFFB6E1" Offset="0"/>
+                        <GradientStop Color="#FFFF69B4" Offset="0.6"/>
+                        <GradientStop Color="#FFC71585" Offset="1"/>
+                    </RadialGradientBrush>
+                </Ellipse.Fill>
+                <Ellipse.Effect>
+                    <DropShadowEffect Color="#FF69B4" BlurRadius="30" OffsetX="0" OffsetY="0" Opacity="0.9"/>
+                </Ellipse.Effect>
+            </Ellipse>
+        </Canvas>
+
+        <!-- Discoverability hint for the global 6-blink recalibrate gesture.
+             Shown on the intro + verify panels (toggled from code-behind), hidden
+             during the dot grid so it never overlaps the top-row dots. -->
+        <Border x:Name="ShortcutHintBanner" IsVisible="False"
+                VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,12,0,0"
+                Background="#22FF69B4" BorderBrush="#55FF69B4" BorderThickness="1"
+                CornerRadius="10" Padding="16,7" ZIndex="100">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="👁" FontSize="13" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <TextBlock Foreground="#FFE3F0" FontSize="12" VerticalAlignment="Center"
+                           Text="Tip: blink fast 6 times in a row, anytime, to stop everything and jump straight back here to recalibrate."/>
+            </StackPanel>
+        </Border>
+
+        <StackPanel x:Name="StatusPanel" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,40,0,0">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock x:Name="TxtTitle" Text="Webcam Calibration" Foreground="White"
+                           FontSize="22" FontWeight="Bold" VerticalAlignment="Center"/>
+                <!-- Inline "?" (HelpButtonStyle lives only in MainWindow, not reachable
+                     from this top-level Window). Always visible, even when gated/locked. -->
+                <Button x:Name="BtnCalibrationHelp" Content="?"
+                        Width="24" Height="24" Margin="12,0,0,0" VerticalAlignment="Center"
+                        Cursor="Help" Foreground="White" Background="Transparent"
+                        BorderBrush="#FF69B4" BorderThickness="1" FontWeight="Bold" FontSize="12"
+                        ToolTip.Tip="Calibration help">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="bd" Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="12">
+                                <ContentPresenter Content="{TemplateBinding Content}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Button.Template>
+                </Button>
+            </StackPanel>
+            <TextBlock x:Name="TxtStatus" Text="Look at the pink dot. Press ESC to cancel."
+                       Foreground="{DynamicResource TextMutedBrush}" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Center"/>
+            <TextBlock x:Name="TxtProgress" Text="" Foreground="#FF69B4" FontSize="13"
+                       Margin="0,4,0,0" HorizontalAlignment="Center" FontFamily="Consolas, Courier New"/>
+        </StackPanel>
+
+        <Border x:Name="IntroPanel" IsVisible="False"
+                Background="#181820" BorderBrush="#FF69B4" BorderThickness="2"
+                CornerRadius="14" Padding="36,28,36,28"
+                HorizontalAlignment="Center" VerticalAlignment="Center"
+                MaxWidth="640">
+            <StackPanel>
+                <TextBlock Text="Webcam Calibration"
+                           Foreground="#FFFFFF" FontSize="26" FontWeight="Bold"
+                           HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <TextBlock Text="Two short phases — under a minute total."
+                           Foreground="#FFB6E1" FontSize="14"
+                           HorizontalAlignment="Center" Margin="0,0,0,22"/>
+
+                <Grid Margin="0,0,0,8" ColumnDefinitions="40,*">
+                    <TextBlock Grid.Column="0" Text="1." Foreground="#FF69B4"
+                               FontSize="15" FontWeight="Bold" VerticalAlignment="Top"/>
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="Dot grid (16 dots)" Foreground="#FFFFFF"
+                                   FontSize="15" FontWeight="SemiBold"/>
+                        <TextBlock Text="A pink dot moves around the screen. Look at it and hold your gaze until the ring around it fills up."
+                                   Foreground="{DynamicResource TextSecondaryBrush}" FontSize="13" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                </Grid>
+
+                <Grid Margin="0,0,0,18" ColumnDefinitions="40,*">
+                    <TextBlock Grid.Column="0" Text="2." Foreground="#FF69B4"
+                               FontSize="15" FontWeight="Bold" VerticalAlignment="Top"/>
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="Quick checks" Foreground="#FFFFFF"
+                                   FontSize="15" FontWeight="SemiBold"/>
+                        <TextBlock Text="Two quick prompts to warm up tracking: blink, then open your mouth wide."
+                                   Foreground="{DynamicResource TextSecondaryBrush}" FontSize="13" TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                </Grid>
+
+                <TextBlock Foreground="#FFC96E" FontSize="12.5"
+                           HorizontalAlignment="Center" TextAlignment="Center"
+                           TextWrapping="Wrap" Margin="0,0,0,8"
+                           Text="⚠ Dim-lit rooms make eye tracking super inconsistent — put some light on your face if you can."/>
+                <TextBlock Foreground="{DynamicResource TextMutedBrush}" FontSize="12"
+                           HorizontalAlignment="Center" TextAlignment="Center"
+                           TextWrapping="Wrap" Margin="0,0,0,18"
+                           Text="Sit comfortably. ESC cancels at any time."/>
+
+                <Button x:Name="BtnIntroContinue"
+                        Padding="32,10" Background="#FF69B4" Foreground="Black"
+                        BorderThickness="0" FontWeight="Bold" FontSize="15"
+                        Cursor="Hand" HorizontalAlignment="Center">
+                    <TextBlock Text="Continue"/>
+                </Button>
+            </StackPanel>
+        </Border>
+
+        <Grid x:Name="ValidationPanel" IsVisible="False">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock x:Name="TxtValidationCue" Text="" Foreground="#FF69B4"
+                           FontSize="160" FontWeight="Bold" HorizontalAlignment="Center"
+                           Margin="0,0,0,20">
+                    <TextBlock.Effect>
+                        <DropShadowEffect Color="#FF69B4" BlurRadius="40" OffsetX="0" OffsetY="0" Opacity="0.7"/>
+                    </TextBlock.Effect>
+                </TextBlock>
+                <TextBlock x:Name="TxtValidationPrompt" Text="" Foreground="White"
+                           FontSize="32" FontWeight="Bold" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtValidationDetail" Text="" Foreground="{DynamicResource TextMutedBrush}"
+                           FontSize="16" HorizontalAlignment="Center" Margin="0,12,0,0"/>
+                <TextBlock x:Name="TxtValidationAttempt" Text="" Foreground="#FF69B4"
+                           FontSize="13" FontFamily="Consolas, Courier New" HorizontalAlignment="Center"
+                           Margin="0,16,0,0"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Bubble accuracy test: optional post-calibration minigame launched
+             from the verify panel. One bubble at a time; the user pops it by
+             holding their gaze cursor on it (~0.7s dwell). Residuals feed a
+             drift fine-tune — see RunBubbleTestAsync.
+
+             The bubble and its ring are deliberately TALLER THAN WIDE. CHI
+             2025 gaze-target guidance says the target's shape should absorb
+             the axis carrying more error, and vertical gaze error runs
+             1.5-2x horizontal (half the eyeball rotation per screen unit,
+             plus eyelid occlusion of the iris top/bottom). Sizes are
+             ~3 degrees wide by ~4 tall: at 60cm on a 27" 1440p panel 1
+             degree is ~45 px, so 3 x 45 = 135 -> 136 wide and 4 x 45 = 180
+             tall. Rings sit 48 DIPs outside on each axis. UpdateRing() uses
+             a Ramanujan perimeter so the dwell arc stays correct on an
+             ellipse. -->
+        <Grid x:Name="BubbleTestPanel" IsVisible="False">
+            <Canvas x:Name="BubbleTestCanvas">
+                <Ellipse x:Name="TestBubbleRingBg" Width="184" Height="228"
+                         Stroke="#33FFFFFF" StrokeThickness="4" IsVisible="False"/>
+                <!-- Width/Height are deliberately SWAPPED relative to TestBubbleRingBg.
+                     The RotateTransform below (-90, to start the dash at 12 o'clock) also
+                     rotates the ellipse's own axes, so an ellipse authored 228x184 RENDERS
+                     as 184x228 and matches the upright background ring. Authoring it
+                     184x228 like the bg makes the pink arc render as a WIDE oval crossing
+                     the grey tall oval at four points. Ramanujan's perimeter is symmetric
+                     in a/b, so UpdateRing is unaffected by the swap. -->
+                <Ellipse x:Name="TestBubbleRingFg" Width="228" Height="184"
+                         Stroke="#FFFF69B4" StrokeThickness="5"
+                         StrokeDashArray="0,10000" StrokeLineCap="Round"
+                         IsVisible="False">
+                    <Ellipse.RenderTransform>
+                        <RotateTransform Angle="-90"/>
+                    </Ellipse.RenderTransform>
+                </Ellipse>
+                <Ellipse x:Name="TestBubble" Width="136" Height="180" IsVisible="False">
+                    <Ellipse.RenderTransform>
+                        <ScaleTransform ScaleX="1" ScaleY="1"/>
+                    </Ellipse.RenderTransform>
+                    <Ellipse.Fill>
+                        <RadialGradientBrush>
+                            <GradientStop Color="#66FFFFFF" Offset="0"/>
+                            <GradientStop Color="#99FF9BD0" Offset="0.7"/>
+                            <GradientStop Color="#CCFF69B4" Offset="1"/>
+                        </RadialGradientBrush>
+                    </Ellipse.Fill>
+                    <Ellipse.Effect>
+                        <DropShadowEffect Color="#FF69B4" BlurRadius="24" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                    </Ellipse.Effect>
+                </Ellipse>
+            </Canvas>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,40,0,0">
+                <TextBlock Text="Accuracy test" Foreground="White" FontSize="22" FontWeight="Bold"
+                           HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtBubbleTestStatus"
+                           Text="Look at each bubble — hold your gaze on it to pop it. ESC cancels."
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="14" Margin="0,8,0,0" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Grid>
+
+        <Border x:Name="ErrorPanel" IsVisible="False"
+                Background="#221A1A" BorderBrush="#FF4040" BorderThickness="2"
+                CornerRadius="10" Padding="24" HorizontalAlignment="Center" VerticalAlignment="Center"
+                MaxWidth="520">
+            <StackPanel>
+                <TextBlock Text="Calibration failed" Foreground="#FF8080" FontSize="18"
+                           FontWeight="Bold" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtErrorDetail" Text="" Foreground="White" FontSize="13"
+                           Margin="0,12,0,16" TextWrapping="Wrap" HorizontalAlignment="Center"/>
+                <Button x:Name="BtnErrorClose" Padding="20,8"
+                        Background="#FF69B4" Foreground="Black" BorderThickness="0"
+                        FontWeight="Bold" Cursor="Hand"
+                        HorizontalAlignment="Center">
+                    <TextBlock Text="Close"/>
+                </Button>
+            </StackPanel>
+        </Border>
+
+        <!-- Verify panel: shown after successful calibration. Replaces the
+             old 2.5s auto-close so the user can sanity-check accuracy via
+             the debug cursor before committing. Placeholder copy — voice-pass
+             at ship time. -->
+        <Border x:Name="VerifyPanel" IsVisible="False"
+                Background="#1A1A2E" BorderBrush="#FF69B4" BorderThickness="2"
+                CornerRadius="10" Padding="28" HorizontalAlignment="Center" VerticalAlignment="Center"
+                MaxWidth="560">
+            <StackPanel>
+                <TextBlock Text="Calibration verified" Foreground="#FF69B4" FontSize="22"
+                           FontWeight="Bold" HorizontalAlignment="Center"/>
+                <TextBlock Text="Calibration complete. Blink and mouth tracking warmed up — you're all set."
+                           Foreground="{DynamicResource TextSecondaryBrush}" FontSize="13" Margin="0,8,0,0"
+                           TextWrapping="Wrap" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="TxtVerifyStatus" Text="Preview accuracy with a live gaze cursor, or pop a few bubbles with your eyes to test (and auto fine-tune) precision."
+                           Foreground="{DynamicResource TextMutedBrush}" FontSize="12" Margin="0,16,0,20"
+                           TextWrapping="Wrap" HorizontalAlignment="Center" MaxWidth="440"/>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                    <Button x:Name="BtnVerifyAccuracy" Padding="20,10"
+                            Background="#33333A" Foreground="White" BorderBrush="#FF69B4"
+                            BorderThickness="1" FontWeight="SemiBold" Cursor="Hand"
+                            Margin="0,0,8,0">
+                        <TextBlock Text="Verify accuracy"/>
+                    </Button>
+                    <Button x:Name="BtnVerifyBubbleTest" Padding="20,10"
+                            Background="#33333A" Foreground="White" BorderBrush="#FF69B4"
+                            BorderThickness="1" FontWeight="SemiBold" Cursor="Hand"
+                            Margin="0,0,8,0">
+                        <TextBlock Text="Bubble test"/>
+                    </Button>
+                    <Button x:Name="BtnVerifyRecalibrate" Padding="20,10"
+                            Background="#33333A" Foreground="White" BorderThickness="0"
+                            Cursor="Hand" Margin="0,0,8,0">
+                        <TextBlock Text="Recalibrate"/>
+                    </Button>
+                    <Button x:Name="BtnVerifyDone" Padding="20,10"
+                            Background="#FF69B4" Foreground="Black" BorderThickness="0"
+                            FontWeight="Bold" Cursor="Hand">
+                        <TextBlock Text="Done"/>
+                    </Button>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
@@ -1,0 +1,500 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// Fullscreen 16-point gaze calibration (4×4 grid). The WPF original samples raw iris vectors
+    /// at each point, fits a 3×3 homography and an over-determined 2nd-order polynomial
+    /// (Cerrolaza asymmetric form, ridge-regularized with λ chosen by leave-one-out CV, iris →
+    /// screen DIPs), and persists via WebcamCalibrationData.
+    ///
+    /// PORTED from ConditioningControlPanel/Windows/WebcamCalibrationWindow.xaml.cs (2,116 lines).
+    ///
+    /// <para><b>No Win32 and no WebView2 here.</b> This view was scheduled in the Win32/WebView2
+    /// wave, but reading it end to end there is exactly one interop site and no web view at all:
+    /// <c>WindowInteropHelper(this).Handle</c> fed to <c>System.Windows.Forms.Screen.FromHandle</c>
+    /// inside <c>FinalizeCalibrationAsync</c>, to record which monitor calibration ran on. That
+    /// maps to <c>Screens.ScreenFromWindow(this)</c> plus <c>screen.Bounds</c> and
+    /// <c>RenderScaling</c> (which also replaces <c>VisualTreeHelper.GetDpi</c>) — but the whole
+    /// method is service-bound and stubbed below, so the mapping is recorded rather than written.
+    /// Nothing here needs <c>X11Overlay</c>: the window is opaque black, focusable and clickable,
+    /// so <c>Topmost</c> + <c>ShowInTaskbar="False"</c> cover it.</para>
+    ///
+    /// <para><b>What is real in this port</b> — everything that only touches the view: the panel
+    /// choreography, the 4×4 grid layout, dot and bubble placement, the Ramanujan stroke-dash
+    /// progress rings, the ring pulse, the error panel and the verify-panel countdown.</para>
+    ///
+    /// <para><b>What is stubbed</b> — everything reaching a service or the camera:
+    /// <c>App.Webcam</c> (OnRawIris / OnHeadPose / OnTrackingStateChanged / SetCalibrationLive /
+    /// ApplyCalibration / ClearGazeAttractor), the entire fit pipeline (TrimmedMean,
+    /// FitCerrolazaPolynomial, FitRidge, EvalPolynomial, BuildAxisCorrection, FitAxisTrim,
+    /// ~1,300 lines of OpenCvSharp-free maths that still needs <c>WebcamCalibrationData</c> from
+    /// the WPF head), the gesture warm-up waiters, <c>RunBubbleTestAsync</c>,
+    /// <c>CalibrationSoundService</c>, <c>App.GazeCursor</c>, <c>App.Settings</c>,
+    /// <c>App.Notifications</c>, <c>App.Logger</c> and the HelpContentService/HelpVideoWindow
+    /// popup.</para>
+    ///
+    /// Other deviations:
+    ///  - WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>, as in TextEditorDialog.
+    ///  - <c>ShowDialogWithRecalibrate</c> becomes async: Avalonia's <c>ShowDialog</c> is awaitable
+    ///    and has no synchronous form.
+    ///  - The ring-pulse <c>Storyboard</c> becomes a <c>DispatcherTimer</c> driving the same
+    ///    sinusoid. Avalonia's <c>Animation</c> CANNOT target a <c>Transform</c> — its
+    ///    TransformAnimator casts the target to <c>Visual</c> and throws at run time, which the
+    ///    compiler says nothing about. See the comment on StartRingPulse.
+    ///  - <c>ActualWidth/Height</c> become <c>Bounds.Width/Height</c>.
+    ///  - The named <c>ScaleTransform</c>s are reached through <c>RenderTransform</c> rather than
+    ///    <c>FindControl</c>, which is constrained to <c>Control</c>.
+    ///  - The pipeline's timing constants (SampleMs, SettleMs, MinSamplesPerPoint, …) are not
+    ///    copied: they belong with the sampling loop, and it is a stub. Only the two the layout
+    ///    actually uses are here.
+    /// </summary>
+    public partial class WebcamCalibrationWindow : Window
+    {
+        private const int GridSize = 4;       // 4×4 = 16 calibration points (corners + interior)
+        private const double EdgeMargin = 40; // distance from screen edge for corner dots (DIPs)
+
+        private readonly Canvas _dotCanvas;
+        private readonly Ellipse _dot;
+        private readonly Ellipse _dotRingBg;
+        private readonly Ellipse _dotRingFg;
+        private readonly ScaleTransform _dotRingScale;
+        private readonly Border _shortcutHintBanner;
+        private readonly StackPanel _statusPanel;
+        private readonly TextBlock _txtTitle;
+        private readonly TextBlock _txtStatus;
+        private readonly TextBlock _txtProgress;
+        private readonly Border _introPanel;
+        private readonly Grid _validationPanel;
+        private readonly TextBlock _txtValidationCue;
+        private readonly TextBlock _txtValidationPrompt;
+        private readonly TextBlock _txtValidationDetail;
+        private readonly TextBlock _txtValidationAttempt;
+        private readonly Grid _bubbleTestPanel;
+        private readonly Ellipse _testBubble;
+        private readonly Ellipse _testBubbleRingBg;
+        private readonly Ellipse _testBubbleRingFg;
+        private readonly Border _errorPanel;
+        private readonly TextBlock _txtErrorDetail;
+        private readonly Border _verifyPanel;
+        private readonly TextBlock _txtVerifyStatus;
+        private readonly Button _btnVerifyAccuracy;
+
+        private DispatcherTimer? _ringPulse;
+        private DispatcherTimer? _verifyCountdownTimer;
+        private int _verifyCountdownSecondsLeft;
+        private bool _completedOk;
+
+        /// <summary>
+        /// True while a calibration window is on screen. The global 6-blink recalibrate gesture
+        /// (MainWindow) checks this so blinking during the verify step — or while calibration is
+        /// already open — can't re-trigger another calibration.
+        /// </summary>
+        public static bool IsShowing { get; private set; }
+
+        /// <summary>
+        /// Set to true when the user clicked Recalibrate on the verify panel. Callers that want to
+        /// loop should re-open the dialog while this is true. Use
+        /// <see cref="ShowDialogWithRecalibrate"/> for the canonical loop pattern.
+        /// </summary>
+        public bool WantsRecalibrate { get; private set; }
+
+        public WebcamCalibrationWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            _dotCanvas = this.FindControl<Canvas>("DotCanvas")!;
+            _dot = this.FindControl<Ellipse>("Dot")!;
+            _dotRingBg = this.FindControl<Ellipse>("DotRingBg")!;
+            _dotRingFg = this.FindControl<Ellipse>("DotRingFg")!;
+            _shortcutHintBanner = this.FindControl<Border>("ShortcutHintBanner")!;
+            _statusPanel = this.FindControl<StackPanel>("StatusPanel")!;
+            _txtTitle = this.FindControl<TextBlock>("TxtTitle")!;
+            _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
+            _txtProgress = this.FindControl<TextBlock>("TxtProgress")!;
+            _introPanel = this.FindControl<Border>("IntroPanel")!;
+            _validationPanel = this.FindControl<Grid>("ValidationPanel")!;
+            _txtValidationCue = this.FindControl<TextBlock>("TxtValidationCue")!;
+            _txtValidationPrompt = this.FindControl<TextBlock>("TxtValidationPrompt")!;
+            _txtValidationDetail = this.FindControl<TextBlock>("TxtValidationDetail")!;
+            _txtValidationAttempt = this.FindControl<TextBlock>("TxtValidationAttempt")!;
+            _bubbleTestPanel = this.FindControl<Grid>("BubbleTestPanel")!;
+            _testBubble = this.FindControl<Ellipse>("TestBubble")!;
+            _testBubbleRingBg = this.FindControl<Ellipse>("TestBubbleRingBg")!;
+            _testBubbleRingFg = this.FindControl<Ellipse>("TestBubbleRingFg")!;
+            _errorPanel = this.FindControl<Border>("ErrorPanel")!;
+            _txtErrorDetail = this.FindControl<TextBlock>("TxtErrorDetail")!;
+            _verifyPanel = this.FindControl<Border>("VerifyPanel")!;
+            _txtVerifyStatus = this.FindControl<TextBlock>("TxtVerifyStatus")!;
+            _btnVerifyAccuracy = this.FindControl<Button>("BtnVerifyAccuracy")!;
+
+            // FindControl is constrained to Control, so the two named ScaleTransforms are reached
+            // through their owner's RenderTransform instead. Deterministic: the shapes and their
+            // transforms are both authored in this file.
+            // Throwing rather than falling back to a detached ScaleTransform: a silent fallback
+            // would pulse an object nobody renders, and a still ring is exactly what a broken
+            // pulse looks like anyway.
+            _dotRingScale = ((TransformGroup)_dotRingFg.RenderTransform!).Children
+                .OfType<ScaleTransform>().Single();
+
+            // Handlers live here rather than in markup, per the porting convention.
+            this.FindControl<Button>("BtnCalibrationHelp")!.Click += (_, _) => BtnCalibrationHelp_Click();
+            this.FindControl<Button>("BtnIntroContinue")!.Click += (_, _) => BtnIntroContinue_Click();
+            this.FindControl<Button>("BtnErrorClose")!.Click += (_, _) => BtnErrorClose_Click();
+            _btnVerifyAccuracy.Click += (_, _) => BtnVerifyAccuracy_Click();
+            this.FindControl<Button>("BtnVerifyBubbleTest")!.Click += (_, _) => BtnVerifyBubbleTest_Click();
+            this.FindControl<Button>("BtnVerifyRecalibrate")!.Click += (_, _) => BtnVerifyRecalibrate_Click();
+            this.FindControl<Button>("BtnVerifyDone")!.Click += (_, _) => BtnVerifyDone_Click();
+            KeyDown += Window_KeyDown;
+            Loaded += Window_Loaded;
+            Closed += Window_Closed;
+
+            IsShowing = true;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        //  Window lifecycle
+        // ─────────────────────────────────────────────────────────────────────
+
+        private void Window_Loaded(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.Webcam (IsRunning gate + OnRawIris / OnHeadPose /
+            // OnTrackingStateChanged subscriptions), wired when the webcam service moves to Core.
+            // The WPF original bails to ShowError when tracking is not running; with no service to
+            // ask, the intro is shown unconditionally so the view still has a first frame.
+
+            // Show the intro overlay first so users know what's coming — the dot grid + validation
+            // checks are otherwise a surprise. DotCanvas / StatusPanel stay hidden until the user
+            // clicks Continue (or presses ESC, which cancels).
+            _dotCanvas.IsVisible = false;
+            _statusPanel.IsVisible = false;
+            _introPanel.IsVisible = true;
+            // Surface the blink-shortcut hint while the user is reading the intro (and again on
+            // the verify panel) — but not during the dot grid, where it would sit over the top-row
+            // dots.
+            _shortcutHintBanner.IsVisible = true;
+        }
+
+        private void Window_Closed(object? sender, EventArgs e)
+        {
+            IsShowing = false;
+            StopRingPulse();
+            _verifyCountdownTimer?.Stop();
+            // ponytail: needs App.Webcam / App.GazeCursor to unsubscribe the iris + pose streams
+            // and release the "calibration-verify" and "calibration-bubbletest" cursor keys and the
+            // gaze attractor, wired when those services move to Core.
+        }
+
+        private void Window_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                StopRingPulse();
+                Close(false);
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        //  Intro / error panels
+        // ─────────────────────────────────────────────────────────────────────
+
+        private void BtnIntroContinue_Click()
+        {
+            _introPanel.IsVisible = false;
+            _shortcutHintBanner.IsVisible = false;
+            _dotCanvas.IsVisible = true;
+            _statusPanel.IsVisible = true;
+
+            // ponytail: needs App.Webcam's iris/pose streams + CalibrationSoundService for the
+            // real per-dot sampling loop (RunSequenceAsync), wired when they move to Core. The
+            // grid layout, the dot placement and the progress ring below are the WPF original's,
+            // parked on the first point so the view still shows what the sequence looks like.
+            var positions = BuildGrid(Bounds.Width, Bounds.Height);
+            MoveDotTo(positions[0].Screen);
+            _txtProgress.Text = $"Point 1 / {positions.Length}  ({positions[0].Label})";
+            _txtStatus.Text = "Look at the pink dot…";
+            ResetProgressRing();
+        }
+
+        /// <summary>
+        /// The 4×4 dot layout from RunSequenceAsync, verbatim. Row-major, 16 dots evenly spaced
+        /// across cols/rows 0..3 of the usable span:
+        /// <code>
+        ///    0  1  2  3      (top row)
+        ///    4  5  6  7
+        ///    8  9 10 11
+        ///   12 13 14 15      (bottom row)
+        /// </code>
+        /// Left column = {0,4,8,12}; right column = {3,7,11,15}.
+        /// </summary>
+        private static (string Label, Point Screen)[] BuildGrid(double w, double h)
+        {
+            double xL = EdgeMargin, xR = w - EdgeMargin;
+            double yT = EdgeMargin, yB = h - EdgeMargin;
+            string[] rowLabels = { "Top", "Upper", "Lower", "Bottom" };
+            string[] colLabels = { "left", "mid-left", "mid-right", "right" };
+            var positions = new (string Label, Point Screen)[GridSize * GridSize];
+            for (int r = 0; r < GridSize; r++)
+            {
+                double y = yT + (yB - yT) * (r / (double)(GridSize - 1));
+                for (int c = 0; c < GridSize; c++)
+                {
+                    double x = xL + (xR - xL) * (c / (double)(GridSize - 1));
+                    positions[r * GridSize + c] = ($"{rowLabels[r]}-{colLabels[c]}", new Point(x, y));
+                }
+            }
+            return positions;
+        }
+
+        private void BtnErrorClose_Click() => Close(_completedOk);
+
+        private void BtnCalibrationHelp_Click()
+        {
+            // ponytail: needs Services.HelpContentService.GetContent("WebcamCalibration") and the
+            // HelpVideoWindow popup (topmost:true so it layers above this fullscreen window),
+            // wired when the help service moves to Core.
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        //  Verify panel
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Helper for callers: shows the dialog, re-opens automatically when the user clicks
+        /// Recalibrate on the verify panel. Returns the terminal result — true when calibration was
+        /// accepted, false when cancelled. Async because Avalonia's ShowDialog has no synchronous
+        /// form; the WPF original returned <c>bool?</c> directly.
+        /// </summary>
+        public static async Task<bool?> ShowDialogWithRecalibrate(Window owner)
+        {
+            bool? final;
+            while (true)
+            {
+                var dlg = new WebcamCalibrationWindow();
+                // ponytail: needs App.ApplyCalibrationScreenPlacement to pick the monitor to open
+                // on (Screens.ScreenFromWindow(owner) / screen.Bounds on this head), wired when
+                // that helper moves to Core.
+                final = await dlg.ShowDialog<bool?>(owner);
+                if (!dlg.WantsRecalibrate) break;
+            }
+            return final;
+        }
+
+        private void BtnVerifyAccuracy_Click()
+        {
+            // ponytail: needs App.GazeCursor.Show/Hide("calibration-verify") to actually draw the
+            // live gaze cursor, wired when the cursor service moves to Core. The 15s countdown is
+            // view-only and runs for real.
+            _verifyCountdownSecondsLeft = 15;
+            UpdateVerifyCountdownUi();
+
+            if (_verifyCountdownTimer == null)
+            {
+                _verifyCountdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                _verifyCountdownTimer.Tick += (_, _) =>
+                {
+                    _verifyCountdownSecondsLeft--;
+                    if (_verifyCountdownSecondsLeft <= 0) StopVerifyCountdown();
+                    else UpdateVerifyCountdownUi();
+                };
+            }
+            _verifyCountdownTimer.Stop();
+            _verifyCountdownTimer.Start();
+
+            _btnVerifyAccuracy.IsEnabled = false;
+        }
+
+        private void UpdateVerifyCountdownUi() =>
+            _txtVerifyStatus.Text = $"Move your eyes around — the pink dot should track them. {_verifyCountdownSecondsLeft}s left.";
+
+        private void StopVerifyCountdown()
+        {
+            _verifyCountdownTimer?.Stop();
+            _btnVerifyAccuracy.IsEnabled = true;
+            _txtVerifyStatus.Text = "Click Verify to preview accuracy with a live gaze cursor, or close when ready.";
+        }
+
+        private void BtnVerifyBubbleTest_Click()
+        {
+            StopVerifyCountdown();
+            _verifyPanel.IsVisible = false;
+            _shortcutHintBanner.IsVisible = false;
+            _bubbleTestPanel.IsVisible = true;
+            // ponytail: needs App.Webcam's gaze stream + SetGazeAttractor and App.GazeCursor for
+            // RunBubbleTestAsync (dwell detection, residual capture, the FitAxisTrim fine-tune),
+            // wired when they move to Core. Placing the first bubble and its rings uses the real
+            // view code so the panel is not empty.
+            var centre = new Point(Bounds.Width / 2, Bounds.Height / 2);
+            MoveBubbleTo(centre);
+            UpdateRing(_testBubbleRingFg, 0.0);
+        }
+
+        private void BtnVerifyRecalibrate_Click()
+        {
+            StopVerifyCountdown();
+            WantsRecalibrate = true;
+            Close(false);
+        }
+
+        private void BtnVerifyDone_Click()
+        {
+            StopVerifyCountdown();
+            Close(true);
+        }
+
+        /// <summary>
+        /// The tail of FinalizeCalibrationAsync: swap the dot UI for the verify panel. Reached
+        /// from the stubbed pipeline today; kept because it is pure view choreography.
+        /// </summary>
+        private void ShowVerifyPanel()
+        {
+            _validationPanel.IsVisible = false;
+            _dotCanvas.IsVisible = false;
+            _statusPanel.IsVisible = false;
+            _verifyPanel.IsVisible = true;
+            _shortcutHintBanner.IsVisible = true;
+            _completedOk = true;
+        }
+
+        /// <summary>
+        /// The prompt half of RunValidationPhaseAsync / RunGestureCheckAsync. The detection half
+        /// (WaitForBlinksAsync / WaitForMouthOpensAsync / WaitForTongueOutsAsync) is a stub.
+        /// </summary>
+        private void ShowValidationPrompt(string cue, string prompt, string detail, string attempt = "")
+        {
+            _dotCanvas.IsVisible = false;
+            _validationPanel.IsVisible = true;
+            _txtTitle.Text = "Verifying calibration";
+            _txtStatus.Text = "Follow the prompts to confirm the system can read your blinks and mouth.";
+            _txtProgress.Text = "";
+            _txtValidationCue.Text = cue;
+            _txtValidationPrompt.Text = prompt;
+            _txtValidationDetail.Text = detail;
+            _txtValidationAttempt.Text = attempt;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        //  Bubble + dot placement
+        // ─────────────────────────────────────────────────────────────────────
+
+        private void MoveBubbleTo(Point p)
+        {
+            Canvas.SetLeft(_testBubble, p.X - _testBubble.Width / 2);
+            Canvas.SetTop(_testBubble, p.Y - _testBubble.Height / 2);
+            Canvas.SetLeft(_testBubbleRingBg, p.X - _testBubbleRingBg.Width / 2);
+            Canvas.SetTop(_testBubbleRingBg, p.Y - _testBubbleRingBg.Height / 2);
+            Canvas.SetLeft(_testBubbleRingFg, p.X - _testBubbleRingFg.Width / 2);
+            Canvas.SetTop(_testBubbleRingFg, p.Y - _testBubbleRingFg.Height / 2);
+            _testBubble.IsVisible = true;
+            _testBubbleRingBg.IsVisible = true;
+            _testBubbleRingFg.IsVisible = true;
+        }
+
+        private void HideBubble()
+        {
+            _testBubble.IsVisible = false;
+            _testBubbleRingBg.IsVisible = false;
+            _testBubbleRingFg.IsVisible = false;
+        }
+
+        private void MoveDotTo(Point screenPoint)
+        {
+            Canvas.SetLeft(_dot, screenPoint.X - _dot.Width / 2);
+            Canvas.SetTop(_dot, screenPoint.Y - _dot.Height / 2);
+            Canvas.SetLeft(_dotRingBg, screenPoint.X - _dotRingBg.Width / 2);
+            Canvas.SetTop(_dotRingBg, screenPoint.Y - _dotRingBg.Height / 2);
+            Canvas.SetLeft(_dotRingFg, screenPoint.X - _dotRingFg.Width / 2);
+            Canvas.SetTop(_dotRingFg, screenPoint.Y - _dotRingFg.Height / 2);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        //  Per-dot progress ring
+        // ─────────────────────────────────────────────────────────────────────
+
+        // Update the foreground ring's stroke-dash to display the given fraction of the perimeter
+        // as filled (0..1). StrokeDashArray is expressed in *stroke-thickness multiples* on
+        // Avalonia exactly as on WPF, so we divide the pixel perimeter by the stroke thickness to
+        // get the right unit.
+        private void UpdateProgressRing(double progress) => UpdateRing(_dotRingFg, progress);
+
+        private static void UpdateRing(Ellipse ring, double progress)
+        {
+            progress = Math.Clamp(progress, 0.0, 1.0);
+            // The bubble-test ring is an ELLIPSE (taller than wide, matching its target), so the
+            // perimeter can't be 2*pi*r. Ramanujan's second approximation is exact when a == b —
+            // the circular calibration dot ring keeps its previous numbers to the last decimal —
+            // and errs by well under 1e-6 relative at our aspect ratio.
+            double a = (ring.Width - ring.StrokeThickness) / 2.0;
+            double b = (ring.Height - ring.StrokeThickness) / 2.0;
+            double t = (a - b) * (a - b) / Math.Max(1e-9, (a + b) * (a + b));
+            double perimeter = Math.PI * (a + b)
+                * (1.0 + 3.0 * t / (10.0 + Math.Sqrt(Math.Max(0.0, 4.0 - 3.0 * t))));
+            double units = perimeter / ring.StrokeThickness;
+            double visible = progress * units;
+            double gap = Math.Max(0.001, units - visible);
+            ring.StrokeDashArray = new AvaloniaList<double> { visible, gap };
+        }
+
+        private void ResetProgressRing()
+        {
+            _dotRingFg.StrokeDashArray = new AvaloniaList<double> { 0.0, 10000.0 };
+            _dotRingScale.ScaleX = 1.0;
+            _dotRingScale.ScaleY = 1.0;
+            _dotRingFg.Opacity = 1.0;
+        }
+
+        // WPF ran a Storyboard on DotRingScale: a 420ms SineEase DoubleAnimation 1.0 -> 1.18 with
+        // RepeatBehavior.Forever + AutoReverse. Avalonia's Animation cannot drive a Transform -
+        // TransformAnimator casts its target to Visual and throws InvalidCastException (found by
+        // rendering, not by reading) - and the TransformOperations alternative would mean rewriting
+        // the ring's TransformGroup in XAML. A timer driving the same sinusoid is the smaller and
+        // exactly equivalent change: SineEase-in-out over 420ms plus auto-reverse IS one full
+        // cosine period of 840ms between 1.0 and 1.18.
+        private const double RingPulsePeriodMs = 840.0;
+        private const double RingPulseAmplitude = 0.18;
+
+        private void StartRingPulse()
+        {
+            StopRingPulse();
+            long start = Environment.TickCount64;
+            var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(16) };
+            timer.Tick += (_, _) =>
+            {
+                double phase = ((Environment.TickCount64 - start) % (long)RingPulsePeriodMs) / RingPulsePeriodMs;
+                double scale = 1.0 + RingPulseAmplitude * (1.0 - Math.Cos(phase * 2.0 * Math.PI)) / 2.0;
+                _dotRingScale.ScaleX = scale;
+                _dotRingScale.ScaleY = scale;
+            };
+            timer.Start();
+            _ringPulse = timer;
+        }
+
+        private void StopRingPulse()
+        {
+            _ringPulse?.Stop();
+            _ringPulse = null;
+            _dotRingScale.ScaleX = 1.0;
+            _dotRingScale.ScaleY = 1.0;
+        }
+
+        private void ShowError(string detail)
+        {
+            StopRingPulse();
+            _dotCanvas.IsVisible = false;
+            _introPanel.IsVisible = false;
+            _txtErrorDetail.Text = detail;
+            _errorPanel.IsVisible = true;
+        }
+    }
+}


### PR DESCRIPTION
823 lines.

The last group: every view here carried Win32 P/Invoke, which is why it was left until the end. No `DllImport` crossed over. Window styles, z-order, activation, transparency and DPI map onto `X11Overlay.SetClickThrough`/`RestackAbove`, `Topmost`, `ShowActivated`, `ShowInTaskbar`, `TransparencyLevelHint` and Avalonia `Screens`; the global keyboard and mouse hooks have no equivalent in the head today and are stubbed with the lost behaviour named.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351