### PR TITLE
feat(avalonia): port DeeperEditorWindow

### DIFF
--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.ItemsList.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.ItemsList.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using ConditioningControlPanel.Models.Deeper;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// One row in the sidebar Items list.
+    ///
+    /// PORTED from the nested <c>DeeperEditorWindow.TimelineListEntry</c> in
+    /// ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.ItemsList.cs, lifted to namespace
+    /// scope so the row <c>DataTemplate</c> can name it in <c>x:DataType</c> without nested-type
+    /// syntax (compiled bindings are on for this head).
+    /// </summary>
+    public sealed class TimelineListEntry
+    {
+        public string Icon { get; init; } = "";
+        public string KindLabel { get; init; } = "";
+        public int KindOrder { get; init; }
+        public string Label { get; init; } = "";
+        public double TimeSeconds { get; init; }
+        public object? Target { get; init; }
+        public HapticTrack? HapticTrack { get; init; }
+        public IBrush KindBrush { get; init; } = Brushes.Gray;
+
+        public string TimeText => FormatTimeShort(TimeSeconds);
+
+        private static string FormatTimeShort(double seconds)
+        {
+            if (seconds < 0) seconds = 0;
+            var t = TimeSpan.FromSeconds(seconds);
+            return t.TotalHours >= 1
+                ? t.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture)
+                : t.ToString(@"m\:ss", CultureInfo.InvariantCulture);
+        }
+    }
+
+    // PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.ItemsList.cs. Deviations:
+    //   TimelineListEntry            -> lifted out of the class (see above)
+    //   Visibility                   -> IsVisible
+    //   ColorConverter.ConvertFromString -> Color.Parse
+    //   TryFindResource(k) as Brush  -> this.TryFindResource(k, out v) is IBrush
+    //   MouseDoubleClick             -> DoubleTapped
+    //
+    // Sidebar Items list: every rule / effect / haptic / region on the current enhancement, with
+    // two-way selection sync to the timeline and a Time / Kind sort toggle.
+    public partial class DeeperEditorWindow
+    {
+        private bool _itemsListSortByKind;
+        private bool _suppressItemsListSelection;
+
+        private void ItemsListSort_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (RbItemsSortKind == null || RbItemsSortTime == null) return;
+            _itemsListSortByKind = RbItemsSortKind.IsChecked == true;
+            BuildItemsList();
+        }
+
+        // Repopulate the list from current enhancement state and re-sync the ListBox's selection to
+        // whatever the timeline is currently showing. Cheap; safe to call from any
+        // SelectXxx / Add / Delete / drag-end hook.
+        internal void BuildItemsList()
+        {
+            if (ItemsListBox == null) return;
+
+            var entries = new List<TimelineListEntry>();
+
+            foreach (var rule in _enhancement.Rules)
+            {
+                if (rule == null) continue;
+                entries.Add(new TimelineListEntry
+                {
+                    Icon = "🎯",
+                    KindLabel = "Rule",
+                    KindOrder = 0,
+                    Label = DescribeRule(rule),
+                    TimeSeconds = ExtractRuleTime(rule),
+                    Target = rule,
+                    KindBrush = TryFindBrush("DeeperAccentBrush") ?? Brushes.MediumPurple
+                });
+            }
+
+            foreach (var region in _enhancement.Regions)
+            {
+                if (region == null) continue;
+                entries.Add(new TimelineListEntry
+                {
+                    Icon = "▦",
+                    KindLabel = "Region",
+                    KindOrder = 1,
+                    Label = string.IsNullOrWhiteSpace(region.Label) ? (region.Id ?? "(region)") : region.Label!,
+                    TimeSeconds = region.Start,
+                    Target = region,
+                    KindBrush = ParseHexBrush(region.Color) ?? Brushes.MediumPurple
+                });
+            }
+
+            foreach (var track in _enhancement.HapticTracks)
+            {
+                if (track?.Events == null) continue;
+                foreach (var ev in track.Events)
+                {
+                    if (ev == null) continue;
+                    entries.Add(new TimelineListEntry
+                    {
+                        Icon = "📳",
+                        KindLabel = "Haptic",
+                        KindOrder = 2,
+                        Label = string.IsNullOrWhiteSpace(ev.PatternName) ? "Haptic" : ev.PatternName!,
+                        TimeSeconds = ev.Start,
+                        Target = ev,
+                        HapticTrack = track,
+                        KindBrush = ParseHexBrush("#7B5CFF") ?? Brushes.MediumPurple
+                    });
+                }
+            }
+
+            foreach (var item in _enhancement.TimelineItems)
+            {
+                if (item == null || item.Kind != TimelineItemKind.Effect) continue;
+                if (item.EffectType == EffectTypes.Haptic) continue; // surfaced via HapticTracks
+                entries.Add(new TimelineListEntry
+                {
+                    Icon = EffectIcon(item.EffectType),
+                    KindLabel = NiceEffectName(item.EffectType),
+                    KindOrder = 3 + EffectSubOrder(item.EffectType),
+                    Label = DescribeEffect(item),
+                    TimeSeconds = item.Start,
+                    Target = item,
+                    KindBrush = ParseHexBrush(item.Color
+                        ?? (EffectColors.TryGetValue(item.EffectType ?? "", out var c) ? c : null))
+                        ?? Brushes.MediumPurple
+                });
+            }
+
+            if (_itemsListSortByKind)
+                entries = entries.OrderBy(x => x.KindOrder).ThenBy(x => x.TimeSeconds).ToList();
+            else
+                entries = entries.OrderBy(x => x.TimeSeconds).ThenBy(x => x.KindOrder).ToList();
+
+            _suppressItemsListSelection = true;
+            try
+            {
+                ItemsListBox.ItemsSource = entries;
+                var match = entries.FirstOrDefault(IsEntrySelected);
+                ItemsListBox.SelectedItem = match;
+                if (match != null) { try { ItemsListBox.ScrollIntoView(match); } catch { } }
+            }
+            finally { ClearWhenEventsDrained(() => _suppressItemsListSelection = false); }
+
+            if (TxtItemsListCount != null)
+                TxtItemsListCount.Text = entries.Count == 0 ? "" : $"({entries.Count})";
+            if (TxtItemsListEmpty != null)
+                TxtItemsListEmpty.IsVisible = entries.Count == 0;
+        }
+
+        private bool IsEntrySelected(TimelineListEntry e)
+        {
+            return ReferenceEquals(e.Target, _selectedRule)
+                || ReferenceEquals(e.Target, _selectedRegion)
+                || ReferenceEquals(e.Target, _selectedHaptic)
+                || ReferenceEquals(e.Target, _selectedEffect);
+        }
+
+        private void ItemsListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressItemsListSelection) return;
+            if (ItemsListBox?.SelectedItem is not TimelineListEntry entry) return;
+            ActivateEntry(entry);
+        }
+
+        // Row-level delete (x button). Routes through the same per-type delete path each toolbar
+        // delete button uses so undo / cleanup / validation behaviour stays identical. Handled
+        // keeps the click from also selecting the row.
+        //
+        // Wired from the constructor by walking the template's Button (Classes="itemsListDelete")
+        // rather than a XAML Click= attribute, because Avalonia's compiled-binding DataTemplates
+        // resolve a Click handler against the DataContext (a TimelineListEntry), not the Window.
+        private void ItemsListDelete_Click(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn) return;
+            if (btn.Tag is not TimelineListEntry entry) return;
+            e.Handled = true;
+
+            switch (entry.Target)
+            {
+                case EnhancementRule rule:
+                    _selectedRule = rule;
+                    BtnDeleteRule_Click(this, new RoutedEventArgs());
+                    break;
+                case Region region:
+                    _selectedRegion = region;
+                    BtnDeleteRegion_Click(this, new RoutedEventArgs());
+                    break;
+                case HapticEvent ev when entry.HapticTrack != null:
+                    _selectedHaptic = ev;
+                    _selectedHapticTrack = entry.HapticTrack;
+                    BtnDeleteHaptic_Click(this, new RoutedEventArgs());
+                    break;
+                case TimelineItem ti:
+                    _selectedEffect = ti;
+                    BtnDeleteEffect_Click(this, new RoutedEventArgs());
+                    break;
+            }
+        }
+
+        // Double-click also seeks the playhead to the item's time so the user can jump to where
+        // the effect fires.
+        private void ItemsListBox_DoubleTapped(object? sender, RoutedEventArgs e)
+        {
+            if (ItemsListBox?.SelectedItem is not TimelineListEntry entry) return;
+            if (_totalSeconds <= 0) return;
+            var frac = Math.Clamp(entry.TimeSeconds / _totalSeconds, 0, 1);
+            SeekToFraction(frac);
+        }
+
+        private void ActivateEntry(TimelineListEntry entry)
+        {
+            switch (entry.Target)
+            {
+                case EnhancementRule rule:
+                    SelectRule(rule);
+                    break;
+                case Region region:
+                    SelectRegion(region);
+                    break;
+                case HapticEvent ev when entry.HapticTrack != null:
+                    SelectHaptic(entry.HapticTrack, ev);
+                    break;
+                case TimelineItem ti:
+                    SelectEffect(ti);
+                    break;
+            }
+        }
+
+        private static double ExtractRuleTime(EnhancementRule rule)
+        {
+            // Time-reached fires at an explicit time; everything else falls back to 0 so the list
+            // is scannable chronologically.
+            if (rule.Trigger is TimeReachedTrigger tr) return Math.Max(0, tr.Time);
+            return 0;
+        }
+
+        private static string DescribeRule(EnhancementRule rule)
+        {
+            var trigger = FriendlyTriggerName(rule.Trigger?.Type ?? "");
+            var action = FriendlyActionName(rule.Action?.Type ?? "");
+            return $"{trigger} → {action}";
+        }
+
+        private static string DescribeEffect(TimelineItem item)
+        {
+            var kind = NiceEffectName(item.EffectType);
+            if (item.EffectType == EffectTypes.Subliminal && !string.IsNullOrWhiteSpace(item.EffectText))
+                return $"{kind}: {Truncate(item.EffectText!, 36)}";
+            if (item.EffectType == EffectTypes.Overlay && !string.IsNullOrWhiteSpace(item.EffectOverlayKind))
+                return $"{kind} · {item.EffectOverlayKind}";
+            return kind;
+        }
+
+        private static string Truncate(string s, int max)
+            => s.Length <= max ? s : s.Substring(0, max - 1) + "…";
+
+        private static string EffectIcon(string? type) => type switch
+        {
+            EffectTypes.Flash      => "⚡",
+            EffectTypes.Bubble     => "🫧",
+            EffectTypes.Subliminal => "💭",
+            EffectTypes.Overlay    => "🟪",
+            _                      => "✨"
+        };
+
+        private static string NiceEffectName(string? type) => type switch
+        {
+            EffectTypes.Flash      => "Flash",
+            EffectTypes.Bubble     => "Bubble",
+            EffectTypes.Subliminal => "Subliminal",
+            EffectTypes.Overlay    => "Overlay",
+            EffectTypes.Haptic     => "Haptic",
+            _                      => string.IsNullOrEmpty(type) ? "Effect" : type!
+        };
+
+        private static int EffectSubOrder(string? type) => type switch
+        {
+            EffectTypes.Flash      => 0,
+            EffectTypes.Bubble     => 1,
+            EffectTypes.Subliminal => 2,
+            EffectTypes.Overlay    => 3,
+            _                      => 9
+        };
+
+        private IBrush? TryFindBrush(string resourceKey)
+        {
+            try
+            {
+                return this.TryFindResource(resourceKey, out var v) && v is IBrush b ? b : null;
+            }
+            catch { return null; }
+        }
+
+        private static IBrush? ParseHexBrush(string? hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex)) return null;
+            try { return new SolidColorBrush(Color.Parse(hex!)); }
+            catch { return null; }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.LaneChrome.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.LaneChrome.cs
@@ -1,0 +1,73 @@
+using System.Globalization;
+using ConditioningControlPanel.Models.Deeper;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    // PORTED near-verbatim from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.LaneChrome.cs.
+    // Pure geometry + counters, no WPF types, so the only edit is Visibility -> IsVisible (none
+    // needed here) and the empty-string convention for a zero count, unchanged.
+    //
+    // Lane chrome bookkeeping: the per-lane item counts in the header column. The shapes still
+    // render onto the single TimelineCanvas with the y-band layout below.
+    public partial class DeeperEditorWindow
+    {
+        // The timeline canvas is split into three equal horizontal lanes, top-to-bottom:
+        // Regions, Effects, Haptics. Rules are NOT a lane - they render as full-height pins
+        // layered across all three. This is the single source of truth for lane geometry;
+        // every Build*/hit-test path resolves its Y band through LaneBand().
+        private enum TimelineLane { Regions, Effects, Haptics }
+
+        private static (double top, double height) LaneBand(TimelineLane lane, double canvasHeight)
+        {
+            if (canvasHeight <= 0) return (0, 0);
+            double laneH = canvasHeight / 3.0;
+            double top = lane switch
+            {
+                TimelineLane.Regions => 0,
+                TimelineLane.Effects => laneH,
+                TimelineLane.Haptics => 2 * laneH,
+                _ => 0
+            };
+            return (top, laneH);
+        }
+
+        // Inset band rect for a lane (a few px of breathing room above/below so adjacent lanes
+        // read as distinct). Used by region/haptic/effect-segment bands.
+        private const double LaneInset = 2.0;
+
+        private static (double top, double height) LaneBandInset(TimelineLane lane, double canvasHeight)
+        {
+            var (top, height) = LaneBand(lane, canvasHeight);
+            return (top + LaneInset, System.Math.Max(0, height - 2 * LaneInset));
+        }
+
+        private void RefreshLaneCounts()
+        {
+            try
+            {
+                int regions = _enhancement?.Regions?.Count ?? 0;
+                int haptics = 0;
+                if (_enhancement?.HapticTracks != null)
+                {
+                    foreach (var t in _enhancement.HapticTracks)
+                        if (t?.Events != null) haptics += t.Events.Count;
+                }
+                int effects = 0;
+                if (_enhancement?.TimelineItems != null)
+                {
+                    foreach (var ti in _enhancement.TimelineItems)
+                        if (ti != null && ti.Kind == TimelineItemKind.Effect &&
+                            ti.EffectType != EffectTypes.Haptic) effects++;
+                }
+
+                if (TxtRegionsLaneCount != null)
+                    TxtRegionsLaneCount.Text = regions == 0 ? "" : regions.ToString(CultureInfo.InvariantCulture);
+                if (TxtEffectsLaneCount != null)
+                    TxtEffectsLaneCount.Text = effects == 0 ? "" : effects.ToString(CultureInfo.InvariantCulture);
+                if (TxtHapticsLaneCount != null)
+                    TxtHapticsLaneCount.Text = haptics == 0 ? "" : haptics.ToString(CultureInfo.InvariantCulture);
+            }
+            catch { }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.MetadataDrawer.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.MetadataDrawer.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models.Deeper;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    // PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.MetadataDrawer.cs.
+    // Deviations:
+    //   Visibility               -> IsVisible
+    //   FontStyles.Italic        -> FontStyle.Italic
+    //   FindResource(k)          -> Res(k) (TryFindResource + IBrush cast; see the main partial)
+    //   UpdateLayout()           -> InvalidateMeasure() (Avalonia has no synchronous UpdateLayout
+    //                               on Window; the drawer is measured on the next layout pass)
+    //   ScrollViewer.ScrollToTop -> Offset = new Vector(x, 0)
+    //   GridSplitter DragCompleted args -> Avalonia's Thumb.DragCompleted (VectorEventArgs)
+    //   App.Settings             -> stubbed, see ApplyPersistedSidebarWidth
+    //
+    // Sidebar restructure plumbing: metadata drawer expand/collapse, the selection summary strip,
+    // GridSplitter persistence and the inspector auto-scroll.
+    public partial class DeeperEditorWindow
+    {
+        // -----------------------------------------------------------------
+        // Metadata drawer
+        // -----------------------------------------------------------------
+
+        // Public so tutorial steps' PrepareTargetWindowAction can expand the drawer before
+        // measuring a target field. Idempotent.
+        public void ExpandMetadataDrawer()
+        {
+            try
+            {
+                if (MetadataDrawerToggle != null && MetadataDrawerToggle.IsChecked != true)
+                    MetadataDrawerToggle.IsChecked = true; // fires IsCheckedChanged -> MetadataDrawerToggle_Changed
+                else
+                    ApplyMetadataDrawerState();
+                InvalidateMeasure();
+            }
+            catch { }
+        }
+
+        private void MetadataDrawerToggle_Changed(object? sender, RoutedEventArgs e)
+        {
+            ApplyMetadataDrawerState();
+        }
+
+        private void ApplyMetadataDrawerState()
+        {
+            if (MetadataDrawerToggle == null || MetadataDrawerContent == null) return;
+            bool open = MetadataDrawerToggle.IsChecked == true;
+            MetadataDrawerContent.IsVisible = open;
+            if (MetadataDrawerChevron != null)
+                MetadataDrawerChevron.Text = open ? "▼" : "▶";
+        }
+
+        // Called from UpdateTitle() so the drawer chip shows the current project name even while
+        // collapsed. Falls back to nothing if no name is set.
+        private void UpdateMetadataDrawerSubtitle()
+        {
+            try
+            {
+                if (TxtMetadataDrawerSubtitle == null) return;
+                var name = _enhancement?.Metadata?.Name;
+                if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrEmpty(_filePath))
+                    name = Path.GetFileNameWithoutExtension(_filePath);
+                TxtMetadataDrawerSubtitle.Text = string.IsNullOrWhiteSpace(name)
+                    ? ""
+                    : "· " + name;
+            }
+            catch { }
+        }
+
+        // -----------------------------------------------------------------
+        // Selection summary strip
+        // -----------------------------------------------------------------
+
+        // Single source of truth for the 44-px strip above the inspector. Re-rendered on every
+        // selection change (single OR multi).
+        private void UpdateSelectionSummary()
+        {
+            if (TxtSelectionSummary == null) return;
+            try
+            {
+                string text;
+                bool active = false;
+
+                if (_selectionSet != null && _selectionSet.Count > 1)
+                {
+                    text = BuildMultiSelectionSummary();
+                    active = true;
+                }
+                else if (_selectedRule != null)
+                {
+                    text = BuildRuleSelectionSummary(_selectedRule);
+                    active = true;
+                }
+                else if (_selectedRegion != null)
+                {
+                    text = BuildRegionSelectionSummary(_selectedRegion);
+                    active = true;
+                }
+                else if (_selectedHaptic != null)
+                {
+                    text = BuildHapticSelectionSummary(_selectedHaptic);
+                    active = true;
+                }
+                else if (_selectedEffect != null)
+                {
+                    text = BuildEffectSelectionSummary(_selectedEffect);
+                    active = true;
+                }
+                else
+                {
+                    text = Loc.Get("deeper_editor_selection_none");
+                }
+
+                TxtSelectionSummary.Text = text;
+                TxtSelectionSummary.FontStyle = active ? FontStyle.Normal : FontStyle.Italic;
+                TxtSelectionSummary.Foreground = active ? Res("TextLightBrush") : Res("TextMutedBrush");
+            }
+            catch (Exception ex) { Log.Debug("DeeperEditor: UpdateSelectionSummary error: {Error}", ex.Message); }
+        }
+
+        private string BuildRuleSelectionSummary(EnhancementRule rule)
+        {
+            var trig = FriendlyTriggerName(rule.Trigger?.Type ?? "");
+            if (rule.Trigger is TimeReachedTrigger trt)
+                return $"{Loc.Get("deeper_editor_selection_kind_rule")} · {trig} @ {FormatTimeShort(trt.Time)}";
+            if (!string.IsNullOrEmpty(rule.RegionConstraint))
+            {
+                var region = _enhancement?.Regions.FirstOrDefault(r => r != null && r.Id == rule.RegionConstraint);
+                if (region != null)
+                    return $"{Loc.Get("deeper_editor_selection_kind_rule")} · {trig} · {region.Label ?? region.Id}";
+            }
+            return $"{Loc.Get("deeper_editor_selection_kind_rule")} · {trig}";
+        }
+
+        private static string BuildRegionSelectionSummary(Region region)
+        {
+            var label = string.IsNullOrWhiteSpace(region.Label) ? region.Id : region.Label;
+            return $"{Loc.Get("deeper_editor_selection_kind_region")} · {label} ({FormatTimeShort(region.Start)}–{FormatTimeShort(region.End)})";
+        }
+
+        private static string BuildHapticSelectionSummary(HapticEvent ev)
+        {
+            var pattern = string.IsNullOrWhiteSpace(ev.PatternName)
+                ? Loc.Get("deeper_editor_haptic_pattern_custom")
+                : ev.PatternName!;
+            return $"{Loc.Get("deeper_editor_selection_kind_haptic")} · {pattern} · {ev.Duration.ToString("0.#", CultureInfo.InvariantCulture)}s";
+        }
+
+        private string BuildEffectSelectionSummary(TimelineItem item)
+        {
+            return $"{FriendlyEffectName(item.EffectType)} · {BuildEffectDetail(item)} @ {FormatTimeShort(item.Start)}";
+        }
+
+        private string BuildMultiSelectionSummary()
+        {
+            int rules = 0, regions = 0, haptics = 0, effects = 0;
+            foreach (var sel in _selectionSet!)
+            {
+                switch (sel)
+                {
+                    case EnhancementRule: rules++; break;
+                    case Region: regions++; break;
+                    case HapticEvent: haptics++; break;
+                    case TimelineItem ti when ti.Kind == TimelineItemKind.Effect: effects++; break;
+                }
+            }
+            int total = rules + regions + haptics + effects;
+            var sb = new StringBuilder();
+            sb.AppendFormat(CultureInfo.InvariantCulture,
+                Loc.Get("deeper_editor_selection_multi_total"), total);
+            var parts = new System.Collections.Generic.List<string>();
+            if (rules > 0)   parts.Add($"{rules} {Loc.Get("deeper_editor_selection_kind_rules_plural")}");
+            if (regions > 0) parts.Add($"{regions} {Loc.Get("deeper_editor_selection_kind_regions_plural")}");
+            if (haptics > 0) parts.Add($"{haptics} {Loc.Get("deeper_editor_selection_kind_haptics_plural")}");
+            if (effects > 0) parts.Add($"{effects} {Loc.Get("deeper_editor_selection_kind_effects_plural")}");
+            if (parts.Count > 0)
+            {
+                sb.Append(" · ");
+                sb.Append(string.Join(", ", parts));
+            }
+            return sb.ToString();
+        }
+
+        // -----------------------------------------------------------------
+        // Sidebar splitter - persist width
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Applied during Loaded so the editor opens at the user's last chosen width.
+        /// ponytail: needs App.Settings (AppSettings.DeeperEditorSidebarWidth), wired when the
+        /// settings service moves to Core. Until then the column keeps its 380 px XAML default,
+        /// which is what the WPF fallback used anyway.
+        /// </summary>
+        /// <summary>The resizable sidebar column. WPF reached it through its x:Name; Avalonia
+        /// only generates fields for Controls, so it is indexed off the named body Grid.</summary>
+        private ColumnDefinition? SidebarColumn =>
+            MainBodyGrid?.ColumnDefinitions is { Count: > 2 } cols ? cols[2] : null;
+
+        public void ApplyPersistedSidebarWidth()
+        {
+            try
+            {
+                var col = SidebarColumn;
+                if (col == null) return;
+                int w = 380;
+                if (w < 320) w = 320;
+                if (w > 520) w = 520;
+                col.Width = new GridLength(w, GridUnitType.Pixel);
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// ponytail: needs App.Settings to persist the dragged width; the drag itself is live
+        /// (Avalonia's GridSplitter writes the ColumnDefinition), only the save is missing.
+        /// </summary>
+        private void SidebarSplitter_DragCompleted(object? sender, VectorEventArgs e)
+        {
+            try
+            {
+                var col = SidebarColumn;
+                if (col == null) return;
+                int w = (int)Math.Round(col.ActualWidth);
+                if (w < 320) w = 320;
+                if (w > 520) w = 520;
+                // App.Settings.Current.DeeperEditorSidebarWidth = w; App.Settings.Save();
+            }
+            catch { }
+        }
+
+        // -----------------------------------------------------------------
+        // Inspector auto-scroll
+        // -----------------------------------------------------------------
+
+        // Called after the inspector swaps in a new editor panel; brings the visible editor's
+        // first row into view so the user doesn't have to hunt for it.
+        public void ScrollInspectorToTop()
+        {
+            try
+            {
+                if (InspectorScroll != null)
+                    InspectorScroll.Offset = new Vector(InspectorScroll.Offset.X, 0);
+            }
+            catch { }
+        }
+
+        // -----------------------------------------------------------------
+        // Shared friendly-label helpers
+        // -----------------------------------------------------------------
+
+        private static string FriendlyEffectName(string? effectType) => effectType switch
+        {
+            EffectTypes.Flash      => Loc.Get("deeper_friendly_effect_flash"),
+            EffectTypes.Bubble     => Loc.Get("deeper_friendly_effect_bubble"),
+            EffectTypes.Subliminal => Loc.Get("deeper_friendly_effect_subliminal"),
+            EffectTypes.Overlay    => Loc.Get("deeper_friendly_effect_overlay"),
+            EffectTypes.Haptic     => Loc.Get("deeper_friendly_effect_haptic"),
+            _ => effectType ?? "Effect"
+        };
+
+        private static string BuildEffectDetail(TimelineItem ti)
+        {
+            switch (ti.EffectType)
+            {
+                case EffectTypes.Subliminal:
+                    return string.IsNullOrEmpty(ti.EffectText)
+                        ? $"{ti.EffectDurationMs} ms"
+                        : ti.EffectText!.Length > 32 ? ti.EffectText![..32] + "…" : ti.EffectText!;
+                case EffectTypes.Overlay:
+                    return $"{ti.EffectOverlayKind ?? OverlayKinds.PinkFilter} · {ti.EffectDurationMs} ms";
+                case EffectTypes.Bubble:
+                    return $"{(ti.EffectDurationMs / 1000.0).ToString("0.#", CultureInfo.InvariantCulture)} s";
+                case EffectTypes.Flash:
+                    return $"{ti.EffectDurationMs} ms";
+                default:
+                    return ti.EffectDurationMs > 0 ? $"{ti.EffectDurationMs} ms" : "";
+            }
+        }
+
+        private static string FormatTimeShort(double seconds)
+        {
+            if (double.IsNaN(seconds) || seconds < 0) seconds = 0;
+            int total = (int)Math.Round(seconds);
+            int m = total / 60;
+            int s = total % 60;
+            return string.Format(CultureInfo.InvariantCulture, "{0}:{1:D2}", m, s);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.MultiSelect.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.MultiSelect.cs
@@ -1,0 +1,720 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Media;
+using ConditioningControlPanel.Models.Deeper;
+using ConditioningControlPanel.Services.Deeper;
+using Newtonsoft.Json;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    // PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.MultiSelect.cs.
+    // Everything here is data manipulation over Core models plus a rubber-band rectangle, so it
+    // ports whole. Deviations:
+    //   Keyboard.Modifiers        -> the modifiers are THREADED from the pointer/key event args.
+    //                                Avalonia has no global modifier query, and inventing a
+    //                                tracker would be a second source of truth. HandleSelectionClick
+    //                                and IsCtrlDown therefore take a KeyModifiers argument.
+    //   System.Windows.Shapes.*   -> Avalonia.Controls.Shapes.*
+    //   Panel.SetZIndex(v, n)     -> v.ZIndex = n
+    //   ActualWidth/Height        -> Bounds.Width / Bounds.Height
+    //   DoubleCollection          -> AvaloniaList<double>
+    //   App.Logger                -> Serilog.Log
+    // Undo/redo is UNCHANGED: EnhancementSerializer and Newtonsoft.Json both live in Core.
+    public partial class DeeperEditorWindow
+    {
+        // -- Multi-select state ------------------------------------------------
+        // Holds Region | HapticEvent | TimelineItem (effects only - Rules don't have a timeline
+        // visual the user can rubber-band). The single _selectedXxx fields remain the *primary*
+        // selection (drives which side-panel editor is shown); _selectionSet drives only the
+        // visual highlight + bulk operations (delete/copy/cut).
+        internal readonly HashSet<object> _selectionSet = new();
+
+        // -- Rubber-band drag state -------------------------------------------
+        private Rectangle? _rubberBandRect;
+        private Point _rbStartCanvasPt;
+        private const double RubberBandThresholdPx = 3.0;
+
+        // -- Clipboard ---------------------------------------------------------
+        // Process-wide so the user can copy in one editor window and paste in another.
+        internal static class DeeperClipboard
+        {
+            public static List<TimelineItem> Items = new();
+            public static List<Region> Regions = new();
+            public static List<HapticEvent> Haptics = new();
+            public static double AnchorSeconds;
+            public static bool HasContent =>
+                Items.Count > 0 || Regions.Count > 0 || Haptics.Count > 0;
+        }
+
+        // -- Undo / Redo (snapshot-based) -------------------------------------
+        // Snapshots are JSON of the entire Enhancement; for a typical project (~10-100KB) and a
+        // cap of 50 entries this is comfortably under any RAM concern and avoids the full
+        // bookkeeping of a command pattern.
+        private readonly Stack<string> _undo = new();
+        private readonly Stack<string> _redo = new();
+        private const int UndoCap = 50;
+        private bool _suppressUndoSnapshot;
+        // Set by drag handlers the first tick a mutation actually happens, cleared on release.
+        internal bool _dragSnapshotPushed;
+
+        // -- Multi-select helpers ---------------------------------------------
+
+        /// <summary>
+        /// Drive selection in response to a click on a timeline item. Ctrl held = toggle the item's
+        /// membership in the selection set (without changing the primary anchor). Plain click on an
+        /// item already part of a multi-selection PRESERVES the set so the click can initiate a
+        /// group drag; clicking an outside item collapses the set to just that item.
+        /// </summary>
+        private void HandleSelectionClick(object item, KeyModifiers modifiers)
+        {
+            bool ctrl = IsCtrlDown(modifiers);
+            if (ctrl)
+            {
+                if (!_selectionSet.Add(item)) _selectionSet.Remove(item);
+            }
+            else if (!_selectionSet.Contains(item))
+            {
+                _selectionSet.Clear();
+                _selectionSet.Add(item);
+            }
+            // else: plain click on an already-selected item - leave the set intact so the
+            // subsequent drag moves the whole group.
+        }
+
+        internal bool IsInSelectionSet(object? item) => item != null && _selectionSet.Contains(item);
+
+        /// <summary>True when Ctrl was held during the current gesture so the caller should treat
+        /// it as a pure selection toggle and skip all drag-init / pointer-capture work.
+        /// WPF read Keyboard.Modifiers statically; Avalonia has no such query, so the caller
+        /// threads the event's own KeyModifiers in.</summary>
+        internal static bool IsCtrlDown(KeyModifiers modifiers)
+            => (modifiers & KeyModifiers.Control) == KeyModifiers.Control;
+
+        // -- Group drag --------------------------------------------------------
+        // When a drag starts on an item that's part of a multi-selection, capture every selected
+        // item's original Start so the move handler can apply a single clamped delta to all of them.
+
+        private readonly Dictionary<object, double> _multiDragOriginalStart = new();
+        private double _multiDragMinDelta;
+        private double _multiDragMaxDelta;
+
+        internal void BeginMultiDragCapture()
+        {
+            _multiDragOriginalStart.Clear();
+            if (_selectionSet.Count <= 1) return;
+
+            double minStart = double.MaxValue;
+            double maxEnd = double.MinValue;
+            foreach (var sel in _selectionSet)
+            {
+                switch (sel)
+                {
+                    case Region r:
+                        _multiDragOriginalStart[r] = r.Start;
+                        if (r.Start < minStart) minStart = r.Start;
+                        if (r.End > maxEnd) maxEnd = r.End;
+                        break;
+                    case TimelineItem ti:
+                        _multiDragOriginalStart[ti] = ti.Start;
+                        if (ti.Start < minStart) minStart = ti.Start;
+                        var tiEnd = ti.Start + Math.Max(0, ti.Duration);
+                        if (tiEnd > maxEnd) maxEnd = tiEnd;
+                        break;
+                    case HapticEvent ev:
+                        _multiDragOriginalStart[ev] = ev.Start;
+                        if (ev.Start < minStart) minStart = ev.Start;
+                        var evEnd = ev.Start + ev.Duration;
+                        if (evEnd > maxEnd) maxEnd = evEnd;
+                        break;
+                }
+            }
+
+            // Bound the group within the timeline. If _totalSeconds is unknown (no media loaded),
+            // don't constrain the right edge.
+            _multiDragMinDelta = -minStart;
+            _multiDragMaxDelta = (_totalSeconds > 0 ? _totalSeconds : double.PositiveInfinity) - maxEnd;
+        }
+
+        internal void EndMultiDragCapture() => _multiDragOriginalStart.Clear();
+
+        internal bool IsMultiDragActive => _multiDragOriginalStart.Count > 1;
+
+        /// <summary>
+        /// Compute the primary item's new Start under the active drag, then - if a multi-selection
+        /// drag is in progress - apply the same clamped delta to every other selected item. The
+        /// caller assigns the return value to primary.Start (and adjusts End / Duration as before).
+        /// </summary>
+        internal double ComputeShift(object primary, double mouseSec, double dragOffsetSec, double primaryDuration)
+        {
+            var desiredNewStart = mouseSec - dragOffsetSec;
+
+            if (!IsMultiDragActive)
+            {
+                var maxStart = _totalSeconds > 0 ? Math.Max(0, _totalSeconds - primaryDuration) : double.MaxValue;
+                return Math.Max(0, Math.Min(maxStart, desiredNewStart));
+            }
+
+            var primaryOrig = _multiDragOriginalStart.TryGetValue(primary, out var po) ? po : 0;
+            var desiredDelta = desiredNewStart - primaryOrig;
+            var clamped = Math.Max(_multiDragMinDelta, Math.Min(_multiDragMaxDelta, desiredDelta));
+
+            foreach (var (item, originalStart) in _multiDragOriginalStart)
+            {
+                if (ReferenceEquals(item, primary)) continue;
+                var newStart = originalStart + clamped;
+                switch (item)
+                {
+                    case Region r:
+                        var len = Math.Max(0, r.End - r.Start);
+                        r.Start = newStart;
+                        r.End = newStart + len;
+                        break;
+                    case TimelineItem ti:
+                        ti.Start = newStart;
+                        break;
+                    case HapticEvent ev:
+                        ev.Start = newStart;
+                        break;
+                }
+            }
+            return primaryOrig + clamped;
+        }
+
+        // -- Rubber-band drag --------------------------------------------------
+
+        private void StartRubberBand(Point canvasPt)
+        {
+            _rbStartCanvasPt = canvasPt;
+            _rubberBandRect = null; // lazy-create once we exceed the threshold
+        }
+
+        private void UpdateRubberBand(Point canvasPt)
+        {
+            // Defer the visual creation until the user has actually moved past the threshold;
+            // otherwise a short click flashes a tiny rectangle.
+            var dx = Math.Abs(canvasPt.X - _rbStartCanvasPt.X);
+            var dy = Math.Abs(canvasPt.Y - _rbStartCanvasPt.Y);
+            if (_rubberBandRect == null && dx < RubberBandThresholdPx && dy < RubberBandThresholdPx) return;
+
+            if (_rubberBandRect == null)
+            {
+                _rubberBandRect = new Rectangle
+                {
+                    Fill = new SolidColorBrush(Color.FromArgb(0x30, 0x68, 0xF0, 0xFF)),
+                    Stroke = new SolidColorBrush(Color.FromArgb(0xC0, 0xB0, 0xE0, 0xFF)),
+                    StrokeThickness = 1,
+                    StrokeDashArray = new global::Avalonia.Collections.AvaloniaList<double> { 2, 2 },
+                    IsHitTestVisible = false,
+                    ZIndex = 50
+                };
+                TimelineCanvas.Children.Add(_rubberBandRect);
+            }
+
+            var x = Math.Min(_rbStartCanvasPt.X, canvasPt.X);
+            var y = Math.Min(_rbStartCanvasPt.Y, canvasPt.Y);
+            var w = Math.Abs(canvasPt.X - _rbStartCanvasPt.X);
+            var h = Math.Abs(canvasPt.Y - _rbStartCanvasPt.Y);
+            Canvas.SetLeft(_rubberBandRect, x);
+            Canvas.SetTop(_rubberBandRect, y);
+            _rubberBandRect.Width = w;
+            _rubberBandRect.Height = h;
+        }
+
+        /// <summary>
+        /// Returns true if the rubber-band actually drew (i.e. the user dragged past the
+        /// threshold). On true, the selection set is replaced with the items inside; on false, the
+        /// caller should treat the gesture as a plain click.
+        /// </summary>
+        private bool FinishRubberBand(Point canvasPt)
+        {
+            if (_rubberBandRect == null) return false;
+
+            try
+            {
+                TimelineCanvas.Children.Remove(_rubberBandRect);
+                var canvasW = TimelineCanvas.Bounds.Width;
+                var canvasH = TimelineCanvas.Bounds.Height;
+                if (canvasW <= 0 || canvasH <= 0 || _totalSeconds <= 0) return true;
+
+                double xMin = Math.Max(0, Math.Min(_rbStartCanvasPt.X, canvasPt.X));
+                double xMax = Math.Min(canvasW, Math.Max(_rbStartCanvasPt.X, canvasPt.X));
+                double yMin = Math.Max(0, Math.Min(_rbStartCanvasPt.Y, canvasPt.Y));
+                double yMax = Math.Min(canvasH, Math.Max(_rbStartCanvasPt.Y, canvasPt.Y));
+
+                double tMin = (xMin / canvasW) * _totalSeconds;
+                double tMax = (xMax / canvasW) * _totalSeconds;
+
+                _selectionSet.Clear();
+
+                // Lane Y mapping goes through LaneBand so the hit math stays in lockstep with the
+                // rebuild methods (the WPF original hardcoded the old two-lane geometry here and
+                // had drifted from what it draws).
+                var (regionLaneTop, regionLaneH) = LaneBand(TimelineLane.Regions, canvasH);
+                var (effectLaneTop, effectLaneH) = LaneBand(TimelineLane.Effects, canvasH);
+                var (hapticLaneTop, hapticLaneH) = LaneBand(TimelineLane.Haptics, canvasH);
+
+                bool RangesOverlap(double a1, double a2, double b1, double b2) => a1 < b2 && a2 > b1;
+
+                if (RangesOverlap(yMin, yMax, regionLaneTop, regionLaneTop + regionLaneH))
+                {
+                    foreach (var r in _enhancement.Regions)
+                    {
+                        if (r == null) continue;
+                        if (RangesOverlap(tMin, tMax, r.Start, r.End))
+                            _selectionSet.Add(r);
+                    }
+                }
+                if (RangesOverlap(yMin, yMax, hapticLaneTop, hapticLaneTop + hapticLaneH))
+                {
+                    foreach (var track in _enhancement.HapticTracks)
+                    {
+                        if (track?.Events == null) continue;
+                        foreach (var ev in track.Events)
+                        {
+                            if (ev == null) continue;
+                            if (RangesOverlap(tMin, tMax, ev.Start, ev.Start + ev.Duration))
+                                _selectionSet.Add(ev);
+                        }
+                    }
+                }
+                if (RangesOverlap(yMin, yMax, effectLaneTop, effectLaneTop + effectLaneH))
+                {
+                    foreach (var item in _enhancement.TimelineItems)
+                    {
+                        if (item == null || item.Kind != TimelineItemKind.Effect) continue;
+                        if (item.EffectType == EffectTypes.Haptic) continue; // legacy lane
+                        var dur = Math.Max(0, item.Duration);
+                        if (RangesOverlap(tMin, tMax, item.Start, item.Start + dur))
+                            _selectionSet.Add(item);
+                    }
+                }
+
+                // Promote the first selected item to be the primary anchor so the side panel shows
+                // something useful.
+                _selectedRegion = _selectionSet.OfType<Region>().FirstOrDefault();
+                _selectedHaptic = _selectionSet.OfType<HapticEvent>().FirstOrDefault();
+                if (_selectedHaptic != null)
+                {
+                    _selectedHapticTrack = _enhancement.HapticTracks.FirstOrDefault(t => t?.Events?.Contains(_selectedHaptic) == true);
+                }
+                _selectedEffect = _selectionSet.OfType<TimelineItem>().FirstOrDefault();
+                _selectedRule = null;
+                UpdateSelectedSidePanel();
+
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+            }
+            finally
+            {
+                _rubberBandRect = null;
+            }
+            return true;
+        }
+
+        // -- Bulk delete -------------------------------------------------------
+
+        internal void DeleteSelection()
+        {
+            if (_selectionSet.Count == 0) return;
+            PushUndoSnapshot();
+            try
+            {
+                foreach (var sel in _selectionSet.ToList())
+                {
+                    switch (sel)
+                    {
+                        case Region r:
+                            _enhancement.Regions.Remove(r);
+                            // Detach any rule that pointed at this region.
+                            foreach (var rule in _enhancement.Rules)
+                            {
+                                if (rule.RegionConstraint == r.Id) rule.RegionConstraint = null;
+                            }
+                            // Remove the paired Rule-kind TimelineItem the loader projected for
+                            // this region, otherwise BackProject on save resurrects it.
+                            if (!string.IsNullOrEmpty(r.Id))
+                            {
+                                _enhancement.TimelineItems.RemoveAll(ti =>
+                                    ti != null
+                                    && ti.Kind == TimelineItemKind.Rule
+                                    && ti.Id == r.Id);
+                            }
+                            break;
+                        case HapticEvent ev:
+                            foreach (var track in _enhancement.HapticTracks)
+                                if (track?.Events != null && track.Events.Remove(ev)) break;
+                            break;
+                        case TimelineItem ti:
+                            _enhancement.TimelineItems.Remove(ti);
+                            break;
+                    }
+                }
+                _selectionSet.Clear();
+                _selectedRegion = null;
+                _selectedHaptic = null;
+                _selectedHapticTrack = null;
+                _selectedEffect = null;
+                _selectedRule = null;
+                UpdateSelectedSidePanel();
+                MarkDirty();
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                RefreshRulesList();
+                ScheduleValidation();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: DeleteSelection error: {Error}", ex.Message);
+            }
+        }
+
+        // -- Clipboard --------------------------------------------------------
+
+        internal void CopySelection()
+        {
+            if (_selectionSet.Count == 0) return;
+            try
+            {
+                DeeperClipboard.Items.Clear();
+                DeeperClipboard.Regions.Clear();
+                DeeperClipboard.Haptics.Clear();
+
+                double anchor = double.MaxValue;
+
+                foreach (var sel in _selectionSet)
+                {
+                    switch (sel)
+                    {
+                        case Region r:
+                            DeeperClipboard.Regions.Add(DeepClone(r));
+                            anchor = Math.Min(anchor, r.Start);
+                            break;
+                        case HapticEvent ev:
+                            DeeperClipboard.Haptics.Add(DeepClone(ev));
+                            anchor = Math.Min(anchor, ev.Start);
+                            break;
+                        case TimelineItem ti:
+                            DeeperClipboard.Items.Add(DeepClone(ti));
+                            anchor = Math.Min(anchor, ti.Start);
+                            break;
+                    }
+                }
+
+                DeeperClipboard.AnchorSeconds = double.IsInfinity(anchor) ? 0 : anchor;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: CopySelection error: {Error}", ex.Message);
+            }
+        }
+
+        internal void CutSelection()
+        {
+            if (_selectionSet.Count == 0) return;
+            CopySelection();
+            DeleteSelection();
+        }
+
+        internal void PasteFromClipboard()
+        {
+            if (!DeeperClipboard.HasContent) return;
+            PushUndoSnapshot();
+            try
+            {
+                // Anchor-relative paste: the earliest item in the original selection lands at the
+                // playhead; everything else preserves its offset from that anchor.
+                double pasteAt = _currentSeconds;
+                double anchor = DeeperClipboard.AnchorSeconds;
+
+                _selectionSet.Clear();
+
+                foreach (var src in DeeperClipboard.Regions)
+                {
+                    var clone = DeepClone(src);
+                    clone.Id = TimelineItem.NewId();
+                    var len = Math.Max(0, src.End - src.Start);
+                    var newStart = Math.Max(0, (src.Start - anchor) + pasteAt);
+                    if (_totalSeconds > 0) newStart = Math.Min(newStart, Math.Max(0, _totalSeconds - len));
+                    clone.Start = newStart;
+                    clone.End = newStart + len;
+                    _enhancement.Regions.Add(clone);
+                    _selectionSet.Add(clone);
+                }
+
+                foreach (var src in DeeperClipboard.Haptics)
+                {
+                    var clone = DeepClone(src);
+                    var newStart = Math.Max(0, (src.Start - anchor) + pasteAt);
+                    if (_totalSeconds > 0)
+                        newStart = Math.Min(newStart, Math.Max(0, _totalSeconds - clone.Duration));
+                    clone.Start = newStart;
+                    var track = _enhancement.HapticTracks.FirstOrDefault();
+                    if (track == null)
+                    {
+                        track = new HapticTrack { Id = "primary" };
+                        _enhancement.HapticTracks.Add(track);
+                    }
+                    track.Events.Add(clone);
+                    _selectionSet.Add(clone);
+                }
+
+                foreach (var src in DeeperClipboard.Items)
+                {
+                    var clone = DeepClone(src);
+                    clone.Id = TimelineItem.NewId();
+                    var dur = Math.Max(0, clone.Duration);
+                    var newStart = Math.Max(0, (src.Start - anchor) + pasteAt);
+                    if (_totalSeconds > 0)
+                        newStart = Math.Min(newStart, Math.Max(0, _totalSeconds - dur));
+                    clone.Start = newStart;
+                    _enhancement.TimelineItems.Add(clone);
+                    _selectionSet.Add(clone);
+                }
+
+                // Promote one of the pasted items to primary so the side panel updates.
+                _selectedRegion = _selectionSet.OfType<Region>().FirstOrDefault();
+                _selectedHaptic = _selectionSet.OfType<HapticEvent>().FirstOrDefault();
+                if (_selectedHaptic != null)
+                {
+                    _selectedHapticTrack = _enhancement.HapticTracks.FirstOrDefault(t => t?.Events?.Contains(_selectedHaptic) == true);
+                }
+                _selectedEffect = _selectionSet.OfType<TimelineItem>().FirstOrDefault();
+                UpdateSelectedSidePanel();
+                MarkDirty();
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                ScheduleValidation();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: PasteFromClipboard error: {Error}", ex.Message);
+            }
+        }
+
+        // -- Undo / Redo ------------------------------------------------------
+
+        /// <summary>
+        /// Push a snapshot exactly once per drag gesture. Drag handlers call this on every move
+        /// tick; the second+ call is a cheap no-op.
+        /// </summary>
+        internal void PushDragSnapshotOnce()
+        {
+            if (_dragSnapshotPushed) return;
+            PushUndoSnapshot();
+            _dragSnapshotPushed = true;
+        }
+
+        /// <summary>
+        /// Snapshot the current Enhancement onto the undo stack. Call BEFORE the mutation so undo
+        /// restores the pre-mutation state. Suppressed during undo/redo replay.
+        /// </summary>
+        internal void PushUndoSnapshot()
+        {
+            if (_suppressUndoSnapshot) return;
+            try
+            {
+                var json = JsonConvert.SerializeObject(_enhancement, EnhancementSerializer.JsonReadSettingsForClone());
+                _undo.Push(json);
+                while (_undo.Count > UndoCap)
+                {
+                    // Stack lacks Dequeue - copy, drop the oldest (bottom), rebuild.
+                    var arr = _undo.ToArray(); // top first
+                    _undo.Clear();
+                    int keep = Math.Min(arr.Length, UndoCap);
+                    for (int i = keep - 1; i >= 0; i--) _undo.Push(arr[i]);
+                    break;
+                }
+                _redo.Clear();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: PushUndoSnapshot error: {Error}", ex.Message);
+            }
+        }
+
+        internal void Undo()
+        {
+            if (_undo.Count == 0) return;
+            try
+            {
+                var current = JsonConvert.SerializeObject(_enhancement, EnhancementSerializer.JsonReadSettingsForClone());
+                _redo.Push(current);
+                var snapshot = _undo.Pop();
+                ApplyHistorySnapshot(snapshot);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: Undo error: {Error}", ex.Message);
+            }
+        }
+
+        internal void Redo()
+        {
+            if (_redo.Count == 0) return;
+            try
+            {
+                var current = JsonConvert.SerializeObject(_enhancement, EnhancementSerializer.JsonReadSettingsForClone());
+                _undo.Push(current);
+                var snapshot = _redo.Pop();
+                ApplyHistorySnapshot(snapshot);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: Redo error: {Error}", ex.Message);
+            }
+        }
+
+        // Common Undo/Redo body: capture selection by id, swap in the snapshot, then re-resolve the
+        // selection against the new object identities so the side-panel editor stays open on the
+        // same item the user was editing.
+        private void ApplyHistorySnapshot(string snapshot)
+        {
+            var sel = CaptureSelectionIds();
+            _suppressUndoSnapshot = true;
+            try
+            {
+                var restored = JsonConvert.DeserializeObject<Enhancement>(snapshot, EnhancementSerializer.JsonReadSettingsForClone())
+                              ?? new Enhancement();
+                _enhancement = restored;
+                SelectNothing();
+                MarkDirty();
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                RefreshRulesList();
+                RestoreSelectionIds(sel);
+                ScheduleValidation();
+            }
+            finally { _suppressUndoSnapshot = false; }
+        }
+
+        // Object identity is lost across the JSON round-trip, so capture id-based handles here and
+        // re-resolve them against the restored Enhancement.
+        private struct SelectionIds
+        {
+            public List<string> Regions;
+            public List<string> TimelineItems;
+            // (TrackId, Start, Duration) - HapticEvent has no id field but the tuple is unique
+            // within an enhancement in practice.
+            public List<(string TrackId, double Start, double Duration)> HapticEvents;
+            public string? PrimaryRegionId;
+            public string? PrimaryTimelineItemId;
+        }
+
+        private SelectionIds CaptureSelectionIds()
+        {
+            var sel = new SelectionIds
+            {
+                Regions = new List<string>(),
+                TimelineItems = new List<string>(),
+                HapticEvents = new List<(string, double, double)>(),
+                PrimaryRegionId = _selectedRegion?.Id,
+                PrimaryTimelineItemId = _selectedEffect?.Id,
+            };
+            foreach (var item in _selectionSet)
+            {
+                switch (item)
+                {
+                    case Region r when !string.IsNullOrEmpty(r.Id):
+                        sel.Regions.Add(r.Id!);
+                        break;
+                    case TimelineItem ti when !string.IsNullOrEmpty(ti.Id):
+                        sel.TimelineItems.Add(ti.Id!);
+                        break;
+                    case HapticEvent ev:
+                        var trackId = _enhancement.HapticTracks
+                            .FirstOrDefault(t => t?.Events?.Contains(ev) == true)?.Id ?? "";
+                        sel.HapticEvents.Add((trackId, ev.Start, ev.Duration));
+                        break;
+                }
+            }
+            return sel;
+        }
+
+        private void RestoreSelectionIds(SelectionIds sel)
+        {
+            try
+            {
+                if (sel.Regions != null)
+                {
+                    foreach (var id in sel.Regions)
+                    {
+                        var r = _enhancement.Regions.FirstOrDefault(x => x?.Id == id);
+                        if (r != null) _selectionSet.Add(r);
+                    }
+                }
+                if (sel.TimelineItems != null)
+                {
+                    foreach (var id in sel.TimelineItems)
+                    {
+                        var ti = _enhancement.TimelineItems.FirstOrDefault(x => x?.Id == id);
+                        if (ti != null) _selectionSet.Add(ti);
+                    }
+                }
+                if (sel.HapticEvents != null)
+                {
+                    foreach (var (trackId, start, dur) in sel.HapticEvents)
+                    {
+                        var track = _enhancement.HapticTracks.FirstOrDefault(t => t?.Id == trackId);
+                        if (track?.Events == null) continue;
+                        var ev = track.Events.FirstOrDefault(e => e != null
+                            && Math.Abs(e.Start - start) < 0.0005
+                            && Math.Abs(e.Duration - dur) < 0.0005);
+                        if (ev != null) _selectionSet.Add(ev);
+                    }
+                }
+                if (!string.IsNullOrEmpty(sel.PrimaryRegionId))
+                    _selectedRegion = _enhancement.Regions.FirstOrDefault(r => r?.Id == sel.PrimaryRegionId);
+                if (!string.IsNullOrEmpty(sel.PrimaryTimelineItemId))
+                    _selectedEffect = _enhancement.TimelineItems.FirstOrDefault(t => t?.Id == sel.PrimaryTimelineItemId);
+                UpdateSelectedSidePanel();
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: RestoreSelectionIds error: {Error}", ex.Message);
+            }
+        }
+
+        // -- Select all -------------------------------------------------------
+
+        internal void SelectAllOnTimeline()
+        {
+            _selectionSet.Clear();
+            foreach (var r in _enhancement.Regions) if (r != null) _selectionSet.Add(r);
+            foreach (var track in _enhancement.HapticTracks)
+            {
+                if (track?.Events == null) continue;
+                foreach (var ev in track.Events) if (ev != null) _selectionSet.Add(ev);
+            }
+            foreach (var ti in _enhancement.TimelineItems)
+            {
+                if (ti == null || ti.Kind != TimelineItemKind.Effect) continue;
+                if (ti.EffectType == EffectTypes.Haptic) continue;
+                _selectionSet.Add(ti);
+            }
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+        }
+
+        // -- Deep clone helper ------------------------------------------------
+
+        private static T DeepClone<T>(T src)
+        {
+            var json = JsonConvert.SerializeObject(src, EnhancementSerializer.JsonReadSettingsForClone());
+            return JsonConvert.DeserializeObject<T>(json, EnhancementSerializer.JsonReadSettingsForClone())!;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.RuleEditor.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.RuleEditor.cs
@@ -1,0 +1,1618 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Styling;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models.Deeper;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// PORTED from the tail of ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs -
+    /// the haptic inspector, the curve editor, the rule inspector and every programmatically built
+    /// trigger/action field. It is a SEPARATE FILE here only because the WPF main file is 5,159
+    /// lines; no member was dropped, and the six WPF partials keep their own names alongside it.
+    ///
+    /// Deviations:
+    ///   Style = (Style)FindResource(k)   -> Theme = (ControlTheme)this.FindResource(k)
+    ///   Visibility                       -> IsVisible
+    ///   ToolTip =                        -> ToolTip.SetTip(control, ...)
+    ///   MouseLeftButtonDown/Move/Up      -> PointerPressed / PointerMoved / PointerReleased
+    ///   Mouse capture on a handle        -> e.Pointer.Capture(handle)
+    ///   ActualWidth/Height               -> Bounds.Width / Bounds.Height
+    ///   CheckBox.Click                   -> IsCheckedChanged
+    ///   MessageBox.Show                  -> Serilog (no message box on this head)
+    /// </summary>
+    public partial class DeeperEditorWindow
+    {
+        private ControlTheme EditorTextBoxTheme => (ControlTheme)this.FindResource("EditorTextBox")!;
+        private ControlTheme EditorLabelTheme => (ControlTheme)this.FindResource("EditorLabel")!;
+        private ControlTheme EditorComboBoxTheme => (ControlTheme)this.FindResource("EditorComboBox")!;
+        private ControlTheme EditorComboBoxItemTheme => (ControlTheme)this.FindResource("EditorComboBoxItem")!;
+
+        private TextBox NewEditorTextBox(string text) => new()
+        {
+            Theme = EditorTextBoxTheme,
+            Text = text,
+        };
+
+        private ComboBox NewEditorComboBox() => new()
+        {
+            Theme = EditorComboBoxTheme,
+            ItemContainerTheme = EditorComboBoxItemTheme,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        private TextBlock NewEditorLabel(string text) => new()
+        {
+            Theme = EditorLabelTheme,
+            Text = text,
+        };
+
+        // ---------------------------------------------------------------------------------
+        // Haptic side panel
+        // ---------------------------------------------------------------------------------
+
+        private void PopulateHapticEditor()
+        {
+            if (_selectedHaptic == null || _selectedHapticTrack == null) return;
+
+            _suppressDirty = true;
+            _suppressPatternSync = true;
+            try
+            {
+                TxtHapticTrackId.Text = _selectedHapticTrack.Id;
+                TxtHapticStart.Text = _selectedHaptic.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                TxtHapticDuration.Text = _selectedHaptic.Duration.ToString("0.##", CultureInfo.InvariantCulture);
+                SliderHapticIntensity.Value = Math.Clamp(_selectedHaptic.Intensity, 0.0, 1.0);
+                TxtHapticIntensityValue.Text = $"{(int)(SliderHapticIntensity.Value * 100)}%";
+                CmbHapticTarget.SelectedIndex = HapticTargetIndex(_selectedHaptic.Target);
+
+                var isCustom = _selectedHaptic.CustomPattern != null && _selectedHaptic.CustomPattern.Count > 0;
+                if (isCustom)
+                {
+                    CmbHapticPattern.SelectedIndex = StockHapticPatterns.Names.Count; // "Custom..."
+                    CurveEditorPanel.IsVisible = true;
+                    EnsureCurveSeed();
+                    RebuildCurveEditor();
+                }
+                else
+                {
+                    var idx = -1;
+                    if (!string.IsNullOrEmpty(_selectedHaptic.PatternName))
+                    {
+                        for (int i = 0; i < StockHapticPatterns.Names.Count; i++)
+                            if (StockHapticPatterns.Names[i] == _selectedHaptic.PatternName) { idx = i; break; }
+                    }
+                    CmbHapticPattern.SelectedIndex = idx >= 0 ? idx : 0;
+                    CurveEditorPanel.IsVisible = false;
+                }
+            }
+            finally
+            {
+                ClearWhenEventsDrained(() =>
+                {
+                    _suppressDirty = false;
+                    _suppressPatternSync = false;
+                });
+            }
+        }
+
+        private void HapticField_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressDirty || _selectedHaptic == null) return;
+            if (double.TryParse(TxtHapticStart.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var s))
+                _selectedHaptic.Start = Math.Max(0, s);
+            if (double.TryParse(TxtHapticDuration.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var d))
+                _selectedHaptic.Duration = Math.Max(0.05, d);
+            MarkDirty();
+            RebuildHapticVisuals();
+            ScheduleValidation();
+        }
+
+        private void SliderHapticIntensity_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (TxtHapticIntensityValue != null)
+                TxtHapticIntensityValue.Text = $"{(int)(e.NewValue * 100)}%";
+            if (_suppressDirty || _selectedHaptic == null) return;
+            _selectedHaptic.Intensity = Math.Clamp(e.NewValue, 0, 1);
+            MarkDirty();
+            RebuildHapticVisuals();
+        }
+
+        private void CmbHapticPattern_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressPatternSync || _suppressDirty || _selectedHaptic == null) return;
+            var idx = CmbHapticPattern.SelectedIndex;
+            if (idx < 0) return;
+            if (idx < StockHapticPatterns.Names.Count)
+            {
+                _selectedHaptic.PatternName = StockHapticPatterns.Names[idx];
+                _selectedHaptic.CustomPattern = null;
+                CurveEditorPanel.IsVisible = false;
+            }
+            else
+            {
+                EnsureCurveSeed();
+                _selectedHaptic.PatternName = null;
+                CurveEditorPanel.IsVisible = true;
+                RebuildCurveEditor();
+            }
+            MarkDirty();
+            ScheduleValidation();
+        }
+
+        private void CmbHapticTarget_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressDirty || _selectedHaptic == null) return;
+            _selectedHaptic.Target = HapticTargetAt(CmbHapticTarget.SelectedIndex);
+            MarkDirty();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Curve editor (the XAML CurveCanvas, for the selected haptic event)
+        // ---------------------------------------------------------------------------------
+
+        private void EnsureCurveSeed()
+        {
+            if (_selectedHaptic == null) return;
+            if (_selectedHaptic.CustomPattern == null || _selectedHaptic.CustomPattern.Count < 2)
+                _selectedHaptic.CustomPattern = StockHapticPatterns.SeedCustomFrom(_selectedHaptic.PatternName);
+        }
+
+        private void CurveCanvas_SizeChanged(object? sender, SizeChangedEventArgs e) => RebuildCurveEditor();
+
+        private void RebuildCurveEditor()
+        {
+            if (CurveCanvas == null) return;
+            CurveCanvas.Children.Clear();
+            _curvePath = null;
+            _curveHandles.Clear();
+
+            if (_selectedHaptic?.CustomPattern == null || _selectedHaptic.CustomPattern.Count == 0) return;
+            var w = CurveCanvas.Bounds.Width;
+            var h = CurveCanvas.Bounds.Height;
+            if (w <= 0 || h <= 0) return;
+
+            // Background grid
+            for (int i = 1; i <= 3; i++)
+            {
+                var y = h * i / 4.0;
+                CurveCanvas.Children.Add(new Line
+                {
+                    StartPoint = new Point(0, y),
+                    EndPoint = new Point(w, y),
+                    Stroke = new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)),
+                    StrokeThickness = 0.5,
+                    IsHitTestVisible = false
+                });
+            }
+
+            // Polyline through the keyframes
+            var pts = _selectedHaptic.CustomPattern;
+            var geom = new StreamGeometry();
+            using (var ctx = geom.Open())
+            {
+                ctx.BeginFigure(KeyframeToCanvas(pts[0], w, h), false);
+                for (int i = 1; i < pts.Count; i++)
+                    ctx.LineTo(KeyframeToCanvas(pts[i], w, h));
+                ctx.EndFigure(false);
+            }
+            _curvePath = new Path
+            {
+                Data = geom,
+                Stroke = Res("DeeperAccentBrush"),
+                StrokeThickness = 1.6,
+                IsHitTestVisible = false
+            };
+            CurveCanvas.Children.Add(_curvePath);
+
+            // Handles (fixed-X dots, drag intensity vertically)
+            for (int i = 0; i < pts.Count; i++)
+            {
+                var pt = KeyframeToCanvas(pts[i], w, h);
+                var dot = new Ellipse
+                {
+                    Width = 10, Height = 10,
+                    Fill = Res("DeeperAccentBrush"),
+                    Stroke = Brushes.White,
+                    StrokeThickness = 1.2,
+                    Cursor = new Cursor(StandardCursorType.SizeNorthSouth),
+                    Tag = i
+                };
+                Canvas.SetLeft(dot, pt.X - 5);
+                Canvas.SetTop(dot, pt.Y - 5);
+                dot.PointerPressed += CurveHandle_PointerPressed;
+                dot.PointerMoved += CurveHandle_PointerMoved;
+                dot.PointerReleased += CurveHandle_PointerReleased;
+                CurveCanvas.Children.Add(dot);
+                _curveHandles.Add(dot);
+            }
+        }
+
+        private static Point KeyframeToCanvas(double[] kf, double w, double h)
+        {
+            var t = Math.Clamp(kf.Length > 0 ? kf[0] : 0, 0, 1);
+            var v = Math.Clamp(kf.Length > 1 ? kf[1] : 0, 0, 1);
+            return new Point(t * w, h - (v * h));
+        }
+
+        private void CurveHandle_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is Ellipse el && el.Tag is int idx)
+            {
+                if (!e.GetCurrentPoint(el).Properties.IsLeftButtonPressed) return;
+                _draggingCurveIndex = idx;
+                e.Pointer.Capture(el);
+                e.Handled = true;
+            }
+        }
+
+        private void CurveHandle_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_draggingCurveIndex < 0 || _selectedHaptic?.CustomPattern == null) return;
+            if (sender is not Ellipse el) return;
+            var h = CurveCanvas.Bounds.Height;
+            if (h <= 0) return;
+            var y = e.GetPosition(CurveCanvas).Y;
+            var v = Math.Clamp(1.0 - (y / h), 0, 1);
+            var kf = _selectedHaptic.CustomPattern[_draggingCurveIndex];
+            if (kf.Length > 1) kf[1] = v;
+            Canvas.SetTop(el, Math.Clamp(y, 0, h) - 5);
+            MarkDirty();
+            RebuildCurveEditor();
+        }
+
+        private void CurveHandle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (_draggingCurveIndex < 0) return;
+            _draggingCurveIndex = -1;
+            e.Pointer.Capture(null);
+            ScheduleValidation();
+        }
+
+        private void BtnResetCurve_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedHaptic == null) return;
+            PushUndoSnapshot();
+            _selectedHaptic.CustomPattern = StockHapticPatterns.SeedCustomFrom(_selectedHaptic.PatternName);
+            MarkDirty();
+            RebuildCurveEditor();
+        }
+
+        /// <summary>ponytail: needs the haptics bus (App's device manager). The WPF handler fired a
+        /// one-shot buzz on the selected pattern so the author could feel it.</summary>
+        private void BtnTestHaptic_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("DeeperEditor: test-haptic needs the haptics device bus");
+
+        private void BtnDeleteHaptic_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedHaptic == null || _selectedHapticTrack == null) return;
+            PushUndoSnapshot();
+            _selectedHapticTrack.Events.Remove(_selectedHaptic);
+            // Remove a now-empty default track to keep the file clean.
+            if (_selectedHapticTrack.Events.Count == 0 && _selectedHapticTrack.Id == DefaultTrackId)
+                _enhancement.HapticTracks.Remove(_selectedHapticTrack);
+            SelectNothing();
+            MarkDirty();
+            RebuildHapticVisuals();
+            ScheduleValidation();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Rules list
+        // ---------------------------------------------------------------------------------
+
+        private void RefreshRulesList()
+        {
+            // Refreshes the selection summary strip + the sidebar Items list. Every add / delete /
+            // select / drag-end call site flows through here.
+            UpdateSelectionSummary();
+            BuildItemsList();
+        }
+
+        private static string FriendlyTriggerName(string type) => type switch
+        {
+            TriggerTypes.GazeTarget    => Loc.Get("deeper_friendly_trigger_gaze_target"),
+            TriggerTypes.GazeAvoid     => Loc.Get("deeper_friendly_trigger_gaze_avoid"),
+            TriggerTypes.AttentionLost => Loc.Get("deeper_friendly_trigger_attention_lost"),
+            TriggerTypes.BlinkDetected => Loc.Get("deeper_friendly_trigger_blink_detected"),
+            TriggerTypes.MouthOpen     => Loc.Get("deeper_friendly_trigger_mouth_open"),
+            TriggerTypes.TimeReached   => Loc.Get("deeper_friendly_trigger_time_reached"),
+            TriggerTypes.RegionEntered => Loc.Get("deeper_friendly_trigger_region_entered"),
+            TriggerTypes.RegionExited  => Loc.Get("deeper_friendly_trigger_region_exited"),
+            _                          => string.IsNullOrEmpty(type) ? "?" : type
+        };
+
+        private static string FriendlyActionName(string type) => type switch
+        {
+            ActionTypes.Seek          => Loc.Get("deeper_friendly_action_seek"),
+            ActionTypes.LoopRegion    => Loc.Get("deeper_friendly_action_loop_region"),
+            ActionTypes.Pause         => Loc.Get("deeper_friendly_action_pause"),
+            ActionTypes.PlayAudio     => Loc.Get("deeper_friendly_action_play_audio"),
+            ActionTypes.TriggerHaptic => Loc.Get("deeper_friendly_action_trigger_haptic"),
+            ActionTypes.TriggerEffect => Loc.Get("deeper_friendly_action_trigger_effect"),
+            ActionTypes.ScreenShake   => Loc.Get("deeper_friendly_action_screen_shake"),
+            ActionTypes.SetIntensity  => Loc.Get("deeper_friendly_action_set_intensity"),
+            ActionTypes.NoOp          => Loc.Get("deeper_friendly_action_noop"),
+            _                         => string.IsNullOrEmpty(type) ? "?" : type
+        };
+
+        // -- Help popups: list every trigger / action with its description ----
+        // ponytail: needs a message box. The text is still assembled from the same keys and
+        // argument order, so wiring a real dialog later is a one-line swap at each site.
+
+        private void BtnTriggerHelp_Click(object? sender, RoutedEventArgs e)
+        {
+            var isAudio = _enhancement?.MediaType == MediaTypes.Audio;
+            var types = isAudio ? TriggerTypesForAudio : TriggerTypesForVideo;
+            var sb = new StringBuilder();
+            foreach (var t in types)
+            {
+                sb.Append("• ").AppendLine(FriendlyTriggerName(t));
+                var desc = Loc.Get(TriggerDescriptionKey(t));
+                if (!string.IsNullOrEmpty(desc) && desc != TriggerDescriptionKey(t))
+                    sb.Append("  ").AppendLine(desc);
+                sb.AppendLine();
+            }
+            Log.Debug("DeeperEditor: trigger help ({Title}) needs a message box:\n{Body}",
+                Loc.Get("deeper_editor_help_browse_triggers"), sb.ToString().TrimEnd());
+        }
+
+        private void BtnActionHelp_Click(object? sender, RoutedEventArgs e)
+        {
+            var sb = new StringBuilder();
+            foreach (var a in AllActionTypes)
+            {
+                sb.Append("• ").AppendLine(FriendlyActionName(a));
+                var desc = Loc.Get(ActionDescriptionKey(a));
+                if (!string.IsNullOrEmpty(desc) && desc != ActionDescriptionKey(a))
+                    sb.Append("  ").AppendLine(desc);
+                sb.AppendLine();
+            }
+            Log.Debug("DeeperEditor: action help ({Title}) needs a message box:\n{Body}",
+                Loc.Get("deeper_editor_help_browse_actions"), sb.ToString().TrimEnd());
+        }
+
+        private void BtnRegionHelp_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("DeeperEditor: region help ({Title}) needs a message box:\n{Body}",
+                Loc.Get("deeper_editor_help_region"), Loc.Get("deeper_editor_help_region_body"));
+
+        private void BtnDeleteRule_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedRule == null) return;
+            PushUndoSnapshot();
+            _enhancement.Rules.Remove(_selectedRule);
+            SelectNothing();
+            MarkDirty();
+            RebuildRuleVisuals();
+            ScheduleValidation();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Rule editor population
+        // ---------------------------------------------------------------------------------
+
+        private static readonly string[] TriggerTypesForVideo =
+        {
+            TriggerTypes.GazeTarget, TriggerTypes.GazeAvoid, TriggerTypes.AttentionLost,
+            TriggerTypes.BlinkDetected, TriggerTypes.MouthOpen,
+            TriggerTypes.TimeReached, TriggerTypes.RegionEntered, TriggerTypes.RegionExited
+        };
+        private static readonly string[] TriggerTypesForAudio =
+        {
+            TriggerTypes.TimeReached, TriggerTypes.RegionEntered, TriggerTypes.RegionExited
+        };
+        // NoOp first: rules created from the timeline default to NoOp, and PopulateRuleEditor falls
+        // back to index 0 for unknown action types - both must display honestly as "Do nothing".
+        private static readonly string[] AllActionTypes =
+        {
+            ActionTypes.NoOp,
+            ActionTypes.Seek, ActionTypes.LoopRegion, ActionTypes.Pause,
+            ActionTypes.PlayAudio, ActionTypes.TriggerHaptic, ActionTypes.TriggerEffect,
+            ActionTypes.ScreenShake, ActionTypes.SetIntensity
+        };
+
+        private void PopulateRuleEditor()
+        {
+            if (_selectedRule == null) return;
+            _suppressRuleSync = true;
+            try
+            {
+                var idx = _enhancement.Rules.IndexOf(_selectedRule);
+                TxtRuleHeader.Text = idx >= 0 ? $"rule #{idx + 1}" : "rule";
+                ChkRuleEnabled.IsChecked = _selectedRule.Enabled;
+
+                // Trigger type combo (filtered by media_type). ComboBoxItem so each entry shows a
+                // friendly name + a hover tooltip with the long description; raw enum in Tag.
+                var isAudio = _enhancement.MediaType == MediaTypes.Audio;
+                var triggerOptions = isAudio ? TriggerTypesForAudio : TriggerTypesForVideo;
+                CmbTriggerType.Items.Clear();
+                int trigIdx = 0;
+                for (int i = 0; i < triggerOptions.Length; i++)
+                {
+                    var rawType = triggerOptions[i];
+                    var item = new ComboBoxItem
+                    {
+                        Theme = EditorComboBoxItemTheme,
+                        Content = FriendlyTriggerName(rawType),
+                        Tag = rawType,
+                    };
+                    ToolTip.SetTip(item, Loc.Get(TriggerDescriptionKey(rawType)));
+                    CmbTriggerType.Items.Add(item);
+                    if (rawType == (_selectedRule.Trigger?.Type ?? "")) trigIdx = i;
+                }
+                CmbTriggerType.SelectedIndex = trigIdx;
+
+                // Action combo (same pattern).
+                CmbActionType.Items.Clear();
+                int actIdx = 0;
+                for (int i = 0; i < AllActionTypes.Length; i++)
+                {
+                    var rawType = AllActionTypes[i];
+                    var item = new ComboBoxItem
+                    {
+                        Theme = EditorComboBoxItemTheme,
+                        Content = FriendlyActionName(rawType),
+                        Tag = rawType,
+                    };
+                    ToolTip.SetTip(item, Loc.Get(ActionDescriptionKey(rawType)));
+                    CmbActionType.Items.Add(item);
+                    if (rawType == (_selectedRule.Action?.Type ?? "")) actIdx = i;
+                }
+                CmbActionType.SelectedIndex = actIdx;
+
+                // Region constraint combo.
+                RebuildRegionConstraintCombo();
+
+                TxtRuleCooldown.Text = _selectedRule.CooldownMs.ToString(CultureInfo.InvariantCulture);
+
+                BuildTriggerFields();
+                BuildActionFields();
+                PopulateRuleBandDetails();
+            }
+            finally { ClearWhenEventsDrained(() => _suppressRuleSync = false); }
+        }
+
+        // Sync the rule editor's "Region details" sub-panel with whichever Region the current rule
+        // constrains to. Hidden when the rule has no RegionConstraint or it doesn't resolve.
+        private void PopulateRuleBandDetails()
+        {
+            if (RuleRegionDetails == null) return;
+            var region = ResolveRuleConstrainedRegion();
+            if (region == null)
+            {
+                RuleRegionDetails.IsVisible = false;
+                return;
+            }
+
+            RuleRegionDetails.IsVisible = true;
+            TxtRuleBandLabel.Text = region.Label ?? "";
+            TxtRuleBandStart.Text = region.Start.ToString("0.##", CultureInfo.InvariantCulture);
+            TxtRuleBandEnd.Text = region.End.ToString("0.##", CultureInfo.InvariantCulture);
+            TxtRuleBandColor.Text = region.Color ?? "";
+            UpdateRuleBandColorSwatchPreview();
+            BuildRuleBandColorSwatches();
+        }
+
+        private Region? ResolveRuleConstrainedRegion()
+        {
+            var id = _selectedRule?.RegionConstraint;
+            if (string.IsNullOrEmpty(id)) return null;
+            foreach (var r in _enhancement.Regions)
+            {
+                if (r != null && string.Equals(r.Id, id, StringComparison.Ordinal)) return r;
+            }
+            return null;
+        }
+
+        private void RuleBandField_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressRuleSync) return;
+            var region = ResolveRuleConstrainedRegion();
+            if (region == null) return;
+            try
+            {
+                if (ReferenceEquals(sender, TxtRuleBandLabel))
+                {
+                    region.Label = TxtRuleBandLabel.Text;
+                }
+                else if (ReferenceEquals(sender, TxtRuleBandColor))
+                {
+                    region.Color = TxtRuleBandColor.Text;
+                    UpdateRuleBandColorSwatchPreview();
+                }
+                else if (ReferenceEquals(sender, TxtRuleBandStart)
+                         && double.TryParse(TxtRuleBandStart.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var s))
+                {
+                    region.Start = Math.Max(0, s);
+                }
+                else if (ReferenceEquals(sender, TxtRuleBandEnd)
+                         && double.TryParse(TxtRuleBandEnd.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var en))
+                {
+                    region.End = en;
+                }
+                MarkDirty();
+                RebuildRegionVisuals();
+                ScheduleValidation();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: RuleBandField sync error: {Error}", ex.Message);
+            }
+        }
+
+        private void UpdateRuleBandColorSwatchPreview()
+        {
+            if (RuleBandColorSwatch == null) return;
+            RuleBandColorSwatch.Background = TryParseBrush(TxtRuleBandColor.Text) ?? Brushes.MediumPurple;
+        }
+
+        private void BuildRuleBandColorSwatches()
+        {
+            if (RuleBandColorSwatches == null) return;
+            RuleBandColorSwatches.Children.Clear();
+            foreach (var hex in RegionPalette)
+            {
+                var captured = hex;
+                var swatch = new Border
+                {
+                    Width = 22,
+                    Height = 22,
+                    Margin = new Thickness(0, 0, 6, 0),
+                    CornerRadius = new CornerRadius(4),
+                    Background = TryParseBrush(hex) ?? Brushes.MediumPurple,
+                    BorderBrush = Res("GlassBorderBrush"),
+                    BorderThickness = new Thickness(1),
+                    Cursor = new Cursor(StandardCursorType.Hand),
+                    Tag = hex,
+                };
+                ToolTip.SetTip(swatch, hex);
+                swatch.PointerReleased += (_, _) =>
+                {
+                    if (_selectedRule == null) return;
+                    TxtRuleBandColor.Text = captured;
+                };
+                RuleBandColorSwatches.Children.Add(swatch);
+            }
+        }
+
+        private void RebuildRegionConstraintCombo()
+        {
+            CmbRuleRegion.Items.Clear();
+            CmbRuleRegion.Items.Add(Loc.Get("deeper_editor_rule_region_none"));
+            int selected = 0;
+            for (int i = 0; i < _enhancement.Regions.Count; i++)
+            {
+                var r = _enhancement.Regions[i];
+                CmbRuleRegion.Items.Add(string.IsNullOrEmpty(r.Label) ? r.Id : $"{r.Id} — {r.Label}");
+                if (_selectedRule?.RegionConstraint == r.Id) selected = i + 1;
+            }
+            CmbRuleRegion.SelectedIndex = selected;
+        }
+
+        private void ChkRuleEnabled_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_suppressRuleSync || _selectedRule == null) return;
+            _selectedRule.Enabled = ChkRuleEnabled.IsChecked == true;
+            MarkDirty();
+            RefreshRulesList();
+            ScheduleValidation();
+        }
+
+        private void CmbTriggerType_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressRuleSync || _selectedRule == null) return;
+            var picked = (CmbTriggerType.SelectedItem as ComboBoxItem)?.Tag as string;
+            if (string.IsNullOrEmpty(picked)) return;
+            if (_selectedRule.Trigger?.Type == picked) return;
+
+            _selectedRule.Trigger = picked switch
+            {
+                TriggerTypes.GazeTarget    => new GazeTargetTrigger(),
+                TriggerTypes.GazeAvoid     => new GazeAvoidTrigger(),
+                TriggerTypes.AttentionLost => new AttentionLostTrigger(),
+                TriggerTypes.BlinkDetected => new BlinkDetectedTrigger(),
+                TriggerTypes.MouthOpen     => new MouthOpenTrigger(),
+                TriggerTypes.TimeReached   => new TimeReachedTrigger { Time = Math.Max(0, _currentSeconds) },
+                TriggerTypes.RegionEntered => new RegionEnteredTrigger(),
+                TriggerTypes.RegionExited  => new RegionExitedTrigger(),
+                _                          => _selectedRule.Trigger
+            };
+            EndGazePick(commit: false);
+            BuildTriggerFields();
+            MarkDirty();
+            RebuildRuleVisuals();
+            RefreshRulesList();
+            ScheduleValidation();
+        }
+
+        private void CmbActionType_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressRuleSync || _selectedRule == null) return;
+            var picked = (CmbActionType.SelectedItem as ComboBoxItem)?.Tag as string;
+            if (string.IsNullOrEmpty(picked)) return;
+            if (_selectedRule.Action?.Type == picked) return;
+
+            _selectedRule.Action = picked switch
+            {
+                ActionTypes.NoOp          => new NoOpEnhancementAction(),
+                // Default the jump target to the playhead, mirroring TimeReachedTrigger.
+                ActionTypes.Seek          => new SeekAction { Target = SeekTargets.Time, Time = Math.Max(0, _currentSeconds) },
+                ActionTypes.LoopRegion    => new LoopRegionAction(),
+                ActionTypes.Pause         => new PauseAction(),
+                ActionTypes.PlayAudio     => new PlayAudioAction(),
+                ActionTypes.TriggerHaptic => new TriggerHapticAction { PatternName = "Pulse" },
+                ActionTypes.TriggerEffect => new TriggerEffectAction { EffectType = EffectTypes.Haptic, PatternName = "Pulse" },
+                ActionTypes.ScreenShake   => new ScreenShakeAction(),
+                ActionTypes.SetIntensity  => new SetIntensityAction(),
+                _                         => _selectedRule.Action
+            };
+            BuildActionFields();
+            MarkDirty();
+            RefreshRulesList();
+            ScheduleValidation();
+        }
+
+        private void CmbRuleRegion_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressRuleSync || _selectedRule == null) return;
+            var idx = CmbRuleRegion.SelectedIndex;
+            if (idx <= 0)
+            {
+                _selectedRule.RegionConstraint = null;
+            }
+            else if (idx - 1 < _enhancement.Regions.Count)
+            {
+                _selectedRule.RegionConstraint = _enhancement.Regions[idx - 1].Id;
+            }
+            MarkDirty();
+            ScheduleValidation();
+        }
+
+        private void TxtRuleCooldown_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressRuleSync || _selectedRule == null) return;
+            if (int.TryParse(TxtRuleCooldown.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var ms))
+                _selectedRule.CooldownMs = Math.Max(0, ms);
+            MarkDirty();
+            ScheduleValidation();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Dynamic field builders (one block per trigger / action type)
+        // ---------------------------------------------------------------------------------
+
+        private void BuildTriggerFields()
+        {
+            TriggerFields.Children.Clear();
+            if (_selectedRule?.Trigger == null) return;
+
+            AddTypeDescription(TriggerFields, TriggerDescriptionKey(_selectedRule.Trigger.Type));
+
+            switch (_selectedRule.Trigger)
+            {
+                case GazeTargetTrigger g:
+                    AddRectFields(TriggerFields, g.Rect, () => g.Rect);
+                    AddIntField(TriggerFields, Loc.Get("deeper_editor_trigger_min_dwell"),
+                        g.MinDwellMs, v => g.MinDwellMs = Math.Max(0, v));
+                    break;
+                case GazeAvoidTrigger g:
+                    AddRectFields(TriggerFields, g.Rect, () => g.Rect);
+                    AddIntField(TriggerFields, Loc.Get("deeper_editor_trigger_min_dwell"),
+                        g.MinDwellMs, v => g.MinDwellMs = Math.Max(0, v));
+                    break;
+                case AttentionLostTrigger a:
+                    AddIntField(TriggerFields, Loc.Get("deeper_editor_trigger_min_duration"),
+                        a.MinDurationMs, v => a.MinDurationMs = Math.Max(0, v));
+                    break;
+                case BlinkDetectedTrigger:
+                case MouthOpenTrigger:
+                    AddInfoText(TriggerFields, Loc.Get("deeper_editor_trigger_no_params"));
+                    break;
+                case TimeReachedTrigger tr:
+                    AddDoubleField(TriggerFields, Loc.Get("deeper_editor_trigger_time"),
+                        tr.Time, v => { tr.Time = Math.Max(0, v); RebuildRuleVisuals(); });
+                    AssignNameToLastTextBox(TriggerFields, "TutorialTriggerTimeField");
+                    break;
+                case RegionEnteredTrigger re:
+                    AddRegionPicker(TriggerFields, re.RegionId, id => re.RegionId = id);
+                    break;
+                case RegionExitedTrigger rx:
+                    AddRegionPicker(TriggerFields, rx.RegionId, id => rx.RegionId = id);
+                    break;
+            }
+        }
+
+        private void BuildActionFields()
+        {
+            ActionFields.Children.Clear();
+            if (_selectedRule?.Action == null) return;
+
+            AddTypeDescription(ActionFields, ActionDescriptionKey(_selectedRule.Action.Type));
+
+            switch (_selectedRule.Action)
+            {
+                case SeekAction seek:
+                    AddSeekFields(seek);
+                    break;
+                case LoopRegionAction loop:
+                    AddRegionPicker(ActionFields, loop.RegionId ?? "",
+                        id => loop.RegionId = string.IsNullOrEmpty(id) ? null : id,
+                        allowNone: true);
+                    break;
+                case PauseAction:
+                    AddInfoText(ActionFields, Loc.Get("deeper_editor_action_pause_info"));
+                    break;
+                case PlayAudioAction pa:
+                    AddTextField(ActionFields, Loc.Get("deeper_editor_action_audio_path"),
+                        pa.Path, v => pa.Path = v);
+                    AddIntField(ActionFields, Loc.Get("deeper_editor_action_volume"),
+                        pa.Volume, v => pa.Volume = Math.Clamp(v, 0, 100));
+                    AddBoolField(ActionFields, Loc.Get("deeper_editor_action_duck"),
+                        pa.DuckOtherAudio, v => pa.DuckOtherAudio = v);
+                    break;
+                case TriggerHapticAction h:
+                    AddHapticActionFields(h);
+                    break;
+                case TriggerEffectAction te:
+                    AddTriggerEffectActionFields(te);
+                    break;
+                case ScreenShakeAction ss:
+                    AddDoubleField(ActionFields, Loc.Get("deeper_editor_action_intensity"),
+                        ss.Intensity, v => ss.Intensity = Math.Clamp(v, 0, 1));
+                    AssignNameToLastTextBox(ActionFields, "TutorialActionIntensityField");
+                    AddIntField(ActionFields, Loc.Get("deeper_editor_action_duration_ms"),
+                        ss.DurationMs, v => ss.DurationMs = Math.Max(50, v));
+                    break;
+                case SetIntensityAction si:
+                    AddDoubleField(ActionFields, Loc.Get("deeper_editor_action_value_0_1"),
+                        si.Value, v => si.Value = Math.Clamp(v, 0, 1));
+                    break;
+            }
+        }
+
+        private void AddRectFields(Panel host, double[] rect, Func<double[]> getter)
+        {
+            var grid = new Grid { Margin = new Thickness(0, 0, 0, 4) };
+            for (int i = 0; i < 4; i++)
+                grid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            string[] labels = { "x", "y", "w", "h" };
+            for (int i = 0; i < 4; i++)
+            {
+                int captured = i;
+                var stack = new StackPanel { Margin = new Thickness(i == 0 ? 0 : 4, 0, 4, 0) };
+                stack.Children.Add(new TextBlock
+                {
+                    Text = labels[i],
+                    Foreground = Res("TextLightBrush"),
+                    FontSize = 11,
+                    FontWeight = FontWeight.SemiBold,
+                    Margin = new Thickness(0, 0, 0, 4)
+                });
+                var tb = NewEditorTextBox(rect.Length > i ? rect[i].ToString("0.##", CultureInfo.InvariantCulture) : "0");
+                tb.TextChanged += (_, _) =>
+                {
+                    if (_suppressRuleSync) return;
+                    var arr = getter();
+                    if (arr.Length > captured && double.TryParse(tb.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                    {
+                        arr[captured] = Math.Clamp(v, 0, 1);
+                        MarkDirty();
+                        ScheduleValidation();
+                    }
+                };
+                stack.Children.Add(tb);
+                Grid.SetColumn(stack, i);
+                grid.Children.Add(stack);
+            }
+            host.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_trigger_rect")));
+            host.Children.Add(grid);
+
+            // Quick-pick presets: a 3x3 grid of corner/edge regions so the user can say
+            // "bottom-left" with one click instead of typing four numbers.
+            host.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_trigger_quick_region")));
+            var presetGrid = new Grid { Margin = new Thickness(0, 0, 0, 6) };
+            for (int c = 0; c < 3; c++)
+                presetGrid.ColumnDefinitions.Add(new ColumnDefinition(new GridLength(1, GridUnitType.Star)));
+            for (int r = 0; r < 3; r++)
+                presetGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+
+            var presetLabels = new[,]
+            {
+                { "↖", "↑", "↗" },
+                { "←", "·", "→" },
+                { "↙", "↓", "↘" }
+            };
+            var presetTooltips = new[,]
+            {
+                { "deeper_editor_quick_region_top_left",    "deeper_editor_quick_region_top",    "deeper_editor_quick_region_top_right"    },
+                { "deeper_editor_quick_region_left",        "deeper_editor_quick_region_center", "deeper_editor_quick_region_right"        },
+                { "deeper_editor_quick_region_bottom_left", "deeper_editor_quick_region_bottom", "deeper_editor_quick_region_bottom_right" }
+            };
+            for (int row = 0; row < 3; row++)
+            {
+                for (int col = 0; col < 3; col++)
+                {
+                    int capturedRow = row;
+                    int capturedCol = col;
+                    var b = new Button
+                    {
+                        Content = presetLabels[row, col],
+                        FontSize = 14,
+                        Padding = new Thickness(0, 4, 0, 4),
+                        Margin = new Thickness(col == 0 ? 0 : 2, row == 0 ? 0 : 2, 0, 0),
+                        Cursor = new Cursor(StandardCursorType.Hand),
+                        Background = Res("DeeperAccentTransparent20Brush"),
+                        Foreground = Res("TextLightBrush"),
+                        BorderBrush = Res("DeeperAccentTransparent40Brush"),
+                        BorderThickness = new Thickness(1),
+                    };
+                    ToolTip.SetTip(b, Loc.Get(presetTooltips[row, col]));
+                    Grid.SetColumn(b, col);
+                    Grid.SetRow(b, row);
+                    b.Click += (_, _) =>
+                    {
+                        var arr = getter();
+                        if (arr == null || arr.Length < 4) return;
+                        // 0,0 = top-left; each cell is 1/3 of the screen.
+                        arr[0] = capturedCol / 3.0;
+                        arr[1] = capturedRow / 3.0;
+                        arr[2] = 1.0 / 3.0;
+                        arr[3] = 1.0 / 3.0;
+                        MarkDirty();
+                        if (_selectedRule != null) BuildTriggerFields();
+                        ScheduleValidation();
+                    };
+                    presetGrid.Children.Add(b);
+                }
+            }
+            host.Children.Add(presetGrid);
+
+            var pickBtn = new Button
+            {
+                Content = Loc.Get("deeper_editor_trigger_pick_on_video"),
+                Padding = new Thickness(10, 4, 10, 4),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Background = Res("DeeperAccentTransparent20Brush"),
+                Foreground = Res("DeeperAccentBrush"),
+                BorderBrush = Res("DeeperAccentBrush"),
+                BorderThickness = new Thickness(1),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            pickBtn.Click += (_, _) => BeginGazePick(getter);
+            host.Children.Add(pickBtn);
+        }
+
+        private void AddSeekFields(SeekAction seek)
+        {
+            ActionFields.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_action_seek_target")));
+            var combo = NewEditorComboBox();
+            string[] targets = { SeekTargets.Time, SeekTargets.RegionStart, SeekTargets.RegionEnd };
+            foreach (var t in targets) combo.Items.Add(t);
+            var curIdx = Array.IndexOf(targets, seek.Target);
+            combo.SelectedIndex = curIdx >= 0 ? curIdx : 0;
+
+            var dynamicHost = new StackPanel();
+            void RebuildDynamic()
+            {
+                dynamicHost.Children.Clear();
+                if (seek.Target == SeekTargets.Time)
+                {
+                    AddDoubleField(dynamicHost, Loc.Get("deeper_editor_action_seek_time"),
+                        seek.Time ?? 0, v => seek.Time = Math.Max(0, v));
+                }
+                else
+                {
+                    AddRegionPicker(dynamicHost, seek.RegionId ?? "",
+                        id => seek.RegionId = string.IsNullOrEmpty(id) ? null : id);
+                }
+            }
+
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                seek.Target = (combo.SelectedItem as string) ?? SeekTargets.Time;
+                if (seek.Target == SeekTargets.Time && seek.Time == null) seek.Time = 0;
+                RebuildDynamic();
+                MarkDirty();
+                ScheduleValidation();
+            };
+
+            ActionFields.Children.Add(combo);
+            ActionFields.Children.Add(dynamicHost);
+            RebuildDynamic();
+        }
+
+        private void AddHapticActionFields(TriggerHapticAction h)
+        {
+            ActionFields.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_haptic_pattern")));
+            var combo = NewEditorComboBox();
+            foreach (var name in StockHapticPatterns.Names) combo.Items.Add(name);
+            combo.Items.Add(Loc.Get("deeper_editor_haptic_pattern_custom"));
+
+            var curveHost = new StackPanel { Margin = new Thickness(0, 4, 0, 8) };
+
+            void SyncCurveVisibility()
+            {
+                bool isCustom = h.CustomPattern != null && h.CustomPattern.Count > 0;
+                curveHost.Children.Clear();
+                if (isCustom) BuildCurveEditor(curveHost, h);
+            }
+
+            int initialIdx = -1;
+            bool initialCustom = h.CustomPattern != null && h.CustomPattern.Count > 0;
+            if (initialCustom) initialIdx = StockHapticPatterns.Names.Count;
+            else if (!string.IsNullOrEmpty(h.PatternName))
+            {
+                for (int i = 0; i < StockHapticPatterns.Names.Count; i++)
+                    if (StockHapticPatterns.Names[i] == h.PatternName) { initialIdx = i; break; }
+            }
+            combo.SelectedIndex = initialIdx >= 0 ? initialIdx : 0;
+
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                var idx = combo.SelectedIndex;
+                if (idx < 0) return;
+                if (idx < StockHapticPatterns.Names.Count)
+                {
+                    h.PatternName = StockHapticPatterns.Names[idx];
+                    h.CustomPattern = null;
+                }
+                else
+                {
+                    h.CustomPattern ??= StockHapticPatterns.SeedCustomFrom(h.PatternName);
+                    h.PatternName = null;
+                }
+                SyncCurveVisibility();
+                MarkDirty();
+                ScheduleValidation();
+            };
+
+            ActionFields.Children.Add(combo);
+            AddHapticTargetField(ActionFields, h);
+            ActionFields.Children.Add(curveHost);
+            SyncCurveVisibility();
+
+            AddDoubleField(ActionFields, Loc.Get("deeper_editor_action_intensity"),
+                h.Intensity, v => h.Intensity = Math.Clamp(v, 0, 1));
+            AddIntField(ActionFields, Loc.Get("deeper_editor_action_duration_ms"),
+                h.DurationMs, v => h.DurationMs = Math.Max(50, v));
+        }
+
+        private void AddHapticTargetField(Panel host, IHapticPatternTarget h)
+        {
+            host.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_haptic_target")));
+            var combo = NewEditorComboBox();
+            FillHapticTargetCombo(combo);
+            combo.SelectedIndex = HapticTargetIndex(h.Target);
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                h.Target = HapticTargetAt(combo.SelectedIndex);
+                MarkDirty();
+                ScheduleValidation();
+            };
+            host.Children.Add(combo);
+        }
+
+        // Generic effect-firing action (TriggerEffect). Lets a rule fire any of the six effect
+        // types with its own intensity / duration / type-specific settings, independent of any
+        // TimelineItem. Mirrors the per-type editor panels.
+        private void AddTriggerEffectActionFields(TriggerEffectAction te)
+        {
+            ActionFields.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_action_effect_type")));
+            var typeCombo = NewEditorComboBox();
+            string[] effectTypes =
+            {
+                EffectTypes.Haptic, EffectTypes.Flash, EffectTypes.Bubble,
+                EffectTypes.Subliminal, EffectTypes.Overlay, EffectTypes.Speak
+            };
+            foreach (var t in effectTypes)
+                typeCombo.Items.Add(new ComboBoxItem { Theme = EditorComboBoxItemTheme, Content = t, Tag = t });
+            var curIdx = Array.IndexOf(effectTypes, te.EffectType);
+            typeCombo.SelectedIndex = curIdx >= 0 ? curIdx : 0;
+            ActionFields.Children.Add(typeCombo);
+
+            // Per-type fields rebuild on type switch.
+            var typeFieldsHost = new StackPanel();
+            ActionFields.Children.Add(typeFieldsHost);
+
+            void RebuildTypeFields()
+            {
+                typeFieldsHost.Children.Clear();
+                switch (te.EffectType)
+                {
+                    case EffectTypes.Haptic:
+                        AddTriggerEffectHapticFields(typeFieldsHost, te);
+                        break;
+                    case EffectTypes.Flash:
+                        AddIntField(typeFieldsHost, Loc.Get("deeper_editor_action_duration_ms"),
+                            te.DurationMs, v => te.DurationMs = Math.Max(50, v));
+                        AddBoolField(typeFieldsHost, Loc.Get("deeper_editor_action_play_sound"),
+                            te.PlaySound, v => te.PlaySound = v);
+                        break;
+                    case EffectTypes.Bubble:
+                        AddIntField(typeFieldsHost, Loc.Get("deeper_editor_action_max_bubbles"),
+                            te.MaxBubbles, v => te.MaxBubbles = Math.Max(1, v));
+                        AddDoubleField(typeFieldsHost, Loc.Get("deeper_editor_action_intensity"),
+                            te.Intensity, v => te.Intensity = Math.Clamp(v, 0, 1));
+                        AddIntField(typeFieldsHost, Loc.Get("deeper_editor_action_duration_ms"),
+                            te.DurationMs, v => te.DurationMs = Math.Max(50, v));
+                        break;
+                    case EffectTypes.Subliminal:
+                        AddTextField(typeFieldsHost, Loc.Get("deeper_editor_action_subliminal_text"),
+                            te.Text ?? "", v => te.Text = v);
+                        AddIntField(typeFieldsHost, Loc.Get("deeper_editor_action_duration_ms"),
+                            te.DurationMs, v => te.DurationMs = Math.Max(50, v));
+                        break;
+                    case EffectTypes.Overlay:
+                        AddOverlayKindCombo(typeFieldsHost, te);
+                        AddDoubleField(typeFieldsHost, Loc.Get("deeper_editor_action_opacity"),
+                            te.Opacity, v => te.Opacity = Math.Clamp(v, 0, 1));
+                        AddIntField(typeFieldsHost, Loc.Get("deeper_editor_action_duration_ms"),
+                            te.DurationMs, v => te.DurationMs = Math.Max(50, v));
+                        break;
+                    case EffectTypes.Speak:
+                        AddSpeakActionFields(typeFieldsHost, te);
+                        break;
+                }
+            }
+            RebuildTypeFields();
+
+            typeCombo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                if (typeCombo.SelectedItem is ComboBoxItem cbi && cbi.Tag is string newType
+                    && newType != te.EffectType)
+                {
+                    te.EffectType = newType;
+                    // Reset stale type-specific fields so a Flash->Haptic switch doesn't leak Flash
+                    // defaults into the haptic interpretation.
+                    if (newType == EffectTypes.Haptic && string.IsNullOrEmpty(te.PatternName))
+                        te.PatternName = "Pulse";
+                    if (newType == EffectTypes.Overlay && string.IsNullOrEmpty(te.OverlayKind))
+                        te.OverlayKind = OverlayKinds.PinkFilter;
+                    if (newType == EffectTypes.Speak && string.IsNullOrWhiteSpace(te.SpeakTarget))
+                    {
+                        te.SpeakTarget = "YES";
+                        te.SpeakCorrectMessage = "good girl";
+                        te.SpeakIncorrectMessage = "try again";
+                    }
+                    RebuildTypeFields();
+                    MarkDirty();
+                    ScheduleValidation();
+                }
+            };
+        }
+
+        // Haptic sub-fields for TriggerEffect. Mirrors AddHapticActionFields but bound to a
+        // TriggerEffectAction's flat fields instead of TriggerHapticAction.
+        private void AddTriggerEffectHapticFields(Panel host, TriggerEffectAction te)
+        {
+            host.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_haptic_pattern")));
+            var combo = NewEditorComboBox();
+            foreach (var name in StockHapticPatterns.Names) combo.Items.Add(name);
+            int idx = -1;
+            if (!string.IsNullOrEmpty(te.PatternName))
+            {
+                for (int i = 0; i < StockHapticPatterns.Names.Count; i++)
+                    if (StockHapticPatterns.Names[i] == te.PatternName) { idx = i; break; }
+            }
+            combo.SelectedIndex = idx >= 0 ? idx : 0;
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                var i = combo.SelectedIndex;
+                if (i >= 0 && i < StockHapticPatterns.Names.Count)
+                {
+                    te.PatternName = StockHapticPatterns.Names[i];
+                    MarkDirty();
+                    ScheduleValidation();
+                }
+            };
+            host.Children.Add(combo);
+
+            AddDoubleField(host, Loc.Get("deeper_editor_action_intensity"),
+                te.Intensity, v => te.Intensity = Math.Clamp(v, 0, 1));
+            AddIntField(host, Loc.Get("deeper_editor_action_duration_ms"),
+                te.DurationMs, v => te.DurationMs = Math.Max(50, v));
+        }
+
+        // Overlay-kind combo for TriggerEffect. Same order, labels and Tag round-trip as the inline
+        // CmbOverlayKind picker; an already-authored withheld kind stays selectable so a rule that
+        // uses one still displays honestly and round-trips on save.
+        private void AddOverlayKindCombo(Panel host, TriggerEffectAction te)
+        {
+            host.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_action_overlay_kind")));
+            var combo = NewEditorComboBox();
+            var kinds  = new List<string> { OverlayKinds.PinkFilter, OverlayKinds.Spiral,
+                                            OverlayKinds.BrainDrain, OverlayKinds.BrainDrainMelt };
+            var labels = new List<string> { "Pink Filter", "Spiral", "Brain Drain", "Brain Melt" };
+            var curK = te.OverlayKind ?? OverlayKinds.PinkFilter;
+            if (OverlayKinds.IsWithheld(curK))
+            {
+                kinds.Add(curK);
+                labels.Add(curK == OverlayKinds.BrainDrainMelt
+                    ? "Brain Melt (unavailable)"
+                    : "Brain Drain (unavailable)");
+            }
+            for (int i = 0; i < kinds.Count; i++)
+                combo.Items.Add(new ComboBoxItem { Theme = EditorComboBoxItemTheme, Content = labels[i], Tag = kinds[i] });
+            var idx = kinds.IndexOf(curK);
+            combo.SelectedIndex = idx >= 0 ? idx : 0;
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                if (combo.SelectedItem is ComboBoxItem cbi && cbi.Tag is string k)
+                {
+                    te.OverlayKind = k;
+                    MarkDirty();
+                    ScheduleValidation();
+                }
+            };
+            host.Children.Add(combo);
+        }
+
+        // Speak (voice prompt) sub-fields for a rule's TriggerEffect action.
+        private void AddSpeakActionFields(Panel host, TriggerEffectAction te)
+        {
+            AddSpeakTextField(host, "Phrase to say (max 24)", te.SpeakTarget ?? "", 24, v => te.SpeakTarget = v);
+            AddSpeakTextField(host, "On-screen cue (blank = \"Say {phrase}\")", te.SpeakCue ?? "", 40, v => te.SpeakCue = v);
+
+            // Cue style + interval (interval only matters for intermittent, but keeping it
+            // always-visible avoids a rebuild dance in the rule inspector).
+            AddSpeakEnumCombo(host, "Cue style", te.SpeakCueMode,
+                new[] { (SpeakCueMode.Intermittent, "Intermittent (flash)"), (SpeakCueMode.Persistent, "Persistent (stay on top)") },
+                v => te.SpeakCueMode = v);
+            AddIntField(host, "Flash interval (ms)", te.SpeakCueIntervalMs, v => te.SpeakCueIntervalMs = Math.Max(80, v));
+
+            AddIntField(host, "Times to say it (1-5)", te.SpeakRequiredReps, v => te.SpeakRequiredReps = Math.Clamp(v, 1, 5));
+
+            AddSpeakEnumCombo(host, "Completion", te.SpeakCompletion,
+                new[] { (SpeakCompletion.UntilSatisfied, "Until satisfied"), (SpeakCompletion.Duration, "For the region (soft)") },
+                v => te.SpeakCompletion = v);
+            AddSpeakEnumCombo(host, "While waiting…", te.SpeakHoldMode,
+                new[] { (SpeakHoldMode.LoopRegion, "Loop the region"), (SpeakHoldMode.Pause, "Pause the video"), (SpeakHoldMode.KeepPlaying, "Keep playing") },
+                v => te.SpeakHoldMode = v);
+
+            AddSpeakTextField(host, "Praise (on correct)", te.SpeakCorrectMessage ?? "", 40, v => te.SpeakCorrectMessage = v);
+            AddSpeakTextField(host, "Scold (on miss)", te.SpeakIncorrectMessage ?? "", 40, v => te.SpeakIncorrectMessage = v);
+        }
+
+        private void AddSpeakTextField(Panel host, string label, string value, int maxLength, Action<string> setter)
+        {
+            host.Children.Add(NewEditorLabel(label));
+            var tb = NewEditorTextBox(value ?? "");
+            tb.MaxLength = maxLength;
+            tb.TextChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                setter(tb.Text ?? "");
+                MarkDirty();
+                ScheduleValidation();
+            };
+            host.Children.Add(tb);
+        }
+
+        private void AddSpeakEnumCombo<TEnum>(Panel host, string label, TEnum current,
+            (TEnum value, string display)[] options, Action<TEnum> setter) where TEnum : struct, Enum
+        {
+            host.Children.Add(NewEditorLabel(label));
+            var combo = NewEditorComboBox();
+            int sel = 0;
+            for (int i = 0; i < options.Length; i++)
+            {
+                combo.Items.Add(new ComboBoxItem
+                {
+                    Theme = EditorComboBoxItemTheme,
+                    Content = options[i].display,
+                    Tag = options[i].value
+                });
+                if (EqualityComparer<TEnum>.Default.Equals(options[i].value, current)) sel = i;
+            }
+            combo.SelectedIndex = sel;
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                if (combo.SelectedItem is ComboBoxItem cbi && cbi.Tag is TEnum v)
+                {
+                    setter(v);
+                    MarkDirty();
+                    ScheduleValidation();
+                }
+            };
+            host.Children.Add(combo);
+        }
+
+        // Self-contained curve editor for any IHapticPatternTarget. Builds its own canvas +
+        // handles + reset button into <paramref name="host"/>, independent of the haptic-event
+        // editor's XAML CurveCanvas.
+        private void BuildCurveEditor(Panel host, IHapticPatternTarget target)
+        {
+            host.Children.Add(new TextBlock
+            {
+                Text = Loc.Get("deeper_editor_haptic_curve"),
+                Foreground = Res("TextMutedBrush"),
+                FontSize = 11,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+
+            var canvas = new Canvas { Height = 120, Background = Brushes.Transparent, ClipToBounds = true };
+            var border = new Border
+            {
+                Background = new SolidColorBrush(Color.FromArgb(0x10, 0, 0, 0x20)),
+                BorderBrush = Res("DeeperAccentTransparent40Brush"),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(6),
+                Child = canvas
+            };
+            host.Children.Add(border);
+
+            void Redraw()
+            {
+                canvas.Children.Clear();
+                var pts = target.CustomPattern;
+                if (pts == null || pts.Count == 0) return;
+                var w = canvas.Bounds.Width;
+                var h = canvas.Bounds.Height;
+                if (w <= 0 || h <= 0) return;
+
+                for (int i = 1; i <= 3; i++)
+                {
+                    var y = h * i / 4.0;
+                    canvas.Children.Add(new Line
+                    {
+                        StartPoint = new Point(0, y),
+                        EndPoint = new Point(w, y),
+                        Stroke = new SolidColorBrush(Color.FromArgb(40, 255, 255, 255)),
+                        StrokeThickness = 0.5,
+                        IsHitTestVisible = false
+                    });
+                }
+
+                var geom = new StreamGeometry();
+                using (var ctx = geom.Open())
+                {
+                    ctx.BeginFigure(KeyframeToCanvas(pts[0], w, h), false);
+                    for (int i = 1; i < pts.Count; i++)
+                        ctx.LineTo(KeyframeToCanvas(pts[i], w, h));
+                    ctx.EndFigure(false);
+                }
+                canvas.Children.Add(new Path
+                {
+                    Data = geom,
+                    Stroke = Res("DeeperAccentBrush"),
+                    StrokeThickness = 1.6,
+                    IsHitTestVisible = false
+                });
+
+                for (int i = 0; i < pts.Count; i++)
+                {
+                    int captured = i;
+                    var pt = KeyframeToCanvas(pts[i], w, h);
+                    var dot = new Ellipse
+                    {
+                        Width = 10, Height = 10,
+                        Fill = Res("DeeperAccentBrush"),
+                        Stroke = Brushes.White,
+                        StrokeThickness = 1.2,
+                        Cursor = new Cursor(StandardCursorType.SizeNorthSouth),
+                    };
+                    Canvas.SetLeft(dot, pt.X - 5);
+                    Canvas.SetTop(dot, pt.Y - 5);
+                    bool dragging = false;
+                    dot.PointerPressed += (_, ev) =>
+                    {
+                        if (!ev.GetCurrentPoint(dot).Properties.IsLeftButtonPressed) return;
+                        dragging = true;
+                        ev.Pointer.Capture(dot);
+                        ev.Handled = true;
+                    };
+                    dot.PointerMoved += (_, ev) =>
+                    {
+                        if (!dragging) return;
+                        var hh = canvas.Bounds.Height;
+                        if (hh <= 0) return;
+                        var y = ev.GetPosition(canvas).Y;
+                        var v = Math.Clamp(1.0 - (y / hh), 0, 1);
+                        var kf = target.CustomPattern![captured];
+                        if (kf.Length > 1) kf[1] = v;
+                        MarkDirty();
+                        Redraw();
+                    };
+                    dot.PointerReleased += (_, ev) =>
+                    {
+                        if (!dragging) return;
+                        dragging = false;
+                        ev.Pointer.Capture(null);
+                        ScheduleValidation();
+                    };
+                    canvas.Children.Add(dot);
+                }
+            }
+
+            canvas.SizeChanged += (_, _) => Redraw();
+            Redraw();
+
+            var reset = new Button
+            {
+                Content = Loc.Get("deeper_editor_haptic_curve_reset"),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Margin = new Thickness(0, 4, 0, 0),
+                Padding = new Thickness(8, 4, 8, 4),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Background = Brushes.Transparent,
+                Foreground = Res("TextLightBrush"),
+                BorderBrush = Res("DeeperAccentTransparent40Brush"),
+                BorderThickness = new Thickness(1),
+            };
+            reset.Click += (_, _) =>
+            {
+                PushUndoSnapshot();
+                target.CustomPattern = StockHapticPatterns.SeedCustomFrom(null);
+                MarkDirty();
+                Redraw();
+                ScheduleValidation();
+            };
+            host.Children.Add(reset);
+        }
+
+        // -- Tiny field helpers ------------------------------------------------
+
+        private void AddIntField(Panel host, string label, int value, Action<int> setter)
+        {
+            host.Children.Add(NewEditorLabel(label));
+            var tb = NewEditorTextBox(value.ToString(CultureInfo.InvariantCulture));
+            tb.TextChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                if (int.TryParse(tb.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v))
+                {
+                    setter(v); MarkDirty(); ScheduleValidation();
+                }
+            };
+            host.Children.Add(tb);
+        }
+
+        private void AddDoubleField(Panel host, string label, double value, Action<double> setter)
+        {
+            host.Children.Add(NewEditorLabel(label));
+            var tb = NewEditorTextBox(value.ToString("0.###", CultureInfo.InvariantCulture));
+            tb.TextChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                if (double.TryParse(tb.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                {
+                    setter(v); MarkDirty(); ScheduleValidation();
+                }
+            };
+            host.Children.Add(tb);
+        }
+
+        private void AddTextField(Panel host, string label, string value, Action<string> setter)
+        {
+            host.Children.Add(NewEditorLabel(label));
+            var tb = NewEditorTextBox(value ?? "");
+            tb.TextChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                setter(tb.Text ?? "");
+                MarkDirty();
+                ScheduleValidation();
+            };
+            host.Children.Add(tb);
+        }
+
+        private void AddBoolField(Panel host, string label, bool value, Action<bool> setter)
+        {
+            var cb = new CheckBox
+            {
+                Content = label,
+                IsChecked = value,
+                Foreground = Res("TextLightBrush"),
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+            cb.IsCheckedChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                setter(cb.IsChecked == true);
+                MarkDirty();
+                ScheduleValidation();
+            };
+            host.Children.Add(cb);
+        }
+
+        // Assigns a name to the most recently-added TextBox in a dynamic field host so the
+        // interactive tutorial can spotlight and gate on it. Avalonia refuses to rename an element
+        // that is already in a tree, so this is best-effort - the try/catch is the port, not a
+        // shortcut.
+        private static void AssignNameToLastTextBox(Panel host, string name)
+        {
+            for (int i = host.Children.Count - 1; i >= 0; i--)
+            {
+                if (host.Children[i] is TextBox tb)
+                {
+                    try { tb.Name = name; } catch { }
+                    return;
+                }
+            }
+        }
+
+        private void AddInfoText(Panel host, string text)
+        {
+            host.Children.Add(new TextBlock
+            {
+                Text = text,
+                Foreground = Res("TextMutedBrush"),
+                FontSize = 11,
+                FontStyle = FontStyle.Italic,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 8)
+            });
+        }
+
+        // Renders the localized one-line description for the currently-picked trigger or action
+        // type, so the user sees what each type does the moment they pick it.
+        private void AddTypeDescription(Panel host, string locKey)
+        {
+            var text = Loc.Get(locKey);
+            if (string.IsNullOrEmpty(text) || text == locKey) return; // no key = skip
+            host.Children.Add(new Border
+            {
+                Background = Res("DeeperAccentTransparent20Brush"),
+                BorderBrush = Res("DeeperAccentTransparent40Brush"),
+                BorderThickness = new Thickness(0, 0, 0, 1),
+                Padding = new Thickness(8, 6, 8, 6),
+                Margin = new Thickness(0, 0, 0, 8),
+                CornerRadius = new CornerRadius(3),
+                Child = new TextBlock
+                {
+                    Text = text,
+                    Foreground = Res("TextLightBrush"),
+                    FontSize = 11,
+                    TextWrapping = TextWrapping.Wrap
+                }
+            });
+        }
+
+        private static string TriggerDescriptionKey(string type) => type switch
+        {
+            TriggerTypes.GazeTarget    => "deeper_desc_trigger_gaze_target",
+            TriggerTypes.GazeAvoid     => "deeper_desc_trigger_gaze_avoid",
+            TriggerTypes.AttentionLost => "deeper_desc_trigger_attention_lost",
+            TriggerTypes.BlinkDetected => "deeper_desc_trigger_blink_detected",
+            TriggerTypes.MouthOpen     => "deeper_desc_trigger_mouth_open",
+            TriggerTypes.TimeReached   => "deeper_desc_trigger_time_reached",
+            TriggerTypes.RegionEntered => "deeper_desc_trigger_region_entered",
+            TriggerTypes.RegionExited  => "deeper_desc_trigger_region_exited",
+            _                          => ""
+        };
+
+        private static string ActionDescriptionKey(string type) => type switch
+        {
+            ActionTypes.Seek          => "deeper_desc_action_seek",
+            ActionTypes.LoopRegion    => "deeper_desc_action_loop_region",
+            ActionTypes.Pause         => "deeper_desc_action_pause",
+            ActionTypes.PlayAudio     => "deeper_desc_action_play_audio",
+            ActionTypes.TriggerHaptic => "deeper_desc_action_trigger_haptic",
+            ActionTypes.TriggerEffect => "deeper_desc_action_trigger_effect",
+            ActionTypes.ScreenShake   => "deeper_desc_action_screen_shake",
+            ActionTypes.SetIntensity  => "deeper_desc_action_set_intensity",
+            ActionTypes.NoOp          => "deeper_desc_action_noop",
+            _                         => ""
+        };
+
+        private void AddRegionPicker(Panel host, string currentId, Action<string> setter, bool allowNone = false)
+        {
+            host.Children.Add(NewEditorLabel(Loc.Get("deeper_editor_rule_region_id")));
+            var combo = NewEditorComboBox();
+            int selected = -1;
+            if (allowNone) combo.Items.Add(Loc.Get("deeper_editor_rule_region_current"));
+            for (int i = 0; i < _enhancement.Regions.Count; i++)
+            {
+                var r = _enhancement.Regions[i];
+                combo.Items.Add(string.IsNullOrEmpty(r.Label) ? r.Id : $"{r.Id} — {r.Label}");
+                if (r.Id == currentId) selected = i + (allowNone ? 1 : 0);
+            }
+            if (selected < 0) selected = combo.Items.Count > 0 ? 0 : -1;
+            combo.SelectedIndex = selected;
+
+            combo.SelectionChanged += (_, _) =>
+            {
+                if (_suppressRuleSync) return;
+                var idx = combo.SelectedIndex;
+                if (allowNone && idx == 0) { setter(""); }
+                else if (idx >= 0)
+                {
+                    var regionIdx = allowNone ? idx - 1 : idx;
+                    if (regionIdx >= 0 && regionIdx < _enhancement.Regions.Count)
+                        setter(_enhancement.Regions[regionIdx].Id);
+                }
+                MarkDirty();
+                ScheduleValidation();
+            };
+            host.Children.Add(combo);
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Preview button
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>ponytail: needs App.DeeperPlayer + App.DeeperHost. The player window itself is
+        /// already ported (EnhancementPlayerWindow), but it takes the live enhancement plus those
+        /// two services, so opening it is left to the layer that moves them. HealEmptyTriggerRegionIds
+        /// below is real and still runs, since it is pure data repair.</summary>
+        private void BtnPreview_Click(object? sender, RoutedEventArgs e)
+        {
+            HealEmptyTriggerRegionIds();
+            Log.Debug("DeeperEditor: preview needs App.DeeperPlayer + App.DeeperHost");
+        }
+
+        /// <summary>
+        /// Heal band-style rules whose trigger.RegionId is empty but whose RegionConstraint already
+        /// points at a real region (an older buggy path left RegionId blank). Without this,
+        /// validation rejects the in-memory enhancement and the player opens with no media.
+        /// </summary>
+        private void HealEmptyTriggerRegionIds()
+        {
+            try
+            {
+                var regionIds = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var r in _enhancement.Regions)
+                    if (!string.IsNullOrEmpty(r?.Id)) regionIds.Add(r!.Id!);
+
+                foreach (var rule in _enhancement.Rules)
+                {
+                    if (rule == null) continue;
+                    var fallbackId = rule.RegionConstraint;
+                    if (string.IsNullOrEmpty(fallbackId) || !regionIds.Contains(fallbackId)) continue;
+
+                    if (rule.Trigger is RegionEnteredTrigger re && string.IsNullOrEmpty(re.RegionId))
+                        re.RegionId = fallbackId;
+                    else if (rule.Trigger is RegionExitedTrigger rx && string.IsNullOrEmpty(rx.RegionId))
+                        rx.RegionId = fallbackId;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: HealEmptyTriggerRegionIds error: {Error}", ex.Message);
+            }
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Gaze rect picker
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>
+        /// ponytail: needs GazePickerWindow plus the Win32 screen placement the WPF version used -
+        /// PreviewHost.PointToScreen for the two corners and VisualTreeHelper.GetDpi(this) to
+        /// convert them back to device-independent units. Avalonia has Screens/Scaling equivalents,
+        /// but the picker window itself is not ported, so this is a named stub: the "Pick on video…"
+        /// button exists and is hit-testable, and the rect stays whatever the four x/y/w/h boxes
+        /// and the 3x3 preset grid put there.
+        /// </summary>
+        private void BeginGazePick(Func<double[]> rectGetter)
+        {
+            _ = rectGetter;
+            Log.Debug("DeeperEditor: gaze rect picker needs GazePickerWindow + screen placement");
+        }
+
+        /// <summary>Force-closes any open picker. A no-op while <see cref="BeginGazePick"/> is a
+        /// stub, but every selection path calls it, so it stays named and called.</summary>
+        private void EndGazePick(bool commit) { _ = commit; }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.Ruler.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.Ruler.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    // PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.Ruler.cs. Deviations:
+    //   Line X1/X2/Y1/Y2      -> StartPoint / EndPoint
+    //   Panel.SetZIndex(v, n) -> v.ZIndex = n
+    //   ActualWidth/Height    -> Bounds.Width / Bounds.Height
+    //   brush.Freeze()        -> dropped (Avalonia brushes are not freezable)
+    //   label.Measure(...)    -> Measure(Size.Infinity) then DesiredSize, same idea
+    //   App.Logger            -> Serilog.Log
+    //
+    // Timeline timestamp ruler: a thin overlay strip at the top of the TimelineCanvas with
+    // adaptive tick spacing. Major ticks carry a time label (m:ss or h:mm:ss); minor ticks fill at
+    // 1/5 of major and stay unlabeled. The interval auto-picks from a "nice numbers" preset list
+    // (0.1s -> 1h) so labels keep at least ~70px between them at any zoom level. Renders inside
+    // TimelineCanvas (not a separate strip) to avoid duplicating the ScrollViewer plumbing.
+    public partial class DeeperEditorWindow
+    {
+        private readonly List<Control> _rulerVisuals = new();
+        private const double RulerStripHeight = 14.0;
+        private const double RulerMinLabelSpacingPx = 70.0;
+
+        // "Nice" major-tick intervals in seconds. The picker finds the first value >= the minimum
+        // spacing needed at the current zoom.
+        private static readonly double[] NiceTickIntervalsSec =
+        {
+            0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30,
+            60, 120, 300, 600, 1800, 3600, 7200, 18000, 36000
+        };
+
+        private void RebuildTimelineRuler()
+        {
+            try
+            {
+                ClearRulerVisuals();
+
+                if (TimelineCanvas == null) return;
+                var w = TimelineCanvas.Bounds.Width;
+                if (w <= 0 || _totalSeconds <= 0) return;
+
+                // Semi-transparent strip behind the labels so regions sitting under the top of the
+                // lane area don't make the text unreadable.
+                var stripBrush = new SolidColorBrush(Color.FromArgb(160, 0, 0, 0));
+                var strip = new Rectangle
+                {
+                    Width = w,
+                    Height = RulerStripHeight,
+                    Fill = stripBrush,
+                    IsHitTestVisible = false,
+                    ZIndex = 50
+                };
+                Canvas.SetLeft(strip, 0);
+                Canvas.SetTop(strip, 0);
+                TimelineCanvas.Children.Add(strip);
+                _rulerVisuals.Add(strip);
+
+                // Lane dividers: faint full-width lines at the Effects + Haptics lane tops so the
+                // three equal lanes read on the canvas itself, not just in the header column.
+                var canvasH = TimelineCanvas.Bounds.Height;
+                if (canvasH > 0)
+                {
+                    var dividerBrush = new SolidColorBrush(Color.FromArgb(40, 230, 230, 230));
+                    foreach (var lane in new[] { TimelineLane.Effects, TimelineLane.Haptics })
+                    {
+                        var (laneTop, _) = LaneBand(lane, canvasH);
+                        var divider = new Line
+                        {
+                            StartPoint = new Point(0, laneTop),
+                            EndPoint = new Point(w, laneTop),
+                            Stroke = dividerBrush,
+                            StrokeThickness = 1,
+                            IsHitTestVisible = false,
+                            ZIndex = 1
+                        };
+                        TimelineCanvas.Children.Add(divider);
+                        _rulerVisuals.Add(divider);
+                    }
+                }
+
+                var pxPerSec = w / _totalSeconds;
+                if (pxPerSec <= 0) return;
+                var minSecPerLabel = RulerMinLabelSpacingPx / pxPerSec;
+                var majorSec = PickNiceTickInterval(minSecPerLabel);
+                var minorSec = majorSec / 5.0;
+
+                var majorBrush = new SolidColorBrush(Color.FromArgb(200, 230, 230, 230));
+                var minorBrush = new SolidColorBrush(Color.FromArgb(110, 230, 230, 230));
+                var labelBrush = new SolidColorBrush(Color.FromArgb(255, 235, 235, 235));
+
+                // Minor ticks first so majors render on top. Skip indices that coincide with
+                // majors (avoid drawing two lines on the same x).
+                if (minorSec > 0)
+                {
+                    int n = (int)Math.Ceiling(_totalSeconds / minorSec);
+                    for (int i = 0; i <= n; i++)
+                    {
+                        double t = i * minorSec;
+                        if (t > _totalSeconds) break;
+                        if (i % 5 == 0) continue; // major
+                        var x = (t / _totalSeconds) * w;
+                        var line = new Line
+                        {
+                            StartPoint = new Point(x, RulerStripHeight - 4),
+                            EndPoint = new Point(x, RulerStripHeight),
+                            Stroke = minorBrush,
+                            StrokeThickness = 1,
+                            IsHitTestVisible = false,
+                            ZIndex = 51
+                        };
+                        TimelineCanvas.Children.Add(line);
+                        _rulerVisuals.Add(line);
+                    }
+                }
+
+                // Major ticks + labels.
+                int m = (int)Math.Floor(_totalSeconds / majorSec);
+                for (int i = 0; i <= m; i++)
+                {
+                    double t = i * majorSec;
+                    var x = (t / _totalSeconds) * w;
+
+                    var tick = new Line
+                    {
+                        StartPoint = new Point(x, 0),
+                        EndPoint = new Point(x, RulerStripHeight),
+                        Stroke = majorBrush,
+                        StrokeThickness = 1,
+                        IsHitTestVisible = false,
+                        ZIndex = 52
+                    };
+                    TimelineCanvas.Children.Add(tick);
+                    _rulerVisuals.Add(tick);
+
+                    // Skip the t=0 label - it overlaps the lane-chrome border and carries nothing
+                    // the playhead's TxtCurrentTime readout doesn't already say. Nudge the final
+                    // label left if it would clip past the canvas edge.
+                    if (i == 0) continue;
+                    var label = new TextBlock
+                    {
+                        Text = FormatRulerTime(t, majorSec),
+                        Foreground = labelBrush,
+                        FontSize = 9,
+                        FontFamily = new FontFamily("Consolas, Courier New, monospace"),
+                        IsHitTestVisible = false,
+                        ZIndex = 53
+                    };
+                    label.Measure(Size.Infinity);
+                    double labelW = label.DesiredSize.Width;
+                    double labelX = x + 2;
+                    if (labelX + labelW > w) labelX = Math.Max(0, x - labelW - 2);
+                    Canvas.SetLeft(label, labelX);
+                    Canvas.SetTop(label, 1);
+                    TimelineCanvas.Children.Add(label);
+                    _rulerVisuals.Add(label);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: RebuildTimelineRuler error: {Error}", ex.Message);
+            }
+        }
+
+        private void ClearRulerVisuals()
+        {
+            foreach (var v in _rulerVisuals)
+            {
+                try { TimelineCanvas.Children.Remove(v); } catch { }
+            }
+            _rulerVisuals.Clear();
+        }
+
+        private static double PickNiceTickInterval(double minSecondsPerTick)
+        {
+            foreach (var n in NiceTickIntervalsSec)
+                if (n >= minSecondsPerTick) return n;
+            return NiceTickIntervalsSec[^1];
+        }
+
+        private static string FormatRulerTime(double seconds, double intervalSec)
+        {
+            if (seconds < 0) seconds = 0;
+            // Sub-second resolution: show e.g. "1.2s".
+            if (intervalSec < 1.0)
+                return seconds.ToString("0.0", CultureInfo.InvariantCulture) + "s";
+            var t = TimeSpan.FromSeconds(Math.Round(seconds));
+            if (t.TotalHours >= 1)
+                return $"{(int)t.TotalHours}:{t.Minutes:D2}:{t.Seconds:D2}";
+            return $"{(int)t.TotalMinutes}:{t.Seconds:D2}";
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.Unified.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.Unified.cs
@@ -1,0 +1,1078 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using ConditioningControlPanel.Models.Deeper;
+using ConditioningControlPanel.Services.Deeper;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.Unified.cs.
+    /// New-design pieces of the editor: unified timeline (Effect dots + Rule pins rendered
+    /// alongside the Region/HapticEvent visuals), the right-click context menu, the hero buttons,
+    /// HypnoTube auto-fill, the Creator lock toggle and the five non-haptic effect editor panels.
+    ///
+    /// Deviations:
+    ///   MouseButtonEventArgs / MouseEventArgs -> PointerPressedEventArgs / PointerEventArgs
+    ///   IsCtrlDown()                          -> IsCtrlDown(e.KeyModifiers) (threaded, see MultiSelect)
+    ///   FindResource("TimelineCtxMenu")       -> the menu is inline in the XAML on TimelineCanvas
+    ///   FindResource("HeroAddEffectMenu")     -> a MenuFlyout on BtnAddEffectHero (opens itself)
+    ///   ToolTip = "…"                         -> ToolTip.SetTip(control, "…")
+    ///   Cursors.Hand / SizeAll / SizeWE       -> new Cursor(StandardCursorType.*)
+    ///   Panel.SetZIndex(v, n)                 -> v.ZIndex = n
+    ///   Visibility                            -> IsVisible
+    ///   TutorialEventBus.Emit                 -> stubbed (App-level service)
+    ///   App.Logger                            -> Serilog.Log
+    /// </summary>
+    public partial class DeeperEditorWindow
+    {
+        // -- State (new) -----------------------------------------------------------
+
+        private TimelineItem? _selectedEffect;
+        private double _rightClickSeconds;
+        private bool _creatorLocked;
+        private bool _suppressEffectFieldSync;
+        private CancellationTokenSource? _htFetchCts;
+
+        // Effect-type colours used by both the timeline dots and the picker labels. The Haptic
+        // entry MUST match DeeperAccent in Theme/Colors.xaml - change both together. Kept as a
+        // string literal (not a DynamicResource) because these colours get written into the saved
+        // .ccpenh.json on every effect dot and need to round-trip stably across builds.
+        private static readonly Dictionary<string, string> EffectColors =
+            new()
+            {
+                [EffectTypes.Haptic]     = "#7B5CFF",
+                [EffectTypes.Flash]      = "#FFC85C",
+                [EffectTypes.Bubble]     = "#5CC8FF",
+                [EffectTypes.Subliminal] = "#FF69B4",
+                [EffectTypes.Overlay]    = "#5CFFB7",
+                [EffectTypes.Speak]      = "#FF8A5C",
+            };
+
+        // -- Right-click context menu --------------------------------------------
+
+        /// <summary>
+        /// Captures the click position before the framework opens the context menu. Not marked
+        /// handled, so Avalonia's automatic ContextMenu opening still fires; the menu items read
+        /// <see cref="_rightClickSeconds"/> to compute the drop location.
+        /// </summary>
+        private void TimelineCanvas_MouseRightButtonDown(PointerPressedEventArgs e)
+        {
+            try
+            {
+                _rightClickSeconds = MouseToSeconds(e);
+
+                // Move the playhead to the click point. Most users right-clicking on the timeline
+                // want to drop something there.
+                if (_totalSeconds > 0)
+                {
+                    var frac = Math.Clamp(_rightClickSeconds / _totalSeconds, 0, 1);
+                    SeekToFraction(frac);
+                }
+                else
+                {
+                    // No duration yet. Move the playhead visually so the click registers.
+                    var pt = e.GetPosition(TimelineCanvas);
+                    PlayheadLine.StartPoint = new Point(pt.X, 0);
+                    PlayheadLine.EndPoint = new Point(pt.X, TimelineCanvas.Bounds.Height);
+                }
+
+                // Refresh the audio-mode hide-of-video-only triggers per open.
+                ApplyAudioModeToContextMenu(TimelineCtxMenu);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: ctx menu prep error: {Error}", ex.Message);
+            }
+        }
+
+        private void ApplyAudioModeToContextMenu(ContextMenu? menu)
+        {
+            if (menu == null) return;
+            bool audio = _enhancement.MediaType == MediaTypes.Audio;
+            // Walk the "Add Rule" submenu and hide video-only triggers when on audio.
+            foreach (var top in menu.Items.OfType<MenuItem>())
+            {
+                foreach (var sub in top.Items.OfType<MenuItem>())
+                {
+                    var name = sub.Name ?? "";
+                    bool videoOnly = name is "CtxRuleGazeTarget" or "CtxRuleGazeAvoid"
+                        or "CtxRuleAttentionLost" or "CtxRuleBlinkDetected" or "CtxRuleMouthOpen";
+                    if (videoOnly) sub.IsVisible = !audio;
+                }
+            }
+        }
+
+        private void CtxAddEffectHaptic_Click(object? sender, RoutedEventArgs e)     => AddEffectAt(EffectTypes.Haptic, _rightClickSeconds);
+        private void CtxAddEffectFlash_Click(object? sender, RoutedEventArgs e)      => AddEffectAt(EffectTypes.Flash, _rightClickSeconds);
+        private void CtxAddEffectBubble_Click(object? sender, RoutedEventArgs e)     => AddEffectAt(EffectTypes.Bubble, _rightClickSeconds);
+        private void CtxAddEffectSubliminal_Click(object? sender, RoutedEventArgs e) => AddEffectAt(EffectTypes.Subliminal, _rightClickSeconds);
+        private void CtxAddEffectOverlay_Click(object? sender, RoutedEventArgs e)    => AddEffectAt(EffectTypes.Overlay, _rightClickSeconds);
+        private void CtxAddEffectSpeak_Click(object? sender, RoutedEventArgs e)      => AddEffectAt(EffectTypes.Speak, _rightClickSeconds);
+
+        private void CtxAddRuleTimeReached_Click(object? sender, RoutedEventArgs e)    => AddRuleAt(TriggerTypes.TimeReached, _rightClickSeconds);
+        private void CtxAddRuleBandEntered_Click(object? sender, RoutedEventArgs e)    => AddRuleAt(TriggerTypes.RegionEntered, _rightClickSeconds);
+        private void CtxAddRuleBandExited_Click(object? sender, RoutedEventArgs e)     => AddRuleAt(TriggerTypes.RegionExited, _rightClickSeconds);
+        private void CtxAddRuleGazeTarget_Click(object? sender, RoutedEventArgs e)     => AddRuleAt(TriggerTypes.GazeTarget, _rightClickSeconds);
+        private void CtxAddRuleGazeAvoid_Click(object? sender, RoutedEventArgs e)      => AddRuleAt(TriggerTypes.GazeAvoid, _rightClickSeconds);
+        private void CtxAddRuleAttentionLost_Click(object? sender, RoutedEventArgs e)  => AddRuleAt(TriggerTypes.AttentionLost, _rightClickSeconds);
+        private void CtxAddRuleBlinkDetected_Click(object? sender, RoutedEventArgs e)  => AddRuleAt(TriggerTypes.BlinkDetected, _rightClickSeconds);
+        private void CtxAddRuleMouthOpen_Click(object? sender, RoutedEventArgs e)      => AddRuleAt(TriggerTypes.MouthOpen, _rightClickSeconds);
+
+        /// <summary>
+        /// Same six options as the right-click menu, dropped at the playhead. WPF opened a
+        /// ContextMenu resource by hand; the Avalonia MenuFlyout on the button opens itself, so all
+        /// this has to do is point <see cref="_rightClickSeconds"/> at the playhead first.
+        /// </summary>
+        private void BtnAddEffectHero_Click(object? sender, RoutedEventArgs e)
+        {
+            _rightClickSeconds = Math.Max(0, _currentSeconds);
+        }
+
+        private void BtnAddRuleHero_Click(object? sender, RoutedEventArgs e)
+        {
+            AddRuleAt(TriggerTypes.TimeReached, _currentSeconds);
+        }
+
+        // -- Add Effect ------------------------------------------------------------
+
+        private void AddEffectAt(string effectType, double seconds)
+        {
+            try
+            {
+                seconds = Math.Max(0, seconds);
+                if (effectType == EffectTypes.Haptic)
+                {
+                    // Haptic effects continue to live on the legacy HapticTrack so the existing
+                    // visualisation, drag-shift and curve editor wiring keep working unchanged.
+                    AddHapticEventAt(seconds);
+                    EmitTutorialEvent("EffectAdded");
+                    return;
+                }
+
+                PushUndoSnapshot();
+
+                var defaultDurationMs = effectType switch
+                {
+                    EffectTypes.Bubble => 5000,
+                    EffectTypes.Overlay => 3000,
+                    EffectTypes.Subliminal => 200,
+                    EffectTypes.Flash => 800,
+                    EffectTypes.Speak => 6000,
+                    _ => 1000
+                };
+                var item = new TimelineItem
+                {
+                    Id = TimelineItem.NewId(),
+                    Kind = TimelineItemKind.Effect,
+                    Start = seconds,
+                    Duration = defaultDurationMs / 1000.0,
+                    EffectType = effectType,
+                    EffectIntensity = 1.0,
+                    EffectDurationMs = defaultDurationMs,
+                    EffectMaxBubbles = 3,
+                    EffectOpacity = 0.5,
+                    EffectOverlayKind = OverlayKinds.PinkFilter,
+                    EffectPlaySound = true,
+                    Color = EffectColors.TryGetValue(effectType, out var c) ? c : null
+                };
+                if (effectType == EffectTypes.Speak)
+                {
+                    item.EffectSpeakTarget = "YES";
+                    item.EffectSpeakCueMode = SpeakCueMode.Intermittent;
+                    item.EffectSpeakCueIntervalMs = 250;
+                    item.EffectSpeakRequiredReps = 1;
+                    item.EffectSpeakCompletion = SpeakCompletion.UntilSatisfied;
+                    item.EffectSpeakHoldMode = SpeakHoldMode.LoopRegion;
+                    item.EffectSpeakCorrectMessage = "good girl";
+                    item.EffectSpeakIncorrectMessage = "try again";
+                }
+                _enhancement.TimelineItems.Add(item);
+                MarkDirty();
+                RebuildEffectVisuals();
+                SelectEffect(item);
+                ScheduleValidation();
+                EmitTutorialEvent("EffectAdded");
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: AddEffectAt error: {Error}", ex.Message);
+            }
+        }
+
+        private void AddHapticEventAt(double seconds)
+        {
+            PushUndoSnapshot();
+            var track = _enhancement.HapticTracks.FirstOrDefault();
+            if (track == null)
+            {
+                track = new HapticTrack { Id = "primary" };
+                _enhancement.HapticTracks.Add(track);
+            }
+
+            // Default 5 s when dropped fresh; clamp to the timeline length.
+            double duration = 5.0;
+            if (_totalSeconds > 0) duration = Math.Min(duration, Math.Max(0.1, _totalSeconds - seconds));
+
+            var ev = new HapticEvent
+            {
+                Start = seconds,
+                Duration = Math.Max(0.1, duration),
+                Intensity = 1.0,
+                PatternName = StockHapticPatterns.Names.FirstOrDefault() ?? "Pulse"
+            };
+            track.Events.Add(ev);
+            MarkDirty();
+            RebuildHapticVisuals();
+            SelectHaptic(track, ev);
+            ScheduleValidation();
+        }
+
+        private void AddRuleAt(string triggerType, double seconds)
+        {
+            try
+            {
+                if (_enhancement.MediaType == MediaTypes.Audio
+                    && (triggerType is TriggerTypes.GazeTarget or TriggerTypes.GazeAvoid
+                            or TriggerTypes.AttentionLost or TriggerTypes.BlinkDetected
+                            or TriggerTypes.MouthOpen))
+                {
+                    Log.Debug("DeeperEditor: AddRuleAt skipped video-only trigger on audio enhancement: {T}", triggerType);
+                    return;
+                }
+
+                seconds = Math.Max(0, seconds);
+                double bandDuration = triggerType == TriggerTypes.TimeReached ? 0.0 : 5.0;
+                if (_totalSeconds > 0 && bandDuration > 0)
+                    bandDuration = Math.Min(bandDuration, Math.Max(0.5, _totalSeconds - seconds));
+
+                PushUndoSnapshot();
+
+                var rule = new EnhancementRule
+                {
+                    Trigger = BuildDefaultTrigger(triggerType, seconds),
+                    Action = new NoOpEnhancementAction(),
+                    CooldownMs = 1000,
+                    Enabled = true
+                };
+
+                if (triggerType == TriggerTypes.TimeReached)
+                {
+                    // Point-style rule: no companion region - just a Rule that fires at the time.
+                    _enhancement.Rules.Add(rule);
+                    MarkDirty();
+                    RebuildRuleVisuals();
+                    SelectRule(rule);
+                }
+                else
+                {
+                    // Band-style rule: create a Region the rule constrains to, so the user can
+                    // drag-resize the band and the rule fires only inside it.
+                    var region = new Region
+                    {
+                        Id = NextRegionId(),
+                        Start = seconds,
+                        End = seconds + bandDuration,
+                        Label = "",
+                        Color = NextRegionColor()
+                    };
+                    _enhancement.Regions.Add(region);
+                    rule.RegionConstraint = region.Id;
+                    // Wire the trigger's RegionId to the same region so validation passes on first
+                    // save/preview.
+                    if (rule.Trigger is RegionEnteredTrigger reTrig) reTrig.RegionId = region.Id;
+                    else if (rule.Trigger is RegionExitedTrigger rxTrig) rxTrig.RegionId = region.Id;
+                    _enhancement.Rules.Add(rule);
+                    MarkDirty();
+                    RebuildRegionVisuals();
+                    // Select the Rule (not the Region) so the user immediately sees the rule editor
+                    // including the gaze rect inputs, the 3x3 quick-region grid and the picker.
+                    SelectRule(rule);
+                }
+                ScheduleValidation();
+                EmitTutorialEvent("RuleAdded");
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: AddRuleAt error: {Error}", ex.Message);
+            }
+        }
+
+        private static EnhancementTrigger BuildDefaultTrigger(string triggerType, double seconds)
+        {
+            return triggerType switch
+            {
+                TriggerTypes.TimeReached    => new TimeReachedTrigger { Time = seconds },
+                TriggerTypes.RegionEntered  => new RegionEnteredTrigger { RegionId = "" },
+                TriggerTypes.RegionExited   => new RegionExitedTrigger { RegionId = "" },
+                TriggerTypes.GazeTarget     => new GazeTargetTrigger(),
+                TriggerTypes.GazeAvoid      => new GazeAvoidTrigger(),
+                TriggerTypes.AttentionLost  => new AttentionLostTrigger(),
+                TriggerTypes.BlinkDetected  => new BlinkDetectedTrigger(),
+                TriggerTypes.MouthOpen      => new MouthOpenTrigger(),
+                _ => new TimeReachedTrigger { Time = seconds }
+            };
+        }
+
+        // -- Effect TimelineItem visualisation ------------------------------------
+
+        private readonly List<Shape> _effectVisuals = new();
+
+        /// <summary>
+        /// Renders Effect TimelineItems (non-haptic) as dots or segments on the unified timeline.
+        /// Tear-down/rebuild keeps the code simple.
+        /// </summary>
+        private void RebuildEffectVisuals()
+        {
+            try
+            {
+                foreach (var v in _effectVisuals)
+                {
+                    try { TimelineCanvas.Children.Remove(v); } catch { }
+                }
+                _effectVisuals.Clear();
+
+                var w = TimelineCanvas.Bounds.Width;
+                var h = TimelineCanvas.Bounds.Height;
+                if (w <= 0 || h <= 0 || _totalSeconds <= 0) return;
+
+                foreach (var item in _enhancement.TimelineItems)
+                {
+                    if (item == null || item.Kind != TimelineItemKind.Effect) continue;
+                    if (item.EffectType == EffectTypes.Haptic) continue; // legacy path renders these
+                    BuildEffectDot(item, w, h);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: RebuildEffectVisuals error: {Error}", ex.Message);
+            }
+        }
+
+        private void BuildEffectDot(TimelineItem item, double canvasWidth, double canvasHeight)
+        {
+            // One-shot effects (Flash, Subliminal) render as a small dot - they have no meaningful
+            // on-screen duration the user would drag. Ongoing effects (Bubble, Overlay, Speak)
+            // render as draggable, resizable segments whose width matches their Duration.
+            if (IsOneShotEffect(item.EffectType))
+                BuildEffectPointDot(item, canvasWidth, canvasHeight);
+            else
+                BuildEffectSegment(item, canvasWidth, canvasHeight);
+        }
+
+        private static bool IsOneShotEffect(string? effectType) =>
+            effectType == EffectTypes.Flash || effectType == EffectTypes.Subliminal;
+
+        // One-shot dot: small ellipse, click-to-select only (no drag/resize).
+        private void BuildEffectPointDot(TimelineItem item, double canvasWidth, double canvasHeight)
+        {
+            var brush = TryParseBrush(EffectColors.TryGetValue(item.EffectType ?? "", out var c) ? c : "#FFFFFF")
+                        ?? Brushes.White;
+            var isSelected = item == _selectedEffect || IsInSelectionSet(item);
+            var dot = new Ellipse
+            {
+                Width = 12,
+                Height = 12,
+                Fill = brush,
+                Stroke = isSelected ? Brushes.White : Brushes.Transparent,
+                StrokeThickness = isSelected ? 2 : 0,
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Tag = item,
+                ZIndex = 10
+            };
+            ToolTip.SetTip(dot, $"{item.EffectType} @ {item.Start:0.##}s");
+            double x = (item.Start / _totalSeconds) * canvasWidth - 6;
+            var (eTop, eH) = LaneBand(TimelineLane.Effects, canvasHeight);
+            double y = eTop + eH / 2.0 - 6; // centre the 12px dot in the Effects lane
+            Canvas.SetLeft(dot, x);
+            Canvas.SetTop(dot, y);
+
+            dot.PointerPressed += (s, e) =>
+            {
+                if (!e.GetCurrentPoint(dot).Properties.IsLeftButtonPressed) return;
+                e.Handled = true;
+                bool ctrl = IsCtrlDown(e.KeyModifiers);
+                HandleSelectionClick(item, e.KeyModifiers);
+                if (ctrl)
+                {
+                    // Pure toggle - refresh all lanes so the new selection-set membership shows.
+                    RebuildRegionVisuals();
+                    RebuildHapticVisuals();
+                    RebuildEffectVisuals();
+                    return;
+                }
+                SelectEffect(item);
+            };
+
+            TimelineCanvas.Children.Add(dot);
+            _effectVisuals.Add(dot);
+        }
+
+        // Ongoing segment: rectangle with width = Duration, draggable + resizable.
+        private void BuildEffectSegment(TimelineItem item, double canvasWidth, double canvasHeight)
+        {
+            var color = TryParseColor(EffectColors.TryGetValue(item.EffectType ?? "", out var c) ? c : "#FFFFFF")
+                        ?? Colors.White;
+            var fill = Color.FromArgb(140, color.R, color.G, color.B);
+            var isSelected = item == _selectedEffect || IsInSelectionSet(item);
+
+            // Segment width tracks Duration; minimum 8px so a near-zero segment is still clickable.
+            double startX = Math.Max(0, (item.Start / _totalSeconds) * canvasWidth);
+            double endX = Math.Min(canvasWidth, ((item.Start + Math.Max(0, item.Duration)) / _totalSeconds) * canvasWidth);
+            double width = Math.Max(8, endX - startX);
+            var (eTop, eH) = LaneBand(TimelineLane.Effects, canvasHeight);
+            double height = Math.Min(18, Math.Max(0, eH - 2 * LaneInset));
+            double y = eTop + (eH - height) / 2.0; // centre the segment in the Effects lane
+
+            var rect = new Rectangle
+            {
+                Width = width,
+                Height = height,
+                Fill = new SolidColorBrush(fill),
+                Stroke = new SolidColorBrush(color),
+                StrokeThickness = isSelected ? 2.0 : 1.0,
+                Cursor = new Cursor(StandardCursorType.SizeAll),
+                Tag = item,
+                ZIndex = 10
+            };
+            ToolTip.SetTip(rect, $"{item.EffectType} @ {item.Start:0.##}s · {item.Duration:0.##}s");
+
+            Canvas.SetLeft(rect, startX);
+            Canvas.SetTop(rect, y);
+
+            rect.PointerPressed += EffectRect_PointerPressed;
+            rect.PointerMoved += EffectRect_PointerMoved;
+
+            TimelineCanvas.Children.Add(rect);
+            _effectVisuals.Add(rect);
+        }
+
+        // Cursor feedback near segment edges so the user can tell resize from drag-move.
+        private void EffectRect_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_dragMode != DragMode.None) return;
+            if (sender is not Rectangle r) return;
+            var pos = e.GetPosition(r);
+            r.Cursor = ClassifyEdgeHit(pos.X, r.Bounds.Width) == EdgeHit.Body
+                ? new Cursor(StandardCursorType.SizeAll)
+                : new Cursor(StandardCursorType.SizeWestEast);
+        }
+
+        private void EffectRect_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is not Rectangle r || r.Tag is not TimelineItem item) return;
+            if (!e.GetCurrentPoint(r).Properties.IsLeftButtonPressed) return;
+
+            // Snapshot pos + width BEFORE selecting - SelectEffect rebuilds visuals, which detaches
+            // `r` from the tree, after which GetPosition(r) returns ~(0,0) and trips the left-edge
+            // resize check unconditionally.
+            var pos = e.GetPosition(r);
+            var rectWidth = r.Bounds.Width;
+            bool ctrl = IsCtrlDown(e.KeyModifiers);
+            HandleSelectionClick(item, e.KeyModifiers);
+            // Ctrl+Click is a pure selection toggle - no drag-init, no capture, no primary swap.
+            if (ctrl)
+            {
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                e.Handled = true;
+                return;
+            }
+            SelectEffect(item);
+
+            _draggedEffect = item;
+            _effectDragOriginalDuration = Math.Max(0, item.Duration);
+            BeginMultiDragCapture();
+
+            switch (ClassifyEdgeHit(pos.X, rectWidth))
+            {
+                case EdgeHit.Start: _dragMode = DragMode.ResizeEffectStart; break;
+                case EdgeHit.End:   _dragMode = DragMode.ResizeEffectEnd; break;
+                default:
+                    _dragMode = DragMode.DragEffect;
+                    _effectDragOffsetSec = MouseToSeconds(e) - item.Start;
+                    break;
+            }
+            e.Pointer.Capture(TimelineCanvas);
+            e.Handled = true;
+        }
+
+        // -- Selection (Effect TimelineItems) -------------------------------------
+
+        private void SelectEffect(TimelineItem item)
+        {
+            _selectedEffect = item;
+            // Clear other selection slots.
+            _selectedRegion = null;
+            _selectedHaptic = null;
+            _selectedHapticTrack = null;
+            _selectedRule = null;
+            UpdateSelectedSidePanelForEffect();
+            ScrollInspectorToTop();
+            RebuildEffectVisuals();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildRuleVisuals();
+            UpdateSelectionSummary();
+            BuildItemsList();
+        }
+
+        private void UpdateSelectedSidePanelForEffect()
+        {
+            HideAllEditors();
+            if (_selectedEffect == null)
+            {
+                if (SelectedPlaceholder != null) SelectedPlaceholder.IsVisible = true;
+                return;
+            }
+            if (SelectedPlaceholder != null) SelectedPlaceholder.IsVisible = false;
+
+            _suppressEffectFieldSync = true;
+            try
+            {
+                switch (_selectedEffect.EffectType)
+                {
+                    case EffectTypes.Flash:
+                        FlashEffectEditor.IsVisible = true;
+                        TxtFlashStart.Text = _selectedEffect.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                        TxtFlashDuration.Text = _selectedEffect.EffectDurationMs.ToString(CultureInfo.InvariantCulture);
+                        ChkFlashSuppressHaptic.IsChecked = _selectedEffect.EffectSuppressHaptic;
+                        break;
+                    case EffectTypes.Bubble:
+                        BubbleEffectEditor.IsVisible = true;
+                        TxtBubbleStart.Text = _selectedEffect.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                        TxtBubbleWindow.Text = (_selectedEffect.EffectDurationMs / 1000.0).ToString("0.##", CultureInfo.InvariantCulture);
+                        SliderBubbleIntensity.Value = _selectedEffect.EffectIntensity;
+                        break;
+                    case EffectTypes.Subliminal:
+                        SubliminalEffectEditor.IsVisible = true;
+                        TxtSubliminalStart.Text = _selectedEffect.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                        TxtSubliminalText.Text = _selectedEffect.EffectText ?? "";
+                        TxtSubliminalDuration.Text = _selectedEffect.EffectDurationMs.ToString(CultureInfo.InvariantCulture);
+                        ChkSubliminalSuppressHaptic.IsChecked = _selectedEffect.EffectSuppressHaptic;
+                        break;
+                    case EffectTypes.Overlay:
+                        OverlayEffectEditor.IsVisible = true;
+                        TxtOverlayStart.Text = _selectedEffect.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                        SelectOverlayKindCombo(_selectedEffect.EffectOverlayKind);
+                        TxtOverlayDuration.Text = _selectedEffect.EffectDurationMs.ToString(CultureInfo.InvariantCulture);
+                        bool ramp = _selectedEffect.EffectOpacityStart.HasValue && _selectedEffect.EffectOpacityEnd.HasValue;
+                        ChkOverlayRamp.IsChecked = ramp;
+                        // When ramping, the main slider is the START opacity.
+                        SliderOverlayOpacity.Value = ramp ? _selectedEffect.EffectOpacityStart!.Value : _selectedEffect.EffectOpacity;
+                        SliderOverlayOpacityEnd.Value = ramp ? _selectedEffect.EffectOpacityEnd!.Value : _selectedEffect.EffectOpacity;
+                        ApplyOverlayRampVisibility(ramp);
+                        break;
+                    case EffectTypes.Speak:
+                        SpeakEffectEditor.IsVisible = true;
+                        TxtSpeakStart.Text = _selectedEffect.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                        TxtSpeakLength.Text = (_selectedEffect.EffectDurationMs / 1000.0).ToString("0.##", CultureInfo.InvariantCulture);
+                        TxtSpeakTarget.Text = _selectedEffect.EffectSpeakTarget ?? "";
+                        TxtSpeakCue.Text = _selectedEffect.EffectSpeakCue ?? "";
+                        TxtSpeakInterval.Text = _selectedEffect.EffectSpeakCueIntervalMs.ToString(CultureInfo.InvariantCulture);
+                        TxtSpeakCorrect.Text = _selectedEffect.EffectSpeakCorrectMessage ?? "";
+                        TxtSpeakIncorrect.Text = _selectedEffect.EffectSpeakIncorrectMessage ?? "";
+                        SelectComboByTag(CmbSpeakCueMode, _selectedEffect.EffectSpeakCueMode.ToString());
+                        SelectComboByTag(CmbSpeakReps, Math.Clamp(_selectedEffect.EffectSpeakRequiredReps, 1, 5).ToString(CultureInfo.InvariantCulture));
+                        SelectComboByTag(CmbSpeakCompletion, _selectedEffect.EffectSpeakCompletion.ToString());
+                        SelectComboByTag(CmbSpeakHold, _selectedEffect.EffectSpeakHoldMode.ToString());
+                        ApplySpeakConditionalVisibility();
+                        break;
+                    default:
+                        if (SelectedPlaceholder != null) SelectedPlaceholder.IsVisible = true;
+                        break;
+                }
+            }
+            finally { ClearWhenEventsDrained(() => _suppressEffectFieldSync = false); }
+        }
+
+        private void HideAllEditors()
+        {
+            if (RegionEditor != null) RegionEditor.IsVisible = false;
+            if (HapticEventEditor != null) HapticEventEditor.IsVisible = false;
+            if (RuleEditor != null) RuleEditor.IsVisible = false;
+            if (FlashEffectEditor != null) FlashEffectEditor.IsVisible = false;
+            if (BubbleEffectEditor != null) BubbleEffectEditor.IsVisible = false;
+            if (SubliminalEffectEditor != null) SubliminalEffectEditor.IsVisible = false;
+            if (OverlayEffectEditor != null) OverlayEffectEditor.IsVisible = false;
+            if (SpeakEffectEditor != null) SpeakEffectEditor.IsVisible = false;
+        }
+
+        /// <summary>
+        /// A withheld overlay kind is hidden from <c>CmbOverlayKind</c>, but creator content
+        /// authored before it was withheld may already carry one. Without this the picker would
+        /// fall through to index 0 and display "Pink Filter" over that effect - a lie the next edit
+        /// would bake into the file. So inject a clearly-labelled entry for the current value only,
+        /// and drop it again once the selection moves to a live kind.
+        /// </summary>
+        private void SyncWithheldOverlayKindItem(string? kind)
+        {
+            for (int i = CmbOverlayKind.Items.Count - 1; i >= 0; i--)
+            {
+                if (CmbOverlayKind.Items[i] is ComboBoxItem stale
+                    && OverlayKinds.IsWithheld(stale.Tag as string))
+                {
+                    CmbOverlayKind.Items.RemoveAt(i);
+                }
+            }
+            if (!OverlayKinds.IsWithheld(kind)) return;
+
+            CmbOverlayKind.Items.Add(new ComboBoxItem
+            {
+                Content = kind == OverlayKinds.BrainDrainMelt
+                    ? "Brain Melt (unavailable)"
+                    : "Brain Drain (unavailable)",
+                Tag = kind
+            });
+        }
+
+        private void SelectOverlayKindCombo(string? kind)
+        {
+            if (CmbOverlayKind == null) return;
+            SyncWithheldOverlayKindItem(kind);
+            foreach (var raw in CmbOverlayKind.Items)
+            {
+                if (raw is ComboBoxItem cbi && (cbi.Tag as string) == (kind ?? OverlayKinds.PinkFilter))
+                {
+                    CmbOverlayKind.SelectedItem = cbi;
+                    return;
+                }
+            }
+            CmbOverlayKind.SelectedIndex = 0;
+        }
+
+        // -- Speak effect combos --------------------------------------------------
+
+        private static void SelectComboByTag(ComboBox? combo, string? tag)
+        {
+            if (combo == null) return;
+            foreach (var raw in combo.Items)
+            {
+                if (raw is ComboBoxItem cbi && (cbi.Tag as string) == tag) { combo.SelectedItem = cbi; return; }
+            }
+            if (combo.Items.Count > 0) combo.SelectedIndex = 0;
+        }
+
+        private static string? SelectedTag(ComboBox combo)
+            => (combo.SelectedItem as ComboBoxItem)?.Tag as string;
+
+        // Interval row only matters for intermittent cues; hold-mode row only for
+        // "until satisfied" completion.
+        private void ApplySpeakConditionalVisibility()
+        {
+            if (_selectedEffect == null) return;
+            bool intermittent = _selectedEffect.EffectSpeakCueMode == SpeakCueMode.Intermittent;
+            if (LblSpeakInterval != null) LblSpeakInterval.IsVisible = intermittent;
+            if (TxtSpeakInterval != null) TxtSpeakInterval.IsVisible = intermittent;
+
+            bool untilSatisfied = _selectedEffect.EffectSpeakCompletion == SpeakCompletion.UntilSatisfied;
+            if (LblSpeakHold != null) LblSpeakHold.IsVisible = untilSatisfied;
+            if (CmbSpeakHold != null) CmbSpeakHold.IsVisible = untilSatisfied;
+        }
+
+        private void CmbSpeakCueMode_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            if (Enum.TryParse<SpeakCueMode>(SelectedTag(CmbSpeakCueMode), out var mode))
+                _selectedEffect.EffectSpeakCueMode = mode;
+            ApplySpeakConditionalVisibility();
+            MarkDirty();
+        }
+
+        private void CmbSpeakReps_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            if (int.TryParse(SelectedTag(CmbSpeakReps), NumberStyles.Integer, CultureInfo.InvariantCulture, out var reps))
+                _selectedEffect.EffectSpeakRequiredReps = Math.Clamp(reps, 1, 5);
+            MarkDirty();
+        }
+
+        private void CmbSpeakCompletion_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            if (Enum.TryParse<SpeakCompletion>(SelectedTag(CmbSpeakCompletion), out var c))
+                _selectedEffect.EffectSpeakCompletion = c;
+            ApplySpeakConditionalVisibility();
+            MarkDirty();
+        }
+
+        private void CmbSpeakHold_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            if (Enum.TryParse<SpeakHoldMode>(SelectedTag(CmbSpeakHold), out var h))
+                _selectedEffect.EffectSpeakHoldMode = h;
+            MarkDirty();
+        }
+
+        // -- Effect editor field syncing ------------------------------------------
+
+        private void EffectField_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            try
+            {
+                if (ReferenceEquals(sender, TxtFlashDuration) && TryParseInt(TxtFlashDuration.Text ?? "", out var fd))
+                    _selectedEffect.EffectDurationMs = Math.Max(50, fd);
+                else if ((ReferenceEquals(sender, TxtFlashStart) || ReferenceEquals(sender, TxtBubbleStart)
+                          || ReferenceEquals(sender, TxtSubliminalStart) || ReferenceEquals(sender, TxtOverlayStart)
+                          || ReferenceEquals(sender, TxtSpeakStart))
+                         && TryParseDouble(((TextBox)sender!).Text ?? "", out var es))
+                    _selectedEffect.Start = Math.Clamp(es, 0, _totalSeconds > 0 ? _totalSeconds : double.MaxValue);
+                else if (ReferenceEquals(sender, TxtBubbleWindow) && TryParseDouble(TxtBubbleWindow.Text ?? "", out var bw))
+                    _selectedEffect.EffectDurationMs = (int)Math.Max(50, bw * 1000);
+                else if (ReferenceEquals(sender, TxtSubliminalText))
+                    _selectedEffect.EffectText = TxtSubliminalText.Text;
+                else if (ReferenceEquals(sender, TxtSubliminalDuration) && TryParseInt(TxtSubliminalDuration.Text ?? "", out var sd))
+                    _selectedEffect.EffectDurationMs = Math.Max(50, sd);
+                else if (ReferenceEquals(sender, TxtOverlayDuration) && TryParseInt(TxtOverlayDuration.Text ?? "", out var od))
+                    _selectedEffect.EffectDurationMs = Math.Max(50, od);
+                else if (ReferenceEquals(sender, TxtSpeakLength) && TryParseDouble(TxtSpeakLength.Text ?? "", out var sl))
+                    _selectedEffect.EffectDurationMs = (int)Math.Max(500, sl * 1000);
+                else if (ReferenceEquals(sender, TxtSpeakTarget))
+                    _selectedEffect.EffectSpeakTarget = TxtSpeakTarget.Text;
+                else if (ReferenceEquals(sender, TxtSpeakCue))
+                    _selectedEffect.EffectSpeakCue = TxtSpeakCue.Text;
+                else if (ReferenceEquals(sender, TxtSpeakInterval) && TryParseInt(TxtSpeakInterval.Text ?? "", out var si))
+                    _selectedEffect.EffectSpeakCueIntervalMs = Math.Max(80, si);
+                else if (ReferenceEquals(sender, TxtSpeakCorrect))
+                    _selectedEffect.EffectSpeakCorrectMessage = TxtSpeakCorrect.Text;
+                else if (ReferenceEquals(sender, TxtSpeakIncorrect))
+                    _selectedEffect.EffectSpeakIncorrectMessage = TxtSpeakIncorrect.Text;
+
+                // Mirror EffectDurationMs into Duration so the timeline segment width stays in
+                // sync with the textbox value.
+                _selectedEffect.Duration = _selectedEffect.EffectDurationMs / 1000.0;
+                MarkDirty();
+                RebuildEffectVisuals();
+                ScheduleValidation();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: EffectField sync error: {Error}", ex.Message);
+            }
+        }
+
+        private void SliderBubbleIntensity_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            _selectedEffect.EffectIntensity = Math.Clamp(e.NewValue, 0, 1);
+            MarkDirty();
+        }
+
+        // Shared by the flash + subliminal "Don't buzz on pop" checkboxes.
+        private void ChkEffectSuppressHaptic_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            _selectedEffect.EffectSuppressHaptic = (sender as CheckBox)?.IsChecked ?? false;
+            MarkDirty();
+        }
+
+        private void SliderOverlayOpacity_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            var v = Math.Clamp(e.NewValue, 0, 1);
+            // Flat opacity always tracks this slider; when ramping it's also the start.
+            _selectedEffect.EffectOpacity = v;
+            if (ChkOverlayRamp.IsChecked == true)
+                _selectedEffect.EffectOpacityStart = v;
+            MarkDirty();
+        }
+
+        private void SliderOverlayOpacityEnd_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            if (ChkOverlayRamp.IsChecked == true)
+                _selectedEffect.EffectOpacityEnd = Math.Clamp(e.NewValue, 0, 1);
+            MarkDirty();
+        }
+
+        private void ChkOverlayRamp_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            bool ramp = ChkOverlayRamp.IsChecked == true;
+            if (ramp)
+            {
+                // Seed start = current flat opacity, end = current end-slider value.
+                _selectedEffect.EffectOpacityStart = Math.Clamp(SliderOverlayOpacity.Value, 0, 1);
+                _selectedEffect.EffectOpacityEnd = Math.Clamp(SliderOverlayOpacityEnd.Value, 0, 1);
+            }
+            else
+            {
+                // Drop the ramp -> fall back to flat EffectOpacity.
+                _selectedEffect.EffectOpacityStart = null;
+                _selectedEffect.EffectOpacityEnd = null;
+            }
+            ApplyOverlayRampVisibility(ramp);
+            MarkDirty();
+        }
+
+        private void ApplyOverlayRampVisibility(bool ramp)
+        {
+            LblOverlayOpacityEnd.IsVisible = ramp;
+            SliderOverlayOpacityEnd.IsVisible = ramp;
+            LblOverlayOpacity.Text = ramp ? "Start opacity" : "Opacity";
+        }
+
+        private void CmbOverlayKind_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressEffectFieldSync || _selectedEffect == null) return;
+            if (CmbOverlayKind.SelectedItem is ComboBoxItem cbi && cbi.Tag is string kind)
+            {
+                _selectedEffect.EffectOverlayKind = kind;
+                MarkDirty();
+            }
+        }
+
+        private void BtnDeleteEffect_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedEffect == null) return;
+            try
+            {
+                PushUndoSnapshot();
+                _enhancement.TimelineItems.Remove(_selectedEffect);
+                _selectedEffect = null;
+                MarkDirty();
+                RebuildEffectVisuals();
+                HideAllEditors();
+                if (SelectedPlaceholder != null) SelectedPlaceholder.IsVisible = true;
+                RefreshRulesList();
+                ScheduleValidation();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: delete effect error: {Error}", ex.Message);
+            }
+        }
+
+        // -- Creator lock toggle --------------------------------------------------
+
+        private void BtnCreatorLockToggle_Click(object? sender, RoutedEventArgs e)
+        {
+            _creatorLocked = BtnCreatorLockToggle.IsChecked == true;
+            UpdateCreatorLockUi();
+        }
+
+        private void UpdateCreatorLockUi()
+        {
+            if (TxtMetaCreator == null || BtnCreatorLockToggle == null) return;
+            BtnCreatorLockToggle.IsChecked = _creatorLocked;
+            BtnCreatorLockToggle.Content = _creatorLocked ? "🔒" : "🔓";
+            TxtMetaCreator.IsReadOnly = _creatorLocked;
+            TxtMetaCreator.Foreground = _creatorLocked ? Res("TextDimBrush") : Res("TextLightBrush");
+        }
+
+        // -- HypnoTube auto-fill --------------------------------------------------
+
+        private async Task TryAutoFillFromHtAsync(string? source)
+        {
+            if (string.IsNullOrWhiteSpace(source)) return;
+            try
+            {
+                // Cancel + dispose the previous CTS so back-to-back URL pastes don't accumulate
+                // orphaned token sources holding kernel handles.
+                var oldCts = _htFetchCts;
+                _htFetchCts = new CancellationTokenSource();
+                try { oldCts?.Cancel(); oldCts?.Dispose(); } catch { }
+
+                var meta = await HtMetadataFetcher.FetchAsync(source!, _htFetchCts.Token);
+                if (meta == null) return;
+                // Window may have closed during the network round-trip; touching the TextBoxes
+                // after teardown throws. (WPF also checked Dispatcher.HasShutdownStarted, which
+                // has no Avalonia twin - IsLoaded covers the case that mattered.)
+                if (!IsLoaded) return;
+                ApplyHtMetadata(meta);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: HT auto-fill error: {Error}", ex.Message);
+            }
+        }
+
+        private void ApplyHtMetadata(HtVideoMetadata meta)
+        {
+            // Don't suppress the dirty flag - if auto-fill actually changes metadata, the user
+            // should see the marker and get the unsaved-changes prompt on close.
+            bool changed = false;
+            try
+            {
+                // Creator: only fill if empty. The pre-fix code unconditionally overwrote whatever
+                // the user typed AND auto-locked the field.
+                if (!string.IsNullOrEmpty(meta.Uploader)
+                    && string.IsNullOrWhiteSpace(TxtMetaCreator.Text))
+                {
+                    TxtMetaCreator.Text = meta.Uploader;
+                    _enhancement.Metadata.Creator = meta.Uploader;
+                    _creatorLocked = true;
+                    UpdateCreatorLockUi();
+                    changed = true;
+                }
+                if (string.IsNullOrWhiteSpace(TxtMetaName.Text) && !string.IsNullOrEmpty(meta.Title))
+                {
+                    TxtMetaName.Text = meta.Title;
+                    _enhancement.Metadata.Name = meta.Title;
+                    changed = true;
+                }
+                if (string.IsNullOrWhiteSpace(TxtMetaDescription.Text) && !string.IsNullOrEmpty(meta.Description))
+                {
+                    TxtMetaDescription.Text = meta.Description;
+                    _enhancement.Metadata.Description = meta.Description;
+                    changed = true;
+                }
+                if (meta.Tags != null && meta.Tags.Count > 0)
+                {
+                    var existing = (TxtMetaTags.Text ?? "")
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .ToList();
+                    foreach (var tag in meta.Tags)
+                    {
+                        if (!string.IsNullOrEmpty(tag) && !existing.Contains(tag, StringComparer.OrdinalIgnoreCase))
+                            existing.Add(tag);
+                    }
+                    var merged = string.Join(", ", existing);
+                    if (merged != TxtMetaTags.Text)
+                    {
+                        TxtMetaTags.Text = merged;
+                        _enhancement.Metadata.Tags = existing;
+                        changed = true;
+                    }
+                }
+                UpdateTitle();
+            }
+            finally
+            {
+                if (changed) MarkDirty();
+            }
+        }
+
+        // -- Rule indicators on timeline ------------------------------------------
+        // TimeReached rules have no Region (so RebuildRegionVisuals skips them) and aren't Effects
+        // either. Without a dedicated visual they were invisible on the timeline. This renders each
+        // as a thin orange pin: a vertical dashed line at the trigger time topped with a small
+        // pennant, click-to-select, with a wider transparent hit area.
+
+        private readonly List<Control> _ruleVisuals = new();
+        private static readonly Color RulePinColor = Color.FromRgb(0xFF, 0x8C, 0x00);
+
+        private void RebuildRuleVisuals()
+        {
+            try
+            {
+                foreach (var v in _ruleVisuals)
+                {
+                    try { TimelineCanvas.Children.Remove(v); } catch { }
+                }
+                _ruleVisuals.Clear();
+
+                var w = TimelineCanvas.Bounds.Width;
+                var h = TimelineCanvas.Bounds.Height;
+                if (w <= 0 || h <= 0 || _totalSeconds <= 0) return;
+
+                int idx = 0;
+                foreach (var rule in _enhancement.Rules)
+                {
+                    idx++;
+                    if (rule?.Trigger is not TimeReachedTrigger tr) continue;
+                    BuildRulePin(rule, tr, idx, w, h);
+                }
+                EnsurePlayheadOnTop();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("DeeperEditor: RebuildRuleVisuals error: {Error}", ex.Message);
+            }
+        }
+
+        private void BuildRulePin(EnhancementRule rule, TimeReachedTrigger tr, int oneBasedIndex,
+            double canvasWidth, double canvasHeight)
+        {
+            double x = (Math.Max(0, tr.Time) / _totalSeconds) * canvasWidth;
+            bool isSelected = rule == _selectedRule;
+
+            var brush = new SolidColorBrush(RulePinColor);
+            var selStroke = isSelected ? Brushes.White : null;
+
+            // Vertical pin line
+            var line = new Line
+            {
+                StartPoint = new Point(x, 0),
+                EndPoint = new Point(x, canvasHeight),
+                Stroke = brush,
+                StrokeThickness = isSelected ? 2.5 : 1.5,
+                StrokeDashArray = new global::Avalonia.Collections.AvaloniaList<double> { 4, 3 },
+                IsHitTestVisible = false,
+                ZIndex = 9
+            };
+            TimelineCanvas.Children.Add(line);
+            _ruleVisuals.Add(line);
+
+            // Flag at top - a small filled triangle (right-pointing pennant) so it reads apart from
+            // region rectangles and effect dots.
+            var flag = new Polygon
+            {
+                Points = new global::Avalonia.Collections.AvaloniaList<Point>
+                {
+                    new Point(x, 2),
+                    new Point(x + 12, 6),
+                    new Point(x, 10)
+                },
+                Fill = brush,
+                Stroke = selStroke,
+                StrokeThickness = isSelected ? 1.5 : 0,
+                IsHitTestVisible = false,
+                ZIndex = 10
+            };
+            TimelineCanvas.Children.Add(flag);
+            _ruleVisuals.Add(flag);
+
+            // Wider transparent hit-rect so the user can click near the pin without pixel-precise
+            // aiming.
+            var hit = new Rectangle
+            {
+                Width = 14,
+                Height = canvasHeight,
+                Fill = Brushes.Transparent,
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Tag = rule,
+                ZIndex = 11
+            };
+            ToolTip.SetTip(hit, $"Rule #{oneBasedIndex} · time {tr.Time:0.##}s");
+            Canvas.SetLeft(hit, x - 7);
+            Canvas.SetTop(hit, 0);
+            hit.PointerPressed += (s, e) =>
+            {
+                if (!e.GetCurrentPoint(hit).Properties.IsLeftButtonPressed) return;
+                e.Handled = true;
+                SelectRule(rule);
+            };
+            TimelineCanvas.Children.Add(hit);
+            _ruleVisuals.Add(hit);
+        }
+
+        // -- Helpers --------------------------------------------------------------
+
+        private static bool TryParseInt(string s, out int v)
+            => int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out v);
+
+        private static bool TryParseDouble(string s, out double v)
+            => double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+
+        /// <summary>
+        /// ponytail: needs TutorialEventBus (App-level service in the WPF head). The editor emitted
+        /// "EffectAdded" / "RuleAdded" so the interactive tutorial could advance a step; nothing in
+        /// the Avalonia head listens yet, so the calls are kept as named no-ops rather than deleted.
+        /// </summary>
+        private static void EmitTutorialEvent(string name) { _ = name; }
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml
@@ -1,0 +1,1294 @@
+<!-- PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.
+     Structure, row/column order, every x:Name, every size and every resource key preserved.
+     Deviations, all forced by the framework:
+
+       Style="{StaticResource X}"          -> Theme="{StaticResource X}"
+       <Style x:Key TargetType>            -> <ControlTheme x:Key TargetType BasedOn="{x:Type X}">
+       Visibility="Collapsed"              -> IsVisible="False"
+       Panel.ZIndex                        -> ZIndex
+       ToolTip=                            -> ToolTip.Tip=
+       Image + EmojiToImageSource (x5)     -> plain TextBlock (Avalonia draws colour emoji natively)
+       Line X1/X2/Y1/Y2                    -> StartPoint / EndPoint
+       wv2:WebView2 x:Name="BrowserPreview"-> controls:WebHost - Microsoft.Web.WebView2 is Windows-only
+       vlc:VideoView x:Name="VideoPreview" -> a labelled Border; LibVLCSharp.WPF cannot be referenced
+                                              from a net8.0 head and no package may be added here
+       ContextMenu x:Shared="False"        -> inlined as <Canvas.ContextMenu> and, for the hero
+                                              "+ Effect" button, a <MenuFlyout>. Avalonia has no
+                                              x:Shared and no FindResource-a-menu; item names and
+                                              handlers are unchanged
+       Popup StaysOpen="False"             -> IsLightDismissEnabled="True"
+       InputGestureText="Ctrl+S"           -> InputGesture="Ctrl+S" (a real KeyGesture)
+       MouseLeftButtonDown / MouseMove /   -> PointerPressed / PointerMoved / PointerReleased /
+       MouseLeftButtonUp / LostMouseCapture   PointerCaptureLost, wired in the constructor
+       Checked/Unchecked, CheckBox.Click   -> IsCheckedChanged
+       PreviewMouseWheel                   -> AddHandler(PointerWheelChangedEvent, ..., Tunnel)
+
+     The WPF ScrollBar re-skin (DeeperScrollBarRepeat / DeeperScrollBarThumb / implicit ScrollBar)
+     is deliberately dropped: it existed because WPF's default scrollbar is white Windows chrome on
+     a dark window. Avalonia's Fluent scrollbar is already a thin dark overlay bar.
+     ponytail: no accent tint on the editor scrollbars; port the three styles if it is missed. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:controls="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls"
+        xmlns:deeper="clr-namespace:ConditioningControlPanel.Avalonia.Views.Deeper"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Deeper.DeeperEditorWindow"
+        Title="Deeper"
+        Height="864" Width="1180"
+        MinHeight="672" MinWidth="980"
+        WindowStartupLocation="CenterScreen"
+        Background="{DynamicResource DarkerBgBrush}"
+        DragDrop.AllowDrop="True">
+
+    <Window.Resources>
+        <!-- ponytail: local copies of DeeperEditorWindow.xaml:EditorTextBox / EditorLabel /
+             EditorComboBox / EditorComboBoxItem. Every one exists in WPF only because WPF's
+             default chrome is a near-white system control on a dark window; Fluent's dark theme
+             already is dark, so each keeps ONLY the property setters and inherits the real
+             template through BasedOn. Hand-porting the WPF ControlTemplates (Popup + Track +
+             ContentPresenter) is exactly traps 4 and 6 in CLAUDE.md. Hoist when a second Avalonia
+             view needs the Deeper editor input chrome. -->
+        <ControlTheme x:Key="EditorTextBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="Background" Value="{DynamicResource PanelBgBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource DeeperAccentTransparent40Brush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Padding" Value="8,6"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="CaretBrush" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="SelectionBrush" Value="{DynamicResource DeeperAccentTransparent40Brush}"/>
+        </ControlTheme>
+
+        <!-- TextBlock is not templated, so property-only is safe here (trap 4 does not apply). -->
+        <ControlTheme x:Key="EditorLabel" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0,0,0,4"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="EditorComboBoxItem" TargetType="ComboBoxItem" BasedOn="{StaticResource {x:Type ComboBoxItem}}">
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="Padding" Value="8,5"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="EditorComboBox" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource PanelBgBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource DeeperAccentTransparent40Brush}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Window.Styles>
+        <!-- The implicit rounded button / toggle. WPF used
+             <Style TargetType="Button" BasedOn="{StaticResource DeeperRoundButton}"/>; an ADDITIVE
+             Style rather than a ControlTheme so the Fluent template survives and each control's
+             own inline Background/Foreground/BorderBrush still wins over these setters.
+             ponytail: local copy of Resources/Theme/Controls.xaml:DeeperRoundButton +
+             DeeperRoundIconToggleButton, hoist when a second Avalonia view needs them. -->
+        <Style Selector="Button">
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+        <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Opacity" Value="0.85"/>
+        </Style>
+        <Style Selector="Button:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Opacity" Value="0.70"/>
+        </Style>
+        <Style Selector="Button:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Opacity" Value="0.40"/>
+        </Style>
+        <Style Selector="ToggleButton">
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="CornerRadius" Value="8"/>
+        </Style>
+        <!-- WPF's implicit Separator style tinted the light system gray. -->
+        <Style Selector="Separator">
+            <Setter Property="Background" Value="{DynamicResource DeeperAccentTransparent40Brush}"/>
+        </Style>
+        <!-- EditorMenuItem + TimelineCtxMenuItem collapse to this: Fluent's MenuItem popup is
+             already dark, so only the foreground carries over. -->
+        <Style Selector="MenuItem">
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="Auto,Auto,*,Auto">
+        <!-- 0 title bar / menu - 1 linked files strip - 2 main content - 3 validation strip -->
+
+        <!-- Title / menu bar -->
+        <Border Grid.Row="0" Background="{DynamicResource PanelBgBrush}"
+                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="0,0,0,1"
+                Padding="10,4">
+            <DockPanel LastChildFill="True">
+                <Menu DockPanel.Dock="Left" Background="Transparent" Foreground="{DynamicResource TextLightBrush}">
+                    <MenuItem Header="{loc:Str menu_file}">
+                        <MenuItem x:Name="MenuSave" Header="{loc:Str menu_file_save}" InputGesture="Ctrl+S"/>
+                        <MenuItem x:Name="MenuSaveAs" Header="{loc:Str menu_file_save_as}" InputGesture="Ctrl+Shift+S"/>
+                        <Separator/>
+                        <MenuItem x:Name="MenuExport" Header="{loc:Str menu_file_export}" InputGesture="Ctrl+E"/>
+                        <Separator/>
+                        <MenuItem x:Name="MenuCloseItem" Header="{loc:Str menu_file_close}"/>
+                    </MenuItem>
+                </Menu>
+                <TextBlock x:Name="TxtTitle" DockPanel.Dock="Left" Margin="22,0,0,0"
+                           Foreground="{DynamicResource DeeperAccentSoftBrush}"
+                           FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                <TextBlock x:Name="TxtDirty" DockPanel.Dock="Left" Margin="6,0,0,0" Text="●"
+                           Foreground="{DynamicResource DeeperAccentBrush}" IsVisible="False"
+                           FontSize="14" VerticalAlignment="Center"
+                           ToolTip.Tip="{loc:Str deeper_editor_unsaved_marker}"/>
+                <Button x:Name="BtnEditorHelp" DockPanel.Dock="Right" Margin="0,0,0,0"
+                        ToolTip.Tip="{loc:Str deeper_editor_help_tooltip}"
+                        Width="30" Height="26" Padding="0" Cursor="Hand"
+                        Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                        BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                    <!-- TextBlock inside the button: Avalonia parses "_" in Content as an access
+                         key and every loc value here can carry one (CLAUDE.md trap 1). -->
+                    <TextBlock Text="{loc:Str deeper_editor_help_btn}" FontSize="14" FontWeight="Bold"
+                               Foreground="{DynamicResource DeeperAccentBrush}"/>
+                </Button>
+                <TextBlock/>
+            </DockPanel>
+        </Border>
+
+        <!-- Linked Files strip: the JSON project + linked media (file or HT URL) with one-click
+             swap/change/clear, always visible above the timeline. -->
+        <Border Grid.Row="1" Background="{DynamicResource PanelBgBrush}"
+                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="0,0,0,1"
+                Padding="14,8">
+            <Grid ColumnDefinitions="*,20,*">
+
+                <!-- Project (JSON) -->
+                <Grid Grid.Column="0" ColumnDefinitions="Auto,*,Auto,Auto,Auto" RowDefinitions="Auto,Auto">
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="📄" FontSize="13"
+                               VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" x:Name="TxtLinkedJsonName"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               FontSize="12" FontWeight="SemiBold"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+
+                    <!-- Browser zoom cluster: page-zooms the embedded preview. Visibility tracks
+                         BrowserPreview so it disappears in video-file / audio modes. -->
+                    <StackPanel Grid.Row="0" Grid.Column="2" x:Name="PreviewZoomCluster"
+                                Orientation="Horizontal" VerticalAlignment="Center"
+                                Margin="8,0,0,0"
+                                IsVisible="{Binding #BrowserPreview.IsVisible}">
+                        <TextBlock Text="🔍" FontSize="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <Button x:Name="BtnPreviewZoomOut" Content="−"
+                                ToolTip.Tip="{loc:Str deeper_zoom_out_tt}"
+                                Width="22" Height="22" Padding="0" FontSize="13" FontWeight="Bold"
+                                Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                Foreground="{DynamicResource DeeperAccentBrush}"
+                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1"/>
+                        <Button x:Name="BtnPreviewZoomIn" Content="+"
+                                ToolTip.Tip="{loc:Str deeper_zoom_in_tt}"
+                                Width="22" Height="22" Padding="0" FontSize="13" FontWeight="Bold" Margin="3,0,0,0"
+                                Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                Foreground="{DynamicResource DeeperAccentBrush}"
+                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1"/>
+                    </StackPanel>
+
+                    <Button Grid.Row="0" Grid.Column="3" x:Name="BtnLinkedJsonOpenFolder"
+                            Content="📁"
+                            ToolTip.Tip="{loc:Str deeper_editor_linked_open_folder_tt}"
+                            Width="30" Height="26" Padding="0" Cursor="Hand" FontSize="12"
+                            Margin="6,0,0,0"
+                            Background="Transparent"
+                            Foreground="{DynamicResource DeeperAccentBrush}"
+                            BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1"/>
+                    <Button Grid.Row="0" Grid.Column="4" x:Name="BtnLinkedJsonSwap"
+                            ToolTip.Tip="{loc:Str deeper_editor_tip_linked_swap_json}"
+                            Padding="8,3" Margin="6,0,0,0" Cursor="Hand"
+                            Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                            BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                        <TextBlock Text="{loc:Str deeper_editor_linked_swap_json_btn}" FontSize="11"
+                                   Foreground="{DynamicResource DeeperAccentBrush}"/>
+                    </Button>
+
+                    <TextBlock Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" x:Name="TxtLinkedJsonPath"
+                               Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                               TextTrimming="CharacterEllipsis" Margin="0,2,0,0"/>
+                </Grid>
+
+                <!-- Linked media -->
+                <Grid Grid.Column="2" ColumnDefinitions="Auto,Auto,*,Auto,Auto" RowDefinitions="Auto,Auto">
+                    <TextBlock Grid.Row="0" Grid.Column="0" x:Name="TxtLinkedMediaIcon"
+                               Text="🎬" FontSize="13"
+                               VerticalAlignment="Center" Margin="0,0,4,0"
+                               Foreground="{DynamicResource DeeperAccentSoftBrush}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" x:Name="TxtLinkedMediaStatus"
+                               Text="✓" FontSize="12" FontWeight="Bold"
+                               VerticalAlignment="Center" Margin="0,0,6,0"
+                               Foreground="{DynamicResource DeeperAccentBrush}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="2" x:Name="TxtLinkedMediaName"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               FontSize="12" FontWeight="SemiBold"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                    <Button Grid.Row="0" Grid.Column="3" x:Name="BtnLinkedMediaChange"
+                            ToolTip.Tip="{loc:Str deeper_editor_tip_linked_change_media}"
+                            Padding="8,3" Margin="6,0,0,0" Cursor="Hand"
+                            Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                            BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                        <TextBlock Text="{loc:Str deeper_editor_linked_change_media_btn}" FontSize="11"
+                                   Foreground="{DynamicResource DeeperAccentBrush}"/>
+                    </Button>
+                    <Button Grid.Row="0" Grid.Column="4" x:Name="BtnLinkedMediaClear"
+                            ToolTip.Tip="{loc:Str deeper_editor_tip_linked_clear_media}"
+                            Padding="8,3" Margin="6,0,0,0" Cursor="Hand"
+                            Background="Transparent"
+                            BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1">
+                        <TextBlock Text="{loc:Str deeper_editor_linked_clear_media_btn}" FontSize="11"
+                                   Foreground="{DynamicResource TextMutedBrush}"/>
+                    </Button>
+
+                    <TextBlock Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="4" x:Name="TxtLinkedMediaPath"
+                               Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                               TextTrimming="CharacterEllipsis" Margin="0,2,0,0"/>
+                </Grid>
+
+                <!-- Change-media popup: file vs URL -->
+                <Popup x:Name="MediaChangePopup" PlacementTarget="{Binding #BtnLinkedMediaChange}"
+                       Placement="Bottom" IsLightDismissEnabled="True">
+                    <Border Background="{DynamicResource DarkerBgBrush}"
+                            BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="2"
+                            CornerRadius="6" Padding="6">
+                        <StackPanel>
+                            <Button x:Name="BtnChangeMediaLocal"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tip_linked_change_local}"
+                                    Padding="10,6" Cursor="Hand" Margin="0,0,0,2"
+                                    HorizontalContentAlignment="Left"
+                                    Background="Transparent" BorderThickness="0">
+                                <TextBlock Text="{loc:Str deeper_editor_linked_change_media_local}" FontSize="11"
+                                           Foreground="{DynamicResource TextLightBrush}"/>
+                            </Button>
+                            <Button x:Name="BtnChangeMediaUrl"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tip_linked_change_url}"
+                                    Padding="10,6" Cursor="Hand"
+                                    HorizontalContentAlignment="Left"
+                                    Background="Transparent" BorderThickness="0">
+                                <TextBlock Text="{loc:Str deeper_editor_linked_change_media_url}" FontSize="11"
+                                           Foreground="{DynamicResource TextLightBrush}"/>
+                            </Button>
+                        </StackPanel>
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+
+        <!-- Main 2-column body with a draggable splitter. Sidebar width persists across editor
+             sessions via AppSettings.DeeperEditorSidebarWidth (clamped 320..520). -->
+        <Grid Grid.Row="2" x:Name="MainBodyGrid">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="4"/>
+                <!-- The resizable sidebar. WPF carried x:Name="SidebarColumn"; Avalonia rejects x:Name
+                     on a ColumnDefinition, so the code-behind indexes MainBodyGrid.ColumnDefinitions[2]. -->
+                <ColumnDefinition Width="380" MinWidth="320" MaxWidth="520"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Left: preview + timeline -->
+            <Grid Grid.Column="0" RowDefinitions="*,160">
+
+                <!-- Preview pane -->
+                <Border Grid.Row="0" Background="{DynamicResource DeeperPreviewSurfaceBgBrush}" Margin="10,10,10,5"
+                        CornerRadius="8">
+                    <Grid x:Name="PreviewHost">
+                        <!-- ponytail: was <vlc:VideoView x:Name="VideoPreview"/>. LibVLCSharp.WPF is
+                             a WPF assembly and LibVLCSharp.Avalonia is a package this layer may not
+                             add, so local video preview is a labelled surface, not a picture. -->
+                        <Border x:Name="VideoPreview" IsVisible="False"
+                                Background="{DynamicResource DeeperWaveformBgBrush}">
+                            <TextBlock x:Name="TxtVideoPreviewStub"
+                                       Text="Video preview needs LibVLCSharp.Avalonia"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       FontSize="12" FontStyle="Italic"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+
+                        <!-- Remote http(s):// preview (HypnoTube etc). WebHost draws its own
+                             fallback panel wherever no web engine is installed. -->
+                        <controls:WebHost x:Name="BrowserPreview" IsVisible="False"/>
+
+                        <Canvas x:Name="WaveformCanvas" IsVisible="False" Background="{DynamicResource DeeperWaveformBgBrush}">
+                            <Path x:Name="WaveformPath" Stroke="{DynamicResource DeeperAccentBrush}"
+                                  StrokeThickness="1.4" StrokeLineCap="Round"/>
+                        </Canvas>
+
+                        <StackPanel x:Name="PreviewPlaceholder" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    IsVisible="False">
+                            <TextBlock x:Name="TxtPlaceholderIcon" Text="🌐" FontSize="42" HorizontalAlignment="Center"
+                                       Foreground="{DynamicResource DeeperAccentSoftBrush}" Margin="0,0,0,12"/>
+                            <TextBlock x:Name="TxtPlaceholderTitle"
+                                       Foreground="{DynamicResource TextLightBrush}" FontSize="14"
+                                       HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="380"
+                                       TextAlignment="Center"/>
+                            <TextBlock x:Name="TxtPlaceholderSource" Foreground="{DynamicResource TextDimBrush}"
+                                       FontSize="11" HorizontalAlignment="Center" TextAlignment="Center"
+                                       TextTrimming="CharacterEllipsis" MaxWidth="420" Margin="0,8,0,0"/>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- Timeline -->
+                <Border Grid.Row="1" Background="{DynamicResource PanelBgBrush}"
+                        BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1"
+                        CornerRadius="8" Margin="10,5,10,10" Padding="10,8">
+                    <Grid RowDefinitions="Auto,*">
+
+                        <!-- Transport row. LEFT: play + time + zoom. RIGHT: Preview / + Rule /
+                             + Effect. The scrub hint is LastChild and eats slack first. -->
+                        <DockPanel Grid.Row="0" LastChildFill="True" Margin="0,0,0,6">
+                            <Button x:Name="BtnPlayPause" DockPanel.Dock="Left"
+                                    Content="▶"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tt_play}"
+                                    Width="34" Height="28" Padding="0" Cursor="Hand"
+                                    Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                    Foreground="{DynamicResource DeeperAccentBrush}"
+                                    BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1"
+                                    FontSize="13"/>
+                            <TextBlock x:Name="TxtCurrentTime" DockPanel.Dock="Left"
+                                       Text="0:00" Foreground="{DynamicResource TextLightBrush}"
+                                       FontSize="12" VerticalAlignment="Center" Margin="10,0,4,0"/>
+                            <TextBlock DockPanel.Dock="Left" Text="/" Foreground="{DynamicResource TextDimBrush}"
+                                       FontSize="12" VerticalAlignment="Center"/>
+                            <TextBlock x:Name="TxtTotalTime" DockPanel.Dock="Left"
+                                       Text="0:00" Foreground="{DynamicResource TextMutedBrush}"
+                                       FontSize="12" VerticalAlignment="Center" Margin="4,0,12,0"/>
+                            <Button x:Name="BtnZoomOut" DockPanel.Dock="Left" Content="−"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tip_zoom_out}"
+                                    Width="28" Height="26" Padding="0" Margin="0,0,2,0" Cursor="Hand"
+                                    FontSize="14" FontWeight="Bold"
+                                    Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                    Foreground="{DynamicResource DeeperAccentBrush}"
+                                    BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1"/>
+                            <TextBlock x:Name="TxtZoomLevel" DockPanel.Dock="Left" Text="100%"
+                                       Width="52" TextAlignment="Center"
+                                       Foreground="{DynamicResource TextDimBrush}" FontSize="11"
+                                       VerticalAlignment="Center"/>
+                            <Button x:Name="BtnZoomIn" DockPanel.Dock="Left" Content="+"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tip_zoom_in}"
+                                    Width="28" Height="26" Padding="0" Margin="2,0,12,0" Cursor="Hand"
+                                    FontSize="14" FontWeight="Bold"
+                                    Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                    Foreground="{DynamicResource DeeperAccentBrush}"
+                                    BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1"/>
+                            <Button x:Name="BtnPreview" DockPanel.Dock="Right"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tt_preview}"
+                                    Cursor="Hand"
+                                    Padding="12,4" Margin="8,0,0,0"
+                                    Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                    BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                                <TextBlock x:Name="TxtPreviewLabel" FontSize="11" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource DeeperAccentBrush}"/>
+                            </Button>
+                            <Button x:Name="BtnAddRuleHero" DockPanel.Dock="Right"
+                                    Content="+ Rule"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tip_add_rule_hero}"
+                                    Padding="10,4" Margin="6,0,0,0" Cursor="Hand" FontSize="11" FontWeight="SemiBold"
+                                    Background="Transparent"
+                                    Foreground="{DynamicResource DeeperAccentBrush}"
+                                    BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1"/>
+                            <!-- Hero "+ Effect" dropdown: the six effect types at the playhead.
+                                 Was ContextMenu x:Key="HeroAddEffectMenu"; a MenuFlyout is the
+                                 Avalonia equivalent and opens itself, so the click handler only
+                                 has to point _rightClickSeconds at the playhead. -->
+                            <Button x:Name="BtnAddEffectHero" DockPanel.Dock="Right"
+                                    Content="+ Effect"
+                                    ToolTip.Tip="{loc:Str deeper_editor_tip_add_effect_hero}"
+                                    Padding="10,4" Margin="6,0,0,0" Cursor="Hand" FontSize="11" FontWeight="SemiBold"
+                                    Background="Transparent"
+                                    Foreground="{DynamicResource DeeperAccentBrush}"
+                                    BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                                <Button.Flyout>
+                                    <MenuFlyout>
+                                        <MenuItem x:Name="HeroEffectHaptic" Header="Haptic"/>
+                                        <MenuItem x:Name="HeroEffectFlash" Header="Flash"/>
+                                        <MenuItem x:Name="HeroEffectBubble" Header="Bubble"/>
+                                        <MenuItem x:Name="HeroEffectSubliminal" Header="Subliminal"/>
+                                        <MenuItem x:Name="HeroEffectOverlay" Header="Overlay"/>
+                                        <MenuItem x:Name="HeroEffectSpeak" Header="Speak (voice)"/>
+                                    </MenuFlyout>
+                                </Button.Flyout>
+                            </Button>
+                            <TextBlock Foreground="{DynamicResource TextDimBrush}"
+                                       FontSize="11" VerticalAlignment="Center"
+                                       Margin="0,0,8,0"
+                                       TextTrimming="CharacterEllipsis"
+                                       Text="{loc:Str deeper_editor_scrub_hint}"/>
+                        </DockPanel>
+
+                        <!-- Three equal lane headers stack down the left column (96 px):
+                             Regions / Effects / Haptics, aligned with the canvas's three equal Y
+                             bands (see LaneBand in LaneChrome.cs). Rules are not a lane. -->
+                        <Grid Grid.Row="1" ColumnDefinitions="96,*">
+
+                            <Grid Grid.Column="0" Background="{DynamicResource DeeperLaneHeaderBrush}"
+                                  RowDefinitions="*,*,*">
+
+                                <Border x:Name="TimelineRegionsLaneHeader" Grid.Row="0"
+                                        Background="{DynamicResource DeeperLaneHeaderBrush}"
+                                        BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                                        BorderThickness="0,0,1,1" Padding="6,2"
+                                        ToolTip.Tip="{loc:Str deeper_editor_tt_lane_regions}">
+                                    <DockPanel LastChildFill="True">
+                                        <TextBlock DockPanel.Dock="Left" Text="▦" FontSize="11"
+                                                   Foreground="{DynamicResource DeeperAccentBrush}"
+                                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                        <TextBlock x:Name="TxtRegionsLaneCount" DockPanel.Dock="Right"
+                                                   Foreground="{DynamicResource TextDimBrush}"
+                                                   FontSize="10" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str deeper_editor_lane_regions}"
+                                                   Foreground="{DynamicResource TextLightBrush}"
+                                                   FontSize="11" FontWeight="SemiBold"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </Border>
+
+                                <Border x:Name="TimelineEffectsLaneHeader" Grid.Row="1"
+                                        Background="{DynamicResource DeeperLaneHeaderBrush}"
+                                        BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                                        BorderThickness="0,0,1,1" Padding="6,2"
+                                        ToolTip.Tip="{loc:Str deeper_editor_tt_lane_effects}">
+                                    <DockPanel LastChildFill="True">
+                                        <TextBlock DockPanel.Dock="Left" Text="✨" FontSize="12"
+                                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                        <TextBlock x:Name="TxtEffectsLaneCount" DockPanel.Dock="Right"
+                                                   Foreground="{DynamicResource TextDimBrush}"
+                                                   FontSize="10" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str deeper_editor_lane_effects}"
+                                                   Foreground="{DynamicResource TextLightBrush}"
+                                                   FontSize="11" FontWeight="SemiBold"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </Border>
+
+                                <Border x:Name="TimelineHapticsLaneHeader" Grid.Row="2"
+                                        Background="{DynamicResource DeeperLaneHeaderBrush}"
+                                        BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                                        BorderThickness="0,0,1,0" Padding="6,2"
+                                        ToolTip.Tip="{loc:Str deeper_editor_tt_lane_haptics}">
+                                    <DockPanel LastChildFill="True">
+                                        <TextBlock DockPanel.Dock="Left" Text="📳" FontSize="12"
+                                                   VerticalAlignment="Center" Margin="0,0,4,0"/>
+                                        <TextBlock x:Name="TxtHapticsLaneCount" DockPanel.Dock="Right"
+                                                   Foreground="{DynamicResource TextDimBrush}"
+                                                   FontSize="10" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str deeper_editor_lane_haptics}"
+                                                   Foreground="{DynamicResource TextLightBrush}"
+                                                   FontSize="11" FontWeight="SemiBold"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </Border>
+                            </Grid>
+
+                            <!-- Timeline canvas inside a ScrollViewer so we can zoom horizontally. -->
+                            <ScrollViewer x:Name="TimelineScroll" Grid.Column="1"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          VerticalScrollBarVisibility="Disabled">
+                                <Canvas x:Name="TimelineCanvas" Background="{DynamicResource DeeperLaneCanvasBrush}"
+                                        Cursor="Hand" ClipToBounds="True"
+                                        ToolTip.Tip="{loc:Str deeper_editor_tt_timeline}">
+                                    <Canvas.ContextMenu>
+                                        <!-- Was <ContextMenu x:Key="TimelineCtxMenu" x:Shared="False">.
+                                             Avalonia has no x:Shared and no FindResource-a-menu, so
+                                             it is inlined on the canvas it belongs to. -->
+                                        <ContextMenu x:Name="TimelineCtxMenu"
+                                                     Background="{DynamicResource DarkerBgBrush}"
+                                                     BorderBrush="{DynamicResource DeeperAccentBrush}"
+                                                     BorderThickness="2">
+                                            <MenuItem Header="Add Effect"
+                                                      Foreground="{DynamicResource DeeperAccentBrush}" FontWeight="Bold">
+                                                <MenuItem x:Name="CtxEffectHaptic" Header="Haptic"/>
+                                                <MenuItem x:Name="CtxEffectFlash" Header="Flash"/>
+                                                <MenuItem x:Name="CtxEffectBubble" Header="Bubble"/>
+                                                <MenuItem x:Name="CtxEffectSubliminal" Header="Subliminal"/>
+                                                <MenuItem x:Name="CtxEffectOverlay" Header="Overlay"/>
+                                                <MenuItem x:Name="CtxEffectSpeak" Header="Speak (voice)"/>
+                                            </MenuItem>
+                                            <MenuItem Header="Add Rule"
+                                                      Foreground="{DynamicResource DeeperAccentBrush}" FontWeight="Bold">
+                                                <MenuItem x:Name="CtxRuleTimeReached" Header="{loc:Str deeper_friendly_trigger_time_reached}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_time_reached}"/>
+                                                <MenuItem x:Name="CtxRuleBandEntered" Header="{loc:Str deeper_friendly_trigger_region_entered}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_region_entered}"/>
+                                                <MenuItem x:Name="CtxRuleBandExited" Header="{loc:Str deeper_friendly_trigger_region_exited}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_region_exited}"/>
+                                                <MenuItem x:Name="CtxRuleGazeTarget" Header="{loc:Str deeper_friendly_trigger_gaze_target}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_gaze_target}"/>
+                                                <MenuItem x:Name="CtxRuleGazeAvoid" Header="{loc:Str deeper_friendly_trigger_gaze_avoid}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_gaze_avoid}"/>
+                                                <MenuItem x:Name="CtxRuleAttentionLost" Header="{loc:Str deeper_friendly_trigger_attention_lost}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_attention_lost}"/>
+                                                <MenuItem x:Name="CtxRuleBlinkDetected" Header="{loc:Str deeper_friendly_trigger_blink_detected}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_blink_detected}"/>
+                                                <MenuItem x:Name="CtxRuleMouthOpen" Header="{loc:Str deeper_friendly_trigger_mouth_open}"
+                                                          ToolTip.Tip="{loc:Str deeper_desc_trigger_mouth_open}"/>
+                                            </MenuItem>
+                                        </ContextMenu>
+                                    </Canvas.ContextMenu>
+                                    <!-- Playhead -->
+                                    <Line x:Name="PlayheadLine" StartPoint="0,0" EndPoint="0,0"
+                                          Stroke="{DynamicResource DeeperAccentBrush}" StrokeThickness="2"
+                                          ZIndex="100"/>
+                                </Canvas>
+                            </ScrollViewer>
+                        </Grid>
+                    </Grid>
+                </Border>
+            </Grid>
+
+            <!-- GridSplitter - drag to resize the sidebar between 320 and 520 px. -->
+            <GridSplitter x:Name="SidebarSplitter" Grid.Column="1"
+                          Width="4" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                          Background="{DynamicResource DeeperLaneSeparatorBrush}"
+                          ResizeBehavior="PreviousAndNext" ResizeDirection="Columns"
+                          Cursor="SizeWestEast"
+                          ToolTip.Tip="{loc:Str deeper_editor_tt_sidebar_splitter}"/>
+
+            <!-- Right: 3-zone side panel. Zone 1 metadata drawer / Zone 1.5 items list /
+                 Zone 2 selection summary strip / Zone 3 inspector. -->
+            <Border Grid.Column="2" Background="{DynamicResource PanelBgBrush}"
+                    BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="0">
+                <Grid RowDefinitions="Auto,Auto,Auto,*">
+
+                    <!-- Zone 1: Metadata drawer -->
+                    <StackPanel Grid.Row="0">
+                        <ToggleButton x:Name="MetadataDrawerToggle" Height="32"
+                                      Cursor="Hand" HorizontalContentAlignment="Stretch"
+                                      HorizontalAlignment="Stretch"
+                                      Padding="12,0" CornerRadius="0"
+                                      Background="{DynamicResource DeeperDrawerStripBrush}"
+                                      BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                                      BorderThickness="0,0,0,1"
+                                      Foreground="{DynamicResource TextLightBrush}"
+                                      ToolTip.Tip="{loc:Str deeper_editor_tt_metadata_drawer}">
+                            <DockPanel LastChildFill="True">
+                                <TextBlock x:Name="MetadataDrawerChevron" DockPanel.Dock="Left"
+                                           Text="▶" FontSize="10"
+                                           Foreground="{DynamicResource DeeperAccentBrush}"
+                                           VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <TextBlock x:Name="TxtMetadataDrawerSubtitle" DockPanel.Dock="Right"
+                                           Foreground="{DynamicResource TextDimBrush}"
+                                           FontSize="11" VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis" MaxWidth="220"/>
+                                <TextBlock Text="{loc:Str deeper_editor_section_metadata}"
+                                           Foreground="{DynamicResource DeeperAccentBrush}"
+                                           FontSize="12" FontWeight="SemiBold"
+                                           VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            </DockPanel>
+                        </ToggleButton>
+                        <Border x:Name="MetadataDrawerContent" IsVisible="False"
+                                Background="{DynamicResource PanelBgBrush}"
+                                BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                                BorderThickness="0,0,0,1">
+                            <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="380" Padding="14,12">
+                                <StackPanel>
+                                    <TextBlock Text="{loc:Str deeper_editor_label_name}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtMetaName" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_meta_name}"/>
+
+                                    <DockPanel Margin="0,0,0,4" LastChildFill="True">
+                                        <TextBlock DockPanel.Dock="Left" Text="{loc:Str deeper_editor_label_creator}"
+                                                   Theme="{StaticResource EditorLabel}" VerticalAlignment="Center"/>
+                                        <ToggleButton x:Name="BtnCreatorLockToggle" DockPanel.Dock="Right"
+                                                      Content="🔒" FontSize="11"
+                                                      Width="22" Height="20" Padding="0" Cursor="Hand"
+                                                      Background="Transparent"
+                                                      Foreground="{DynamicResource TextDimBrush}"
+                                                      BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="1"
+                                                      ToolTip.Tip="{loc:Str deeper_editor_tip_creator_lock}"/>
+                                        <TextBlock/>
+                                    </DockPanel>
+                                    <TextBox x:Name="TxtMetaCreator" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_meta_creator}"/>
+
+                                    <TextBlock Text="Remixer" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtMetaRemixer" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="Your name (the remixer who edited the rules/effects on top of the original media)"/>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_label_description}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtMetaDescription" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_meta_description}"
+                                             TextWrapping="Wrap" AcceptsReturn="True" Height="68"/>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_label_tags}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtMetaTags" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_meta_tags}"/>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_label_license}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtMetaLicense" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_meta_license}"/>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </Border>
+                    </StackPanel>
+
+                    <!-- Zone 1.5: Items list - every rule, effect, haptic and region, with a
+                         Time / Kind sort toggle and two-way selection sync with the timeline. -->
+                    <Border Grid.Row="1"
+                            Background="{DynamicResource DeeperDrawerStripBrush}"
+                            BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                            BorderThickness="0,0,0,1"
+                            Padding="10,6">
+                        <Grid RowDefinitions="Auto,Auto">
+
+                            <DockPanel Grid.Row="0" LastChildFill="True" Margin="0,0,0,6">
+                                <TextBlock DockPanel.Dock="Left" Text="📋" FontSize="13"
+                                           VerticalAlignment="Center" Margin="0,0,6,0"/>
+                                <TextBlock DockPanel.Dock="Left" Text="Items"
+                                           Foreground="{DynamicResource DeeperAccentBrush}"
+                                           FontSize="12" FontWeight="SemiBold"
+                                           VerticalAlignment="Center"/>
+                                <TextBlock x:Name="TxtItemsListCount" DockPanel.Dock="Left"
+                                           Margin="6,0,0,0"
+                                           Foreground="{DynamicResource TextDimBrush}"
+                                           FontSize="11" VerticalAlignment="Center"/>
+                                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                                    <TextBlock Text="Sort"
+                                               Foreground="{DynamicResource TextDimBrush}"
+                                               FontSize="10" VerticalAlignment="Center"
+                                               Margin="0,0,6,0"/>
+                                    <RadioButton x:Name="RbItemsSortTime"
+                                                 Content="Time" IsChecked="True"
+                                                 GroupName="ItemsListSort"
+                                                 ToolTip.Tip="Sort items by their position on the timeline"
+                                                 Foreground="{DynamicResource TextLightBrush}"
+                                                 FontSize="10" VerticalAlignment="Center"
+                                                 Margin="0,0,8,0"/>
+                                    <RadioButton x:Name="RbItemsSortKind"
+                                                 Content="Kind"
+                                                 GroupName="ItemsListSort"
+                                                 ToolTip.Tip="Group by item kind (rules, regions, haptics, effects)"
+                                                 Foreground="{DynamicResource TextLightBrush}"
+                                                 FontSize="10" VerticalAlignment="Center"/>
+                                </StackPanel>
+                                <TextBlock/>
+                            </DockPanel>
+
+                            <Border Grid.Row="1"
+                                    Background="{DynamicResource DarkerBgBrush}"
+                                    BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                    BorderThickness="1" CornerRadius="6">
+                                <ListBox x:Name="ItemsListBox"
+                                         MaxHeight="186"
+                                         Background="Transparent"
+                                         BorderThickness="0"
+                                         Foreground="{DynamicResource TextLightBrush}"
+                                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                    <ListBox.Styles>
+                                        <!-- WPF's ListBox.ItemContainerStyle. Property-only plus two
+                                             state selectors; the Fluent ListBoxItem template stays. -->
+                                        <Style Selector="ListBoxItem">
+                                            <Setter Property="Padding" Value="6,3"/>
+                                            <Setter Property="Margin" Value="0"/>
+                                            <Setter Property="MinHeight" Value="0"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+                                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                            <Setter Property="Cursor" Value="Hand"/>
+                                        </Style>
+                                        <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
+                                            <Setter Property="Background" Value="{DynamicResource DeeperMenuItemHoverBgBrush}"/>
+                                        </Style>
+                                        <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+                                            <Setter Property="Background" Value="{DynamicResource DeeperAccentTransparent40Brush}"/>
+                                        </Style>
+                                    </ListBox.Styles>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate x:DataType="deeper:TimelineListEntry">
+                                            <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+                                                <TextBlock Grid.Column="0" Text="{Binding Icon}"
+                                                           FontSize="12" VerticalAlignment="Center"
+                                                           Margin="0,0,6,0"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding KindLabel}"
+                                                           Foreground="{Binding KindBrush}"
+                                                           FontSize="10" FontWeight="SemiBold"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,0,8,0"/>
+                                                <TextBlock Grid.Column="2" Text="{Binding Label}"
+                                                           Foreground="{DynamicResource TextLightBrush}"
+                                                           FontSize="11" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"/>
+                                                <TextBlock Grid.Column="3" Text="{Binding TimeText}"
+                                                           Foreground="{DynamicResource TextDimBrush}"
+                                                           FontFamily="Consolas, Courier New, monospace" FontSize="10"
+                                                           VerticalAlignment="Center"
+                                                           Margin="8,0,6,0"/>
+                                                <Button Grid.Column="4"
+                                                        Content="×"
+                                                        Tag="{Binding}"
+                                                        Classes="itemsListDelete"
+                                                        ToolTip.Tip="Delete this item"
+                                                        Width="18" Height="18" Padding="0"
+                                                        FontSize="14" FontWeight="Bold"
+                                                        Cursor="Hand"
+                                                        Background="Transparent"
+                                                        Foreground="{DynamicResource TextDimBrush}"
+                                                        BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                        BorderThickness="1"
+                                                        VerticalAlignment="Center"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </Border>
+
+                            <TextBlock x:Name="TxtItemsListEmpty" Grid.Row="1"
+                                       Text="No rules, effects, or regions yet"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       FontSize="11" FontStyle="Italic"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       Margin="0,12,0,12"
+                                       IsVisible="False"
+                                       IsHitTestVisible="False"/>
+                        </Grid>
+                    </Border>
+
+                    <!-- Zone 2: Selection summary strip - always visible (~44px). -->
+                    <Border Grid.Row="2" Height="44"
+                            Background="{DynamicResource DeeperSelectionStripBrush}"
+                            BorderBrush="{DynamicResource DeeperLaneSeparatorBrush}"
+                            BorderThickness="0,0,0,1"
+                            Padding="14,0">
+                        <TextBlock x:Name="TxtSelectionSummary"
+                                   Foreground="{DynamicResource TextMutedBrush}"
+                                   FontSize="12" FontStyle="Italic"
+                                   VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis"/>
+                    </Border>
+
+                    <!-- Zone 3: Inspector - internally scrollable. -->
+                    <Border Grid.Row="3" Background="{DynamicResource PanelBgBrush}">
+                        <ScrollViewer x:Name="InspectorScroll"
+                                      VerticalScrollBarVisibility="Auto" Padding="14,12">
+                            <StackPanel>
+                                <TextBlock x:Name="SelectedPlaceholder"
+                                           Text="{loc:Str deeper_editor_section_selected_empty}"
+                                           Foreground="{DynamicResource TextMutedBrush}" FontSize="11" FontStyle="Italic"
+                                           TextWrapping="Wrap"/>
+
+                                <StackPanel x:Name="RegionEditor" IsVisible="False">
+                                    <TextBlock Text="{loc:Str deeper_editor_region_id}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock x:Name="TxtRegionId" Foreground="{DynamicResource TextDimBrush}"
+                                               FontSize="11" FontFamily="Consolas, Courier New, monospace" Margin="0,0,0,8"/>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_region_label}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtRegionLabel" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_region_label}"/>
+
+                                    <Grid Margin="0,0,0,4" ColumnDefinitions="*,8,*">
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{loc:Str deeper_editor_region_start}" Theme="{StaticResource EditorLabel}"/>
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <TextBox x:Name="TxtRegionStart" Theme="{StaticResource EditorTextBox}"
+                                                         ToolTip.Tip="{loc:Str deeper_editor_tt_region_start}"/>
+                                                <Button x:Name="BtnSnapRegionStartPrev" Grid.Column="1"
+                                                        Content="⇤"
+                                                        ToolTip.Tip="{loc:Str deeper_editor_tt_region_snap_prev}"
+                                                        Width="26" Margin="4,0,0,8" Padding="0" FontSize="13" Cursor="Hand"
+                                                        Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                                        Foreground="{DynamicResource DeeperAccentBrush}"
+                                                        BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                        BorderThickness="1"/>
+                                            </Grid>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Text="{loc:Str deeper_editor_region_end}" Theme="{StaticResource EditorLabel}"/>
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <TextBox x:Name="TxtRegionEnd" Theme="{StaticResource EditorTextBox}"
+                                                         ToolTip.Tip="{loc:Str deeper_editor_tt_region_end}"/>
+                                                <Button x:Name="BtnSnapRegionEndNext" Grid.Column="1"
+                                                        Content="⇥"
+                                                        ToolTip.Tip="{loc:Str deeper_editor_tt_region_snap_next}"
+                                                        Width="26" Margin="4,0,0,8" Padding="0" FontSize="13" Cursor="Hand"
+                                                        Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                                                        Foreground="{DynamicResource DeeperAccentBrush}"
+                                                        BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                        BorderThickness="1"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_region_color}" Theme="{StaticResource EditorLabel}"/>
+                                    <Grid Margin="0,0,0,4" ColumnDefinitions="Auto,*">
+                                        <Border x:Name="RegionColorSwatch" Grid.Column="0"
+                                                Width="24" Height="24" Margin="0,0,8,0" CornerRadius="4"
+                                                Background="{DynamicResource DeeperAccentBrush}"
+                                                BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"/>
+                                        <TextBox x:Name="TxtRegionColor" Grid.Column="1" Theme="{StaticResource EditorTextBox}"
+                                                 ToolTip.Tip="{loc:Str deeper_editor_tt_region_color}" Margin="0"/>
+                                    </Grid>
+                                    <WrapPanel x:Name="RegionColorSwatches" Margin="0,4,0,12"/>
+
+                                    <Button x:Name="BtnDeleteRegion"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_region_delete}"
+                                            Background="{DynamicResource DangerBrush}"
+                                            BorderThickness="0" Padding="10,6" Cursor="Hand"
+                                            HorizontalAlignment="Left" Margin="0,4,0,0">
+                                        <TextBlock Text="{loc:Str deeper_editor_region_delete}" Foreground="White"/>
+                                    </Button>
+                                </StackPanel>
+
+                                <StackPanel x:Name="HapticEventEditor" IsVisible="False">
+                                    <TextBlock Text="{loc:Str deeper_editor_haptic_event}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock x:Name="TxtHapticTrackId" Foreground="{DynamicResource TextDimBrush}"
+                                               FontSize="11" FontFamily="Consolas, Courier New, monospace" Margin="0,0,0,8"/>
+
+                                    <Grid Margin="0,0,0,4" ColumnDefinitions="*,8,*">
+                                        <StackPanel Grid.Column="0">
+                                            <TextBlock Text="{loc:Str deeper_editor_haptic_start}" Theme="{StaticResource EditorLabel}"/>
+                                            <TextBox x:Name="TxtHapticStart" Theme="{StaticResource EditorTextBox}"
+                                                     ToolTip.Tip="{loc:Str deeper_editor_tt_haptic_start}"/>
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Text="{loc:Str deeper_editor_haptic_duration}" Theme="{StaticResource EditorLabel}"/>
+                                            <TextBox x:Name="TxtHapticDuration" Theme="{StaticResource EditorTextBox}"
+                                                     ToolTip.Tip="{loc:Str deeper_editor_tt_haptic_duration}"/>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_haptic_intensity}" Theme="{StaticResource EditorLabel}"/>
+                                    <Grid Margin="0,0,0,8" ColumnDefinitions="*,44"
+                                          ToolTip.Tip="{loc:Str deeper_editor_tt_haptic_intensity}">
+                                        <Slider x:Name="SliderHapticIntensity" Grid.Column="0"
+                                                Minimum="0" Maximum="1" SmallChange="0.05" LargeChange="0.1"
+                                                TickFrequency="0.1" IsSnapToTickEnabled="False"
+                                                Foreground="{DynamicResource DeeperAccentBrush}"
+                                                VerticalAlignment="Center"/>
+                                        <TextBlock x:Name="TxtHapticIntensityValue" Grid.Column="1"
+                                                   Text="100%" Foreground="{DynamicResource TextLightBrush}"
+                                                   HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                   FontFamily="Consolas, Courier New, monospace" FontSize="11"/>
+                                    </Grid>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_haptic_pattern}" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbHapticPattern" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="{loc:Str deeper_editor_tt_haptic_pattern}"/>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_haptic_target}" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbHapticTarget" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"/>
+
+                                    <StackPanel x:Name="CurveEditorPanel" IsVisible="False" Margin="0,4,0,8">
+                                        <TextBlock Text="{loc:Str deeper_editor_haptic_curve}"
+                                                   Foreground="{DynamicResource TextMutedBrush}"
+                                                   FontSize="11" Margin="0,0,0,4"/>
+                                        <Border Background="{DynamicResource DeeperWaveformBgBrush}"
+                                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                BorderThickness="1" CornerRadius="6">
+                                            <Canvas x:Name="CurveCanvas" Height="120" Background="Transparent"
+                                                    ClipToBounds="True"/>
+                                        </Border>
+                                        <Button x:Name="BtnResetCurve"
+                                                ToolTip.Tip="{loc:Str deeper_editor_tip_haptic_reset_curve}"
+                                                HorizontalAlignment="Left" Margin="0,4,0,0"
+                                                Padding="8,4" Cursor="Hand"
+                                                Background="Transparent"
+                                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}">
+                                            <TextBlock Text="{loc:Str deeper_editor_haptic_curve_reset}" FontSize="11"
+                                                       Foreground="{DynamicResource TextLightBrush}"/>
+                                        </Button>
+                                    </StackPanel>
+
+                                    <Grid Margin="0,4,0,0" ColumnDefinitions="*,8,Auto">
+                                        <Button Grid.Column="0" x:Name="BtnTestHaptic"
+                                                ToolTip.Tip="{loc:Str deeper_editor_tt_haptic_test}"
+                                                Background="{DynamicResource DeeperAccentBrush}"
+                                                BorderThickness="0" Padding="10,6" Cursor="Hand">
+                                            <TextBlock Text="{loc:Str deeper_editor_haptic_test}" Foreground="White" FontWeight="SemiBold"/>
+                                        </Button>
+                                        <Button Grid.Column="2" x:Name="BtnDeleteHaptic"
+                                                ToolTip.Tip="{loc:Str deeper_editor_tip_haptic_delete}"
+                                                Background="{DynamicResource DangerBrush}"
+                                                BorderThickness="0" Padding="10,6" Cursor="Hand">
+                                            <TextBlock Text="{loc:Str deeper_editor_haptic_delete}" Foreground="White"/>
+                                        </Button>
+                                    </Grid>
+                                </StackPanel>
+
+                                <StackPanel x:Name="RuleEditor" IsVisible="False">
+                                    <DockPanel Margin="0,0,0,10" LastChildFill="True">
+                                        <TextBlock x:Name="TxtRuleHeader" DockPanel.Dock="Left"
+                                                   Foreground="{DynamicResource TextDimBrush}"
+                                                   FontSize="11" FontFamily="Consolas, Courier New, monospace" VerticalAlignment="Center"/>
+                                        <Button x:Name="BtnDeleteRule" DockPanel.Dock="Right"
+                                                ToolTip.Tip="{loc:Str deeper_editor_tip_rule_delete}"
+                                                Background="{DynamicResource DangerBrush}"
+                                                BorderThickness="0" Padding="8,4" Cursor="Hand"
+                                                HorizontalAlignment="Right">
+                                            <TextBlock Text="{loc:Str deeper_editor_rule_delete}" Foreground="White" FontSize="11"/>
+                                        </Button>
+                                        <TextBlock/>
+                                    </DockPanel>
+
+                                    <CheckBox x:Name="ChkRuleEnabled"
+                                              ToolTip.Tip="{loc:Str deeper_editor_tt_rule_enabled}"
+                                              Foreground="{DynamicResource TextLightBrush}"
+                                              Margin="0,0,0,10">
+                                        <TextBlock Text="{loc:Str deeper_editor_rule_enabled}"/>
+                                    </CheckBox>
+
+                                    <DockPanel LastChildFill="False">
+                                        <TextBlock Text="{loc:Str deeper_editor_rule_trigger}" Theme="{StaticResource EditorLabel}" DockPanel.Dock="Left"/>
+                                        <Button x:Name="BtnTriggerHelp" DockPanel.Dock="Right" Content="?"
+                                                ToolTip.Tip="{loc:Str deeper_editor_help_browse_triggers}"
+                                                Width="20" Height="20" Padding="0" FontSize="11" Cursor="Hand"
+                                                Background="Transparent"
+                                                Foreground="{DynamicResource DeeperAccentBrush}"
+                                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                BorderThickness="1"/>
+                                    </DockPanel>
+                                    <ComboBox x:Name="CmbTriggerType" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="{loc:Str deeper_editor_tt_rule_trigger}"/>
+                                    <StackPanel x:Name="TriggerFields"/>
+
+                                    <DockPanel LastChildFill="False" Margin="0,4,0,4">
+                                        <TextBlock Text="{loc:Str deeper_editor_rule_action}" Theme="{StaticResource EditorLabel}" DockPanel.Dock="Left"/>
+                                        <Button x:Name="BtnActionHelp" DockPanel.Dock="Right" Content="?"
+                                                ToolTip.Tip="{loc:Str deeper_editor_help_browse_actions}"
+                                                Width="20" Height="20" Padding="0" FontSize="11" Cursor="Hand"
+                                                Background="Transparent"
+                                                Foreground="{DynamicResource DeeperAccentBrush}"
+                                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                BorderThickness="1"/>
+                                    </DockPanel>
+                                    <ComboBox x:Name="CmbActionType" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="{loc:Str deeper_editor_tt_rule_action}"/>
+                                    <StackPanel x:Name="ActionFields"/>
+
+                                    <DockPanel LastChildFill="False" Margin="0,4,0,4">
+                                        <TextBlock Text="{loc:Str deeper_editor_rule_region_constraint}" Theme="{StaticResource EditorLabel}" DockPanel.Dock="Left"/>
+                                        <Button x:Name="BtnRegionHelp" DockPanel.Dock="Right" Content="?"
+                                                ToolTip.Tip="{loc:Str deeper_editor_help_region}"
+                                                Width="20" Height="20" Padding="0" FontSize="11" Cursor="Hand"
+                                                Background="Transparent"
+                                                Foreground="{DynamicResource DeeperAccentBrush}"
+                                                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}"
+                                                BorderThickness="1"/>
+                                    </DockPanel>
+                                    <ComboBox x:Name="CmbRuleRegion" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="{loc:Str deeper_editor_tt_rule_region}"/>
+
+                                    <TextBlock Text="{loc:Str deeper_editor_rule_cooldown}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtRuleCooldown" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_rule_cooldown}"/>
+
+                                    <!-- Region details sub-panel: the band this rule constrains to,
+                                         editable without leaving the rule editor. -->
+                                    <StackPanel x:Name="RuleRegionDetails" IsVisible="False" Margin="0,12,0,0">
+                                        <Separator Margin="0,0,0,10"/>
+                                        <TextBlock Text="{loc:Str deeper_editor_rule_band_details}"
+                                                   Foreground="{DynamicResource DeeperAccentSoftBrush}"
+                                                   FontSize="12" FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+                                        <TextBlock Text="{loc:Str deeper_editor_region_label}" Theme="{StaticResource EditorLabel}"/>
+                                        <TextBox x:Name="TxtRuleBandLabel" Theme="{StaticResource EditorTextBox}"
+                                                 ToolTip.Tip="{loc:Str deeper_editor_tip_rule_band_label}"/>
+
+                                        <Grid Margin="0,0,0,4" ColumnDefinitions="*,8,*">
+                                            <StackPanel Grid.Column="0">
+                                                <TextBlock Text="{loc:Str deeper_editor_region_start}" Theme="{StaticResource EditorLabel}"/>
+                                                <TextBox x:Name="TxtRuleBandStart" Theme="{StaticResource EditorTextBox}"
+                                                         ToolTip.Tip="{loc:Str deeper_editor_tt_region_start}"/>
+                                            </StackPanel>
+                                            <StackPanel Grid.Column="2">
+                                                <TextBlock Text="{loc:Str deeper_editor_region_end}" Theme="{StaticResource EditorLabel}"/>
+                                                <TextBox x:Name="TxtRuleBandEnd" Theme="{StaticResource EditorTextBox}"
+                                                         ToolTip.Tip="{loc:Str deeper_editor_tt_region_end}"/>
+                                            </StackPanel>
+                                        </Grid>
+                                        <TextBlock Text="{loc:Str deeper_editor_rule_band_drag_hint}"
+                                                   Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                                                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+                                        <TextBlock Text="{loc:Str deeper_editor_region_color}" Theme="{StaticResource EditorLabel}"/>
+                                        <Grid Margin="0,0,0,4" ColumnDefinitions="Auto,*">
+                                            <Border x:Name="RuleBandColorSwatch" Grid.Column="0"
+                                                    Width="24" Height="24" Margin="0,0,8,0" CornerRadius="4"
+                                                    Background="{DynamicResource DeeperAccentBrush}"
+                                                    BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"/>
+                                            <TextBox x:Name="TxtRuleBandColor" Grid.Column="1" Theme="{StaticResource EditorTextBox}"
+                                                     ToolTip.Tip="{loc:Str deeper_editor_tip_rule_band_color}" Margin="0"/>
+                                        </Grid>
+                                        <WrapPanel x:Name="RuleBandColorSwatches" Margin="0,4,0,8"/>
+                                    </StackPanel>
+                                </StackPanel>
+
+                                <!-- Effect editors for non-haptic Effect TimelineItems. -->
+                                <StackPanel x:Name="FlashEffectEditor" IsVisible="False">
+                                    <TextBlock Text="Flash effect" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock Text="Image / sound / opacity inherit your CCP Flashes settings."
+                                               Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                                               TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                    <TextBlock Text="{loc:Str deeper_editor_effect_start}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtFlashStart" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_effect_start}"/>
+                                    <TextBlock Text="Duration (ms)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtFlashDuration" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tip_flash_duration}"/>
+                                    <CheckBox x:Name="ChkFlashSuppressHaptic"
+                                              Content="Don't buzz on pop"
+                                              ToolTip.Tip="Skip the automatic haptic buzz that normally fires when this flash appears."
+                                              Foreground="{DynamicResource TextLightBrush}"
+                                              Margin="0,4,0,4"/>
+                                    <Button x:Name="BtnDeleteFlashEffect" Content="Delete"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_effect_delete}"
+                                            Background="{DynamicResource DangerBrush}" Foreground="White"
+                                            BorderThickness="0" Padding="10,6" Cursor="Hand"
+                                            HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                                </StackPanel>
+
+                                <StackPanel x:Name="BubbleEffectEditor" IsVisible="False">
+                                    <TextBlock Text="Bubble effect" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock Text="Burst rate / volume inherit your CCP Bubbles settings."
+                                               Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                                               TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                    <TextBlock Text="{loc:Str deeper_editor_effect_start}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtBubbleStart" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_effect_start}"/>
+                                    <TextBlock Text="Window (s)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtBubbleWindow" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tip_bubble_window}"/>
+                                    <TextBlock Text="Intensity" Theme="{StaticResource EditorLabel}"/>
+                                    <Slider x:Name="SliderBubbleIntensity" Minimum="0" Maximum="1"
+                                            SmallChange="0.05" LargeChange="0.1" Margin="0,0,0,8"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_bubble_intensity}"
+                                            Foreground="{DynamicResource DeeperAccentBrush}"/>
+                                    <Button x:Name="BtnDeleteBubbleEffect" Content="Delete"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_effect_delete}"
+                                            Background="{DynamicResource DangerBrush}" Foreground="White"
+                                            BorderThickness="0" Padding="10,6" Cursor="Hand"
+                                            HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                                </StackPanel>
+
+                                <StackPanel x:Name="SubliminalEffectEditor" IsVisible="False">
+                                    <TextBlock Text="Subliminal effect" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock Text="{loc:Str deeper_editor_effect_start}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSubliminalStart" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_effect_start}"/>
+                                    <TextBlock Text="Text" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSubliminalText" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tip_subliminal_text}"/>
+                                    <TextBlock Text="Duration (ms)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSubliminalDuration" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tip_subliminal_duration}"/>
+                                    <CheckBox x:Name="ChkSubliminalSuppressHaptic"
+                                              Content="Don't buzz on pop"
+                                              ToolTip.Tip="Skip the automatic haptic buzz that normally fires when this subliminal appears."
+                                              Foreground="{DynamicResource TextLightBrush}"
+                                              Margin="0,4,0,4"/>
+                                    <Button x:Name="BtnDeleteSubliminalEffect" Content="Delete"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_effect_delete}"
+                                            Background="{DynamicResource DangerBrush}" Foreground="White"
+                                            BorderThickness="0" Padding="10,6" Cursor="Hand"
+                                            HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                                </StackPanel>
+
+                                <StackPanel x:Name="OverlayEffectEditor" IsVisible="False">
+                                    <TextBlock Text="Overlay effect" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock Text="{loc:Str deeper_editor_effect_start}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtOverlayStart" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_effect_start}"/>
+                                    <TextBlock Text="Kind" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbOverlayKind" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="{loc:Str deeper_editor_tip_overlay_kind}">
+                                        <!-- Brain Drain + Brain Melt are live again; keep these paired
+                                             with OverlayService.BrainDrainWithheld and with
+                                             AddOverlayKindCombo in the code-behind. -->
+                                        <ComboBoxItem Content="Pink Filter" Tag="pink_filter"/>
+                                        <ComboBoxItem Content="Spiral" Tag="spiral"/>
+                                        <ComboBoxItem Content="Brain Drain" Tag="braindrain"/>
+                                        <ComboBoxItem Content="Brain Melt" Tag="braindrain_melt"/>
+                                    </ComboBox>
+                                    <TextBlock Text="Duration (ms)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtOverlayDuration" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tip_overlay_duration}"/>
+                                    <TextBlock x:Name="LblOverlayOpacity" Text="Opacity" Theme="{StaticResource EditorLabel}"/>
+                                    <Slider x:Name="SliderOverlayOpacity" Minimum="0" Maximum="1"
+                                            SmallChange="0.05" LargeChange="0.1" Margin="0,0,0,8"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_overlay_opacity}"
+                                            Foreground="{DynamicResource DeeperAccentBrush}"/>
+                                    <CheckBox x:Name="ChkOverlayRamp"
+                                              Content="Ramp opacity over the region"
+                                              ToolTip.Tip="Fade the overlay from a start opacity to an end opacity across this region's duration (pink filter + spiral)."
+                                              Foreground="{DynamicResource TextLightBrush}"
+                                              Margin="0,0,0,6"/>
+                                    <TextBlock x:Name="LblOverlayOpacityEnd" Text="End opacity"
+                                               Theme="{StaticResource EditorLabel}" IsVisible="False"/>
+                                    <Slider x:Name="SliderOverlayOpacityEnd" Minimum="0" Maximum="1"
+                                            SmallChange="0.05" LargeChange="0.1" Margin="0,0,0,8"
+                                            IsVisible="False"
+                                            ToolTip.Tip="Opacity at the end of the region."
+                                            Foreground="{DynamicResource DeeperAccentBrush}"/>
+                                    <Button x:Name="BtnDeleteOverlayEffect" Content="Delete"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_effect_delete}"
+                                            Background="{DynamicResource DangerBrush}" Foreground="White"
+                                            BorderThickness="0" Padding="10,6" Cursor="Hand"
+                                            HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                                </StackPanel>
+
+                                <StackPanel x:Name="SpeakEffectEditor" IsVisible="False">
+                                    <TextBlock Text="Speak (voice prompt)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBlock Text="Prompts the user to say a phrase out loud and listens (offline mic). Needs mic consent; skips silently if unavailable."
+                                               Foreground="{DynamicResource TextDimBrush}" FontSize="10"
+                                               TextWrapping="Wrap" Margin="0,0,0,8"/>
+                                    <TextBlock Text="{loc:Str deeper_editor_effect_start}" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakStart" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="{loc:Str deeper_editor_tt_effect_start}"/>
+                                    <TextBlock Text="Region length (s)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakLength" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="How long this voice-prompt band runs on the timeline."/>
+                                    <TextBlock Text="Phrase to say (max 24 chars)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakTarget" Theme="{StaticResource EditorTextBox}"
+                                             MaxLength="24"
+                                             ToolTip.Tip="The word/short phrase the user must say, e.g. YES. Keep it short for reliable recognition."/>
+                                    <TextBlock Text="On-screen cue (blank = &quot;Say {phrase}&quot;)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakCue" Theme="{StaticResource EditorTextBox}"
+                                             MaxLength="40"
+                                             ToolTip.Tip="The text shown on screen. Leave blank to auto-use 'Say {phrase}'."/>
+                                    <TextBlock Text="Cue style" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbSpeakCueMode" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="Intermittent flashes the cue repeatedly; Persistent keeps it on top until done.">
+                                        <ComboBoxItem Content="Intermittent (flash)" Tag="Intermittent"/>
+                                        <ComboBoxItem Content="Persistent (stay on top)" Tag="Persistent"/>
+                                    </ComboBox>
+                                    <TextBlock x:Name="LblSpeakInterval" Text="Flash interval (ms)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakInterval" Theme="{StaticResource EditorTextBox}"
+                                             ToolTip.Tip="How often the cue flashes (intermittent only)."/>
+                                    <TextBlock Text="Times to say it correctly" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbSpeakReps" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="How many correct reps are required (1-5).">
+                                        <ComboBoxItem Content="1" Tag="1"/>
+                                        <ComboBoxItem Content="2" Tag="2"/>
+                                        <ComboBoxItem Content="3" Tag="3"/>
+                                        <ComboBoxItem Content="4" Tag="4"/>
+                                        <ComboBoxItem Content="5" Tag="5"/>
+                                    </ComboBox>
+                                    <TextBlock Text="Completion" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbSpeakCompletion" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="Until satisfied holds the region until they say it; For the region just listens for the band's length.">
+                                        <ComboBoxItem Content="Until satisfied" Tag="UntilSatisfied"/>
+                                        <ComboBoxItem Content="For the region (soft)" Tag="Duration"/>
+                                    </ComboBox>
+                                    <TextBlock x:Name="LblSpeakHold" Text="While waiting…" Theme="{StaticResource EditorLabel}"/>
+                                    <ComboBox x:Name="CmbSpeakHold" Theme="{StaticResource EditorComboBox}"
+                                              HorizontalAlignment="Stretch"
+                                              ToolTip.Tip="What playback does while waiting for the user (until satisfied only).">
+                                        <ComboBoxItem Content="Loop the region" Tag="LoopRegion"/>
+                                        <ComboBoxItem Content="Pause the video" Tag="Pause"/>
+                                        <ComboBoxItem Content="Keep playing" Tag="KeepPlaying"/>
+                                    </ComboBox>
+                                    <TextBlock Text="Praise (on correct)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakCorrect" Theme="{StaticResource EditorTextBox}"
+                                             MaxLength="40"
+                                             ToolTip.Tip="Flashed after each correct rep, e.g. 'good girl'."/>
+                                    <TextBlock Text="Scold (on miss)" Theme="{StaticResource EditorLabel}"/>
+                                    <TextBox x:Name="TxtSpeakIncorrect" Theme="{StaticResource EditorTextBox}"
+                                             MaxLength="40"
+                                             ToolTip.Tip="Flashed after a wrong/too-quiet attempt, e.g. 'try again'."/>
+                                    <Button x:Name="BtnDeleteSpeakEffect" Content="Delete"
+                                            ToolTip.Tip="{loc:Str deeper_editor_tip_effect_delete}"
+                                            Background="{DynamicResource DangerBrush}" Foreground="White"
+                                            BorderThickness="0" Padding="10,6" Cursor="Hand"
+                                            HorizontalAlignment="Left" Margin="0,4,0,0"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <!-- Validation strip -->
+        <Border Grid.Row="3" Background="{DynamicResource PanelBgBrush}"
+                BorderBrush="{DynamicResource DeeperAccentTransparent40Brush}" BorderThickness="0,1,0,0"
+                Padding="14,8">
+            <DockPanel LastChildFill="True">
+                <Button x:Name="BtnEditorSave" DockPanel.Dock="Right"
+                        ToolTip.Tip="{loc:Str deeper_editor_tt_save}"
+                        Padding="14,6" Cursor="Hand"
+                        Background="{DynamicResource DeeperAccentBrush}"
+                        BorderThickness="0">
+                    <TextBlock Text="{loc:Str deeper_editor_save_project}" Foreground="White" FontWeight="SemiBold"/>
+                </Button>
+                <Button x:Name="BtnEditorExport" DockPanel.Dock="Right"
+                        ToolTip.Tip="{loc:Str deeper_editor_tt_export_media}"
+                        Padding="14,6" Margin="0,0,8,0" Cursor="Hand"
+                        Background="{DynamicResource DeeperAccentTransparent20Brush}"
+                        BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1">
+                    <TextBlock Text="{loc:Str btn_export_media}" FontWeight="SemiBold"
+                               Foreground="{DynamicResource DeeperAccentBrush}"/>
+                </Button>
+                <TextBlock x:Name="TxtValidationSummary"
+                           Foreground="{DynamicResource TextLightBrush}"
+                           FontSize="12" VerticalAlignment="Center" Margin="0,0,12,0"
+                           ToolTip.Tip="{loc:Str deeper_editor_tt_validation}"/>
+                <Popup x:Name="ValidationDetailsPopup"
+                       PlacementTarget="{Binding #TxtValidationSummary}"
+                       Placement="Top" IsLightDismissEnabled="True">
+                    <Border Background="{DynamicResource DarkerBgBrush}"
+                            BorderBrush="{DynamicResource DeeperAccentBrush}" BorderThickness="1"
+                            CornerRadius="6" Padding="12,10"
+                            MaxWidth="520" MaxHeight="360">
+                        <DockPanel LastChildFill="True">
+                            <TextBlock x:Name="TxtValidationPopupHeader"
+                                       DockPanel.Dock="Top"
+                                       Foreground="{DynamicResource DeeperAccentBrush}"
+                                       FontSize="11" FontWeight="SemiBold"
+                                       Margin="0,0,0,8"/>
+                            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Disabled">
+                                <ItemsControl x:Name="LstValidationIssues">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="deeper:ValidationIssueRow">
+                                            <Grid Margin="0,0,0,6" ColumnDefinitions="Auto,*">
+                                                <TextBlock Grid.Column="0"
+                                                           Text="{Binding Glyph}"
+                                                           Foreground="{Binding Brush}"
+                                                           FontSize="11" FontWeight="Bold"
+                                                           VerticalAlignment="Top"
+                                                           Margin="0,0,8,0"/>
+                                                <TextBlock Grid.Column="1"
+                                                           Text="{Binding Message}"
+                                                           Foreground="{DynamicResource TextLightBrush}"
+                                                           FontSize="11"
+                                                           TextWrapping="Wrap"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </DockPanel>
+                    </Border>
+                </Popup>
+            </DockPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml.cs
@@ -1,0 +1,2450 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using ShapePath = Avalonia.Controls.Shapes.Path;
+using IOPath = System.IO.Path;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models.Deeper;
+using ConditioningControlPanel.Services.Deeper;
+using ConditioningControlPanel.Services.Haptics.Core;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// One row in the validation-details popup.
+    ///
+    /// PORTED from the anonymous type <c>PopulateValidationPopup</c> built in WPF. Compiled
+    /// bindings need a named <c>x:DataType</c>, and an anonymous type cannot be one.
+    /// </summary>
+    public sealed class ValidationIssueRow
+    {
+        public string Glyph { get; init; } = "";
+        public IBrush Brush { get; init; } = Brushes.Gray;
+        public string Message { get; init; } = "";
+    }
+
+    /// <summary>
+    /// PORTED from ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs and its six
+    /// partials (.ItemsList, .LaneChrome, .MetadataDrawer, .MultiSelect, .Ruler, .Unified), which
+    /// are ported alongside this file under the same names. One extra partial,
+    /// <c>DeeperEditorWindow.RuleEditor.cs</c>, carries the rule-inspector and dynamic field
+    /// builders that lived in the tail of the WPF main file; nothing was dropped, only split.
+    ///
+    /// <para><b>What is real here.</b> Everything that is view state, data manipulation and
+    /// drawing: the unified timeline (ruler, three lanes, region bands, haptic bands, effect dots
+    /// and segments, TimeReached rule pins, playhead), click/drag/resize/rubber-band selection,
+    /// multi-select with group drag, clipboard, snapshot undo/redo, the items list, the metadata
+    /// drawer, the selection summary strip, every inspector panel including the programmatically
+    /// built trigger/action fields, the haptic curve editor, and validation via
+    /// <see cref="EnhancementValidator"/>. All of that runs off Core models, so it ports whole.</para>
+    ///
+    /// <para><b>What is stubbed, and why.</b> Each site carries a <c>ponytail:</c> comment.</para>
+    /// <list type="bullet">
+    ///   <item><b>Media playback.</b> LibVLCSharp.WPF (video) and NAudio (audio + waveform peaks)
+    ///         are Windows/WPF-only assemblies and this layer may not add a package, so
+    ///         <see cref="InitializeVideo"/>, <see cref="InitializeAudioAsync"/> and the transport's
+    ///         play/pause/seek drive <see cref="_totalSeconds"/> / <see cref="_currentSeconds"/>
+    ///         directly instead of a player. Everything downstream of those two numbers is real.</item>
+    ///   <item><b>WebView2.</b> The WPF preview drove <c>CoreWebView2</c> for navigation, injected
+    ///         JS, WebMessage time reporting, fullscreen and ZoomFactor.
+    ///         <see cref="Controls.WebHost"/> exposes only <c>Source</c>, so navigation is a Source
+    ///         assignment and the rest (BrowserVideoTimeSource, the fullscreen reparent,
+    ///         ExecuteScriptAsync, AddScriptToExecuteOnDocumentCreatedAsync, WebMessageReceived,
+    ///         ContainsFullScreenElementChanged, ZoomFactor) is a stub.</item>
+    ///   <item><b>Win32.</b> <c>WindowChromeHelper.ApplyDarkTitleBar</c> (DwmSetWindowAttribute),
+    ///         <c>RestoreOwnerOnClose</c>, <c>System.Windows.Forms.Screen.FromHandle</c> +
+    ///         <c>WindowInteropHelper</c> (the borderless-fullscreen preview window) and
+    ///         <c>VisualTreeHelper.GetDpi</c> (the gaze picker's screen placement).</item>
+    ///   <item><b>App services.</b> App.Settings (sidebar width, first-run flag), App.Tutorial +
+    ///         TutorialOverlay, App.EnhancementLibrary, App.DeeperPlayer / App.DeeperHost,
+    ///         the haptics bus, ExplorerLauncher, GazePickerWindow, and every file dialog and
+    ///         MessageBox. Save / Save As / Export / Swap / Change media / drag-drop all land on
+    ///         those, so they log their intent and return.</item>
+    /// </list>
+    /// </summary>
+    public partial class DeeperEditorWindow : Window
+    {
+        private Enhancement _enhancement = new();
+        private string? _filePath;
+
+        /// <summary>
+        /// On-disk path of the currently loaded project (null for a new/unsaved one). Read by the
+        /// Player's "Open in editor" dedupe loop so it can activate an existing editor instead of
+        /// opening a duplicate.
+        /// </summary>
+        public string? LoadedFilePath => _filePath;
+
+        private bool _isDirty;
+        private bool _suppressDirty;
+
+        // ponytail: needs LibVLCSharp (video), NAudio (audio + AudioWaveformResult) and
+        // BrowserVideoTimeSource (WebView2 time source). The three player handles the WPF window
+        // held are replaced by the two numbers every drawing path actually reads.
+        private double[]? _waveformPeaks;
+        private bool _isPlaying;
+
+        // Common
+        private double _totalSeconds;
+        private double _currentSeconds;
+        private bool _isScrubbing;
+        private DispatcherTimer? _playheadTimer;
+        private DispatcherTimer? _validationTimer;
+
+        // Regions
+        private static readonly string[] RegionPalette =
+        {
+            "#7B5CFF", "#FF69B4", "#5CFFB7", "#FFC85C", "#5CC8FF", "#FF7B5C"
+        };
+        private Region? _selectedRegion;
+        private readonly List<Rectangle> _regionVisuals = new();
+
+        private enum DragMode
+        {
+            None, Scrub, CreateRegion,
+            ShiftHapticEvent, ResizeHapticStart, ResizeHapticEnd,
+            DragRegion, ResizeRegionStart, ResizeRegionEnd,
+            DragEffect, ResizeEffectStart, ResizeEffectEnd,
+            RubberBand
+        }
+        private DragMode _dragMode = DragMode.None;
+        private double _dragCreateStartSec;
+        private Rectangle? _dragCreatePreview;
+        // Region drag/resize state
+        private Region? _draggedRegion;
+        private double _regionDragOffsetSec;
+        private double _regionDragOriginalLength;
+        // Effect segment drag/resize state
+        private TimelineItem? _draggedEffect;
+        private double _effectDragOffsetSec;
+        private double _effectDragOriginalDuration;
+        // Pixel band on left/right of a band where the cursor switches to resize.
+        private const double EdgeResizePx = 6.0;
+        // Narrower rects become pure drag-to-move so the user can always grab and reposition them.
+        private const double MinResizableRectPx = 24.0;
+        // Minimum visual width for region / haptic rectangles, so a tiny duration on a wide
+        // timeline stays clickable.
+        private const double MinBandVisualWidthPx = 8.0;
+
+        private enum EdgeHit { Body, Start, End }
+
+        private static EdgeHit ClassifyEdgeHit(double posX, double rectWidth)
+        {
+            if (rectWidth < MinResizableRectPx) return EdgeHit.Body;
+            var edge = Math.Min(EdgeResizePx, rectWidth / 3.0);
+            if (posX <= edge) return EdgeHit.Start;
+            if (posX >= rectWidth - edge) return EdgeHit.End;
+            return EdgeHit.Body;
+        }
+
+        // Timeline zoom state. 1.0 = canvas fills the viewport (default).
+        private double _zoomFactor = 1.0;
+        private const double MinZoom = 1.0;
+        private const double MaxZoom = 16.0;
+
+        // Haptic events
+        private const string DefaultTrackId = "primary";
+        private HapticEvent? _selectedHaptic;
+        private HapticTrack? _selectedHapticTrack;
+        private readonly List<Rectangle> _hapticVisuals = new();
+        private double _hapticDragStartSec;
+        private double _hapticDragOffsetSec;
+        private HapticEvent? _draggedHaptic;
+        private HapticTrack? _draggedHapticTrack;
+
+        // Curve editor
+        private const int CurveKeyframeCount = 5;
+        private ShapePath? _curvePath;
+        private readonly List<Ellipse> _curveHandles = new();
+        private int _draggingCurveIndex = -1;
+        private bool _suppressPatternSync;
+
+        // Rules
+        private EnhancementRule? _selectedRule;
+        private bool _suppressRuleSync;
+
+        // ---------------------------------------------------------------------------------
+        // Construction
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Render/design constructor: a sample enhancement with two regions, a TimeReached rule, a
+        /// haptic event and two effects, on a remote https:// source so the preview takes the
+        /// browser branch and WebHost's fallback panel draws. Required by <c>--render-all</c>,
+        /// which only discovers parameterless constructors.
+        /// </summary>
+        internal DeeperEditorWindow() : this(SampleEnhancement(), "/home/sample/deep-dive.ccpenh.json")
+        {
+            _totalSeconds = 180;
+            _currentSeconds = 42;
+            TxtTotalTime.Text = FormatTime(_totalSeconds);
+            TxtCurrentTime.Text = FormatTime(_currentSeconds);
+            MetadataDrawerToggle.IsChecked = true;
+            // Select the sample rule so the inspector shows the rule editor with its
+            // code-built TriggerFields / ActionFields rather than the empty placeholder.
+            SelectRule(_enhancement.Rules.FirstOrDefault());
+        }
+
+        public DeeperEditorWindow(Enhancement enhancement, string? filePath)
+        {
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
+
+            // ponytail: needs WindowChromeHelper.ApplyDarkTitleBar (DwmSetWindowAttribute) and
+            // RestoreOwnerOnClose. The title-bar tint has no Linux equivalent short of
+            // SystemDecorations="None" plus a hand-drawn bar, which would cost this resizable
+            // window its native move/resize/maximize for a colour. Left native and untinted.
+            Closed += (_, _) => { try { (Owner as Window)?.Activate(); } catch { } };
+
+            Loaded += DeeperEditorWindow_Loaded;
+            KeyDown += DeeperEditorWindow_KeyDown;
+            Closing += Window_Closing;
+
+            _validationTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(220) };
+            _validationTimer.Tick += (_, _) => { _validationTimer.Stop(); RefreshValidation(); };
+
+            _playheadTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(80) };
+            _playheadTimer.Tick += PlayheadTimer_Tick;
+
+            WireEvents();
+
+            BuildColorSwatches();
+            BuildPatternCombo();
+            FillHapticTargetCombo(CmbHapticTarget);
+            LoadEnhancement(enhancement, filePath);
+        }
+
+        /// <summary>
+        /// Every handler the WPF XAML attached with a Click= / TextChanged= attribute. Wired in
+        /// code rather than in the .axaml for two reasons: the two menus are now an inline
+        /// ContextMenu plus a MenuFlyout (so their items are reachable only by x:Name), and the
+        /// timeline's mouse events collapse into three pointer events that fan out by button and
+        /// drag mode.
+        /// </summary>
+        private void WireEvents()
+        {
+            // -- File menu + the two validation-strip buttons
+            MenuSave.Click += MenuSave_Click;
+            MenuSaveAs.Click += MenuSaveAs_Click;
+            MenuExport.Click += MenuExportEnhanced_Click;
+            MenuCloseItem.Click += MenuClose_Click;
+            BtnEditorSave.Click += MenuSave_Click;
+            BtnEditorExport.Click += MenuExportEnhanced_Click;
+            BtnEditorHelp.Click += BtnEditorHelp_Click;
+            TxtValidationSummary.PointerReleased += TxtValidationSummary_PointerReleased;
+
+            // -- Linked files strip
+            BtnPreviewZoomIn.Click += BtnPreviewZoomIn_Click;
+            BtnPreviewZoomOut.Click += BtnPreviewZoomOut_Click;
+            BtnLinkedJsonOpenFolder.Click += BtnLinkedJsonOpenFolder_Click;
+            BtnLinkedJsonSwap.Click += BtnLinkedJsonSwap_Click;
+            BtnLinkedMediaChange.Click += BtnLinkedMediaChange_Click;
+            BtnLinkedMediaClear.Click += BtnLinkedMediaClear_Click;
+            BtnChangeMediaLocal.Click += BtnChangeMediaLocal_Click;
+            BtnChangeMediaUrl.Click += BtnChangeMediaUrl_Click;
+
+            // -- Transport
+            BtnPlayPause.Click += BtnPlayPause_Click;
+            BtnZoomIn.Click += BtnZoomIn_Click;
+            BtnZoomOut.Click += BtnZoomOut_Click;
+            BtnPreview.Click += BtnPreview_Click;
+            BtnAddRuleHero.Click += BtnAddRuleHero_Click;
+            BtnAddEffectHero.Click += BtnAddEffectHero_Click;
+
+            // -- Hero "+ Effect" flyout + the timeline context menu
+            HeroEffectHaptic.Click += CtxAddEffectHaptic_Click;
+            HeroEffectFlash.Click += CtxAddEffectFlash_Click;
+            HeroEffectBubble.Click += CtxAddEffectBubble_Click;
+            HeroEffectSubliminal.Click += CtxAddEffectSubliminal_Click;
+            HeroEffectOverlay.Click += CtxAddEffectOverlay_Click;
+            HeroEffectSpeak.Click += CtxAddEffectSpeak_Click;
+            CtxEffectHaptic.Click += CtxAddEffectHaptic_Click;
+            CtxEffectFlash.Click += CtxAddEffectFlash_Click;
+            CtxEffectBubble.Click += CtxAddEffectBubble_Click;
+            CtxEffectSubliminal.Click += CtxAddEffectSubliminal_Click;
+            CtxEffectOverlay.Click += CtxAddEffectOverlay_Click;
+            CtxEffectSpeak.Click += CtxAddEffectSpeak_Click;
+            CtxRuleTimeReached.Click += CtxAddRuleTimeReached_Click;
+            CtxRuleBandEntered.Click += CtxAddRuleBandEntered_Click;
+            CtxRuleBandExited.Click += CtxAddRuleBandExited_Click;
+            CtxRuleGazeTarget.Click += CtxAddRuleGazeTarget_Click;
+            CtxRuleGazeAvoid.Click += CtxAddRuleGazeAvoid_Click;
+            CtxRuleAttentionLost.Click += CtxAddRuleAttentionLost_Click;
+            CtxRuleBlinkDetected.Click += CtxAddRuleBlinkDetected_Click;
+            CtxRuleMouthOpen.Click += CtxAddRuleMouthOpen_Click;
+
+            // -- Timeline canvas + scroller
+            TimelineCanvas.PointerPressed += TimelineCanvas_PointerPressed;
+            TimelineCanvas.PointerMoved += TimelineCanvas_PointerMoved;
+            TimelineCanvas.PointerReleased += TimelineCanvas_PointerReleased;
+            TimelineCanvas.PointerCaptureLost += TimelineCanvas_PointerCaptureLost;
+            TimelineCanvas.SizeChanged += TimelineCanvas_SizeChanged;
+            TimelineScroll.SizeChanged += TimelineScroll_SizeChanged;
+            // WPF's PreviewMouseWheel: tunnelling, so it beats the ScrollViewer's own handling.
+            TimelineScroll.AddHandler(PointerWheelChangedEvent, TimelineScroll_PointerWheelChanged,
+                RoutingStrategies.Tunnel);
+
+            // -- Sidebar: drawer, items list, splitter
+            MetadataDrawerToggle.IsCheckedChanged += MetadataDrawerToggle_Changed;
+            RbItemsSortTime.IsCheckedChanged += ItemsListSort_Changed;
+            RbItemsSortKind.IsCheckedChanged += ItemsListSort_Changed;
+            ItemsListBox.SelectionChanged += ItemsListBox_SelectionChanged;
+            ItemsListBox.DoubleTapped += ItemsListBox_DoubleTapped;
+            // The per-row delete button lives inside a compiled-binding DataTemplate, whose Click
+            // handler would resolve against the row's TimelineListEntry, not this window. Catch it
+            // on the way up by class instead.
+            ItemsListBox.AddHandler(Button.ClickEvent, (object? s, RoutedEventArgs e) =>
+            {
+                if (e.Source is Button b && b.Classes.Contains("itemsListDelete"))
+                    ItemsListDelete_Click(b, e);
+            }, RoutingStrategies.Bubble);
+            SidebarSplitter.DragCompleted += SidebarSplitter_DragCompleted;
+
+            // -- Metadata fields
+            foreach (var tb in new[] { TxtMetaName, TxtMetaCreator, TxtMetaRemixer,
+                                       TxtMetaDescription, TxtMetaTags, TxtMetaLicense })
+                tb.TextChanged += MetadataField_TextChanged;
+            BtnCreatorLockToggle.Click += BtnCreatorLockToggle_Click;
+
+            // -- Region editor
+            TxtRegionLabel.TextChanged += RegionField_TextChanged;
+            TxtRegionStart.TextChanged += RegionField_TextChanged;
+            TxtRegionEnd.TextChanged += RegionField_TextChanged;
+            TxtRegionColor.TextChanged += RegionField_TextChanged;
+            BtnSnapRegionStartPrev.Click += BtnSnapRegionStartPrev_Click;
+            BtnSnapRegionEndNext.Click += BtnSnapRegionEndNext_Click;
+            BtnDeleteRegion.Click += BtnDeleteRegion_Click;
+
+            // -- Haptic editor
+            TxtHapticStart.TextChanged += HapticField_TextChanged;
+            TxtHapticDuration.TextChanged += HapticField_TextChanged;
+            SliderHapticIntensity.ValueChanged += SliderHapticIntensity_ValueChanged;
+            CmbHapticPattern.SelectionChanged += CmbHapticPattern_SelectionChanged;
+            CmbHapticTarget.SelectionChanged += CmbHapticTarget_SelectionChanged;
+            CurveCanvas.SizeChanged += CurveCanvas_SizeChanged;
+            BtnResetCurve.Click += BtnResetCurve_Click;
+            BtnTestHaptic.Click += BtnTestHaptic_Click;
+            BtnDeleteHaptic.Click += BtnDeleteHaptic_Click;
+
+            // -- Rule editor
+            BtnDeleteRule.Click += BtnDeleteRule_Click;
+            ChkRuleEnabled.IsCheckedChanged += ChkRuleEnabled_Changed;
+            BtnTriggerHelp.Click += BtnTriggerHelp_Click;
+            BtnActionHelp.Click += BtnActionHelp_Click;
+            BtnRegionHelp.Click += BtnRegionHelp_Click;
+            CmbTriggerType.SelectionChanged += CmbTriggerType_SelectionChanged;
+            CmbActionType.SelectionChanged += CmbActionType_SelectionChanged;
+            CmbRuleRegion.SelectionChanged += CmbRuleRegion_SelectionChanged;
+            TxtRuleCooldown.TextChanged += TxtRuleCooldown_TextChanged;
+            TxtRuleBandLabel.TextChanged += RuleBandField_TextChanged;
+            TxtRuleBandStart.TextChanged += RuleBandField_TextChanged;
+            TxtRuleBandEnd.TextChanged += RuleBandField_TextChanged;
+            TxtRuleBandColor.TextChanged += RuleBandField_TextChanged;
+
+            // -- Effect editors
+            foreach (var tb in new[] { TxtFlashStart, TxtFlashDuration,
+                                       TxtBubbleStart, TxtBubbleWindow,
+                                       TxtSubliminalStart, TxtSubliminalText, TxtSubliminalDuration,
+                                       TxtOverlayStart, TxtOverlayDuration,
+                                       TxtSpeakStart, TxtSpeakLength, TxtSpeakTarget, TxtSpeakCue,
+                                       TxtSpeakInterval, TxtSpeakCorrect, TxtSpeakIncorrect })
+                tb.TextChanged += EffectField_TextChanged;
+            ChkFlashSuppressHaptic.IsCheckedChanged += ChkEffectSuppressHaptic_Changed;
+            ChkSubliminalSuppressHaptic.IsCheckedChanged += ChkEffectSuppressHaptic_Changed;
+            SliderBubbleIntensity.ValueChanged += SliderBubbleIntensity_ValueChanged;
+            SliderOverlayOpacity.ValueChanged += SliderOverlayOpacity_ValueChanged;
+            SliderOverlayOpacityEnd.ValueChanged += SliderOverlayOpacityEnd_ValueChanged;
+            ChkOverlayRamp.IsCheckedChanged += ChkOverlayRamp_Changed;
+            CmbOverlayKind.SelectionChanged += CmbOverlayKind_SelectionChanged;
+            CmbSpeakCueMode.SelectionChanged += CmbSpeakCueMode_SelectionChanged;
+            CmbSpeakReps.SelectionChanged += CmbSpeakReps_SelectionChanged;
+            CmbSpeakCompletion.SelectionChanged += CmbSpeakCompletion_SelectionChanged;
+            CmbSpeakHold.SelectionChanged += CmbSpeakHold_SelectionChanged;
+            foreach (var b in new[] { BtnDeleteFlashEffect, BtnDeleteBubbleEffect,
+                                      BtnDeleteSubliminalEffect, BtnDeleteOverlayEffect,
+                                      BtnDeleteSpeakEffect })
+                b.Click += BtnDeleteEffect_Click;
+
+            // -- Drag & drop (WPF: Window DragOver / Drop attributes)
+            AddHandler(DragDrop.DragOverEvent, Window_DragOver);
+            AddHandler(DragDrop.DropEvent, Window_Drop);
+        }
+
+        /// <summary>Resource brush lookup. WPF's <c>FindResource(k)</c> threw on a miss; this
+        /// returns a visible fallback so a missing key is a wrong colour, never a crash.</summary>
+        private IBrush Res(string key)
+            => this.TryFindResource(key, out var v) && v is IBrush b ? b : Brushes.Gray;
+
+        /// <summary>Sample project for the render constructor. Placeholder data, deliberately
+        /// shaped so the PNG proves the timeline, the lanes, the items list and the rule
+        /// inspector all draw.</summary>
+        private static Enhancement SampleEnhancement()
+        {
+            var e = new Enhancement
+            {
+                MediaType = MediaTypes.Video,
+                MediaSource = "https://example.com/video/sample-render-proof.mp4",
+            };
+            e.Metadata.Name = "Descent Sample";
+            e.Metadata.Creator = "sample-creator";
+            e.Metadata.Description = "Placeholder project used by the headless render proof.";
+            e.Metadata.Tags = new List<string> { "sample", "render" };
+            e.Metadata.License = "CC BY-NC 4.0";
+
+            e.Regions.Add(new Region { Id = "r1", Start = 12, End = 48, Label = "Induction", Color = RegionPalette[0] });
+            e.Regions.Add(new Region { Id = "r2", Start = 70, End = 132, Label = "Deepener", Color = RegionPalette[1] });
+
+            e.Rules.Add(new EnhancementRule
+            {
+                Trigger = new TimeReachedTrigger { Time = 30 },
+                Action = new ScreenShakeAction { Intensity = 0.4, DurationMs = 600 },
+                CooldownMs = 1000,
+                Enabled = true,
+            });
+
+            var track = new HapticTrack { Id = DefaultTrackId };
+            track.Events.Add(new HapticEvent { Start = 90, Duration = 14, Intensity = 0.8, PatternName = "Pulse" });
+            e.HapticTracks.Add(track);
+
+            e.TimelineItems.Add(new TimelineItem
+            {
+                Id = TimelineItem.NewId(),
+                Kind = TimelineItemKind.Effect,
+                Start = 20,
+                Duration = 0.8,
+                EffectType = EffectTypes.Flash,
+                EffectDurationMs = 800,
+                EffectIntensity = 1.0,
+                Color = "#FFC85C",
+            });
+            e.TimelineItems.Add(new TimelineItem
+            {
+                Id = TimelineItem.NewId(),
+                Kind = TimelineItemKind.Effect,
+                Start = 100,
+                Duration = 24,
+                EffectType = EffectTypes.Overlay,
+                EffectDurationMs = 24000,
+                EffectOpacity = 0.55,
+                EffectOverlayKind = OverlayKinds.Spiral,
+                Color = "#5CFFB7",
+            });
+            return e;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Combos + swatches
+        // ---------------------------------------------------------------------------------
+
+        private void BuildPatternCombo()
+        {
+            CmbHapticPattern.Items.Clear();
+            foreach (var name in StockHapticPatterns.Names)
+                CmbHapticPattern.Items.Add(name);
+            CmbHapticPattern.Items.Add(Loc.Get("deeper_editor_haptic_pattern_custom"));
+        }
+
+        // Index 0 is "All", stored as null so files stay clean.
+        private static readonly ToyRole?[] HapticTargets = { null, ToyRole.Reward, ToyRole.Punish, ToyRole.Ambient };
+
+        private static void FillHapticTargetCombo(ComboBox combo)
+        {
+            combo.Items.Clear();
+            combo.Items.Add(Loc.Get("haptics_role_all"));
+            combo.Items.Add(Loc.Get("haptics_role_reward"));
+            combo.Items.Add(Loc.Get("haptics_role_punish"));
+            combo.Items.Add(Loc.Get("haptics_role_ambient"));
+        }
+
+        private static int HapticTargetIndex(ToyRole? role)
+        {
+            var idx = Array.IndexOf(HapticTargets, role);
+            return idx >= 0 ? idx : 0;
+        }
+
+        private static ToyRole? HapticTargetAt(int index)
+            => index > 0 && index < HapticTargets.Length ? HapticTargets[index] : null;
+
+        private void BuildColorSwatches()
+        {
+            RegionColorSwatches.Children.Clear();
+            foreach (var hex in RegionPalette)
+            {
+                var captured = hex;
+                var brush = TryParseBrush(hex) ?? Brushes.MediumPurple;
+                var swatch = new Border
+                {
+                    Width = 22, Height = 22, Margin = new Thickness(0, 0, 6, 0),
+                    CornerRadius = new CornerRadius(4),
+                    Background = brush,
+                    BorderBrush = Res("GlassBorderBrush"),
+                    BorderThickness = new Thickness(1),
+                    Cursor = new Cursor(StandardCursorType.Hand),
+                    Tag = hex,
+                };
+                ToolTip.SetTip(swatch, hex);
+                swatch.PointerReleased += (_, _) =>
+                {
+                    if (_selectedRegion == null) return;
+                    TxtRegionColor.Text = captured;
+                };
+                RegionColorSwatches.Children.Add(swatch);
+            }
+        }
+
+        private static IBrush? TryParseBrush(string? hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex)) return null;
+            try { return new SolidColorBrush(Color.Parse(hex!)); }
+            catch { return null; }
+        }
+
+        private static Color? TryParseColor(string? hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex)) return null;
+            try { return Color.Parse(hex!); }
+            catch { return null; }
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Lifecycle
+        // ---------------------------------------------------------------------------------
+
+        private void DeeperEditorWindow_Loaded(object? sender, RoutedEventArgs e)
+        {
+            // Restore the user's last sidebar width before the preview kicks off.
+            ApplyPersistedSidebarWidth();
+
+            _ = InitializePreviewAsync();
+
+            // ponytail: needs TutorialEventBus + App.Tutorial + TutorialOverlay + App.Settings.
+            // The WPF Loaded handler dispatched the interactive tutorial's Part 2 (queued by the
+            // New Enhancement dialog) and, failing that, auto-launched the first-run editor
+            // coachmarks once. Neither service exists on this head, so both are dropped here and
+            // BtnEditorHelp is inert; nothing else in the editor depended on them.
+        }
+
+        private void BtnEditorHelp_Click(object? sender, RoutedEventArgs e)
+        {
+            StartEditorTutorial();
+        }
+
+        /// <summary>ponytail: needs App.Tutorial + TutorialOverlay, wired when the tutorial service
+        /// moves to Core. The "?" button is present and hit-testable but opens nothing.</summary>
+        private void StartEditorTutorial()
+        {
+            Log.Debug("DeeperEditor: editor tutorial requested; App.Tutorial is not on this head");
+        }
+
+        private void LoadEnhancement(Enhancement enhancement, string? filePath)
+        {
+            _enhancement = enhancement;
+            _filePath = filePath;
+            _isDirty = false;
+
+            _suppressDirty = true;
+            try
+            {
+                TxtMetaName.Text = _enhancement.Metadata.Name;
+                TxtMetaCreator.Text = _enhancement.Metadata.Creator;
+                TxtMetaRemixer.Text = _enhancement.Metadata.Remixer ?? "";
+                TxtMetaDescription.Text = _enhancement.Metadata.Description;
+                TxtMetaTags.Text = string.Join(", ", _enhancement.Metadata.Tags);
+                TxtMetaLicense.Text = _enhancement.Metadata.License;
+            }
+            finally { ClearWhenEventsDrained(() => _suppressDirty = false); }
+
+            // Set from code, not {loc:Str}: Avalonia keeps a binding alive under a local value, so
+            // the Preview button's label has to be chosen here once rather than bound and then
+            // overwritten by BtnPreview_Click.
+            TxtPreviewLabel.Text = Loc.Get("deeper_editor_preview_off");
+
+            UpdateTitle();
+            RefreshLinkedFilesUi();
+            UpdateCreatorLockUi();
+            RefreshValidation();
+            SelectNothing();
+            RebuildTimelineRuler();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+            RebuildRuleVisuals();
+            UpdateSelectionSummary();
+
+            // Fire HT metadata auto-fill in the background. Hostname-gated inside the fetcher;
+            // non-HT URLs are silent no-ops.
+            _ = TryAutoFillFromHtAsync(_enhancement.MediaSource);
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Preview
+        // ---------------------------------------------------------------------------------
+
+        private async Task InitializePreviewAsync()
+        {
+            try
+            {
+                var source = _enhancement.MediaSource;
+
+                // Remote http(s):// URL -> embedded browser preview.
+                if (IsRemoteVideoUrl(source))
+                {
+                    await InitializeBrowserAsync(source);
+                    return;
+                }
+
+                if (!IsLocalFile(source))
+                {
+                    ShowPlaceholder();
+                    return;
+                }
+
+                if (_enhancement.MediaType == MediaTypes.Audio)
+                    await InitializeAudioAsync(source);
+                else
+                    InitializeVideo(source);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "DeeperEditor: preview init failed");
+                ShowPlaceholder();
+            }
+        }
+
+        private bool IsRemoteVideoUrl(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source)) return false;
+            if (_enhancement.MediaType != MediaTypes.Video) return false;
+            return source.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || source.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// ponytail: needs the CoreWebView2 surface. The WPF version created the WebView2
+        /// environment, gated navigation on IsAllowedPreviewHost, injected a script that posted the
+        /// &lt;video&gt; element's currentTime back over WebMessage (driving BrowserVideoTimeSource
+        /// and thus _totalSeconds / the playhead), and handled fullscreen. WebHost exposes only
+        /// Source, so this navigates and stops; the timeline runs off whatever duration the project
+        /// itself carries.
+        /// </summary>
+        private Task InitializeBrowserAsync(string url)
+        {
+            VideoPreview.IsVisible = false;
+            WaveformCanvas.IsVisible = false;
+            PreviewPlaceholder.IsVisible = false;
+            BrowserPreview.IsVisible = true;
+            try { BrowserPreview.Source = new Uri(url); }
+            catch (Exception ex) { Log.Debug("DeeperEditor: preview URL rejected: {Error}", ex.Message); }
+            return Task.CompletedTask;
+        }
+
+        /// <summary>ponytail: needs LibVLCSharp. The WPF path created a MediaPlayer on VideoView and
+        /// hooked LengthChanged / TimeChanged / EndReached to drive _totalSeconds, _currentSeconds
+        /// and the play/pause glyph.</summary>
+        private void InitializeVideo(string path)
+        {
+            BrowserPreview.IsVisible = false;
+            WaveformCanvas.IsVisible = false;
+            PreviewPlaceholder.IsVisible = false;
+            VideoPreview.IsVisible = true;
+            Log.Debug("DeeperEditor: local video preview unavailable on this head: {Path}", path);
+        }
+
+        /// <summary>ponytail: needs NAudio (WaveOutEvent + AudioFileReader) and the waveform peak
+        /// extractor. The canvas and its Path are here and <see cref="UpdateWaveformPath"/> is real,
+        /// so wiring peaks in later is a one-line assignment to <c>_waveformPeaks</c>.</summary>
+        private Task InitializeAudioAsync(string path)
+        {
+            BrowserPreview.IsVisible = false;
+            VideoPreview.IsVisible = false;
+            PreviewPlaceholder.IsVisible = false;
+            WaveformCanvas.IsVisible = true;
+            Log.Debug("DeeperEditor: local audio preview unavailable on this head: {Path}", path);
+            return Task.CompletedTask;
+        }
+
+        private void ShowPlaceholder()
+        {
+            VideoPreview.IsVisible = false;
+            WaveformCanvas.IsVisible = false;
+            BrowserPreview.IsVisible = false;
+            PreviewPlaceholder.IsVisible = true;
+
+            var src = _enhancement.MediaSource ?? "";
+            // "*" or empty source = wildcard binding ("works on any media"). The editor can't
+            // preview a wildcard because there is no media file - the project is still valid.
+            if (string.IsNullOrWhiteSpace(src) || src.Contains('*'))
+            {
+                TxtPlaceholderIcon.Text = "✱";
+                TxtPlaceholderTitle.Text = Loc.Get("deeper_editor_wildcard_preview_unavailable");
+            }
+            else
+            {
+                TxtPlaceholderIcon.Text = "🌐";
+                TxtPlaceholderTitle.Text = Loc.Get("deeper_editor_remote_preview_unavailable");
+            }
+            TxtPlaceholderSource.Text = src;
+        }
+
+        private static bool IsLocalFile(string source)
+        {
+            if (string.IsNullOrWhiteSpace(source)) return false;
+            if (source.Contains("://")) return false;
+            if (source.Contains('*')) return false;
+            // Reject UNC and extended-length prefixes: a shared .ccpenh.json pointing at
+            // \\attacker-smb\share\beacon would leak the user's NTLM hash on first access.
+            // ponytail: Core's UrlSafety.IsSafeLocalAbsolute is internal and CCP.Avalonia is not in
+            // its InternalsVisibleTo list, so the same two rejections are inlined here. Drop this
+            // block and call UrlSafety the moment the head is added to that attribute.
+            if (source.StartsWith("\\\\", StringComparison.Ordinal)) return false;   // UNC
+            if (source.StartsWith("\\\\?\\", StringComparison.Ordinal)) return false; // extended-length
+            if (!IOPath.IsPathRooted(source)) return false;
+            return File.Exists(source);
+        }
+
+        private void UpdateWaveformPath()
+        {
+            if (_waveformPeaks == null || _waveformPeaks.Length == 0)
+            {
+                WaveformPath.Data = null;
+                return;
+            }
+
+            var peaks = _waveformPeaks;
+            var width = WaveformCanvas.Bounds.Width;
+            var height = WaveformCanvas.Bounds.Height;
+            if (width <= 0 || height <= 0) return;
+
+            // Vertical bars (one per peak) - the classic editor look. Each bar is centred on its X
+            // column, from (midY - amp) to (midY + amp).
+            var midY = height / 2.0;
+            var stepX = width / peaks.Length;
+            var geom = new StreamGeometry();
+            using (var ctx = geom.Open())
+            {
+                for (int i = 0; i < peaks.Length; i++)
+                {
+                    var x = i * stepX + stepX / 2.0;
+                    var amp = peaks[i] * (height * 0.46);
+                    if (amp < 0.5) amp = 0.5;
+                    ctx.BeginFigure(new Point(x, midY - amp), false);
+                    ctx.LineTo(new Point(x, midY + amp));
+                    ctx.EndFigure(false);
+                }
+            }
+            WaveformPath.Data = geom;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Transport
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>ponytail: needs a media player. With none, play/pause toggles the glyph and the
+        /// playhead timer so the timeline still animates against the project's own duration.</summary>
+        private void BtnPlayPause_Click(object? sender, RoutedEventArgs e)
+        {
+            _isPlaying = !_isPlaying;
+            BtnPlayPause.Content = _isPlaying ? "⏸" : "▶";
+            if (_isPlaying) _playheadTimer?.Start(); else _playheadTimer?.Stop();
+        }
+
+        private void PlayheadTimer_Tick(object? sender, EventArgs e)
+        {
+            if (_isScrubbing) return;
+            if (!_isPlaying || _totalSeconds <= 0) return;
+            // ponytail: the WPF tick read AudioFileReader.CurrentTime (video time arrived on
+            // MediaPlayer.TimeChanged). With no player, advance by the timer interval so the
+            // playhead, the readout and any time-driven redraw stay honest about elapsed time.
+            _currentSeconds = Math.Min(_totalSeconds, _currentSeconds + 0.08);
+            TxtCurrentTime.Text = FormatTime(_currentSeconds);
+            UpdatePlayheadPosition();
+        }
+
+        private void SeekToFraction(double frac)
+        {
+            frac = Math.Clamp(frac, 0, 1);
+            _currentSeconds = frac * _totalSeconds;
+            TxtCurrentTime.Text = FormatTime(_currentSeconds);
+            // ponytail: needs the media player's Seek; the WPF version pushed the new position to
+            // BrowserVideoTimeSource / MediaPlayer / AudioFileReader here.
+            UpdatePlayheadPosition();
+        }
+
+        private void UpdatePlayheadPosition()
+        {
+            if (TimelineCanvas.Bounds.Width <= 0) return;
+            double frac = _totalSeconds > 0 ? Math.Clamp(_currentSeconds / _totalSeconds, 0, 1) : 0;
+            double x = frac * TimelineCanvas.Bounds.Width;
+            PlayheadLine.StartPoint = new Point(x, 0);
+            PlayheadLine.EndPoint = new Point(x, TimelineCanvas.Bounds.Height);
+        }
+
+        private void TimelineCanvas_SizeChanged(object? sender, SizeChangedEventArgs e)
+        {
+            UpdatePlayheadPosition();
+            UpdateWaveformPath();
+            RebuildTimelineRuler();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+            RebuildRuleVisuals();
+            RefreshLaneCounts();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Timeline zoom
+        // ---------------------------------------------------------------------------------
+
+        private void TimelineScroll_SizeChanged(object? sender, SizeChangedEventArgs e)
+        {
+            // Recompute Canvas.Width whenever the viewport changes so zoom=1 keeps the canvas
+            // stretched to fill and higher zooms proportionally expand it.
+            ApplyZoom();
+        }
+
+        private void ApplyZoom(double? anchorViewportX = null)
+        {
+            if (TimelineScroll == null || TimelineCanvas == null) return;
+            var viewportW = TimelineScroll.Viewport.Width;
+            if (viewportW <= 0) return;
+
+            // Capture the scroll-relative time of the anchor point (cursor X for wheel zoom) so we
+            // can re-anchor after resize, for a "zoom centred on cursor" feel.
+            double? timeAnchor = null;
+            if (anchorViewportX is double ax && _totalSeconds > 0 && TimelineCanvas.Bounds.Width > 0)
+            {
+                var contentX = TimelineScroll.Offset.X + ax;
+                timeAnchor = (contentX / TimelineCanvas.Bounds.Width) * _totalSeconds;
+            }
+
+            double newWidth = viewportW * _zoomFactor;
+            TimelineCanvas.Width = newWidth;
+
+            if (TxtZoomLevel != null)
+                TxtZoomLevel.Text = $"{(int)Math.Round(_zoomFactor * 100)}%";
+
+            // Defer the rebuild + re-anchor until layout has seen the new width.
+            Dispatcher.UIThread.Post(() =>
+            {
+                UpdatePlayheadPosition();
+                UpdateWaveformPath();
+                RebuildTimelineRuler();
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                RebuildRuleVisuals();
+
+                if (timeAnchor is double ta && _totalSeconds > 0 && anchorViewportX is double ax2)
+                {
+                    var newContentX = (ta / _totalSeconds) * TimelineCanvas.Bounds.Width;
+                    var newOffset = newContentX - ax2;
+                    TimelineScroll.Offset = new Vector(Math.Max(0, newOffset), TimelineScroll.Offset.Y);
+                }
+            }, DispatcherPriority.Render);
+        }
+
+        private void SetZoom(double newZoom, double? anchorViewportX = null)
+        {
+            newZoom = Math.Clamp(newZoom, MinZoom, MaxZoom);
+            if (Math.Abs(newZoom - _zoomFactor) < 0.001) return;
+            _zoomFactor = newZoom;
+            ApplyZoom(anchorViewportX);
+        }
+
+        private void BtnZoomIn_Click(object? sender, RoutedEventArgs e) => SetZoom(_zoomFactor * 1.5);
+        private void BtnZoomOut_Click(object? sender, RoutedEventArgs e) => SetZoom(_zoomFactor / 1.5);
+
+        // +/-10% page zoom on the embedded browser preview. Distinct from BtnZoomIn/Out above,
+        // which scale the timeline canvas.
+        // ponytail: needs CoreWebView2.ZoomFactor; WebHost exposes only Source, so these two
+        // buttons are inert until the wrapper grows a zoom property.
+        private void BtnPreviewZoomIn_Click(object? sender, RoutedEventArgs e) => AdjustPreviewZoom(+0.10);
+        private void BtnPreviewZoomOut_Click(object? sender, RoutedEventArgs e) => AdjustPreviewZoom(-0.10);
+
+        private void AdjustPreviewZoom(double delta)
+        {
+            Log.Debug("DeeperEditor: preview zoom {Delta:+0.00;-0.00} ignored; WebHost has no ZoomFactor", delta);
+        }
+
+        private void TimelineScroll_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
+        {
+            if (TimelineScroll == null) return;
+            if ((e.KeyModifiers & KeyModifiers.Control) == KeyModifiers.Control)
+            {
+                // Ctrl+wheel = zoom, anchored on the cursor position.
+                var pos = e.GetPosition(TimelineScroll);
+                var factor = e.Delta.Y > 0 ? 1.2 : 1.0 / 1.2;
+                SetZoom(_zoomFactor * factor, pos.X);
+                e.Handled = true;
+                return;
+            }
+            // Plain wheel = horizontal scroll along the timeline. Wheel down advances time.
+            // Avalonia reports the delta in notches rather than WPF's 120-unit steps, so the
+            // multiplier restores roughly the same "half a viewport per notch" feel at zoom 1.
+            var newOffset = TimelineScroll.Offset.X - e.Delta.Y * 120;
+            if (newOffset < 0) newOffset = 0;
+            var max = Math.Max(0, TimelineScroll.Extent.Width - TimelineScroll.Viewport.Width);
+            if (newOffset > max) newOffset = max;
+            TimelineScroll.Offset = new Vector(newOffset, TimelineScroll.Offset.Y);
+            e.Handled = true;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Timeline pointer handling
+        //
+        // WPF had five separate handlers (MouseLeftButtonDown/Move/Up, MouseRightButtonDown,
+        // LostMouseCapture). Avalonia routes press/move/release through one event each, so the
+        // button branch happens at the top of Pressed and everything below is unchanged.
+        // ---------------------------------------------------------------------------------
+
+        private void TimelineCanvas_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            var props = e.GetCurrentPoint(TimelineCanvas).Properties;
+            if (props.IsRightButtonPressed)
+            {
+                TimelineCanvas_MouseRightButtonDown(e);
+                return; // not handled: Avalonia still opens the ContextMenu
+            }
+            if (!props.IsLeftButtonPressed) return;
+
+            // Shift+drag creates a region - power-user shortcut.
+            if ((e.KeyModifiers & KeyModifiers.Shift) == KeyModifiers.Shift && _totalSeconds > 0)
+            {
+                _dragMode = DragMode.CreateRegion;
+                _dragCreateStartSec = MouseToSeconds(e);
+                StartDragCreatePreview(_dragCreateStartSec, _dragCreateStartSec);
+                e.Pointer.Capture(TimelineCanvas);
+                e.Handled = true;
+                return;
+            }
+
+            // Ctrl+drag = rubber-band multi-select (moved off the plain-drag gesture so the latter
+            // can do player-style continuous scrubbing).
+            if ((e.KeyModifiers & KeyModifiers.Control) == KeyModifiers.Control)
+            {
+                _dragMode = DragMode.RubberBand;
+                StartRubberBand(e.GetPosition(TimelineCanvas));
+                e.Pointer.Capture(TimelineCanvas);
+                e.Handled = true;
+                return;
+            }
+
+            // Plain click+drag on empty timeline = scrub. Insta-seek on the down-click and follow
+            // the cursor while dragging. Clears prior selection so the inspector isn't stale.
+            SelectNothing();
+            _dragMode = DragMode.Scrub;
+            _isScrubbing = true;
+            e.Pointer.Capture(TimelineCanvas);
+            ApplyScrubFromMouse(e);
+            e.Handled = true;
+        }
+
+        private void TimelineCanvas_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_dragMode == DragMode.RubberBand)
+            {
+                UpdateRubberBand(e.GetPosition(TimelineCanvas));
+                return;
+            }
+            if (_dragMode == DragMode.CreateRegion)
+            {
+                UpdateDragCreatePreview(MouseToSeconds(e));
+                return;
+            }
+            if (_dragMode == DragMode.ShiftHapticEvent && _draggedHaptic != null)
+            {
+                PushDragSnapshotOnce();
+                var newStart = ComputeShift(_draggedHaptic, MouseToSeconds(e), _hapticDragOffsetSec, _draggedHaptic.Duration);
+                _draggedHaptic.Start = newStart;
+                MarkDirty();
+                RebuildHapticVisuals();
+                if (IsMultiDragActive)
+                {
+                    RebuildRegionVisuals();
+                    RebuildEffectVisuals();
+                }
+                if (_selectedHaptic == _draggedHaptic) PopulateHapticEditor();
+                return;
+            }
+            if (_dragMode == DragMode.ResizeHapticStart && _draggedHaptic != null)
+            {
+                PushDragSnapshotOnce();
+                var endSec = _hapticDragStartSec + _draggedHaptic.Duration;
+                var newStart = Math.Max(0, Math.Min(MouseToSeconds(e), endSec - 0.05));
+                _draggedHaptic.Duration = endSec - newStart;
+                _draggedHaptic.Start = newStart;
+                MarkDirty();
+                RebuildHapticVisuals();
+                if (_selectedHaptic == _draggedHaptic) PopulateHapticEditor();
+                return;
+            }
+            if (_dragMode == DragMode.ResizeHapticEnd && _draggedHaptic != null)
+            {
+                PushDragSnapshotOnce();
+                var newEnd = Math.Min(_totalSeconds, Math.Max(MouseToSeconds(e), _draggedHaptic.Start + 0.05));
+                _draggedHaptic.Duration = newEnd - _draggedHaptic.Start;
+                MarkDirty();
+                RebuildHapticVisuals();
+                if (_selectedHaptic == _draggedHaptic) PopulateHapticEditor();
+                return;
+            }
+            if (_dragMode == DragMode.DragRegion && _draggedRegion != null)
+            {
+                PushDragSnapshotOnce();
+                var newStart = ComputeShift(_draggedRegion, MouseToSeconds(e), _regionDragOffsetSec, _regionDragOriginalLength);
+                _draggedRegion.Start = newStart;
+                _draggedRegion.End = newStart + _regionDragOriginalLength;
+                MarkDirty();
+                RebuildRegionVisuals();
+                if (IsMultiDragActive)
+                {
+                    RebuildHapticVisuals();
+                    RebuildEffectVisuals();
+                }
+                if (_selectedRegion == _draggedRegion) UpdateSelectedSidePanel();
+                return;
+            }
+            if (_dragMode == DragMode.ResizeRegionStart && _draggedRegion != null)
+            {
+                PushDragSnapshotOnce();
+                var newStart = Math.Max(0, Math.Min(MouseToSeconds(e), _draggedRegion.End - 0.05));
+                _draggedRegion.Start = newStart;
+                MarkDirty();
+                RebuildRegionVisuals();
+                if (_selectedRegion == _draggedRegion) UpdateSelectedSidePanel();
+                return;
+            }
+            if (_dragMode == DragMode.ResizeRegionEnd && _draggedRegion != null)
+            {
+                PushDragSnapshotOnce();
+                var newEnd = Math.Min(_totalSeconds, Math.Max(MouseToSeconds(e), _draggedRegion.Start + 0.05));
+                _draggedRegion.End = newEnd;
+                MarkDirty();
+                RebuildRegionVisuals();
+                if (_selectedRegion == _draggedRegion) UpdateSelectedSidePanel();
+                return;
+            }
+            if (_dragMode == DragMode.DragEffect && _draggedEffect != null)
+            {
+                PushDragSnapshotOnce();
+                var newStart = ComputeShift(_draggedEffect, MouseToSeconds(e), _effectDragOffsetSec, _effectDragOriginalDuration);
+                _draggedEffect.Start = newStart;
+                MarkDirty();
+                RebuildEffectVisuals();
+                if (IsMultiDragActive)
+                {
+                    RebuildRegionVisuals();
+                    RebuildHapticVisuals();
+                }
+                if (_selectedEffect == _draggedEffect) UpdateSelectedSidePanelForEffect();
+                return;
+            }
+            if (_dragMode == DragMode.ResizeEffectStart && _draggedEffect != null)
+            {
+                PushDragSnapshotOnce();
+                var oldEnd = _draggedEffect.Start + Math.Max(0, _draggedEffect.Duration);
+                var newStart = Math.Max(0, Math.Min(MouseToSeconds(e), oldEnd - 0.05));
+                _draggedEffect.Duration = oldEnd - newStart;
+                _draggedEffect.Start = newStart;
+                _draggedEffect.EffectDurationMs = (int)Math.Max(50, _draggedEffect.Duration * 1000);
+                MarkDirty();
+                RebuildEffectVisuals();
+                if (_selectedEffect == _draggedEffect) UpdateSelectedSidePanelForEffect();
+                return;
+            }
+            if (_dragMode == DragMode.ResizeEffectEnd && _draggedEffect != null)
+            {
+                PushDragSnapshotOnce();
+                var newEnd = Math.Min(_totalSeconds, Math.Max(MouseToSeconds(e), _draggedEffect.Start + 0.05));
+                _draggedEffect.Duration = newEnd - _draggedEffect.Start;
+                _draggedEffect.EffectDurationMs = (int)Math.Max(50, _draggedEffect.Duration * 1000);
+                MarkDirty();
+                RebuildEffectVisuals();
+                if (_selectedEffect == _draggedEffect) UpdateSelectedSidePanelForEffect();
+                return;
+            }
+            if (_dragMode == DragMode.Scrub && _isScrubbing) ApplyScrubFromMouse(e);
+        }
+
+        private void TimelineCanvas_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (e.InitialPressMouseButton != MouseButton.Left) return;
+
+            if (_dragMode == DragMode.RubberBand)
+            {
+                FinishRubberBand(e.GetPosition(TimelineCanvas));
+                e.Pointer.Capture(null);
+                _dragMode = DragMode.None;
+                return;
+            }
+            if (_dragMode == DragMode.CreateRegion)
+            {
+                var endSec = MouseToSeconds(e);
+                FinishDragCreate(endSec);
+                e.Pointer.Capture(null);
+                _dragMode = DragMode.None;
+                return;
+            }
+            if (_dragMode == DragMode.ShiftHapticEvent ||
+                _dragMode == DragMode.ResizeHapticStart ||
+                _dragMode == DragMode.ResizeHapticEnd)
+            {
+                _draggedHaptic = null;
+                _draggedHapticTrack = null;
+                _dragMode = DragMode.None;
+                _dragSnapshotPushed = false;
+                EndMultiDragCapture();
+                e.Pointer.Capture(null);
+                ScheduleValidation();
+                BuildItemsList();
+                return;
+            }
+            if (_dragMode == DragMode.DragRegion ||
+                _dragMode == DragMode.ResizeRegionStart ||
+                _dragMode == DragMode.ResizeRegionEnd)
+            {
+                _draggedRegion = null;
+                _dragMode = DragMode.None;
+                _dragSnapshotPushed = false;
+                EndMultiDragCapture();
+                e.Pointer.Capture(null);
+                ScheduleValidation();
+                BuildItemsList();
+                return;
+            }
+            if (_dragMode == DragMode.DragEffect ||
+                _dragMode == DragMode.ResizeEffectStart ||
+                _dragMode == DragMode.ResizeEffectEnd)
+            {
+                _draggedEffect = null;
+                _dragMode = DragMode.None;
+                _dragSnapshotPushed = false;
+                EndMultiDragCapture();
+                e.Pointer.Capture(null);
+                ScheduleValidation();
+                BuildItemsList();
+                return;
+            }
+            if (_dragMode == DragMode.Scrub)
+            {
+                _isScrubbing = false;
+                _dragMode = DragMode.None;
+                e.Pointer.Capture(null);
+            }
+        }
+
+        // A canvas that loses its pointer capture mid-drag (alt-tab, a popup steals focus, window
+        // deactivation) never sees the release. Without this hook the rubber-band rectangle and the
+        // drag-create preview stay on the canvas as orphan visuals and _dragMode stays stuck in a
+        // non-None state - both observed in the field on Ctrl+drag rubber-band selection.
+        private void TimelineCanvas_PointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+        {
+            if (_rubberBandRect != null)
+            {
+                try { TimelineCanvas.Children.Remove(_rubberBandRect); } catch { }
+                _rubberBandRect = null;
+            }
+            if (_dragCreatePreview != null)
+            {
+                try { TimelineCanvas.Children.Remove(_dragCreatePreview); } catch { }
+                _dragCreatePreview = null;
+            }
+            _dragMode = DragMode.None;
+            _isScrubbing = false;
+            _dragSnapshotPushed = false;
+            _draggedHaptic = null;
+            _draggedHapticTrack = null;
+            _draggedRegion = null;
+            _draggedEffect = null;
+            EndMultiDragCapture();
+        }
+
+        private void ApplyScrubFromMouse(PointerEventArgs e)
+        {
+            var pt = e.GetPosition(TimelineCanvas);
+            var w = TimelineCanvas.Bounds.Width;
+            if (w <= 0) return;
+            SeekToFraction(pt.X / w);
+        }
+
+        private double MouseToSeconds(PointerEventArgs e)
+        {
+            var pt = e.GetPosition(TimelineCanvas);
+            var w = TimelineCanvas.Bounds.Width;
+            if (w <= 0 || _totalSeconds <= 0) return 0;
+            var frac = Math.Clamp(pt.X / w, 0, 1);
+            return frac * _totalSeconds;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Region creation
+        // ---------------------------------------------------------------------------------
+
+        private void StartDragCreatePreview(double startSec, double endSec)
+        {
+            _dragCreatePreview = new Rectangle
+            {
+                Fill = Res("DeeperAccentTransparent40Brush"),
+                Stroke = Res("DeeperAccentBrush"),
+                StrokeThickness = 1.5,
+                IsHitTestVisible = false
+            };
+            TimelineCanvas.Children.Insert(0, _dragCreatePreview);
+            UpdateDragCreatePreview(endSec);
+        }
+
+        private void UpdateDragCreatePreview(double endSec)
+        {
+            if (_dragCreatePreview == null) return;
+            var w = TimelineCanvas.Bounds.Width;
+            var h = TimelineCanvas.Bounds.Height;
+            if (w <= 0 || _totalSeconds <= 0) return;
+
+            var lo = Math.Min(_dragCreateStartSec, endSec);
+            var hi = Math.Max(_dragCreateStartSec, endSec);
+            var leftX = (lo / _totalSeconds) * w;
+            var rightX = (hi / _totalSeconds) * w;
+
+            var (regionTop, regionH) = LaneBandInset(TimelineLane.Regions, h);
+            _dragCreatePreview.Width = Math.Max(0, rightX - leftX);
+            _dragCreatePreview.Height = regionH;
+            Canvas.SetLeft(_dragCreatePreview, leftX);
+            Canvas.SetTop(_dragCreatePreview, regionTop);
+        }
+
+        private void FinishDragCreate(double endSec)
+        {
+            if (_dragCreatePreview != null)
+            {
+                TimelineCanvas.Children.Remove(_dragCreatePreview);
+                _dragCreatePreview = null;
+            }
+            CreateRegion(_dragCreateStartSec, endSec);
+        }
+
+        private void CreateRegion(double a, double b)
+        {
+            var lo = Math.Min(a, b);
+            var hi = Math.Max(a, b);
+            if (hi - lo < 0.1) return;
+            if (_totalSeconds > 0) hi = Math.Min(hi, _totalSeconds);
+            lo = Math.Max(0, lo);
+            PushUndoSnapshot();
+
+            var region = new Region
+            {
+                Id = NextRegionId(),
+                Start = lo,
+                End = hi,
+                Label = "",
+                Color = NextRegionColor()
+            };
+            _enhancement.Regions.Add(region);
+            MarkDirty();
+            RebuildRegionVisuals();
+            SelectRegion(region);
+            ScheduleValidation();
+        }
+
+        private string NextRegionId()
+        {
+            int n = _enhancement.Regions.Count + 1;
+            while (true)
+            {
+                var candidate = "r" + n;
+                if (!_enhancement.Regions.Any(r => r.Id == candidate)) return candidate;
+                n++;
+            }
+        }
+
+        private string NextRegionColor()
+            => RegionPalette[_enhancement.Regions.Count % RegionPalette.Length];
+
+        // ---------------------------------------------------------------------------------
+        // Selection
+        // ---------------------------------------------------------------------------------
+
+        private void SelectNothing()
+        {
+            _selectedRegion = null;
+            _selectedHaptic = null;
+            _selectedHapticTrack = null;
+            _selectedRule = null;
+            _selectedEffect = null;
+            _selectionSet.Clear();
+            EndGazePick(commit: false);
+            UpdateSelectedSidePanel();
+            ScrollInspectorToTop();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+            RefreshRulesList();
+        }
+
+        private void SelectRegion(Region? region)
+        {
+            _selectedRegion = region;
+            _selectedHaptic = null;
+            _selectedHapticTrack = null;
+            _selectedRule = null;
+            _selectedEffect = null;
+            EndGazePick(commit: false);
+            UpdateSelectedSidePanel();
+            ScrollInspectorToTop();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+            RebuildRuleVisuals();
+            RefreshRulesList();
+        }
+
+        // Finds the first rule whose RegionConstraint matches the given region id. Used by the
+        // band-click handler to route to the rule editor when the band represents a rule's scope.
+        private EnhancementRule? FindRuleByRegionConstraint(string? regionId)
+        {
+            if (string.IsNullOrEmpty(regionId)) return null;
+            foreach (var rule in _enhancement.Rules)
+            {
+                if (rule != null && string.Equals(rule.RegionConstraint, regionId, StringComparison.Ordinal))
+                    return rule;
+            }
+            return null;
+        }
+
+        private void SelectHaptic(HapticTrack track, HapticEvent ev)
+        {
+            _selectedRegion = null;
+            _selectedHaptic = ev;
+            _selectedHapticTrack = track;
+            _selectedRule = null;
+            _selectedEffect = null;
+            EndGazePick(commit: false);
+            UpdateSelectedSidePanel();
+            ScrollInspectorToTop();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+            RebuildRuleVisuals();
+            RefreshRulesList();
+        }
+
+        private void SelectRule(EnhancementRule? rule)
+        {
+            _selectedRegion = null;
+            _selectedHaptic = null;
+            _selectedHapticTrack = null;
+            _selectedRule = rule;
+            _selectedEffect = null;
+            EndGazePick(commit: false);
+            UpdateSelectedSidePanel();
+            ScrollInspectorToTop();
+            RebuildRegionVisuals();
+            RebuildHapticVisuals();
+            RebuildEffectVisuals();
+            RebuildRuleVisuals();
+            RefreshRulesList();
+        }
+
+        private void UpdateSelectedSidePanel()
+        {
+            if (SelectedPlaceholder == null || RegionEditor == null || HapticEventEditor == null || RuleEditor == null) return;
+
+            // Always reset the unified-editor groups; the unified path repopulates if needed.
+            HideAllEditors();
+
+            if (_selectedEffect != null)
+            {
+                UpdateSelectedSidePanelForEffect();
+                return;
+            }
+
+            if (_selectedRegion != null)
+            {
+                SelectedPlaceholder.IsVisible = false;
+                RegionEditor.IsVisible = true;
+
+                _suppressDirty = true;
+                try
+                {
+                    TxtRegionId.Text = _selectedRegion.Id;
+                    TxtRegionLabel.Text = _selectedRegion.Label;
+                    TxtRegionStart.Text = _selectedRegion.Start.ToString("0.##", CultureInfo.InvariantCulture);
+                    TxtRegionEnd.Text = _selectedRegion.End.ToString("0.##", CultureInfo.InvariantCulture);
+                    TxtRegionColor.Text = _selectedRegion.Color;
+                    UpdateRegionColorSwatchPreview();
+                    BtnSnapRegionStartPrev.IsEnabled = FindSnapPrevRegion() != null;
+                    BtnSnapRegionEndNext.IsEnabled = FindSnapNextRegion() != null;
+                }
+                finally { ClearWhenEventsDrained(() => _suppressDirty = false); }
+                return;
+            }
+
+            if (_selectedHaptic != null && _selectedHapticTrack != null)
+            {
+                SelectedPlaceholder.IsVisible = false;
+                HapticEventEditor.IsVisible = true;
+                PopulateHapticEditor();
+                return;
+            }
+
+            if (_selectedRule != null)
+            {
+                SelectedPlaceholder.IsVisible = false;
+                RuleEditor.IsVisible = true;
+                PopulateRuleEditor();
+                return;
+            }
+
+            SelectedPlaceholder.IsVisible = true;
+
+            // Keep the selection summary strip in sync even when UpdateSelectedSidePanel is called
+            // outside the SelectXxx path (e.g. drag-end). Cheap; safe to repeat.
+            UpdateSelectionSummary();
+        }
+
+        private void UpdateRegionColorSwatchPreview()
+        {
+            var brush = TryParseBrush(_selectedRegion?.Color ?? "#7B5CFF");
+            if (brush != null) RegionColorSwatch.Background = brush;
+        }
+
+        private void RegionField_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressDirty || _selectedRegion == null) return;
+            _selectedRegion.Label = TxtRegionLabel.Text ?? "";
+            if (double.TryParse(TxtRegionStart.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var s))
+                _selectedRegion.Start = Math.Max(0, s);
+            if (double.TryParse(TxtRegionEnd.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var ev))
+                _selectedRegion.End = ev;
+            if (!string.IsNullOrWhiteSpace(TxtRegionColor.Text))
+            {
+                _selectedRegion.Color = TxtRegionColor.Text!.Trim();
+                UpdateRegionColorSwatchPreview();
+            }
+            MarkDirty();
+            RebuildRegionVisuals();
+            ScheduleValidation();
+        }
+
+        // -- Region snap buttons ------------------------------------------------
+        // "Region 4 ends at 93.52 -> region 5 starts at 93.52" without typing.
+
+        /// <summary>The region whose End the selected region's Start can snap to, or null when
+        /// there is none / it is already flush.</summary>
+        private Region? FindSnapPrevRegion()
+        {
+            if (_selectedRegion == null) return null;
+            Region? best = null;
+            foreach (var r in _enhancement.Regions)
+            {
+                if (r == null || ReferenceEquals(r, _selectedRegion)) continue;
+                if (r.End > _selectedRegion.Start + 0.001) continue;
+                if (best == null || r.End > best.End) best = r;
+            }
+            if (best != null && Math.Abs(best.End - _selectedRegion.Start) < 0.0001) return null; // already flush
+            return best;
+        }
+
+        private Region? FindSnapNextRegion()
+        {
+            if (_selectedRegion == null) return null;
+            Region? best = null;
+            foreach (var r in _enhancement.Regions)
+            {
+                if (r == null || ReferenceEquals(r, _selectedRegion)) continue;
+                if (r.Start < _selectedRegion.End - 0.001) continue;
+                if (best == null || r.Start < best.Start) best = r;
+            }
+            if (best != null && Math.Abs(best.Start - _selectedRegion.End) < 0.0001) return null; // already flush
+            return best;
+        }
+
+        private void BtnSnapRegionStartPrev_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedRegion == null) return;
+            var prev = FindSnapPrevRegion();
+            if (prev == null) return;
+            PushUndoSnapshot();
+            _selectedRegion.Start = prev.End;
+            _suppressDirty = true;
+            try { TxtRegionStart.Text = _selectedRegion.Start.ToString("0.##", CultureInfo.InvariantCulture); }
+            finally { ClearWhenEventsDrained(() => _suppressDirty = false); }
+            BtnSnapRegionStartPrev.IsEnabled = FindSnapPrevRegion() != null;
+            MarkDirty();
+            RebuildRegionVisuals();
+            ScheduleValidation();
+        }
+
+        private void BtnSnapRegionEndNext_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedRegion == null) return;
+            var next = FindSnapNextRegion();
+            if (next == null) return;
+            PushUndoSnapshot();
+            _selectedRegion.End = next.Start;
+            _suppressDirty = true;
+            try { TxtRegionEnd.Text = _selectedRegion.End.ToString("0.##", CultureInfo.InvariantCulture); }
+            finally { ClearWhenEventsDrained(() => _suppressDirty = false); }
+            BtnSnapRegionEndNext.IsEnabled = FindSnapNextRegion() != null;
+            MarkDirty();
+            RebuildRegionVisuals();
+            ScheduleValidation();
+        }
+
+        private void BtnDeleteRegion_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_selectedRegion == null) return;
+            PushUndoSnapshot();
+            _enhancement.Regions.Remove(_selectedRegion);
+            SelectNothing();
+            MarkDirty();
+            RebuildRegionVisuals();
+            ScheduleValidation();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Region rendering
+        // ---------------------------------------------------------------------------------
+
+        private void RebuildRegionVisuals()
+        {
+            if (TimelineCanvas == null) return;
+            foreach (var r in _regionVisuals) TimelineCanvas.Children.Remove(r);
+            _regionVisuals.Clear();
+
+            if (_totalSeconds <= 0 || TimelineCanvas.Bounds.Width <= 0)
+            {
+                EnsurePlayheadOnTop();
+                return;
+            }
+
+            foreach (var region in _enhancement.Regions)
+            {
+                var rect = BuildRegionVisual(region);
+                if (rect != null)
+                {
+                    TimelineCanvas.Children.Insert(0, rect);
+                    _regionVisuals.Add(rect);
+                }
+            }
+            EnsurePlayheadOnTop();
+        }
+
+        private Rectangle? BuildRegionVisual(Region region)
+        {
+            var w = TimelineCanvas.Bounds.Width;
+            var h = TimelineCanvas.Bounds.Height;
+            if (w <= 0 || _totalSeconds <= 0) return null;
+
+            var (laneTop, laneH) = LaneBandInset(TimelineLane.Regions, h);
+            var startX = Math.Max(0, (region.Start / _totalSeconds) * w);
+            var endX = Math.Min(w, (region.End / _totalSeconds) * w);
+            // Floor at MinBandVisualWidthPx so a region whose duration would otherwise render at
+            // sub-pixel width stays clickable. The data model keeps the real Start/End.
+            var width = Math.Max(MinBandVisualWidthPx, endX - startX);
+
+            var color = TryParseColor(region.Color) ?? Colors.MediumPurple;
+            var fill = Color.FromArgb(80, color.R, color.G, color.B);
+            var isSelected = _selectedRegion == region || IsInSelectionSet(region);
+
+            var rect = new Rectangle
+            {
+                Width = width,
+                Height = laneH,
+                Fill = new SolidColorBrush(fill),
+                Stroke = new SolidColorBrush(color),
+                StrokeThickness = isSelected ? 2.0 : 1.0,
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Tag = region,
+            };
+            ToolTip.SetTip(rect, string.IsNullOrEmpty(region.Label) ? region.Id : $"{region.Id} — {region.Label}");
+            Canvas.SetLeft(rect, startX);
+            Canvas.SetTop(rect, laneTop);
+            rect.PointerPressed += RegionRect_PointerPressed;
+            rect.PointerMoved += RegionRect_PointerMoved;
+            return rect;
+        }
+
+        private void RegionRect_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_dragMode != DragMode.None) return;
+            if (sender is not Rectangle r) return;
+            var pos = e.GetPosition(r);
+            r.Cursor = ClassifyEdgeHit(pos.X, r.Bounds.Width) == EdgeHit.Body
+                ? new Cursor(StandardCursorType.SizeAll)
+                : new Cursor(StandardCursorType.SizeWestEast);
+        }
+
+        private void EnsurePlayheadOnTop()
+        {
+            // Keep the playhead in front of dynamically inserted region/haptic/effect visuals.
+            if (PlayheadLine == null) return;
+            if (TimelineCanvas.Children.Contains(PlayheadLine))
+                TimelineCanvas.Children.Remove(PlayheadLine);
+            TimelineCanvas.Children.Add(PlayheadLine);
+        }
+
+        private void RegionRect_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is not Rectangle r || r.Tag is not Region region) return;
+            if (!e.GetCurrentPoint(r).Properties.IsLeftButtonPressed) return;
+
+            // Snapshot pos + width BEFORE selecting - SelectRegion rebuilds visuals, which detaches
+            // `r` from the tree, after which GetPosition(r) returns ~(0,0) and trips the left-edge
+            // resize check unconditionally.
+            var pos = e.GetPosition(r);
+            var rectWidth = r.Bounds.Width;
+            bool ctrl = IsCtrlDown(e.KeyModifiers);
+
+            HandleSelectionClick(region, e.KeyModifiers);
+            if (ctrl)
+            {
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                e.Handled = true;
+                return;
+            }
+
+            // If a rule constrains this region, treat the band as the rule's visual representation:
+            // select the Rule (so trigger / action / gaze rect / picker are one click away) and let
+            // the rule editor's region-details sub-panel handle label/colour/start-end. Orphan
+            // regions still fall back to the standalone Region editor.
+            var attachedRule = FindRuleByRegionConstraint(region.Id);
+            if (attachedRule != null) SelectRule(attachedRule);
+            else SelectRegion(region);
+
+            _draggedRegion = region;
+            _regionDragOriginalLength = Math.Max(0, region.End - region.Start);
+            BeginMultiDragCapture();
+
+            switch (ClassifyEdgeHit(pos.X, rectWidth))
+            {
+                case EdgeHit.Start: _dragMode = DragMode.ResizeRegionStart; break;
+                case EdgeHit.End:   _dragMode = DragMode.ResizeRegionEnd; break;
+                default:
+                    _dragMode = DragMode.DragRegion;
+                    _regionDragOffsetSec = MouseToSeconds(e) - region.Start;
+                    break;
+            }
+            e.Pointer.Capture(TimelineCanvas);
+            e.Handled = true;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Haptic events: rendering + interaction
+        // ---------------------------------------------------------------------------------
+
+        private HapticTrack EnsureDefaultTrack()
+        {
+            if (_enhancement.HapticTracks.Count == 0)
+                _enhancement.HapticTracks.Add(new HapticTrack { Id = DefaultTrackId });
+            return _enhancement.HapticTracks[0];
+        }
+
+        private void CreateHapticEventAtPlayhead()
+        {
+            if (_totalSeconds <= 0) return;
+            var track = EnsureDefaultTrack();
+            var start = _currentSeconds;
+            var duration = 1.0;
+            // Avoid overlapping: nudge to the first free slot after the current events.
+            foreach (var existing in track.Events.OrderBy(x => x.Start))
+            {
+                if (start < existing.Start + existing.Duration && start + duration > existing.Start)
+                    start = existing.Start + existing.Duration + 0.05;
+            }
+            if (start + duration > _totalSeconds) start = Math.Max(0, _totalSeconds - duration);
+
+            // Snapshot BEFORE the mutation so Ctrl+Z restores the pre-create state.
+            PushUndoSnapshot();
+
+            var ev = new HapticEvent
+            {
+                Start = start,
+                Duration = duration,
+                Intensity = 1.0,
+                PatternName = "Pulse"
+            };
+            track.Events.Add(ev);
+            MarkDirty();
+            RebuildHapticVisuals();
+            SelectHaptic(track, ev);
+            ScheduleValidation();
+        }
+
+        private void RebuildHapticVisuals()
+        {
+            if (TimelineCanvas == null) return;
+            foreach (var v in _hapticVisuals) TimelineCanvas.Children.Remove(v);
+            _hapticVisuals.Clear();
+
+            if (_totalSeconds <= 0 || TimelineCanvas.Bounds.Width <= 0)
+            {
+                EnsurePlayheadOnTop();
+                return;
+            }
+
+            foreach (var track in _enhancement.HapticTracks)
+            {
+                foreach (var ev in track.Events)
+                {
+                    var rect = BuildHapticVisual(track, ev);
+                    if (rect != null)
+                    {
+                        TimelineCanvas.Children.Insert(0, rect);
+                        _hapticVisuals.Add(rect);
+                    }
+                }
+            }
+            EnsurePlayheadOnTop();
+        }
+
+        private Rectangle? BuildHapticVisual(HapticTrack track, HapticEvent ev)
+        {
+            var w = TimelineCanvas.Bounds.Width;
+            var h = TimelineCanvas.Bounds.Height;
+            if (w <= 0 || _totalSeconds <= 0) return null;
+
+            var (laneTop, laneH) = LaneBandInset(TimelineLane.Haptics, h);
+            var startX = Math.Max(0, (ev.Start / _totalSeconds) * w);
+            var endX = Math.Min(w, ((ev.Start + ev.Duration) / _totalSeconds) * w);
+            var width = Math.Max(MinBandVisualWidthPx, endX - startX);
+
+            var isSelected = _selectedHaptic == ev || IsInSelectionSet(ev);
+            // Resolve DeeperAccent from the theme so a runtime palette change reflows the haptic
+            // stroke too. Falls back to the canonical violet if the lookup fails.
+            Color accent = (Res("DeeperAccentBrush") as ISolidColorBrush)?.Color
+                           ?? Color.Parse("#FF7B5CFF");
+            var fill = Color.FromArgb(isSelected ? (byte)180 : (byte)130, accent.R, accent.G, accent.B);
+
+            var rect = new Rectangle
+            {
+                Width = width,
+                Height = laneH,
+                Fill = new SolidColorBrush(fill),
+                Stroke = new SolidColorBrush(accent),
+                StrokeThickness = isSelected ? 2.0 : 1.0,
+                Cursor = new Cursor(StandardCursorType.SizeAll),
+                Tag = (track, ev),
+            };
+            ToolTip.SetTip(rect, string.IsNullOrEmpty(ev.PatternName)
+                ? $"{track.Id} · custom · {ev.Duration:0.##}s"
+                : $"{track.Id} · {ev.PatternName} · {ev.Duration:0.##}s");
+            Canvas.SetLeft(rect, startX);
+            Canvas.SetTop(rect, laneTop);
+            rect.PointerPressed += HapticRect_PointerPressed;
+            rect.PointerMoved += HapticRect_PointerMoved;
+            return rect;
+        }
+
+        private void HapticRect_PointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (_dragMode != DragMode.None) return; // don't churn the cursor mid-drag
+            if (sender is not Rectangle r) return;
+            var pos = e.GetPosition(r);
+            r.Cursor = ClassifyEdgeHit(pos.X, r.Bounds.Width) == EdgeHit.Body
+                ? new Cursor(StandardCursorType.SizeAll)
+                : new Cursor(StandardCursorType.SizeWestEast);
+        }
+
+        private void HapticRect_PointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (sender is not Rectangle r || r.Tag is not ValueTuple<HapticTrack, HapticEvent> tuple) return;
+            if (!e.GetCurrentPoint(r).Properties.IsLeftButtonPressed) return;
+
+            var (track, ev) = tuple;
+            var pos = e.GetPosition(r);
+            var rectWidth = r.Bounds.Width;
+            bool ctrl = IsCtrlDown(e.KeyModifiers);
+            HandleSelectionClick(ev, e.KeyModifiers);
+            if (ctrl)
+            {
+                RebuildRegionVisuals();
+                RebuildHapticVisuals();
+                RebuildEffectVisuals();
+                e.Handled = true;
+                return;
+            }
+            SelectHaptic(track, ev);
+
+            // Begin drag-shift on hold (no Shift modifier - that's region-create).
+            if ((e.KeyModifiers & KeyModifiers.Shift) != KeyModifiers.Shift)
+            {
+                var hit = ClassifyEdgeHit(pos.X, rectWidth);
+                if (hit == EdgeHit.Start)
+                {
+                    _dragMode = DragMode.ResizeHapticStart;
+                    _draggedHaptic = ev;
+                    _draggedHapticTrack = track;
+                    _hapticDragStartSec = ev.Start;
+                    e.Pointer.Capture(TimelineCanvas);
+                    e.Handled = true;
+                    return;
+                }
+                if (hit == EdgeHit.End)
+                {
+                    _dragMode = DragMode.ResizeHapticEnd;
+                    _draggedHaptic = ev;
+                    _draggedHapticTrack = track;
+                    _hapticDragStartSec = ev.Start;
+                    e.Pointer.Capture(TimelineCanvas);
+                    e.Handled = true;
+                    return;
+                }
+
+                _dragMode = DragMode.ShiftHapticEvent;
+                _draggedHaptic = ev;
+                _draggedHapticTrack = track;
+                _hapticDragStartSec = ev.Start;
+                _hapticDragOffsetSec = MouseToSeconds(e) - ev.Start;
+                BeginMultiDragCapture();
+                e.Pointer.Capture(TimelineCanvas);
+            }
+            e.Handled = true;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Metadata sync, dirty flag, validation
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>
+        /// DEVIATION from the WPF handler, and a real bug the straight port inherited: Avalonia
+        /// raises <c>TextBox.TextChanged</c> DEFERRED, not synchronously on the assignment. WPF's
+        /// guard was "set _suppressDirty, assign the six boxes, clear it" in a try/finally - on
+        /// Avalonia the event lands AFTER that finally has cleared the flag, so merely loading a
+        /// project marked it dirty, lit the unsaved dot, and (once a close dialog exists) would
+        /// have prompted to save on every exit. Caught by stack-tracing MarkDirty during the
+        /// headless render, not by reading.
+        ///
+        /// The flag is kept for the synchronous callers that still rely on it; the decision to
+        /// mark dirty is now made by COMPARING against the model rather than by trusting a timing
+        /// window, so writing a field its current value is a no-op whenever the event arrives.
+        /// </summary>
+        private void MetadataField_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressDirty) return;
+
+            var m = _enhancement.Metadata;
+            var name = TxtMetaName.Text ?? "";
+            var creator = TxtMetaCreator.Text ?? "";
+            var remixer = string.IsNullOrWhiteSpace(TxtMetaRemixer?.Text) ? null : TxtMetaRemixer!.Text;
+            var description = TxtMetaDescription.Text ?? "";
+            var tags = (TxtMetaTags.Text ?? "")
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+            var license = TxtMetaLicense.Text ?? "";
+
+            bool changed = m.Name != name
+                || m.Creator != creator
+                || m.Remixer != remixer
+                || m.Description != description
+                || m.License != license
+                || !(m.Tags ?? new List<string>()).SequenceEqual(tags, StringComparer.Ordinal);
+            if (!changed) return;
+
+            m.Name = name;
+            m.Creator = creator;
+            m.Remixer = remixer;
+            m.Description = description;
+            m.Tags = tags;
+            m.License = license;
+            MarkDirty();
+            ScheduleValidation();
+        }
+
+
+        /// <summary>
+        /// Clears a "suppress my own change handlers" flag only AFTER Avalonia has drained the
+        /// events that the just-completed assignments queued.
+        ///
+        /// This exists because of a framework difference that silently breaks the WPF idiom used
+        /// throughout this window. WPF raises <c>TextBox.TextChanged</c> and
+        /// <c>Selector.SelectionChanged</c> SYNCHRONOUSLY on the assignment, so the pattern
+        /// "set flag - assign the controls - clear flag in finally" reliably swallowed the echo.
+        /// Avalonia raises them DEFERRED, on a later dispatcher turn, by which time the finally has
+        /// already cleared the flag - so every populate-the-inspector path fed its own echo back
+        /// into the model, marked the project dirty and lit the unsaved-changes dot on load.
+        /// Caught by stack-tracing MarkDirty during the headless render, not by reading.
+        ///
+        /// Posting the clear at Background priority puts it behind those queued events (input and
+        /// layout priorities both run first), so the guard still ends, and it ends late enough.
+        /// ponytail: one helper at every existing guard site rather than a value-comparison in each
+        /// of ~30 handlers - same fix, a tenth of the diff.
+        /// </summary>
+        private static void ClearWhenEventsDrained(Action clear)
+            => Dispatcher.UIThread.Post(clear, DispatcherPriority.Background);
+
+        private void MarkDirty()
+        {
+            if (_suppressDirty) return;
+            _isDirty = true;
+            TxtDirty.IsVisible = true;
+            // Lane counts piggyback here (cheap) so the chrome stays in sync with any
+            // add/remove/edit that touches the data model.
+            RefreshLaneCounts();
+        }
+
+        private void ScheduleValidation()
+        {
+            _validationTimer?.Stop();
+            _validationTimer?.Start();
+        }
+
+        // Backing list for the click-to-expand popup. Refreshed in lockstep with the summary so the
+        // popup always shows the current set.
+        private List<ValidationError> _lastValidationIssues = new();
+
+        private void RefreshValidation()
+        {
+            _lastValidationIssues = EnhancementValidator.Validate(_enhancement);
+            int errorCount = _lastValidationIssues.Count(x => x.Severity == ValidationSeverity.Error);
+            int warningCount = _lastValidationIssues.Count(x => x.Severity == ValidationSeverity.Warning);
+            if (errorCount == 0 && warningCount == 0)
+            {
+                TxtValidationSummary.Text = Loc.Get("deeper_editor_validation_clean");
+                TxtValidationSummary.Foreground = Res("TextLightBrush");
+                TxtValidationSummary.Cursor = null;
+                TxtValidationSummary.TextDecorations = null;
+                if (ValidationDetailsPopup != null) ValidationDetailsPopup.IsOpen = false;
+            }
+            else
+            {
+                var bits = new List<string>();
+                if (errorCount > 0) bits.Add(string.Format(Loc.Get("deeper_editor_validation_errors_fmt"), errorCount));
+                if (warningCount > 0) bits.Add(string.Format(Loc.Get("deeper_editor_validation_warnings_fmt"), warningCount));
+                TxtValidationSummary.Text = string.Join("  ·  ", bits)
+                    + "  " + Loc.Get("deeper_editor_validation_click_for_details_hint");
+                TxtValidationSummary.Foreground = errorCount > 0 ? Res("DangerBrush") : Res("PinkSoftBrush");
+                TxtValidationSummary.Cursor = new Cursor(StandardCursorType.Hand);
+                TxtValidationSummary.TextDecorations = TextDecorations.Underline;
+                ToolTip.SetTip(TxtValidationSummary, Loc.Get("deeper_editor_validation_click_for_details_tip"));
+
+                // If the popup is already open (user toggled it then made an edit), refresh its
+                // contents in place rather than closing it.
+                if (ValidationDetailsPopup?.IsOpen == true) PopulateValidationPopup();
+            }
+        }
+
+        private void TxtValidationSummary_PointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (e.InitialPressMouseButton != MouseButton.Left) return;
+            // No issues = nothing to expand.
+            if (_lastValidationIssues == null || _lastValidationIssues.Count == 0) return;
+            if (ValidationDetailsPopup == null) return;
+            if (ValidationDetailsPopup.IsOpen)
+            {
+                ValidationDetailsPopup.IsOpen = false;
+                return;
+            }
+            PopulateValidationPopup();
+            ValidationDetailsPopup.IsOpen = true;
+            e.Handled = true;
+        }
+
+        // Builds the row VMs for LstValidationIssues, fresh from _lastValidationIssues so a re-open
+        // after edits always shows current state.
+        private void PopulateValidationPopup()
+        {
+            if (LstValidationIssues == null) return;
+            int errorCount = _lastValidationIssues.Count(x => x.Severity == ValidationSeverity.Error);
+            int warningCount = _lastValidationIssues.Count(x => x.Severity == ValidationSeverity.Warning);
+            if (TxtValidationPopupHeader != null)
+                TxtValidationPopupHeader.Text = string.Format(
+                    Loc.Get("deeper_editor_validation_popup_header_fmt"),
+                    errorCount, warningCount);
+
+            LstValidationIssues.ItemsSource = _lastValidationIssues
+                .OrderBy(i => i.Severity == ValidationSeverity.Error ? 0 : 1)
+                .Select(i => new ValidationIssueRow
+                {
+                    Glyph = i.Severity == ValidationSeverity.Error ? "✕" : "⚠",
+                    Brush = Res(i.Severity == ValidationSeverity.Error ? "DangerBrush" : "PinkSoftBrush"),
+                    Message = i.Message ?? "",
+                })
+                .ToList();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // File ops
+        //
+        // ponytail: every member below needs App.EnhancementLibrary, a file dialog
+        // (IStorageProvider is available but the library's folder + suffix conventions are not),
+        // EnhancementMediaBundler for export, and a MessageBox for the result. The WPF bodies are
+        // ~450 lines of that plumbing; ported as named stubs that log what they would have done, so
+        // no member silently disappears and the wiring above stays honest.
+        // ---------------------------------------------------------------------------------
+
+        private void MenuSave_Click(object? sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(_filePath))
+            {
+                MenuSaveAs_Click(sender, e);
+                return;
+            }
+            SaveTo(_filePath!);
+        }
+
+        private void MenuSaveAs_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("DeeperEditor: Save As needs App.EnhancementLibrary + a save dialog");
+
+        private void SaveTo(string path)
+            => Log.Debug("DeeperEditor: Save needs EnhancementSerializer.Write + App.EnhancementLibrary: {Path}", path);
+
+        private void MenuExportEnhanced_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("DeeperEditor: Export needs EnhancementMediaBundler + a save dialog");
+
+        private void MenuClose_Click(object? sender, RoutedEventArgs e) => Close();
+
+        private void UpdateTitle()
+        {
+            var name = string.IsNullOrEmpty(_enhancement.Metadata.Name)
+                ? Loc.Get("deeper_editor_untitled") : _enhancement.Metadata.Name;
+            TxtTitle.Text = name;
+            Title = $"Deeper — {name}";
+            // Linked-files strip shows the file path; keep it in sync.
+            RefreshLinkedFilesUi();
+            // Metadata drawer subtitle ("Metadata · {name}") shown when collapsed.
+            UpdateMetadataDrawerSubtitle();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Linked Files strip
+        // ---------------------------------------------------------------------------------
+
+        private void RefreshLinkedFilesUi()
+        {
+            // JSON side
+            if (string.IsNullOrEmpty(_filePath))
+            {
+                TxtLinkedJsonName.Text = Loc.Get("deeper_editor_unsaved");
+                TxtLinkedJsonPath.Text = "";
+                BtnLinkedJsonOpenFolder.IsEnabled = false;
+            }
+            else
+            {
+                TxtLinkedJsonName.Text = IOPath.GetFileName(_filePath);
+                TxtLinkedJsonPath.Text = _filePath;
+                ToolTip.SetTip(TxtLinkedJsonPath, _filePath);
+                BtnLinkedJsonOpenFolder.IsEnabled = true;
+            }
+
+            // Media side
+            var src = _enhancement?.MediaSource ?? "";
+            var isUrl = src.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                     || src.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+
+            TxtLinkedMediaIcon.Text = _enhancement?.MediaType == MediaTypes.Audio ? "🎵" : "🎬";
+
+            if (string.IsNullOrEmpty(src))
+            {
+                TxtLinkedMediaStatus.Text = "⚠";
+                ToolTip.SetTip(TxtLinkedMediaStatus, Loc.Get("deeper_editor_linked_status_local_missing"));
+                TxtLinkedMediaName.Text = Loc.Get("deeper_editor_linked_no_media");
+                TxtLinkedMediaPath.Text = "";
+                BtnLinkedMediaClear.IsEnabled = false;
+            }
+            else if (isUrl)
+            {
+                TxtLinkedMediaStatus.Text = "🌐";
+                ToolTip.SetTip(TxtLinkedMediaStatus, Loc.Get("deeper_editor_linked_status_url"));
+                string display;
+                try { display = new Uri(src).Host; } catch { display = src; }
+                TxtLinkedMediaName.Text = display;
+                TxtLinkedMediaPath.Text = src;
+                ToolTip.SetTip(TxtLinkedMediaPath, src);
+                BtnLinkedMediaClear.IsEnabled = true;
+            }
+            else
+            {
+                var exists = false;
+                try { exists = File.Exists(src); } catch { }
+                TxtLinkedMediaStatus.Text = exists ? "✓" : "⚠";
+                ToolTip.SetTip(TxtLinkedMediaStatus, exists
+                    ? Loc.Get("deeper_editor_linked_status_local_ok")
+                    : Loc.Get("deeper_editor_linked_status_local_missing"));
+                TxtLinkedMediaName.Text = IOPath.GetFileName(src);
+                TxtLinkedMediaPath.Text = src;
+                ToolTip.SetTip(TxtLinkedMediaPath, src);
+                BtnLinkedMediaClear.IsEnabled = true;
+            }
+        }
+
+        /// <summary>ponytail: needs Helpers.ExplorerLauncher.RevealInExplorer (Windows shell).</summary>
+        private void BtnLinkedJsonOpenFolder_Click(object? sender, RoutedEventArgs e)
+            => Log.Debug("DeeperEditor: reveal-in-file-manager needs a Linux launcher: {Path}", _filePath ?? "");
+
+        /// <summary>ponytail: needs App.EnhancementLibrary + an open dialog.</summary>
+        private void BtnLinkedJsonSwap_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!ConfirmDiscardChanges()) return;
+            Log.Debug("DeeperEditor: swap project needs App.EnhancementLibrary + an open dialog");
+        }
+
+        private void BtnLinkedMediaChange_Click(object? sender, RoutedEventArgs e)
+        {
+            if (MediaChangePopup != null) MediaChangePopup.IsOpen = true;
+        }
+
+        /// <summary>ponytail: needs an open-file dialog.</summary>
+        private void BtnChangeMediaLocal_Click(object? sender, RoutedEventArgs e)
+        {
+            if (MediaChangePopup != null) MediaChangePopup.IsOpen = false;
+            Log.Debug("DeeperEditor: change media (local) needs a file dialog");
+        }
+
+        /// <summary>ponytail: needs UrlPromptDialog.</summary>
+        private void BtnChangeMediaUrl_Click(object? sender, RoutedEventArgs e)
+        {
+            if (MediaChangePopup != null) MediaChangePopup.IsOpen = false;
+            Log.Debug("DeeperEditor: change media (URL) needs UrlPromptDialog");
+        }
+
+        /// <summary>ponytail: needs the media pipeline (re-probe duration, reload the preview) plus
+        /// the same dialogs as the two callers above.</summary>
+        private void ApplyChangedMedia(string newSource, bool isLocal)
+            => Log.Debug("DeeperEditor: ApplyChangedMedia({Source}, local={Local}) needs the media pipeline", newSource, isLocal);
+
+        private void BtnLinkedMediaClear_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_enhancement == null) return;
+            PushUndoSnapshot();
+            _enhancement.MediaSource = "";
+            MarkDirty();
+            RefreshLinkedFilesUi();
+            ShowPlaceholder();
+            ScheduleValidation();
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Drag & drop
+        // ---------------------------------------------------------------------------------
+
+        private void Window_DragOver(object? sender, DragEventArgs e)
+        {
+            e.DragEffects = DragDropEffects.None;
+            var files = e.DataTransfer.TryGetFiles();
+            if (files == null) return;
+            foreach (var f in files)
+            {
+                var p = f.TryGetLocalPath();
+                if (p != null && IsDroppableEditorPath(p)) { e.DragEffects = DragDropEffects.Copy; return; }
+            }
+        }
+
+        /// <summary>ponytail: the accept/reject half is real; loading the dropped file needs
+        /// EnhancementSerializer.Read plus the media pipeline, so the drop logs and returns.</summary>
+        private void Window_Drop(object? sender, DragEventArgs e)
+        {
+            var files = e.DataTransfer.TryGetFiles();
+            if (files == null) return;
+            foreach (var f in files)
+            {
+                var p = f.TryGetLocalPath();
+                if (p == null) continue;
+                if (IsEnhancementJsonPath(p)) { LoadEnhancementFromDrop(p); return; }
+                if (IsLocalMediaFile(p)) { ApplyChangedMedia(p, isLocal: true); return; }
+            }
+        }
+
+        /// <summary>ponytail: needs EnhancementSerializer.Read + ConfirmDiscardChanges' dialog.</summary>
+        private void LoadEnhancementFromDrop(string ccpenhJsonPath)
+            => Log.Debug("DeeperEditor: drop-load needs EnhancementSerializer.Read: {Path}", ccpenhJsonPath);
+
+        private static bool IsDroppableEditorPath(string path)
+            => IsEnhancementJsonPath(path) || IsLocalMediaFile(path);
+
+        private static bool IsLocalMediaFile(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            var ext = IOPath.GetExtension(path).ToLowerInvariant();
+            return IsLocalVideoFile(path)
+                || ext is ".mp3" or ".wav" or ".flac" or ".ogg" or ".m4a" or ".aac";
+        }
+
+        private static bool IsEnhancementJsonPath(string path)
+            => !string.IsNullOrWhiteSpace(path)
+               && path.EndsWith(".ccpenh.json", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>ponytail: needs a modal confirm dialog. Returning true keeps the caller's flow
+        /// intact; the unsaved-changes guard is lost until a dialog exists on this head.</summary>
+        private bool ConfirmDiscardChanges()
+        {
+            if (!_isDirty) return true;
+            Log.Debug("DeeperEditor: discard-changes confirm needs a modal dialog; proceeding");
+            return true;
+        }
+
+        private static bool IsLocalVideoFile(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            var ext = IOPath.GetExtension(path).ToLowerInvariant();
+            return ext is ".mp4" or ".webm" or ".mkv" or ".mov" or ".avi" or ".m4v";
+        }
+
+        private static string FormatTime(double seconds)
+        {
+            if (seconds < 0 || double.IsNaN(seconds)) seconds = 0;
+            var ts = TimeSpan.FromSeconds(seconds);
+            return ts.TotalHours >= 1
+                ? $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}"
+                : $"{ts.Minutes}:{ts.Seconds:D2}";
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Window lifecycle
+        // ---------------------------------------------------------------------------------
+
+        private void DeeperEditorWindow_KeyDown(object? sender, KeyEventArgs e)
+        {
+            // Don't hijack typing inside text fields.
+            var inTextBox = FocusManager?.GetFocusedElement() is TextBox;
+            bool ctrl = (e.KeyModifiers & KeyModifiers.Control) == KeyModifiers.Control;
+            bool shift = (e.KeyModifiers & KeyModifiers.Shift) == KeyModifiers.Shift;
+
+            if (e.Key == Key.Space && !inTextBox)
+            {
+                BtnPlayPause_Click(this, new RoutedEventArgs());
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Home && !inTextBox)
+            {
+                SeekToFraction(0);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.R && !inTextBox && _totalSeconds > 0)
+            {
+                var start = _currentSeconds;
+                var end = Math.Min(_totalSeconds, start + 5);
+                CreateRegion(start, end);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.H && !inTextBox && _totalSeconds > 0)
+            {
+                CreateHapticEventAtPlayhead();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Delete && !inTextBox && _selectionSet.Count > 1)
+            {
+                // Multi-select takes priority - bulk delete everything in the set.
+                DeleteSelection();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Delete && !inTextBox && _selectedRegion != null)
+            {
+                BtnDeleteRegion_Click(this, new RoutedEventArgs());
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Delete && !inTextBox && _selectedHaptic != null)
+            {
+                BtnDeleteHaptic_Click(this, new RoutedEventArgs());
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Delete && !inTextBox && _selectedEffect != null)
+            {
+                BtnDeleteEffect_Click(this, new RoutedEventArgs());
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Escape && !inTextBox && (_selectedRegion != null || _selectedHaptic != null || _selectionSet.Count > 0))
+            {
+                SelectNothing();
+                e.Handled = true;
+            }
+            // Ctrl+Z / Ctrl+Shift+Z (or Ctrl+Y) - undo / redo. The !inTextBox guard keeps standard
+            // text-box undo intact when typing.
+            else if (e.Key == Key.Z && !inTextBox && ctrl)
+            {
+                if (shift) Redo(); else Undo();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Y && !inTextBox && ctrl)
+            {
+                Redo();
+                e.Handled = true;
+            }
+            // Ctrl+C / Ctrl+X / Ctrl+V - clipboard ops on the current selection.
+            else if (e.Key == Key.C && !inTextBox && ctrl && _selectionSet.Count > 0)
+            {
+                CopySelection();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.X && !inTextBox && ctrl && _selectionSet.Count > 0)
+            {
+                CutSelection();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.V && !inTextBox && ctrl)
+            {
+                PasteFromClipboard();
+                e.Handled = true;
+            }
+            // Ctrl+A - select every region/haptic/effect on the timeline.
+            else if (e.Key == Key.A && !inTextBox && ctrl)
+            {
+                SelectAllOnTimeline();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.S && ctrl)
+            {
+                if (shift) MenuSaveAs_Click(this, new RoutedEventArgs());
+                else MenuSave_Click(this, new RoutedEventArgs());
+                e.Handled = true;
+            }
+            else if (e.Key == Key.E && !inTextBox && ctrl)
+            {
+                MenuExportEnhanced_Click(this, new RoutedEventArgs());
+                e.Handled = true;
+            }
+        }
+
+        // Set by the app shell on shutdown to skip the unsaved-changes prompt. A user-initiated
+        // cancel there would block the whole app from exiting.
+        private bool _suppressDirtyPromptOnClose;
+
+        public void ForceClose()
+        {
+            _suppressDirtyPromptOnClose = true;
+            try { Close(); } catch { }
+        }
+
+        /// <summary>ponytail: the unsaved-changes prompt needs a modal dialog (WPF used
+        /// MessageBox.Show with Yes/No/Cancel and could cancel the close). Without one the editor
+        /// closes and the teardown below still runs, so nothing leaks - only the prompt is lost.</summary>
+        private void Window_Closing(object? sender, WindowClosingEventArgs e)
+        {
+            if (_isDirty && !_suppressDirtyPromptOnClose)
+                Log.Debug("DeeperEditor: closing with unsaved changes; no modal prompt on this head");
+            TeardownPreview();
+            DisposePlayback();
+        }
+
+        /// <summary>ponytail: the WPF body detached the WebView2 handlers, exited preview
+        /// fullscreen and disposed the CoreWebView2 environment. WebHost owns its own control's
+        /// lifetime, so only the timers need stopping here.</summary>
+        private void TeardownPreview()
+        {
+            try { _playheadTimer?.Stop(); } catch { }
+            try { _validationTimer?.Stop(); } catch { }
+            try { _htFetchCts?.Cancel(); _htFetchCts?.Dispose(); } catch { }
+            _htFetchCts = null;
+        }
+
+        /// <summary>ponytail: needs LibVLCSharp / NAudio - the WPF body disposed MediaPlayer,
+        /// Media, WaveOutEvent and AudioFileReader.</summary>
+        private void DisposePlayback()
+        {
+            _isPlaying = false;
+            _waveformPeaks = null;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // WebView2 / VLC / NAudio surface
+        //
+        // Every one of these is a member of the WPF window that has no counterpart on this head:
+        // the CoreWebView2 event surface, the borderless-fullscreen preview window (Forms.Screen +
+        // WindowInteropHelper + WS_EX_TOOLWINDOW), and the four player callbacks. They are kept
+        // named and typed against portable signatures rather than deleted, so nothing silently
+        // disappears and the layer that brings a player or a richer WebHost has an exact list of
+        // what to fill in. The framework-typed parameters (CoreWebView2NavigationStartingEventArgs,
+        // MediaPlayerLengthChangedEventArgs, MediaPlayerTimeChangedEventArgs, StoppedEventArgs)
+        // become object?/EventArgs, since naming them would require the very packages this head
+        // must not reference.
+        // ---------------------------------------------------------------------------------
+
+        // The WebView2 preview's own state. Held so the members below read as the port they are.
+        private object? _browserSource;          // ponytail: BrowserVideoTimeSource
+        private bool _browserInitInFlight;
+        private bool _previewBrowserConfigured;
+        private bool _isPreviewFullscreen;
+        private bool _fsTransitionInFlight;
+        private Window? _previewFullscreenWindow;
+
+        /// <summary>ponytail: needs Core's UrlSafety.HostMatches + DeeperConfig.PreviewHostAllowlist,
+        /// both <c>internal</c> to CCP.Core, which does not list CCP.Avalonia in its
+        /// InternalsVisibleTo. Returning false is the safe direction: it denies rather than
+        /// allows. One line to make real once the head is added to that attribute.</summary>
+        private static bool IsAllowedPreviewHost(Uri uri) { _ = uri; return false; }
+
+        /// <summary>ponytail: needs CoreWebView2.NavigationStarting. Gated navigation on
+        /// <see cref="IsAllowedPreviewHost"/> and cancelled anything off the allow-list.</summary>
+        private void OnBrowserNavigationStarting(object? sender, EventArgs e) { }
+
+        /// <summary>ponytail: needs CoreWebView2.WebMessageReceived. Carried the page's
+        /// &lt;video&gt; currentTime and the Ctrl+wheel zoom requests back from injected JS.</summary>
+        private void OnPreviewWebMessageReceived(object? sender, EventArgs e) { }
+
+        /// <summary>ponytail: needs CoreWebView2.ContainsFullScreenElementChanged.</summary>
+        private void OnPreviewFullscreenChanged(object? sender, EventArgs e) { }
+
+        /// <summary>ponytail: part of the fullscreen reparent - detached the WebView2 from whichever
+        /// panel/decorator currently owned it before re-hosting it in the fullscreen window.</summary>
+        private static bool TryDetachFromUiParent(Control child) { _ = child; return false; }
+
+        /// <summary>ponytail: needs Forms.Screen.FromHandle + WindowInteropHelper + a borderless
+        /// topmost window. On Linux the Avalonia parts exist (Screens.ScreenFromVisual,
+        /// SystemDecorations="None", Topmost, ShowInTaskbar=false) but the WebView2 reparent this
+        /// wrapped does not, so the whole path is a stub.</summary>
+        private void EnterPreviewFullscreen() { }
+
+        /// <summary>ponytail: the recovery half of the reparent - put BrowserPreview back into
+        /// PreviewHost if the fullscreen window died without an orderly exit.</summary>
+        private void SafeRestoreBrowserPreviewToHost() { }
+
+        /// <summary>ponytail: the orderly half of the reparent.</summary>
+        private void ExitPreviewFullscreen() { }
+
+        /// <summary>ponytail: needs CoreWebView2.ExecuteScriptAsync - asked the page itself to leave
+        /// fullscreen, so the site's own player chrome stayed consistent.</summary>
+        private void ExitPreviewFullscreenViaScript() { }
+
+        /// <summary>
+        /// Time report from the browser preview. REAL apart from its source: the duration probe and
+        /// the play/pause glyph came off BrowserVideoTimeSource, which is a WPF-head type, but the
+        /// playhead, the read-out and the mid-scrub guard are the WPF logic unchanged. Wire a time
+        /// source to this method and the browser-driven timeline works.
+        /// </summary>
+        private void OnBrowserTimeChanged(double seconds)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => OnBrowserTimeChanged(seconds));
+                return;
+            }
+            if (_isScrubbing) return;
+            // Reparent in progress - touching BrowserPreview now would race the swap.
+            if (_fsTransitionInFlight) return;
+            _currentSeconds = Math.Max(0, seconds);
+            TxtCurrentTime.Text = FormatTime(_currentSeconds);
+            UpdatePlayheadPosition();
+        }
+
+        /// <summary>ponytail: needs LibVLCSharp MediaPlayer.LengthChanged - set _totalSeconds and
+        /// rebuilt every timeline visual against the new duration.</summary>
+        private void OnVlcLengthChanged(object? sender, EventArgs args) { }
+
+        /// <summary>ponytail: needs LibVLCSharp MediaPlayer.TimeChanged - the video half of what
+        /// <see cref="PlayheadTimer_Tick"/> does for audio.</summary>
+        private void OnVlcTimeChanged(object? sender, EventArgs args) { }
+
+        /// <summary>ponytail: needs LibVLCSharp MediaPlayer.EndReached - reset the playhead and the
+        /// play/pause glyph at end of media.</summary>
+        private void OnVlcEndReached(object? sender, EventArgs args) { }
+
+        /// <summary>ponytail: needs NAudio WaveOutEvent.PlaybackStopped - the audio twin of
+        /// <see cref="OnVlcEndReached"/>.</summary>
+        private void OnWaveOutPlaybackStopped(object? sender, EventArgs args) { }
+    }
+}


### PR DESCRIPTION
8,048 lines across nine files, the largest layer in the stack. All six WPF partials ported under their own names, none stubbed wholesale; a seventh file holds the rule inspector and curve editor split out of the 5,159-line main file for readability.

The timeline is real, because Core already owns its models: ruler, lanes, bands, rule pins, playhead, drag and resize, rubber-band multi-select with group drag, clipboard, snapshot undo/redo and validation. Media playback, the web view beyond a Source, and every Win32 call are stubs.

Two defects found that a straight port would have inherited. Avalonia raises TextChanged and SelectionChanged deferred, so WPF's set-flag, assign, clear-in-finally guard had already reopened by the time the echo arrived, which marked a freshly loaded project dirty; every guard site now clears once the events have drained. And the rubber-band hit test had drifted from the geometry it draws, assuming two lanes where the band renders three.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351