### PR TITLE
feat(avalonia): port MainWindow as MainShellWindow

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AccountShell.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AccountShell.cs
@@ -1,0 +1,54 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.AccountShell.cs (506 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (24):
+//   internal void BtnPatreonExclusives_Click(…)
+//   private static bool IsVisualDescendant(…)
+//   internal void ShowAccountSettings(…)
+//   internal void ShowAppInfoPopup(…)
+//   private void BtnAwareness_Click(…)
+//   private async void BtnQuickPatreonLogin_Click(…)
+//   private async Task HandleQuickPatreonLoginAsync(…)
+//   private void UpdateQuickPatreonUI(…)
+//   private async void BtnQuickDiscordLogin_Click(…)
+//   private async Task HandleDiscordLoginAsync(…)
+//   private void SetDiscordButtonsEnabled(…)
+//   private void SetDiscordButtonsContent(…)
+//   private void UpdateQuickDiscordUI(…)
+//   internal void BtnDiscord_Click(…)
+//   internal void ChkDiscordRichPresence_Changed(…)
+//   private bool _syncingLanguageSelectors
+//   private void InitializeLanguageSelector(…)
+//   private void PopulateLanguageCombo(…)
+//   private void CmbLanguagePill_SelectionChanged(…)
+//   internal void ApplyLanguageSelection(…)
+//   private void SyncLanguageSelectors(…)
+//   internal async void BtnCheckUpdates_Click(…)
+//   private async void BtnUpdateAvailable_Click(…)
+//   public void ShowUpdateAvailableButton(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.AccountShell.cs; wired when they move to Core.
+        private void BtnAwareness_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.AccountShell.cs; wired when they move to Core.
+        private void BtnPatreonExclusives_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.AccountShell.cs; wired when they move to Core.
+        private void BtnUpdateAvailable_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.AccountShell.cs; wired when they move to Core.
+        private void CmbLanguagePill_SelectionChanged(object? sender, global::Avalonia.Controls.SelectionChangedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AchievementsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AchievementsTab.cs
@@ -1,0 +1,75 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.AchievementsTab.cs (875 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (48):
+//   private const double AchvBadgePx
+//   private const double AchvRewardIconPx
+//   private static readonly SolidColorBrush AchvMutedBrush
+//   private static readonly SolidColorBrush AchvDimBrush
+//   private static readonly SolidColorBrush AchvTickBrush
+//   private static readonly SolidColorBrush AchvRuleBrush
+//   private static readonly SolidColorBrush AchvPatreonFillBrush
+//   private static readonly SolidColorBrush AchvPatreonEdgeBrush
+//   private static readonly SolidColorBrush AchvPatreonInkBrush
+//   private sealed class AchievementCardParts
+//   private readonly Dictionary<string, ToggleButton> _achievementCards
+//   private readonly Dictionary<ToggleButton, AchievementCardParts> _achievementCardParts
+//   private readonly Dictionary<string, Services.WardrobeItem> _achievementRewards
+//   private readonly List<ToggleButton> _achievementFilterChips
+//   private string _achievementFilter
+//   private const string AchvFilterAll
+//   private const string AchvFilterUnlocked
+//   private const string AchvFilterLocked
+//   private const string AchvFilterRewards
+//   private void BtnAchievements_Click(…)
+//   private void BtnCompanion_Click(…)
+//   private void BtnLeaderboard_Click(…)
+//   internal void BtnViewSeasonRecap_Click(…)
+//   private void UpdateAchievementCount(…)
+//   private void UpdateRewardCount(…)
+//   private void PopulateAchievementGrid(…)
+//   private void BuildAchievementRewardMap(…)
+//   private ToggleButton BuildAchievementCard(…)
+//   private void ApplyAchievementInfoText(…)
+//   private void BuildRewardBand(…)
+//   private FrameworkElement? BuildRewardIcon(…)
+//   private static FrameworkElement CategoryGlyphBox(…)
+//   private static string CategoryGlyph(…)
+//   private void BuildAchievementFilters(…)
+//   private void AchievementFilterChip_Changed(…)
+//   private void ApplyAchievementFilter(…)
+//   private BitmapImage? LoadAchievementImage(…)
+//   private void RefreshAchievementTile(…)
+//   private void RefreshAllAchievementTiles(…)
+//   private void OnAchievementUnlockedInMainWindow(…)
+//   private void ApplyAchievementCardTooltip(…)
+//   private static bool IsAchievementUnlocked(…)
+//   private static string AchName(…)
+//   private static string AchReq(…)
+//   private static string AchFlavor(…)
+//   private static string ModAware(…)
+//   private static string LocFmtOr(…)
+//   private static SolidColorBrush FrozenBrush(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.AchievementsTab.cs; wired when they move to Core.
+        private void BtnAchievements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.AchievementsTab.cs; wired when they move to Core.
+        private void BtnCompanion_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.AchievementsTab.cs; wired when they move to Core.
+        private void BtnLeaderboard_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AmbientFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AmbientFx.cs
@@ -1,0 +1,20 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.AmbientFx.cs (57 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (4):
+//   internal const int AmbientFrameRate
+//   private readonly Dictionary<string, List<AmbientFxCanvas>> _tabFxCanvases
+//   internal void RegisterTabFx(…)
+//   private void SwitchTabFx(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Animations.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Animations.cs
@@ -1,0 +1,22 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Animations.cs (199 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (6):
+//   private void StartSeasonTitleShimmer(…)
+//   private void StopSeasonTitleShimmer(…)
+//   private void StartLockdownPulse(…)
+//   private void StopLockdownPulse(…)
+//   private void StopSkillTreeAnimations(…)
+//   private void RestartSkillTreeAnimations(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Assets.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Assets.cs
@@ -1,0 +1,127 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Assets.cs (2911 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (106):
+//   private ObservableCollection<AssetTreeItem> _assetTree
+//   private ObservableCollection<AssetFileItem> _currentFolderFiles
+//   private AssetTreeItem? _selectedFolder
+//   private void BtnAssets_Click(…)
+//   internal void BtnOpenAssetsFolder_Click(…)
+//   internal void BtnDeleteDownloadedPacks_Click(…)
+//   private async Task RefreshPacksAsync(…)
+//   private void StartPackPreviewRotation(…)
+//   private void StopPackPreviewRotation(…)
+//   private async Task<List<BitmapImage>> LoadPreviewImagesFromUrlsAsync(…)
+//   private static string GetPackPreviewFileStem(…)
+//   private void OnPackDownloadProgress(…)
+//   private void OnPackDownloadCompleted(…)
+//   private void OnPackAuthenticationRequired(…)
+//   private void OnPackRateLimitExceeded(…)
+//   internal void BtnCreatorDiscord_Click(…)
+//   internal void BtnGetPacks_Click(…)
+//   internal void PacksScrollViewer_PreviewMouseWheel(…)
+//   internal void HorizontalScrollViewer_PreviewMouseWheel(…)
+//   internal void InnerScrollViewer_PreviewMouseWheel(…)
+//   internal void BtnRefreshPacks_Click(…)
+//   private void RefreshAssetTree(…)
+//   private AssetTreeItem? BuildPackTree(…)
+//   private AssetTreeItem BuildFolderTree(…)
+//   internal void AssetTreeView_SelectedItemChanged(…)
+//   private void RecalculateFolderCheckState(…)
+//   private void RecalculateAllFolderCheckStates(…)
+//   private void LoadPackFolderThumbnails(…)
+//   private const int MaxThumbnailCacheEntries
+//   private const long MaxThumbnailCacheBytes
+//   private static readonly Dictionary<string, ImageSource> _packThumbnailCache
+//   private static readonly Dictionary<string, long> _packThumbnailLastAccess
+//   private static readonly Dictionary<string, long> _packThumbnailSizes
+//   private static long _packThumbnailCacheBytes
+//   private static long _packThumbnailAccessCounter
+//   private static readonly SemaphoreSlim _thumbnailSemaphore
+//   private async Task LoadPackThumbnailAsync(…)
+//   private void LoadFolderThumbnails(…)
+//   private async Task LoadThumbnailAsync(…)
+//   private bool _isUpdatingFolderCheckState
+//   internal void FolderCheckBox_Changed(…)
+//   private void SetFolderAndChildrenChecked(…)
+//   private void RefreshThumbnailCheckboxes(…)
+//   private void UpdateFolderFilesCheckState(…)
+//   internal void ThumbnailCheckBox_Changed(…)
+//   internal void ThumbnailItem_Click(…)
+//   internal void ThumbnailItem_Preview_Click(…)
+//   internal void ThumbnailItem_OpenInExplorer_Click(…)
+//   private void OpenAssetPreview(…)
+//   private void UpdateFileCheckState(…)
+//   private void UpdateParentFolderCheckState(…)
+//   private void InvalidateAssetPoolsAfterSelectionChange(…)
+//   internal void BtnSelectAllAssets_Click(…)
+//   internal void BtnDeselectAllAssets_Click(…)
+//   private void BtnSaveAssetSelection_Click(…)
+//   private bool _isLoadingPreset
+//   private void InitializeAssetPresets(…)
+//   private void UpdatePresetCountsFromCurrentState(…)
+//   private void CountEnabledFilesRecursive(…)
+//   private void RefreshAssetPresetsComboBox(…)
+//   internal void CmbAssetPresets_SelectionChanged(…)
+//   internal void BtnSaveAssetPreset_Click(…)
+//   internal void BtnUpdateAssetPreset_Click(…)
+//   internal void BtnDeleteAssetPreset_Click(…)
+//   private bool _isLoadingPhrasePreset
+//   private void InitializePhrasePresets(…)
+//   private void RefreshPhrasePresetsComboBox(…)
+//   internal void CmbPhrasePresets_SelectionChanged(…)
+//   internal void BtnSavePhrasePreset_Click(…)
+//   internal void BtnDeletePhrasePreset_Click(…)
+//   private void UpdateAssetCounts(…)
+//   private void CountAssetsRecursive(…)
+//   internal async void BtnPackDownload_Click(…)
+//   internal void BtnPackActivate_Click(…)
+//   private void BtnPackUpgrade_Click(…)
+//   private void BtnPackPatreon_Click(…)
+//   private const string MediaSrcLocal
+//   private const string MediaSrcOnline
+//   private const string MediaSrcMixed
+//   private bool _remotePickerWired
+//   private bool _remotePickerSyncing
+//   private readonly List<ToggleButton> _remoteSourceChipButtons
+//   private readonly List<ToggleButton> _remoteNicheChipButtons
+//   private readonly HashSet<string> _remoteNicheExpanded
+//   private string? _remoteSubPending
+//   private const int RemoteCustomSubCap
+//   private void InitializeRemoteMediaPicker(…)
+//   private void BuildRemoteSourceChips(…)
+//   private void BuildRemoteNicheChips(…)
+//   private void RefreshRemoteMediaPicker(…)
+//   private void RemoteSourceChip_Changed(…)
+//   private bool AskRemoteMediaConsent(…)
+//   private void RemoteNicheChip_Changed(…)
+//   private void SliderRemoteRatio_Changed(…)
+//   private void BtnRemoteAddSub_Click(…)
+//   private void TxtRemoteCustomSub_KeyDown(…)
+//   private async void AddRemoteCustomSub(…)
+//   private void EndRemoteSubProbe(…)
+//   private void ShowRemoteSubError(…)
+//   private void RemoveRemoteCustomSub(…)
+//   private void ToggleRemoteSubSelection(…)
+//   private void PersistRemoteChannelChange(…)
+//   private void RebuildRemoteCustomSubChips(…)
+//   private Border BuildRemoteChip(…)
+//   private void RebuildRemoteNicheSubs(…)
+//   private static TextBlock MutedRemoteNote(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Assets.cs; wired when they move to Core.
+        private void BtnAssets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AssetsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AssetsFx.cs
@@ -1,0 +1,34 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.AssetsFx.cs (226 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (18):
+//   private const double AssetTreeRowNudgePx
+//   private const int AssetTreeRowNudgeMs
+//   private const double PackCardCornerRadius
+//   private const int MediaLogPulseBeats
+//   private const double MediaLogPulseSeconds
+//   private const double MediaLogPulseFloor
+//   private bool _assetsFxInitialized
+//   private CardSheenAdorner? _packCardSheen
+//   private AdornerLayer? _packCardSheenLayer
+//   private FrameworkElement? _packCardSheenHost
+//   private int _mediaLogSeenCount
+//   internal void OnAssetsTabVisibilityChanged(…)
+//   private void InitializeAssetsFx(…)
+//   internal void OnAssetTreeRowHover(…)
+//   internal void OnPackCardHover(…)
+//   private void DetachPackCardSheen(…)
+//   private void PulseMediaLogIfUnseen(…)
+//   private void MediaLogButton_Clicked(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Autonomy.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Autonomy.cs
@@ -1,0 +1,49 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Autonomy.cs (728 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (33):
+//   internal void ChkAutonomyEnabled_Changed(…)
+//   internal void BtnAutonomyStartStop_Click(…)
+//   private void UpdateAutonomyButtonState(…)
+//   public void SyncAutonomyCheckbox(…)
+//   internal void SliderAutonomyIntensity_Changed(…)
+//   internal void SliderAutonomyCooldown_Changed(…)
+//   internal void SliderAutonomyInterval_Changed(…)
+//   internal void ChkAutonomyIdle_Changed(…)
+//   internal void ChkAutonomyRandom_Changed(…)
+//   internal void ChkAutonomyTimeAware_Changed(…)
+//   internal void ChkAutonomyBehavior_Changed(…)
+//   internal void BtnWallpaperFolder_Click(…)
+//   internal void RefreshWallpaperFolderLabel(…)
+//   private void RefreshWallpaperDurationVisibility(…)
+//   internal void ChkWallpaperKeep_Changed(…)
+//   internal void SliderWallpaperDuration_Changed(…)
+//   internal void SliderAutonomyAnnounce_Changed(…)
+//   internal void BtnTestAutonomy_Click(…)
+//   internal void BtnTestVoice_Click(…)
+//   internal void ChkAutonomyVoice_Changed(…)
+//   internal void RefreshAutonomyVoiceHint(…)
+//   internal void ChkAutonomyResume_Changed(…)
+//   internal void ChkShowTakeoverCountdown_Changed(…)
+//   internal void ChkSpeechWakeWord_Changed(…)
+//   internal void TxtSpeechWakeWords_LostFocus(…)
+//   internal void ChkSpeechPushToTalk_Changed(…)
+//   private bool _capturingPttKey
+//   internal void BtnSetPttKey_Click(…)
+//   private void CapturePttKey(…)
+//   private void RestorePttKeyButtonCaption(…)
+//   private void UpdateVoiceModeHints(…)
+//   private void RevertToggle(…)
+//   internal void BtnForceStartAutonomy_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Awareness.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Awareness.cs
@@ -1,0 +1,57 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Awareness.cs (1200 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (41):
+//   private bool _awarenessSubscribed
+//   private void SyncAwarenessTabUI(…)
+//   private bool _presetsChangedSubscribed
+//   private void OnPresetsChanged(…)
+//   private void OnAwarenessTriggerFired(…)
+//   private void RefreshAwarenessPulseFeed(…)
+//   private Border BuildPulseRow(…)
+//   private StackPanel BuildActionChipStrip(…)
+//   private static(…)
+//   private static string FormatTimeAgo(…)
+//   private void UpdateAwarenessStatusIndicator(…)
+//   internal void ChkAwarenessMaster_Changed(…)
+//   internal void ChkAwarenessOcr_Changed(…)
+//   internal void ChkAwarenessKeyboard_Changed(…)
+//   internal void ChkAwarenessIgnoreOwnUi_Changed(…)
+//   private void RefreshAwarenessAppScopeUi(…)
+//   private void RefreshAwarenessSeenAppChips(…)
+//   private void AwarenessSeenAppChip_Click(…)
+//   internal void CmbAwarenessAppScope_SelectionChanged(…)
+//   internal void TxtAwarenessAppList_KeyDown(…)
+//   internal void TxtAwarenessAppList_LostFocus(…)
+//   private void CommitAwarenessAppList(…)
+//   internal void ChkAwarenessIgnoreOwnFocus_Changed(…)
+//   internal void ChkAwarenessLoopProtection_Changed(…)
+//   internal void ChkAwarenessHighlight_Changed(…)
+//   internal void ChkAwarenessHighlightVisibleInCapture_Changed(…)
+//   internal void AwarenessHighlightSwatch_Click(…)
+//   internal void TxtAwarenessHighlightHex_LostFocus(…)
+//   internal void TxtAwarenessHighlightHex_KeyDown(…)
+//   private void ApplyAwarenessHighlightColor(…)
+//   private void SyncAwarenessHighlightSwatchUi(…)
+//   private void AwarenessPresetCard_Click(…)
+//   public void RefreshAwarenessPresetCards(…)
+//   private System.Windows.Controls.Border BuildAwarenessPresetCard(…)
+//   private System.Windows.Controls.Button BuildPresetToggleButton(…)
+//   private System.Windows.Controls.Button BuildPresetTrashButton(…)
+//   private System.Windows.Controls.Border BuildNewPresetCard(…)
+//   private void NewPresetCard_Click(…)
+//   private void UpdateAwarenessAdvancedLinkText(…)
+//   private KeywordTriggerPreset? GetMostRecentlyInstalledPreset(…)
+//   internal void LnkAwarenessAdvanced_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.BankFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.BankFx.cs
@@ -1,0 +1,72 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.BankFx.cs (923 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (56):
+//   private const double BankBoxPadPx
+//   private const double BankBoxMaxPx
+//   private const double BankFallbackOriginDx
+//   private const int BankPollMs
+//   private const double BankWatchdogMs
+//   private const double BankPopScale
+//   private const double BankPopOutMs
+//   private const double BankPopSpringMs
+//   private const double BankPopSpringAmplitude
+//   private const string BankThudOverride
+//   private const string BankThudFallback
+//   private const float BankThudScale
+//   private const string BankThudTag
+//   private BankAccumulator? _bank
+//   private DispatcherTimer? _bankPoll
+//   private readonly Stopwatch _bankClock
+//   private AmbientFxCanvas? _bankLayer
+//   private bool _bankLayerFailed
+//   private Point _bankLayerOrigin
+//   private ScaleTransform? _bankPopTransform
+//   private volatile bool _bankAwardPending
+//   private bool _bankHolding
+//   private double _bankHeldXp
+//   private double _bankHeldNeeded
+//   private int _bankHeldLevel
+//   private bool _bankFlightLive
+//   private double _bankFlightStartedMs
+//   private double _bankFlightPot
+//   private double _bankFlightFrom
+//   private double _bankFlightShown
+//   private int _bankFlightTokens
+//   private int _bankFlightId
+//   internal void InitializeBankFx(…)
+//   internal void ShutdownBankFx(…)
+//   private void OnBankWindowStateish(…)
+//   private void OnBankXpChanged(…)
+//   private void OnBankXpAwarded(…)
+//   internal bool TryHoldXpDisplay(…)
+//   private void ReleaseXpHold(…)
+//   private void StartBankPoll(…)
+//   private DispatcherTimer? CreateBankPoll(…)
+//   private void StopBankPoll(…)
+//   private void OnBankPollTick(…)
+//   private void LaunchBankFlight(…)
+//   private void OnBankTokenLanded(…)
+//   private void AbortBankFlight(…)
+//   private void StepBankCounter(…)
+//   private void PopXpCounter(…)
+//   private void FlashXpBarOnBankLanding(…)
+//   private static void PlayBankThud(…)
+//   private bool TryResolveBankTarget(…)
+//   private bool TryResolveBankOrigin(…)
+//   private bool TryBankAnchorCenter(…)
+//   private bool TryBankAnchorBounds(…)
+//   private static bool IsFiniteBankPoint(…)
+//   private AmbientFxCanvas? EnsureBankLayer(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.BlinkTrainer.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.BlinkTrainer.cs
@@ -1,0 +1,91 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.BlinkTrainer.cs (1537 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (75):
+//   private DispatcherTimer? _blinkTrainerDemoTimer
+//   private int _blinkTrainerDemoIndex
+//   private bool _blinkTrainerDemoUsingA
+//   private List<BitmapImage>? _blinkTrainerDemoAssets
+//   private void EnsureBlinkTrainerDemoAssetsLoaded(…)
+//   private void StartBlinkTrainerDemoLoop(…)
+//   private void BlinkTrainerDemoTimer_Tick(…)
+//   private void StopBlinkTrainerDemoLoop(…)
+//   private void AdvanceBlinkTrainerDemo(…)
+//   internal async void BtnBlinkTrainerStartSession_Click(…)
+//   private enum BlinkTrainerStageMode
+//   private BlinkTrainerStageMode _currentBlinkTrainerStageMode
+//   private bool _blinkTrainerLiveSubscribed
+//   private BlinkTrainerAssetPool? _blinkTrainerLivePool
+//   private string _blinkTrainerLivePoolToken
+//   private string? _blinkTrainerLiveLastPickedPath
+//   private BlinkTrainerStageMode DetermineBlinkTrainerStageMode(…)
+//   private void RefreshBlinkTrainerGate(…)
+//   internal async void BtnBlinkTrainerStartStopTracker_Click(…)
+//   internal async Task ToggleWebcamTrackingAsync(…)
+//   private void ToggleWebcamFromHotkey(…)
+//   private void RefreshBlinkTrainerTrackerButton(…)
+//   internal void BtnBlinkTrainerGateUnlock_Click(…)
+//   private void ApplyBlinkTrainerStageMode(…)
+//   private void ResetBlinkTrainerStageForLive(…)
+//   private void SubscribeBlinkTrainerLiveBlink(…)
+//   private void UnsubscribeBlinkTrainerLiveBlink(…)
+//   private void InvalidateBlinkTrainerLivePool(…)
+//   private BlinkTrainerAssetPool GetOrBuildBlinkTrainerLivePool(…)
+//   private void OnBlinkTrainerStagePreviewBlink(…)
+//   private void ApplyBlinkTrainerLiveImage(…)
+//   private void ApplyBlinkTrainerLiveVideo(…)
+//   internal void BlinkTrainerStageMedia_MediaEnded(…)
+//   private enum BlinkTrainerStatusState
+//   private BlinkTrainerStatusState _currentBlinkTrainerStatusState
+//   private RoutedEventHandler? _blinkTrainerStatusActionHandler
+//   private BlinkTrainerStatusState DetermineBlinkTrainerStatusState(…)
+//   private static bool IsMultiMonitorEnvironment(…)
+//   private static bool HasUsableCalibration(…)
+//   private void RefreshBlinkTrainerStatusRow(…)
+//   private void ApplyBlinkTrainerStatusState(…)
+//   private void SetStartButtonState(…)
+//   private void WireBlinkTrainerStatusAction(…)
+//   private void BlinkTrainerStatusAction_GrantConsent(…)
+//   private void BlinkTrainerStatusAction_AddFolder(…)
+//   private void BlinkTrainerStatusAction_Calibrate(…)
+//   private void RebuildBlinkTrainerFolderCards(…)
+//   private Border BuildBlinkTrainerFolderCard(…)
+//   internal void BtnBlinkTrainerAddFolderCard_Click(…)
+//   private void BtnBlinkTrainerRemoveFolderCard_Click(…)
+//   internal void ToggleBlinkTrainerIncludeVideos_Changed(…)
+//   internal void SliderBlinkTrainerDurationNew_Changed(…)
+//   internal void SliderBlinkTrainerOpacityNew_Changed(…)
+//   private RepeatButton? _blinkTrainerOpacityFillButton
+//   internal void SliderBlinkTrainerOpacityNew_Loaded(…)
+//   private void ApplyBlinkTrainerOpacityFillOpacity(…)
+//   internal void BlinkTrainerSlider_DragStart(…)
+//   internal void BlinkTrainerSlider_DragEnd(…)
+//   internal void BlinkTrainerSlider_LostCapture(…)
+//   private void AnimateBlinkTrainerSliderLabel(…)
+//   internal void BlinkTrainerMixOptionSame_Click(…)
+//   internal void BlinkTrainerMixOptionMix_Click(…)
+//   private void SetMixMode(…)
+//   private void SetMixModeSelection(…)
+//   private void RefreshBlinkTrainerWebcamColumn(…)
+//   internal void BtnBlinkTrainerManageConsent_Click(…)
+//   internal void BtnBlinkTrainerRevokeConsent_Click(…)
+//   internal void BtnBlinkTrainerCalibrate_Click(…)
+//   internal async void BtnBlinkTrainerQuickRecal_Click(…)
+//   internal void BtnDeeperWebcamManageConsent_Click(…)
+//   internal void BtnDeeperWebcamRevokeConsent_Click(…)
+//   internal void BtnDeeperWebcamCalibrate_Click(…)
+//   internal void BtnDeeperWebcamQuickRecal_Click(…)
+//   internal void BtnDeeperWebcamStartStopTracker_Click(…)
+//   private void RefreshDeeperWebcamColumn(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Browser.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Browser.cs
@@ -1,0 +1,87 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Browser.cs (3084 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (66):
+//   private bool _browserInitializing
+//   private bool _browserCorePending
+//   private async System.Threading.Tasks.Task InitializeBrowserAsync(…)
+//   internal async void BrowserLoadingText_Click(…)
+//   private void TearDownBrowserForReinit(…)
+//   private void FocusBrowserSurface(…)
+//   private async System.Threading.Tasks.Task InitAndNavigateAsync(…)
+//   private async System.Threading.Tasks.Task NavigateWhenBrowserReadyAsync(…)
+//   private void OpenUrlExternallyAfterBrowserFailure(…)
+//   private void NotifyBrowserBlockedOffline(…)
+//   private bool IsBrowserShowingKnownSite(…)
+//   internal void SyncSiteRadiosToActiveMod(…)
+//   internal async void BrowserSiteToggle_Click(…)
+//   public bool NavigateToUrlInBrowser(…)
+//   private async Task AutoPlayAndFullscreenVideoAsync(…)
+//   internal void EndWebVideoTakeover(…)
+//   private async Task AutoPlayBambiCloudPlaylistAsync(…)
+//   private void OnBrowserWebMessageReceived(…)
+//   private void HandleBrowserMediaMessage(…)
+//   private void HandleAudioSyncVideoDetected(…)
+//   private void HandleAudioSyncState(…)
+//   private void HandleAudioSyncSeek(…)
+//   private void HandleAudioSyncEnded(…)
+//   private bool _hapticAudioSyncConnHooked
+//   private void HookHapticAudioSyncRearm(…)
+//   private void OnHapticConnectionChangedForAudioSync(…)
+//   private void BtnDiscordTab_Click(…)
+//   internal async void BtnDiscordTabLogin_Click(…)
+//   private void UpdateDiscordTabUI(…)
+//   internal void TxtProfileSearch_KeyDown(…)
+//   internal void BtnProfileSearch_Click(…)
+//   internal void BtnViewMyProfile_Click(…)
+//   internal void BtnClearProfile_Click(…)
+//   private void ClearProfileViewer(…)
+//   private void ProfileDiscordHandle_Click(…)
+//   internal void BtnProfileDiscord_Click(…)
+//   internal async void BtnChangeDisplayName_Click(…)
+//   internal async void BtnDeleteProfile_Click(…)
+//   private bool SearchAndDisplayProfile(…)
+//   private async Task RefreshAndSearchAsync(…)
+//   private void DisplayOwnProfile(…)
+//   private void DisplayProfileEntry(…)
+//   private void ApplyProfileIdentityBadges(…)
+//   private async Task RefreshProfileViewerAsync(…)
+//   private void ResolveProfilePictureUnavailable(…)
+//   private System.Windows.Media.Imaging.BitmapImage? LoadPatreonBadgeImage(…)
+//   private void LoadProfileAchievementImages(…)
+//   private string FormatNumber(…)
+//   internal void BtnMuteBrowser_Click(…)
+//   internal void SyncBrowserMuteIcon(…)
+//   internal async void BtnPopOutBrowser_Click(…)
+//   private void HandleBrowserFullscreenChanged(…)
+//   private Window? _browserFsEscapeTarget
+//   private EventHandler? _browserFsActivated
+//   private EventHandler? _browserFsDeactivated
+//   private System.Windows.Input.KeyEventHandler? _browserFsKeyDown
+//   private void ArmFullscreenEscapes(…)
+//   private void DisarmFullscreenEscapes(…)
+//   internal void ExitBrowserFullscreenForTeardown(…)
+//   public void EnterBrowserFullscreen(…)
+//   private void ExitBrowserFullscreen(…)
+//   private bool _remoteBrowserVideoActive
+//   public void PlayHypnotubeFromRemote(…)
+//   public void StopBrowserVideoFromRemote(…)
+//   private void NavigateBrowserToCurrentSiteHome(…)
+//   internal void BtnReloadBrowser_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Browser.cs; wired when they move to Core.
+        private void BtnDiscordTab_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CatalogueSubmissions.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CatalogueSubmissions.cs
@@ -1,0 +1,30 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CatalogueSubmissions.cs (223 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (14):
+//   public const string CatalogueKindPresets
+//   public const string CatalogueKindSessions
+//   public const string CatalogueKindMods
+//   private static readonly TimeSpan CatalogueCheckThrottle
+//   private readonly Dictionary<string, DateTime> _lastCatalogueCheckUtc
+//   private readonly HashSet<string> _catalogueChecksInFlight
+//   private static bool IsCatalogueAcceptedStatus(…)
+//   private static string CanonicalCataloguePathKey(…)
+//   private static Dictionary<string, DeeperSubmissionRecord>? GetCatalogueDict(…)
+//   internal static DeeperSubmissionRecord? GetCatalogueRecord(…)
+//   private void RecordCatalogueSubmission(…)
+//   public async Task CheckCatalogueSubmissionStatusesAsync(…)
+//   private void NotifyCatalogueSubmissionAccepted(…)
+//   private string ResolveCatalogueDisplayName(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ChromeFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ChromeFx.cs
@@ -1,0 +1,84 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ChromeFx.cs (914 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (63):
+//   private const int TabFadeOutMs
+//   private const int TabFadeInMs
+//   private const double TabSlidePx
+//   private const double NavIconHoverScale
+//   private const int NavIconHoverMs
+//   private const double NavGlowMinOpacity
+//   private const double NavGlowMaxOpacity
+//   private const double NavGlowBreathSeconds
+//   private const double StartGlowMinOpacity
+//   private const double StartGlowMaxOpacity
+//   private const double StartGlowBreathSeconds
+//   private const double StartSheenSeconds
+//   private const int StartSheenIntervalSeconds
+//   private const double BannerSheenSeconds
+//   private const int BannerSheenMinGapSeconds
+//   private const double XpSheenSeconds
+//   private bool _chromeFxInitialized
+//   private bool _chromeFxWindowActive
+//   private string _pendingTabKey
+//   private string _activeTabKey
+//   private UIElement? _activeTabElement
+//   private Button? _navGlowButton
+//   private Button? _navGlowDoor
+//   private FrameworkElement? _navActiveBar
+//   private DispatcherTimer? _startSheenTimer
+//   private DateTime _lastBannerSheenUtc
+//   private DispatcherTimer? _staggerCleanupTimer
+//   private List<FrameworkElement>? _staggeredElements
+//   private double _lastXpShown
+//   private int _lastXpLevelShown
+//   private IEnumerable<Button> NavButtons
+//   internal void InitializeChromeFx(…)
+//   private void OnChromeFxWindowStateish(…)
+//   internal void RefreshChromeFx(…)
+//   private bool ChromeAmbientAllowed
+//   private void ApplyChromeFxLoops(…)
+//   private void AnimateTabIn(…)
+//   private void SlideTabIn(…)
+//   private void FadeOutgoingTab(…)
+//   private static void CollapseOutgoingTab(…)
+//   private static TranslateTransform? EnsureTabTranslate(…)
+//   private static void ResetTabSlide(…)
+//   private void StaggerTabCards(…)
+//   private void StaggerCleanupTimer_Tick(…)
+//   private void CancelStaggerCleanup(…)
+//   private static List<FrameworkElement> FindStaggerTargets(…)
+//   private void NavButton_MouseEnter(…)
+//   private void NavButton_MouseLeave(…)
+//   private void NudgeNavIcon(…)
+//   private static ScaleTransform? EnsureIconScale(…)
+//   private Button? NavButtonForTab(…)
+//   private void ApplyNavActiveGlow(…)
+//   private static FrameworkElement? SetNavIndicator(…)
+//   private void ApplyNavGlowBreath(…)
+//   private void ApplyStartButtonGlow(…)
+//   private void StartSheenHost_SizeChanged(…)
+//   private void SweepStartSheen(…)
+//   private void SweepSheen(…)
+//   private static void ParkSheen(…)
+//   private void AnimateXpDisplay(…)
+//   private void FillXpBarTo(…)
+//   private void ApplyXpSheen(…)
+//   internal void SweepBannerSheen(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.ChromeFx.cs; wired when they move to Core.
+        private void StartSheenHost_SizeChanged(object? sender, global::Avalonia.Controls.SizeChangedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CloudBackup.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CloudBackup.cs
@@ -1,0 +1,22 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CloudBackup.cs (286 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (6):
+//   internal void ReloadSettingsUiAfterRestore(…)
+//   internal async void BtnBackupSettingsNow_Click(…)
+//   internal async void BtnRestoreSettings_Click(…)
+//   internal async void BtnExportData_Click(…)
+//   internal void BtnPrivacyPolicy_Click(…)
+//   private async Task UpdateBackupStatus(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Companion.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Companion.cs
@@ -1,0 +1,27 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Companion.cs (312 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (11):
+//   private void OnCompanionXPAwarded(…)
+//   private void OnCompanionLevelUp(…)
+//   private void OnCompanionXPDrained(…)
+//   private void FlashXpBarOnDrain(…)
+//   private static void FlashOverlay(…)
+//   private void OnCompanionSwitched(…)
+//   private void InitializeAvatarTube(…)
+//   public void ShowAvatarTube(…)
+//   public void HideAvatarTube(…)
+//   public void WakeBambiUp(…)
+//   public void SetAvatarPose(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionFx.cs
@@ -1,0 +1,20 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CompanionFx.cs (95 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (4):
+//   private bool _companionFxInitialized
+//   internal void OnCompanionTabVisibilityChanged(…)
+//   private void InitializeCompanionFx(…)
+//   private void OnCompanionFxModChanged(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionRoom.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionRoom.cs
@@ -1,0 +1,31 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CompanionRoom.cs (410 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (15):
+//   private CompanionRoomRuntimeVm? CompanionRoom
+//   internal void SyncCompanionRoom(…)
+//   private bool _awarenessV2ConsentAsked
+//   internal void EnsureAwarenessV2Consent(…)
+//   internal void SetAvatarEnabled(…)
+//   internal void SetAvatarMuted(…)
+//   internal bool SetSlutMode(…)
+//   internal bool ActivatePersonalityPreset(…)
+//   internal bool SetAwarenessEnabled(…)
+//   internal void SetAwarenessIntensity(…)
+//   internal void SetAiProviderMode(…)
+//   internal void SetCustomApiKey(…)
+//   internal void PromptForDailyRequestLimit(…)
+//   internal void TestCloudConnection(…)
+//   internal void ClearCompanionConversation(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionTab.cs
@@ -1,0 +1,24 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CompanionTab.cs (472 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (8):
+//   private void SyncCompanionTabUI(…)
+//   private void UpdateCompanionCardsUI(…)
+//   private string GetActivePromptDisplayName(…)
+//   private void UpdateCommunityPromptsUI(…)
+//   private FrameworkElement CreatePromptRow(…)
+//   internal void CompanionCard_Click(…)
+//   internal void BtnCompanionPersonality_Click(…)
+//   private void UpdateCompanionPromptLabels(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DashboardFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DashboardFx.cs
@@ -1,0 +1,88 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DashboardFx.cs (1112 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (72):
+//   private const double MosaicFxIntensity
+//   private const int MosaicFogPuffs
+//   private const double LogoDriftScaleTo
+//   private const double LogoDriftSeconds
+//   private const int LogoDriftFrameRate
+//   private const double LogoSheenSeconds
+//   private const int LogoSheenMinGapSeconds
+//   private const int LogoSheenMaxGapSeconds
+//   private const double RailHoverArtNudge
+//   private const int RailHoverMs
+//   private const double DotPulseMinOpacity
+//   private const double DotPulseSeconds
+//   private const double BrowserFrameSweepSeconds
+//   private const double BrowserFrameCycleSeconds
+//   private const double BrowserStatusPulseSeconds
+//   private bool _dashboardFxInitialized
+//   private DispatcherTimer? _logoSheenTimer
+//   private readonly Random _dashboardFxRng
+//   private readonly List<Ellipse> _pulsingRailDots
+//   private TextBlock? _browserStatusWatched
+//   private IEnumerable<FeatureCard> DashboardFeatureCards
+//   private IEnumerable<SplitFeatureCard> DashboardSplitCards
+//   private IEnumerable<FrameworkElement> PremiumRailItems
+//   internal void InitializeDashboardFx(…)
+//   private void ApplyDashboardFxLoops(…)
+//   private const double VaultCtaBreathTo
+//   private const double VaultCtaBreathSeconds
+//   private void ApplyVaultCtaBreath(…)
+//   private const double MysteryGlowRestOpacity
+//   private const double MysteryPopGlowMax
+//   private const double MysteryPopBadgeTo
+//   private static readonly TimeSpan MysteryPopHalfCycle
+//   private const int MysteryFlipHalfMs
+//   private const double MysterySkewDeg
+//   private int _mysterySpinGen
+//   private bool _mysteryShowingReveal
+//   private bool _mysteryWantReveal
+//   private bool _mysteryVisHooked
+//   private bool _mysteryHoverHooked
+//   private bool _mysteryFlipping
+//   private bool _mysteryPopPlaying
+//   private bool MysteryGiftUnopened
+//   private void ApplyMysteryFx(…)
+//   private void ApplyMysteryBreath(…)
+//   private void ApplyMysteryBadgeVisibility(…)
+//   internal void EnsureMysteryTileFx(…)
+//   private void RequestMysteryFace(…)
+//   private void RunMysteryFlip(…)
+//   private void OpenMysteryPlate(…)
+//   private void SettleMysteryPlate(…)
+//   private bool MysteryPointerOverPlate(…)
+//   private void ReconcileMysteryHover(…)
+//   private void SetMysteryFace(…)
+//   private void CancelMysteryReveal(…)
+//   private void StartMysteryPop(…)
+//   private void StopMysteryPop(…)
+//   private void LogoFace_IsVisibleChanged(…)
+//   private void ApplyLogoDrift(…)
+//   private void ApplyLogoSheenTimer(…)
+//   private TimeSpan NextLogoSheenGap(…)
+//   private void SweepLogoSheen(…)
+//   private readonly List<(…)
+//   private void PrepareRailArtNudge(…)
+//   private void RefreshRailArtClones(…)
+//   private void RailItem_MouseEnter(…)
+//   private void RailItem_MouseLeave(…)
+//   private void ApplyRailHover(…)
+//   private void ApplyRailDotPulse(…)
+//   private void ApplyBrowserFrameSweep(…)
+//   private void HookBrowserStatusWatcher(…)
+//   private void BrowserStatus_TextChanged(…)
+//   private void ApplyBrowserStatusPulse(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperFx.cs
@@ -1,0 +1,34 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperFx.cs (207 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (18):
+//   private const double DeeperGlyphDriftY
+//   private const double DeeperGlyphDriftX
+//   private const double DeeperGlyphDriftYSeconds
+//   private const double DeeperGlyphDriftXSeconds
+//   private const int DeeperGlyphFrameRate
+//   private const double DeeperRowLiftPx
+//   private const int DeeperRowLiftMs
+//   private bool _deeperFxInitialized
+//   private TranslateTransform? _deeperGlyphDrift
+//   private AnimationClock? _deeperGlyphClockY
+//   private AnimationClock? _deeperGlyphClockX
+//   private bool DeeperFxOnScreen
+//   internal void OnDeeperTabVisibilityChanged(…)
+//   private void InitializeDeeperFx(…)
+//   private void OnDeeperFxWindowStateish(…)
+//   private void ApplyDeeperGlyphDrift(…)
+//   private void StopDeeperGlyphDrift(…)
+//   internal void OnDeeperRowHover(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperHub.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperHub.cs
@@ -1,0 +1,64 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperHub.cs (528 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (48):
+//   public enum DeeperMediaTypeFilter
+//   public enum DeeperSortMode
+//   public sealed class DeeperLibraryRowVm
+//   public sealed class DeeperAutoTagVm
+//   private readonly List<EnhancementLibraryEntry> _deeperAllEntries
+//   public ObservableCollection<DeeperLibraryRowVm> DeeperFilteredEntries
+//   private string _deeperSearchText
+//   private DeeperMediaTypeFilter _deeperMediaTypeFilter
+//   private bool _deeperFilterHaptics
+//   private bool _deeperFilterWebcam
+//   private DeeperSortMode _deeperSortMode
+//   private DispatcherTimer? _deeperSearchDebounceTimer
+//   private const int DeeperSearchDebounceMs
+//   private bool _deeperHubInitDone
+//   private static bool DeeperEntryMatchesSearch(…)
+//   private static bool DeeperEntryMatchesMediaType(…)
+//   private static bool DeeperEntryHasTag(…)
+//   private IEnumerable<EnhancementLibraryEntry> SortDeeperEntries(…)
+//   private void ApplyDeeperFilterAndSort(…)
+//   private DeeperLibraryRowVm BuildRowVm(…)
+//   private static(…)
+//   private static readonly Brush SubBadgePublishedBg
+//   private static readonly Brush SubBadgePendingBg
+//   private static readonly Brush SubBadgeRejectedBg
+//   private static readonly Brush SubBadgePublishedFg
+//   private static readonly Brush SubBadgePendingFg
+//   private static readonly Brush SubBadgeRejectedFg
+//   private static SolidColorBrush FrozenBrush(…)
+//   private static string FormatRelativeTime(…)
+//   private void UpdateDeeperFilterPillCounts(…)
+//   private void UpdateDeeperEmptyState(…)
+//   internal void DeeperSearch_TextChanged(…)
+//   internal void DeeperPillAll_Click(…)
+//   internal void DeeperPillVideo_Click(…)
+//   internal void DeeperPillAudio_Click(…)
+//   internal void DeeperPillHaptics_Click(…)
+//   internal void DeeperPillWebcam_Click(…)
+//   private void SetDeeperMediaTypeFilter(…)
+//   private void RefreshDeeperPillVisuals(…)
+//   internal void BtnDeeperCatalogue_Click(…)
+//   internal void DeeperSort_SelectionChanged(…)
+//   private static EnhancementLibraryEntry? EntryFromDataContext(…)
+//   internal void DeeperRow_Click(…)
+//   internal void DeeperRowPlay_Click(…)
+//   internal void DeeperRowDelete_Click(…)
+//   internal void DeeperRowSubmit_Click(…)
+//   private void InitializeDeeperHub(…)
+//   private void ReloadDeeperLibraryFromDisk(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperSubmissions.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperSubmissions.cs
@@ -1,0 +1,24 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperSubmissions.cs (183 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (8):
+//   private DateTime _lastSubmissionCheckUtc
+//   private static readonly TimeSpan SubmissionCheckThrottle
+//   private bool _submissionCheckInFlight
+//   private static bool IsAcceptedStatus(…)
+//   private static string CanonicalSubmissionKey(…)
+//   private void RecordDeeperSubmission(…)
+//   public async Task CheckDeeperSubmissionStatusesAsync(…)
+//   private void NotifyDeeperSubmissionAccepted(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperTab.cs
@@ -1,0 +1,74 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperTab.cs (1241 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (53):
+//   internal void BtnDeeper_Click(…)
+//   private void UpdateDeeperWelcomeCardVisibility(…)
+//   private void DismissDeeperWelcomeCard(…)
+//   internal void BtnDeeperWelcomeTour_Click(…)
+//   internal void BtnDeeperWelcomeDemo_Click(…)
+//   internal void BtnDeeperWelcomeDismiss_Click(…)
+//   internal void BtnDeeperTutorial_Click(…)
+//   private void OpenDeeperBundledDemo(…)
+//   private void StartDeeperTabTutorial(…)
+//   internal void ChkEnableDeeper_Changed(…)
+//   private bool _deeperPulseRunning
+//   private void StartDeeperTabPulse(…)
+//   private void StopDeeperTabPulse(…)
+//   internal void BtnDeeperNewEnhancement_Click(…)
+//   internal void BtnDeeperOpenPlayer_Click(…)
+//   private void OnDeeperBrowserBound(…)
+//   private void OnDeeperBrowserUnbound(…)
+//   private bool _browserWebcamStateSubscribed
+//   private Action<WebcamTrackingState>? _onBrowserWebcamStateChanged
+//   private string? _browserWebcamPromptShownForUrl
+//   private void EnsureBrowserWebcamStateSubscribed(…)
+//   private void RefreshBrowserWebcamButton(…)
+//   internal async void BtnWebcamTracking_Click(…)
+//   private static bool BrowserEnhancementNeedsWebcam(…)
+//   private void MaybePromptBrowserWebcamForEnhancement(…)
+//   private bool _mandatoryVideoEnhanceNudgeShown
+//   private async void MaybePromptMandatoryVideoEnhancement(…)
+//   internal void ToggleEnhanceIfPossible_Changed(…)
+//   internal void ChkForceShowBambiCloud_Changed(…)
+//   private void OnBrowserEnhanceMatchChanged(…)
+//   private void OpenDeeperEditor(…)
+//   public void OpenInDeeperPlayer(…)
+//   public void OpenDeeperEditorFromPlayer(…)
+//   public void OpenDeeperEnhancementInPlayer(…)
+//   public void OpenInDeeperEditorForMedia(…)
+//   public void HandlePendingFileOpen(…)
+//   private void OnDeeperLibraryChanged(…)
+//   private void RefreshDeeperLibraryUI(…)
+//   private void OpenDeeperFile(…)
+//   internal void BtnDeeperOpenLibraryFolder_Click(…)
+//   internal void BtnDeeperImport_Click(…)
+//   private static bool IsImportableEnhancementPath(…)
+//   private void ImportEnhancementFiles(…)
+//   private void DeleteDeeperLibraryEntry(…)
+//   private void TriggerCatalogueLookupForNavigation(…)
+//   private async System.Threading.Tasks.Task RunCatalogueLookupAsync(…)
+//   private void ShowCatalogueLookupToast(…)
+//   private void OpenCataloguePickerDialog(…)
+//   private async System.Threading.Tasks.Task DownloadAndOpenCatalogueEntryAsync(…)
+//   private void SwitchToDeeperLibraryTab(…)
+//   private static bool IsCatalogueEligible(…)
+//   private async Task SubmitDeeperLibraryEntryAsync(…)
+//   private void ShowCatalogueSubmissionResultToast(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.DeeperTab.cs; wired when they move to Core.
+        private void BtnDeeper_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DescentFuse.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DescentFuse.cs
@@ -1,0 +1,30 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DescentFuse.cs (275 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (14):
+//   private static readonly Color FuseGold
+//   private static readonly Brush FuseGoldBrush
+//   private static readonly Brush FuseNeutralDigits
+//   private TextBlock? _fuseTooltipDigits
+//   private int _fuseLastDimStep
+//   private bool _fuseBreathing
+//   private static Brush Freeze(…)
+//   internal static void RestoreFuseChrome(…)
+//   private void InitializeDescentFuse(…)
+//   private void OnFusePhaseChanged(…)
+//   private void OnFuseTick(…)
+//   private void ApplyFusePhase(…)
+//   private void ApplyFusePresence(…)
+//   private object BuildFuseTooltip(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Enhancements.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Enhancements.cs
@@ -1,0 +1,57 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Enhancements.cs (2318 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (41):
+//   private const double NodeWidth
+//   private const double NodeHeight
+//   private const double TierSpacing
+//   private const double SecretCardWidth
+//   private const double SecretCardHeight
+//   private void RefreshEnhancementsUI(…)
+//   private void DrawSkillTree(…)
+//   private void CreateSkillTreeHeader(…)
+//   private LinearGradientBrush CreateAnimatedSkillTreeBrush(…)
+//   private void DrawConnectionLines(…)
+//   private Border CreateSkillNode(…)
+//   private LinearGradientBrush CreateSkillPlaceholderGradient(…)
+//   private void AddProSection(…)
+//   private static string FormatProMinutes(…)
+//   private static TextBlock ProLabel(…)
+//   private static TextBlock ProValue(…)
+//   private static readonly Color ChartInkDim
+//   private static readonly Color ChartInk
+//   private static readonly Color ChartBaseline
+//   private static readonly Color ChartPink
+//   private static readonly Color ChartGold
+//   private static readonly Color ChartSurface
+//   private static readonly Color ChartCellIdle
+//   private List<(…)
+//   private static string SeasonMonthLabel(…)
+//   private UIElement BuildSeasonBarChart(…)
+//   private UIElement BuildLevelSparkline(…)
+//   private UIElement BuildActivityHeatmap(…)
+//   private static TextBlock ProChartTitle(…)
+//   private UIElement BuildProLifetimePanel(…)
+//   private UIElement BuildSeasonRewindPanel(…)
+//   private UIElement BuildBestieRecordsPanel(…)
+//   private UIElement BuildBrainDrainPanel(…)
+//   private void PopulateSecretSkills(…)
+//   private Border CreateHiddenSecretCard(…)
+//   private Border CreateSecretSkillCard(…)
+//   private async void SkillCard_Click(…)
+//   private void RefreshActiveBonuses(…)
+//   private void OnPinkRushStarted(…)
+//   private void OnPinkRushEnded(…)
+//   private void OnLuckyProc(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.EnhancementsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.EnhancementsFx.cs
@@ -1,0 +1,37 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.EnhancementsFx.cs (256 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (21):
+//   private const double SkillTreeFxIntensity
+//   private const double OwnedNodeGlowMinOpacity
+//   private const double OwnedNodeGlowMaxOpacity
+//   private const double OwnedNodeGlowSeconds
+//   private const double SkillNodeHoverScale
+//   private const int SkillNodeHoverInMs
+//   private const int SkillNodeHoverOutMs
+//   private bool _enhancementsFxInitialized
+//   private readonly List<DropShadowEffect> _ownedNodeGlows
+//   private AnimationClock? _ownedNodeGlowClock
+//   private static bool EnhancementsAmbientAllowed
+//   private bool EnhancementsFxOnScreen
+//   private void EnsureEnhancementsFx(…)
+//   private void OnEnhancementsFxWindowStateish(…)
+//   private void OnEnhancementsTabVisibilityChanged(…)
+//   private void ApplyEnhancementsFxLoops(…)
+//   private void ResetOwnedNodeGlows(…)
+//   private void RegisterOwnedNodeGlow(…)
+//   private void ApplyOwnedNodeBreath(…)
+//   private void StopOwnedNodeGlowClock(…)
+//   private void ApplySkillNodeHover(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.EventFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.EventFx.cs
@@ -1,0 +1,44 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs (460 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (28):
+//   private const double BurstBoxPx
+//   private const int LevelUpBurstCount
+//   private const int AchievementBurstCount
+//   private const int QuestBurstCount
+//   private const int ProgramDayBurstCount
+//   private const int EnhancementBurstCount
+//   private const int PrestigeBurstCount
+//   private const double PrestigeSheenSeconds
+//   private const double PrestigeSheenPeak
+//   private const int AchievementRevealMs
+//   private const double AchievementRevealBlurRadius
+//   private const double AchievementRevealScale
+//   private AmbientFxCanvas? _eventBurstLayer
+//   private bool _eventBurstLayerFailed
+//   private Border? _prestigeRowBorder
+//   private static long PrestigeRankNow(…)
+//   private bool EventFxAllowed
+//   private AmbientFxCanvas? EnsureEventBurstLayer(…)
+//   internal bool FireBurstAt(…)
+//   private void FireBurstAtFirstVisible(…)
+//   internal void CelebrateLevelUp(…)
+//   internal void CelebrateAchievementUnlock(…)
+//   private void RevealAchievementTile(…)
+//   internal void CelebrateQuestComplete(…)
+//   private Views.Controls.DailyQuestCard? FindDailyCard(…)
+//   internal void CelebrateProgramDayComplete(…)
+//   internal void CelebrateEnhancementPurchase(…)
+//   internal void CelebratePrestige(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Exclusives.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Exclusives.cs
@@ -1,0 +1,64 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Exclusives.cs (1296 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (48):
+//   private sealed class ExclusiveCardUi
+//   private readonly List<ExclusiveCardUi> _exclusiveCards
+//   private readonly List<TextBlock> _exclusiveTeaserMarks
+//   private readonly List<Border> _exclusiveTeaserCards
+//   private readonly List<(…)
+//   private readonly List<DropShadowEffect> _exclusiveAccentShadows
+//   private bool _exclusivesBuilt
+//   private bool _exclusivesSheenRetryQueued
+//   private Storyboard? _spotFreeFx
+//   private static readonly FontFamily FredokaFont
+//   private static readonly Color FreeTodayGold
+//   private static SolidColorBrush Freeze(…)
+//   private static Color VaultAccent(…)
+//   private const byte TeaserMarkAlpha
+//   private const double VaultPartnerHueShift
+//   internal static Color VaultPartner(…)
+//   private static Color VaultPartner(…)
+//   internal static Color ShiftHue(…)
+//   private static SolidColorBrush ExclusiveEdgeDefault(…)
+//   private static SolidColorBrush SpotlightEdgeDefault(…)
+//   private LinearGradientBrush AccentGradient(…)
+//   private DropShadowEffect AccentTitleShadow(…)
+//   private static bool IsExclusiveFreeToday(…)
+//   internal void OpenExclusiveSpotlight(…)
+//   private void EnsureExclusivesBuilt(…)
+//   private void ApplySpotlightArt(…)
+//   private Border BuildExclusiveCard(…)
+//   private Border BuildComingSoonCard(…)
+//   private static string TeaserEmoji(…)
+//   private static void OnExclusiveCardHover(…)
+//   internal void RefreshExclusivesTab(…)
+//   private void RetintVaultChrome(…)
+//   private static void TintShadow(…)
+//   private static void TintGradient(…)
+//   private void ApplyExclusiveCardState(…)
+//   private static void ApplyVeilLockBreath(…)
+//   private static Storyboard? ApplyFreeTodayPulse(…)
+//   private void RefreshExclusiveTierPlates(…)
+//   private void StartExclusivesMotion(…)
+//   private void StopExclusivesMotion(…)
+//   private int _exclusivesSheenRetries
+//   private void RestartExclusiveSheens(…)
+//   private void AttachExclusiveSheens(…)
+//   private static string ExclusiveTitle(…)
+//   private static string ExclusiveArtPath(…)
+//   private const int ExclusiveCardDecodeWidth
+//   private const int ExclusiveHeroDecodeWidth
+//   private static ImageSource? LoadPackImage(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Haptics.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Haptics.cs
@@ -1,0 +1,94 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Haptics.cs (1158 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (78):
+//   private bool _hapticsTabBuilt
+//   private readonly ObservableCollection<HapticProviderChipVm> _hapticProviderChips
+//   private readonly ObservableCollection<HapticRoutingGroupVm> _hapticRoutingGroups
+//   private readonly ObservableCollection<HapticToyCardVm> _hapticToyCards
+//   private string _hapticToyCardsShape
+//   private readonly HapticRowExpansionScope _hapticRowScope
+//   private DispatcherTimer? _hapticSliderDebounce
+//   private DispatcherTimer? _hapticLiveStatusTimer
+//   private static HapticSettings HapticCfg
+//   internal void InitializeHapticsTab(…)
+//   private void OnHapticRoutingRowChanged(…)
+//   private void OnHapticDevicesChanged(…)
+//   private void OnHapticConnectionChanged(…)
+//   private void OnHapticActivity(…)
+//   private void HapticsRunOnUi(…)
+//   private static void SafeRun(…)
+//   internal void RefreshHapticToys(…)
+//   private static string BuildHapticToyShapeSignature(…)
+//   internal void RefreshHapticConnectionUi(…)
+//   internal void RefreshAudioSyncCardVisibility(…)
+//   private void OnHapticsTabVisibilityChanged(…)
+//   private void StartHapticLiveStatusTimer(…)
+//   private void StopHapticLiveStatusTimer(…)
+//   internal void RefreshHapticLiveStatus(…)
+//   internal void RefreshHapticRoutingRows(…)
+//   internal void LoadHapticsSettingsToUi(…)
+//   private void LoadHapticTemperamentToUi(…)
+//   private void LoadHapticToyInputToUi(…)
+//   private void ApplyHapticToyInputEnabledState(…)
+//   private static void SetSliderEnabled(…)
+//   private void LoadHapticMediaExtrasToUi(…)
+//   private void LoadHapticAudioDspToUi(…)
+//   private static void SetDspSlider(…)
+//   private static string FormatDsp(…)
+//   internal void ChkHapticsEnabled_Changed(…)
+//   internal void ChkHapticProvider_Changed(…)
+//   internal void TxtHapticUrl_TextChanged(…)
+//   internal void TxtHapticIntifaceUrl_TextChanged(…)
+//   internal void ChkHapticAutoConnect_Changed(…)
+//   internal async void BtnHapticConnect_Click(…)
+//   internal void BtnHapticPanic_Click(…)
+//   internal async void BtnHapticTest_Click(…)
+//   internal async void BtnHapticToyTest_Click(…)
+//   internal void BtnHapticsHelp_Click(…)
+//   internal void SliderHapticIntensity_ValueChanged(…)
+//   internal void SliderHapticMaxPower_ValueChanged(…)
+//   internal void SliderHapticDtrhAmbient_Changed(…)
+//   internal void CmbHapticDtrhDensity_SelectionChanged(…)
+//   private RadioButton?[] HapticTemperamentChips
+//   internal void RbHapticTemperament_Checked(…)
+//   internal void ChkHapticToyInput_Changed(…)
+//   internal void ChkHapticToyAttentionCheck_Changed(…)
+//   internal void SliderHapticOverrideCooldown_Changed(…)
+//   internal void ChkHapticFunScript_Changed(…)
+//   internal void ChkHapticFunScriptVibe_Changed(…)
+//   internal void ChkHapticLuminance_Changed(…)
+//   internal void SliderHapticLuminance_Changed(…)
+//   internal void ChkHapticBandSplit_Changed(…)
+//   internal void SliderDspSensitivity_Changed(…)
+//   internal void SliderDspSmoothing_Changed(…)
+//   internal void SliderDspBass_Changed(…)
+//   internal void SliderDspRms_Changed(…)
+//   internal void SliderDspOnset_Changed(…)
+//   internal void SliderDspMax_Changed(…)
+//   private void OnDspSliderChanged(…)
+//   internal void BtnDspReset_Click(…)
+//   internal void SliderVideoHapticDelay_Changed(…)
+//   internal void SliderVideoHapticPower_Changed(…)
+//   internal void SliderAudioSyncLatency_Changed(…)
+//   internal void SliderAudioSyncIntensity_Changed(…)
+//   internal void CmbPatternMode_SelectionChanged(…)
+//   internal void SliderPatternIntensity_Changed(…)
+//   internal void PatternPreviewCanvas_SizeChanged(…)
+//   private VibrationMode SelectedPatternMode
+//   private double SelectedPatternIntensity
+//   private void UpdateHapticPatternPreview(…)
+//   private void RefreshPatternToyPicker(…)
+//   internal async void BtnPatternPlay_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.HeroFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.HeroFx.cs
@@ -1,0 +1,78 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.HeroFx.cs (789 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (62):
+//   private const double StartChargeDriftSeconds
+//   private const double StartExhaleCycleSeconds
+//   private const double StartExhaleTravelSeconds
+//   private const double StartExhalePeakOpacity
+//   private const double StartExhaleGrowPx
+//   private const double StartBurstAGrowPx
+//   private const double StartBurstBGrowPx
+//   private const int StartBurstAMs
+//   private const int StartBurstBMs
+//   private const int StartBurstStaggerMs
+//   private const double StartBurstPeakOpacity
+//   private const int StartDipMs
+//   private const double StartDipScale
+//   private const int StartIgnitionFlashMs
+//   private const double StartIgnitionFlashPeak
+//   private const double StartHeartbeatGrowPx
+//   private const double StartHeartbeatSeconds
+//   private const double StartCtaFallbackWidth
+//   private const double StartCtaHeight
+//   private const int XpMeniscusSlideMs
+//   private const double XpMeniscusPulseSeconds
+//   private const double XpMeniscusMinOpacity
+//   private const double XpMeniscusMaxOpacity
+//   private const double XpMeniscusRestOpacity
+//   private const double XpMeniscusMinFillPx
+//   private const int LevelChipPopMs
+//   private const double LevelChipPopScale
+//   private const double LevelChipPopDegrees
+//   private const int SaveTickDrawMs
+//   private const int SaveRippleMs
+//   private const double SaveRippleGrowPx
+//   private const double SaveAbsorbHoldMs
+//   private const double SaveAbsorbFadeMs
+//   private const double SaveButtonHeight
+//   private LinearGradientBrush? _startChargeBrush
+//   private GradientStop[]? _startChargeStops
+//   private object? _startChargeRestore
+//   private bool _startChargeApplied
+//   private bool _startDipInFlight
+//   private double _xpMeniscusFillWidth
+//   private void InitializeHeroFx(…)
+//   private void ApplyHeroFxLoops(…)
+//   internal void ApplyStartHeroState(…)
+//   private void ApplyStartCharge(…)
+//   private void ReleaseStartCharge(…)
+//   private LinearGradientBrush? EnsureStartChargeBrush(…)
+//   private void TintStartCharge(…)
+//   private void ApplyStartRingExhale(…)
+//   private static DoubleAnimationUsingKeyFrames ExhaleScale(…)
+//   private void StopStartRingExhale(…)
+//   private static void ParkRing(…)
+//   internal void FlashStartIgnition(…)
+//   private static void FireStartRing(…)
+//   private void ApplyStartHeartbeat(…)
+//   private double StartCtaWidth
+//   private static double GrowFactor(…)
+//   private void AnimateXpMeniscus(…)
+//   private void ApplyXpMeniscusPulse(…)
+//   internal void PopLevelChip(…)
+//   internal void FlashSaveAbsorb(…)
+//   private static(…)
+//   private static Color FromHsv(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.HomeAudio.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.HomeAudio.cs
@@ -1,0 +1,24 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.HomeAudio.cs (185 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (8):
+//   private bool _homeAudioMirroring
+//   internal void HomeSliderMaster_Changed(…)
+//   internal void HomeChkAudioDuck_Changed(…)
+//   internal void HomeSliderVideoVolume_Changed(…)
+//   internal void HomeSliderDuck_Changed(…)
+//   internal void HomeChkExcludeBambiCloudDucking_Changed(…)
+//   internal void HomeCmbAudioOutputDevice_SelectionChanged(…)
+//   internal void MirrorAudioToHome(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.JustDrop.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.JustDrop.cs
@@ -1,0 +1,21 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.JustDrop.cs (138 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (5):
+//   private const int JustDropCheckDelayMs
+//   private bool _justDropDoorHooked
+//   private void InitializeJustDropDoor(…)
+//   private void OnJustDropAvailabilityChanged(…)
+//   private void ApplyJustDropDoorVisibility(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.KeywordTriggers.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.KeywordTriggers.cs
@@ -1,0 +1,38 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.KeywordTriggers.cs (622 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (22):
+//   internal void SliderKeywordBufferTimeout_ValueChanged(…)
+//   internal void SliderAwarenessGlobalCooldown_ValueChanged(…)
+//   internal void SliderAwarenessSameWordCooldown_ValueChanged(…)
+//   internal void SliderKeywordSessionMultiplier_ValueChanged(…)
+//   internal void SliderScreenOcrInterval_ValueChanged(…)
+//   internal void SliderKeywordHighlightDuration_ValueChanged(…)
+//   internal void CmbOcrHighlightMode_SelectionChanged(…)
+//   internal void CmbOcrConfirmation_SelectionChanged(…)
+//   internal void BtnAddKeywordTrigger_Click(…)
+//   internal void BtnImportFromCustomTriggers_Click(…)
+//   private void BtnDeleteKeywordTrigger_Click(…)
+//   private void ChkKeywordTriggerEnabled_Changed(…)
+//   private void TxtKeywordTriggerKeyword_LostFocus(…)
+//   private void BtnKeywordTriggerBrowseAudio_Click(…)
+//   private void CmbKeywordVisualEffect_SelectionChanged(…)
+//   private void SliderKeywordTriggerCooldown_ValueChanged(…)
+//   private void SliderKeywordTriggerVolume_ValueChanged(…)
+//   private void ChkKeywordTriggerHaptic_Changed(…)
+//   private void ChkKeywordTriggerDuckAudio_Changed(…)
+//   private void RefreshKeywordTriggerList(…)
+//   internal void SyncKeywordRescuePanelUi(…)
+//   private Border CreateKeywordTriggerRow(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Lab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Lab.cs
@@ -1,0 +1,68 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Lab.cs (1354 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (47):
+//   private void InitializeLockdown(…)
+//   internal void BtnActivateLockdown_Click(…)
+//   internal void BtnStartQuiz_Click(…)
+//   internal void BtnStartIntake_Click(…)
+//   internal void BtnStartBureau_Click(…)
+//   internal void BtnStartGoon_Click(…)
+//   internal void BtnStartChaos_Click(…)
+//   internal void OpenFypFeed(…)
+//   internal void BtnStartArcademy_Click(…)
+//   internal void BtnQuickStartChaos_Click(…)
+//   private bool _intakePassHooked
+//   internal void RefreshGradedIntakeGate(…)
+//   private void SetGradedIntakeGateCopy(…)
+//   private void EnsureIntakePassHooked(…)
+//   private void OnIntakePassStateChanged(…)
+//   private void RefreshPastQuizzes(…)
+//   internal void ChkPopQuizEnabled_Changed(…)
+//   internal void SliderPopQuizFrequency_ValueChanged(…)
+//   internal void BtnTestPopQuiz_Click(…)
+//   private void OnLockdownActivated(…)
+//   private void OnLockdownDeactivated(…)
+//   private void OnLockdownTick(…)
+//   private static string FormatLockdownClock(…)
+//   private void SetLockdownBadge(…)
+//   private void LockdownBadge_Click(…)
+//   internal void TxtLockdownTimer_Click(…)
+//   internal void TxtLockdownExit_KeyDown(…)
+//   private Action<PossessionRung>? _possessionRungHandler
+//   private static readonly Color PossessionEmber
+//   private static readonly Color PossessionEmberDim
+//   private void HookPossessionReadout(…)
+//   private void DetachPossessionRungHandler(…)
+//   private void UnhookPossessionReadout(…)
+//   private void UpdatePossessionReadout(…)
+//   private Action<string>? _lockdownRestartHandler
+//   private void HookLockdownRestart(…)
+//   private void UnhookLockdownRestart(…)
+//   private void OnLockdownTimerRestarted(…)
+//   internal void PreviewShowLockdownActivePanel(…)
+//   private void ShowPossessionRulesIfFirstTime(…)
+//   private static readonly Color LockdownCrimson
+//   private static readonly Color LockdownDarkRed
+//   private static readonly Color LockdownPanelBg
+//   private static readonly Color LockdownWindowBg
+//   private void ApplyLockdownTheme(…)
+//   private void RestoreLockdownTheme(…)
+//   private void PlayLockdownActivationAnimation(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Lab.cs; wired when they move to Core.
+        private void LockdownBadge_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.LabTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.LabTab.cs
@@ -1,0 +1,103 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs (1413 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (79):
+//   private bool _webcamDebugSubscribed
+//   private int _webcamDebugBlinkCount
+//   private int _webcamDebugMouthOpenCount
+//   private int _webcamDebugTongueOutCount
+//   private GazeSide _webcamDebugLastGaze
+//   private bool _webcamDebugLastGazeSet
+//   private string _webcamDebugFaceLabel
+//   private Action<WebcamTrackingState>? _onDebugStateChanged
+//   private Action? _onDebugFaceFound
+//   private Action? _onDebugFaceLost
+//   private Action? _onDebugBlink
+//   private Action? _onDebugMouthOpen
+//   private Action? _onDebugTongueOut
+//   private Action<GazeSide>? _onDebugGazeSide
+//   private Action<WebcamTrackingState>? _onPillStateChanged
+//   private EventHandler<bool>? _onMicListeningChanged
+//   private EventHandler<bool>? _onWakeListeningChanged
+//   private void WireMicActivePill(…)
+//   internal void UpdateMicPill(…)
+//   private void MicActivePill_Click(…)
+//   private void WireWebcamActivePill(…)
+//   private const int RapidBlinkRecalCount
+//   private const int RapidBlinkRecalWindowMs
+//   private readonly Queue<DateTime> _rapidBlinkTimes
+//   private Action? _onRapidBlinkRecal
+//   private bool _rapidBlinkRecalInProgress
+//   private void WireRapidBlinkRecalibrateShortcut(…)
+//   private async Task TriggerRapidBlinkRecalibrateAsync(…)
+//   private void StopAllForRecalibration(…)
+//   private bool _syncingBlinkRecalToggles
+//   internal void ChkBlinkRecalShortcut_Changed(…)
+//   private void SyncBlinkRecalToggles(…)
+//   private void UpdateLabTrackerUi(…)
+//   private void UpdateWebcamStatusChips(…)
+//   private static string WebcamStateText(…)
+//   internal void OpenDeviceSettings(…)
+//   internal void RefreshDeviceSettingsLists(…)
+//   private string? _quickRecalTooltipBase
+//   private void RefreshQuickRecalHotkeyHint(…)
+//   private void WebcamActivePill_Click(…)
+//   internal async void BtnWebcamDebugStart_Click(…)
+//   private async Task<bool> StartWebcamOffUiThreadAsync(…)
+//   private WebcamLoadingSplash? _webcamLoadingSplash
+//   private Action<double, string>? _onWebcamStartupProgress
+//   private Action<WebcamTrackingState>? _onWebcamStartupState
+//   private void InstallWebcamLoadingSplash(…)
+//   private void EnsureWebcamDebugSubscribed(…)
+//   private void UnsubscribeWebcamDebug(…)
+//   private void UpdateWebcamDebugCounters(…)
+//   internal async void BtnWebcamDebugCalibrate_Click(…)
+//   internal void BtnGazeMinigame_Click(…)
+//   private bool _focusGazeSyncing
+//   private void HookFocusGazeService(…)
+//   private void SyncFocusGazeToggle(…)
+//   internal async void ChkFocusGaze_Changed(…)
+//   private DispatcherTimer? _blinkTrainerTickTimer
+//   private void HookBlinkTrainerService(…)
+//   private void OnBlinkTrainerServiceStateChanged(…)
+//   private void SyncBlinkTrainerCountdownTimer(…)
+//   private void BlinkTrainerTick(…)
+//   internal void BtnLabBlinkTrainerOpenNew_Click(…)
+//   internal async void BtnWebcamDebugTrackerTest_Click(…)
+//   internal async void BtnWebcamDebugQuickRecal_Click(…)
+//   internal void BtnWebcamReviewPrivacy_Click(…)
+//   internal void BtnWebcamRevokeConsent_Click(…)
+//   internal void ChkWebcamDebugCursor_Changed(…)
+//   internal void ChkWebcamDriftCorrection_Changed(…)
+//   internal void ChkRestrictGazeToCalScreen_Changed(…)
+//   private bool _webcamDevicePopulating
+//   private void PopulateWebcamDeviceCombos(…)
+//   private static void PopulateWebcamCombo(…)
+//   private void RefreshWebcamDeviceList(…)
+//   internal void CmbWebcamDevice_SelectionChanged(…)
+//   internal void BtnWebcamDeviceRefresh_Click(…)
+//   private bool _webcamMonitorPopulating
+//   private void RefreshWebcamMonitorList(…)
+//   private static void FillMonitorCombo(…)
+//   internal void CmbWebcamMonitor_SelectionChanged(…)
+//   private void AppendWebcamDebugLog(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.LabTab.cs; wired when they move to Core.
+        private void MicActivePill_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.LabTab.cs; wired when they move to Core.
+        private void WebcamActivePill_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Leaderboard.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Leaderboard.cs
@@ -1,0 +1,70 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs (1452 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (54):
+//   private List<Services.LeaderboardEntry> _leaderboardRanked
+//   private string _leaderboardSortKey
+//   private string _leaderboardFilter
+//   private string _leaderboardSearch
+//   private int? _youPreviousRank
+//   private bool _youPreviousRankKnown
+//   private static int EarnableAchievementCount
+//   internal async void BtnRefreshLeaderboard_Click(…)
+//   internal void LeaderboardSortHeader_Click(…)
+//   internal void LeaderboardSearch_TextChanged(…)
+//   internal void LeaderboardFilter_Checked(…)
+//   internal void BtnJumpToMe_Click(…)
+//   private void SetLeaderboardStatus(…)
+//   private int _lbFxGeneration
+//   private readonly List<FrameworkElement> _lbFxDecorated
+//   private ScrollViewer? _lbFxScroller
+//   private bool? _lbFxClipWas
+//   private static readonly DependencyProperty LbScrollOffsetProperty
+//   private static void OnLbScrollOffsetChanged(…)
+//   private Color LeaderboardAccentColor(…)
+//   private static T? FindVisualDescendant<T>(…)
+//   private void JumpToMyRow(…)
+//   private static double? TryMeasureCenteredOffset(…)
+//   private void QueueCenterAndPulse(…)
+//   private void PulseMyRow(…)
+//   private void BounceToBoardEnd(…)
+//   private void PlayOverscrollBounce(…)
+//   private const double BounceOvershootPx
+//   private void PulseYouBar(…)
+//   private void PulseElement(…)
+//   private void ClearFxDecoration(…)
+//   private static void StripFxDecoration(…)
+//   private void CancelJumpToMeFx(…)
+//   private void AnimateScrollOffset(…)
+//   private static string OutsideBoardMessage(…)
+//   private void UpdateYourRankDisplay(…)
+//   internal async void BtnLeaderboardMode_Click(…)
+//   private void UpdateLeaderboardModeButtons(…)
+//   private void ApplyLeaderboardTheme(…)
+//   internal void BtnLeaderboardDiscord_Click(…)
+//   internal void LstLeaderboard_MouseDoubleClick(…)
+//   private async Task RefreshLeaderboardAsync(…)
+//   private void RankLeaderboardEntries(…)
+//   private void ApplyLeaderboardSort(…)
+//   private void RebuildLeaderboardView(…)
+//   private static int TierIndexForRank(…)
+//   private static readonly string[] TierNameKeys
+//   private static readonly string[] TierSubKeys
+//   private static readonly int[] TierLowerBounds
+//   private static readonly int[] TierUpperBounds
+//   private static LeaderboardTierBand BuildTierBand(…)
+//   private void UpdateYouBar(…)
+//   private static string FormatCompact(…)
+//   private void UpdateTrophyCaseColumns(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.LeaderboardFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.LeaderboardFx.cs
@@ -1,0 +1,46 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.LeaderboardFx.cs (405 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (30):
+//   private const double PodiumGlowMinOpacity
+//   private const double PodiumGlowMaxOpacity
+//   private const double PodiumGlowSeconds
+//   private const double RankFlashPeakOpacity
+//   private const int RankFlashMs
+//   private const int RankFlashRiseMs
+//   private const int RankFlashStaggerMs
+//   private const int RankFlashMaxRows
+//   private bool _leaderboardFxInitialized
+//   private FrameworkElement? _lbPodiumGlowCard
+//   private double _lbPodiumGlowRest
+//   private readonly List<FrameworkElement> _lbPodiumStaggered
+//   private readonly List<FrameworkElement> _lbFlashDecorated
+//   private bool _lbRankFlashPending
+//   private bool LeaderboardAmbientAllowed
+//   private void EnsureLeaderboardFx(…)
+//   private void OnLeaderboardFxWindowStateish(…)
+//   private void OnLeaderboardTabVisibilityChanged(…)
+//   private void ApplyLeaderboardFxLoops(…)
+//   private void RunLeaderboardFxPass(…)
+//   private void ApplyPodiumFx(…)
+//   private void ApplyPodiumGlowBreath(…)
+//   private void ReleasePodiumGlow(…)
+//   private void ClearPodiumFx(…)
+//   private static List<Services.LeaderboardEntry> CollectMovedRows(…)
+//   private void FlashMovedRows(…)
+//   private void FlashRow(…)
+//   private void ClearRankFlashes(…)
+//   private static void StripRowFlash(…)
+//   private static Color ThemeColor(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Login.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Login.cs
@@ -1,0 +1,22 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Login.cs (400 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (6):
+//   internal void BtnUnifiedLogin_Click(…)
+//   private void OpenUnifiedLoginDialog(…)
+//   private void ClearProgressionData(…)
+//   private void ClearAccountData(…)
+//   internal async void BtnQuickLogout_Click(…)
+//   private void UpdateQuickLoginUI(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Marquee.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Marquee.cs
@@ -1,0 +1,44 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs (1171 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (28):
+//   internal const string WebBannerSeenKey
+//   private TextBlock[] _bannerBeats
+//   private void InitializeBannerRotation(…)
+//   private TextBlock[] BuildBannerBeats(…)
+//   private void UpdateBannerWelcomeMessage(…)
+//   private void ShowOgWelcomePopup(…)
+//   public static bool IsStartupDialogShowing
+//   private bool _seasonRecapShown
+//   public void TryPresentSeasonRecap(…)
+//   private void ShowWhatsNewIfNeeded(…)
+//   private void BannerRotationTimer_Tick(…)
+//   public void SetBannerAnnouncement(…)
+//   private void BannerWebLink_Click(…)
+//   internal void RetireWebBannerBeat(…)
+//   private void InitializeMarqueeBanner(…)
+//   private async void RefreshMarqueeFromSettings(…)
+//   private class MarqueeResponse
+//   private class UpdateBannerResponse
+//   private string? _serverUpdateUrl
+//   private async void CheckServerUpdateBanner(…)
+//   private class AnnouncementResponse
+//   private async void CheckServerAnnouncement(…)
+//   private bool _serverAnnouncementShownThisLaunch
+//   private void CheckIntakePassNudge(…)
+//   private void StartIntakeFromNudge(…)
+//   private static string LocOr(…)
+//   private void StartMarqueeAnimation(…)
+//   public void UpdateMarqueeMessage(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ModCatalogue.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ModCatalogue.cs
@@ -1,0 +1,24 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ModCatalogue.cs (192 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (8):
+//   private const string CatalogueSchemaMod
+//   private const int ModPreviewMaxPixels
+//   private const int ModPreviewMaxBytes
+//   internal async Task ShareModToCatalogueAsync(…)
+//   private async Task HandleModDropAsync(…)
+//   private static JObject BuildModCatalogueAsset(…)
+//   private static long SafeDirectorySize(…)
+//   private static string? TryBuildPreviewThumb(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.NavPremiumTags.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.NavPremiumTags.cs
@@ -1,0 +1,26 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.NavPremiumTags.cs (191 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (10):
+//   private IEnumerable<(…)
+//   internal IEnumerable<FrameworkElement> NavPremiumTagElements
+//   private bool _navTagPatreonHooked
+//   private bool _navTagSubStarHooked
+//   private bool _navTagDailyFreeHooked
+//   private bool _navTagIntakePassHooked
+//   private void HookNavPremiumTags(…)
+//   private void QueueNavPremiumTagRefresh(…)
+//   internal void RefreshNavPremiumTags(…)
+//   private static bool IsNavEntryLocked(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.NavRail.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.NavRail.cs
@@ -1,0 +1,82 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs (1107 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (61):
+//   private const double NavRailCollapsedWidth
+//   private const double NavRailExpandedWidth
+//   private const int NavRailAnimMs
+//   private const int NavRailCollapseAnimMs
+//   private const double NavDoorTileCollapsed
+//   private const double NavDoorTileExpanded
+//   private const double NavDoorIconCollapsed
+//   private const double NavDoorIconExpanded
+//   private const double NavDoorGlowCollapsed
+//   private const double NavDoorGlowExpanded
+//   private const double NavDoorGlowActive
+//   private const double NavDoorGlowOpen
+//   private const int NavDoorGlowFadeMs
+//   private const double NavDoorTileIdleOpacity
+//   private const double NavDoorLabelRise
+//   private const int NavDoorLabelFadeMs
+//   private const int NavDoorLabelSlideMs
+//   private const int NavDoorLabelStaggerMs
+//   private const double NavDoorLabelGlowLo
+//   private const double NavDoorLabelGlowHi
+//   private const double NavDoorLabelGlowStatic
+//   private const int NavDoorLabelGlowBreathMs
+//   private const int NavDoorLabelShimmerSweepMs
+//   private const int NavDoorLabelShimmerPeriodMs
+//   private const int NavDoorLabelFxStaggerMs
+//   private const string NavDoorLabelHostTag
+//   private const string NavRailStaticTextTag
+//   private bool _navRailExpanded
+//   private bool _navRailReady
+//   private int _navRailHoldCount
+//   private readonly List<TextBlock> _navRailLabels
+//   private readonly List<ButtonBase> _navRailButtons
+//   private readonly List<NavDoorRow> _navDoorRows
+//   private readonly HashSet<TextBlock> _navDoorLabelTexts
+//   private sealed class NavDoorRow
+//   private void InitializeNavRail(…)
+//   internal static Func<string, string?>? PossessionReroute
+//   private void HookNavDoorRerouteSeam(…)
+//   private void NavDoor_PossessionReroute(…)
+//   private void BtnNavSearch_Click(…)
+//   private const int NavDoorArtDecodeWidth
+//   private void ApplyDoorArt(…)
+//   private void CacheNavRailParts(…)
+//   private void CacheNavDoorRows(…)
+//   private void BuildNavDoorLabelFx(…)
+//   private static void StartNavDoorLabelFx(…)
+//   private static void StopNavDoorLabelFx(…)
+//   private static Brush? BuildNavDoorGlow(…)
+//   private void RefreshNavDoorActive(…)
+//   private void SetNavDoorGlow(…)
+//   private void ApplyNavDoorRows(…)
+//   private static void SetNavRailSize(…)
+//   private void SetNavRailExpanded(…)
+//   private readonly List<(…)
+//   private bool _navRailAirspaceLogged
+//   private void ApplyNavRailAirspace(…)
+//   private void HoldOverlappingBrowsers(…)
+//   private void ApplyNavRailDoorState(…)
+//   internal void SyncNavRailToPointer(…)
+//   internal void HoldNavRailOpen(…)
+//   internal void ReleaseNavRailOpen(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.NavRail.cs; wired when they move to Core.
+        private void BtnNavSearch_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Patreon.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Patreon.cs
@@ -1,0 +1,99 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs (2195 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (78):
+//   internal void BtnGateUnlock_Click(…)
+//   private void RefreshPremiumGate(…)
+//   private void EnforceEntitlementLapse(…)
+//   internal void RefreshEntitlementVeils(…)
+//   private void UpdatePatreonUI(…)
+//   internal async void BtnPatreonLogin_Click(…)
+//   internal async void BtnDiscordLogin_Click(…)
+//   private void UpdateDiscordUI(…)
+//   private void UpdateAccountLinkingUI(…)
+//   internal async void BtnLinkPatreon_Click(…)
+//   internal async void BtnLinkDiscord_Click(…)
+//   internal void OfferAchievementSharingAfterDiscordLink(…)
+//   internal void ChkShareAchievements_Changed(…)
+//   internal void ChkShareLevelUps_Changed(…)
+//   internal void ChkShowLevelInPresence_Changed(…)
+//   internal async void ChkAllowDiscordDm_Changed(…)
+//   internal async void ChkShareProfilePicture_Changed(…)
+//   internal async void ChkPublicShareRealAvatar_Changed(…)
+//   internal async void ChkGoonShareAvatar_Changed(…)
+//   internal async void ChkGoonShareDiscordDm_Changed(…)
+//   internal void ChkGoonRichPresence_Changed(…)
+//   internal async void ChkShowOnlineStatus_Changed(…)
+//   internal void BtnVisitPatreon_Click(…)
+//   private void OnPatreonTierChanged(…)
+//   private void MaybeShowPremiumCelebration(…)
+//   private void InitializePatreonTab(…)
+//   internal void BtnDetachCompanion_Click(…)
+//   internal void BtnCustomizeCompanion_Click(…)
+//   internal void BtnManagePhrases_Click(…)
+//   private void UpdatePhraseCountDisplay(…)
+//   private void RestoreCompanionSectionStates(…)
+//   internal const string CompanionEngineDrawerKey
+//   internal const string CompanionWorkshopDrawerKey
+//   internal void PersistCompanionDrawerStates(…)
+//   internal void SliderIdleInterval_ValueChanged(…)
+//   internal void SliderBubbleDuration_ValueChanged(…)
+//   internal void ChkTriggerMode_Changed(…)
+//   public void SyncTriggerModeUI(…)
+//   internal void SliderTriggerInterval_ValueChanged(…)
+//   internal void BtnEditTriggers_Click(…)
+//   internal void BtnPrivacySpoiler_Click(…)
+//   internal void SliderAwarenessCooldown_ValueChanged(…)
+//   internal void SliderAwarenessCooldownMax_ValueChanged(…)
+//   internal void BtnSwitchCompanion_Click(…)
+//   internal void RevealCompanionWorkshopCell(…)
+//   private void OnCompanionProviderSelected(…)
+//   private async Task MaybeOfferLocalAiSetupAsync(…)
+//   internal void BtnSetupLocalAi_Click(…)
+//   internal void BtnLabEffectsSetupLocal_Click(…)
+//   private void LaunchLocalAiSetupWizard(…)
+//   private static void CommitFocusedEdit(…)
+//   internal async void BtnTestOllamaConnection_Click(…)
+//   internal void BtnOpenAiSamplerSettings_Click(…)
+//   internal async void BtnTestOpenAiConnection_Click(…)
+//   internal void BtnClearChatMemory_Click(…)
+//   internal void ChkChatMemoryEnabled_Changed(…)
+//   internal void ChkCapEffects_Changed(…)
+//   internal void ChkAllowEffect_Changed(…)
+//   internal void SliderMaxHapticIntensity_ValueChanged(…)
+//   private void UpdateAiBrainPills(…)
+//   private static bool ProviderSupportsEffects(…)
+//   private void UpdateLiveActionsPlaceholder(…)
+//   internal void SyncLabEffectPermsUI(…)
+//   private void SyncAiBrainUI(…)
+//   internal void ChkMuteWhispers_Changed(…)
+//   internal async void ChkPauseBrowser_Changed(…)
+//   internal void ChkVoiceLines_Changed(…)
+//   private async Task SetBrowserPaused(…)
+//   public void SyncQuickControlsUI(…)
+//   public void SyncWhispersUI(…)
+//   private int _preMuteMasterVolume
+//   public void ApplyVoiceMute(…)
+//   public void AdjustMasterVolume(…)
+//   internal async void BtnRefreshPrompts_Click(…)
+//   internal void BtnDeactivatePrompt_Click(…)
+//   internal async void BtnBrowsePrompts_Click(…)
+//   internal void BtnImportPrompt_Click(…)
+//   internal async void BtnExportPrompt_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Patreon.cs; wired when they move to Core.
+        private void BtnManagePhrases_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
@@ -1,0 +1,22 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.PlayTab.cs (332 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (6):
+//   private const double GoonPerkLockedOpacity
+//   internal void RefreshPlayCards(…)
+//   private static void RefreshPlayFreeStamps(…)
+//   private static void SetFreeStamp(…)
+//   private void RefreshPlayIntakeCard(…)
+//   internal void StartMantraSession(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Possession.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Possession.cs
@@ -1,0 +1,47 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Possession.cs (673 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (31):
+//   private Canvas? _possessionGhostLayer
+//   private Canvas? _possessionRubbleFloor
+//   private bool _possessionHostHooked
+//   private readonly ConditionalWeakTable<FrameworkElement, PossessionTarget> _possessionTargets
+//   private void InitializePossessionHost(…)
+//   private void EnsurePossessionLayers(…)
+//   private void HookPossessionInvalidation(…)
+//   private List<PossessionTarget>? _possessionTargetCache
+//   private DateTime _possessionCacheAt
+//   private bool _possessionCacheDirty
+//   private DateTime _possessionLayoutSeenAt
+//   private bool _possessionLayoutHooked
+//   private static readonly TimeSpan PossessionRebuildFloor
+//   private static readonly TimeSpan PossessionCacheMaxAge
+//   private static readonly HashSet<string> PossessionNeverNames
+//   private const int MaxAutoLabels
+//   private const double MinTargetPx
+//   internal IReadOnlyList<PossessionTarget> GetPossessionTargets(…)
+//   private void TrimLabels(…)
+//   private readonly record struct PossessionSubtree(…)
+//   private PossessionSubtree WalkPossession(…)
+//   private PossessionTarget? TargetFor(…)
+//   private static PossessionRole InferLeafRole(…)
+//   private static bool IsInsideScrollBar(…)
+//   private static bool IsInteractiveRole(…)
+//   private static bool IsCardBorder(…)
+//   private bool PassesSizeAndPlacement(…)
+//   internal bool TryWindowBounds(…)
+//   private static string DisplayNameFor(…)
+//   private static string? Tidy(…)
+//   private static string FallbackDisplayName(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PremiumRail.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PremiumRail.cs
@@ -1,0 +1,51 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.PremiumRail.cs (682 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (35):
+//   private static readonly Brush PremiumDotOn
+//   private static readonly Brush PremiumDotOff
+//   private bool _premiumRailSubscribed
+//   private bool _lockdownEventsBound
+//   private int _railLockdownMinutes
+//   private bool _blinkEventsBound
+//   private bool _railIntakePassBound
+//   private DispatcherTimer? _blinkCountdownTimer
+//   private static Brush CreateFrozenBrush(…)
+//   internal void InitPremiumRail(…)
+//   private void EnsureIntakePassRailHooked(…)
+//   internal void PremiumBlinkAdjust(…)
+//   internal void PremiumBlinkToggle(…)
+//   private void SetBlinkActiveUi(…)
+//   private void UpdateBlinkCountdown(…)
+//   internal void PremiumRemoteOpenFlyout(…)
+//   internal void PremiumRemoteStart(…)
+//   internal void PremiumLockdownAdjust(…)
+//   internal void PremiumLockdownActivate(…)
+//   private void SetLockdownActiveUi(…)
+//   private object? _lockdownChipToolTip
+//   private MouseButtonEventHandler? _lockdownChipNavHandler
+//   private void WireLockdownChipNav(…)
+//   private void UpdateLockdownCountdown(…)
+//   internal void PremiumChip_Click(…)
+//   internal void PremiumChip_Toggle(…)
+//   internal void PremiumRail_RightClick(…)
+//   private static void ToggleTabCheckBox(…)
+//   internal void RefreshPremiumRail(…)
+//   private void SetDot(…)
+//   private static string RailFeatureName(…)
+//   private static string? RailDailyKey(…)
+//   private void RefreshRailLockbands(…)
+//   internal static void SetLockband(…)
+//   internal static void SetLockbandVisible(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PresetIO.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PresetIO.cs
@@ -1,0 +1,30 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.PresetIO.cs (368 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (14):
+//   private const string CatalogueSchemaPreset
+//   private const string CatalogueSchemaSession
+//   private Services.PresetFileService? _presetFileService
+//   internal void BtnExportPreset_Click(…)
+//   private Services.PhraseBackupService? _phraseBackupService
+//   internal void BtnExportPhrases_Click(…)
+//   internal void BtnImportPhrases_Click(…)
+//   private void HandlePresetDrop(…)
+//   internal async void BtnSharePreset_Click(…)
+//   private async Task SharePresetToCatalogueAsync(…)
+//   private async Task ShareSessionToCatalogueAsync(…)
+//   internal static Border? CreateCatalogueStatusBadge(…)
+//   private void UpdatePresetShareStatusBadge(…)
+//   private void RefreshCatalogueShareBadges(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Presets.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Presets.cs
@@ -1,0 +1,115 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Presets.cs (2316 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (88):
+//   private void SetupHelpButtons(…)
+//   private void SetHelpContent(…)
+//   private void HelpVideoButton_Click(…)
+//   private Models.Preset? _selectedPreset
+//   private List<Models.Preset> _allPresets
+//   private void InitializePresets(…)
+//   private void RefreshPresetsDropdown(…)
+//   private void CmbPresets_SelectionChanged(…)
+//   private void RefreshPresetsList(…)
+//   private void RefreshPresetsModVisuals(…)
+//   private Border CreatePresetCard(…)
+//   private Style? TryFindTabStyle(…)
+//   private void AddStatIcon(…)
+//   private string GetPresetQuickStats(…)
+//   private void SelectPreset(…)
+//   internal void SessionCard_Click(…)
+//   private Models.Session? _selectedSession
+//   internal void ChkCornerGifEnabled_Changed(…)
+//   internal void BtnSelectCornerGif_Click(…)
+//   private System.Windows.Threading.DispatcherTimer? _cornerGifSizeDebounce
+//   internal void SliderCornerGifSize_ValueChanged(…)
+//   internal void RbCornerPos_Checked(…)
+//   internal void SliderCornerGifOpacity_ValueChanged(…)
+//   private string _selectedCornerGifPath
+//   private Models.CornerPosition GetSelectedCornerPosition(…)
+//   internal void BtnRevealSpoilers_Click(…)
+//   private bool ShowStyledDialog(…)
+//   private MediaDropChoice ShowMediaDropChoiceDialog(…)
+//   private Features.FeaturePopupWindow? _activeFeaturePopup
+//   private void ShowFeaturePopup(…)
+//   internal void OpenStudioModule(…)
+//   internal void CardFlash_Click(…)
+//   internal void CardSubliminal_Click(…)
+//   internal void CardBouncingText_Click(…)
+//   internal void CardBubblePop_Click(…)
+//   internal void CardLockCard_Click(…)
+//   internal void CardMystery_Click(…)
+//   internal void CardVault_Click(…)
+//   internal void CardJustDrop_Click(…)
+//   internal void RefreshMosaicTierBadges(…)
+//   internal void RefreshMysteryTile(…)
+//   private static string? MysteryFeatureName(…)
+//   private static int MysteryFeatureTier(…)
+//   private static string MysteryFeatureArtPath(…)
+//   internal void ToggleWallFeature(…)
+//   internal static bool IsWallFeatureOn(…)
+//   internal void SetWallFeature(…)
+//   private void OnSettingsPropertyChangedForWall(…)
+//   internal void RefreshWallActiveStates(…)
+//   private static void SetTierBadge(…)
+//   internal void CardSystem_Click(…)
+//   internal void VelvetBtnWebcam_Click(…)
+//   internal void VelvetBtnAppInfo_Click(…)
+//   internal void VelvetBtnSchedulerRamp_Click(…)
+//   internal void BtnCatalogue_Click(…)
+//   internal void BtnSessionHistory_Click(…)
+//   internal void BtnStartSession_Click(…)
+//   private async void StartSession(…)
+//   private void OnSessionCompleted(…)
+//   private DateTime _suppressSessionSummaryUntil
+//   internal void SuppressNextSessionSummary(…)
+//   private void OnSessionLogReady(…)
+//   private SessionCompleteWindow? _liveSessionRecap
+//   private bool _liveSessionRecapTeardownHooked
+//   private void CloseLiveSessionRecap(…)
+//   private void ShowSessionSummaryWhenClear(…)
+//   private void OnSessionProgressUpdated(…)
+//   private void OnSessionPhaseChanged(…)
+//   private void OnSessionStarted(…)
+//   private void OnSessionStopped(…)
+//   private void BtnStopSession_Click(…)
+//   private void BtnPauseSession_Click(…)
+//   public void ApplySessionSettings(…)
+//   public void UpdateSpiralOpacity(…)
+//   public void EnablePinkFilter(…)
+//   public void EnableSpiral(…)
+//   public void UpdatePinkFilterOpacity(…)
+//   public void EnableBrainDrain(…)
+//   public void UpdateBrainDrainIntensity(…)
+//   public void SetBubblesActive(…)
+//   private void HandleHyperlinkClick(…)
+//   private void LoadPreset(…)
+//   private void ReconcileRunningServices(…)
+//   internal void BtnLoadPreset_Click(…)
+//   internal void BtnNewPreset_Click(…)
+//   private void PromptSaveNewPreset(…)
+//   internal void BtnSaveOverPreset_Click(…)
+//   internal void BtnDeletePreset_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Presets.cs; wired when they move to Core.
+        private void BtnCatalogue_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Presets.cs; wired when they move to Core.
+        private void BtnPauseSession_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Presets.cs; wired when they move to Core.
+        private void CmbPresets_SelectionChanged(object? sender, global::Avalonia.Controls.SelectionChangedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileBubble.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileBubble.cs
@@ -1,0 +1,99 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileBubble.cs (705 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (51):
+//   private const int ProfileBubbleOpenDelayMs
+//   private const int ProfileBubbleCloseGraceMs
+//   private DispatcherTimer? _profileBubbleOpenTimer
+//   private DispatcherTimer? _profileBubbleCloseTimer
+//   private bool _profileBubbleWatchersOn
+//   private string? _profileBubbleAvatarUrl
+//   private ImageBrush? _profileBubblePhotoBrush
+//   private DateTime _profileBubbleLastXpPulse
+//   private DateTime _profileBubbleLastWobble
+//   private DateTime _profileBubbleLastShimmer
+//   private static readonly Color ProfileBubbleGold
+//   private void InitializeProfileBubble(…)
+//   private void CleanupProfileBubble(…)
+//   private void RefreshProfileBubble(…)
+//   private static readonly SolidColorBrush ProfileBubbleNeutralBrush
+//   private static SolidColorBrush MakeFrozenBrush(…)
+//   private async System.Threading.Tasks.Task LoadProfileBubblePhotoAsync(…)
+//   private void RefreshProfileMenu(…)
+//   private void ProfileBubble_MouseEnter(…)
+//   private void ProfileBubble_MouseLeave(…)
+//   private void ProfileBubblePopupRoot_MouseEnter(…)
+//   private void ProfileBubblePopupRoot_MouseLeave(…)
+//   private void OnProfileBubbleOpenTick(…)
+//   private void OnProfileBubbleCloseTick(…)
+//   private void OpenProfileBubbleMenu(…)
+//   private void OnProfileBubblePopupClosed(…)
+//   private CustomPopupPlacement[] PlaceProfileBubblePopup(…)
+//   private void SubscribeProfileBubbleWatchers(…)
+//   private void UnsubscribeProfileBubbleWatchers(…)
+//   private void OnProfileBubbleHostDeactivated(…)
+//   private void OnProfileBubbleHostStateChanged(…)
+//   private void OnProfileBubbleWindowMouseDown(…)
+//   private void BtnProfileBubble_Click(…)
+//   private void ProfileMenuProfile_Click(…)
+//   private void ProfileMenuPublicProfile_Click(…)
+//   internal void OpenPublicProfilePage(…)
+//   internal void RefreshProfileShareButton(…)
+//   private void ProfileMenuAchievements_Click(…)
+//   private void ProfileMenuSettings_Click(…)
+//   private void ProfileMenuAccount_Click(…)
+//   private void RunOnBubbleUi(…)
+//   private void OnBubbleXPChanged(…)
+//   private void OnBubbleLevelUp(…)
+//   private void OnBubbleAchievementUnlocked(…)
+//   private void OnBubbleFlashDisplayed(…)
+//   private void OnBubbleSubliminalDisplayed(…)
+//   private void OnBubbleAuthChanged(…)
+//   private void PulseProfileBubble(…)
+//   private void WobbleProfileBubble(…)
+//   private void ShimmerProfileBubble(…)
+//   private void FlashProfileBubbleGlow(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void BtnProfileBubble_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileBubblePopupRoot_MouseEnter(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileBubblePopupRoot_MouseLeave(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileBubble_MouseEnter(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileBubble_MouseLeave(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileMenuAccount_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileMenuAchievements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileMenuProfile_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileMenuPublicProfile_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.ProfileBubble.cs; wired when they move to Core.
+        private void ProfileMenuSettings_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCard.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCard.cs
@@ -1,0 +1,33 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileCard.cs (417 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (17):
+//   public string Id
+//   public string Name
+//   public System.Windows.Media.ImageSource? Image
+//   private bool _profileMeFirstDone
+//   private bool _profileViewingSelf
+//   private Visibility PinPlaceholderVisibility(…)
+//   internal void EnsureProfileMeFirst(…)
+//   internal void SetProfileViewingSelf(…)
+//   private bool _profileStatBadgesModHooked
+//   internal void RefreshProfileStatBadges(…)
+//   internal void UpdateProfileXpMeter(…)
+//   private DescentReceiptKind OwnDescentReceiptKind(…)
+//   internal void RefreshProfileDescentReceipt(…)
+//   internal void UpdateProfileShowcase(…)
+//   private static string? FindNextAchievementName(…)
+//   internal void UpdateProfileSharingSummary(…)
+//   internal void OpenProfilePrivacyDialog(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCosmetics.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCosmetics.cs
@@ -1,0 +1,36 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileCosmetics.cs (532 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (20):
+//   private static readonly Color DefaultHeroBorderColor
+//   internal void ApplyOwnProfileCosmetics(…)
+//   internal void ApplyViewedProfileCosmetics(…)
+//   private void ApplyProfileCosmetics(…)
+//   private ImageSource? _appliedPresetAvatar
+//   private ProfilePictureLoad _profilePictureLoad
+//   internal void SetProfilePictureLoad(…)
+//   private void ApplyProfileAvatarPreset(…)
+//   private void ApplyProfileBanner(…)
+//   private void ApplyProfileAccent(…)
+//   private void ApplyProfileTitle(…)
+//   internal static string? ResolveAchievementTitle(…)
+//   private void ApplyProfilePins(…)
+//   internal void RefreshShowcasePinArt(…)
+//   internal void OpenProfileCustomizeDialog(…)
+//   private void PersistOwnCosmetics(…)
+//   internal void ToggleOwnAchievementPin(…)
+//   private DispatcherTimer? _pinCapNoticeTimer
+//   private void FlashPinCapNotice(…)
+//   internal static bool PresetMayClaim(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileFaucet.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileFaucet.cs
@@ -1,0 +1,87 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileFaucet.cs (1146 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (71):
+//   private const double FaucetSpoutXInBox
+//   private const double FaucetSpoutYInBox
+//   private const double FaucetBoxWidth
+//   private const double FaucetBoxHeight
+//   private const double FaucetRingBox
+//   private const double FaucetRingRadius
+//   private const double ChargeFloorMs
+//   private const double ChargeCapMs
+//   private const double ChargeXpPerMs
+//   private const int ChargeRungs
+//   private const int ChargeCompactAfter
+//   private readonly VatFaucetHold _faucetHold
+//   private bool _faucetWired
+//   private bool _faucetWobbling
+//   private bool _faucetSparkling
+//   private bool _faucetChipBreathing
+//   private DispatcherTimer? _faucetTickTimer
+//   private DispatcherTimer? _faucetSettleTimer
+//   private DispatcherTimer? _faucetChargeTimer
+//   private DateTime _faucetChargeStart
+//   private double _faucetChargeBudgetMs
+//   private int _faucetChargeRungsPlayed
+//   private bool _faucetCharging
+//   private bool _faucetChargeCompact
+//   private int _faucetPoursToday
+//   private string _faucetPourDayUtc
+//   private static readonly Random FaucetRng
+//   private void ArmFaucet(…)
+//   private void PositionVatTickGlyphs(…)
+//   private void DisarmFaucet(…)
+//   private void OnFaucetVatOffScreen(…)
+//   private void WireFaucet(…)
+//   private void UpdateFaucetPresentation(…)
+//   private static ToolTip BuildFaucetTooltip(…)
+//   private void StartFaucetWobble(…)
+//   private void StopFaucetWobble(…)
+//   private DispatcherTimer CreateFaucetTickTimer(…)
+//   private void StartFaucetSparkle(…)
+//   private void StopFaucetSparkle(…)
+//   private void StartChipBreath(…)
+//   private void StopChipBreath(…)
+//   private void OnFaucetMouseEnter(…)
+//   private void OnFaucetMouseLeave(…)
+//   private void AnimateFaucetScale(…)
+//   private void OnFaucetMouseDown(…)
+//   private void OnFaucetMouseUp(…)
+//   private void OnFaucetLostCapture(…)
+//   private void OnFaucetKeyDown(…)
+//   private void OnFaucetKeyUp(…)
+//   private void OnFaucetLostFocus(…)
+//   private void BeginFaucetCharge(…)
+//   private DispatcherTimer CreateFaucetChargeTimer(…)
+//   private void CancelFaucetCharge(…)
+//   private void CompleteFaucetCharge(…)
+//   private void ShowChargeRing(…)
+//   private void UpdateChargeRing(…)
+//   private void HideChargeRing(…)
+//   private static Geometry BuildChargeArc(…)
+//   private void FaucetThud(…)
+//   private void FaucetShiver(…)
+//   private void FaucetDrip(…)
+//   private void SpawnFaucetSparkles(…)
+//   private void AnimateFaucetTilt(…)
+//   private void StartFaucetSettleWatch(…)
+//   private void StopFaucetSettleWatch(…)
+//   private DispatcherTimer CreateFaucetSettleTimer(…)
+//   private int FaucetPourCountToday(…)
+//   private void NoteFaucetPourToday(…)
+//   private static void PlayChargeRung(…)
+//   private static void PlayFaucetSfx(…)
+//   private static void FireFaucetPourHaptic(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileFx.cs
@@ -1,0 +1,30 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileFx.cs (239 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (14):
+//   private const int ProfileSearchGlowMs
+//   private const byte ProfileSearchGlowAlpha
+//   private bool _profileFxInitialized
+//   private bool _ogBorderLoopRunning
+//   private SolidColorBrush? _profileSearchBrush
+//   internal void OnProfileTabVisibilityChanged(…)
+//   private void InitializeProfileFx(…)
+//   private void OnProfileFxWindowStateish(…)
+//   internal void ApplyOgBorderLoop(…)
+//   private void StaggerProfileCards(…)
+//   private void EnsureProfileSearchBrush(…)
+//   private void ProfileSearch_GotFocus(…)
+//   private void ProfileSearch_LostFocus(…)
+//   private void ApplyProfileSearchGlow(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileSpiral.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileSpiral.cs
@@ -1,0 +1,32 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileSpiral.cs (231 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (11):
+//   private bool _profileSpiralWired
+//   private static bool SpiralWithheld
+//   private void WireProfileSpiral(…)
+//   private void UnwireProfileSpiral(…)
+//   private void OnSpiralBlockChanged(…)
+//   internal void RefreshSpiralGlyphMotion(…)
+//   internal void RefreshProfileSpiralPlate(…)
+//   internal void RefreshProfileMenuSpiral(…)
+//   private static string BuildSpiralSummary(…)
+//   internal void OpenSpiralMapFromProfile(…)
+//   private void ProfileMenuSpiral_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.ProfileSpiral.cs; wired when they move to Core.
+        private void ProfileMenuSpiral_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileVat.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileVat.cs
@@ -1,0 +1,34 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileVat.cs (420 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (18):
+//   private const double VatJarHeight
+//   private const double VatDarkAvatarSize
+//   private readonly VatFillCoordinator _vatCoordinator
+//   private DispatcherTimer? _vatPollTimer
+//   private bool _vatWired
+//   private bool _vatArmed
+//   private bool _vatOnScreen
+//   private int _vatCap
+//   private void OnProfileVatVisibilityChanged(…)
+//   private void EvaluateVatPoll(…)
+//   private DispatcherTimer CreateVatPollTimer(…)
+//   private void WireProfileVat(…)
+//   private void OnDescentBlockChanged(…)
+//   private void OnVatFillPercentChanged(…)
+//   private void UpdateVatReadout(…)
+//   private void ApplyDescentToVat(…)
+//   private void ArmVat(…)
+//   private void DisarmVat(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileWardrobe.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileWardrobe.cs
@@ -1,0 +1,23 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileWardrobe.cs (168 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (7):
+//   private List<string>? _appliedCharmIds
+//   private Dictionary<string, CosmeticTransform>? _appliedCharmTransforms
+//   private bool _charmResizeHooked
+//   private void ApplyProfileWardrobe(…)
+//   private void ApplyProfileAvatarDecoration(…)
+//   private void ApplyProfileCharms(…)
+//   private void LayoutProfileCharms(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramBanner.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramBanner.cs
@@ -1,0 +1,41 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProgramBanner.cs (496 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (25):
+//   private const string ProgramBannerFolder
+//   private const double ProgramBannerArtOpacity
+//   private const double ProgramBannerParallax
+//   private bool _programBannerHooked
+//   private bool _programBannerFxRunning
+//   private bool _programBannerSparklesBuilt
+//   internal void ApplyProgramBannerArt(…)
+//   private void EnsureProgramBannerHooks(…)
+//   private void ProgramBannerCard_IsVisibleChanged(…)
+//   private void ProgramBannerDecor_SizeChanged(…)
+//   private void LayoutProgramBannerDecor(…)
+//   private static ImageSource? ResolveProgramBannerArt(…)
+//   private static Color ProgramBannerAccentColor(…)
+//   private static Color WithAlpha(…)
+//   private static Color TowardWhite(…)
+//   private static Brush ProgramBannerFogBrush(…)
+//   private static Brush ProgramBannerSheenBrush(…)
+//   private void StartProgramBannerFx(…)
+//   private void StopProgramBannerFx(…)
+//   private void BuildProgramBannerSparkles(…)
+//   private void PositionProgramBannerSparkles(…)
+//   private void StartProgramBannerSparkles(…)
+//   private void ProgramBannerCard_MouseEnter(…)
+//   private void ProgramBannerCard_MouseLeave(…)
+//   private void NudgeProgramBannerArt(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsFx.cs
@@ -1,0 +1,76 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProgramsFx.cs (1210 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (60):
+//   private const double ProgramSigilRestOpacity
+//   private const byte ProgramWashAlphaCold
+//   private const byte ProgramWashAlphaHot
+//   private const double ProgramAccentFadeSeconds
+//   private const double ProgramSealSeconds
+//   private static readonly Color ProgramGraduationGold
+//   private SolidColorBrush? _programAccent
+//   private string? _programAccentRunKey
+//   private Color? _programAccentTarget
+//   private double _programHeat
+//   private ProgramHeatTier _programTier
+//   private bool _programBossToday
+//   private string? _programFxSignature
+//   private LinearGradientBrush? _programBorderBrush
+//   private RotateTransform? _programBorderRotate
+//   private LinearGradientBrush? _programCounterBrush
+//   private TranslateTransform? _programCounterSlide
+//   private LinearGradientBrush? _programCometBrush
+//   private Brush? _programWashBrush
+//   private Brush? _programEdgeBrush
+//   private Brush? _programSigilGlowBrush
+//   private ScaleTransform? _programSigilScale
+//   private RadialGradientBrush? _programWaveBrush
+//   private DropShadowEffect? _programRailGlow
+//   private DropShadowEffect? _programBossGlow
+//   private AmbientFxCanvas? _programParticles
+//   private int _programCometAttempts
+//   private double _programSheenSeconds
+//   private string? _programChapterSealed
+//   private string? _programGraduationCelebrated
+//   private string? _programChapterBaselineRun
+//   private int? _programIgniteDay
+//   private bool _programDayJustCompleted
+//   private bool _programWindowFxHooked
+//   private static Color ProgramAccentColor(…)
+//   private SolidColorBrush ProgramRunAccent(…)
+//   private Color ProgramAccentColorNow(…)
+//   private void ComputeProgramHeat(…)
+//   private void ApplyProgramIgnition(…)
+//   private void BuildProgramIgnitionScenery(…)
+//   private void ApplyProgramSigilBreath(…)
+//   private void ApplyProgramBorderRotation(…)
+//   private void ApplyProgramWashBloom(…)
+//   private void ApplyProgramRailGlow(…)
+//   private void ApplyProgramCounterShimmer(…)
+//   private void ApplyProgramEdgeGlow(…)
+//   private void ApplyProgramBossFlare(…)
+//   private void ApplyProgramRailComet(…)
+//   private void ApplyProgramParticles(…)
+//   private AmbientFxCanvas? EnsureProgramParticleLayer(…)
+//   private void EnsureProgramWindowFxHooked(…)
+//   private void StopProgramIgnitionLoops(…)
+//   private void NoteProgramDayCompletion(…)
+//   private void PlayProgramDayCompleteMoment(…)
+//   private void CelebrateProgramTaskCompletions(…)
+//   private void NoteProgramChapterSeal(…)
+//   private void PlayProgramChapterSeal(…)
+//   private void CelebrateProgramGraduation(…)
+//   private static Color WithAccentAlpha(…)
+//   private static Color LightenToward(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsTab.cs
@@ -1,0 +1,79 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProgramsTab.cs (2312 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (63):
+//   private bool _programsSubscribed
+//   private bool _programsAppHooked
+//   private bool _programsPulseRunning
+//   private void StartProgramsTabPulse(…)
+//   private void StopProgramsTabPulse(…)
+//   private void EnsureProgramsSubscribed(…)
+//   private void EnsureProgramsAppHooks(…)
+//   private void OnProgramTodayChanged(…)
+//   private void OnProgramLapsed(…)
+//   private void OnProgramGraduated(…)
+//   private void MarshalProgramRefresh(…)
+//   internal void ProgramTodayCard_Loaded(…)
+//   private static Brush ProgramThemeBrush(…)
+//   private static Brush ProgramAccentBrush(…)
+//   private static bool ProgramHasPremium
+//   private static Brush ProgramContrastForeground(…)
+//   private static double SrgbToLinear(…)
+//   private static string ProgramRunKey(…)
+//   private static Brush ProgramRailFillBrush(…)
+//   private static Brush ProgramRadialGlowBrush(…)
+//   private static void ApplyProgramArtMask(…)
+//   private static string? ProgramTaskIconPath(…)
+//   private static string? ProgramTaskHowTo(…)
+//   private static readonly(…)
+//   private static Models.SessionSettings? ProgramDaySettings(…)
+//   internal void RefreshProgramsUI(…)
+//   private void RebuildProgramsTab(…)
+//   private void BuildProgramBrowseList(…)
+//   private void BuildProgramRunPanel(…)
+//   private void BuildProgramDayStrip(…)
+//   private void BuildProgramTodayPanel(…)
+//   private void BuildProgramTodayLayers(…)
+//   private void BuildProgramUpNext(…)
+//   private static string FormatProgramClock(…)
+//   internal void UpdateProgramSessionRow(…)
+//   private bool _programsFxHooked
+//   private bool _programSheenActive
+//   private string? _programDayCompletePopped
+//   private readonly HashSet<string> _programTasksSeenIncomplete
+//   private string? _programRunKeySeen
+//   private bool _programsRefreshPending
+//   private void ResetProgramRunPopsIfRunChanged(…)
+//   private void EnsureProgramsFxHooked(…)
+//   private void OnProgramsTabVisibleChanged(…)
+//   private void StartProgramRunEntrance(…)
+//   private static void AnimateProgramPanelIn(…)
+//   private void EnsureProgramSessionSheen(…)
+//   private void StopProgramSessionSheen(…)
+//   private static void PopProgramScale(…)
+//   internal void AnnounceProgramSessionStarted(…)
+//   internal void AnnounceProgramSessionEnded(…)
+//   private void BuildProgramLapsedPanel(…)
+//   private void BuildProgramGraduatedPanel(…)
+//   internal void BtnProgramEnroll_Click(…)
+//   internal void BtnProgramPauseResume_Click(…)
+//   internal void BtnProgramWithdraw_Click(…)
+//   internal void BtnProgramRestart_Click(…)
+//   internal void BtnProgramDismissGraduated_Click(…)
+//   internal void BtnProgramSubmitRitual_Click(…)
+//   internal void BtnStartTodaySession_Click(…)
+//   internal async void StartProgramSession(…)
+//   internal void ProgramTodayCard_Click(…)
+//   internal void RefreshProgramTodayCard(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.QuestStamps.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.QuestStamps.cs
@@ -1,0 +1,100 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs (1034 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (73):
+//   private const double QuestStampDailySize
+//   private const double QuestStampWeeklySize
+//   private static readonly double[] QuestStampOffsets
+//   private static readonly double[] QuestStampAngles
+//   private const double QuestStampFillInset
+//   private const double QuestStampFillHeight
+//   private const double QuestStampHoverScale
+//   private const double QuestStampPopWidth
+//   private const double QuestStampPopTrackWidth
+//   private static readonly Brush QuestStampGoldStroke
+//   private static readonly Brush QuestStampGoldFill
+//   private static readonly Brush QuestStampGoldInk
+//   private static readonly Brush QuestStampGoldWash
+//   private static readonly Brush QuestStampPinkStroke
+//   private static readonly Brush QuestStampPanelFill
+//   private static readonly Brush QuestStampDarkFill
+//   private static readonly Brush QuestStampPurpleStroke
+//   private static readonly Brush QuestStampPurpleFill
+//   private static readonly Brush QuestStampGhostStroke
+//   private static readonly Brush QuestStampGhostFill
+//   private static readonly Brush QuestStampArtScrim
+//   private static readonly Brush QuestStampDoneInk
+//   private static readonly Brush QuestStampMutedInk
+//   private static readonly Brush QuestStampWhiteInk
+//   private static readonly Brush QuestStampChipFill
+//   private static Brush Frozen(…)
+//   private bool _questStampsWired
+//   private sealed class QuestStampInfo
+//   private readonly Dictionary<string, QuestStampInfo> _stampInfos
+//   private readonly Dictionary<string, bool> _stampCompletedSeen
+//   private string? _hoveredStampKey
+//   private Popup? _stampPopup
+//   private Border? _stampPopCard
+//   private TranslateTransform? _stampPopSlide
+//   private Image? _stampPopArt
+//   private Border? _stampPopArtScrim
+//   private TextBlock? _stampPopKind
+//   private TextBlock? _stampPopXp
+//   private TextBlock? _stampPopIcon
+//   private TextBlock? _stampPopName
+//   private TextBlock? _stampPopDesc
+//   private Border? _stampPopTrack
+//   private Border? _stampPopFill
+//   private TextBlock? _stampPopProgress
+//   private TextBlock? _stampPopRemaining
+//   private Border? _stampPopDone
+//   private void InitializeQuestStamps(…)
+//   private void OnQuestStampsQuestCompleted(…)
+//   private void OnQuestStampsProgressChanged(…)
+//   private void OnQuestStampsRefreshed(…)
+//   private void OnQuestStampsLanguageChanged(…)
+//   private void OnQuestStampsDismiss(…)
+//   private void OnQuestStampsModChanged(…)
+//   private void QueueQuestStampRepaint(…)
+//   internal void RefreshQuestStamps(…)
+//   private void AddStamp(…)
+//   private static double QuestStampFraction(…)
+//   private FrameworkElement BuildQuestStamp(…)
+//   private static string QuestStampName(…)
+//   private static string QuestStampDescription(…)
+//   private static void PlayStampStampedPop(…)
+//   private static void ZoomStamp(…)
+//   private static double QuestStampRestAngle(…)
+//   private void EnsureStampPopup(…)
+//   private void PaintStampPopup(…)
+//   private void ShowStampPopup(…)
+//   private void HideStampPopup(…)
+//   private void Stamp_MouseEnter(…)
+//   private void Stamp_MouseLeave(…)
+//   private void RestoreStampHover(…)
+//   private void QuestStamps_Click(…)
+//   private void QuestStamps_MouseEnter(…)
+//   private void QuestStamps_MouseLeave(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.QuestStamps.cs; wired when they move to Core.
+        private void QuestStamps_Click(object? sender, global::Avalonia.Input.PointerReleasedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.QuestStamps.cs; wired when they move to Core.
+        private void QuestStamps_MouseEnter(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.QuestStamps.cs; wired when they move to Core.
+        private void QuestStamps_MouseLeave(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Quests.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Quests.cs
@@ -1,0 +1,21 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Quests.cs (124 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (5):
+//   private QuestCompletePopup? _questCompletePopup
+//   private SolidColorBrush? _dailySegmentGold
+//   private SolidColorBrush? _dailySegmentGrey
+//   private void OnQuestCompleted(…)
+//   private void OnQuestProgressChanged(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.QuestsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.QuestsTab.cs
@@ -1,0 +1,33 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs (991 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (17):
+//   internal void RerollDailySlot(…)
+//   internal void BtnRerollWeekly_Click(…)
+//   private readonly string?[] _dailyCardQuestIds
+//   private readonly Dictionary<string, BitmapImage> _questArtCache
+//   internal BitmapImage? GetQuestArt(…)
+//   internal void ClearQuestArtCache(…)
+//   private Views.Controls.DailyQuestCardModel BuildDailyCardModel(…)
+//   private void RefreshQuestUI(…)
+//   private void RefreshPunchCard(…)
+//   private static FrameworkElement BuildPunchHole(…)
+//   private void RefreshStreakCalendar(…)
+//   internal void StreakCalendarCanvas_SizeChanged(…)
+//   internal void BtnFixStreak_Click(…)
+//   private void ExitStreakFixMode(…)
+//   private async void StreakFixDay_Click(…)
+//   private void OnSettingsPropertyChangedForQuests(…)
+//   private void RecalculateDailyQuestStreak(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Remember.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Remember.cs
@@ -1,0 +1,35 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Remember.cs (119 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (11):
+//   public Models.Preset? Preset
+//   public bool Takeover
+//   public bool Awareness
+//   public bool Haptics
+//   public bool BrowserMuted
+//   internal void BtnRemember_Click(…)
+//   internal void BtnRemember_RightClick(…)
+//   private void SnapshotRememberedConfig(…)
+//   private void RecallRememberedConfig(…)
+//   private void SetPremiumFeature(…)
+//   internal void SyncRememberButton(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Remember.cs; wired when they move to Core.
+        private void BtnRemember_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Remember.cs; wired when they move to Core.
+        private void BtnRemember_RightClick(object? sender, global::Avalonia.Input.PointerReleasedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.RemoteControl.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.RemoteControl.cs
@@ -1,0 +1,110 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs (1575 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (77):
+//   internal async void ChkRemoteControlEnabled_Changed(…)
+//   private string GetSelectedRemoteTier(…)
+//   private bool ShowRemoteControlWaiver(…)
+//   internal async void CmbRemoteTier_SelectionChanged(…)
+//   internal void BtnCopyRemoteCode_Click(…)
+//   internal void BtnCopyRemoteLink_Click(…)
+//   internal async void BtnStopRemote_Click(…)
+//   internal void ChkStopEffectsOnRemoteDisconnect_Changed(…)
+//   internal async void ChkRemoteShareAvatar_Changed(…)
+//   private Models.EmotePreset? _editingPreset
+//   internal async void BtnEmotePreset_Click(…)
+//   internal async void BtnEmoteCustomSend_Click(…)
+//   internal async void TxtEmoteCustom_KeyDown(…)
+//   private async void BtnEmotePresetBig_Click(…)
+//   private async void BtnEmoteCustomSendBig_Click(…)
+//   private async void TxtEmoteCustomBig_KeyDown(…)
+//   private async Task SendCustomEmoteAsync(…)
+//   internal async Task<bool> SendEmoteAndReportAsync(…)
+//   internal void BtnEmoteEdit_Click(…)
+//   internal void TxtEditEmoteText_TextChanged(…)
+//   internal void BtnEditEmoteSave_Click(…)
+//   internal void BtnEditEmoteCancel_Click(…)
+//   private bool _availableSubjectsBound
+//   internal void BtnAvailableSubjects_Click(…)
+//   internal void BtnBecomeASubject_Click(…)
+//   private void RefreshBecomeASubjectCta(…)
+//   private void EnsureAvailableSubjectsBound(…)
+//   private void OnAvailableSubjectsServicePropertyChanged(…)
+//   internal void AvailableSubjectsScroller_PreviewMouseWheel(…)
+//   private void UpdateAvailableSubjectsEmptyAndError(…)
+//   internal async void BtnConnectSubject_Click(…)
+//   private const int OptInMaxTags
+//   private System.Windows.Controls.CheckBox[] OptInTagCheckBoxes(…)
+//   internal void ChkOptIntoDirectory_Changed(…)
+//   private void PopulateOptInFormFromSavedSettings(…)
+//   internal void TxtOptInStatus_TextChanged(…)
+//   private void UpdateOptInStatusCharCount(…)
+//   internal void ChkOptInTag_Click(…)
+//   private List<string> GetSelectedDirectoryTags(…)
+//   private System.Windows.Threading.DispatcherTimer? _optInFeedbackTimer
+//   private void ShowOptInFeedback(…)
+//   private async Task RunOptInChainAsync(…)
+//   private bool _directoryOptedIn
+//   private void UpdateDirectoryListingStatus(…)
+//   private async Task StopRemoteControl(…)
+//   private void OnRemoteControllerChanged(…)
+//   private void OnRemoteControllerIdleChanged(…)
+//   private void OnRemoteSessionEnded(…)
+//   private void UpdateRemoteStatus(…)
+//   private void ShowRemoteControlOverlay(…)
+//   private void HideRemoteControlOverlay(…)
+//   private void WireRemoteSessionCallbacks(…)
+//   private void StartRemoteSessionInfoTimer(…)
+//   private void UpdateRemoteSessionInfo(…)
+//   private void OnRemoteCommandReceived(…)
+//   private void AppendRemoteCommandLog(…)
+//   private void UpdateRemoteControlUI(…)
+//   private string BuildRemotePairingUrl(…)
+//   private void RefreshRemoteQrCode(…)
+//   private void RefreshTierCardHighlight(…)
+//   internal void TierCard_Click(…)
+//   private void ShowCommandNotification(…)
+//   private void HideCommandNotification(…)
+//   private async void BtnEndRemoteSession_Click(…)
+//   private Models.Session? _remoteStartedSession
+//   internal bool IsSessionRemoteStarted
+//   internal async void StartSessionFromRemote(…)
+//   internal void PauseSessionFromRemote(…)
+//   internal void ResumeSessionFromRemote(…)
+//   internal void StopSessionFromRemote(…)
+//   internal void StopEngineAndSession(…)
+//   internal void TriggerPanicFromRemote(…)
+//   internal void MinimizeToTrayForRemote(…)
+//   public void MinimizeToTrayForChaos(…)
+//   private void NotifyRemoteControllerJoined(…)
+//   internal void RestoreFromTrayForRemote(…)
+//   public void ShowFromTray(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
+        private void BtnAvailableSubjects_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
+        private void BtnEmoteCustomSendBig_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
+        private void BtnEmotePresetBig_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
+        private void BtnEndRemoteSession_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
+        private void TxtEmoteCustomBig_KeyDown(object? sender, global::Avalonia.Input.KeyEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs
@@ -1,0 +1,28 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs (501 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (12):
+//   private Models.RoadmapTrack _currentRoadmapTrack
+//   internal void BtnQuestSubDaily_Click(…)
+//   internal void BtnQuestSubRoadmap_Click(…)
+//   internal void BtnTrack_Click(…)
+//   private void RefreshRoadmapUI(…)
+//   private void GenerateRoadmapNodes(…)
+//   private Border CreateRoadmapNode(…)
+//   private void RoadmapNode_Click(…)
+//   private void ShowPhotoConfirmation(…)
+//   private void RefreshRoadmapStats(…)
+//   private void OnRoadmapStepCompleted(…)
+//   private void OnRoadmapTrackUnlocked(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SessionFeatureLock.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SessionFeatureLock.cs
@@ -1,0 +1,35 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SessionFeatureLock.cs (532 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (19):
+//   private const string SessionLockBannerTag
+//   private UserControl? _activeFeaturePopupContent
+//   internal bool IsSessionFeatureLockActive
+//   private bool IsProgramSessionActive
+//   internal string SessionFeatureLockReason
+//   private bool? _sessionLockPainted
+//   internal void RefreshSessionFeatureLock(…)
+//   private static bool PaintSection(…)
+//   private void ApplySessionLockRibbon(…)
+//   private void ApplySessionLockToTabs(…)
+//   private void ApplySessionLockToFeaturePopup(…)
+//   private void ApplySessionLockToStudioRack(…)
+//   private static Border? FindSessionLockBanner(…)
+//   private static void UpdateSessionLockBanner(…)
+//   private static Border BuildSessionLockBanner(…)
+//   private static void SetToggleLock(…)
+//   internal bool RefuseIfSessionFeatureLocked(…)
+//   internal bool RefuseActionIfSessionLocked(…)
+//   private void PulseSessionLockRibbon(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SessionIO.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SessionIO.cs
@@ -1,0 +1,109 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SessionIO.cs (2212 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (93):
+//   private Services.SessionManager? _sessionManager
+//   private Services.SessionFileService? _sessionFileService
+//   private Services.AssetImportService? _assetImportService
+//   private void InitializeSessionManager(…)
+//   private void OnSessionsReloaded(…)
+//   public bool RegisterExternallySavedSession(…)
+//   private void OnSessionAdded(…)
+//   private void OnSessionRemoved(…)
+//   private const string RackSourceAll
+//   private const string RackSourceBuiltIn
+//   private const string RackSourceYours
+//   private const string RackSourceCatalogue
+//   private string _rackSourceFilter
+//   private string _rackSort
+//   private string _rackSearch
+//   private readonly HashSet<Models.SessionDifficulty> _rackDifficulties
+//   private readonly List<ToggleButton> _rackSourceChips
+//   private readonly List<ToggleButton> _rackDifficultyChips
+//   private bool _rackToolbarBuilt
+//   private bool _rackToolbarSyncing
+//   internal void RepaintSessionRack(…)
+//   private List<Models.Session> EnumerateRackSessions(…)
+//   private bool RackAccepts(…)
+//   private List<Models.Session> SortRackSessions(…)
+//   private static DateTime? RackFileStamp(…)
+//   private Border BuildSessionRackRow(…)
+//   private TextBlock MakeRackMeta(…)
+//   private static(…)
+//   private static void AttachRoundedClip(…)
+//   private void EnsureSessionRackToolbar(…)
+//   private static string RackSourceLabel(…)
+//   private static string RackSourceChipLabel(…)
+//   private static string RackDifficultyLabel(…)
+//   private void UpdateRackToolbarCounts(…)
+//   private void RackSourceChip_Changed(…)
+//   private void RackDifficultyChip_Changed(…)
+//   internal void CmbRackSort_SelectionChanged(…)
+//   internal void TxtRackSearch_TextChanged(…)
+//   private void ClearSessionRackFilters(…)
+//   private void RefreshSessionRackSelection(…)
+//   private bool HasSessionRackRow(…)
+//   private Border MakeRackPill(…)
+//   private Button CreateSessionActionButton(…)
+//   private Button CreateSessionDeleteButton(…)
+//   private Button CreateSessionRowButton(…)
+//   private void SelectSession(…)
+//   private string GenerateSessionTimelineDescription(…)
+//   internal void SessionDropZone_DragEnter(…)
+//   internal void SessionDropZone_DragOver(…)
+//   internal void SessionDropZone_DragLeave(…)
+//   private void Window_DragEnter(…)
+//   private void OpenAvatarChat_Executed(…)
+//   internal void BtnChatShortcut_Click(…)
+//   private void ApplyGlobalChatHotkey(…)
+//   private void BringToForegroundAndOpenChat(…)
+//   public void RefreshChatShortcutLabel(…)
+//   public static readonly RoutedUICommand ToggleCameraCommand
+//   private bool _cameraCommandBound
+//   private void ApplyCameraShortcutTo(…)
+//   private void ApplyGlobalCameraHotkey(…)
+//   private static ModifierKeys ParseModifiers(…)
+//   private static string FormatCameraShortcut(…)
+//   public void RefreshCameraShortcutLabel(…)
+//   internal void BtnCameraShortcut_Click(…)
+//   private void Window_DragOver(…)
+//   private void Window_DragLeave(…)
+//   private async void Window_Drop(…)
+//   private enum DropType
+//   private static readonly HashSet<string> AssetVideoExtensions
+//   private static readonly HashSet<string> AssetImageExtensions
+//   private static readonly HashSet<string> DeeperVideoExtensions
+//   private static readonly HashSet<string> DeeperAudioExtensions
+//   private enum MediaDropChoice
+//   private static bool IsDeeperPlayableMedia(…)
+//   private static DropType DetectDropType(…)
+//   private void UpdateDropOverlay(…)
+//   private void HandleSessionDrop(…)
+//   private async Task HandleAssetDropAsync(…)
+//   private void RefreshImagesList(…)
+//   private void RefreshVideosList(…)
+//   internal void SessionBtn_Edit(…)
+//   internal void SessionBtn_Export(…)
+//   private async void SessionBtn_Share(…)
+//   private void SyncCustomSessionsFromDisk(…)
+//   private void SessionBtn_Delete(…)
+//   private Models.Session? GetSessionById(…)
+//   internal bool RevealSessionInLibrary(…)
+//   internal void SessionDropZone_Drop(…)
+//   private void ShowDropZoneStatus(…)
+//   internal void BtnExportSession_Click(…)
+//   internal void BtnCreateSession_Click(…)
+//   private void SessionContextMenu_Export(…)
+//   private void ExportSessionToFile(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Settings.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Settings.cs
@@ -1,0 +1,102 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Settings.cs (726 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (30):
+//   internal void OpenAppSettingsSection(…)
+//   private void LoadSettings(…)
+//   private void UpdateSliderTexts(…)
+//   private void SaveSettings(…)
+//   private void BtnSave_Click(…)
+//   private void BtnExit_Click(…)
+//   private void BtnMainHelp_Click(…)
+//   internal void BtnReportBug_Click(…)
+//   private void BtnTutorialReportBug_Click(…)
+//   private void OpenBugReportWindow(…)
+//   private void MainTutorial_Close(…)
+//   private void MainTutorial_ContentClick(…)
+//   private TutorialOverlay? _tutorialOverlay
+//   private void BtnStartTutorial_Click(…)
+//   public void StartTutorial(…)
+//   private void BtnTutorialWhatMoved_Click(…)
+//   private void BtnTutorialGettingStarted_Click(…)
+//   private void BtnTutorialSettings_Click(…)
+//   private void BtnTutorialPresets_Click(…)
+//   private void BtnTutorialProgression_Click(…)
+//   private void BtnTutorialAchievements_Click(…)
+//   private void BtnTutorialCompanion_Click(…)
+//   private void BtnTutorialPatreon_Click(…)
+//   private void BtnTutorialAvatar_Click(…)
+//   private void BtnTutorialAwareness_Click(…)
+//   internal void BtnAwarenessTutorial_Click(…)
+//   internal void BtnCompanionTutorial_Click(…)
+//   private void StartAwarenessTutorial(…)
+//   private void BtnTutorialModding_Click(…)
+//   private void OpenLinktree(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnMainHelp_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnReportBug_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnSave_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnStartTutorial_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialAchievements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialAvatar_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialAwareness_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialCompanion_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialGettingStarted_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialModding_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialPatreon_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialPresets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialProgression_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialReportBug_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialSettings_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void BtnTutorialWhatMoved_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void MainTutorial_Close(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.Settings.cs; wired when they move to Core.
+        private void MainTutorial_ContentClick(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SheListening.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SheListening.cs
@@ -1,0 +1,33 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SheListening.cs (481 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (17):
+//   private static bool DemandSheListeningPremium(…)
+//   internal void SL_Mantras_Changed(…)
+//   private bool _calibratingWake
+//   internal async void SL_Calibrate_Click(…)
+//   private void RefreshWakeEngineStatus(…)
+//   internal bool MicIsArmed(…)
+//   internal void ToggleVoiceMic(…)
+//   internal void DisarmVoiceMic(…)
+//   internal void SL_RevokeMicConsent_Click(…)
+//   internal void RefreshSheListeningTab(…)
+//   internal void RefreshSheListeningDeviceChips(…)
+//   private const double LoudThrAtMinSens
+//   private const double LoudThrAtMaxSens
+//   private static double SensToThreshold(…)
+//   private static double ThresholdToSens(…)
+//   internal void SL_MicSensitivity_Changed(…)
+//   private void RefreshSheListeningStatus(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SpiralRoom.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SpiralRoom.cs
@@ -1,0 +1,31 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SpiralRoom.cs (157 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (10):
+//   private const string SpiralRailAnonymousLabel
+//   private static readonly Brush SpiralRailAnonymousBrush
+//   private bool _spiralRoomWired
+//   private void InitializeSpiralRoom(…)
+//   private void OnSpiralRoomPhaseChanged(…)
+//   private void OnSpiralRoomBlockChanged(…)
+//   private void OnSpiralRoomLanguageChanged(…)
+//   internal void RefreshSpiralRailEntry(…)
+//   private void BtnNavSpiral_Click(…)
+//   internal void BeginSpiralFirstLight(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.SpiralRoom.cs; wired when they move to Core.
+        private void BtnNavSpiral_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.StartStop.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.StartStop.cs
@@ -1,0 +1,58 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs (1067 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (28):
+//   private void BtnStart_Click(…)
+//   private void BtnStartMenu_Click(…)
+//   private void MenuStartNormal_Click(…)
+//   private void MenuJumpRightIn_Click(…)
+//   internal void RandomizeAndStart(…)
+//   private static readonly string[] FlashImageExtensions
+//   private static readonly string[] WallpaperImageExtensions
+//   private static bool FolderHasAnyMedia(…)
+//   private static bool IsLocalOnlyMediaSource(…)
+//   private static void OpenPackCatalogue(…)
+//   private void WarnIfFlashLibraryEmpty(…)
+//   internal void WarnIfWallpaperLibraryEmpty(…)
+//   public void StartEngine(…)
+//   private bool _stopInProgress
+//   private DateTime? _emiEngineStartedUtc
+//   public void StopEngine(…)
+//   private void StopEngineCore(…)
+//   private void StartRampTimer(…)
+//   private void StopRampTimer(…)
+//   private void RampTimer_Tick(…)
+//   private void CheckSchedulerOnStartup(…)
+//   private void CheckSchedulerAfterSettingsChange(…)
+//   private void SchedulerTimer_Tick(…)
+//   private bool IsInScheduledTimeWindow(…)
+//   private void ApplySettingsLive(…)
+//   private void UpdateStartButton(…)
+//   private void UpdateStartButtonForRemoteControl(…)
+//   private static T? FindVisualChild<T>(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.StartStop.cs; wired when they move to Core.
+        private void BtnStartMenu_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.StartStop.cs; wired when they move to Core.
+        private void BtnStart_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.StartStop.cs; wired when they move to Core.
+        private void MenuJumpRightIn_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.StartStop.cs; wired when they move to Core.
+        private void MenuStartNormal_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SubjectsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SubjectsFx.cs
@@ -1,0 +1,23 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SubjectsFx.cs (143 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (7):
+//   private const int SubjectsFogPuffs
+//   private const double SubjectsFogIntensity
+//   private bool _subjectsFxInitialized
+//   internal void OnAvailableSubjectsTabVisibilityChanged(…)
+//   private void InitializeSubjectsFx(…)
+//   private void StaggerSubjectCards(…)
+//   internal void OnSubjectConnectPress(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SubscribeStar.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SubscribeStar.cs
@@ -1,0 +1,20 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SubscribeStar.cs (121 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (4):
+//   private void InitializeSubscribeStarTab(…)
+//   private void OnSubscribeStarTierChanged(…)
+//   private void UpdateSubscribeStarUI(…)
+//   internal void BtnSubscribeStarLogin_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TabFxPresetsQuestsAchievements.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TabFxPresetsQuestsAchievements.cs
@@ -1,0 +1,78 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.TabFxPresetsQuestsAchievements.cs (834 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (62):
+//   private const double SessionRowLiftPx
+//   private const int CardLiftMs
+//   private const double AchievementTiltDegrees
+//   private const int AchievementTiltMs
+//   private const double PresetCardCornerRadius
+//   private const double SessionCardCornerRadius
+//   private bool _tabFxWindowHooked
+//   private bool _presetsFxInitialized
+//   private bool _questsFxInitialized
+//   private bool _achievementsFxInitialized
+//   private CardSheenAdorner? _cardSheen
+//   private FrameworkElement? _cardSheenHost
+//   private AdornerLayer? _cardSheenLayer
+//   private bool _presetsTabVisible
+//   private RowSweepAdorner? _rowSweep
+//   private FrameworkElement? _rowSweepHost
+//   private AdornerLayer? _rowSweepLayer
+//   private double _weeklyQuestFraction
+//   private bool _questTracksHooked
+//   private readonly HashSet<FrameworkElement> _achievementTilesUnlocked
+//   private readonly Dictionary<FrameworkElement, FrameworkElement> _achievementTiltTargets
+//   private readonly Dictionary<FrameworkElement, FrameworkElement> _achievementPopTargets
+//   private bool TabFxAmbientAllowed
+//   private bool IsIncomingTab(…)
+//   private void HookTabFxWindowEvents(…)
+//   private void TabFx_WindowStateish(…)
+//   private void TabFx_ModChanged(…)
+//   private static TransformGroup? EnsureCardTransforms(…)
+//   private static T? FindTransform<T>(…)
+//   private void WireButtonPress(…)
+//   private void FxButton_PressDown(…)
+//   private void FxButton_PressUp(…)
+//   private void PressFx(…)
+//   internal void OnPresetsTabVisibilityChanged(…)
+//   private void InitializePresetsFx(…)
+//   internal void PreparePresetCardFx(…)
+//   private void PresetCard_MouseEnter(…)
+//   private void PresetCard_MouseLeave(…)
+//   internal void PrepareSessionRowFx(…)
+//   private void SessionRow_MouseEnter(…)
+//   private void SessionRow_MouseLeave(…)
+//   private void AttachRowSweep(…)
+//   private void ReleaseRowSweep(…)
+//   private void DetachRowSweep(…)
+//   private void LiftSessionRow(…)
+//   private void StaggerPresetCards(…)
+//   internal void RefreshCardSheen(…)
+//   private void DetachCardSheen(…)
+//   private FrameworkElement? FindSelectedCard(…)
+//   internal void OnQuestsTabVisibilityChanged(…)
+//   private void InitializeQuestsFx(…)
+//   private void QuestTrack_SizeChanged(…)
+//   private void SetQuestProgress(…)
+//   private void ApplyQuestProgressBars(…)
+//   internal void OnAchievementsTabVisibilityChanged(…)
+//   private void StaggerAchievementTiles(…)
+//   internal void PrepareAchievementTileFx(…)
+//   internal void SetAchievementTileUnlocked(…)
+//   private FrameworkElement? TiltTargetFor(…)
+//   private void AchievementTile_MouseEnter(…)
+//   private void AchievementTile_MouseLeave(…)
+//   private void TiltAchievementTile(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TabFxTakeoverLabStatus.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TabFxTakeoverLabStatus.cs
@@ -1,0 +1,38 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.TabFxTakeoverLabStatus.cs (336 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (22):
+//   private const double StatusPulseMinOpacity
+//   private const double StatusPulseMaxOpacity
+//   private const double StatusPulseSeconds
+//   private const double StatusPulseBlurSmall
+//   private const double StatusPulseBlurLarge
+//   private bool _pr4aFxInitialized
+//   private readonly Dictionary<FrameworkElement, StatusPulseRequest> _statusPulses
+//   private sealed class StatusPulseRequest
+//   private bool Pr4aAmbientAllowed
+//   private void EnsurePr4aFx(…)
+//   private void HookPr4aTab(…)
+//   private void OnPr4aFxWindowStateish(…)
+//   private void OnPr4aTabVisibilityChanged(…)
+//   private void OnPr4aModChanged(…)
+//   private void ApplyPr4aFxLoops(…)
+//   private void SetStatusPulse(…)
+//   private void ApplyPr4aStatusPulses(…)
+//   private void ApplyStatusPulse(…)
+//   private void SetBlinkTrainerStatusPulse(…)
+//   private void SetHapticsStatusPulse(…)
+//   private void SetSheListeningStatusPulse(…)
+//   private void SetAwarenessStatusPulse(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
@@ -1,0 +1,113 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs (1174 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (44):
+//   private void BtnSettings_Click(…)
+//   private void BtnPresets_Click(…)
+//   private void BtnQuests_Click(…)
+//   private void BtnPrograms_Click(…)
+//   private void BtnEnhancements_Click(…)
+//   private static readonly Dictionary<string, string> BarkTabAliases
+//   private static string CanonicalTabKey(…)
+//   internal void ShowTab(…)
+//   private static readonly(…)
+//   internal static readonly string[] NavLauncherDoors
+//   internal const string WebAppUrl
+//   internal const string ProfileSharingUrl
+//   private const double NavEntryRowHeight
+//   private const int NavDoorExpandMs
+//   private string _expandedDoor
+//   private static string? NavDoorForTab(…)
+//   private Button? NavDoorHeaderForTab(…)
+//   private bool IsDoorExpandedForTab(…)
+//   internal Button? NavAnchorForTab(…)
+//   private readonly Dictionary<string, Button> _navHeaderPulses
+//   private bool StartNavDoorHeaderPulse(…)
+//   private void StopNavDoorHeaderPulse(…)
+//   internal void ExpandDoorForTab(…)
+//   private void SetExpandedDoor(…)
+//   private bool IsDoorPanelOpenFor(…)
+//   private void SetDoorPanelExpanded(…)
+//   private static double MeasureDoorPanel(…)
+//   private void NavDoor_Click(…)
+//   private void DoorWebApp_Click(…)
+//   internal Views.Tabs.HapticsTabView HapticsTab
+//   private void BtnNavStudio_Click(…)
+//   private void BtnNavHaptics_Click(…)
+//   private void BtnNavPlay_Click(…)
+//   private void BtnNavBambiTakeover_Click(…)
+//   private void BtnNavSheListening_Click(…)
+//   private void BtnNavGradedIntake_Click(…)
+//   private void BtnNavLockdown_Click(…)
+//   private void BtnNavBlinkTrainer_Click(…)
+//   private void BtnNavRemoteControl_Click(…)
+//   private void BtnNavMediaLog_Click(…)
+//   private void MaybeShowFeatureIntro(…)
+//   private bool _dashboardIntroQueued
+//   internal void OnDashboardTabVisibilityChanged(…)
+//   private void RefreshBlinkTrainerTab(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnEnhancements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavBambiTakeover_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavBlinkTrainer_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavGradedIntake_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavHaptics_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavLockdown_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavMediaLog_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavPlay_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavRemoteControl_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavSheListening_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnNavStudio_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnPresets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnPrograms_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnQuests_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void BtnSettings_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void DoorWebApp_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        private void NavDoor_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Takeaway.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Takeaway.cs
@@ -1,0 +1,41 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Takeaway.cs (671 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (25):
+//   private const int TakeawayShelfCap
+//   private bool _takeawayLoading
+//   private bool _takeawayTrayOpen
+//   private TextBlock? _takeawayMoreLabel
+//   private int _takeawayMoreCount
+//   internal void RefreshTakeawayShelf(…)
+//   private async System.Threading.Tasks.Task LoadTakeawayShelfAsync(…)
+//   private void PaintTakeawayShelf(…)
+//   private void SetTakeawayTrayOpen(…)
+//   private static string TakeawayMoreText(…)
+//   private Border? BuildTakeawayDropChip(…)
+//   private Border? BuildTakeawayMoreChip(…)
+//   private Border? BuildTakeawayTrayRow(…)
+//   private TextBlock MakeTakeawayRowMeta(…)
+//   private Border? BuildTakeawayCopyChip(…)
+//   private Border? BuildTakeawayDoorChip(…)
+//   private static string FormatTakeawayMeta(…)
+//   private static string FormatTakeawayDate(…)
+//   private static string FormatTakeawayMinutes(…)
+//   private static string FormatTakeawayAge(…)
+//   private static string SafeOrderName(…)
+//   private void TakeawayCard_Click(…)
+//   private void TakeawayCopyLink_Click(…)
+//   private void TakeawayMore_Click(…)
+//   private void TakeawayDoor_Click(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TakeoverUi.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TakeoverUi.cs
@@ -1,0 +1,29 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.TakeoverUi.cs (165 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (13):
+//   private static readonly Color GreenColor
+//   private static readonly Color MutedColor
+//   private DispatcherTimer? _voicePanelHideTimer
+//   internal void InitTakeoverVoiceUi(…)
+//   private void RunOnUi(…)
+//   private void OnTakeoverEnabledChanged(…)
+//   private void SetTakeoverActiveUi(…)
+//   private void OnVoicePromptStarted(…)
+//   private void OnSpeechPartial(…)
+//   private void OnSpeechLevel(…)
+//   private void SetVoiceLevel(…)
+//   private void OnVoicePromptFinished(…)
+//   private void HideVoicePanel(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TeaseCard.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TeaseCard.cs
@@ -1,0 +1,25 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.TeaseCard.cs (111 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (9):
+//   private const int TeaseCardTier
+//   private const string TeaseCardTitle
+//   private const string TeaseCardBadge
+//   private static bool TeaseCardRevealed
+//   private const string TeaseCardRevealTab
+//   private const string TeaseCardRevealedTitle
+//   private Features.FeatureCard? TeaseCard
+//   internal void ApplyTeaseCard(…)
+//   internal void TeaseCardClicked(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ToolTipHygiene.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ToolTipHygiene.cs
@@ -1,0 +1,28 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ToolTipHygiene.cs (247 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// Members dropped (12):
+//   private const int ToolTipSweepMaxDepth
+//   private const int ToolTipSweepMaxVisuals
+//   private bool _toolTipHygieneHooked
+//   private WeakReference<DependencyObject>? _openToolTipOwner
+//   internal void EnsureToolTipHygiene(…)
+//   private void OnAnyToolTipOpening(…)
+//   private void OnAnyToolTipClosing(…)
+//   private void CloseStaleToolTip(…)
+//   private static void CloseToolTipOn(…)
+//   private static void SweepOpenToolTips(…)
+//   private static IEnumerable<ToolTip> FindToolTips(…)
+//   private static void SyntheticMouseLeave(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // No member of this partial is referenced from MainShellWindow.axaml.
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.UiUpdates.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.UiUpdates.cs
@@ -1,0 +1,120 @@
+// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs (2904 lines).
+//
+// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
+// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
+// move services"). The file exists and each member is NAMED so nothing disappears
+// silently; the bodies come back when the services move to Core.
+//
+// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
+// missing one is a XAML compile error, not a runtime gap.
+//
+// Members dropped (99):
+//   private void UpdateUI(…)
+//   private void UpdateLevelDisplay(…)
+//   private void ApplyModFeatureNames(…)
+//   private bool _modSweepQueued
+//   private bool _modSweepWatchersHooked
+//   private bool _presetsModDirty
+//   private void QueueModAwareSurfaceSweep(…)
+//   private void RefreshModAwareSurfaces(…)
+//   private static void SweepStep(…)
+//   private void EnsureModSweepWatchers(…)
+//   internal static string ModAwareLabel(…)
+//   private static string StripLeadingGlyph(…)
+//   private void ApplyBimboJournalModVisibility(…)
+//   private void UpdateXPBarLoginState(…)
+//   private static SolidColorBrush AccountChipBrush(…)
+//   private static readonly SolidColorBrush AccountChipTier1Brush
+//   private static readonly SolidColorBrush AccountChipTier2Brush
+//   private static readonly SolidColorBrush AccountChipNeutralBrush
+//   private void RefreshAccountChip(…)
+//   private void BtnAccountChip_Click(…)
+//   private void UpdateStatPills(…)
+//   private void RefreshXPBarBonuses(…)
+//   private static string? GetBonusChipTooltip(…)
+//   private void StartStatPillUpdateTimer(…)
+//   private void StartConditioningTimeTracker(…)
+//   private void StopConditioningTimeTracker(…)
+//   private async Task SyncConditioningTimeToServerAsync(…)
+//   private void UpdateUnlockablesVisibility(…)
+//   private void SetFeatureImageBlur(…)
+//   internal void SliderMaster_Changed(…)
+//   internal void SliderVideoVolume_Changed(…)
+//   internal void SliderDuck_Changed(…)
+//   internal void ChkAudioDuck_Changed(…)
+//   internal void ChkExcludeBambiCloudDucking_Changed(…)
+//   private bool _testingAudio
+//   internal async void BtnTestAudio_Click(…)
+//   private bool _populatingAudioOutputs
+//   private void PopulateAudioOutputDevices(…)
+//   internal void CmbAudioOutputDevice_SelectionChanged(…)
+//   internal void BtnAudioOutputRefresh_Click(…)
+//   internal void ImgLogo_MouseLeftButtonDown(…)
+//   private const int IntakePassFaceHoldMs
+//   private static readonly int[] IntakePassHalfTurnMs
+//   private const double IntakePassSkewDeg
+//   private int _intakePassSpinGen
+//   private bool _intakePassLoopRunning
+//   private bool _intakePassShowingCard
+//   private bool _intakePassLoadedHooked
+//   private bool _intakePassStateHooked
+//   private bool _intakePassVisibilityHooked
+//   private bool _intakePassModHooked
+//   private bool _intakePassHelpAttached
+//   private static readonly TimeSpan IntakePassCtaBreath
+//   private bool _intakePassCtaShouldPulse
+//   private bool _intakePassCtaPulsing
+//   internal void RefreshIntakePassTile(…)
+//   private void SetIntakePassFace(…)
+//   private void ApplyIntakePassFaceState(…)
+//   private void StartIntakePassCtaPulse(…)
+//   private void StopIntakePassCtaPulse(…)
+//   private void EnsureIntakePassHelpPopover(…)
+//   private static HelpContent BuildIntakePassHelpContent(…)
+//   private void CancelIntakePassSpin(…)
+//   private void StartIntakePassFlipLoop(…)
+//   private void HoldIntakePassFace(…)
+//   private void RunIntakePassSpinPhase(…)
+//   private void FinishIntakePassSpin(…)
+//   internal void IntakePassFace_MouseLeftButtonDown(…)
+//   private async void ShowEasterEgg(…)
+//   private void TriggerStartupVideo(…)
+//   internal void BtnSelectStartupVideo_Click(…)
+//   internal void BtnClearStartupVideo_Click(…)
+//   internal void BtnManageAttention_Click(…)
+//   internal void BtnAttentionStyle_Click(…)
+//   internal void BtnSubliminalSettings_Click(…)
+//   internal void BtnManageMessages_Click(…)
+//   private void BtnPrevImage_Click(…)
+//   private void BtnNextImage_Click(…)
+//   internal void BtnPickAssetsFolder_Click(…)
+//   private static void CopyDirectoryRecursive(…)
+//   private static string FormatFileSize(…)
+//   internal void BtnRefreshAssets_Click(…)
+//   private void BtnViewLog_Click(…)
+//   internal void ChkPanicOverridesAll_Changed(…)
+//   internal void BtnPauseKey_Click(…)
+//   internal void BtnPanicKey_Click(…)
+//   internal void ChkNoPanic_Changed(…)
+//   internal void ChkPerformanceMode_Changed(…)
+//   internal void ChkAutoPerformance_Changed(…)
+//   internal void CmbMotionLevel_SelectionChanged(…)
+//   internal void ChkVideoHwDecode_Changed(…)
+//   internal void ChkUnifiedOverlay_Changed(…)
+//   internal void ChkOfflineMode_Changed(…)
+//   private static void SetOfflineDisabled(…)
+//   private void UpdateOfflineModeUI(…)
+//   private void DisconnectNetworkServices(…)
+//   internal void ChkWinStart_Click(…)
+//   internal void ChkStartHidden_Click(…)
+//   private void XPBarTrack_ToolTipOpening(…)
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // ponytail: needs the services in MainWindow.UiUpdates.cs; wired when they move to Core.
+        private void BtnAccountChip_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.WindowChrome.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.WindowChrome.cs
@@ -1,0 +1,78 @@
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs (478 lines).
+//
+// The four title-bar handlers are the ONLY members of this partial that touch nothing but the
+// window, so they are ported for real; everything else in the WPF file reaches App.Bark,
+// App.Lockdown, the avatar tube window or Win32 and is listed below rather than faked.
+//
+// Win32 -> Avalonia, per the port's mapping table:
+//   DragMove()                         -> BeginMoveDrag(PointerPressedEventArgs)
+//   WindowState = Minimized/Maximized  -> unchanged; Avalonia has the same enum
+//   e.ClickCount == 2                  -> e.ClickCount == 2 on PointerPressedEventArgs
+//   PointToScreen + Left/Top fixup     -> dropped. BeginMoveDrag restores from maximized itself
+//                                         on every backend, so the manual re-anchor is not needed.
+//   OnDpiChanged / OnStateChanged      -> no such overrides on Avalonia's Window. Scaling changes
+//                                         arrive as ScalingChanged; WindowState is an
+//                                         AvaloniaProperty you observe. See the WorkAreaFit
+//                                         partial, which is where the DPI re-fit actually lives.
+//
+// Members dropped (App.*/avatar-tube/Win32 only):
+//   private void EnsureSessionRestoredForExit(…)
+//   protected override void OnClosing(…)          // session save, tray, Bark, Lockdown
+//   protected override void OnDpiChanged(…)       // queues the work-area re-fit; see WorkAreaFit
+//   protected override void OnStateChanged(…)     // avatar re-attach, Bark, taskbar thumbnail
+//   private void HideAvatarTube(…)                // called by BtnMinimize_Click below
+
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        private void TitleBar_MouseLeftButtonDown(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.ClickCount == 2)
+            {
+                BtnMaximize_Click(sender, new RoutedEventArgs());
+                return;
+            }
+
+            // BeginMoveDrag hands the drag to the window manager, which is what makes an
+            // undecorated window draggable on X11 the way DragMove() did on Win32. It also
+            // un-maximizes on the way, so the WPF PointToScreen re-anchor above it is gone.
+            BeginMoveDrag(e);
+        }
+
+        private void BtnMinimize_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.Bark (NotifyUiAction) and App.Lockdown (NotifyEscapeAttempt),
+            // plus HideAvatarTube; wired when those move to Core.
+            WindowState = WindowState.Minimized;
+        }
+
+        private void BtnMaximize_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs the avatar tube window (detach before maximizing, re-attach after);
+            // wired when AvatarTubeWindow's host service moves to Core.
+            if (WindowState == WindowState.Maximized)
+            {
+                WindowState = WindowState.Normal;
+                BtnMaximize.Content = "☐";
+            }
+            else
+            {
+                WindowState = WindowState.Maximized;
+                BtnMaximize.Content = "❐";
+            }
+        }
+
+        private void BtnClose_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: the WPF handler runs EnsureSessionRestoredForExit and the tray/minimise-to-
+            // tray preference first. Both are services; this closes the window, which is what the
+            // button says it does.
+            Close();
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.WorkAreaFit.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.WorkAreaFit.cs
@@ -1,0 +1,168 @@
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.WorkAreaFit.cs (297 lines).
+//
+// This is the one Win32-heavy partial that maps CLEANLY, so it is a real port rather than a stub.
+// The problem it solves is unchanged on Linux: the window ships at a fixed 1563x943 DIP with
+// 1131x620 floors, and on a TV at 300% scaling the work area is a third of that in DIP space, so
+// the bottom bar (START, the status strip) lands off the desktop with no way to drag it back.
+// Shrinking is visually safe because the whole UI is a Viewbox with Stretch="Fill" over a fixed
+// 1585x901 design canvas: a smaller window scales the content down rather than clipping it.
+//
+// Win32 -> Avalonia, per the port's mapping table:
+//   Screen.FromHandle / MonitorFromWindow -> Screens.ScreenFromWindow(this) ?? Screens.Primary
+//   Screen.WorkingArea (physical px)       -> screen.WorkingArea (PixelRect, physical px)
+//   VisualTreeHelper.GetDpi / DpiScale     -> screen.Scaling (one factor, not x/y - X11 and
+//                                             Wayland both report a single scale)
+//   GetWindowRect + SetWindowPos           -> Position (PixelPoint) + Width/Height. Avalonia's
+//                                             Position IS physical-pixel screen space, which is
+//                                             exactly the space the WPF version dropped to
+//                                             SetWindowPos for, so the conversion the comment in
+//                                             the original warns about disappears.
+//   OnSourceInitialized                    -> OnOpened (the first point at which there is a
+//                                             platform window to ask which screen it is on)
+//   OnDpiChanged + dispatcher coalescing   -> ScalingChanged. There is no modal move loop and no
+//                                             WM_DPICHANGED ping-pong to break here, so the
+//                                             coalescing, the drag deferral and the 4-fit burst cap
+//                                             are all dropped; the idempotence early-out below is
+//                                             what stops a loop.
+//
+// Members dropped: RunWorkAreaFitDeferredByMove / QueueWorkAreaFitAfterDpiChange /
+// RunQueuedWorkAreaFit and their five coalescing fields - all of them exist only to tame
+// WM_DPICHANGED during an interactive move, which is a Win32-specific hazard.
+
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        // The XAML floors, captured before we ever lower them so they can be restored.
+        private double _designMinWidth = double.NaN;
+        private double _designMinHeight = double.NaN;
+
+        // Re-entrancy guard: relaxing MinWidth/MinHeight and moving the window both raise
+        // size/position changes that could route back here.
+        private bool _workAreaFitInProgress;
+
+        private void EnsureDesignFloorsCaptured()
+        {
+            if (double.IsNaN(_designMinWidth))
+            {
+                _designMinWidth = MinWidth;
+                _designMinHeight = MinHeight;
+            }
+        }
+
+        /// <summary>
+        /// Lowers MinWidth/MinHeight so they cannot out-vote a work area smaller than the design
+        /// floors, and raises them back toward the XAML values when the screen can take it.
+        /// Sizes are DIPs, the space MinWidth/MinHeight themselves live in.
+        /// </summary>
+        private void RelaxSizeFloorsTo(double maxWidthDip, double maxHeightDip)
+        {
+            EnsureDesignFloorsCaptured();
+            if (maxWidthDip > 0)
+            {
+                // 200 DIP is a sanity floor: below that the window stops being a window.
+                var w = Math.Max(200, Math.Min(_designMinWidth, maxWidthDip));
+                if (Math.Abs(MinWidth - w) > 0.5) MinWidth = w;
+            }
+            if (maxHeightDip > 0)
+            {
+                var h = Math.Max(200, Math.Min(_designMinHeight, maxHeightDip));
+                if (Math.Abs(MinHeight - h) > 0.5) MinHeight = h;
+            }
+        }
+
+        /// <summary>
+        /// Clamps the window to the work area of the monitor it is on and nudges it back on-screen.
+        /// Safe to call repeatedly; a no-op when the window already fits.
+        /// </summary>
+        private void FitToCurrentMonitorWorkArea(string reason)
+        {
+            if (_workAreaFitInProgress) return;
+            try
+            {
+                // Maximized/minimized windows are sized by the shell against this same work area,
+                // and full-screen mode is deliberately larger than it. Only Normal is ours to clamp.
+                if (WindowState != WindowState.Normal) return;
+
+                // Null during display-topology churn: treat it as "don't touch the window" rather
+                // than guessing at primary, exactly as the WPF original does.
+                var screen = Screens?.ScreenFromWindow(this) ?? Screens?.Primary;
+                if (screen is null) return;
+
+                var wa = screen.WorkingArea;
+                if (wa.Width <= 0 || wa.Height <= 0) return;
+
+                var scale = screen.Scaling > 0 ? screen.Scaling : 1.0;
+
+                _workAreaFitInProgress = true;
+
+                // Step 1: let the floors down to the work area so step 2's resize is not vetoed.
+                RelaxSizeFloorsTo(wa.Width / scale, wa.Height / scale);
+
+                // Step 2: clamp size, then nudge fully on-screen - all in physical pixels, which
+                // is the space both WorkingArea and Position already live in.
+                var pos = Position;
+                var w = Math.Max(1, (int)Math.Round(Width * scale));
+                var h = Math.Max(1, (int)Math.Round(Height * scale));
+                var newW = Math.Min(w, wa.Width);
+                var newH = Math.Min(h, wa.Height);
+                var newL = pos.X;
+                var newT = pos.Y;
+                if (newL + newW > wa.Right) newL = wa.Right - newW;
+                if (newT + newH > wa.Bottom) newT = wa.Bottom - newH;
+                // Left/Top last: if the window still cannot fit (a floor we refused to go under),
+                // the two corrections disagree, and keeping the TOP-LEFT corner on-screen is what
+                // keeps the title bar draggable and the window recoverable.
+                if (newL < wa.X) newL = wa.X;
+                if (newT < wa.Y) newT = wa.Y;
+
+                if (newW == w && newH == h && newL == pos.X && newT == pos.Y) return;
+
+                Width = newW / scale;
+                Height = newH / scale;
+                Position = new PixelPoint(newL, newT);
+
+                Log.Information(
+                    "MainShellWindow work-area fit ({Reason}): {W}x{H}@{L},{T} -> {NW}x{NH}@{NL},{NT}; " +
+                    "work area {WW}x{WH} at {Scale:0.##}x, floors now {MinW:0}x{MinH:0} DIP",
+                    reason, w, h, pos.X, pos.Y, newW, newH, newL, newT,
+                    wa.Width, wa.Height, scale, MinWidth, MinHeight);
+            }
+            catch (Exception ex)
+            {
+                // Never let a placement tweak take the window down.
+                Log.Warning(ex, "MainShellWindow work-area fit failed ({Reason})", reason);
+            }
+            finally
+            {
+                _workAreaFitInProgress = false;
+            }
+        }
+
+        /// <summary>
+        /// First point at which there is a platform window, so the first point at which we can ask
+        /// which monitor we are on and what its scale is - the Avalonia twin of the WPF
+        /// OnSourceInitialized hook, and early enough that an oversized window is corrected
+        /// without ever flashing at the wrong size.
+        /// </summary>
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            try
+            {
+                EnsureDesignFloorsCaptured();
+                FitToCurrentMonitorWorkArea("opened");
+                ScalingChanged += (_, __) => FitToCurrentMonitorWorkArea("scaling-changed");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "OnOpened work-area fit failed");
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.axaml
@@ -1,0 +1,3380 @@
+<!-- PORTED from ConditioningControlPanel/MainWindow/MainWindow.xaml (3,474 lines) - the app
+     shell, and the last and largest view in the port. Class is MainShellWindow, NOT MainWindow:
+     this head already owns a MainWindow (the diagnostics window RenderProof hosts views in) and
+     an AppShell, and neither may be overwritten. Making this the startup window is a later
+     layer's call; nothing here wires it up.
+
+     Structure, row/column indices, x:Names, sizes and resource keys are preserved. Deviations,
+     all forced:
+
+       Style="{StaticResource X}"          -> Theme="{StaticResource X}"
+       <Style x:Key TargetType>            -> <ControlTheme x:Key TargetType> WITH a Template
+       <X.Style><Style TargetType>         -> <X.Theme><ControlTheme TargetType>  (Avalonia has
+                                              no Control.Style; ItemContainerStyle -> ItemContainerTheme)
+       Visibility="Collapsed"              -> IsVisible="False"
+       Panel.ZIndex                        -> ZIndex
+       ToolTip="…"                         -> ToolTip.Tip="…"
+       Mouse* events                       -> Pointer* events (handler NAMES kept verbatim so the
+                                              partials still own the members they always did)
+       Image + EmojiToImageSource          -> plain TextBlock (Avalonia draws colour emoji natively)
+       helpers:EmojiTextBlock              -> TextBlock (same reason)
+       DropShadowEffect ShadowDepth="0"    -> OffsetX="0" OffsetY="0"
+       LinearGradientBrush "0,0"/"0,1"     -> "0%,0%" / "0%,100%"
+       <AdornerDecorator>                  -> <Panel> (no adorner layer on this head; the tab
+                                              views stack in one cell exactly as before)
+       WindowStyle="None" + WindowChrome   -> SystemDecorations="None" (the bar is drawn in XAML)
+       ResizeMode=CanResizeWithGrip        -> CanResize="True"; the grip itself is lost
+       Window.CommandBindings              -> dropped; Avalonia has no RoutedCommand/CommandBinding
+       poss:Possession.* attached props    -> dropped (Services/Possession stays in the WPF head)
+       x:Name on a non-Control              -> dropped. Avalonia only names Controls, so the 20
+                                              named ScaleTransform / RotateTransform /
+                                              TranslateTransform / GradientStop / DropShadowEffect
+                                              / ColumnDefinition handles are gone. Every one of
+                                              them was a handle for a MainWindow.*Fx partial
+                                              (HeroFx, ChromeFx, ProfileBubble, EventFx), and all
+                                              of those partials are stubs on this head - so no
+                                              live code lost a handle. ponytail: give them back as
+                                              code-built transforms when the FX partials land.
+       StrokeStartLineCap/StrokeLineJoin    -> StrokeLineCap / StrokeJoin
+       StrokeDashArray="9 9"                -> "9,9"
+       <ContentPresenter/> (bare)           -> Content/ContentTemplate TemplateBindings. Trap 6:
+                                              the first render came back with Exit, Pause and the
+                                              update button as empty outlines.
+
+     x:CompileBindings="False" on the root: the shell carries 67 loose {Binding}s against the
+     window's own CLR properties, which live in partials this head cannot bring over. One opt-out
+     beats 67 invented x:DataTypes.
+
+     Every ControlTemplate.Triggers block became a ponytail comment naming the trigger properties
+     it dropped: Avalonia writes those as Style selectors OUTSIDE the template, and there are ~20
+     inline templates here. The two rail themes below (the ones the user actually looks at) got
+     real ":pointerover /template/" selectors instead. -->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
+        xmlns:views="clr-namespace:ConditioningControlPanel.Avalonia.Views.Tabs"
+        xmlns:cmp="clr-namespace:ConditioningControlPanel.Avalonia.Views.Controls"
+        xmlns:fx="clr-namespace:ConditioningControlPanel.Avalonia.Controls"
+        x:Class="ConditioningControlPanel.Avalonia.Views.Windows.MainShellWindow"
+        x:CompileBindings="False"
+        Title="Conditioning Control Panel"
+        Height="943" Width="1563"
+        MinHeight="620" MinWidth="1131"
+        Background="{DynamicResource DarkerBgBrush}"
+        WindowStartupLocation="Manual"
+        SystemDecorations="None"
+        CanResize="True"
+        DragDrop.AllowDrop="True">
+
+    <Window.Resources>
+        <!-- ===================== Phase 1: the nav rail =====================
+             New style keys on purpose. "TabButton"/"TabButtonActive" are ALSO used by
+             the quest sub-tabs and the roadmap track buttons, so restyling them for a
+             vertical rail would silently restyle the Quests tab.
+
+             Every rail template exposes two parts the code drives directly:
+               NavActiveBar  - the 3px accent bar on the row's left edge
+               NavActiveFill - the tinted row background
+             ApplyNavActiveGlow (MainWindow.ChromeFx.cs) found them by name; that partial is a
+             stub on this head, but the parts stay so the ported code has them when it lands.
+
+             The row shape is Grid > [fill][hover][bar][ContentPresenter] and the button's
+             Content stays a Panel holding an icon, because NudgeNavIcon's hover nudge
+             hard-requires that shape.
+
+             Height 30 + Margin 0,1 = the 32px row pitch the accordion measures with. -->
+        <ControlTheme x:Key="NavRailButton" TargetType="Button">
+            <!-- Background is the row TINT (used by both the active fill and the hover
+                 wash), never a painted background: the template's own Grid takes the
+                 hit-test area instead. -->
+            <Setter Property="Background" Value="{DynamicResource TransparentPink20Brush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="HorizontalAlignment" Value="Stretch"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="Margin" Value="0,1"/>
+            <!-- 21 centers a 14px entry icon in the 56px collapsed strip (21+14+21). -->
+            <Setter Property="Padding" Value="21,0,8,0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Grid Background="Transparent">
+                        <Border x:Name="NavActiveFill" Background="{TemplateBinding Background}"
+                                CornerRadius="0,6,6,0" Opacity="0" IsHitTestVisible="False"/>
+                        <Border x:Name="NavHover" Background="{TemplateBinding Background}"
+                                CornerRadius="0,6,6,0" Opacity="0" IsHitTestVisible="False"/>
+                        <Border x:Name="NavActiveBar" Width="3" HorizontalAlignment="Left"
+                                Background="{TemplateBinding BorderBrush}" CornerRadius="0,2,2,0"
+                                IsVisible="False" IsHitTestVisible="False"/>
+                        <!-- Content/ContentTemplate are MANDATORY on Avalonia: a bare
+                             ContentPresenter finds nothing and the row draws empty. -->
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <!-- WPF: <Trigger Property="IsMouseOver"> on NavHover. -->
+            <Style Selector="^:pointerover /template/ Border#NavHover">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- Door header: the MEDALLION row. Same two named parts; the bar is LAST because the
+             open medallion is 56px wide in a 56px column and would otherwise hide it. -->
+        <ControlTheme x:Key="NavDoorButton" TargetType="Button" BasedOn="{StaticResource NavRailButton}">
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="Height" Value="64"/>
+            <Setter Property="Margin" Value="0,2"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Grid Background="Transparent">
+                        <Border x:Name="NavActiveFill" Background="{TemplateBinding Background}"
+                                CornerRadius="0,12,12,0" Opacity="0" IsHitTestVisible="False"/>
+                        <Border x:Name="NavHover" Background="{TemplateBinding Background}"
+                                CornerRadius="0,12,12,0" Opacity="0" IsHitTestVisible="False"/>
+                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+                        <Border x:Name="NavActiveBar" Width="3" HorizontalAlignment="Left"
+                                Background="{TemplateBinding BorderBrush}" CornerRadius="0,2,2,0"
+                                IsVisible="False" IsHitTestVisible="False"/>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#NavHover">
+                <Setter Property="Opacity" Value="0.6"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The big door name. Width 160 = the open rail (236) minus the 56px medallion column
+             minus the 10px lead-in, FIXED so the Viewbox inside never re-scales the text
+             mid-flyout. Opacity 0 is the shut state. Grid and TextBlock are not templated
+             controls, so a property-only ControlTheme is safe here (unlike Button). -->
+        <ControlTheme x:Key="NavDoorLabelHost" TargetType="Grid">
+            <Setter Property="Tag" Value="navdoorlabel"/>
+            <Setter Property="Width" Value="160"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="10,0,0,0"/>
+            <Setter Property="Opacity" Value="0"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="NavDoorLabelText" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="21"/>
+            <Setter Property="FontWeight" Value="ExtraBold"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
+            <Setter Property="TextWrapping" Value="NoWrap"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="NavEntryButton" TargetType="Button" BasedOn="{StaticResource NavRailButton}"/>
+
+        <!-- Brand-accented entries. Same template, different accent: Deeper violet,
+             Available Subjects neon purple, Profile Discord blue, Premium Patreon red. -->
+        <ControlTheme x:Key="NavEntryButtonDeeper" TargetType="Button" BasedOn="{StaticResource NavRailButton}">
+            <Setter Property="Background" Value="{DynamicResource DeeperAccentTransparent20Brush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource DeeperAccentBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource DeeperAccentBrush}"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="NavEntryButtonNeon" TargetType="Button" BasedOn="{StaticResource NavRailButton}">
+            <Setter Property="Background" Value="{DynamicResource NeonPurpleTransparent20Brush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource NeonPurpleBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource NeonPurpleBrush}"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="NavEntryButtonDiscord" TargetType="Button" BasedOn="{StaticResource NavRailButton}">
+            <Setter Property="Background" Value="#335865F2"/>
+            <Setter Property="BorderBrush" Value="#5865F2"/>
+            <Setter Property="Foreground" Value="#8E9BFF"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="NavEntryButtonPatreon" TargetType="Button" BasedOn="{StaticResource NavRailButton}">
+            <Setter Property="Background" Value="#33FF424D"/>
+            <Setter Property="BorderBrush" Value="#FF424D"/>
+            <Setter Property="Foreground" Value="#FF8A91"/>
+        </ControlTheme>
+
+        <!-- The PREMIUM tag on a rail entry: a ~26px gold pill that rides after an entry's
+             label. A glyph and not the word "PREMIUM" because the flyout is a hard 176px and
+             the worst premium label in the nine shipped locales leaves ~65px for the tag.
+             Gold is LITERAL: a tier mark is commerce and must not take colour from the mod chain.
+             Collapsed AS AUTHORED - a rail whose Loaded hook never ran must show no tags at all
+             rather than tag every row. -->
+        <ControlTheme x:Key="NavEntryPremiumTag" TargetType="Border">
+            <Setter Property="Background" Value="#26F0C24B"/>
+            <Setter Property="BorderBrush" Value="#66F0C24B"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="3"/>
+            <Setter Property="Padding" Value="4,0"/>
+            <Setter Property="Margin" Value="6,0,0,0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="IsVisible" Value="False"/>
+        </ControlTheme>
+
+        <ControlTheme x:Key="NavEntryPremiumTagText" TargetType="TextBlock">
+            <Setter Property="Text" Value="★"/>
+            <Setter Property="FontSize" Value="9"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="#F0C24B"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </ControlTheme>
+
+        <!-- ponytail: local copy of ConditioningControlPanel/Resources/Theme/MainWindow.xaml:
+             WindowControlButton / WindowCloseButton / EmoteCircleButtonBigStyle /
+             EmoteCustomTextBoxStyle. Hoist into Theme/Styles.xaml when a second view needs them;
+             MainWindow is the only caller today. -->
+        <ControlTheme x:Key="WindowControlButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" Padding="0">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Background" Value="{DynamicResource TransparentWhiteBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="WindowCloseButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd" Background="{TemplateBinding Background}" Padding="0">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Background" Value="{DynamicResource DangerBrush}"/>
+            </Style>
+        </ControlTheme>
+
+        <ControlTheme x:Key="EmoteCircleButtonBigStyle" TargetType="Button">
+            <Setter Property="Width" Value="72"/>
+            <Setter Property="Height" Value="72"/>
+            <Setter Property="Background" Value="#252542"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+            <Setter Property="BorderThickness" Value="2"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="36">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border#bd">
+                <Setter Property="Background" Value="#33335A"/>
+            </Style>
+            <Style Selector="^:pressed /template/ Border#bd">
+                <Setter Property="Background" Value="#3F3F66"/>
+            </Style>
+        </ControlTheme>
+
+        <!-- The WPF original templated a watermark driven by two EmoteHelper attached properties
+             and a MultiBinding converter; both live in the WPF head.
+             ponytail: watermark dropped, plain dark TextBox kept. Restore it with Avalonia's own
+             Watermark property once EmoteHelper moves to Core. -->
+        <ControlTheme x:Key="EmoteCustomTextBoxStyle" TargetType="TextBox"
+                      BasedOn="{StaticResource {x:Type TextBox}}">
+            <Setter Property="Background" Value="#252542"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="CaretBrush" Value="White"/>
+            <Setter Property="BorderBrush" Value="#3A3A55"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="Padding" Value="10,8"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="MaxLength" Value="60"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </ControlTheme>
+    </Window.Resources>
+
+    <Grid x:Name="RootGrid">
+    <!-- Viewbox scales all content proportionally with window size -->
+    <Viewbox Stretch="Fill">
+        <!-- Design canvas at reference size. Phase 1 grew it 1489 -> 1679 by ADDING a
+             190px nav-rail column on the left; column 1 is still exactly 1489 wide, so
+             every tab layout keeps the width it was authored against (fx-inventory §12.8:
+             they clip silently otherwise). The Window's default/min Width grew by the same
+             1.1276 factor so the Viewbox's Stretch="Fill" keeps the old aspect.
+
+             2026-08-11: column 0 now reserves only the COLLAPSED rail (56px), so the canvas
+             is 1545 and the window shed the 132px the labels used to occupy. Column 1 is
+             still untouched at 1489 - the point of the exercise is to stop paying for the
+             labels, not to re-author every tab. The expanded rail overlays this column
+             instead of widening it; see MainWindow.NavRail.cs for why that is mandatory
+             rather than merely convenient. Window Width/MinWidth moved by the same 1545/1679
+             factor so Stretch="Fill" keeps the aspect it was tuned at (1656 -> 1524,
+             1198 -> 1102) - change one of these four numbers and you must change all four.
+
+             2026-08-11 (later, owner: "hovering the menu opens it correctly, but it covers
+             the UI - leave some empty space on the side and shrink the menu a little, half
+             and half"). Column 0 is now 96 = the 56px collapsed rail + a 40px PERMANENT
+             GUTTER of bare canvas. The rail Border still hard-pins itself to 56 and sits
+             left-aligned, so the gutter is dead space the flyout can grow into before it
+             touches a single pixel of page. Paired with the flyout dropping 190 -> 176
+             (MainWindow.NavRail.cs), the true overlay over live UI falls 134px -> 80px.
+
+             The gutter is paid for by GROWING the canvas (1545 -> 1585), never by shrinking
+             column 1: it stays exactly 1489, because that is the width every tab was
+             authored against and they clip silently with no scrollbar if it moves
+             (fx-inventory §12.8). Same rule Phase 1 followed. And because the canvas grew,
+             the two Window widths at the top of this file move by the same 1585/1679 factor
+             (1656 -> 1563, 1198 -> 1131) to hold the aspect Stretch="Fill" was tuned at. -->
+        <Grid x:Name="DesignCanvas" Width="1585" Height="901">
+            <Grid.ColumnDefinitions>
+                <!-- 56 rail + 40 gutter. The rail does NOT stretch into the gutter. -->
+                <ColumnDefinition Width="96"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="36"/>
+                <RowDefinition Height="Auto"/>
+                <!-- 2: was the full-width support banner. 0813 nested that banner into the
+                     header row (HeaderBannerHost) and pinned this row to 0 - the height it
+                     used to cost is now tab canvas in row 4. Kept as a row, not deleted, so
+                     rows 3/4/5 keep the indices every Grid.Row below is authored against. -->
+                <RowDefinition Height="0"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+        <!-- Custom Title Bar. Spans BOTH canvas columns: it is the window's own chrome,
+             so the pink strip has to reach the left edge and the min/max/close cluster
+             has to sit at the true top-right, above the nav rail rather than beside it. -->
+        <!-- 2026-08-11: was a full-width slab of solid PinkBrush. At 1545px it out-weighed every
+             real control on the page and forced START, Save and the marquee to shout back just to
+             be seen. Accent survives as a 2px underline and in the glyph/title colour; the one
+             saturated pink mass on any screen is now the primary CTA. -->
+        <Border x:Name="TitleBarBorder" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                Background="{DynamicResource PanelBgBrush}"
+                BorderBrush="{DynamicResource PinkBrush}" BorderThickness="0,0,0,2"
+                PointerPressed="TitleBar_MouseLeftButtonDown">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                
+                <!-- Icon and Title -->
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="12,0,0,0">
+                    <TextBlock Text="💗" FontSize="18" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                    <TextBlock x:Name="TxtTitleBarVersion" Text="{loc:Str app_title}" Foreground="{DynamicResource TextLightBrush}" FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <!-- Title-bar status pills (right-aligned, visible from every tab):
+                     directory-listing status + camera-active indicator. -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal"
+                            HorizontalAlignment="Right" VerticalAlignment="Center">
+
+                    <!-- Directory listing status — Listed / Private only / Claimed.
+                         Visible only while a remote-control session is active. Text,
+                         dot colour and tooltip are set in UpdateDirectoryListingStatus(). -->
+                    <Border x:Name="DirectoryStatusPill"
+                            IsVisible="False"
+                            VerticalAlignment="Center"
+                            Background="#2E2E48" CornerRadius="12" Padding="10,4"
+                            Margin="0,0,12,0">
+                        <StackPanel Orientation="Horizontal">
+                            <Ellipse x:Name="DirectoryStatusDot" Width="8" Height="8"
+                                     Fill="#B47BFF" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                            <TextBlock x:Name="TxtDirectoryStatus" Text="Private only"
+                                       Foreground="White" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Takeover-active indicator — visible whenever AutonomyService.IsEnabled is true.
+                         Toggled from SetTakeoverActiveUi(). Stop UI lives on the Bambi Takeover tab. -->
+                    <Border x:Name="TakeoverActivePill"
+                            IsVisible="False"
+                            VerticalAlignment="Center"
+                            Background="#5A2E7A" CornerRadius="12" Padding="10,4"
+                            Margin="0,0,12,0"
+                            ToolTip.Tip="Takeover is active.">
+                        <StackPanel Orientation="Horizontal">
+                            <Ellipse Width="8" Height="8" Fill="#C9A0FF" Margin="0,0,6,0" VerticalAlignment="Center">
+                                <Ellipse.Effect>
+                                    <DropShadowEffect Color="#C9A0FF" BlurRadius="6" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                                </Ellipse.Effect>
+                            </Ellipse>
+                            <TextBlock Text="Takeover active" Foreground="White" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Microphone-active indicator — visible whenever SpeechService.IsListening is true
+                         (any feature: Takeover "Hey Bambi"/push-to-talk/mantras, Voice Lock Cards…).
+                         Same privacy posture as the camera pill: if we're taking mic input we show it.
+                         Click to stop all mic capture. -->
+                    <Border x:Name="MicActivePill"
+                            IsVisible="False"
+                            VerticalAlignment="Center"
+                            Background="#7A4A14" CornerRadius="12" Padding="10,4"
+                            Margin="0,0,12,0"
+                            Cursor="Hand"
+                            PointerPressed="MicActivePill_Click"
+                            ToolTip.Tip="Microphone is active. Click to stop listening.">
+                        <StackPanel Orientation="Horizontal">
+                            <Ellipse Width="8" Height="8" Fill="#FFA726" Margin="0,0,6,0" VerticalAlignment="Center">
+                                <Ellipse.Effect>
+                                    <DropShadowEffect Color="#FFA726" BlurRadius="6" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                                </Ellipse.Effect>
+                            </Ellipse>
+                            <TextBlock Text="Mic active" Foreground="White" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Camera-active indicator — visible whenever WebcamTrackingService.IsRunning is true.
+                         Click to stop tracking. -->
+                    <Border x:Name="WebcamActivePill"
+                            IsVisible="False"
+                            VerticalAlignment="Center"
+                            Background="#882B2B" CornerRadius="12" Padding="10,4"
+                            Margin="0,0,12,0"
+                            Cursor="Hand"
+                            PointerPressed="WebcamActivePill_Click"
+                            ToolTip.Tip="Webcam tracking is active. Click to stop.">
+                        <StackPanel Orientation="Horizontal">
+                            <Ellipse Width="8" Height="8" Fill="#FF4444" Margin="0,0,6,0" VerticalAlignment="Center">
+                                <Ellipse.Effect>
+                                    <DropShadowEffect Color="#FF4444" BlurRadius="6" OffsetX="0" OffsetY="0" Opacity="0.8"/>
+                                </Ellipse.Effect>
+                            </Ellipse>
+                            <TextBlock Text="Camera active" Foreground="White" FontSize="11" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Lockdown badge — the exit affordance that follows you off the Lockdown tab.
+                         Last in the pill row so it sits hard against the window buttons: while a
+                         lockdown runs this is the one thing on screen the user is allowed to trust,
+                         and it has to be findable without hunting.
+
+                         Crimson only, no ember: crimson is the Lockdown THEME, ember is Possession's
+                         verb (POSSESSION.md "clarity in front"). A badge that glowed ember would read
+                         as one of the ghosts, which is the exact opposite of its job.
+
+                         Exclude inherits, so the badge and everything in it stays out of the Wave 2
+                         auto-tagger's deck. Visibility, the clock and the click are all owned by
+                         MainWindow.Lab.cs (OnLockdownActivated / OnLockdownTick / LockdownBadge_Click). -->
+                    <Border x:Name="LockdownBadge"
+                            IsVisible="False"
+                            VerticalAlignment="Center"
+                            Background="#DC143C" CornerRadius="12" Padding="11,4"
+                            Margin="0,0,12,0"
+                            Cursor="Hand"
+                            PointerPressed="LockdownBadge_Click"
+                            ToolTip.Tip="{loc:Str lockdown_badge_tooltip}">
+                        <StackPanel Orientation="Horizontal">
+                            <Ellipse Width="8" Height="8" Fill="#FFE3E8" Margin="0,0,7,0" VerticalAlignment="Center"/>
+                            <TextBlock Text="{loc:Str lockdown_badge_label}" Foreground="White" FontSize="11"
+                                       FontWeight="Bold" VerticalAlignment="Center"/>
+                            <TextBlock x:Name="TxtLockdownBadgeTime" Text="00:00"
+                                       Foreground="White" FontSize="11.5" FontWeight="SemiBold"
+                                       Margin="9,0,0,0" VerticalAlignment="Center"/>
+                            <Border Width="1" Height="12" Background="#59FFFFFF" Margin="9,0,9,0" VerticalAlignment="Center"/>
+                            <TextBlock Text="{loc:Str lockdown_badge_end}" Foreground="#FFE3E8" FontSize="11"
+                                       FontWeight="SemiBold" VerticalAlignment="Center"
+                                       TextDecorations="Underline"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Window Control Buttons -->
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="BtnTitleBarBugReport" Content="🐛" Width="46" Height="36"
+                            Click="BtnReportBug_Click" Theme="{StaticResource WindowControlButton}"
+                            ToolTip.Tip="{loc:Str btn_report_bug}" FontSize="14"/>
+                    <Button x:Name="BtnMinimize" Content="─" Width="46" Height="36"
+                            Click="BtnMinimize_Click" Theme="{StaticResource WindowControlButton}"/>
+                    <Button x:Name="BtnMaximize" Content="☐" Width="46" Height="36" 
+                            Click="BtnMaximize_Click" Theme="{StaticResource WindowControlButton}"/>
+                    <Button x:Name="BtnClose" Content="✕" Width="46" Height="36" 
+                            Click="BtnClose_Click" Theme="{StaticResource WindowCloseButton}"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ===================== NAV RAIL (canvas column 0) =====================
+             Six doors + a pinned Settings door. A door header navigates to the door's
+             default tab AND expands its entry list; exactly one door is open at a time
+             (MainWindow.TabNavigation.cs: NavDoorMap / SetExpandedDoor / ExpandDoorForTab).
+
+             The entry buttons are the ORIGINAL header tab buttons, moved here whole -
+             same x:Name, Click handler, Tag, tooltip, icon-inside-a-Panel content shape
+             and (Programs/Deeper) first-visit pulse ScaleTransform. Only the Style changed.
+
+             Collapsed doors keep Visibility=Visible and animate Height to 0 instead, so an
+             entry in a shut door still measures and still maps through TransformToVisual
+             (a Collapsed anchor maps nowhere). Where it maps is meaningless, though - every
+             entry of a shut door lands on one zero-height strip - so EventFx bursts and the
+             first-visit pulses route through MainWindow.NavAnchorForTab, which hands back
+             the DOOR HEADER while that door is shut. -->
+        <!-- ColumnSpan=2 + left alignment + a hard Width is what makes the open rail a flyout
+             OVER the page rather than a column that shoves it. ZIndex lifts it above the page
+             content; ClipToBounds keeps the labels inside the 56px strip while it is shut.
+             The Width here is the COLLAPSED width and is owned by MainWindow.NavRail.cs from
+             the first Loaded onwards.
+
+             HorizontalAlignment=Left is also what creates the 40px gutter: column 0 is 96
+             wide now, and this Border refuses to fill it, so the first 40px the flyout grows
+             land on dead canvas instead of on the page. Do NOT switch this to Stretch. -->
+        <Border x:Name="NavSidebar" Grid.Row="1" Grid.RowSpan="5" Grid.Column="0" Grid.ColumnSpan="2"
+                HorizontalAlignment="Left" Width="56" ZIndex="60" ClipToBounds="True"
+                BorderBrush="{DynamicResource PanelAccentBrush}" BorderThickness="0,0,1,0">
+            <!-- Static depth gradient (was flat PanelBgBrush): top matches the panel tone the
+                 title bar hands off, sinking slightly by the bottom so the rail reads as its own
+                 column instead of a stripe of the same slab every panel uses. Not animated.
+
+                 2026-08-12 (Velvet Kit): the three hand-mixed hexes were #262649 / #222240 /
+                 #1C1C36 - i.e. ElevatedSurface and PanelBg with a 4-unit lift on the top stop.
+                 They are the tokens now, so a mod that repaints the palette repaints the rail
+                 too instead of leaving one lilac column behind. DynamicResource on the *Color*
+                 keys, which is how Brushes.xaml itself does it. -->
+            <Border.Background>
+                <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+                    <GradientStop Color="{DynamicResource ElevatedSurface}" Offset="0"/>
+                    <GradientStop Color="{DynamicResource ElevatedSurface}" Offset="0.55"/>
+                    <GradientStop Color="{DynamicResource PanelBg}" Offset="1"/>
+                </LinearGradientBrush>
+            </Border.Background>
+            <Grid Margin="0,10,0,10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- THE SEARCH PILL. The Ctrl+K palette existed for a full release without a
+                     single pixel advertising it; this is that pixel. Clicking it routes through
+                     the exact same Toggle the InputBindings entry in MainWindow.xaml.cs uses, so
+                     the pill and the shortcut can never open two different things.
+
+                     Deliberately NOT a door medallion: no NavDoorMap row, no four-child contract,
+                     and no 40px Grid.Column="0" Viewbox (NavRailFlyoutTests counts those - keep it
+                     that way). It is a plain pill whose parts ride the rail's existing machinery:
+                     - the lens glyph is a TextBlock tagged "navrailstatic", the one tag
+                       CacheNavRailParts (MainWindow.NavRail.cs) exempts from the global label
+                       fade, so it stays visible while the rail is shut;
+                     - the name and the keycap text are ordinary rail TextBlocks, so the same
+                       global fade that reveals every other label reveals them (authored Opacity 0
+                       = the shut state, and what a failed InitializeNavRail leaves on screen);
+                     - the keycap's chrome is a Border, which the fade walk cannot drive, so its
+                       Opacity is BOUND to the name's - one animation, two riders.
+                     Sized for the shut rail: 56 column - 8px margins - 1px borders = a 40x30 pill
+                     with the lens centred in its fixed 38px first column. -->
+                <Button x:Name="BtnNavSearch" Grid.Row="0" Height="30" Margin="8,0,8,10"
+                        Cursor="Hand" Click="BtnNavSearch_Click"
+                        ToolTip.Tip="{loc:Str tooltip_nav_search}">
+                    <Button.Template>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="SearchPillBg" CornerRadius="15"
+                                    Background="#14FFFFFF"
+                                    BorderBrush="{DynamicResource PanelAccentBrush}"
+                                    BorderThickness="1">
+                                <ContentPresenter
+                                                 Content="{TemplateBinding Content}"
+                                                 ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                            </Border>
+                            <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver, IsPressed) dropped. Avalonia writes these as
+                                 Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                 rest state renders correctly and only the hover/press/tag skins are lost. -->
+                        </ControlTemplate>
+                    </Button.Template>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="38"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Tag="navrailstatic" Text="🔍" FontSize="13"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="TxtNavSearchLabel" Grid.Column="1" Opacity="0"
+                                   Text="{loc:Str nav_search_label}" FontSize="13" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource TextLightBrush}"
+                                   VerticalAlignment="Center" TextWrapping="NoWrap"/>
+                        <Border Grid.Column="2" CornerRadius="6" Margin="0,0,9,0" Padding="6,1"
+                                VerticalAlignment="Center" IsHitTestVisible="False"
+                                Background="#22000000" BorderThickness="1"
+                                BorderBrush="{DynamicResource PanelAccentBrush}"
+                                Opacity="{Binding #TxtNavSearchLabel.Opacity}">
+                            <TextBlock Text="{loc:Str nav_search_keys}" Opacity="0" FontSize="11"
+                                       Foreground="{DynamicResource TextMutedBrush}"
+                                       TextWrapping="NoWrap"/>
+                        </Border>
+                    </Grid>
+                </Button>
+
+                <!-- VerticalScrollBarVisibility authors the COLLAPSED state, like every other
+                     rail part: Hidden, because a WPF vertical scrollbar is ~17px and the shut
+                     rail is 56px of which the medallion tile is 44 - the bar does not sit BESIDE
+                     the icons, it lands on top of the right third of every one of them, and once
+                     the extent clears the viewport by even a rounding pixel (the content grid's
+                     MinHeight is bound to the viewport, under a Viewbox at a fractional scale) it
+                     never goes away again. Reported on Discord against v6.8.6 as a permanent
+                     scrollbar drawn over the collapsed rail.
+
+                     Hidden, not Disabled: the wheel still scrolls, so a rail that really does
+                     overflow while shut is still reachable. MainWindow.NavRail.cs hands it back
+                     to Auto while the flyout is out, where 236px has room to show a bar. -->
+                <ScrollViewer x:Name="NavRailScroll" Grid.Row="1" ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                              ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                    <!-- ============ TOP-PACKED DOORS (Velvet Kit, UI polish 2) ============
+                         Six Auto door rows with fixed SPACER rows between them, all pooled at
+                         the top: row 0 is 0, the five gaps between doors are 8, and the LAST
+                         spacer is the only star, so every bit of slack lands at the bottom.
+
+                         This replaces the space-evenly version of this grid (seven star
+                         spacers). Owner call 2026-08-12: even distribution pushed the
+                         medallions far enough apart that the rail read as six unrelated
+                         buttons instead of one menu. Skewed to the top is explicitly fine;
+                         the doors just have to keep opening big and staying functional, which
+                         is all NavRail.cs hover work and is untouched by row heights.
+
+                         Pitch: each door carries Margin 0,2 around a 64px row = 68, plus the
+                         8px spacer = ~76px between medallion centres.
+
+                         Why the spacers are their own rows instead of margin on the doors: the
+                         doors stay Auto rows, and an Auto row is guaranteed its measured height
+                         at arrange time where a star row is not (a star row only keeps what a
+                         MEASURE recorded as its minimum - exactly the case this grid is in the
+                         middle of while an accordion tweens). Empty spacers can be squeezed
+                         without losing anything, so overflow degrades trivially: the bottom
+                         star collapses to 0, then the fixed gaps are all that is left, and when
+                         the doors plus an open accordion still exceed the viewport this
+                         ScrollViewer takes over. No mode switch, no code.
+
+                         MinHeight is what makes the bottom star resolve to anything: a
+                         ScrollViewer measures its content at infinite height, where star rows
+                         resolve to nothing, so without this the grid would be exactly as tall
+                         as its content. Binding it to the viewport (never to the extent - that
+                         WOULD be a layout cycle) makes the grid fill the column when the
+                         content is short and overflow it when it is not.
+
+                         Headroom, in fixed canvas units (the whole UI is a Viewbox over a
+                         1585x901 canvas, so this NEVER changes with the window size): the
+                         column is ~760px minus the 40px search pill row above = ~720, the six
+                         68px door rows plus five 8px gaps are 448, and the widest accordion
+                         (Play, 8 entries x NavEntryRowHeight 32) is 256 - 704 total. A door
+                         would need ~9 entries before the rail starts scrolling. -->
+                    <Grid MinHeight="{Binding #NavRailScroll.Viewport.Height}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="0"/>
+                            <RowDefinition Height="Auto"/>   <!-- 1: home -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>   <!-- 3: studio -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>   <!-- 5: companion -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>   <!-- 7: play -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>   <!-- 9: you -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>   <!-- 11: library -->
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- ===== HOME (default: settings) ===== -->
+                        <StackPanel Grid.Row="1">
+                        <Button x:Name="DoorHome" Tag="home" Theme="{StaticResource NavDoorButton}"
+                                Background="#22FF69B4" BorderBrush="#FF69B4"
+                                Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_home}">
+                            <!-- THE MEDALLION. Child order and TYPES are API: NavRail.cs's
+                                 CacheNavDoorRows picks the glow (Ellipse), the tile (Border),
+                                 the icon (Viewbox) and the label host (Tag="navdoorlabel") out
+                                 of this panel BY TYPE, and ChromeFx's NudgeNavIcon takes the
+                                 first "Image or Viewbox" among the direct children as the icon
+                                 to nudge on hover. So: the icon Viewbox stays a direct child,
+                                 and the label's Viewbox stays nested inside its host grid, or
+                                 the hover nudge starts scaling the door's name.
+
+                                 The icon is a Viewbox around the art at its native 64px rather
+                                 than a resized Image because a Clip does not scale with Width:
+                                 the Viewbox's own scale carries the rounded clip with it, and
+                                 it leaves the Image's RenderTransform free for the nudge.
+
+                                 BorderBrush (not Background) is the door's hue - see the style. -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <!-- 56 = the collapsed rail, so the tile is centred on the
+                                         icon strip and does not move sideways when it grows. -->
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                         IsHitTestVisible="False"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                        BorderThickness="1" BorderBrush="Transparent">
+                                            <TextBlock Text="🏠" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                <Viewbox Grid.Column="0" Width="40" Height="40"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <!-- x:Name = the handle ApplyDoorArt (MainWindow.NavRail.cs) uses to
+                                         re-point the art at the active mod's override. The literal
+                                         Source stays: it is what renders before that call, and what
+                                         stays on screen if the resolver comes back empty. -->
+                                    <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_home.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorHome" Width="64" Height="64"/>
+                                </Viewbox>
+                                <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                    <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock Text="{loc:Str nav_door_home}"
+                                                   Theme="{StaticResource NavDoorLabelText}"/>
+                                    </Viewbox>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                        <!-- The one door open at startup, so it keeps auto height in markup. -->
+                        <Border x:Name="DoorPanelHome" ClipToBounds="True">
+                            <StackPanel x:Name="DoorEntriesHome">
+                                <Button x:Name="BtnSettings" Tag="Settings" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnSettings_Click" ToolTip.Tip="{loc:Str tooltip_dashboard}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📊" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_dashboard}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        </StackPanel>
+
+                        <!-- ===== STUDIO (default: presets) ===== -->
+                        <StackPanel Grid.Row="3">
+                        <Button x:Name="DoorStudio" Tag="studio" Theme="{StaticResource NavDoorButton}"
+                                Background="#22FF7E6B" BorderBrush="#FF7E6B"
+                                Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_studio}">
+                            <!-- Medallion: see DoorHome for what the four children are for. -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                         IsHitTestVisible="False"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                        BorderThickness="1" BorderBrush="Transparent">
+                                            <TextBlock Text="🎛" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                <Viewbox Grid.Column="0" Width="40" Height="40"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_studio.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorStudio" Width="64" Height="64"/>
+                                </Viewbox>
+                                <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                    <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock Text="{loc:Str nav_door_studio}"
+                                                   Theme="{StaticResource NavDoorLabelText}"/>
+                                    </Viewbox>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                        <Border x:Name="DoorPanelStudio" ClipToBounds="True" Height="0" IsHitTestVisible="False">
+                            <StackPanel x:Name="DoorEntriesStudio">
+                                <!-- Phase 4: the effects rack. First entry, so it is what the
+                                     Studio door header lands on (NavDoorMap default = "studio"). -->
+                                <Button x:Name="BtnNavStudio" Tag="Studio" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavStudio_Click" ToolTip.Tip="{loc:Str st4_nav_studio_tip}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🎚️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str st4_nav_studio}" VerticalAlignment="Center"/>
+                                        <!-- v6.8.0 NEW pill: remove in 6.9 -->
+                                        <!-- Literal properties only, no StaticResource: a cross-file style
+                                             reference here is the BAML EndOfStream trap. Sized to the rail's
+                                             own BETA pill (BtnPrograms) and kept narrow because the flyout is
+                                             a hard 176px - see NavRailExpandedWidth's label-floor arithmetic. -->
+                                        <Border Margin="4,0,0,0" VerticalAlignment="Center" CornerRadius="6"
+                                                Padding="3,0" Background="#33FF69B4"
+                                                BorderBrush="#FF69B4" BorderThickness="1">
+                                            <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
+                                                       FontWeight="Bold" Foreground="#FF8FC7"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnPresets" Tag="Presets" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnPresets_Click" ToolTip.Tip="{loc:Str tooltip_presets_sessions}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📋" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_presets}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavHaptics" Tag="Haptics" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavHaptics_Click" ToolTip.Tip="{loc:Str tab_haptics}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📳" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_haptics}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumHaptics" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        </StackPanel>
+
+                        <!-- ===== COMPANION (default: companion) ===== -->
+                        <StackPanel Grid.Row="5">
+                        <Button x:Name="DoorCompanion" Tag="companion" Theme="{StaticResource NavDoorButton}"
+                                Background="#22E85CE0" BorderBrush="#E85CE0"
+                                Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_companion}">
+                            <!-- Medallion: see DoorHome for what the four children are for. -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                         IsHitTestVisible="False"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                        BorderThickness="1" BorderBrush="Transparent">
+                                            <TextBlock Text="🤖" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                <Viewbox Grid.Column="0" Width="40" Height="40"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_companion.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorCompanion" Width="64" Height="64"/>
+                                </Viewbox>
+                                <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                    <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock Text="{loc:Str nav_door_companion}"
+                                                   Theme="{StaticResource NavDoorLabelText}"/>
+                                    </Viewbox>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                        <Border x:Name="DoorPanelCompanion" ClipToBounds="True" Height="0" IsHitTestVisible="False">
+                            <StackPanel x:Name="DoorEntriesCompanion">
+                                <Button x:Name="BtnCompanion" Tag="Companion" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnCompanion_Click" ToolTip.Tip="{loc:Str tooltip_companion_settings}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🤖" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_companion}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavBambiTakeover" Tag="Takeover" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavBambiTakeover_Click" ToolTip.Tip="{loc:Str tab_takeover}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="💫" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_takeover}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumTakeover" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavSheListening" Tag="SheListening" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavSheListening_Click" ToolTip.Tip="{loc:Str tab_shelistening}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🎙️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_shelistening}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumSheListening" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <!-- Awareness finally gets a real button: BtnAwareness_Click has been an
+                                     orphan handler (MainWindow.AccountShell.cs) with no XAML owner. -->
+                                <Button x:Name="BtnNavAwareness" Tag="Awareness" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnAwareness_Click" ToolTip.Tip="{loc:Str tab_awareness}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="👁️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_awareness}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumAwareness" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        </StackPanel>
+
+                        <!-- ===== PLAY (default: play) ===== -->
+                        <StackPanel Grid.Row="7">
+                        <Button x:Name="DoorPlay" Tag="play" Theme="{StaticResource NavDoorButton}"
+                                Background="#22B8E85C" BorderBrush="#B8E85C"
+                                Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_play}">
+                            <!-- Medallion: see DoorHome for what the four children are for. -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                         IsHitTestVisible="False"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                        BorderThickness="1" BorderBrush="Transparent">
+                                            <TextBlock Text="🕹" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                <Viewbox Grid.Column="0" Width="40" Height="40"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_play.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorPlay" Width="64" Height="64"/>
+                                </Viewbox>
+                                <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                    <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock Text="{loc:Str nav_door_play}"
+                                                   Theme="{StaticResource NavDoorLabelText}"/>
+                                    </Viewbox>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                        <Border x:Name="DoorPanelPlay" ClipToBounds="True" Height="0" IsHitTestVisible="False">
+                            <StackPanel x:Name="DoorEntriesPlay">
+                                <!-- Phase 6: this row is the Play card wall now (ShowTab("play")),
+                                     the Play door's first entry and therefore its default
+                                     destination. The x:Name STAYS BtnLab: it is API for
+                                     NavButtonForTab, MainWindow.ChromeFx's NavButtons list and
+                                     TutorialService.NavEntryDoorKeys, which is keyed by the
+                                     x:Names the nav has always used. The old "Lab" label and the
+                                     🧪 flask went with the page - the flask is the Tier 2 badge on
+                                     the wall's lockbands now, and nothing else. -->
+                                <Button x:Name="BtnLab" Tag="Play" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavPlay_Click" ToolTip.Tip="{loc:Str nav_door_play}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🕹️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str nav_door_play}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnDeeper" Tag="Deeper" Theme="{StaticResource NavEntryButtonDeeper}"
+                                        Click="BtnDeeper_Click" ToolTip.Tip="{loc:Str tooltip_deeper}"
+                                        RenderTransformOrigin="0.5,0.5">
+                                    <Button.RenderTransform>
+                                        <ScaleTransform ScaleX="1" ScaleY="1"/>
+                                    </Button.RenderTransform>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🌊" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_deeper}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnPatreonExclusives" Tag="Patreon" Theme="{StaticResource NavEntryButtonPatreon}"
+                                        Click="BtnPatreonExclusives_Click" ToolTip.Tip="{loc:Str tooltip_patreon_exclusives}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="⭐" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_exclusives}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavGradedIntake" Tag="GradedIntake" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavGradedIntake_Click" ToolTip.Tip="{loc:Str tab_gradedintake}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📝" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_gradedintake}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumGradedIntake" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavLockdown" Tag="Lockdown" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavLockdown_Click" ToolTip.Tip="{loc:Str tab_lockdown_mode}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🔒" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_lockdown_mode}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumLockdown" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavBlinkTrainer" Tag="BlinkTrainer" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavBlinkTrainer_Click" ToolTip.Tip="{loc:Str tab_blink_trainer}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="👀" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_blink_trainer}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumBlinkTrainer" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavRemoteControl" Tag="RemoteControl" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavRemoteControl_Click" ToolTip.Tip="{loc:Str tab_remote_control}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📱" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_remote_control}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumRemoteControl" Theme="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip.Tip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Theme="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnAvailableSubjects" Tag="AvailableSubjects"
+                                        Theme="{StaticResource NavEntryButtonNeon}"
+                                        Click="BtnAvailableSubjects_Click"
+                                        ToolTip.Tip="{loc:Str tooltip_available_subjects}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🛰️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_available_subjects}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        </StackPanel>
+
+                        <!-- ===== YOU (default: discord / Profile) ===== -->
+                        <StackPanel Grid.Row="9">
+                        <Button x:Name="DoorYou" Tag="you" Theme="{StaticResource NavDoorButton}"
+                                Background="#225EA8FF" BorderBrush="#5EA8FF"
+                                Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_you}">
+                            <!-- Medallion: see DoorHome for what the four children are for. -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                         IsHitTestVisible="False"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                        BorderThickness="1" BorderBrush="Transparent">
+                                            <TextBlock Text="👤" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                <Viewbox Grid.Column="0" Width="40" Height="40"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_you.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorYou" Width="64" Height="64"/>
+                                </Viewbox>
+                                <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                    <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock Text="{loc:Str nav_door_you}"
+                                                   Theme="{StaticResource NavDoorLabelText}"/>
+                                    </Viewbox>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                        <Border x:Name="DoorPanelYou" ClipToBounds="True" Height="0" IsHitTestVisible="False">
+                            <StackPanel x:Name="DoorEntriesYou">
+                                <Button x:Name="BtnDiscordTab" Tag="Profile" Theme="{StaticResource NavEntryButtonDiscord}"
+                                        Click="BtnDiscordTab_Click" ToolTip.Tip="{loc:Str tab_profile}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="👤" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_profile}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <!-- THE SPIRAL ROOM (CONTRACT-FUSE-0816 2.4). Collapsed unless this
+                                     account is in the fog era or has an open spiral - a fuse-dark
+                                     account with no descent block, which is every install today,
+                                     never sees this row and the You door measures exactly as it
+                                     did before. MainWindow.SpiralRoom.cs owns the visibility and
+                                     the label: during the fog era the row is a gold ellipsis,
+                                     because naming the room would spoil it. -->
+                                <Button x:Name="BtnNavSpiral" Tag="Spiral" Theme="{StaticResource NavEntryButton}"
+                                        IsVisible="False"
+                                        Click="BtnNavSpiral_Click" ToolTip.Tip="{loc:Str tooltip_spiral_room}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🌀" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock x:Name="TxtNavSpiral" Text="{loc:Str tab_spiral}"
+                                                   VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnQuests" Tag="Quests" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnQuests_Click" ToolTip.Tip="{loc:Str tooltip_daily_weekly_quests}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📜" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_quests}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnAchievements" Tag="Achievements" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnAchievements_Click" ToolTip.Tip="{loc:Str tab_achievements}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🏆" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_achievements}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnEnhancements" Tag="Enhancements" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnEnhancements_Click" ToolTip.Tip="{loc:Str tooltip_enhancement_tree}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="✨" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_enhancements}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <!-- Training Programs — multi-day arcs (Programs tab, v6.6) -->
+                                <Button x:Name="BtnPrograms" Tag="Programs" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnPrograms_Click" ToolTip.Tip="{loc:Str tooltip_programs}"
+                                        RenderTransformOrigin="0.5,0.5">
+                                    <Button.RenderTransform>
+                                        <ScaleTransform ScaleX="1" ScaleY="1"/>
+                                    </Button.RenderTransform>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📅" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_programs}" VerticalAlignment="Center"/>
+                                        <!-- BETA pill: gold on purpose - it must stand apart from the pink
+                                             accent so it reads as a status, not a highlight. Literal text
+                                             like the version strings, not a loc key. -->
+                                        <Border Margin="5,0,0,0" VerticalAlignment="Center" CornerRadius="9999"
+                                                Padding="4,0" Background="#33FFD700"
+                                                BorderBrush="#AAFFD700" BorderThickness="1">
+                                            <TextBlock Text="BETA" FontSize="8" FontWeight="Bold" Foreground="#FFD700"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnLeaderboard" Tag="Leaderboard" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnLeaderboard_Click" ToolTip.Tip="{loc:Str tab_leaderboard}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📊" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_leaderboard}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        </StackPanel>
+
+                        <!-- ===== LIBRARY (default: assets) ===== -->
+                        <StackPanel Grid.Row="11">
+                        <Button x:Name="DoorLibrary" Tag="library" Theme="{StaticResource NavDoorButton}"
+                                Background="#225ED4E8" BorderBrush="#5ED4E8"
+                                Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_library}">
+                            <!-- Medallion: see DoorHome for what the four children are for. -->
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                         IsHitTestVisible="False"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                        Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                        BorderThickness="1" BorderBrush="Transparent">
+                                            <TextBlock Text="📚" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                    </Border>
+                                <Viewbox Grid.Column="0" Width="40" Height="40"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_library.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorLibrary" Width="64" Height="64"/>
+                                </Viewbox>
+                                <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                    <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock Text="{loc:Str nav_door_library}"
+                                                   Theme="{StaticResource NavDoorLabelText}"/>
+                                    </Viewbox>
+                                    <!-- v6.8.0 NEW pill: remove in 6.9 -->
+                                    <!-- On the DOOR, not only on its rows: the panel below ships shut
+                                         (Height=0), so a row-only pill is invisible until the door is
+                                         already open. It also stands in for the Phrases row, which has
+                                         no pixels left for a pill of its own. Top-right overlay so the
+                                         DownOnly label Viewbox keeps its full width budget. -->
+                                    <Border HorizontalAlignment="Right" VerticalAlignment="Top"
+                                            Margin="0,2,2,0" CornerRadius="6"
+                                            Padding="3,0" Background="#33FF69B4"
+                                            BorderBrush="#FF69B4" BorderThickness="1">
+                                        <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
+                                                   FontWeight="Bold" Foreground="#FF8FC7"/>
+                                    </Border>
+                                </Grid>
+                            </Grid>
+                        </Button>
+                        <Border x:Name="DoorPanelLibrary" ClipToBounds="True" Height="0" IsHitTestVisible="False">
+                            <StackPanel x:Name="DoorEntriesLibrary">
+                                <!-- Assets STAYS first: it is the Library door's default destination
+                                     in NavDoorMap ("library" -> "assets"), and the four rows below
+                                     are launchers, not tabs. -->
+                                <Button x:Name="BtnOpenAssetsTop" Tag="Assets" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnAssets_Click" ToolTip.Tip="{loc:Str tooltip_assets_packs}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="📁" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str tab_assets}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <!-- Phase 7 · Library door. These four rows are LAUNCHERS, not tabs:
+                                     none of them calls ShowTab, none of them appears in NavDoorMap,
+                                     and none of them may (a rail row that claims a tab key the app
+                                     has no view for would leave the active indicator pointing at
+                                     nothing). Each one calls the EXACT handler that already owned
+                                     the launch, so there is precisely one code path per window:
+
+                                       Mods      -> BtnManageMods_Click   (MainWindow.xaml.cs:1789,
+                                                    the title-bar gear's own handler - _isLoading
+                                                    guard, share-badge poll and ApplyActiveModChange
+                                                    all included). The Mod Creator is untouched: it
+                                                    is a button INSIDE ModManagerDialog.
+                                       Catalogue -> BtnCatalogue_Click    (MainWindow.Presets.cs:1104)
+                                       Phrases   -> BtnManagePhrases_Click(MainWindow.Patreon.cs:898,
+                                                    which also refreshes the Companion tab's count)
+                                       Media Log -> BtnNavMediaLog_Click  (TabNavigation.cs), which
+                                                    re-fires the Assets tab's own BtnMediaLog rather
+                                                    than newing a second MediaHistoryWindow - see the
+                                                    comment there for why that matters.
+
+                                     Deliberately NOT duplicated here: the Mod Catalogue browser
+                                     (a button inside ModManagerDialog) and Session History (a
+                                     Studio/Presets surface). -->
+                                <Button x:Name="BtnNavMods" Tag="Mods" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnManageMods_Click" ToolTip.Tip="{loc:Str yl7_nav_mods_tip}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🧩" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str yl7_nav_mods}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavCatalogue" Tag="Catalogue" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnCatalogue_Click" ToolTip.Tip="{loc:Str yl7_nav_catalogue_tip}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🌐" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str yl7_nav_catalogue}" VerticalAlignment="Center"/>
+                                        <!-- v6.8.0 NEW pill: remove in 6.9 -->
+                                        <Border Margin="4,0,0,0" VerticalAlignment="Center" CornerRadius="6"
+                                                Padding="3,0" Background="#33FF69B4"
+                                                BorderBrush="#FF69B4" BorderThickness="1">
+                                            <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
+                                                       FontWeight="Bold" Foreground="#FF8FC7"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavPhrases" Tag="Phrases" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnManagePhrases_Click" ToolTip.Tip="{loc:Str yl7_nav_phrases_tip}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="💬" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str yl7_nav_phrases}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <Button x:Name="BtnNavMediaLog" Tag="MediaLog" Theme="{StaticResource NavEntryButton}"
+                                        Click="BtnNavMediaLog_Click" ToolTip.Tip="{loc:Str yl7_nav_medialog_tip}">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="🎞️" FontSize="14" Margin="0,0,6,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str yl7_nav_medialog}" VerticalAlignment="Center"/>
+                                        <!-- v6.8.0 NEW pill: remove in 6.9 -->
+                                        <Border Margin="4,0,0,0" VerticalAlignment="Center" CornerRadius="6"
+                                                Padding="3,0" Background="#33FF69B4"
+                                                BorderBrush="#FF69B4" BorderThickness="1">
+                                            <TextBlock Text="NEW" FontFamily="Consolas, Courier New" FontSize="8"
+                                                       FontWeight="Bold" Foreground="#FF8FC7"/>
+                                        </Border>
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- ===== NO JUST DROP DOOR HERE, DELIBERATELY =====
+                             Just Drop had a rail door and a tab until it became a WINDOW
+                             (Services/JustDrop/JustDropHostService.cs), the same shell the Graded
+                             Intake and DtRH use. A shop that opens borderless over the app has no
+                             business also being a row in the rail, and the two places it is
+                             actually reached from - the Play door's rack and the Exclusives shelf -
+                             are where someone looking for a session already is.
+
+                             The key "justdrop" still exists and still routes through ShowTab, which
+                             intercepts it and launches the window (exactly as it does for "fyp").
+                             That is what keeps the dashboard tease tile and the Ctrl+K palette row
+                             working without either of them knowing a window is involved. -->
+                        </StackPanel>
+                    </Grid>
+                </ScrollViewer>
+
+                <!-- Settings door: pinned to the bottom and visually separated. Phase 1 routes
+                     it at the Dashboard; Phase 2 gives it its own view (key "appsettings"). -->
+                <StackPanel Grid.Row="2">
+                    <!-- THE SPIRAL RAIL (CONTRACTS-0812-FINISH §9). Collapsed in every shipped
+                         build: AppSettings.DescentSpiralRailEnabled is false and has no editor,
+                         and even with it set the control stays collapsed until the server ships
+                         this account a descent block. Collapsed measures as zero, so the rail's
+                         layout is identical to the build before this element existed.
+                         See Controls/SpiralRailHost.cs - especially the airspace note. -->
+                    <!-- ponytail: Controls/SpiralRailHost.cs (278 lines) is not on this base and is out of scope for
+                         this layer; a collapsed stand-in keeps the rail measuring as it does today. -->
+                    <Border x:Name="SpiralRail" IsVisible="False"/>
+                    <Border Height="1" Background="{DynamicResource PanelAccentBrush}" Margin="10,8,10,6"/>
+                    <!-- THE FUSE RAIL CHIP (CONTRACT-FUSE-0816 2.2). A gold clock that appears
+                         seven days before the migration ceremony, shakes harder the closer it gets,
+                         and is gone for good once this account has taken its ceremony. Clicking it
+                         opens the Spiral Room.
+                         Self-wiring and Collapsed by default, so a build with no cached ceremony
+                         timestamp - i.e. every install today - measures as if it were not here.
+                         Code-built on purpose: it is NOT a door medallion. It has no NavDoorMap
+                         row, ChromeFx never lights it, CacheNavDoorRows never walks it, and it must
+                         not contribute the 40px door Viewbox markup NavRailFlyoutTests counts.
+                         See Controls/DescentFuseRailChip.cs. -->
+                    <!-- ponytail: Controls/DescentFuseRailChip.cs (803 lines) is not on this base and is out of scope
+                         for this layer; collapsed stand-in, which is its shipped default state. -->
+                    <Border x:Name="FuseRailChip" IsVisible="False"/>
+                    <!-- v6.8.0 Web App door: a LAUNCHER, not a tab (same rule as the four Library
+                         launchers) - it opens app.cclabs.app in the default browser, so it has its
+                         own Click and deliberately no NavDoorMap row: NavDoor_Click on this Tag
+                         would log-and-stay, and the "you are here" ring must never light for a
+                         door you cannot be in. The medallion keeps the full four-child shape
+                         (see DoorHome) because CacheNavDoorRows walks it via NavLauncherDoors. -->
+                    <Button x:Name="DoorWebApp" Tag="webapp" Theme="{StaticResource NavDoorButton}"
+                            Background="#225EC8F2" BorderBrush="#5EC8F2"
+                            Click="DoorWebApp_Click" ToolTip.Tip="{loc:Str tooltip_nav_door_webapp}">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="56"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                     IsHitTestVisible="False"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                    BorderThickness="1" BorderBrush="Transparent">
+                                        <TextBlock Text="🌐" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                            <Viewbox Grid.Column="0" Width="40" Height="40"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_webapp.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorWebApp" Width="64" Height="64"/>
+                            </Viewbox>
+                            <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str nav_door_webapp}"
+                                               Theme="{StaticResource NavDoorLabelText}"/>
+                                </Viewbox>
+                            </Grid>
+                        </Grid>
+                    </Button>
+                    <Button x:Name="DoorSettings" Tag="appsettings" Theme="{StaticResource NavDoorButton}"
+                            Background="#225CE0A5" BorderBrush="#5CE0A5"
+                            Click="NavDoor_Click" ToolTip.Tip="{loc:Str nav_door_settings}">
+                        <!-- Medallion: see DoorHome for what the four children are for. -->
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="56"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Ellipse Grid.Column="0" Width="64" Height="64" Opacity="0"
+                                     IsHitTestVisible="False"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            <Border Grid.Column="0" Width="44" Height="44" CornerRadius="12"
+                                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
+                                    BorderThickness="1" BorderBrush="Transparent">
+                                        <TextBlock Text="⚙" FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                            <Viewbox Grid.Column="0" Width="40" Height="40"
+                                     HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <!-- ponytail: WPF loaded pack://application:,,,/Resources/nav/door_settings.png clipped to a
+                                             16px round rect. This head ships no Resources/ art, so the Image
+                                             stays sourceless (ApplyDoorArt's handle survives) and the medallion
+                                             tile below carries a stand-in glyph. -->
+                                        <Image x:Name="ImgDoorSettings" Width="64" Height="64"/>
+                            </Viewbox>
+                            <Grid Grid.Column="1" Theme="{StaticResource NavDoorLabelHost}">
+                                <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <TextBlock Text="{loc:Str nav_door_settings}"
+                                               Theme="{StaticResource NavDoorLabelText}"/>
+                                </Viewbox>
+                            </Grid>
+                        </Grid>
+                    </Button>
+                    <!-- EMI DESK's dock chip: the last thing in the pinned stack, under the
+                         Settings door. NOT a door - no NavDoorMap row, no "you are here" ring, and
+                         no 40px door Viewbox markup in THIS file (NavRailFlyoutTests counts eight
+                         of those). Self-wiring like the fuse chip: adding the element is the whole
+                         integration. See Controls/EmiDock.xaml. -->
+                    <cmp:EmiDock x:Name="EmiDockChip"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Header Bar - Row 1 -->
+        <!-- 2026-08-13: was an opaque PanelBg slab; its square edges read as sharp corners
+             against the darker base coat. Every child is a self-contained rounded pill, so
+             the slab is simply transparent now and the pills float on the window background
+             like the cards below do. -->
+        <Border Grid.Row="1" Grid.Column="1" Background="Transparent" Padding="15,8">
+            <Grid>
+                <!-- #857 note, kept for the record: navigation used to live here in an Auto
+                     column and had to size to content BEFORE the identity cluster, or the
+                     right-aligned strip overflowed left and hid Dashboard behind the mod
+                     switcher. Phase 1 moved navigation into the rail, so the header is now
+                     just identity (elastic) + the right-hand chrome cluster (Auto). -->
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Title + Player Title + App Name + Version -->
+                <!-- #860: a Grid, not a StackPanel, so this cluster can give width back.
+                     Column 1 (the player title) is the single elastic cell and carries the
+                     200px cap the TextBlock used to own on its own: with room to spare the
+                     level pill still hugs the title exactly as before, and when the window
+                     narrows the title ellipsizes instead of the cluster shouldering the tabs
+                     out of the header. HorizontalAlignment used to be Left here; 0813 dropped it
+                     so the cluster stretches and column 5 (the support banner, moved out of its
+                     own row) can claim the leftover width between the version text and the
+                     right-hand chrome. Nothing spreads: columns 0-4 are still Auto/capped, and
+                     the banner is the only thing that grows. -->
+                <Grid Grid.Column="0" VerticalAlignment="Center">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*" MaxWidth="200"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <!-- 5: support banner. Star, so it is the FIRST thing to give width
+                             back; the right-hand chrome (language pill, update button) lives in
+                             an Auto column of the outer grid and can never be pushed out.
+                             2*, not *, because column 1 is capped at 200 anyway: the weight is
+                             what keeps the support line off an ellipsis once the update button
+                             is showing. -->
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- v6.0 Mod Switcher: ComboBox + gear button for management -->
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,10,0">
+                        <!-- #860: MaxWidth caps a long mod name (creator mods name themselves)
+                             so the switcher can never shove the header around. The item template
+                             is a Grid rather than a StackPanel on purpose - a horizontal
+                             StackPanel measures its children against infinite width, so
+                             TextTrimming there would never fire and the name would hard-clip.
+                             In the drop-down the popup measures unconstrained, so items there
+                             still show their full name. -->
+                        <ComboBox x:Name="ModSelectorCombo" SelectedIndex="0"
+                                  Theme="{StaticResource DarkComboBoxStyle}"
+                                  ItemsSource="{Binding $parent[Window].AvailableMods}"
+                                  SelectionChanged="ModSelectorCombo_SelectionChanged"
+                                  MinWidth="100" MaxWidth="150" Height="24" VerticalAlignment="Center"
+                                  FontSize="11" FontWeight="SemiBold"
+                                  ToolTip.Tip="{loc:Str tooltip_mod_chip}">
+                            <!-- Phase 1 mod chip: a local Template (not a new Style) so the
+                                 DarkComboBoxStyle ItemContainerStyle - and every ItemsSource /
+                                 SelectedValuePath / SelectionChanged binding above - stays exactly
+                                 as it was. Only the closed-state chrome changes: 3px-corner dark
+                                 box -> rounded pill in the mod accent. The accent DOT is not new
+                                 here; it already comes from the ItemTemplate below, which the
+                                 SelectionBox reuses. -->
+                            <ComboBox.Template>
+                                <ControlTemplate TargetType="ComboBox">
+                                    <Grid>
+                                        <ToggleButton x:Name="ToggleButton"
+                                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                      Focusable="False" ClickMode="Press">
+                                            <ToggleButton.Template>
+                                                <ControlTemplate TargetType="ToggleButton">
+                                                    <Border x:Name="chip" CornerRadius="12" Cursor="Hand"
+                                                            Background="{DynamicResource SurfaceBgBrush}"
+                                                            BorderBrush="{DynamicResource PinkBrush}"
+                                                            BorderThickness="1">
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="16"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Path Grid.Column="1" Fill="{DynamicResource PinkBrush}"
+                                                                  HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                  Data="M 0 0 L 3.5 3.5 L 7 0 Z"/>
+                                                        </Grid>
+                                                    </Border>
+                                                    <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                                         Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                         rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                                </ControlTemplate>
+                                            </ToggleButton.Template>
+                                        </ToggleButton>
+                                        <ContentPresenter IsHitTestVisible="False"
+                                                          Content="{TemplateBinding SelectionBoxItem}"
+                                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                          Margin="10,0,19,0" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                                          Foreground="White"/>
+                                        <Popup x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}"
+                                               Placement="Bottom" Focusable="False">
+                                            <Border Background="{DynamicResource PanelBgBrush}" BorderBrush="#3A3A5C"
+                                                    BorderThickness="1" CornerRadius="6" Margin="0,2,0,0">
+                                                <ScrollViewer MaxHeight="200" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                                    <ItemsPresenter/>
+                                                </ScrollViewer>
+                                            </Border>
+                                        </Popup>
+                                    </Grid>
+                                </ControlTemplate>
+                            </ComboBox.Template>
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0" Width="8" Height="8" CornerRadius="4" Margin="0,0,8,0"
+                                                Background="{Binding AccentBrush}" VerticalAlignment="Center"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding Name}" Foreground="White"
+                                                   VerticalAlignment="Center" FontSize="11"
+                                                   TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Name}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <!-- Accent capsule, not a bare glyph: the old 22px muted gear was the
+                             single most-asked "where is it?" control in the app. Gear + caption
+                             live inside the template so one hit area covers both.
+                             Height 28 is free vertical room - the Row 1 tab buttons in column 1
+                             are already Height 32, so this cannot grow the header row. 0813 turned
+                             the stacked gear-over-caption into a one-line wordmark (the gear IS
+                             the O of "MOD"), so the 28px now holds a single line with room to
+                             spare and nothing needs a pinned LineHeight to avoid clipping.
+                             AutomationProperties.Name keeps the localized string on the control
+                             for screen readers - the visible letters are split across runs. -->
+                        <Button x:Name="BtnManageMods" Click="BtnManageMods_Click"
+                                ToolTip.Tip="{loc:Str tooltip_manage_mods}"
+                                Margin="4,0,0,0" Height="28" VerticalAlignment="Center"
+                                Background="Transparent" BorderThickness="0" Cursor="Hand">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <!-- #857: padding trimmed 7->5 so the capsule costs the
+                                         header a few px less; the caption still drives the width. -->
+                                    <Border x:Name="capsule" CornerRadius="4" Padding="5,1"
+                                            Background="{DynamicResource TransparentPink20Brush}"
+                                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+                                        <!-- The wordmark. Sizes are measured, not eyeballed. Segoe UI
+                                             Bold at 11 has a 7.97px cap band running from 0.13 BELOW
+                                             the baseline to 7.83 above it, so its optical centre is
+                                             3.85 above the baseline. The MDL2 gear's ink is 0.994em
+                                             tall and fills its whole advance, so FontSize 10 draws a
+                                             9.94px glyph whose inner body reads at about cap height
+                                             with the teeth as the overshoot a round letter wants next
+                                             to a flat-topped M and D.
+                                             It shares ONE TextBlock with the letters, so the text
+                                             engine baselines it instead of a guessed margin: an
+                                             InlineUIContainer bottom-aligns to the baseline, and at
+                                             this font the glyph's own baseline IS its box bottom. The
+                                             -1 bottom margin then drops it to a 4.00 centre, i.e.
+                                             onto the cap band's 3.85 to within a sixth of a pixel,
+                                             instead of leaving the whole overshoot above the baseline.
+                                             The 0.7 side margins are the side bearings a real "O"
+                                             would have and this glyph does not.
+                                             The three inlines are written with NO whitespace between
+                                             them on purpose: a line break there collapses to a real
+                                             space and the button reads "M (gear) D MANAGER".
+                                             The letters are literal because label_mod_manager is the
+                                             string "MOD MANAGER" in all nine language files; the key
+                                             is still bound, as this button's AutomationProperties.Name. -->
+                                        <TextBlock FontSize="11" FontWeight="Bold" TextWrapping="NoWrap"
+                                                   Foreground="{DynamicResource PinkBrush}"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"><Run Text="M"/><InlineUIContainer
+                                                       BaselineAlignment="Baseline"><TextBlock
+                                                           Text="&#xE713;" FontFamily="Segoe MDL2 Assets, Segoe UI Symbol, Segoe UI"
+                                                           FontSize="10" FontWeight="Normal"
+                                                           Foreground="{DynamicResource PinkBrush}"
+                                                           Margin="0.7,0,0.7,-1"/></InlineUIContainer><Run
+                                                       Text="D MANAGER"/></TextBlock>
+                                    </Border>
+                                    <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                         Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                         rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
+
+                        <!-- Account chip (Phase 1, net-new). Sits beside the mod chip so the two
+                             "who am I / what am I running" facts read as one cluster.
+                             States are painted by RefreshAccountChip (MainWindow.UiUpdates.cs):
+                             signed out = pink CTA border, no badge; signed in free = neutral;
+                             T1 = gold 🔒; T2/whitelist = violet 🧪. Background/BorderBrush are
+                             TemplateBindings on purpose - the refresh sets them on the Button,
+                             and the signed-out/free states use SetResourceReference so a mod
+                             switch still repaints the accent.
+                             Phase 2 re-points the click at the real Settings/Account page. -->
+                        <Button x:Name="BtnAccountChip" Click="BtnAccountChip_Click"
+                                Margin="8,0,0,0" Height="24" VerticalAlignment="Center" Cursor="Hand"
+                                Background="{DynamicResource SurfaceBgBrush}"
+                                BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1"
+                                ToolTip.Tip="{loc:Str tooltip_account_chip}">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="chip" CornerRadius="12" Padding="9,0"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}">
+                                        <ContentPresenter VerticalAlignment="Center" HorizontalAlignment="Left"
+                                                         Content="{TemplateBinding Content}"
+                                                         ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                    </Border>
+                                    <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                         Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                         rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                </ControlTemplate>
+                            </Button.Template>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock x:Name="TxtAccountChipBadge" Text="🔒" FontSize="10"
+                                           Margin="0,0,5,0" VerticalAlignment="Center"
+                                           IsVisible="False"/>
+                                <TextBlock x:Name="TxtAccountChipName" Text="{loc:Str account_chip_sign_in}"
+                                           FontSize="11" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}"
+                                           VerticalAlignment="Center"
+                                           MaxWidth="110" TextTrimming="CharacterEllipsis"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                    <!-- The rank title used to ellipsise here: "PERFECT FUCKPUPPET" (level 100+,
+                         MainWindow.UiUpdates.cs) measures past 200px at 18px bold and rendered as
+                         "Perfect Fuckpupp...". The 200px cap has to stay - it is what stops the
+                         identity cluster shouldering the header chrome out (#860) - so scale the
+                         title down inside the cap instead of trimming it. StretchDirection
+                         DownOnly means every shorter rank still renders at the full 18px and the
+                         level pill sits exactly where it did; only an over-long title shrinks,
+                         and only as far as it has to. -->
+                    <Viewbox Grid.Column="1" MaxWidth="200" Margin="0,0,12,0"
+                             HorizontalAlignment="Left" VerticalAlignment="Center"
+                             Stretch="Uniform" StretchDirection="DownOnly">
+                        <TextBlock x:Name="TxtPlayerTitle" Text="{loc:Str label_basic_subject}" Foreground="{DynamicResource PinkBrush}"
+                                   FontSize="18" FontWeight="Bold"
+                                   ToolTip.Tip="{Binding #TxtPlayerTitle.Text}">
+                            <TextBlock.Effect>
+                                <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="8" OffsetX="0" OffsetY="0" Opacity="0.6"/>
+                            </TextBlock.Effect>
+                        </TextBlock>
+                    </Viewbox>
+                    <Border Grid.Column="2" Background="{DynamicResource PinkBrush}" CornerRadius="12" Padding="10,4" Margin="0,0,20,0">
+                        <TextBlock x:Name="TxtLevel" Text="{loc:Str label_lvl_1}" Foreground="White" FontWeight="Bold" FontSize="12"/>
+                    </Border>
+                    <TextBlock Grid.Column="3" x:Name="TxtHeaderVersion" Text="" Foreground="{DynamicResource PinkBrush}" FontSize="10" FontWeight="Normal"
+                               VerticalAlignment="Bottom" Margin="4,0,0,3"/>
+                    <!-- Streak Fire Icon (unlocked by Good Girl Streak skill) -->
+                    <Border Grid.Column="4" x:Name="StreakFirePill" VerticalAlignment="Center"
+                            Margin="10,0,0,0" IsVisible="False" CornerRadius="11" Padding="7,4"
+                            Background="#1E1232" BorderBrush="#5C3D6E" BorderThickness="1"
+                            ToolTip.Tip="{loc:Str tooltip_daily_login_streak_good_girl_streak_skill}">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <!-- Flame vector icon -->
+                            <Viewbox Width="13" Height="13" VerticalAlignment="Center">
+                                <Path Fill="#C47DAA"
+                                      Data="M8,1 C8,1 2.5,6.5 2.5,10 C2.5,13 5,15.5 8,15.5 C11,15.5 13.5,13 13.5,10 C13.5,6.5 8,1 8,1 Z M8,13.5 C6,13.5 4.5,12 4.5,10 C4.5,8 7,5 8,3.8 C9,5 11.5,8 11.5,10 C11.5,12 10,13.5 8,13.5 Z"/>
+                            </Viewbox>
+                            <TextBlock x:Name="TxtStreakFireCount" Text="0" Foreground="#C9A0D0" FontSize="13"
+                                       FontWeight="Bold" VerticalAlignment="Center" Margin="4,0,0,0"/>
+                            <!-- Shield vector icon -->
+                            <Viewbox x:Name="TxtStreakShieldIcon" Width="12" Height="12"
+                                     VerticalAlignment="Center" Margin="5,0,0,0" IsVisible="False"
+                                     ToolTip.Tip="{loc:Str tooltip_streak_shield_available_protects_your_streak}">
+                                <Path Fill="#8B7BA0"
+                                      Data="M8,1 L2,4 V9.5 C2,13 5,15.5 8,17 C11,15.5 14,13 14,9.5 V4 Z M8,15 C5.8,13.8 4,11.8 4,9.5 V5.2 L8,3 L12,5.2 V9.5 C12,11.8 10.2,13.8 8,15 Z"/>
+                            </Viewbox>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Support/welcome banner (0813). It used to own canvas row 2 outright, a
+                         full-width strip whose only job was two rotating one-liners; the row is
+                         gone and the banner now rides the header's leftover width, between the
+                         version text and the right-hand chrome. Sizing rules that keep that
+                         honest: Height 26 is BELOW the 28px mod capsule already in this row, so
+                         the banner can never grow the header; the host is centred in a star
+                         column that collapses before any Auto column, so the language pill and
+                         update button cannot be pushed out; and both beats trim with an
+                         ellipsis rather than wrap, so a narrow window loses banner text and
+                         nothing else. The third beat (the Platinum Puppets thanks hyperlink) was
+                         retired with the row - see MainWindow.Marquee.cs, where the rotation is
+                         now a two-beat crossfade. -->
+                    <Border Grid.Column="5" x:Name="HeaderBannerHost"
+                            Background="{DynamicResource SurfaceBgBrush}"
+                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1"
+                            CornerRadius="13" Padding="12,0" Height="26" MaxWidth="620"
+                            Margin="12,0,12,0"
+                            HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Grid>
+                            <TextBlock x:Name="TxtBannerPrimary" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="12" FontStyle="Italic"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                       Opacity="1">
+                                <Run Text="{loc:Str label_if_you_love_the_project_please}"/>
+                                <Run Text="{loc:Str label_consider_supporting_it}" FontWeight="Bold"/>
+                                <Run Text=" "/>
+                                <!-- ponytail: WPF Hyperlink/RequestNavigate has no Avalonia inline twin; renders as text. --><Run Text="https://linktr.ee/CodeBambi"/>
+                                
+                            </TextBlock>
+                            <TextBlock x:Name="TxtBannerSecondary" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="12" FontStyle="Italic"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                       Opacity="0" IsHitTestVisible="False"
+                                       Text="{loc:Str login_welcome_back}"/>
+                            <!-- v6.8.0 One Account beat. In the rotation ONLY until acted on:
+                                 InitializeBannerRotation includes it while SeenFeatureIntros lacks
+                                 "banner-web", and RetireWebBannerBeat spends that key from the
+                                 hyperlink here, the Web App door, and the one-account card's CTA.
+                                 An inline Hyperlink, never a printed URL (comms rule: the banner
+                                 carries no addresses). Remove the whole beat in 6.9 with the NEW
+                                 pills. -->
+                            <TextBlock x:Name="TxtBannerWeb" Foreground="{DynamicResource PinkBrush}"
+                                       FontSize="12" FontStyle="Italic"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                       Opacity="0" IsHitTestVisible="False">
+                                <Run Text="{loc:Str label_banner_web_xp}"/>
+                                <Run Text=" "/>
+                                <!-- ponytail: WPF Hyperlink/RequestNavigate has no Avalonia inline twin; renders as text. --><Run Text="{loc:Str label_banner_web_link}" FontWeight="Bold"/>
+                                
+                            </TextBlock>
+                            <!-- Chrome FX (PR-1): one-shot sheen pass over the banner when the
+                                 message changes. Its own ClipToBounds host so the band can't
+                                 escape the card - deliberately NOT ClipToBounds on the shared
+                                 Grid, which would start clipping the banner text itself.
+                                 Hit-test invisible so the hyperlinks underneath keep working.
+                                 Driven from MainWindow.ChromeFx.cs. -->
+                            <Grid x:Name="BannerSheenHost" ClipToBounds="True" IsHitTestVisible="False">
+                                <Border x:Name="BannerSheen" Width="110" HorizontalAlignment="Left" Opacity="0"
+                                        RenderTransformOrigin="0.5,0.5">
+                                    <Border.Background>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                            <GradientStop Offset="0" Color="#00FFFFFF"/>
+                                            <GradientStop Offset="0.5" Color="{DynamicResource FxGlowColor}"/>
+                                            <GradientStop Offset="1" Color="#00FFFFFF"/>
+                                        </LinearGradientBrush>
+                                    </Border.Background>
+                                    <Border.RenderTransform>
+                                        <TransformGroup>
+                                            <SkewTransform AngleX="-20"/>
+                                            <TranslateTransform/>
+                                        </TransformGroup>
+                                    </Border.RenderTransform>
+                                </Border>
+                            </Grid>
+                        </Grid>
+                    </Border>
+                </Grid>
+
+                <!-- Phase 1: the row-1 tab strip moved into the nav rail (canvas column 0).
+                     The eight buttons were MOVED, not rebuilt - same x:Name, Click, Tag,
+                     tooltip, icon-in-a-Panel content shape and pulse transforms. -->
+
+                <!-- Right side: preset picker (collapsed but live), language pill, update
+                     button, Help, and the profile bubble (avatar + hover account menu).
+                     Bug Report lives in the title bar (BtnTitleBarBugReport) - the copy that
+                     used to sit here was a duplicate and was removed for the bubble. -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                    <ComboBox x:Name="CmbPresets" Width="160" Margin="0,0,10,0" IsVisible="False"
+                              SelectionChanged="CmbPresets_SelectionChanged"
+                              ToolTip.Tip="{loc:Str tooltip_select_a_preset_configuration}">
+                        <ComboBox.Theme>
+                            <ControlTheme TargetType="ComboBox">
+                                <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+                                <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+                                <Setter Property="BorderBrush" Value="{DynamicResource PinkBrush}"/>
+                                <Setter Property="BorderThickness" Value="1"/>
+                                <Setter Property="Padding" Value="8,6"/>
+                                <Setter Property="Template">
+                                        <ControlTemplate TargetType="ComboBox">
+                                            <Grid>
+                                                <ToggleButton x:Name="ToggleButton"
+                                                              IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                              Focusable="False" ClickMode="Press">
+                                                    <ToggleButton.Template>
+                                                        <ControlTemplate TargetType="ToggleButton">
+                                                            <Border Background="{DynamicResource SurfaceBgBrush}" BorderBrush="{DynamicResource PinkBrush}"
+                                                                    BorderThickness="1" CornerRadius="4" Cursor="Hand">
+                                                                <Grid>
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                        <ColumnDefinition Width="20"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Path Grid.Column="1" Fill="#E0E0E0" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                          Data="M 0 0 L 4 4 L 8 0 Z"/>
+                                                                </Grid>
+                                                            </Border>
+                                                        </ControlTemplate>
+                                                    </ToggleButton.Template>
+                                                </ToggleButton>
+                                                <ContentPresenter x:Name="ContentSite" IsHitTestVisible="False"
+                                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                                  Margin="8,6,25,6" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                                                  Foreground="{StaticResource TextLightBrush}"/>
+                                                <TextBlock x:Name="Watermark" Text="{loc:Str label_preset}" Foreground="{DynamicResource TextMutedBrush}"
+                                                           Margin="8,6,25,6" VerticalAlignment="Center" IsHitTestVisible="False"
+                                                           IsVisible="False"/>
+                                                <Popup x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}"
+                                                       Placement="Bottom" Focusable="False">
+                                                    <Border Background="{DynamicResource SurfaceBgBrush}" BorderBrush="{DynamicResource PinkBrush}"
+                                                            BorderThickness="1" CornerRadius="4" Margin="0,2,0,0">
+                                                        <ScrollViewer MaxHeight="200" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                                            <ItemsPresenter/>
+                                                        </ScrollViewer>
+                                                    </Border>
+                                                </Popup>
+                                            </Grid>
+                                            <!-- ponytail: WPF ControlTemplate.Triggers (SelectedItem) dropped. Avalonia writes these as
+                                                 Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                 rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                        </ControlTemplate>
+                                </Setter>
+                            </ControlTheme>
+                        </ComboBox.Theme>
+                        <ComboBox.ItemContainerTheme>
+                            <ControlTheme TargetType="ComboBoxItem">
+                                <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+                                <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+                                <Setter Property="Padding" Value="8,6"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                                <Setter Property="Template">
+                                        <ControlTemplate TargetType="ComboBoxItem">
+                                            <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                                                <ContentPresenter
+                                                                 Content="{TemplateBinding Content}"
+                                                                 ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                            </Border>
+                                            <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver, IsSelected) dropped. Avalonia writes these as
+                                                 Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                 rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                        </ControlTemplate>
+                                </Setter>
+                            </ControlTheme>
+                        </ComboBox.ItemContainerTheme>
+                    </ComboBox>
+                    <!-- Language Pill -->
+                    <ComboBox x:Name="CmbLanguagePill" Width="90" Margin="0,0,10,0"
+                              SelectionChanged="CmbLanguagePill_SelectionChanged"
+                              ToolTip.Tip="{loc:Str tooltip_change_language}">
+                        <ComboBox.Theme>
+                            <ControlTheme TargetType="ComboBox">
+                                <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+                                <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+                                <Setter Property="BorderBrush" Value="#3D3D60"/>
+                                <Setter Property="BorderThickness" Value="1"/>
+                                <Setter Property="Padding" Value="8,4"/>
+                                <Setter Property="FontSize" Value="12"/>
+                                <Setter Property="Template">
+                                        <ControlTemplate TargetType="ComboBox">
+                                            <Grid>
+                                                <ToggleButton x:Name="ToggleButton"
+                                                              IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                              Focusable="False" ClickMode="Press">
+                                                    <ToggleButton.Template>
+                                                        <ControlTemplate TargetType="ToggleButton">
+                                                            <Border Background="{DynamicResource SurfaceBgBrush}" BorderBrush="#3D3D60"
+                                                                    BorderThickness="1" CornerRadius="4" Cursor="Hand">
+                                                                <Grid>
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="*"/>
+                                                                        <ColumnDefinition Width="16"/>
+                                                                    </Grid.ColumnDefinitions>
+                                                                    <Path Grid.Column="1" Fill="#808080" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                          Data="M 0 0 L 3 3 L 6 0 Z"/>
+                                                                </Grid>
+                                                            </Border>
+                                                        </ControlTemplate>
+                                                    </ToggleButton.Template>
+                                                </ToggleButton>
+                                                <ContentPresenter x:Name="ContentSite" IsHitTestVisible="False"
+                                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                                  Margin="6,4,18,4" VerticalAlignment="Center" HorizontalAlignment="Left"
+                                                                  Foreground="{StaticResource TextLightBrush}"/>
+                                                <Popup x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}"
+                                                       Placement="Bottom" Focusable="False">
+                                                    <Border Background="{DynamicResource SurfaceBgBrush}" BorderBrush="#3D3D60"
+                                                            BorderThickness="1" CornerRadius="4" Margin="0,2,0,0">
+                                                        <ScrollViewer MaxHeight="300" ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                                            <ItemsPresenter/>
+                                                        </ScrollViewer>
+                                                    </Border>
+                                                </Popup>
+                                            </Grid>
+                                        </ControlTemplate>
+                                </Setter>
+                            </ControlTheme>
+                        </ComboBox.Theme>
+                        <ComboBox.ItemContainerTheme>
+                            <ControlTheme TargetType="ComboBoxItem">
+                                <Setter Property="Foreground" Value="{StaticResource TextLightBrush}"/>
+                                <Setter Property="Background" Value="{DynamicResource SurfaceBgBrush}"/>
+                                <Setter Property="Padding" Value="8,4"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                                <Setter Property="Template">
+                                        <ControlTemplate TargetType="ComboBoxItem">
+                                            <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                                                <ContentPresenter
+                                                                 Content="{TemplateBinding Content}"
+                                                                 ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                            </Border>
+                                            <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver, IsSelected) dropped. Avalonia writes these as
+                                                 Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                 rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                        </ControlTemplate>
+                                </Setter>
+                            </ControlTheme>
+                        </ComboBox.ItemContainerTheme>
+                    </ComboBox>
+                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_9_1_is_out}"
+                            Click="BtnUpdateAvailable_Click" ToolTip.Tip="{loc:Str tooltip_v6_9_1_the_spiral}"
+                            FontSize="11" FontWeight="Bold" Cursor="Hand">
+                        <Button.Theme>
+                            <ControlTheme TargetType="Button">
+                                <Setter Property="Background" Value="#3D1A3D"/>
+                                <Setter Property="Foreground" Value="{DynamicResource PinkBrush}"/>
+                                <Setter Property="MinWidth" Value="110"/>
+                                <Setter Property="Height" Value="32"/>
+                                <Setter Property="Padding" Value="12,6"/>
+                                <Setter Property="Tag" Value="NoUpdate"/>
+                                <Setter Property="Template">
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border" Background="{TemplateBinding Background}"
+                                                    CornerRadius="6" BorderThickness="1" BorderBrush="#3D3D60"
+                                                    Padding="{TemplateBinding Padding}">
+                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                 Content="{TemplateBinding Content}"
+                                                                 ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                            </Border>
+                                            <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver, Tag) dropped. Avalonia writes these as
+                                                 Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                 rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                        </ControlTemplate>
+                                </Setter>
+                            </ControlTheme>
+                        </Button.Theme>
+                    </Button>
+                    <!-- Re-homed from the row-2 button grid Phase 1 deleted. BtnMainHelp is a
+                         tutorial spotlight target (TutorialService.cs) - the name must survive. -->
+                    <Button x:Name="BtnMainHelp" Content="?" Click="BtnMainHelp_Click"
+                            Width="26" Height="26" ToolTip.Tip="{loc:Str tooltip_how_to_use}" Margin="10,0,0,0">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border Background="{DynamicResource PinkBrush}" CornerRadius="13" Width="26" Height="26" Cursor="Hand">
+                                    <TextBlock Text="?" Foreground="White" FontWeight="Bold" FontSize="16"
+                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                </Border>
+                                <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                     Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                     rest state renders correctly and only the hover/press/tag skins are lost. -->
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+                    <!-- THE FUSE's spark (CONTRACT-FUSE-0816 2.2). A small gold glyph that appears
+                         seven days before the ceremony and says NOTHING - no digits, no tooltip, no
+                         explanation until T-72h, at which point hovering it reads out T-minus.
+                         Collapsed here and only ever shown by MainWindow.DescentFuse.cs, which does
+                         nothing at all without a cached ceremony timestamp, so on every install
+                         today this is one collapsed 18px Grid and no code.
+                         Background="Transparent" so the host hit-tests for the hover readout; the
+                         glyph itself is pure decoration. -->
+                    <Grid x:Name="FuseSparkHost" Width="18" Height="18" Margin="10,0,0,0"
+                          VerticalAlignment="Center" IsVisible="False"
+                          Background="Transparent" RenderTransformOrigin="0.5,0.5">
+                        <Grid.RenderTransform>
+                            <ScaleTransform/>
+                        </Grid.RenderTransform>
+                        <Path x:Name="FuseSparkGlyph" Width="14" Height="14" Stretch="Uniform"
+                              Fill="#FFE0B052" IsHitTestVisible="False"
+                              Data="M 8,0 L 9.5,6.5 L 16,8 L 9.5,9.5 L 8,16 L 6.5,9.5 L 0,8 L 6.5,6.5 Z"/>
+                    </Grid>
+
+                    <!-- Profile bubble: the user's avatar (Discord photo / preset bust / initials).
+                         Hover opens the account menu below; a direct click jumps to the Profile
+                         tab (key "discord"). It also reacts to app moments - XP pulses, level-up
+                         bounce+burst, flash wobble, achievement glow. All logic lives in
+                         MainWindow.ProfileBubble.cs; the visuals are named here so that partial
+                         can paint and animate them without template digging. -->
+                    <Button x:Name="BtnProfileBubble" Width="34" Height="34" Margin="8,0,0,0"
+                            Click="BtnProfileBubble_Click" Cursor="Hand"
+                            PointerEntered="ProfileBubble_MouseEnter" PointerExited="ProfileBubble_MouseLeave">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <ContentPresenter
+                                                 Content="{TemplateBinding Content}"
+                                                 ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                            </ControlTemplate>
+                        </Button.Template>
+                        <Grid x:Name="ProfileBubbleVisual" Width="34" Height="34" RenderTransformOrigin="0.5,0.5">
+                            <Grid.RenderTransform>
+                                <TransformGroup>
+                                    <ScaleTransform/>
+                                    <RotateTransform/>
+                                </TransformGroup>
+                            </Grid.RenderTransform>
+                            <Ellipse x:Name="ProfileBubbleFill" Margin="3" Fill="#3D3D60"/>
+                            <TextBlock x:Name="ProfileBubbleInitials" Text="?" FontWeight="Bold" FontSize="12"
+                                       Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       IsHitTestVisible="False"/>
+                            <Ellipse x:Name="ProfileBubbleRing" Stroke="{DynamicResource PinkBrush}"
+                                     StrokeThickness="2" Margin="1"/>
+                            <!-- Celebration ring: opacity-0 until an unlock/level-up flashes it gold. -->
+                            <Ellipse x:Name="ProfileBubbleGlowRing" Stroke="#FFD700" StrokeThickness="2"
+                                     Margin="1" Opacity="0" IsHitTestVisible="False">
+                                <Ellipse.Effect>
+                                    <DropShadowEffect Color="#FFD700" BlurRadius="12" OffsetX="0" OffsetY="0" Opacity="0.9"/>
+                                </Ellipse.Effect>
+                            </Ellipse>
+                        </Grid>
+                    </Button>
+                    <!-- The bubble's account menu. StaysOpen + manual close-grace timers, same
+                         recipe as Controls/HelpPopover.cs; placement is Custom (right-aligned
+                         under the bubble) set from MainWindow.ProfileBubble.cs. The transparent
+                         12px shell keeps the popup alive while the cursor crosses the shadow. -->
+                    <Popup x:Name="ProfileBubblePopup" IsLightDismissEnabled="False" Placement="BottomEdgeAlignedRight"
+                           PlacementTarget="{Binding #BtnProfileBubble}">
+                        <Border Background="Transparent" Padding="12"
+                                PointerEntered="ProfileBubblePopupRoot_MouseEnter"
+                                PointerExited="ProfileBubblePopupRoot_MouseLeave">
+                            <Border Background="#F0252542" BorderBrush="{DynamicResource PinkBrush}"
+                                    BorderThickness="2" CornerRadius="10" Width="248" Padding="14,12">
+                                <Border.Effect>
+                                    <DropShadowEffect Color="#FF69B4" BlurRadius="10" OffsetX="0" OffsetY="0" Opacity="0.15"/>
+                                </Border.Effect>
+                                <StackPanel>
+                                    <StackPanel.Resources>
+                                        <ControlTheme x:Key="ProfileMenuItemStyle" TargetType="Button">
+                                            <Setter Property="Height" Value="30"/>
+                                            <Setter Property="Cursor" Value="Hand"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource TextMutedBrush}"/>
+                                            <Setter Property="FontSize" Value="12"/>
+                                            <Setter Property="Template">
+                                                    <ControlTemplate TargetType="Button">
+                                                        <Border x:Name="bg" Background="Transparent" CornerRadius="6" Padding="10,0">
+                                                            <ContentPresenter HorizontalAlignment="Left" VerticalAlignment="Center"
+                                                                             Content="{TemplateBinding Content}"
+                                                                             ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                                        </Border>
+                                                        <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                                             Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                             rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                                    </ControlTemplate>
+                                            </Setter>
+                                        </ControlTheme>
+                                        <!-- Same skin, stretched presenter. The row above hosts a
+                                             single left-aligned caption, which is all any of the
+                                             plain links needs; the spiral row carries a glyph, a
+                                             label AND a right-aligned summary, and a Left-aligned
+                                             ContentPresenter measures to the content instead of the
+                                             row, so the summary would sit against the label rather
+                                             than the panel edge. Everything else (height feel,
+                                             hover fill, foreground swap) is inherited. -->
+                                        <ControlTheme x:Key="ProfileMenuWideItemStyle" TargetType="Button"
+                                               BasedOn="{StaticResource ProfileMenuItemStyle}">
+                                            <Setter Property="Height" Value="34"/>
+                                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                            <Setter Property="Template">
+                                                    <ControlTemplate TargetType="Button">
+                                                        <Border x:Name="bg" Background="Transparent" CornerRadius="6" Padding="10,0">
+                                                            <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                                                                             Content="{TemplateBinding Content}"
+                                                                             ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                                        </Border>
+                                                        <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                                             Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                             rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                                    </ControlTemplate>
+                                            </Setter>
+                                        </ControlTheme>
+                                    </StackPanel.Resources>
+
+                                    <!-- Identity: display name + tier badge (🧪 Lab / 🔒 Premium),
+                                         same truth RefreshAccountChip paints. -->
+                                    <DockPanel>
+                                        <TextBlock x:Name="ProfileMenuBadge" DockPanel.Dock="Right" Text=""
+                                                   FontSize="12" VerticalAlignment="Center" Margin="6,0,0,0"
+                                                   IsVisible="False"/>
+                                        <TextBlock x:Name="ProfileMenuName" FontSize="14" FontWeight="Bold"
+                                                   Foreground="{StaticResource TextLightBrush}"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+
+                                    <!-- Level + XP rail: same numbers as the header XP bar. -->
+                                    <StackPanel x:Name="ProfileMenuXpBlock" Margin="0,10,0,0">
+                                        <Grid Margin="0,0,0,4">
+                                            <TextBlock x:Name="ProfileMenuLevel" Foreground="{DynamicResource PinkBrush}"
+                                                       FontSize="11" FontWeight="Bold"/>
+                                            <TextBlock x:Name="ProfileMenuXp" HorizontalAlignment="Right"
+                                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11"/>
+                                        </Grid>
+                                        <Border Background="#1A1A2E" BorderBrush="#3D3D60" BorderThickness="1"
+                                                CornerRadius="4" Height="8">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="0*"/>
+                                                    <ColumnDefinition Width="1*"/>
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" Background="{DynamicResource PinkBrush}"
+                                                        CornerRadius="3" Margin="1"/>
+                                            </Grid>
+                                        </Border>
+                                        <TextBlock x:Name="ProfileMenuBadges" Margin="0,6,0,0"
+                                                   Foreground="{DynamicResource TextMutedBrush}" FontSize="10.5"/>
+                                    </StackPanel>
+
+                                    <Border Height="1" Background="#3D3D60" Margin="0,10,0,6"/>
+
+                                    <!-- THE SPIRAL. Collapsed by default and shown only when the
+                                         server has actually shipped this account a descent block
+                                         (MainWindow.ProfileBubble.cs / RefreshProfileMenuSpiral) -
+                                         block presence IS the rollout gate, so there is no flag to
+                                         check and nothing to see for anyone outside the dial.
+                                         The summary is numbers and a Roman numeral only: stage
+                                         NAMES are still an open owner call with no loc keys. -->
+                                    <Button x:Name="ProfileMenuSpiralRow" IsVisible="False"
+                                            Theme="{StaticResource ProfileMenuWideItemStyle}"
+                                            Click="ProfileMenuSpiral_Click">
+                                        <DockPanel LastChildFill="True">
+                                            <fx:SpiralGlyph x:Name="ProfileMenuSpiralGlyph" DockPanel.Dock="Left"
+                                                                  Width="22" Height="22" Margin="0,0,8,0"
+                                                                  VerticalAlignment="Center"/>
+                                            <TextBlock x:Name="ProfileMenuSpiralSummary" DockPanel.Dock="Right"
+                                                       Foreground="{DynamicResource TextDimBrush}" FontSize="11"
+                                                       VerticalAlignment="Center" Margin="8,0,0,0"/>
+                                            <TextBlock Text="{loc:Str profile_menu_spiral}" VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </DockPanel>
+                                    </Button>
+                                    <Button Theme="{StaticResource ProfileMenuItemStyle}"
+                                            Content="{loc:Str tab_profile}" Click="ProfileMenuProfile_Click"/>
+                                    <!-- The outward-facing half of the row above, and a door out of
+                                         the app rather than a tab: everything about a public profile
+                                         (the slug, the featured drops, the kill switch) lives on the
+                                         web, and deliberately never renders here. -->
+                                    <Button Theme="{StaticResource ProfileMenuItemStyle}"
+                                            Content="{loc:Str profile_menu_public}"
+                                            ToolTip.Tip="{loc:Str tooltip_profile_menu_public}"
+                                            Click="ProfileMenuPublicProfile_Click"/>
+                                    <Button Theme="{StaticResource ProfileMenuItemStyle}"
+                                            Content="{loc:Str tab_achievements}" Click="ProfileMenuAchievements_Click"/>
+                                    <Button Theme="{StaticResource ProfileMenuItemStyle}"
+                                            Content="{loc:Str tab_settings}" Click="ProfileMenuSettings_Click"/>
+
+                                    <Border Height="1" Background="#3D3D60" Margin="0,6,0,6"/>
+
+                                    <!-- Logout when signed in, "Sign in" (to Settings > Account) when not;
+                                         RefreshProfileMenu swaps the caption, the handler checks live. -->
+                                    <Button x:Name="ProfileMenuAccountBtn" Theme="{StaticResource ProfileMenuItemStyle}"
+                                            Content="{loc:Str btn_logout}" Click="ProfileMenuAccount_Click"/>
+                                </StackPanel>
+                            </Border>
+                        </Border>
+                    </Popup>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Canvas row 2 is EMPTY on purpose (0813). It carried the full-width support/marquee
+             banner; the banner is now nested in the header row beside the version text
+             (HeaderBannerHost, above), and the ~53px this row cost went back to the tab
+             canvas in row 4. The row DEFINITION survives, pinned to 0, so every Grid.Row
+             below it keeps its index. -->
+        <!-- XP Progress Bar + Stat Pills - Row 3 -->
+        <Grid Grid.Row="3" Grid.Column="1" Margin="15,10,15,5">
+            <!-- Main content with XP bar and stat pills -->
+            <Grid x:Name="XPBarContent">
+                <Grid.ColumnDefinitions>
+                    <!-- XP Bar section (fills remaining space) -->
+                    <ColumnDefinition Width="*"/>
+                    <!-- Bonuses + Stat Pills (shrinks to fit content) -->
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- LEFT SIDE: XP Bar -->
+                <Grid Grid.Column="0">
+                    <Grid.ColumnDefinitions>
+                        <!-- Quest stamp cluster (MainWindow.QuestStamps.cs). Auto-width, so the
+                             star-width bar column below simply gets shorter by however wide the
+                             cluster measures - and reclaims the full width again the moment the
+                             host collapses (no QuestService). -->
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <!-- The 4 stamps (3 daily slots + 1 weekly) are BUILT IN CODE, not here: their
+                         count is fixed but their state, tilt, fill and tooltip all come from live
+                         quest data, so there is nothing worth templating.
+
+                         Height is PINNED at 22 on purpose. The tallest thing in this row is a stat
+                         pill (~23px), and a pinned height means the tilted squares - whose rotated
+                         bounding boxes run a couple of px past 22 - overhang without ever
+                         contributing to the row's measure. ClipToBounds stays false so the
+                         overhang draws; Background is a transparent brush (NOT null) so the whole
+                         cluster, gaps included, is one hit-test target. -->
+                    <Grid x:Name="QuestStampHost" Grid.Column="0"
+                          Height="22" ClipToBounds="False"
+                          Background="Transparent" Cursor="Hand"
+                          VerticalAlignment="Center" HorizontalAlignment="Left"
+                          Margin="0,0,12,0" IsVisible="False"
+                          RenderTransformOrigin="0.5,0.5"
+                          PointerReleased="QuestStamps_Click"
+                          PointerEntered="QuestStamps_MouseEnter"
+                          PointerExited="QuestStamps_MouseLeave"/>
+                    <!-- Velvet Kit 2 (FX lane B): the LVL chip owns a scale+rotate rig so a level-up
+                         can pop it. Named transforms, animated from MainWindow.HeroFx.cs via
+                         BeginAnimation - nothing else drives this TextBlock's RenderTransform. -->
+                    <TextBlock x:Name="TxtLevelLabel" Grid.Column="1" Text="{loc:Str label_lvl_1_2}" Foreground="{DynamicResource PinkBrush}"
+                               FontWeight="Bold" FontSize="12" VerticalAlignment="Center" Margin="0,0,10,0"
+                               RenderTransformOrigin="0.5,0.5">
+                        <TextBlock.RenderTransform>
+                            <TransformGroup>
+                                <ScaleTransform/>
+                                <RotateTransform/>
+                            </TransformGroup>
+                        </TextBlock.RenderTransform>
+                    </TextBlock>
+                    <!-- x:Name is for the PR-5 level-up burst: the TRACK is where the bar's cap
+                         sits, and after a level-up the fill has already wrapped back to a sliver. -->
+                    <!-- ToolTip is a live readout of the ambient-bubble daily XP budget (#1019/#1026);
+                         the placeholder here only exists so ToolTipOpening fires, which rewrites it. -->
+                    <Border x:Name="XPBarTrack" Grid.Column="2" Background="{DynamicResource PanelAccentBrush}" CornerRadius="4" Height="8" Margin="0,0,10,0"
+                            ToolTip.Tip="{loc:Str label_ambient_bubble_xp_budget}">
+                        <Grid>
+                            <Border x:Name="XPBar" Background="{DynamicResource PinkBrush}" CornerRadius="4"
+                                    HorizontalAlignment="Left" Width="100">
+                                <!-- Chrome FX (PR-1): a slow gloss travelling along the filled part of
+                                     the bar. White on purpose - it reads as light catching the fill
+                                     rather than a second accent colour on top of the accent. Parked at
+                                     Opacity 0 with no clock unless ambient loops are allowed; the three
+                                     stop offsets are animated from MainWindow.ChromeFx.cs. -->
+                                <!-- Inset past the pill's rounded caps: a Border does not clip its
+                                     child to CornerRadius, so a full-bleed gloss would show square
+                                     corners poking out of the 8px-tall bar at each end. -->
+                                <Border x:Name="XPBarSheen" Margin="4,0" IsHitTestVisible="False" Opacity="0">
+                                    <Border.Background>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                            <GradientStop Offset="-0.30" Color="#00FFFFFF"/>
+                                            <GradientStop Offset="-0.15" Color="#59FFFFFF"/>
+                                            <GradientStop Offset="0.00" Color="#00FFFFFF"/>
+                                        </LinearGradientBrush>
+                                    </Border.Background>
+                                </Border>
+                            </Border>
+                            <Border x:Name="XPBarFlashOverlay" Background="{DynamicResource PinkBrush}" CornerRadius="4"
+                                    HorizontalAlignment="Left"
+                                    Width="{Binding #XPBar.Width}"
+                                    Opacity="0" IsHitTestVisible="False">
+                                <Border.Effect>
+                                    <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="0.95"/>
+                                </Border.Effect>
+                            </Border>
+                            <!-- Velvet Kit 2 (FX lane B): the meniscus - a small radial glow dot that
+                                 rides the tip of the fill, so the bar reads as liquid with a surface
+                                 rather than a rectangle. Pre-built and parked at Opacity 0; its X is
+                                 tweened on the fill's own clock from AnimateXpDisplay, and the pulse
+                                 is an ambient loop owned by MainWindow.HeroFx.cs. No Effect: the
+                                 halo IS the gradient, so nothing here needs an intermediate surface. -->
+                            <Border x:Name="XPMeniscus" Width="12" Height="12" CornerRadius="6"
+                                    HorizontalAlignment="Left" VerticalAlignment="Center"
+                                    Opacity="0" IsHitTestVisible="False">
+                                <Border.Background>
+                                    <RadialGradientBrush>
+                                        <GradientStop Offset="0" Color="#FFFFFFFF"/>
+                                        <GradientStop Offset="0.35" Color="#CCFFFFFF"/>
+                                        <GradientStop Offset="1" Color="#00FFFFFF"/>
+                                    </RadialGradientBrush>
+                                </Border.Background>
+                                <Border.RenderTransform>
+                                    <TranslateTransform/>
+                                </Border.RenderTransform>
+                            </Border>
+                        </Grid>
+                    </Border>
+                    <TextBlock x:Name="TxtXP" Grid.Column="3" Text="{loc:Str label_0_70_xp}" Foreground="{StaticResource TextMutedBrush}"
+                               FontSize="11" VerticalAlignment="Center" Margin="0,0,15,0"/>
+                </Grid>
+
+                <!-- RIGHT SIDE: Active Bonuses + Stat Pills -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <!-- Active XP Bonus Chips (dynamically populated) -->
+                    <StackPanel x:Name="XPBarBonusList" Orientation="Horizontal"/>
+
+                    <!-- Pink Hours Stat: Total Conditioning Time (Unlocks at 5 points) -->
+                    <Border x:Name="PillConditioningTime" Background="#2A2A4A" CornerRadius="10" Padding="10,4" Margin="0,0,8,0"
+                            IsVisible="False" ToolTip.Tip="{loc:Str tooltip_total_conditioning_time_pink_hours_skill}">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="⏱️" FontSize="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                            <TextBlock x:Name="TxtPillConditioningTime" Text="{loc:Str label_0h_0m}" Foreground="#B0B0B0" FontSize="11" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Hive Mind Stat: Online Users (Unlocks at 60 points total) -->
+                    <Border x:Name="PillOnlineUsers" Background="#2A2A4A" CornerRadius="10" Padding="10,4" Margin="0,0,8,0"
+                            IsVisible="False" ToolTip.Tip="{loc:Str tooltip_bimbos_online_now_hive_mind_skill}">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="👯‍♀️" FontSize="14" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                            <TextBlock x:Name="TxtPillOnlineUsers" Text="0" Foreground="#00FF88" FontSize="11" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Popular Girl Stat: Rank Percentile (Unlocks at 130 points total) -->
+                    <Border x:Name="PillRankPercentile" Background="#2A2A4A" CornerRadius="10" Padding="10,4"
+                            IsVisible="False" ToolTip.Tip="{loc:Str tooltip_your_rank_percentile_popular_girl_skill}">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="👑" FontSize="14" Margin="0,0,4,0" VerticalAlignment="Center"/>
+                            <TextBlock x:Name="TxtPillRankPercentile" Text="{loc:Str label_top_0}" Foreground="#FFD700" FontSize="11" FontWeight="Bold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </Grid>
+
+            <!-- Login overlay - shown when not logged in -->
+            <Border x:Name="XPBarLoginOverlay" Background="#CC1A1A2E" CornerRadius="4" IsVisible="False">
+                <TextBlock Text="{loc:Str label_login_with_discord_or_patreon_to_track_your_x}"
+                           Foreground="{DynamicResource PinkBrush}" FontSize="11" FontWeight="SemiBold"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           Opacity="0.9"/>
+            </Border>
+        </Grid>
+
+        <!-- ===================== THE PAGE (the tab views) =====================
+             The 24 tab views still stack in one cell exactly as they did; the only thing
+             this AdornerDecorator changes is WHERE their adorners are drawn.
+
+             Without it, every card FX adorner on this page (TierFxBorder's tier livery
+             band, PerimeterCometAdorner, PremiumGateFx, the Assets/Exclusives/Quests
+             sheens) went to the WINDOW's adorner layer, which the Window template paints
+             above every child of this Grid - Panel.ZIndex included. So the instant the
+             nav rail flyout (NavSidebar, ZIndex 60) opened over the page, the livery band
+             of a card sitting underneath it kept shining straight through the rail. With
+             the layer scoped here those adorners belong to an ordinary ZIndex-0 element,
+             so the rail covers them exactly as it covers the cards they decorate.
+
+             (A card inside a ScrollViewer was never affected - WPF already scopes its
+             adorners to the ScrollContentPresenter. The dashboard mosaic is not in one,
+             which is why the tease card's rim was the surface that showed it.)
+
+             AdornerDecorator takes a single child, hence the Grid - a one-cell stack,
+             which is all Row 4 / Column 1 ever was, so the per-view Grid.Row/Grid.Column
+             moved onto the wrapper. Nothing about tab visibility, ShowTab or any x:Name
+             changed. -->
+        <Panel Grid.Row="4" Grid.Column="1">
+            <Grid>
+                <!-- Main Content - Settings Tab -->
+                <views:SettingsTabView x:Name="SettingsTab" Margin="10,5,10,2" />
+
+
+                <!-- Presets Tab (Hidden by default) -->
+                <views:PresetsTabView x:Name="PresetsTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Progression Tab: DEMOLISHED (UX restructure, Phase 8). ProgressionTabView was a
+                     permanently Collapsed ghost - no ShowTab case ever revealed it - whose 114 controls
+                     were a second copy of the Studio rack's dose dials plus Scheduler/Ramp. The tab key
+                     "progression" survives forever as a redirect onto Home (MainWindow.TabNavigation.cs)
+                     because 54 bark rules per mod and the tutorial ladder still fire it. -->
+
+
+                <!-- Quests Tab -->
+                <views:QuestsTabView x:Name="QuestsTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Achievements Tab -->
+                <views:AchievementsTabView x:Name="AchievementsTab" Margin="10,5,10,10" IsVisible="False" />
+
+                <!-- Companion Tab (v5.9 - Hero + AI Brain redesign) -->
+                <views:CompanionTabView x:Name="CompanionTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Patreon Exclusives Tab: DEMOLISHED (UX restructure, Phase 8). PatreonTabView was a
+                     permanently Collapsed ghost - ShowTab("patreon") early-returns into ShowAppInfoPopup()
+                     and never revealed it. Its 7 account cards left in Phase 2 (Settings · Account,
+                     Views/Controls/AppSettings/AccountSettingsSection.xaml) and its keyword/OCR editors in
+                     Phase 5 (Awareness, Views/Controls/Companion/KeywordTriggersPanel.xaml). The tab key
+                     "patreon" survives forever as a redirect (MainWindow.TabNavigation.cs) because
+                     TutorialService still declares it. -->
+
+
+                <!-- Profile Tab -->
+                <views:DiscordTabView x:Name="DiscordTab" Margin="10,5,10,10" IsVisible="False" />
+
+                <!-- Spiral Room ("spiral") - the tab that replaced SpiralMapWindow, and the room the
+                     first-light reveal now plays inside (CONTRACT-FUSE-0816 2.4).
+                     Three states: FOG while a ceremony is owed or scheduled, the one-shot FIRST
+                     LIGHT the moment a choice commits, then the SPIRAL itself - the /embed/spiral
+                     canvas at ?mode=map. The embed is built on entering that state and disposed on
+                     leaving the tab: a WebView2 is a native child HWND and must never exist under
+                     the fog or under the reveal. See Views/Tabs/SpiralTabView.xaml.cs.
+                     "spiral" is in ChromeFxNav's Airspace set for the same reason - a browser HWND
+                     does not follow a RenderTransform, so this tab crossfades and never slides. -->
+                <views:SpiralTabView x:Name="SpiralTab" Margin="10,5,10,10" IsVisible="False" />
+
+                <!-- Lab Tab — RETIRED in Phase 6 of the UX restructure; LabTabView.xaml(.cs) deleted.
+                     Its cards live on the Play wall below and "lab" is a permanent ShowTab alias onto it,
+                     so nothing that ever asked for this view lost its destination. -->
+
+                <!-- Play Tab ("play") — the Play door's card wall, added in Phase 6 of the UX restructure.
+                     A scrollable wall of named slots (DTRH hero, Goon, Gaze, Focus Gaze, Bureau, Mantra,
+                     Deeper, For You, Blink Trainer, Graded Intake, Lockdown, Remote Control, Available
+                     Subjects, Loom, Showcase). Cards are shims onto the handlers that always owned them,
+                     so an entitled click runs exactly the code the old Lab button ran; the gold/violet
+                     lockbands are decoration and TierGate does the refusing.
+                     ShowTab("lab") is a permanent alias onto this view — the key is API (54 bark rules
+                     per mod match on it) and BarkTabAliases["play"]="lab" keeps those rules firing.
+                     Owns this door's single ambient loop, RabbitHoleFx, registered as "play". -->
+                <views:PlayTabView x:Name="PlayTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Leaderboard Tab -->
+                <views:LeaderboardTabView x:Name="LeaderboardTab" Margin="10,5,10,10" IsVisible="False" />
+
+                <!-- Assets & Packs Tab -->
+                <views:AssetsTabView x:Name="AssetsTab" Margin="10,5,10,10" IsVisible="False" />
+
+                <!-- Enhancements Tab (Skill Tree) -->
+                <views:EnhancementsTabView x:Name="EnhancementsTab" Margin="10,5,10,10" IsVisible="False" />
+
+                <!-- Deeper Tab — universal media enhancement system.
+                     Mission 2 (hub redesign): single-column layout, unified library
+                     list with virtualization, search + filter pills + sort dropdown
+                     replace the two-column Library/Recent grid. -->
+                <!-- Drag-and-drop is handled by the window-wide Window_Drop system (media →
+                     Play/Edit/Library prompt, *.ccpenh.json → library import) so the whole
+                     tab is a uniform drop target. A tab-local AllowDrop handler here would
+                     steal the bubbling events from the global overlay and only cover part of
+                     the tab, so it's intentionally absent. -->
+                <views:DeeperTabView x:Name="DeeperTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Awareness Engine Tab -->
+                <views:AwarenessTabView x:Name="AwarenessTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Remote Control Tab — Patreon premium feature, full redesign with QR pairing -->
+                <views:RemoteControlTabView x:Name="RemoteControlTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- SP5 layer 3: Available Subjects directory tab. Controller side of
+                     remote control. NeonPurple accent throughout. Free-tier; the
+                     content is fetched per-poll from /v2/directory/list (X-Auth-Token
+                     auth). Click Connect on a card → POST /v2/directory/claim → on
+                     200, the returned session_url opens in the user's default browser
+                     via Process.Start (one-click pairing URL with PIN in the hash
+                     fragment, never logged or persisted on the desktop). -->
+                <views:AvailableSubjectsTabView x:Name="AvailableSubjectsTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Bambi Takeover Tab — Patreon premium feature, visible-but-locked for free users -->
+                <views:BambiTakeoverTabView x:Name="BambiTakeoverTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Haptics Tab — Patreon premium feature, visible-but-locked for free users.
+                     MOVED in Phase 4: HapticsTabView is now a module of the Studio rack
+                     (Views/Tabs/StudioTabView.xaml, rack key "haptics"). The x:Name "HapticsTab" it
+                     used to declare here survives as a MainWindow passthrough property in
+                     MainWindow.TabNavigation.cs, so every HapticsTab.<x:Name> dereference across the
+                     MainWindow partials, both features/vibe.png repaint rows, the IsVisibleChanged
+                     live-status hook and the SessionLock sweep keep working verbatim.
+                     ShowTab("haptics") still fires the bark key "haptics", never "studio". -->
+
+
+                <!-- Lockdown Mode Tab (graduated from Lab in v5.8.4) -->
+                <views:LockdownTabView x:Name="LockdownTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Blink Trainer Tab — Patreon premium feature, flagship webcam experience.
+                     Promoted from Lab Webcam Games card in v5.9.8. Phase A: scaffold + header only. -->
+                <views:BlinkTrainerTabView x:Name="BlinkTrainerTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- She's Listening Tab — voice control Exclusive (offline mic commands + spoken mantras) -->
+                <views:SheListeningTabView x:Name="SheListeningTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Graded Intake Tab — banded-descent intake Exclusive. Graduated out of the Lab;
+                     the controls moved here verbatim (see GradedIntakeTabView.xaml). -->
+                <views:GradedIntakeTabView x:Name="GradedIntakeTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Training Programs Tab — multi-day arcs (enrollment ceremony, day clock, ledger).
+                     Browse / run / lapsed / graduated are four panels inside one view, switched from
+                     MainWindow.ProgramsTab.cs. -->
+                <views:ProgramsTabView x:Name="ProgramsTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Exclusives Tab — "the Velvet Vault". Registry-driven showcase of the
+                     supporter-only features (ExclusiveFeature.All); replaced the launcher
+                     popup submenu. Cards navigate; destination tabs own the premium gates. -->
+                <views:ExclusivesTabView x:Name="ExclusivesTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Settings Tab ("appsettings") — the Settings door's own page, added in Phase 2 of
+                     the UX restructure. NOT "SettingsTab": that name belongs to the dashboard/Home and
+                     is API for ~200 call sites. Eight sections + a mini-rail; see AppSettingsTabView.xaml. -->
+                <views:AppSettingsTabView x:Name="AppSettingsTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- Studio Tab ("studio") — the Studio door's effects rack, added in Phase 4 of the UX
+                     restructure. Master-detail: a fixed rack list on the left, exactly one module panel
+                     on the right. Every module is instantiated with this view and toggled by Visibility
+                     (ground rule §2.3); nothing is ever re-parented, so the dashboard mosaic's
+                     FeaturePopupWindow path keeps building its own separate instances and keeps working.
+                     Hosts the Haptics page as its "haptics" module. -->
+                <views:StudioTabView x:Name="StudioTab" Margin="10,5,10,10" IsVisible="False" />
+
+
+                <!-- No Just Drop tab. It is a window now - see the rail comment above and
+                     Services/JustDrop/JustDropHostService.cs. -->
+            </Grid>
+        </Panel>
+
+
+
+        <!-- Global Bottom Bar: Start / Save / Exit (Always visible) -->
+        <Border Grid.Row="5" Grid.Column="1" Background="{StaticResource PanelBgBrush}" Margin="10,5,10,10" CornerRadius="10" Padding="15,12">
+            <!-- One flat grid so the Start controls and Save/Exit can't collide. Auto
+                 columns (Remember / caret / Pause) take their size first, START flexes,
+                 and Save/Exit share the rest — nothing clips at any window width. -->
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>   <!-- Remember -->
+                    <ColumnDefinition Width="1.5*"/>   <!-- START -->
+                    <ColumnDefinition Width="Auto"/>   <!-- Start-options caret -->
+                    <ColumnDefinition Width="Auto"/>   <!-- Pause (session only) -->
+                    <ColumnDefinition Width="18"/>     <!-- gap between the two groups -->
+                    <ColumnDefinition Width="*"/>      <!-- Save -->
+                    <ColumnDefinition Width="*"/>      <!-- Exit -->
+                </Grid.ColumnDefinitions>
+
+                <!-- Status Text (overlaid on top of buttons, shown when running) -->
+                <TextBlock x:Name="TxtPresetsStatus" Grid.ColumnSpan="7"
+                           Text="" Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                           HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,-20,0,0"/>
+
+                <!-- Remember: snapshot current setup / recall it. Right-click to re-save. -->
+                <Button x:Name="BtnRemember" Grid.Column="0" Width="68" Height="50" Margin="0,0,8,0"
+                        Theme="{StaticResource PinkButton}" FontSize="20" Click="BtnRemember_Click"
+                        PointerReleased="BtnRemember_RightClick"
+                        ToolTip.Tip="Remember my current setup">
+                    <TextBlock x:Name="TxtRememberIcon" Text="☆" FontSize="24" VerticalAlignment="Center" TextAlignment="Center"/>
+                </Button>
+
+                <!-- START glow layer (chrome FX, PR-1). A separate element UNDER the button, not an
+                     Effect on the button itself: WPF renders any element carrying an Effect through
+                     an intermediate surface, which would drop ClearType on the app's biggest label.
+                     Inset 4px behind a CornerRadius=8 button, so only its halo is ever visible; the
+                     breath animates this layer's Opacity, never the blur radius. Both colours are
+                     Fx* dynamic resources, so a mod switch re-tints it with no code involved. -->
+                <Border x:Name="StartGlowLayer" Grid.Column="1" Height="42" Margin="4,0"
+                        VerticalAlignment="Center" CornerRadius="8"
+                        Background="{DynamicResource FxGlowBrush}" IsHitTestVisible="False"
+                        Opacity="0" IsVisible="False">
+                    <Border.Effect>
+                        <DropShadowEffect Color="{DynamicResource FxGlowColor}"
+                                          BlurRadius="20" OffsetX="0" OffsetY="0" Opacity="1"/>
+                    </Border.Effect>
+                </Border>
+
+                <!-- START ring layer (Velvet Kit 2, FX lane B). Three pre-built 2px rings sharing the
+                     button's cell, CornerRadius and height, BEHIND the button so only the part that
+                     has travelled past its edge is ever visible. One breathes on the idle clock; the
+                     other two are the ignition burst. Everything is Opacity + RenderTransform, so no
+                     ring has ever cost a layout pass or an Effect; MainWindow.HeroFx.cs owns them and
+                     parks them invisible whenever motion, focus or the running state say so. -->
+                <Grid x:Name="StartRingHost" Grid.Column="1" Height="50" IsHitTestVisible="False">
+                    <Border x:Name="StartRingExhale" CornerRadius="8" BorderThickness="2"
+                            BorderBrush="{DynamicResource FxGlowBrush}" Opacity="0"
+                            RenderTransformOrigin="0.5,0.5">
+                        <Border.RenderTransform>
+                            <ScaleTransform/>
+                        </Border.RenderTransform>
+                    </Border>
+                    <Border x:Name="StartRingBurstA" CornerRadius="8" BorderThickness="2"
+                            BorderBrush="{DynamicResource FxGlowBrush}" Opacity="0"
+                            RenderTransformOrigin="0.5,0.5">
+                        <Border.RenderTransform>
+                            <ScaleTransform/>
+                        </Border.RenderTransform>
+                    </Border>
+                    <Border x:Name="StartRingBurstB" CornerRadius="8" BorderThickness="2"
+                            BorderBrush="{DynamicResource FxGlowBrush}" Opacity="0"
+                            RenderTransformOrigin="0.5,0.5">
+                        <Border.RenderTransform>
+                            <ScaleTransform/>
+                        </Border.RenderTransform>
+                    </Border>
+                </Grid>
+
+                <!-- START Button (with session timer display) -->
+                <!-- StartPressScale is the ignition dip (Velvet Kit 2). It is the button's only
+                     RenderTransform and nothing else may claim it - HoverPop deliberately refuses
+                     named transforms, so this stays a lane-B-only surface. -->
+                <Button x:Name="BtnStart" Grid.Column="1" Theme="{StaticResource PinkButton}"
+                        Background="{DynamicResource AccentGradientBrush}"
+                        Height="50" FontSize="18" Click="BtnStart_Click"
+                        RenderTransformOrigin="0.5,0.5"
+                        ToolTip.Tip="{loc:Str tooltip_start_stop_the_conditioning_engine}">
+                    <Button.RenderTransform>
+                        <ScaleTransform/>
+                    </Button.RenderTransform>
+                    <StackPanel x:Name="StartButtonContent" Orientation="Horizontal" Height="24" VerticalAlignment="Center">
+                        <TextBlock x:Name="TxtStartIcon" Text="▶" FontSize="16" Width="20" Margin="0,0,10,0" VerticalAlignment="Center" TextAlignment="Center"/>
+                        <TextBlock x:Name="TxtStartLabel" Text="{loc:Str label_start}" FontSize="18" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
+                <!-- START sheen band (chrome FX, PR-1). Deliberately a SIBLING overlay rather than
+                     button content: PinkButton's ContentPresenter is centre-aligned and sizes to its
+                     child, so a band placed inside the button could only ever sweep the label. This
+                     host shares the button's cell and height, is hit-test invisible, and is clipped
+                     to the button's rounded rect in code (StartSheenHost_SizeChanged) so the band
+                     can't poke out of the corners. Colour comes from FxGlowColor, so it re-tints
+                     with the mod; the sweep itself is driven from MainWindow.ChromeFx.cs and only
+                     runs while the window is active and ambient loops are allowed. -->
+                <Grid x:Name="StartSheenHost" Grid.Column="1" Height="50" IsHitTestVisible="False"
+                      SizeChanged="StartSheenHost_SizeChanged">
+                    <Border x:Name="StartSheen" Width="80" HorizontalAlignment="Left" Opacity="0"
+                            RenderTransformOrigin="0.5,0.5">
+                        <Border.Background>
+                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                <GradientStop Offset="0" Color="#00FFFFFF"/>
+                                <GradientStop Offset="0.5" Color="{DynamicResource FxGlowColor}"/>
+                                <GradientStop Offset="1" Color="#00FFFFFF"/>
+                            </LinearGradientBrush>
+                        </Border.Background>
+                        <Border.RenderTransform>
+                            <TransformGroup>
+                                <SkewTransform AngleX="-18"/>
+                                <TranslateTransform/>
+                            </TransformGroup>
+                        </Border.RenderTransform>
+                    </Border>
+                </Grid>
+
+                <!-- START ignition flash (Velvet Kit 2, FX lane B). A white wash over the button for
+                     300ms on press - the "it caught" frame. Sits ABOVE the button (later sibling) and
+                     is hit-test invisible, so the click it decorates always lands on the button. -->
+                <Border x:Name="StartIgnitionFlash" Grid.Column="1" Height="50" CornerRadius="8"
+                        Background="White" Opacity="0" IsHitTestVisible="False"/>
+
+                <!-- Start options caret (Start normally / Jump right in). Its own independent
+                     button: a real width and a gap from START so it doesn't read as a split-button
+                     sliver glued to it. -->
+                <Button x:Name="BtnStartMenu" Grid.Column="2" Width="68" Height="50" Margin="8,0,0,0"
+                        Theme="{StaticResource PinkButton}" Background="{DynamicResource AccentGradientBrush}"
+                        FontSize="22" Click="BtnStartMenu_Click"
+                        ToolTip.Tip="Start options">
+                    <TextBlock Text="▼" FontSize="18" VerticalAlignment="Center" HorizontalAlignment="Center" TextAlignment="Center"/>
+                    <Button.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem x:Name="MenuStartNormal" Header="▶  Start normally" Click="MenuStartNormal_Click"/>
+                            <MenuItem x:Name="MenuJumpRightIn" Header="🎲  Jump right in (randomize + start)" Click="MenuJumpRightIn_Click"/>
+                        </ContextMenu>
+                    </Button.ContextMenu>
+                </Button>
+
+                <!-- Pause Button (visible only during sessions) -->
+                <Button x:Name="BtnPauseSession" Grid.Column="3" Width="50" Height="50" Margin="6,0,0,0"
+                        IsVisible="False" Click="BtnPauseSession_Click"
+                        ToolTip.Tip="{loc:Str tooltip_pause_session_100_xp_penalty_per_pause}">
+                    <Button.Theme>
+                        <ControlTheme TargetType="Button">
+                            <Setter Property="Background" Value="#FFA500"/>
+                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="FontWeight" Value="Bold"/>
+                            <Setter Property="FontSize" Value="20"/>
+                            <Setter Property="Template">
+                                    <ControlTemplate TargetType="Button">
+                                        <Border Background="{TemplateBinding Background}" CornerRadius="6">
+                                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                             Content="{TemplateBinding Content}"
+                                                             ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                        </Border>
+                                    </ControlTemplate>
+                            </Setter>
+                        </ControlTheme>
+                    </Button.Theme>
+                    <TextBlock x:Name="TxtPauseIcon" Text="⏸" FontSize="20"/>
+                </Button>
+
+                <!-- Save (col 5) / Exit (col 6); col 4 is the gap.
+                     2026-08-11: Save was PinkButton, i.e. the same saturated mass as START sitting
+                     right next to it, so the action bar had two primaries and no hierarchy. It is
+                     the house SecondaryButton now; START is the only filled pink on the bar. -->
+                <Button x:Name="BtnSaveAll" Grid.Column="5" Content="{loc:Str btn_save_2}" Theme="{StaticResource SecondaryButton}"
+                        Height="50" FontSize="16" Margin="0,0,10,0" Click="BtnSave_Click"
+                        ToolTip.Tip="{loc:Str tooltip_save_all_settings_to_disk}"/>
+                <!-- Save "absorb" (Velvet Kit 2, FX lane B): one ripple ring off the button's edge and
+                     a tick that draws itself, both purely decorative and hit-test invisible. The save
+                     itself is untouched - BtnSave_Click just fires these on its way in. The tick is
+                     drawn with an animated StrokeDashOffset, so it costs one Path and no Effect. -->
+                <Grid x:Name="SaveAbsorbHost" Grid.Column="5" Height="50" Margin="0,0,10,0" IsHitTestVisible="False">
+                    <Border x:Name="SaveRipple" CornerRadius="8" BorderThickness="2"
+                            BorderBrush="#00FF88" Opacity="0" RenderTransformOrigin="0.5,0.5">
+                        <Border.RenderTransform>
+                            <ScaleTransform/>
+                        </Border.RenderTransform>
+                    </Border>
+                    <Path x:Name="SaveTick" Data="M 0,6 L 5,11 L 14,1"
+                          Stroke="#00FF88" StrokeThickness="2.5"
+                          StrokeLineCap="Round" StrokeJoin="Round"
+                          StrokeDashArray="9,9" StrokeDashOffset="9"
+                          Width="16" Height="14" Opacity="0"
+                          HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                </Grid>
+                <!-- 2026-08-11: Exit was a hand-rolled #FF6B6B slab as wide and loud as START -
+                     a coral that matched neither the Danger token nor the DangerButton style the
+                     rest of the app uses for destructive actions (PANIC STOP does use the real
+                     red). Quiet outline at rest, fills on hover: still findable, no longer
+                     competing with the primary action for the eye. -->
+                <Button Grid.Column="6" Content="{loc:Str btn_exit}" Height="50" FontSize="16" Click="BtnExit_Click"
+                        ToolTip.Tip="{loc:Str tooltip_exit_the_application_completely}">
+                    <Button.Theme>
+                        <ControlTheme TargetType="Button">
+                            <Setter Property="Background" Value="Transparent"/>
+                            <Setter Property="Foreground" Value="{DynamicResource DangerBrush}"/>
+                            <Setter Property="FontWeight" Value="Bold"/>
+                            <Setter Property="Cursor" Value="Hand"/>
+                            <Setter Property="Template">
+                                    <ControlTemplate TargetType="Button">
+                                        <Border x:Name="b" Background="{TemplateBinding Background}"
+                                                BorderBrush="{DynamicResource DangerBrush}" BorderThickness="1"
+                                                CornerRadius="6" Padding="20,10">
+                                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                             Content="{TemplateBinding Content}"
+                                                             ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                        </Border>
+                                        <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                             Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                             rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                    </ControlTemplate>
+                            </Setter>
+                        </ControlTheme>
+                    </Button.Theme>
+                </Button>
+            </Grid>
+        </Border>
+
+        <!-- Remote Control Overlay (shown when controller is connected) -->
+        <Border x:Name="RemoteControlOverlay" Grid.Row="1" Grid.RowSpan="5" Grid.Column="0" Grid.ColumnSpan="2" ZIndex="999" IsVisible="False" Background="#E0000000" Opacity="0">
+            <Grid>
+                <!-- Command notification banner at top -->
+                <Border x:Name="RemoteCommandNotification" VerticalAlignment="Top" HorizontalAlignment="Center"
+                        Background="#2200FF88" CornerRadius="0,0,10,10" Padding="24,10" Margin="0,0,0,0" Opacity="0">
+                    <TextBlock x:Name="TxtRemoteCommand" Text="" Foreground="#00FF88" FontSize="16" FontWeight="SemiBold"
+                               HorizontalAlignment="Center"/>
+                </Border>
+
+                <!-- Center content -->
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                    <TextBlock Text="🎮" FontSize="60" Margin="0,0,0,10" HorizontalAlignment="Center"/>
+                    <TextBlock Text="{loc:Str label_remote_controlled}" Foreground="#00FF88" FontSize="28" FontWeight="Bold"
+                               HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                    <TextBlock x:Name="TxtOverlaySessionCode" Text="" Foreground="{DynamicResource TextMutedBrush}" FontSize="18"
+                               FontFamily="Consolas, Courier New" HorizontalAlignment="Center" Margin="0,0,0,16"/>
+
+                    <TextBlock x:Name="TxtRemoteOverlaySubtitle" Text="{loc:Str label_someone_else_is_controlling_your_app}" Foreground="#A0A0A0" FontSize="14"
+                               HorizontalAlignment="Center" Margin="0,0,0,24"/>
+
+                    <!-- Session info card — always visible -->
+                    <Border HorizontalAlignment="Center" Margin="0,0,0,24"
+                            Background="#18FFFFFF" CornerRadius="10" Padding="32,16" MinWidth="320">
+                        <Grid>
+                            <!-- Idle state: no session running -->
+                            <StackPanel x:Name="RemoteSessionIdle" HorizontalAlignment="Center">
+                                <TextBlock Text="📋" FontSize="32" Margin="0,0,0,4" HorizontalAlignment="Center"/>
+                                <TextBlock Text="{loc:Str label_no_active_session}" Foreground="#606080" FontSize="14"
+                                           HorizontalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Active state: session name + timer -->
+                            <StackPanel x:Name="RemoteSessionActive" IsVisible="False" HorizontalAlignment="Center">
+                                <TextBlock x:Name="TxtRemoteSessionName" Text="" Foreground="{DynamicResource PinkBrush}" FontSize="20" FontWeight="Bold"
+                                                        HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                                <TextBlock x:Name="TxtRemoteSessionTime" Text="" Foreground="#FFFFFF" FontSize="28"
+                                           FontFamily="Consolas, Courier New" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,6"/>
+                                <TextBlock x:Name="TxtRemoteSessionPhase" Text="" Foreground="#A0A0B0" FontSize="13"
+                                           HorizontalAlignment="Center"/>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <!-- ════════════════════════════════════════════════════════════════
+                         Big emote picker — only visible while the splash overlay is shown
+                         (i.e. an active controller session). The small picker in the
+                         remote-control tab body stays the source-of-truth for editing.
+                         Both bind to App.Settings.Current.RemoteEmotePresets so edits
+                         propagate via INotifyPropertyChanged on EmotePreset.
+                         The 3-above / 2-below split + ItemsSource for each row is wired
+                         in LoadSettings() via two ListCollectionView filters keyed on
+                         the item's index in the source list.
+                         ════════════════════════════════════════════════════════════════ -->
+                    <ItemsControl x:Name="LstEmotePresetsBigTop"
+                                  HorizontalAlignment="Center" Margin="0,0,0,16">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="10,0" HorizontalAlignment="Center" Width="110">
+                                    <Button Theme="{StaticResource EmoteCircleButtonBigStyle}"
+                                            Tag="{Binding}"
+                                            Click="BtnEmotePresetBig_Click"
+                                            HorizontalAlignment="Center"
+                                            ToolTip.Tip="{Binding Text}">
+                                        <Grid>
+                                            <!-- ponytail: EmojiToImageSource is WPF-only (Twemoji SVG through SharpVectors). Avalonia
+                                                     draws colour emoji natively, so the Image collapses into the TextBlock. -->
+                                            <TextBlock Text="{Binding Icon}" FontSize="32"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Grid>
+                                    </Button>
+                                    <TextBlock Text="{Binding Text}"
+                                               Foreground="White" FontSize="13"
+                                               HorizontalAlignment="Center" TextAlignment="Center"
+                                               TextWrapping="Wrap" MaxHeight="36"
+                                               TextTrimming="CharacterEllipsis"
+                                               MaxWidth="104" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- End Session button -->
+                    <Button Content="{loc:Str btn_end_session}" Click="BtnEndRemoteSession_Click" Cursor="Hand"
+                            Foreground="White" FontSize="15" FontWeight="SemiBold" Padding="32,12"
+                            HorizontalAlignment="Center">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border x:Name="BtnBorder" Background="#CC3333" CornerRadius="8" Padding="{TemplateBinding Padding}">
+                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                     Content="{TemplateBinding Content}"
+                                                     ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                </Border>
+                                <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver, IsPressed) dropped. Avalonia writes these as
+                                     Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                     rest state renders correctly and only the hover/press/tag skins are lost. -->
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
+
+                    <!-- Bottom row of presets (4-5) -->
+                    <ItemsControl x:Name="LstEmotePresetsBigBottom"
+                                  HorizontalAlignment="Center" Margin="0,16,0,12">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="10,0" HorizontalAlignment="Center" Width="110">
+                                    <Button Theme="{StaticResource EmoteCircleButtonBigStyle}"
+                                            Tag="{Binding}"
+                                            Click="BtnEmotePresetBig_Click"
+                                            HorizontalAlignment="Center"
+                                            ToolTip.Tip="{Binding Text}">
+                                        <Grid>
+                                            <!-- ponytail: EmojiToImageSource is WPF-only (Twemoji SVG through SharpVectors). Avalonia
+                                                     draws colour emoji natively, so the Image collapses into the TextBlock. -->
+                                            <TextBlock Text="{Binding Icon}" FontSize="32"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Grid>
+                                    </Button>
+                                    <TextBlock Text="{Binding Text}"
+                                               Foreground="White" FontSize="13"
+                                               HorizontalAlignment="Center" TextAlignment="Center"
+                                               TextWrapping="Wrap" MaxHeight="36"
+                                               TextTrimming="CharacterEllipsis"
+                                               MaxWidth="104" Margin="0,6,0,0"/>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <!-- Custom textbox row, centered, max width 400. Reuses
+                         EmoteCustomTextBoxStyle; bumped FontSize/Padding for the
+                         bigger surface. Watermark uses the same EmoteHelper
+                         attached properties — independent ghost state from the
+                         small picker because it's a different TextBox instance. -->
+                    <Grid HorizontalAlignment="Center" MaxWidth="400" Width="400">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBox Grid.Column="0" x:Name="TxtEmoteCustomBig"
+                                 Theme="{StaticResource EmoteCustomTextBoxStyle}"
+                                 FontSize="16" Padding="12,10"
+                                 Margin="0,0,8,0"
+                                 KeyDown="TxtEmoteCustomBig_KeyDown"/>
+                        <Button Grid.Column="1" x:Name="BtnEmoteCustomSendBig"
+                                Content="{loc:Str btn_emote_send}"
+                                Click="BtnEmoteCustomSendBig_Click"
+                                Background="{DynamicResource PinkBrush}" Foreground="White"
+                                FontWeight="Bold" Padding="20,10"
+                                BorderThickness="0" Cursor="Hand"/>
+                    </Grid>
+
+                    <TextBlock x:Name="TxtEmoteStatusBig" Text=""
+                               Foreground="#A0A0A0" FontSize="12"
+                               HorizontalAlignment="Center" Margin="0,8,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- Global Drop Overlay (shown when dragging files anywhere) -->
+        <Border x:Name="GlobalDropOverlay" Grid.RowSpan="5" Grid.Column="0" Grid.ColumnSpan="2" IsVisible="False" Background="#D0000000" IsHitTestVisible="False">
+            <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="16" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="3"
+                    MaxWidth="450" MaxHeight="220" VerticalAlignment="Center" HorizontalAlignment="Center"
+                    Padding="40,30">
+                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <TextBlock x:Name="DropOverlayIcon" Text="📂" FontSize="48" HorizontalAlignment="Center"/>
+                    <TextBlock x:Name="DropOverlayTitle" Text="{loc:Str label_drop_to_import}" Foreground="{DynamicResource PinkBrush}" FontSize="20" FontWeight="Bold"
+                               HorizontalAlignment="Center" Margin="0,15,0,5"/>
+                    <TextBlock x:Name="DropOverlaySubtitle" Text="{loc:Str label_images_videos_zips_folders}" Foreground="#909090" FontSize="14"
+                               HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"/>
+                </StackPanel>
+            </Border>
+        </Border>
+
+        <!-- Main App Tutorial Overlay -->
+        <Border x:Name="MainTutorialOverlay" Grid.RowSpan="5" Grid.Column="0" Grid.ColumnSpan="2" ZIndex="1000" IsVisible="False" Background="#E8000000">
+            <Grid>
+                <Border Background="Transparent" PointerPressed="MainTutorial_Close"/>
+                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+                        MaxWidth="700" MaxHeight="600" VerticalAlignment="Center" HorizontalAlignment="Center"
+                        Margin="40" PointerPressed="MainTutorial_ContentClick">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- Header -->
+                        <Border Grid.Row="0" Background="{DynamicResource SurfaceBgBrush}" CornerRadius="10,10,0,0" Padding="20,15">
+                            <Grid>
+                                <TextBlock Text="{loc:Str label_how_to_use_the_app}" Foreground="{DynamicResource PinkBrush}" FontSize="18" FontWeight="Bold"
+                                           HorizontalAlignment="Center"/>
+                                <Button Content="✕" Click="MainTutorial_Close" HorizontalAlignment="Right" VerticalAlignment="Top"
+                                        Background="Transparent" Foreground="#888" FontSize="14" BorderThickness="0" Cursor="Hand"
+                                        Margin="0,-5,-5,0"/>
+                            </Grid>
+                        </Border>
+
+                        <!-- Tutorial Content -->
+                        <ScrollViewer Grid.Row="1" ScrollViewer.VerticalScrollBarVisibility="Auto" Padding="20,15">
+                            <StackPanel>
+                                <!-- Quick Tip -->
+                                <Border Background="#3A2542" CornerRadius="8" Padding="12" Margin="0,0,0,15" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="💡" FontSize="18" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{loc:Str label_hover_over_any_control_for_tooltips_click_a_g}"
+                                                   Foreground="#D0B0C0" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Border>
+
+                                <!-- What moved in 6.8 - FIRST row on purpose: for an upgrader this is the
+                                     only question they have, and this row is the permanent re-run path for
+                                     the tour the What's New dialog offers once. Copy is hardcoded English
+                                     (same convention as Windows/FeatureIntroPopup) - no new loc keys. -->
+                                <Border Background="#3A2542" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand"
+                                        BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="🚪" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="What moved in 6.8" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="The 60-second map: the six doors, where your old tabs went, and why left-click and right-click swapped."
+                                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialWhatMoved_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Getting Started -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="🚀" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_getting_started}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_quick_overview_of_the_basics_start_button_add}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialGettingStarted_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Settings Tab -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="⚙️" FontSize="20" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_settings_tab}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_flash_images_videos_subliminals_overlays_audi}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialSettings_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Presets Tab -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="💾" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_presets_sessions}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_save_configurations_run_timed_sessions_create}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialPresets_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Progression Tab -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="📊" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str tab_progression}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_xp_system_level_unlocks_scheduler_and_intensi}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialProgression_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Achievements Tab -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="🏆" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str tab_achievements}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_unlock_achievements_by_reaching_milestones_an}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialAchievements_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Companion Tab -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="💬" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_companion_settings_2}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_speech_bubbles_trigger_messages_and_ai_person}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialCompanion_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Patreon Tab -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="💎" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_patreon_exclusives}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_ai_chat_window_awareness_slut_mode_and_premiu}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialPatreon_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Awareness Engine -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="👁" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_awareness_engine}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_awareness_engine_desc}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialAwareness_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Avatar -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="💗" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_avatar_companion}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_interacting_detaching_resizing_evolution_stag}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialAvatar_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Modding Guide -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="{loc:Str label_text_4}" FontSize="20" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str label_modding_guide}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str label_opens_the_mod_creator_with_a_step_by_step_wal}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_start_guide}" Click="BtnTutorialModding_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Report a Bug -->
+                                <Border Background="{DynamicResource SurfaceBgBrush}" CornerRadius="8" Padding="12" Margin="0,0,0,8" Cursor="Hand">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="🐞" FontSize="22" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center"/>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                            <TextBlock Text="{loc:Str btn_report_bug}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold"/>
+                                            <TextBlock Text="{loc:Str bug_report_privacy_notice}" Foreground="{DynamicResource TextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Content="{loc:Str btn_report_bug}" Click="BtnTutorialReportBug_Click"
+                                                Theme="{StaticResource SmallPinkButton}" VerticalAlignment="Center"/>
+                                    </Grid>
+                                </Border>
+
+                                <!-- Pro Tips -->
+                                <Border Background="#3A2542" CornerRadius="8" Padding="12" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" Margin="0,8,0,0">
+                                    <StackPanel>
+                                        <TextBlock Text="{loc:Str label_pro_tips}" Foreground="{DynamicResource PinkBrush}" FontSize="13" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                                        <TextBlock Foreground="#D0B0C0" FontSize="11" TextWrapping="Wrap">
+                                            <Run Text="•"/><Run Text="{loc:Str label_assets_images}" FontWeight="SemiBold"/><Run Text="{loc:Str label_add_your_flash_images_here}"/>
+                                        </TextBlock>
+                                        <TextBlock Foreground="#D0B0C0" FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0">
+                                            <Run Text="•"/><Run Text="{loc:Str label_assets_videos}" FontWeight="SemiBold"/><Run Text="{loc:Str label_add_your_videos_here}"/>
+                                        </TextBlock>
+                                        <TextBlock Foreground="#D0B0C0" FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0">
+                                            <Run Text="{loc:Str label_use_borderless_windowed_mode_in_games_for_bes}"/>
+                                        </TextBlock>
+                                        <TextBlock Foreground="#D0B0C0" FontSize="11" TextWrapping="Wrap" Margin="0,2,0,0">
+                                            <Run Text="{loc:Str label_right_click_on_features_for_additional_option}"/>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                        </ScrollViewer>
+
+                        <!-- Footer -->
+                        <Border Grid.Row="2" Background="{DynamicResource SurfaceBgBrush}" CornerRadius="0,0,10,10" Padding="20,15">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                <Button Content="{loc:Str btn_start_interactive_tutorial}" Click="BtnStartTutorial_Click" Margin="0,0,15,0"
+                                        Background="Transparent" Foreground="{DynamicResource PinkBrush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1"
+                                        Padding="20,10" FontWeight="SemiBold" Cursor="Hand">
+                                    <Button.Template>
+                                        <ControlTemplate TargetType="Button">
+                                            <Border x:Name="border" Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                    CornerRadius="6" Padding="{TemplateBinding Padding}">
+                                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                 Content="{TemplateBinding Content}"
+                                                                 ContentTemplate="{TemplateBinding ContentTemplate}"/>
+                                            </Border>
+                                            <!-- ponytail: WPF ControlTemplate.Triggers (IsMouseOver) dropped. Avalonia writes these as
+                                                 Style selectors outside the template (":pointerover /template/ Border#x"); the
+                                                 rest state renders correctly and only the hover/press/tag skins are lost. -->
+                                        </ControlTemplate>
+                                    </Button.Template>
+                                </Button>
+                                <Button Content="{loc:Str btn_got_it}" Theme="{StaticResource PinkButton}"
+                                        Click="MainTutorial_Close" Padding="40,10"/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+        </Grid>
+    </Viewbox>
+
+    <!-- Browser fullscreen overlay - sits outside Viewbox so WebView gets native resolution.
+         WebView stays within same Window HWND, avoiding DirectX swapchain recreation that causes HDR blinks. -->
+    <Grid x:Name="BrowserFullscreenOverlay" Background="Black" IsVisible="False" ZIndex="9999"/>
+
+    <!-- In-app toast/banner host. No Background = empty area is click-through
+         (WPF rule: panels with unset/null Background do not hit-test on empty
+         pixels even with IsHitTestVisible=True, while individual toast Borders
+         have their own Background and capture their own clicks). Panel.ZIndex
+         sits below the browser overlay so a fullscreen browser still covers
+         it. -->
+    <StackPanel x:Name="NotificationHost"
+                HorizontalAlignment="Right" VerticalAlignment="Top"
+                Margin="0,40,16,0" Width="380"
+                ZIndex="9998"/>
+
+    <!-- Event FX layer (PR-5). Deliberately OUTSIDE the Viewbox: everything inside it is
+         bitmap-scaled from the fixed 1489x901 design canvas, which is fine for a soft fog wash
+         but turns crisp particles to mush. This host lives in the window's own pixel space, so a
+         burst lands at native resolution wherever its anchor happens to be on screen.
+
+         It holds no clock and no Skia surface until the first event moment: the AmbientFxCanvas
+         is created lazily by EnsureEventBurstLayer(), and between bursts it runs no timer at all
+         (AmbientFxCanvas.ShouldRun only says yes while sparks are alive). ZIndex matches the
+         toast host and it is declared after it, so a burst reads on top of a toast, while the
+         fullscreen browser overlay (9999) still covers everything. -->
+    <Grid x:Name="EventFxHost" IsHitTestVisible="False" ZIndex="9998">
+        <!-- Prestige only: one full-chrome sheen pass, swept from MainWindow.EventFx.cs. Parked
+             at Opacity 0 holding no clock; the band rides FxGlowColor so it re-tints per mod. -->
+        <Border x:Name="PrestigeSheen" Width="260" HorizontalAlignment="Left" Opacity="0"
+                IsHitTestVisible="False" RenderTransformOrigin="0.5,0.5">
+            <Border.Background>
+                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                    <GradientStop Offset="0" Color="#00FFFFFF"/>
+                    <GradientStop Offset="0.5" Color="{DynamicResource FxGlowColor}"/>
+                    <GradientStop Offset="1" Color="#00FFFFFF"/>
+                </LinearGradientBrush>
+            </Border.Background>
+            <Border.RenderTransform>
+                <TransformGroup>
+                    <SkewTransform AngleX="-18"/>
+                    <TranslateTransform/>
+                </TransformGroup>
+            </Border.RenderTransform>
+        </Border>
+    </Grid>
+
+    <!-- 2026-08-13: accent window frame. A 3px edge so the app pops off the desktop instead
+         of melting into whatever sits behind it. Rides PinkBrush = the mod accent, so it
+         re-tints with the mod. CornerRadius matches the DWMWCP_ROUND corner DWM already
+         clips the window to. Below EventFxHost (9998) and the fullscreen browser overlay
+         (9999) on purpose. -->
+    <Border x:Name="GlassWindowEdge" Grid.RowSpan="6" Grid.ColumnSpan="2" ZIndex="9997"
+            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="3" CornerRadius="8"
+            IsHitTestVisible="False"/>
+
+    <!-- THE FUSE's corner readout (CONTRACT-FUSE-0816 2.2). From T-1h the T-minus stops being a
+         hover reward and becomes a thing in the room: a small clock in the corner that does not go
+         away. IN-APP, deliberately not a separate window - the contract is explicit, and a topmost
+         countdown window would be the app shouting rather than waiting.
+
+         OUTSIDE the Viewbox for the same reason EventFxHost is: everything inside is bitmap-scaled
+         from the fixed design canvas, and small tabular digits are exactly what that ruins. Here it
+         renders in native window pixels. ZIndex 9996 puts it under the accent frame (9997), the FX
+         layer and the fullscreen browser overlay, so nothing it can ever cover matters.
+
+         Collapsed, hit-test invisible, and owned entirely by MainWindow.DescentFuse.cs. -->
+    <Border x:Name="FuseCornerReadout" ZIndex="9996"
+            HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,24,20"
+            Padding="10,5" CornerRadius="6" IsVisible="False" IsHitTestVisible="False"
+            Background="#B00A0514" BorderBrush="#40E0B052" BorderThickness="1">
+        <StackPanel>
+            <TextBlock x:Name="FuseCornerDigits" Text=""
+                       FontFamily="Consolas, Courier New, monospace" FontSize="15"
+                       Foreground="#FFC9C4D6" HorizontalAlignment="Center"/>
+            <TextBlock x:Name="FuseCornerPresence" Text="" IsVisible="False"
+                       FontSize="10" Margin="0,3,0,0" Foreground="#8AC9C4D6"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+    </Border>
+    </Grid>
+</Window>

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.axaml.cs
@@ -1,0 +1,300 @@
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.xaml.cs (4,073 lines) — the app
+// shell's main code-behind, and with its 83 sibling partials the largest view in the app
+// (72,317 lines of C# plus 3,474 lines of XAML across ConditioningControlPanel/MainWindow/).
+//
+// The class is MainShellWindow, NOT MainWindow: this head already has a MainWindow (the
+// diagnostics window RenderProof hosts views inside) and an AppShell, and the layer rules forbid
+// overwriting either. Whether this becomes the startup window is a later layer's decision.
+//
+// WHAT THIS FILE DOES: load the XAML, wire the four window-level drag-and-drop events WPF
+// declared as Window attributes, and hold the handful of members MainShellWindow.axaml
+// dereferences that live in MainWindow.xaml.cs. Everything else in the WPF file reaches App.*,
+// a service, a device, WebView2 or Win32 and is a stub — see the ledger at the bottom, and the
+// 83 MainShellWindow.<Suffix>.cs partials for the rest.
+//
+// Win32 in this file (10 P/Invokes), mapped rather than copied — user32/dwmapi do not exist on
+// a net8.0 head:
+//   DwmSetWindowAttribute(DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND)
+//        -> dropped. The rounded corner is the compositor's business on Linux; the accent frame
+//           the app draws over it (GlassWindowEdge, CornerRadius 8) is in the XAML and unchanged.
+//   SetForegroundWindow / BringWindowToTop / ShowWindow(SW_RESTORE)
+//        -> Activate(), plus WindowState = Normal. All three collapse into the one call.
+//   SetWindowPos(HWND_TOPMOST / HWND_NOTOPMOST, SWP_NOACTIVATE)
+//        -> Window.Topmost, which Avalonia maps to _NET_WM_STATE_ABOVE. Ordering between our OWN
+//           windows would be X11Overlay.RestackAbove; the shell never needs that — it is the
+//           bottom of our own stack, not a member of the overlay band.
+//   SetWindowPos(x, y, cx, cy) for the work-area clamp
+//        -> Position/Width/Height. See MainShellWindow.WorkAreaFit.cs, which is a real port.
+//   GetForegroundWindow / GetWindowThreadProcessId
+//        -> dropped. "Is some OTHER process focused" has no portable answer and no Avalonia
+//           equivalent; the shell used it to decide whether an ambient FX loop may run.
+//           LOST BEHAVIOUR, named here so it is not lost silently.
+//
+// Also dropped, with nothing to map onto:
+//   Window.CommandBindings + AvatarTubeWindow.OpenChatCommand ("OpenAvatarChat_Executed").
+//        Avalonia has no RoutedCommand/CommandBinding; the chat window is opened by a service.
+//   InputBindings (Ctrl+K palette and friends) — Avalonia uses KeyBindings; they are declared
+//        in code by the WPF ctor, which is entirely App.*, so they went with it.
+//
+// DRAG AND DROP: WPF declared AllowDrop + Drop/DragEnter/DragOver/DragLeave as Window
+// attributes. Avalonia routes those as attached events, so the XAML carries
+// DragDrop.AllowDrop="True" and the four handlers are added in the constructor below.
+
+using System;
+using System.Collections.ObjectModel;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    /// <summary>
+    /// One row of the header's mod switcher. PORTED verbatim from the nested
+    /// <c>ModSelectorItem</c> at the bottom of MainWindow.xaml.cs, lifted to the namespace so the
+    /// ComboBox's ItemTemplate can name it. <c>Brush</c> is Avalonia's, not WPF's.
+    /// </summary>
+    public sealed class ModSelectorItem
+    {
+        public string Id { get; }
+        public string Name { get; }
+        public IBrush AccentBrush { get; }
+
+        public ModSelectorItem(string id, string name, IBrush accentBrush)
+        {
+            Id = id;
+            Name = name;
+            AccentBrush = accentBrush;
+        }
+    }
+
+    public partial class MainShellWindow : Window
+    {
+        /// <summary>
+        /// The header mod switcher's rows. In the WPF head this is repopulated from ModService on
+        /// every mod change; here it is SAMPLE DATA so the chip draws a real name and a real
+        /// accent dot in the render proof instead of an empty pill.
+        /// ponytail: needs ModService; wired when it moves to Core.
+        /// </summary>
+        public ObservableCollection<ModSelectorItem> AvailableMods { get; } = new()
+        {
+            new ModSelectorItem("default", "Default", Brushes.HotPink),
+        };
+
+        public MainShellWindow()
+        {
+            AvaloniaXamlLoader.Load(this);
+
+            // WPF put these on the Window element itself; Avalonia routes them as attached events.
+            AddHandler(DragDrop.DropEvent, Window_Drop);
+            AddHandler(DragDrop.DragEnterEvent, Window_DragEnter);
+            AddHandler(DragDrop.DragOverEvent, Window_DragOver);
+            AddHandler(DragDrop.DragLeaveEvent, Window_DragLeave);
+        }
+
+        // ---- window-level drag and drop ------------------------------------------------------
+        // ponytail: every one of these needs the asset/import pipeline (MainWindow.Assets.cs:
+        // media -> Play/Edit/Library prompt, *.ccpenh.json -> Deeper library import) plus the
+        // GlobalDropOverlay copy chooser. Wired when those services move to Core. The overlay
+        // itself is in the XAML and still collapses/expands correctly once they are.
+        private void Window_Drop(object? sender, DragEventArgs e) { }
+        private void Window_DragEnter(object? sender, DragEventArgs e) { }
+        private void Window_DragOver(object? sender, DragEventArgs e) { }
+        private void Window_DragLeave(object? sender, RoutedEventArgs e) { }
+
+        // ---- the two handlers MainShellWindow.axaml takes from this file ---------------------
+        // ponytail: needs ModService + ModManagerDialog's host; wired when they move to Core.
+        private void BtnManageMods_Click(object? sender, RoutedEventArgs e) { }
+        private void ModSelectorCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e) { }
+
+        // ponytail: MainWindow.Settings.cs's BtnExit_Click saves the session and shuts the
+        // application down through App. Closing the shell is the part that is ours.
+        private void BtnExit_Click(object? sender, RoutedEventArgs e) => Close();
+    }
+}
+
+// Members of ConditioningControlPanel/MainWindow/MainWindow.xaml.cs dropped (182). Named here so
+// nothing disappears silently; each one reaches App.*, a service, a device, WebView2 or Win32.
+//   private static extern void DwmSetWindowAttribute(…)
+//   private const int DWMWA_WINDOW_CORNER_PREFERENCE
+//   private const int DWMWCP_ROUND
+//   private const int DWMWCP_ROUNDSMALL
+//   private static extern bool SetForegroundWindow(…)
+//   private static extern bool ShowWindow(…)
+//   private static extern bool BringWindowToTop(…)
+//   private static extern bool SetWindowPos(…)
+//   private static extern IntPtr GetForegroundWindow(…)
+//   private static extern uint GetWindowThreadProcessId(…)
+//   private static readonly IntPtr HWND_TOPMOST
+//   private static readonly IntPtr HWND_NOTOPMOST
+//   private const uint SWP_NOACTIVATE
+//   private const int SW_RESTORE
+//   private const int SW_SHOW
+//   private bool _isRunning
+//   public bool IsEngineRunning
+//   private bool _isLoading
+//   public ObservableCollection<ModSelectorItem> AvailableMods
+//   private bool _suppressModSelectorChange
+//   private BrowserService? _browser
+//   private bool _browserInitialized
+//   private Window? _browserPopoutWindow
+//   private bool _isDualMonitorPlaybackActive
+//   private bool _isBrowserFullscreen
+//   private bool _browserFullscreenWasPopout
+//   private double _browserPreFullscreenZoom
+//   private System.Threading.CancellationTokenSource? _catalogueLookupCts
+//   private string? _currentCatalogueHtVideoId
+//   private WindowStyle _popoutPreFsStyle
+//   private ResizeMode _popoutPreFsResize
+//   private WindowState _popoutPreFsState
+//   private double _popoutPreFsLeft, _popoutPreFsTop, _popoutPreFsWidth, _popoutPreFsHeight
+//   private bool _popoutPreFsTopmost
+//   private TrayIconService? _trayIcon
+//   private GlobalKeyboardHook? _keyboardHook
+//   private bool _isCapturingPanicKey
+//   internal bool IsCapturingPanicKey
+//   private bool _isCapturingPauseKey
+//   private bool _exitRequested
+//   private int _panicPressCount
+//   private string _leaderboardMode
+//   private int _lockdownTimerClickCount
+//   private DateTime _lockdownTimerLastClick
+//   private Brush? _preLockdownWindowBg
+//   private Brush? _preLockdownTitleBarBg
+//   private bool _isStreakFixMode
+//   private bool _streakFixInFlight
+//   private DispatcherTimer? _remoteNotificationTimer
+//   private DispatcherTimer? _remoteSessionInfoTimer
+//   private Storyboard? _seasonTitleStoryboard
+//   private Storyboard? _lockdownPulseStoryboard
+//   private bool _skillTreeAnimationsActive
+//   private static readonly Dictionary<string, string> CommandLabels
+//   private static readonly HashSet<string> SuppressedCommands
+//   public event EventHandler? EngineStopped
+//   private DateTime _lastPanicTime
+//   private string? _lastKnownUnifiedId
+//   public Microsoft.Web.WebView2.Wpf.WebView2? GetBrowserWebView(…)
+//   private SessionEngine? _sessionEngine
+//   private AvatarTubeWindow? _avatarTubeWindow
+//   private Services.AudioPlaybackHandle? _levelUpSoundHandle
+//   private bool _avatarWasAttachedBeforeMaximize
+//   private bool _avatarWasAttachedBeforeBrowserFullscreen
+//   private bool _autonomyWasPausedOnMinimize
+//   private bool _avatarWasMutedOnMinimize
+//   private bool _wasAutonomyRunningBeforeMinimize
+//   private bool _wasAvatarUnmutedBeforeMinimize
+//   private Dictionary<string, Image> _achievementImages
+//   private PinkRushPopup? _pinkRushPopup
+//   private Window? _luckyProcPopup
+//   private DispatcherTimer? _rampTimer
+//   private DateTime _rampStartTime
+//   private Dictionary<string, double> _rampBaseValues
+//   private int _easterEggClickCount
+//   private DateTime _easterEggFirstClick
+//   private bool _easterEggTriggered
+//   private DispatcherTimer? _schedulerTimer
+//   private bool _schedulerAutoStarted
+//   private bool _manuallyStoppedDuringSchedule
+//   private DispatcherTimer? _bannerRotationTimer
+//   private int _bannerCurrentIndex
+//   private List<string> _bannerMessages
+//   private System.Windows.Media.Animation.Storyboard? _marqueeStoryboard
+//   private DispatcherTimer? _marqueeRefreshTimer
+//   private string _currentMarqueeMessage
+//   private const bool PacksSectionEnabled
+//   private ObservableCollection<ContentPack> _availablePacks
+//   private DispatcherTimer? _packPreviewTimer
+//   private DispatcherTimer? _statPillUpdateTimer
+//   private DispatcherTimer? _conditioningTimeTimer
+//   private DateTime _conditioningStartTime
+//   private double _conditioningBaselineMinutes
+//   private DispatcherTimer? _conditioningTimeSyncTimer
+//   private int _conditioningTimeSecondCounter
+//   public MainWindow(…)
+//   private void OnXPChanged(…)
+//   private void OnProfileLoaded(…)
+//   private void OnSyncHealthChanged(…)
+//   private void OnLevelUp(…)
+//   private void PlayLevelUpSound(…)
+//   private void StopLevelUpSound(…)
+//   private void OnGlobalKeyPressed(…)
+//   private static readonly TimeSpan PanicWatchdogTimeout
+//   private static int _panicFallbackRunning
+//   private void ArmPanicWatchdog(…)
+//   private void RunEmergencyPanicTeardown(…)
+//   private static void LogPanicFallbackStep(…)
+//   private void QueuePanicFallbackRecovery(…)
+//   internal const Key QuickRecalHotkeyKey
+//   internal const ModifierKeys QuickRecalHotkeyModifiers
+//   internal static string QuickRecalHotkeyChord
+//   internal static string CameraShortcutChord
+//   internal static string QuickRecalHotkeyHint(…)
+//   private bool _quickRecalHotkeyBusy
+//   private static string FormatChord(…)
+//   private void ApplyGlobalQuickRecalHotkey(…)
+//   private static bool IsGazeCalibrationSurfaceOpen(…)
+//   private async void OpenQuickRecalFromHotkey(…)
+//   private void HandlePanicKeyPress(…)
+//   private static bool AnyGameSurfaceOwnsTheScreen(…)
+//   private void RunPanicStopTail(…)
+//   private void PanicStopEverySurface(…)
+//   private void StopAdHocEffects(…)
+//   private void UpdatePanicKeyButton(…)
+//   internal void UpdatePauseKeyButton(…)
+//   internal void RequestPickAssetsFolder(…)
+//   internal void RequestBeginPanicKeyCapture(…)
+//   internal void RequestToggleOfflineMode(…)
+//   internal void RequestToggleNoPanic(…)
+//   internal bool ApplyNoPanic(…)
+//   internal bool ApplyOfflineMode(…)
+//   internal void SyncNoPanicState(…)
+//   internal void SyncOfflineModeState(…)
+//   internal bool RequestToggleWindowsStartup(…)
+//   private void LoadLogo(…)
+//   private void LoadTakeoverImage(…)
+//   private void RefreshThemeAwareElements(…)
+//   private static Color LightenColor(…)
+//   private static Color DarkenColor(…)
+//   private void InitializeModSelector(…)
+//   private static ModSelectorItem BuildSelectorItem(…)
+//   private void RefreshBrowserLoadingText(…)
+//   private static System.Windows.Media.ImageSource? ModTileVariant(…)
+//   private const int TileDecodeWidth
+//   private const int WideTileDecodeWidth
+//   private void LoadFeatureImages(…)
+//   private static ImageSource? LoadModImageDecoded(…)
+//   private static void ApplyArtFraming(…)
+//   private static ModArtFraming? ActiveModFraming(…)
+//   private void BtnManageMods_Click(…)
+//   private void ModSelectorCombo_SelectionChanged(…)
+//   internal void ActivateChosenMod(…)
+//   private void ApplyActiveModChange(…)
+//   private readonly List<(…)
+//   private void RefreshHypnotubeLinksUI(…)
+//   private static bool IsListingUrl(…)
+//   internal void BtnAddVideoLink_Click(…)
+//   private TextBox MakePoolTextBox(…)
+//   private void PersistVideoLinks(…)
+//   private void UpdateNoVideoLinksPlaceholder(…)
+//   private string GetModeAwareQuestImagePath(…)
+//   private System.Windows.Media.Imaging.BitmapImage? LoadQuestImage(…)
+//   private void CenterOnPrimaryScreen(…)
+//   private async void MainWindow_Loaded(…)
+//   private async Task CheckPendingRegistrationAsync(…)
+//   private async Task CheckFirstRunAssetsPromptAsync(…)
+//   private static bool HasAnyLocalMedia(…)
+//   private const int WM_GETMINMAXINFO
+//   private const int WM_ENTERSIZEMOVE
+//   private const int WM_EXITSIZEMOVE
+//   private const int WM_DPICHANGED_MAIN
+//   private struct POINT
+//   private struct MINMAXINFO
+//   private IntPtr WndProc(…)
+//   private void QueueEmiKnock(…)
+//   public IntPtr Handle
+//   public Win32WindowWrapper(…)
+//   public string Id
+//   public string Name
+//   public Brush AccentBrush
+//   public ModSelectorItem(…)


### PR DESCRIPTION
8,252 lines. The app shell: a 3,474-line XAML and 84 partials totalling 72,317 lines of C#.

Ported as `MainShellWindow`, deliberately not `MainWindow`, so the head's diagnostics window and AppShell are untouched. Wiring it as the startup window is a later layer's decision.

Real here: the XAML and its window-level drag-and-drop, the title-bar chrome, and the work-area fit, which is a genuine port rather than a stub (Avalonia `Screens`, `WorkingArea`, `Scaling` and `Position` replace the Win32 rect and position calls, and `ScalingChanged` replaces the DPI-changed hook). The other 81 partials are stubbed one file per WPF partial, each naming its source, its line count and every dropped member: 1,743 in total. The 86 handlers the XAML references exist as real empty methods, because a missing one is a XAML compile error.

Ten Win32 calls were mapped rather than copied. One is genuinely lost and named in place: asking whether another application holds focus, which gated the ambient effect loops, has no portable answer.

Trap 6 again, caught by the render and not the compiler: the first PNG showed Exit, Pause and the update button as empty outlines. All 32 content presenters now carry their template bindings.

Verified alone at this layer: Core and Avalonia build, `--smoke`, `--render-view` with the PNG read, `--render-all` N/N, core guards. Review bottom-up; `gh stack merge <pr> --yes` lands this and everything below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351