### PR TITLE
fix(flash): shuffle bag so a 1000-file pool actually gets used

### DIFF
--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -108,6 +108,17 @@ namespace ConditioningControlPanel.Services
         private static int BucketUp(int v) => ((Math.Max(0, v) + FLASH_SHELL_SLACK + FLASH_SHELL_BUCKET - 1) / FLASH_SHELL_BUCKET) * FLASH_SHELL_BUCKET;
         private List<string> _imageList = new();  // Cached image list for random selection
         private List<(string PackId, PackFileEntry File)> _packImageList = new();  // Cached pack images for random selection
+
+        // Draw-without-replacement over each pool. Until now every flash was an independent
+        // Random.Next(pool.Count), i.e. a draw WITH replacement: 1000 draws from a 1000-gif folder
+        // surface only ~632 distinct files, a third of the folder never shows at all, and the ones
+        // that do repeat three or four times. That is the "I have 1000 gifs and keep seeing the
+        // same 50" report. The bags deal the whole pool in a random order and only reshuffle once
+        // it is spent. Both are guarded by _lockObj, like every other read of the pools.
+        private readonly ShuffleBag<string> _imageBag;
+        private readonly ShuffleBag<(string PackId, PackFileEntry File)> _packImageBag;
+        // When the pools were last re-listed, for the bag-exhaustion rescan (MaybeRescanExhaustedPools).
+        private DateTime _lastPoolScanUtc = DateTime.MinValue;
         // Size of DisabledAssetPaths when the live pools were last reconciled against it. Every
         // asset-manager toggle moves that count, so one int compare per draw is enough to notice a
         // pool that predates the user's latest selection — see PruneDeselectedFromPools.
@@ -374,6 +385,10 @@ namespace ConditioningControlPanel.Services
 
         public FlashService()
         {
+            // Before RefreshImagesPath: it clears the pools, which touches the bags.
+            _imageBag = new ShuffleBag<string>(_random);
+            _packImageBag = new ShuffleBag<(string PackId, PackFileEntry File)>(_random);
+
             RefreshImagesPath();
             // Same hazard as SubliminalService's ctor: the voice-line folder is install-dir anchored
             // and Program Files is read-only, so once flashes_audio ships as a downloadable content
@@ -2888,6 +2903,10 @@ namespace ConditioningControlPanel.Services
                 // wrote DisabledAssetPaths forgot to invalidate the pools.
                 PruneDeselectedFromPools();
 
+                // Both bags spent = the library has been shown end to end. Cheapest honest moment
+                // to notice files the user dropped in while the app was running.
+                MaybeRescanExhaustedPools();
+
                 // Third pool: remote stills. Non-blocking - it only kicks a background top-up
                 // and reads how many URLs are already warm. No-op when the user is on "local".
                 EnsureRemotePrefetch();
@@ -2934,11 +2953,10 @@ namespace ConditioningControlPanel.Services
                         usePackImage = true;
                     }
 
-                    if (usePackImage && _packImageList.Count > 0)
+                    if (usePackImage && _packImageBag.TryNext(_packImageList, out var packImage))
                     {
-                        // Randomly select a pack image (true random, not sequential)
-                        var index = _random.Next(_packImageList.Count);
-                        var packImage = _packImageList[index];
+                        // Drawn from the shuffle bag: every pack image gets its turn before any
+                        // of them comes round again.
                         // Decrypt pack image to temp file
                         var tempPath = App.ContentPacks?.GetPackFileTempPath(packImage.PackId, packImage.File);
                         if (!string.IsNullOrEmpty(tempPath))
@@ -2951,11 +2969,11 @@ namespace ConditioningControlPanel.Services
                         // If decryption failed, try regular list
                     }
 
-                    if (_imageList.Count > 0)
+                    if (_imageBag.TryNext(_imageList, out var diskImage))
                     {
-                        // Randomly select an image (true random, not sequential)
-                        var index = _random.Next(_imageList.Count);
-                        result.Add(_imageList[index]);
+                        // Shuffle bag, not Random.Next: consecutive draws are distinct until the
+                        // whole folder has been shown once.
+                        result.Add(diskImage);
                     }
                 }
                 return result;
@@ -3010,18 +3028,20 @@ namespace ConditioningControlPanel.Services
                 if (_imageList.Count == 0 && _packImageList.Count == 0 && remoteReady == 0)
                     return new List<string>();
 
-                // Dedup on the SOURCE index (disk image / pack entry), not the resulting path: a pack
-                // image decrypts to a fresh temp path each call, so path-level dedup would neither
-                // catch pack dupes nor stop us re-decrypting the same file. Distinct sources also mean
-                // each chosen pack image decrypts exactly once. Cap at the pool size.
+                // Dedup on the SOURCE identity (disk path / pack entry key), not the resulting path:
+                // a pack image decrypts to a fresh temp path each call, so temp-path dedup would
+                // neither catch pack dupes nor stop us re-decrypting the same file. Distinct sources
+                // also mean each chosen pack image decrypts exactly once. Cap at the pool size.
+                // The shuffle bags already hand out distinct entries until they wrap, so these sets
+                // now only catch a wrap inside one oversized batch.
                 // Remote picks dedup on the URL itself — there the URL *is* the source identity
                 // (no decrypt step, no temp path, so it is stable across picks).
                 int localPool = _imageList.Count + _packImageList.Count;
                 int poolSize = localPool + remoteReady;
                 int want = Math.Min(count, poolSize);
                 bool haveLocal = localPool > 0;
-                var chosenDisk = new HashSet<int>();
-                var chosenPack = new HashSet<int>();
+                var chosenDisk = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var chosenPack = new HashSet<string>(StringComparer.Ordinal);
                 var chosenRemote = new HashSet<string>(StringComparer.Ordinal);
                 var result = new List<string>(want);
                 int guard = 0, maxGuard = poolSize * 8 + 16;   // backstop vs. random-collision / decrypt-fail retries
@@ -3060,24 +3080,22 @@ namespace ConditioningControlPanel.Services
                     else if (_packImageList.Count > 0)
                         usePackImage = true;
 
-                    if (usePackImage && _packImageList.Count > 0)
+                    if (usePackImage && _packImageBag.TryNext(_packImageList, out var packImage))
                     {
-                        var index = _random.Next(_packImageList.Count);
-                        if (!chosenPack.Add(index)) continue;   // already drew this pack entry
-                        var packImage = _packImageList[index];
+                        if (!chosenPack.Add($"{packImage.PackId}|{packImage.File.OriginalName}"))
+                            continue;   // already drew this pack entry
                         var tempPath = App.ContentPacks?.GetPackFileTempPath(packImage.PackId, packImage.File);
                         if (!string.IsNullOrEmpty(tempPath))
                         {
                             _tempPackFiles.Add(tempPath);   // track for cleanup
                             result.Add(tempPath);
                         }
-                        // decrypt failed → index stays marked chosen so we don't retry a broken entry
+                        // decrypt failed → entry stays marked chosen so we don't retry a broken one
                     }
-                    else if (_imageList.Count > 0)
+                    else if (_imageBag.TryNext(_imageList, out var diskImage))
                     {
-                        var index = _random.Next(_imageList.Count);
-                        if (!chosenDisk.Add(index)) continue;   // already drew this disk image
-                        result.Add(_imageList[index]);
+                        if (!chosenDisk.Add(diskImage)) continue;   // already drew this disk image
+                        result.Add(diskImage);
                     }
                 }
                 return result;
@@ -3092,7 +3110,17 @@ namespace ConditioningControlPanel.Services
         {
             // Clean up old temp pack files
             CleanupTempPackFiles();
+            ReloadPoolsFromDisk();
+        }
 
+        /// <summary>
+        /// Re-lists both pools and reshuffles the bags over them. Split out of
+        /// <see cref="RefreshImageLists"/> so the periodic rescan can pick up newly added files
+        /// WITHOUT deleting the temp files a pack flash currently on screen is still reading.
+        /// Caller must hold <see cref="_lockObj"/>.
+        /// </summary>
+        private void ReloadPoolsFromDisk()
+        {
             // Load regular images (include common extensions and variants)
             // GetMediaFiles has its own 60-second cache, so this is efficient
             _imageList = GetMediaFiles(_imagesPath, new[] { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".gif", ".webp", ".bmp", ".tif", ".tiff", ".heic", ".avif", ".ico" });
@@ -3103,8 +3131,29 @@ namespace ConditioningControlPanel.Services
             // Both sources filtered against the live disabled set, so the pools are in sync with it.
             _poolDisabledStamp = App.Settings?.Current?.DisabledAssetPaths.Count ?? 0;
 
+            // These are NEW lists, so any order the bags already dealt points at the old ones.
+            _imageBag.Invalidate();
+            _packImageBag.Invalidate();
+            _lastPoolScanUtc = DateTime.UtcNow;
+
             App.Logger?.Information("Image lists refreshed: {RegularCount} regular images, {PackCount} pack images from {Path}",
                 _imageList.Count, _packImageList.Count, _imagesPath);
+        }
+
+        /// <summary>
+        /// Re-lists the pools once both bags have been dealt out end to end, so files added while
+        /// the app is running start showing up without a restart. Before the bags existed,
+        /// <see cref="RefreshImageLists"/> only ran when the pools were EMPTY - and since they were
+        /// drawn from by random index and never drained, that meant "once per LoadAssets", so a gif
+        /// dropped into the folder mid-session stayed invisible until the user reloaded assets.
+        /// Rate-limited to the listing cache's own expiry so a small pool cannot turn this into a
+        /// disk scan per flash. Caller must hold <see cref="_lockObj"/>.
+        /// </summary>
+        private void MaybeRescanExhaustedPools()
+        {
+            if (_imageBag.Remaining > 0 || _packImageBag.Remaining > 0) return;
+            if ((DateTime.UtcNow - _lastPoolScanUtc).TotalSeconds < CACHE_EXPIRY_SECONDS) return;
+            ReloadPoolsFromDisk();
         }
 
         #endregion
@@ -3668,7 +3717,13 @@ namespace ConditioningControlPanel.Services
                 disabled.Contains($"pack:{p.PackId}/{p.File.OriginalName}"));
 
             if (removed > 0)
+            {
+                // The pools are shorter now, so the dealt order points past the end (or at the
+                // wrong entries). Reshuffle over what is left.
+                _imageBag.Invalidate();
+                _packImageBag.Invalidate();
                 App.Logger?.Information("FlashService: dropped {Count} deselected image(s) from the live pool", removed);
+            }
         }
 
         /// <summary>
@@ -3782,6 +3837,11 @@ namespace ConditioningControlPanel.Services
 
             // Scan directory (cache miss or expired)
             var files = new List<string>();
+            // Windows matches a THREE-character search extension as a prefix (documented behaviour of
+            // Directory.GetFiles: "*.xls" also returns "book.xlsx"), so "*.jpe" also returns every
+            // .jpeg and "*.tif" every .tiff. Those files were being added to the pool twice and drawn
+            // twice as often as everything else. Seen paths keep one entry per file.
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var blockedCount = 0;
             var sanitizeFailedCount = 0;
 
@@ -3791,6 +3851,8 @@ namespace ConditioningControlPanel.Services
                 // Note: Directory.GetFiles is case-insensitive on Windows NTFS
                 foreach (var file in Directory.GetFiles(folder, $"*{ext}", SearchOption.AllDirectories))
                 {
+                    if (!seen.Add(file)) continue;   // already matched by a shorter extension pattern
+
                     // Security: Validate path is within allowed directories (app dir, user assets, or custom path)
                     var isInAppDir = SecurityHelper.IsPathSafe(file, AppDomain.CurrentDomain.BaseDirectory);
                     var isInUserAssets = SecurityHelper.IsPathSafe(file, App.UserDataPath);

--- a/ConditioningControlPanel/Services/Flash/ShuffleBag.cs
+++ b/ConditioningControlPanel/Services/Flash/ShuffleBag.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Draw-without-replacement picker ("shuffle bag") over a pool somebody else owns.
+    ///
+    /// Why this exists: the flash picker used to call <c>Random.Next(pool.Count)</c> for every
+    /// image, which is a draw WITH replacement. Over 1000 draws from a 1000-file folder that
+    /// surfaces only ~632 distinct files, some of them three or four times, and roughly a third
+    /// of the folder never shows up at all - which is exactly what a user with a large library
+    /// reports as "I keep seeing the same fifty gifs". A shuffle bag deals the whole pool in a
+    /// random order, hands it out one at a time, and only reshuffles once the pool is spent, so
+    /// N draws from an N-file pool touch every file exactly once.
+    ///
+    /// Memory: the bag keeps an int per pool entry plus one reference to the item it handed out
+    /// last. It never holds decoded images and never copies the pool.
+    ///
+    /// The pool is passed in on every draw rather than stored, because the caller rebuilds its
+    /// list from disk (and prunes deselected assets out of it) whenever the library changes. A
+    /// change in pool size reshuffles on its own; when the pool changes WITHOUT changing size,
+    /// the owner calls <see cref="Invalidate"/>.
+    ///
+    /// Not thread-safe: callers hold their own lock (FlashService uses <c>_lockObj</c>).
+    /// </summary>
+    internal sealed class ShuffleBag<T>
+    {
+        private readonly Random _random;
+        private int[] _order = Array.Empty<int>();
+        private int _cursor;            // next slot of _order to hand out
+        private int _builtFor = -1;     // pool size the current order was dealt for
+        private bool _hasLast;
+        private T? _last;               // last item handed out, for the reshuffle boundary guard
+
+        public ShuffleBag(Random random)
+        {
+            _random = random ?? throw new ArgumentNullException(nameof(random));
+        }
+
+        /// <summary>Draws left before the bag reshuffles. Zero means the next draw reshuffles.</summary>
+        public int Remaining => _builtFor < 0 ? 0 : Math.Max(0, _order.Length - _cursor);
+
+        /// <summary>
+        /// Forces a reshuffle on the next draw. Call this when the pool contents changed but the
+        /// count did not (a rescan that swapped one file for another, a mod or folder switch).
+        /// </summary>
+        public void Invalidate()
+        {
+            _builtFor = -1;
+            _cursor = 0;
+        }
+
+        /// <summary>
+        /// Hands out the next item. Returns false only for an empty pool.
+        /// </summary>
+        public bool TryNext(IReadOnlyList<T> pool, out T item)
+        {
+            item = default!;
+            if (pool == null || pool.Count == 0) return false;
+
+            if (_builtFor != pool.Count || _cursor >= _order.Length) Deal(pool);
+
+            int index = _order[_cursor++];
+            if (index >= pool.Count)
+            {
+                // The pool shrank under us without an Invalidate. Re-deal rather than throw.
+                Deal(pool);
+                index = _order[_cursor++];
+            }
+
+            item = pool[index];
+            _last = item;
+            _hasLast = true;
+            return true;
+        }
+
+        private void Deal(IReadOnlyList<T> pool)
+        {
+            int n = pool.Count;
+            if (_order.Length != n) _order = new int[n];
+            for (int i = 0; i < n; i++) _order[i] = i;
+
+            // Fisher-Yates, matching VideoService.ShuffleList.
+            for (int i = n - 1; i > 0; i--)
+            {
+                int j = _random.Next(i + 1);
+                (_order[i], _order[j]) = (_order[j], _order[i]);
+            }
+
+            // A fresh bag must not open on the item the old one closed on: back-to-back repeats
+            // across the seam are the one thing a shuffle bag is supposed to make impossible, and
+            // they are the most visible kind of repeat there is.
+            if (n > 1 && _hasLast && EqualityComparer<T>.Default.Equals(pool[_order[0]], _last!))
+            {
+                int swap = 1 + _random.Next(n - 1);
+                (_order[0], _order[swap]) = (_order[swap], _order[0]);
+            }
+
+            _builtFor = n;
+            _cursor = 0;
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/FlashShuffleBagTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/FlashShuffleBagTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #tier-2 2026-08-26 (Yiin, echoed by Wobberjockey): "about 1000 gifs in the flash folder and I
+/// keep seeing the same 50". The flash picker drew with replacement - a fresh
+/// <c>Random.Next(pool.Count)</c> per image - so the pool was never actually walked. These tests
+/// pin the shuffle-bag replacement: N draws from an N-file pool return N distinct files, the bag
+/// reshuffles only when it is spent, and a new bag never opens on the file the old one closed on.
+/// </summary>
+public class FlashShuffleBagTests
+{
+    private static List<string> Pool(int n) =>
+        Enumerable.Range(0, n).Select(i => $"C:/assets/images/gif_{i:D4}.gif").ToList();
+
+    [Fact]
+    public void ThousandDrawsFromThousandFiles_AreAllDistinct()
+    {
+        var pool = Pool(1000);
+        var bag = new ShuffleBag<string>(new Random(20260826));
+
+        var drawn = new List<string>(1000);
+        for (int i = 0; i < 1000; i++)
+        {
+            Assert.True(bag.TryNext(pool, out var path));
+            drawn.Add(path);
+        }
+
+        Assert.Equal(1000, drawn.Distinct().Count());
+        Assert.Equal(pool.OrderBy(p => p, StringComparer.Ordinal),
+                     drawn.OrderBy(p => p, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void TheOldWithReplacementDraw_MissesMostOfTheFolder()
+    {
+        // The regression this replaces, stated as a number: 1000 independent picks from a
+        // 1000-file pool surface roughly 632 distinct files, so a third of the library never
+        // appears at all and the rest repeats. Fixed seed, so this is a fact, not a coin flip.
+        var pool = Pool(1000);
+        var rng = new Random(20260826);
+        var drawn = new List<string>(1000);
+        for (int i = 0; i < 1000; i++) drawn.Add(pool[rng.Next(pool.Count)]);
+
+        Assert.InRange(drawn.Distinct().Count(), 1, 800);
+    }
+
+    [Fact]
+    public void ThreeFullCycles_ShowEveryFileExactlyThreeTimes()
+    {
+        var pool = Pool(250);
+        var bag = new ShuffleBag<string>(new Random(7));
+
+        var counts = new Dictionary<string, int>();
+        for (int i = 0; i < 750; i++)
+        {
+            Assert.True(bag.TryNext(pool, out var path));
+            counts[path] = counts.TryGetValue(path, out var c) ? c + 1 : 1;
+        }
+
+        Assert.Equal(250, counts.Count);
+        Assert.All(counts.Values, v => Assert.Equal(3, v));
+    }
+
+    [Fact]
+    public void ReshuffleSeam_NeverRepeatsTheLastDraw()
+    {
+        // A tiny pool makes the seam come round constantly, which is where a naive
+        // "shuffle, drain, shuffle" leaks a back-to-back repeat.
+        for (int seed = 0; seed < 25; seed++)
+        {
+            var pool = Pool(4);
+            var bag = new ShuffleBag<string>(new Random(seed));
+            string? previous = null;
+            for (int i = 0; i < 4000; i++)
+            {
+                Assert.True(bag.TryNext(pool, out var path));
+                Assert.NotEqual(previous, path);
+                previous = path;
+            }
+        }
+    }
+
+    [Fact]
+    public void GrowingThePool_StartsDrawingTheNewFile()
+    {
+        var pool = Pool(100);
+        var bag = new ShuffleBag<string>(new Random(11));
+        for (int i = 0; i < 100; i++) Assert.True(bag.TryNext(pool, out _));
+
+        pool.Add("C:/assets/images/brand_new.gif");
+        var seen = new HashSet<string>();
+        for (int i = 0; i < 101; i++)
+        {
+            Assert.True(bag.TryNext(pool, out var path));
+            seen.Add(path);
+        }
+
+        Assert.Contains("C:/assets/images/brand_new.gif", seen);
+        Assert.Equal(101, seen.Count);
+    }
+
+    [Fact]
+    public void Invalidate_ReshufflesWithoutRepeatingTheLastDraw()
+    {
+        // Same count, different contents (a rescan that swapped a file, or a mod switch).
+        var pool = Pool(50);
+        var bag = new ShuffleBag<string>(new Random(3));
+        Assert.True(bag.TryNext(pool, out var last));
+
+        bag.Invalidate();
+        Assert.Equal(0, bag.Remaining);
+
+        Assert.True(bag.TryNext(pool, out var first));
+        Assert.NotEqual(last, first);
+        Assert.Equal(49, bag.Remaining);
+    }
+
+    [Fact]
+    public void ShrinkingThePoolUnderTheBag_DoesNotThrow()
+    {
+        var pool = Pool(500);
+        var bag = new ShuffleBag<string>(new Random(5));
+        for (int i = 0; i < 10; i++) Assert.True(bag.TryNext(pool, out _));
+
+        pool.RemoveRange(1, 499);   // deselecting almost everything, without an Invalidate
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.True(bag.TryNext(pool, out var path));
+            Assert.Contains(path, pool);
+        }
+    }
+
+    [Fact]
+    public void EmptyPool_DrawsNothing()
+    {
+        var bag = new ShuffleBag<string>(new Random(1));
+        Assert.False(bag.TryNext(new List<string>(), out _));
+        Assert.False(bag.TryNext(null!, out _));
+        Assert.Equal(0, bag.Remaining);
+    }
+
+    [Fact]
+    public void SingleFilePool_KeepsReturningIt()
+    {
+        // The one case where a repeat is unavoidable: the seam guard must not deadlock or throw.
+        var pool = Pool(1);
+        var bag = new ShuffleBag<string>(new Random(2));
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.True(bag.TryNext(pool, out var path));
+            Assert.Equal(pool[0], path);
+        }
+    }
+}


### PR DESCRIPTION
## Who asked

Yiin in #tier-2 on 2026-08-26: about 1000 gifs in the flash folder, keeps seeing
"the same 50". Wobberjockey echoed it. Nobody had looked at why.

## Root cause

The flash picker drew **with replacement**. Every image was an independent
`_random.Next(pool.Count)` in `FlashService.GetNextImages`, with nothing tracking
what had already been shown.

That is a coupon-collector problem: 1000 draws from a 1000-file pool return only
**631 distinct files** (measured, `new Random(20260826)`), roughly a third of the
folder never comes up at all, and the files that do come up repeat three or four
times. Seeing all 1000 would take about 7500 flashes. So the pool is fine, it was
just never being walked.

Things I checked and ruled out, since the brief asked for them explicitly:

- **No cap.** No `Take(N)`, no max-files constant, no page size anywhere in the
  flash path. `GetMediaFiles` returns the full listing.
- **No recency or favourite weighting.** There is no history and no tag weighting.
- **RNG is not re-seeded per call.** `_random` is one `new Random()` field.
- **No per-mod or per-niche filter.** The only filter is the user's own
  `DisabledAssetPaths` deselection set.
- **Subfolders are scanned.** `Directory.GetFiles(..., SearchOption.AllDirectories)`.
- **Videos do not share the picker.** `VideoService.GetNextVideo` already drains a
  Fisher-Yates shuffled `Queue`, so it does not have this bug and is untouched here.

Two smaller amplifiers in the same code path, both fixed:

1. **Some files were listed twice.** `GetMediaFiles` loops the extension list and
   calls `Directory.GetFiles(folder, "*.jpe")`, `"*.tif"` and so on. Windows treats
   a three-character search extension as a prefix (documented: `"*.xls"` also
   returns `book.xlsx`), so `*.jpe` also matched every `.jpeg` and `*.tif` every
   `.tiff`. Those files sat in the pool twice and were drawn at double weight.
2. **The pool was built once and never refreshed.** `RefreshImageLists` only ran
   when the pools were *empty*, and since they were indexed rather than drained
   they were never empty. In practice that meant "once per `LoadAssets`", so a gif
   added while the app was running stayed invisible until an asset reload.

## What changed

- **New `ShuffleBag<T>`** (`ConditioningControlPanel/Services/Flash/ShuffleBag.cs`):
  deals the whole pool in a random Fisher-Yates order, hands entries out one at a
  time, reshuffles only when spent, and guarantees a fresh bag never opens on the
  entry the old one closed on. It keeps one `int` per pool entry plus a single
  reference to the last item; it never holds decoded images and never copies the pool.
- **One bag per source**: disk images and content-pack images. Both
  `GetNextImages` (flashes) and `GetChaosImagePaths` (chaos wash / gif cascade) draw
  from them, so both surfaces share one cycle through the library.
- **Bags are invalidated when the pool changes**: rescan, asset deselection
  (`PruneDeselectedFromPools`), mod or assets-folder switch, `LoadAssets`.
  `TryNext` also re-deals on its own if the pool count moved underneath it.
- **`ReloadPoolsFromDisk` split out of `RefreshImageLists`** so the new
  exhausted-bag rescan can pick up newly added files *without* running
  `CleanupTempPackFiles`, which would delete temp files a pack flash currently on
  screen is still reading. The rescan is rate limited to the listing cache's own
  60s expiry, so a small pool cannot turn it into a disk scan per flash.
- **`GetMediaFiles` keeps one entry per path.**

The GIF decode and image-cache path is untouched. The only thing that changed is
which index gets picked.

## How I tested

`Tests/ConditioningControlPanel.Tests/FlashShuffleBagTests.cs`, 9 xunit cases,
`dotnet test --filter FullyQualifiedName~FlashShuffleBagTests` → **9 passed, 0 failed**:

- `ThousandDrawsFromThousandFiles_AreAllDistinct` - the headline proof: 1000 draws
  from a 1000-file pool return 1000 distinct paths, and sorted they equal the pool.
- `TheOldWithReplacementDraw_MissesMostOfTheFolder` - pins the old behaviour at
  under 800 distinct (actual: 631) so the regression cannot creep back quietly.
- `ThreeFullCycles_ShowEveryFileExactlyThreeTimes` - 750 draws from 250 files gives
  every file exactly three times.
- `ReshuffleSeam_NeverRepeatsTheLastDraw` - 25 seeds x 4000 draws from a 4-file
  pool, no back-to-back repeat anywhere across the reshuffle seam.
- `GrowingThePool_StartsDrawingTheNewFile`, `Invalidate_ReshufflesWithoutRepeatingTheLastDraw`,
  `ShrinkingThePoolUnderTheBag_DoesNotThrow`, `EmptyPool_DrawsNothing`,
  `SingleFilePool_KeepsReturningIt` - pool churn and degenerate pools.

Full app build: `dotnet build -nologo -v q` → **0 errors** (344 pre-existing
warnings, CA1416 and nullable, unchanged).

Not done: no live run against a real 1000-gif folder on this machine, so the
end-to-end behaviour is proven at the picker level rather than on screen.

## Size

`git diff --stat origin/main...HEAD`: `3 files changed, 349 insertions(+), 23 deletions(-)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtSyPepqh8Ugh3TZ7R6vmX
