### PR TITLE
feat(arcademy): report card export as image

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -65,7 +65,22 @@ shell/splitflap.js departure-board reveal. The campus hangs it COLLAPSED behind 
                    first open of the day, store key boardOpenedDate); expanding
                    rolls the flaps, which is why there is no "flip the board
                    again" button any more
-shell/reportcard.js day summary + THE one share pipeline
+shell/reportcard.js day summary + THE one share pipeline. v1 = Daily Trigger's
+                   emoji grid copied as TEXT; v2 (Wobberjockey, 2026-09-02) adds
+                   SAVE AS IMAGE beside it, on every report whether or not the
+                   day had a grid. The picture is drawn from the render state,
+                   never from the DOM
+shell/cardshot.js  the drawing half of that: `drawCard(model)` paints the card
+                   onto a 1280px canvas in the HOUSE palette (literals, never
+                   init.palette) and `handOut(canvas)` walks the doors - on the
+                   web a download plus a best-effort image clipboard, on a NATIVE
+                   host (WebView2 / react-native-webview) the clipboard first,
+                   then the download, then `.arc-shotsheet`: the PNG painted into
+                   the page so a phone can long-press it. Imports nothing (no
+                   lexicon, no bridge, no store), because every word on the image
+                   is a neutral literal by trap 13 - the button and the toasts are
+                   the only mod-skinnable strings in the beat. There is NO host
+                   message for saving a file and this wave did not add one
 shell/settings.js  THE settings page (3 tiers) + SETTING_KEYS; `gameKey` scopes it to ONE
                    game group (the pause card's door) - argless = the full sheet
 shell/ceremonies.js stamp / 10-segment meter / reward beats (engine-delegated; the

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -79,6 +79,15 @@ export const DEFAULT_LEXICON = Object.freeze({
   replay_board: 'Flip the board again',
   share: 'Copy share card',
   shared: 'Copied to clipboard',
+  /* the picture half of the share (shell/cardshot.js). These are the ONLY
+     strings the image beat can be re-voiced through - the copy drawn ON the
+     picture is neutral by ruling, so a paste never outs a mod. */
+  share_image: 'Save as image',
+  share_image_saved: 'Card saved as a picture',
+  share_image_copied: 'Card copied. Paste it anywhere.',
+  share_image_hold: 'Press and hold the card to save it',
+  share_image_failed: 'The card would not save',
+  share_image_close: 'Close',
   done: 'Done',
   xp: 'XP',
   streak: 'Streak',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/cardshot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/cardshot.js
@@ -1,0 +1,290 @@
+/* ============================================================================
+ * shell/cardshot.js - the report card, drawn to a canvas and handed out as a
+ * PNG. The DRAWING HALF of the one share pipeline (trap 13); reportcard.js is
+ * still the only thing that decides WHAT goes on the paper and is still the
+ * only caller. Nothing here imports the lexicon, the bridge, a store or EMI:
+ * it is handed a finished plain model and it paints it.
+ *
+ * WHY THE STRINGS ON THE IMAGE ARE LITERALS. The same reason the share header
+ * is the literal 'The Arcademy' and never t('arcademy') (trap 13): a paste in
+ * Discord must not out the player's mod. So the copy BAKED INTO the picture is
+ * neutral English and the mod-skinnable half - the button, the toasts - stays
+ * in the DOM where the lexicon serves it. The palette is the house palette by
+ * literal for the same reason, not init.palette: two players who both went
+ * perfect should be able to post the same card.
+ *
+ * NO SERIF, anywhere in the stack (house law). The CSS --disp chain ends in
+ * `serif` as a last resort; the canvas one deliberately does not.
+ * ==========================================================================*/
+
+/** House palette, verbatim from styles.css :root. Never init.palette. */
+const C = Object.freeze({
+  ground: '#14142B', navy: '#1A1A2E', line: '#3A3A5E',
+  ink: '#F2EBDD', dim: '#B9B3CE', faint: '#8A84A8',
+  pink: '#FF69B4', lav: '#B8A6E8', gold: '#F0C24B', slate: '#7A7594',
+});
+const GRADE_INK = Object.freeze({
+  s: C.gold, splus: C.gold, a: C.pink, b: C.lav, c: C.slate, pass: C.lav,
+});
+const F_DISP = "'Arcademy Display','Arial Black',Impact,sans-serif";
+const F_BODY = "'Segoe UI Variable Text','Segoe UI',system-ui,-apple-system,sans-serif";
+const F_MONO = "'Cascadia Mono','Consolas','Courier New',monospace";
+
+const W = 640;          // logical width; the bitmap is this times SCALE
+const SCALE = 2;        // 1280px wide reads sharp in a Discord embed
+const PAD = 28;
+
+function gradeInk(grade) {
+  const k = String(grade || '').toLowerCase().replace('+', 'plus');
+  return GRADE_INK[k] || C.faint;
+}
+
+function box(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  if (typeof ctx.roundRect === 'function') ctx.roundRect(x, y, w, h, r);
+  else ctx.rect(x, y, w, h);
+}
+
+/**
+ * Draw the card.
+ *
+ * @param {Object} m  the model reportcard.js builds:
+ *   {header, title, date, rows:[{name, grade, xp}], streak, perfectDays,
+ *    perfect, tickets, token, totalXp, tier, grid:[string]}
+ * @returns {HTMLCanvasElement|null}
+ */
+export function drawCard(m) {
+  if (typeof document === 'undefined' || !document.createElement) return null;
+  const model = m || {};
+  const rows = Array.isArray(model.rows) ? model.rows.slice(0, 8) : [];
+  const grid = Array.isArray(model.grid) ? model.grid.slice(0, 12) : [];
+
+  /* The height is the layout, added up in advance: 120 for the header block,
+   * one ROW_H per class, 56 for the XP + attendance lines, then whatever the
+   * night actually earned, then 46 for the wordmark's air. Every one of these
+   * is the same number the draw below walks past, so a block that grows has to
+   * grow in both places or the card gets a hole in it. */
+  const ROW_H = 40;
+  const gridH = grid.length ? 22 + grid.length * 22 : 0;
+  const stampH = model.perfect ? 54 : 0;
+  const tillH = (model.tickets || model.token) ? 32 : 0;
+  const H = 120 + rows.length * ROW_H + 56 + tillH + gridH + stampH + 46;
+
+  const cv = document.createElement('canvas');
+  cv.width = W * SCALE; cv.height = H * SCALE;
+  const ctx = cv.getContext && cv.getContext('2d');
+  if (!ctx) return null;
+  ctx.scale(SCALE, SCALE);
+  ctx.textBaseline = 'middle';
+
+  /* the ground, then the paper laid on it */
+  ctx.fillStyle = C.ground; ctx.fillRect(0, 0, W, H);
+  ctx.fillStyle = C.navy;
+  box(ctx, 12, 12, W - 24, H - 24, 16); ctx.fill();
+  ctx.strokeStyle = C.line; ctx.lineWidth = 1;
+  box(ctx, 12.5, 12.5, W - 25, H - 25, 16); ctx.stroke();
+
+  const mid = W / 2;
+  let y = 48;
+
+  /* THE HEADER, mod-anonymous by ruling. Centre line, like every other room. */
+  ctx.textAlign = 'center';
+  ctx.fillStyle = C.ink;
+  ctx.font = '24px ' + F_DISP;
+  ctx.fillText(String(model.header || 'The Arcademy'), mid, y);
+  y += 26;
+  ctx.fillStyle = C.faint;
+  ctx.font = '12px ' + F_BODY;
+  ctx.fillText([model.title, model.date].filter(Boolean).join('   -   '), mid, y);
+  y += 24;
+
+  ctx.strokeStyle = C.line;
+  ctx.beginPath(); ctx.moveTo(PAD + 12, y); ctx.lineTo(W - PAD - 12, y); ctx.stroke();
+  y += 22;
+
+  /* one row per class: badge, neutral class name, the XP the HOST paid */
+  const left = PAD + 12;
+  const right = W - PAD - 12;
+  for (const r of rows) {
+    const g = String(r.grade || '').toUpperCase();
+    const ink = gradeInk(r.grade);
+    if (g) { ctx.fillStyle = ink; box(ctx, left, y - 13, 38, 26, 8); ctx.fill(); }
+    else { ctx.strokeStyle = C.line; box(ctx, left + 0.5, y - 12.5, 37, 25, 8); ctx.stroke(); }
+    ctx.textAlign = 'center';
+    ctx.fillStyle = g ? C.navy : C.faint;
+    ctx.font = 'bold 13px ' + F_BODY;
+    ctx.fillText(g || '--', left + 19, y + 1);
+
+    ctx.textAlign = 'left';
+    ctx.fillStyle = g ? C.ink : C.faint;
+    ctx.font = '14px ' + F_BODY;
+    ctx.fillText(String(r.name || ''), left + 52, y);
+
+    if (r.xp != null) {
+      ctx.textAlign = 'right';
+      ctx.fillStyle = C.dim;
+      ctx.font = '13px ' + F_MONO;
+      ctx.fillText('+' + Math.round(r.xp) + ' XP', right, y);
+    }
+    y += ROW_H;
+  }
+
+  /* the day's totals, centred and loud - the number people screenshot */
+  y += 6;
+  ctx.textAlign = 'center';
+  ctx.fillStyle = C.pink;
+  ctx.font = '20px ' + F_DISP;
+  ctx.fillText('+' + Math.round(model.totalXp || 0) + ' XP', mid, y);
+  y += 24;
+  ctx.fillStyle = C.dim;
+  ctx.font = '13px ' + F_BODY;
+  const att = ['Attendance ' + (model.streak | 0)];
+  if (model.perfectDays) att.push('Perfect x' + (model.perfectDays | 0));
+  if (model.tier) att.push(String(model.tier));
+  ctx.fillText(att.join('   |   '), mid, y);
+  y += 26;
+
+  if (model.tickets || model.token) {
+    ctx.fillStyle = C.gold;
+    ctx.font = '13px ' + F_BODY;
+    const till = [];
+    if (model.tickets) till.push((model.tickets | 0) + ' tickets');
+    if (model.token) till.push('1 token');
+    ctx.fillText(till.join('   +   '), mid, y);
+    y += 32;
+  }
+
+  if (grid.length) {
+    y += 10;
+    ctx.fillStyle = C.ink;
+    ctx.font = '17px ' + F_MONO;
+    for (const line of grid) { ctx.fillText(String(line), mid, y); y += 22; }
+    y += 12;
+  }
+
+  /* the seal. A tilted box, the way the ceremony stamps the paper. */
+  if (model.perfect) {
+    ctx.save();
+    ctx.translate(mid, y + 14);
+    ctx.rotate(-0.05);
+    ctx.strokeStyle = C.pink; ctx.lineWidth = 2;
+    box(ctx, -112, -18, 224, 36, 8); ctx.stroke();
+    ctx.fillStyle = C.pink;
+    ctx.textAlign = 'center';
+    ctx.font = '15px ' + F_DISP;
+    ctx.fillText('PERFECT ATTENDANCE', 0, 1);
+    ctx.restore();
+    y += stampH;
+  }
+
+  /* the wordmark, so a card posted with no caption still says where it came from */
+  ctx.fillStyle = C.lav;
+  ctx.font = '11px ' + F_DISP;
+  ctx.textAlign = 'center';
+  ctx.globalAlpha = 0.85;
+  ctx.fillText('A R C A D E M Y', mid, H - 30);
+  ctx.globalAlpha = 1;
+  return cv;
+}
+
+/** Canvas -> Blob, never throwing. */
+function toBlob(cv) {
+  return new Promise((resolve) => {
+    try {
+      if (typeof cv.toBlob === 'function') { cv.toBlob((b) => resolve(b || null), 'image/png'); return; }
+    } catch (e) { /* fall through */ }
+    resolve(null);
+  });
+}
+
+/** Is there a native host under us? A download there may go nowhere. */
+export function hosted() {
+  if (typeof window === 'undefined') return false;
+  const w = window;
+  return !!((w.chrome && w.chrome.webview) || w.ReactNativeWebView);
+}
+
+/**
+ * The last rung: paint the PNG into the page so a phone can long-press it.
+ * An overlay, never a screen (traps 48/50) - it owns no Esc rung and no state,
+ * and a press anywhere takes it away again.
+ */
+function showSheet(url, closeLabel) {
+  const doc = document;
+  const wrap = doc.createElement('div');
+  wrap.className = 'arc-shotsheet';
+  const img = doc.createElement('img');
+  img.src = url;
+  img.alt = '';
+  wrap.appendChild(img);
+  const shut = doc.createElement('button');
+  shut.type = 'button';
+  shut.className = 'btn';
+  shut.textContent = String(closeLabel || 'Close');
+  wrap.appendChild(shut);
+  const close = () => { try { wrap.remove(); } catch (e) { /* noop */ } };
+  wrap.addEventListener('click', close);
+  doc.body.appendChild(wrap);
+}
+
+/**
+ * Hand the drawn card out, by whichever door this host actually has.
+ *
+ * WEB: download it AND try the clipboard, so the file is on disk and the paste
+ * into Discord works too. HOSTED (WebView2 / react-native-webview): the
+ * clipboard first, because a download in a fullscreen kiosk either opens a
+ * flyout over the beat or is dropped on the floor; the download is the second
+ * rung and the long-press sheet is the last. There is no host message for
+ * saving a file, so the page never asks for one.
+ *
+ * @returns {Promise<'download'|'clipboard'|'both'|'view'|null>}
+ */
+export async function handOut(cv, opts) {
+  const o = opts || {};
+  if (!cv) return null;
+  const blob = await toBlob(cv);
+  const name = String(o.filename || 'arcademy-report.png');
+  let clip = false;
+  let down = false;
+
+  const tryClip = async () => {
+    try {
+      if (!blob || typeof ClipboardItem !== 'function') return false;
+      if (!navigator.clipboard || typeof navigator.clipboard.write !== 'function') return false;
+      await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+      return true;
+    } catch (e) { return false; }
+  };
+  const tryDown = () => {
+    try {
+      if (!blob || typeof URL === 'undefined' || !URL.createObjectURL) return false;
+      const a = document.createElement('a');
+      if (!('download' in a)) return false;
+      const url = URL.createObjectURL(blob);
+      a.href = url; a.download = name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => { try { URL.revokeObjectURL(url); } catch (e) { /* noop */ } }, 8000);
+      return true;
+    } catch (e) { return false; }
+  };
+
+  if (hosted()) {
+    clip = await tryClip();
+    if (!clip) down = tryDown();
+  } else {
+    down = tryDown();
+    clip = await tryClip();
+  }
+  if (down && clip) return 'both';
+  if (down) return 'download';
+  if (clip) return 'clipboard';
+
+  try {
+    showSheet(cv.toDataURL('image/png'), o.closeLabel);
+    return 'view';
+  } catch (e) { return null; }
+}
+
+export default { drawCard, handOut, hosted };

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/reportcard.js
@@ -8,9 +8,22 @@
  *
  * SHARE, v1 (DECISIONS #6, SYNTHESIS #5): exactly one renderer, and exactly one
  * payload shape reaches it - Daily Trigger's spoiler-free emoji grid, copied to
- * the clipboard as TEXT. No canvas, no image export, no URL. Every other game's
- * `share` payload is IGNORED with one log line (once per session, not once per
- * class - a shell that logs 60 times a day is a shell nobody reads).
+ * the clipboard as TEXT. No URL, ever. Every other game's `share` payload is
+ * IGNORED with one log line (once per session, not once per class - a shell
+ * that logs 60 times a day is a shell nobody reads).
+ *
+ * SHARE, v2 (Wobberjockey's ask, tier-2 2026-09-02): THE SAME CARD, AS A
+ * PICTURE. The text copy is untouched and still the first button; beside it is
+ * one that paints the whole night onto a canvas (shell/cardshot.js) and hands
+ * the PNG out. People were already doing this by hand - Wobberjockey pasted the
+ * grid himself on 08-27, Mort screenshotted his card on 08-26 - so this is the
+ * manual thing, done properly.
+ *
+ * The picture is drawn from THIS state, never from the DOM: no html2canvas, no
+ * screenshot API, nothing that can catch a stray overlay or a mod's skin. That
+ * is also what keeps it mod-anonymous end to end (trap 13), the way the share
+ * TEXT already was - neutral keys and literals on the image, the lexicon only
+ * on the button and the toast.
  *
  * The share header is deliberately MOD-ANONYMOUS: the literal string "The
  * Arcademy", not t('arcademy'). A skinned header would out the player's mod in a
@@ -20,6 +33,7 @@
 import { t, gradeLabel, tierLabel } from '../core/lexicon.js';
 import { gradeKey } from '../core/grades.js';
 import { exitBar, sign as signExit, campusPillRow } from './exits.js';
+import { drawCard, handOut } from './cardshot.js';
 
 /** Mod-anonymous, name-only, no URL. Do not "improve" this. */
 export const SHARE_HEADER = 'The Arcademy';
@@ -27,6 +41,17 @@ export const SHARE_HEADER = 'The Arcademy';
 export const SHARE_ALLOWED = Object.freeze(['daily_trigger']);
 /** Mod-anonymous display names for share text only (never for the UI). */
 const SHARE_NAMES = Object.freeze({ daily_trigger: 'Daily Trigger' });
+
+/**
+ * A class name for the PICTURE. Never `t('game_' + key)`: that row is the one a
+ * mod re-titles, and a re-titled class on a posted card outs the mod as loudly
+ * as a skinned header would (trap 13). The neutral system key de-snaked is the
+ * same name the share text has always used for Daily Trigger.
+ */
+function neutralName(key) {
+  if (SHARE_NAMES[key]) return SHARE_NAMES[key];
+  return String(key || '').replace(/_/g, ' ').replace(/(^|\s)\w/g, (c) => c.toUpperCase());
+}
 
 let ignoredShareLogged = false;
 
@@ -109,6 +134,57 @@ export function buildShareText(payload, ctx) {
   const storm = Array.isArray(payload.storm) ? payload.storm.filter((s) => typeof s === 'string') : [];
   if (storm.length) { lines.push(''); lines.push(storm.slice(0, 8).join('')); }
   return lines.join('\n');
+}
+
+/**
+ * The same day, shaped for the canvas. Pure, so a suite can read the model
+ * without a DOM, and MOD-ANONYMOUS by construction: neutral class names, the
+ * raw grade letter rather than `gradeLabel()`, a plain 'Year N' rather than
+ * `tierLabel()`. Only the emoji marks go through the lexicon, exactly as the
+ * share text already does - a mod ships its own set and no set names the mod.
+ *
+ * @param {Object} state  the same object render() was handed
+ * @param {Object=} payload  the accepted share payload, if the day had one
+ */
+export function buildShotModel(state, payload) {
+  const s = state || {};
+  const results = s.results || {};
+  const classes = (s.timetable && s.timetable.classes) || [];
+  const streak = s.streak || { count: 0, perfectDays: 0 };
+  const rows = [];
+  let totalXp = 0;
+  let tickets = 0;
+  let token = false;
+  for (const c of classes) {
+    const r = results[c.gameKey];
+    rows.push({ name: neutralName(c.gameKey), grade: r ? (r.grade || '') : '', xp: (r && r.xp != null) ? r.xp : null });
+    if (r && r.xp) totalXp += Math.round(r.xp);
+    const p = r && r.payout;
+    if (p) {
+      tickets += Math.max(0, Math.round(Number(p.tickets) || 0));
+      if (p.token === true) token = true;
+    }
+  }
+  const grid = [];
+  const gridRows = (payload && Array.isArray(payload.rows)) ? payload.rows : [];
+  for (const row of gridRows.slice(0, 12)) {
+    const cells = Array.isArray(row) ? row : [];
+    grid.push(cells.slice(0, 12).map(markEmoji).join(''));
+  }
+  return {
+    header: SHARE_HEADER,
+    title: s.title || 'Report Card',
+    date: s.dateLabel || (s.timetable && s.timetable.dateSeed) || '',
+    rows,
+    totalXp,
+    tickets,
+    token,
+    streak: streak.count | 0,
+    perfectDays: streak.perfectDays | 0,
+    perfect: !!s.perfect,
+    tier: s.tier != null ? 'Year ' + s.tier : null,
+    grid,
+  };
 }
 
 /** Clipboard with a synchronous fallback (WebView2 without the async API). */
@@ -503,11 +579,12 @@ export function createReportCard({ ceremonies, seep, toast, log, onCounter } = {
       }
     }
 
+    const box = el('div', 'arc-sharebox');
+    let preview = null;
     if (sharePayload) {
       const r = results[sharePayload.gameKey] || {};
       const text = buildShareText(sharePayload, { grade: r.grade, streak: streak.count | 0 });
       if (text) {
-        const box = el('div', 'arc-sharebox');
         const btn = el('button', 'btn', t('share', 'Copy share card'));
         btn.type = 'button';
         btn.addEventListener('click', () => {
@@ -517,10 +594,44 @@ export function createReportCard({ ceremonies, seep, toast, log, onCounter } = {
           });
         });
         box.appendChild(btn);
-        box.appendChild(el('pre', 'arc-sharepreview', text));
-        put(box);
+        preview = el('pre', 'arc-sharepreview', text);
       }
     }
+
+    /* THE PICTURE (v2). It sits BESIDE the text copy and never in front of it:
+     * the grid paste is the small, fast, spoiler-free thing and stays first.
+     * This one is here on EVERY report, grid or no grid - a night with no Daily
+     * Trigger in it is still a night worth posting, and the card is the whole
+     * day anyway. The draw is synchronous and the hand-out is not, so the chip
+     * shuts its own door for the round trip (setBusy, same as the till's). */
+    const shot = el('button', 'btn', t('share_image', 'Save as image'));
+    shot.type = 'button';
+    shot.addEventListener('click', () => {
+      const nope = (why) => {
+        setBusy(shot, false);
+        shout(t('share_image_failed', 'The card would not save'));
+        if (why) say('card image: ' + why);
+      };
+      setBusy(shot, true);
+      let cv = null;
+      try { cv = drawCard(buildShotModel(s, sharePayload)); }
+      catch (e) { return nope('draw threw: ' + ((e && e.message) || e)); }
+      if (!cv) return nope('no canvas on this host');
+      const stamp = String(s.dateLabel || 'report').replace(/[^0-9A-Za-z]+/g, '-').replace(/^-|-$/g, '');
+      handOut(cv, {
+        filename: 'arcademy-' + (stamp || 'report') + '.png',
+        closeLabel: t('share_image_close', 'Close'),
+      }).then((how) => {
+        if (!how) return nope('every door refused');
+        setBusy(shot, false);
+        if (how === 'view') shout(t('share_image_hold', 'Press and hold the card to save it'));
+        else if (how === 'clipboard') shout(t('share_image_copied', 'Card copied. Paste it anywhere.'));
+        else shout(t('share_image_saved', 'Card saved as a picture'));
+      }).catch((e) => nope('hand-out threw: ' + ((e && e.message) || e)));
+    });
+    box.appendChild(shot);
+    if (preview) box.appendChild(preview);
+    put(box);
 
     /* --- out ---
      * A STICKY LIT SIGN, not a button at the bottom of a page. The paper

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -362,6 +362,23 @@ kbd {
   padding:10px 12px; color:var(--ink-dim); overflow-x:auto; max-width:100%;
 }
 
+/* THE LONG-PRESS SHEET - shell/cardshot.js's last rung. A host with neither a
+   download nor an image clipboard (a phone webview) gets the PNG painted into
+   the page instead, so it can be held and saved. z 58 puts it over the report
+   stage and the corkboard and UNDER the toast, which is the thing telling you
+   to press and hold. Any press anywhere takes it away again. */
+.arc-shotsheet {
+  position:fixed; inset:0; z-index:58;
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:14px; padding:24px;
+  background:color-mix(in srgb, var(--ground), transparent 6%);
+}
+.arc-shotsheet img {
+  max-width:min(560px, 92vw); max-height:72vh; width:auto; height:auto;
+  border-radius:14px; border:var(--hairline);
+  box-shadow:0 18px 48px rgba(0,0,0,.55);
+}
+
 /* ---- the fullscreen report beat (shell marks <html> arc-report-on) ----
    The stage is the night ground under a desk lamp; the report itself is a
    graded PAPER laid on it. Base .reportcard/.rcell/.grade rules above still

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1812,6 +1812,14 @@ internal static class ArcademyHostService
         ["replay_board"] = "Flip the board again",
         ["share"] = "Copy share card",
         ["shared"] = "Copied to clipboard",
+        // The picture half of the share (shell/cardshot.js). Button + toast only:
+        // every word drawn ON the image is a neutral literal, so a paste never outs a mod.
+        ["share_image"] = "Save as image",
+        ["share_image_saved"] = "Card saved as a picture",
+        ["share_image_copied"] = "Card copied. Paste it anywhere.",
+        ["share_image_hold"] = "Press and hold the card to save it",
+        ["share_image_failed"] = "The card would not save",
+        ["share_image_close"] = "Close",
         ["done"] = "Done",
         ["retake"] = "Retake",
         ["xp"] = "XP",


### PR DESCRIPTION
## What

A **Save as image** button on the report card, beside the existing text copy. The text copy is untouched and still the first button.

`shell/cardshot.js` (new) does the drawing. `drawCard(model)` paints a 1280px PNG in the house palette **from the render state, never from the DOM** (no html2canvas, no screenshot API, nothing that could catch a stray overlay):

- title and date
- one row per class: grade badge, class name, the XP the host paid
- the day's XP total, the attendance / perfect-attendance / year line
- the till (tickets, and the token on the night it drops)
- the Daily Trigger emoji grid when the day had one
- the perfect-attendance stamp
- an `A R C A D E M Y` wordmark, so a card posted with no caption still says where it came from

`handOut()` walks whichever doors the host actually has:

| host | ladder |
|---|---|
| web (`app.cclabs.app/arcademy`) | `a.download` PNG **and** a best-effort `navigator.clipboard.write` image/png, so paste-into-Discord works |
| WebView2 / react-native-webview | clipboard first (a download in a fullscreen kiosk opens a flyout over the beat or is dropped), then the download, then `.arc-shotsheet` - the PNG painted into the page so a phone can long-press and save |

**No new C# host message.** I grepped `ArcademyHostService.cs` for an existing save/export/share frame and there is none, so the page never asks for one; the only C# touched is six `NeutralLexicon` rows. Toasts on every outcome, through the shell's existing `shout`.

## Why

#tier-2, 2026-09-02: Wobberjockey asked for report cards you can share as an image, owner said "amazing as an idea". People were already doing it by hand - Wobberjockey pasted the emoji grid himself on 08-27, Mort screenshotted his card on 08-26.

## Mod anonymity (trap 13)

Every word drawn **on** the image is a neutral literal, the way `SHARE_HEADER` already was: neutral class names off the system key (never `t('game_' + key)`), the raw grade letter (never `gradeLabel()`), plain `Year N` (never `tierLabel()`), and the house palette by literal rather than `init.palette`. A paste must never out the player's mod. The six new lexicon rows are the **button and the toasts only**, mirrored into `NeutralLexicon` so a mod can still re-voice those.

## How I tested

No headless suite ships in this repo (the arcademy suites live in scratchpad), so I stood up a throwaway static server over the worktree's `Resources/web/arcademy` and drove it with headless Chrome.

- `node --check` on every JS file touched: `shell/cardshot.js`, `shell/reportcard.js`, `core/lexicon.js`.
- **Rendered the card** for a full day (S+/A/B plus one ungraded class, 83 tickets, a token, a 3-row grid, perfect attendance) and eyeballed the PNG: centre-line composition, house palette, no serif, the layout height matches the draw with no hole in it.
- **Bare day** (one class, no grade, no XP, no grid, no stamp) draws 1280x524 with the same math.
- **Every rung of `handOut`**, headless: web ladder returned `download`; with `ClipboardItem` removed and `URL.createObjectURL` throwing it fell to `view`, mounted exactly one `.arc-shotsheet` with a `data:image/png;base64,` img and the localised close label, and one press took it away again. `hosted()` reads true under a faked `window.ReactNativeWebView`. `handOut(null)` returns null rather than throwing.
- **DOM level, through the real `createReportCard`**: with no share payload the box renders with just `Save as image`; with the Daily Trigger payload the order is `Copy share card` | `Save as image` | preview. The button disables for the round trip and re-enables, and the success toast is the lexicon row.

Not verified by machine: the WebView2 and react-native-webview clipboard paths (no desktop or phone run in this environment) - both are wrapped so a refusal falls to the next rung rather than throwing.

## Size

```
6 files changed, 457 insertions(+), 7 deletions(-)
```

Merging syncs the web build to `app.cclabs.app/arcademy` via the arcademy sync Action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtSyPepqh8Ugh3TZ7R6vmX
