### PR TITLE
feat(avalonia): the shell is the startup window; diagnostics moves behind a button

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -28,8 +28,12 @@ namespace ConditioningControlPanel.Avalonia
         public override void OnFrameworkInitializationCompleted()
         {
 
+            // The app shell is the startup window. Until now this head opened the diagnostics
+            // MainWindow, which was right while the shell did not exist and is wrong now that it
+            // does. The diagnostics window is still reachable, from Settings, and RenderProof
+            // still hosts single views inside it - neither depends on it being the startup window.
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-                desktop.MainWindow = new MainWindow();
+                desktop.MainWindow = new Views.Windows.MainShellWindow();
             base.OnFrameworkInitializationCompleted();
         }
     }

--- a/CCP.Avalonia/MainWindow.axaml
+++ b/CCP.Avalonia/MainWindow.axaml
@@ -40,6 +40,17 @@
   <ScrollViewer Padding="20">
     <StackPanel>
 
+      <!-- Back to the shell. This window is opened from Settings as a second window, so the
+           shell is still there behind it and returning is just a close. The button hides itself
+           when there is nothing to go back to - RenderProof hosts views in this window, and a
+           dead control in every one of 186 render proofs would be noise. -->
+      <Button x:Name="BtnBackToShell" HorizontalAlignment="Left" Margin="0,0,0,14"
+              Theme="{StaticResource SecondaryButton}" Cursor="Hand"
+              Click="BtnBackToShell_Click"
+              ToolTip.Tip="Close diagnostics and return to the app">
+        <TextBlock Text="← Back to the app"/>
+      </Button>
+
       <TextBlock Classes="h1" Text="Conditioning Control Panel"/>
       <TextBlock Classes="dim" Margin="0,2,0,16"
                  Text="CCP.Avalonia head — the same CCP.Core engine the Windows app runs, rendering on Linux."/>

--- a/CCP.Avalonia/MainWindow.axaml.cs
+++ b/CCP.Avalonia/MainWindow.axaml.cs
@@ -25,6 +25,9 @@ namespace ConditioningControlPanel.Avalonia
         {
             AvaloniaXamlLoader.Load(this);
 
+            // Owner is not known until the window is shown, so the Back button decides then.
+            Opened += (_, _) => SyncBackButton();
+
             var runtime = this.FindControl<TextBlock>("TxtRuntime")!;
             var paths = this.FindControl<TextBlock>("TxtPaths")!;
             var engine = this.FindControl<TextBlock>("TxtEngine")!;
@@ -86,6 +89,23 @@ namespace ConditioningControlPanel.Avalonia
                 target.Text = $"BLOCK   category={result.Category}   {result.Note}";
                 target.Foreground = Brush("DangerBrush", "#E53935");
             }
+        }
+
+        /// <summary>
+        /// Closes this window, which returns the user to the shell that opened it. Not a swap:
+        /// the shell was never taken down, so there is nothing to restore.
+        /// </summary>
+        private void BtnBackToShell_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => Close();
+
+        /// <summary>
+        /// The Back button only means something when a shell opened this window. RenderProof also
+        /// hosts single views in a MainWindow, and this window is still reachable as a standalone
+        /// diagnostics run, so hide the button unless there is an owner to go back to.
+        /// </summary>
+        private void SyncBackButton()
+        {
+            var back = this.FindControl<global::Avalonia.Controls.Button>("BtnBackToShell");
+            if (back is not null) back.IsVisible = Owner is not null;
         }
     }
 }

--- a/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml
@@ -1887,6 +1887,20 @@
           <TextBlock Text="CCP Catalogue" Foreground="White" VerticalAlignment="Center"/>
         </StackPanel>
       </Button>
+
+      <!-- Diagnostics. Deliberately small and last in the row: a developer affordance, not a
+           setting. Opens this head's diagnostics window (platform, Core paths, engine values, a
+           live moderation verdict) as a SECOND window, so the shell keeps its state and that
+           window's own Back button is just a close. -->
+      <Button Grid.Column="6" x:Name="BtnOpenDiagnostics"
+              HorizontalAlignment="Right" VerticalAlignment="Bottom"
+              Margin="0,0,4,-2" Padding="8,2" FontSize="10"
+              Background="Transparent" BorderThickness="0" Cursor="Hand"
+              Foreground="{DynamicResource TextMutedBrush}"
+              Click="BtnOpenDiagnostics_Click"
+              ToolTip.Tip="Open the Linux head's diagnostics window">
+        <TextBlock Text="diagnostics"/>
+      </Button>
     </Grid>
 
     <!-- Scrolling Marquee Banner - row 3, spans all columns -->

--- a/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
@@ -341,6 +341,30 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void VelvetBtnSchedulerRamp_Click(object? sender, RoutedEventArgs e) { }     // mw.VelvetBtnSchedulerRamp_Click(...)
         private void VelvetBtnCatalogue_Click(object? sender, RoutedEventArgs e) { }         // mw.BtnCatalogue_Click(...)
 
+        /// <summary>
+        /// Opens the head's diagnostics window. A second window rather than a swap, so the shell
+        /// keeps its state and the diagnostics window's own Back button is just a Close.
+        /// Re-entrant: a second click focuses the window that is already open instead of stacking
+        /// duplicates.
+        /// </summary>
+        private void BtnOpenDiagnostics_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_diagnostics is { } open)
+            {
+                open.Activate();
+                return;
+            }
+
+            var owner = TopLevel.GetTopLevel(this) as Window;
+            _diagnostics = new MainWindow();
+            _diagnostics.Closed += (_, _) => _diagnostics = null;
+
+            if (owner is not null) _diagnostics.Show(owner);
+            else _diagnostics.Show();
+        }
+
+        private MainWindow? _diagnostics;
+
         // -- training programs "today" card ----------------------------------------------
         private void ProgramTodayCard_Loaded(object? sender, RoutedEventArgs e) { }          // mw.ProgramTodayCard_Loaded(...)
         private void ProgramTodayCard_Click(object? sender, RoutedEventArgs e) { }           // mw.ProgramTodayCard_Click(...)


### PR DESCRIPTION
The head opened its diagnostics `MainWindow` at startup. That was right while the app shell did not exist, and wrong now that it does.

## What changes
- **Startup is `MainShellWindow`.** One line in `App.axaml.cs`.
- **Diagnostics moves behind a small muted `diagnostics` button** at the end of the Settings action row. Deliberately not styled as a setting: it is a developer affordance.
- It opens as a **second window owned by the shell**, not a swap, so the shell keeps its state. A second click focuses the window already open rather than stacking duplicates.
- **The diagnostics window gains a `← Back to the app` button**, which is therefore just a close.

## Two things worth a reviewer's eye
- The Back button **hides itself when there is no owner**. `RenderProof` also hosts single views inside a `MainWindow`, and a dead control sitting in 186 render proofs is noise. It appears only when a shell actually opened the window.
- **`RenderProof` is untouched.** Hosting a view in a `MainWindow` never depended on that window being the startup one, so the render path is unchanged and still proves what it proved before.

## Verified
Solution builds, Core guards pass, `--smoke` passes, 186/186 views render, and the app launches to the shell on KDE Wayland with an empty log.

75 changed lines across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351