### PR TITLE
feat(avalonia): shell navigation - ShowTab, the door accordion, every rail handler

### DIFF
--- a/CCP.Avalonia/NavCheck.cs
+++ b/CCP.Avalonia/NavCheck.cs
@@ -1,0 +1,48 @@
+using System;
+using Avalonia.Controls;
+using ConditioningControlPanel.Avalonia.Views.Windows;
+
+namespace ConditioningControlPanel.Avalonia
+{
+    /// <summary>
+    /// The smallest thing that fails if shell navigation breaks. Constructs the shell headlessly,
+    /// calls ShowTab the way every rail handler does, and asserts what the user would see.
+    /// </summary>
+    internal static class NavCheck
+    {
+        public static int Run()
+        {
+            RenderProof.EnsureSetUp();
+            var w = new MainShellWindow();
+            bool Vis(string n) => w.FindControl<Control>(n)?.IsVisible == true;
+            double H(string n) => w.FindControl<Control>(n)?.Height ?? -1;
+
+            var fails = 0;
+            void Check(bool ok, string what) { if (!ok) { fails++; Console.Error.WriteLine("FAIL " + what); } }
+
+            Check(Vis("SettingsTab") && !Vis("QuestsTab"), "startup shows Settings only");
+
+            w.ShowTab("quests");
+            Check(Vis("QuestsTab") && !Vis("SettingsTab"), "quests shows QuestsTab and hides Settings");
+            Check(double.IsNaN(H("DoorPanelYou")) && H("DoorPanelStudio") == 0, "quests unfolds the You door only");
+
+            w.ShowTab("Haptics");                       // alias + case-insensitive
+            Check(Vis("StudioTab") && !Vis("QuestsTab"), "haptics lands on StudioTab");
+            Check(double.IsNaN(H("DoorPanelStudio")) && H("DoorPanelYou") == 0, "haptics unfolds the Studio door only");
+
+            w.ShowTab("no-such-tab");
+            Check(Vis("StudioTab"), "unknown key keeps the current tab, never a blank page");
+
+            w.ShowTab("fyp");
+            Check(Vis("StudioTab") && w.CurrentTab == "haptics", "a window key leaves the tab alone");
+
+            var shown = 0;
+            foreach (var n in new[] { "SettingsTab","PresetsTab","QuestsTab","ProgramsTab","EnhancementsTab","DeeperTab","AchievementsTab","CompanionTab","PlayTab","LeaderboardTab","AssetsTab","DiscordTab","AwarenessTab","RemoteControlTab","AvailableSubjectsTab","BambiTakeoverTab","StudioTab","LockdownTab","BlinkTrainerTab","SheListeningTab","GradedIntakeTab","AppSettingsTab","SpiralTab","ExclusivesTab" })
+                if (Vis(n)) shown++;
+            Check(shown == 1, $"exactly one tab visible (saw {shown})");
+
+            Console.WriteLine(fails == 0 ? "nav-check: shell navigation holds." : $"nav-check: {fails} failure(s).");
+            return fails == 0 ? 0 : 1;
+        }
+    }
+}

--- a/CCP.Avalonia/Program.cs
+++ b/CCP.Avalonia/Program.cs
@@ -13,6 +13,12 @@ namespace ConditioningControlPanel.Avalonia
             if (Array.IndexOf(args, "--smoke") >= 0)
                 return HeadlessSmoke.Run();
 
+            // --nav-check drives the shell's tab navigation headlessly and fails if a click
+            // would land on a blank page. The render proofs are still frames; this is the one
+            // check that exercises a click.
+            if (Array.IndexOf(args, "--nav-check") >= 0)
+                return NavCheck.Run();
+
             // --render <path> draws the real window offscreen and saves a PNG. Visual proof that
             // survives on a CI runner with no display server.
             var r = Array.IndexOf(args, "--render");

--- a/CCP.Avalonia/RenderProof.cs
+++ b/CCP.Avalonia/RenderProof.cs
@@ -50,7 +50,7 @@ namespace ConditioningControlPanel.Avalonia
         /// One headless platform per process. SetupWithoutStarting() throws if called twice,
         /// which is what --render-all would otherwise do for every view.
         /// </summary>
-        private static void EnsureSetUp()
+        internal static void EnsureSetUp()
         {
             if (_setUp) return;
             // Start from the app's own builder so the render uses the same Inter font the user

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SpiralRoom.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SpiralRoom.cs
@@ -25,7 +25,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     public partial class MainShellWindow
     {
         // ponytail: needs the services in MainWindow.SpiralRoom.cs; wired when they move to Core.
-        private void BtnNavSpiral_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        private void BtnNavSpiral_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("spiral");  // WPF: ShowTab(SpiralRoom.TabKey)
 
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
@@ -1,113 +1,145 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs (1174 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs (1,174 lines),
+// the part of it that is navigation.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// What is REAL here: ShowTab (hide every tab panel, show one), the door accordion (one door's
+// entry panel open at a time, the door that owns the tab), and every rail/door click handler
+// the XAML names, each of which is now one ShowTab call - exactly what it is in WPF.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// What is NOT, on purpose, each named so it is not lost silently:
+//   - The transition choreography (AnimateTabIn, SwitchTabFx, the Stop*Shimmer/Pulse/Motion
+//     calls) and the door open/close height animation. ponytail: panels snap open (Height =
+//     NaN) and shut (0); the WPF MeasureDoorPanel + NavDoorExpandMs tween returns with the FX
+//     partials.
+//   - Per-tab side effects on the way in (RefreshPresetsList, spending HasSeenProgramsTab and
+//     the first-run explainer, StopPolling on leaving Available Subjects, SelectRack for the
+//     studio rack, ShowSettingsSection for "progression"). All reach App.* or a service.
+//   - Bark (App.Bark.NotifyTabNavigated) and EmiDesk (EmiTargets.NoteTabOpened) hooks.
+//   - The three keys that are WINDOWS, not tabs, and the one launcher door: "patreon" (opens
+//     Settings · Account via ShowAppInfoPopup), "fyp" (OpenFypFeed), "justdrop" (the shop host)
+//     and the "webapp" door. Each is a documented no-op below until its service exists here.
+//   - BtnNavMediaLog: WPF raises AssetsTab.BtnMediaLog's Click. That button is inside the
+//     ported AssetsTabView and its handler is a stub, so this lands on the Assets tab instead.
+//   - An "active" state on the rail. NavDoorButton has no :checked/.active selector on this
+//     head, so nothing is highlighted yet.
 //
-// Members dropped (44):
-//   private void BtnSettings_Click(…)
-//   private void BtnPresets_Click(…)
-//   private void BtnQuests_Click(…)
-//   private void BtnPrograms_Click(…)
-//   private void BtnEnhancements_Click(…)
-//   private static readonly Dictionary<string, string> BarkTabAliases
-//   private static string CanonicalTabKey(…)
-//   internal void ShowTab(…)
-//   private static readonly(…)
-//   internal static readonly string[] NavLauncherDoors
-//   internal const string WebAppUrl
-//   internal const string ProfileSharingUrl
-//   private const double NavEntryRowHeight
-//   private const int NavDoorExpandMs
-//   private string _expandedDoor
-//   private static string? NavDoorForTab(…)
-//   private Button? NavDoorHeaderForTab(…)
-//   private bool IsDoorExpandedForTab(…)
-//   internal Button? NavAnchorForTab(…)
-//   private readonly Dictionary<string, Button> _navHeaderPulses
-//   private bool StartNavDoorHeaderPulse(…)
-//   private void StopNavDoorHeaderPulse(…)
-//   internal void ExpandDoorForTab(…)
-//   private void SetExpandedDoor(…)
-//   private bool IsDoorPanelOpenFor(…)
-//   private void SetDoorPanelExpanded(…)
-//   private static double MeasureDoorPanel(…)
-//   private void NavDoor_Click(…)
-//   private void DoorWebApp_Click(…)
-//   internal Views.Tabs.HapticsTabView HapticsTab
-//   private void BtnNavStudio_Click(…)
-//   private void BtnNavHaptics_Click(…)
-//   private void BtnNavPlay_Click(…)
-//   private void BtnNavBambiTakeover_Click(…)
-//   private void BtnNavSheListening_Click(…)
-//   private void BtnNavGradedIntake_Click(…)
-//   private void BtnNavLockdown_Click(…)
-//   private void BtnNavBlinkTrainer_Click(…)
-//   private void BtnNavRemoteControl_Click(…)
-//   private void BtnNavMediaLog_Click(…)
-//   private void MaybeShowFeatureIntro(…)
-//   private bool _dashboardIntroQueued
-//   internal void OnDashboardTabVisibilityChanged(…)
-//   private void RefreshBlinkTrainerTab(…)
+// Every panel and door is resolved by x:Name through FindControl, never by generated field, so
+// a panel this head does not carry is skipped rather than a compile error.
+
+using System;
+using System.Collections.Generic;
+using Avalonia.Controls;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnEnhancements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>The tab key currently shown, lower-case. "settings" until the first switch,
+        /// which is the panel the XAML leaves visible.</summary>
+        internal string CurrentTab { get; private set; } = "settings";
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavBambiTakeover_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>Tab key -> the x:Name of the panel it shows. Aliases point at one panel:
+        /// "lab" is the old name for the Play card wall, "haptics" is a module inside Studio,
+        /// "progression" is a section of Settings. Same table as the WPF switch.</summary>
+        private static readonly Dictionary<string, string> TabPanels = new(StringComparer.Ordinal)
+        {
+            ["settings"] = "SettingsTab",        ["progression"] = "SettingsTab",
+            ["presets"] = "PresetsTab",          ["quests"] = "QuestsTab",
+            ["programs"] = "ProgramsTab",        ["enhancements"] = "EnhancementsTab",
+            ["deeper"] = "DeeperTab",            ["achievements"] = "AchievementsTab",
+            ["companion"] = "CompanionTab",      ["play"] = "PlayTab",  ["lab"] = "PlayTab",
+            ["leaderboard"] = "LeaderboardTab",  ["assets"] = "AssetsTab",
+            ["discord"] = "DiscordTab",          ["awareness"] = "AwarenessTab",
+            ["remotecontrol"] = "RemoteControlTab", ["availablesubjects"] = "AvailableSubjectsTab",
+            ["bambitakeover"] = "BambiTakeoverTab", ["studio"] = "StudioTab", ["haptics"] = "StudioTab",
+            ["lockdown"] = "LockdownTab",        ["blinktrainer"] = "BlinkTrainerTab",
+            ["shelistening"] = "SheListeningTab", ["gradedintake"] = "GradedIntakeTab",
+            ["appsettings"] = "AppSettingsTab",  ["spiral"] = "SpiralTab",
+            ["exclusives"] = "ExclusivesTab",
+        };
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavBlinkTrainer_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>Keys that open a window or a service rather than a tab. ShowTab leaves the
+        /// current tab alone for them, as WPF does; the launch itself is not on this head yet.</summary>
+        private static readonly HashSet<string> WindowKeys = new(StringComparer.Ordinal)
+            { "patreon", "fyp", "justdrop", "webapp" };
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavGradedIntake_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>The rail's doors: Tag on the door button, the tab it opens, the tabs it owns,
+        /// and the entry panel that unfolds under it (null for the two doors that have none).
+        /// Copied from WPF's NavDoorMap.</summary>
+        private static readonly (string Door, string DefaultTab, string[] Tabs, string? Panel)[] NavDoorMap =
+        {
+            ("home",        "settings",    new[] { "settings", "progression" },                                   null),
+            ("studio",      "studio",      new[] { "studio", "presets", "haptics" },                              "DoorPanelStudio"),
+            ("companion",   "companion",   new[] { "companion", "bambitakeover", "shelistening", "awareness" },   "DoorPanelCompanion"),
+            ("play",        "play",        new[] { "play", "lab", "deeper", "exclusives", "gradedintake", "lockdown", "blinktrainer", "remotecontrol", "availablesubjects" }, "DoorPanelPlay"),
+            ("you",         "discord",     new[] { "discord", "spiral", "quests", "achievements", "enhancements", "programs", "leaderboard" }, "DoorPanelYou"),
+            ("library",     "assets",      new[] { "assets" },                                                    "DoorPanelLibrary"),
+            ("appsettings", "appsettings", new[] { "appsettings" },                                               null),
+        };
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavHaptics_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>
+        /// Shows one tab and hides the rest, and unfolds the door that owns it. Case-insensitive
+        /// at the door for the same reason WPF is: a deep link or a mod that says "Settings" must
+        /// not land on a blank page. An unknown key is a no-op that keeps the current tab, never a
+        /// page with nothing on it.
+        /// </summary>
+        internal void ShowTab(string? tab)
+        {
+            tab = (tab ?? string.Empty).ToLowerInvariant();
+            if (WindowKeys.Contains(tab)) return;                 // a window, not a tab - see header
+            if (!TabPanels.TryGetValue(tab, out var target)) return;
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavLockdown_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+            foreach (var name in new HashSet<string>(TabPanels.Values))
+            {
+                var panel = this.FindControl<Control>(name);
+                if (panel is not null) panel.IsVisible = name == target;
+            }
+            CurrentTab = tab;
+            SetExpandedDoor(NavDoorForTab(tab));
+        }
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavMediaLog_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        private static string? NavDoorForTab(string tab)
+        {
+            foreach (var d in NavDoorMap)
+                if (Array.IndexOf(d.Tabs, tab) >= 0) return d.Door;
+            return null;
+        }
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavPlay_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>One door open at a time. ponytail: snaps, no height tween.</summary>
+        private void SetExpandedDoor(string? door)
+        {
+            foreach (var d in NavDoorMap)
+            {
+                if (d.Panel is null) continue;
+                var panel = this.FindControl<Control>(d.Panel);
+                if (panel is not null) panel.Height = d.Door == door ? double.NaN : 0;
+            }
+        }
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavRemoteControl_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        private void NavDoor_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.Tag is not string door) return;
+            foreach (var d in NavDoorMap)
+                if (string.Equals(d.Door, door, StringComparison.Ordinal)) { ShowTab(d.DefaultTab); return; }
+            // "webapp" and any unmapped door: a launcher, not a tab. No-op here, as in WPF.
+        }
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavSheListening_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        private void BtnSettings_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("settings");
+        private void BtnPresets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("presets");
+        private void BtnQuests_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("quests");
+        private void BtnPrograms_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("programs");
+        private void BtnEnhancements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("enhancements");
+        private void BtnNavStudio_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("studio");
+        private void BtnNavHaptics_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("haptics");
+        private void BtnNavPlay_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("play");
+        private void BtnNavBambiTakeover_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("bambitakeover");
+        private void BtnNavSheListening_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("shelistening");
+        private void BtnNavGradedIntake_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("gradedintake");
+        private void BtnNavLockdown_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("lockdown");
+        private void BtnNavBlinkTrainer_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("blinktrainer");
+        private void BtnNavRemoteControl_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("remotecontrol");
 
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnNavStudio_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnPresets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnPrograms_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnQuests_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void BtnSettings_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
+        // Still a stub: the web-app door launches a browser, which is a service on this head.
         private void DoorWebApp_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
-        // ponytail: needs the services in MainWindow.TabNavigation.cs; wired when they move to Core.
-        private void NavDoor_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
+        private void BtnNavMediaLog_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) => ShowTab("assets");
     }
 }


### PR DESCRIPTION
The shell drew but nothing responded: all 86 handlers the XAML names were empty. This restores the part of `MainWindow.TabNavigation.cs` that is navigation, so every door and rail entry switches tabs.

## Real
- **`ShowTab`**: hide every tab panel, show one. Case-insensitive at the door, for the reason WPF is: a deep link or a mod saying `Settings` must not land on a blank page. An unknown key keeps the current tab.
- **The door accordion**: the door that owns the tab unfolds, the others fold. WPF's `NavDoorMap` copied row for row.
- **Every rail and door click handler**, each the one `ShowTab` call it is in WPF.
- Panels and doors resolve by `x:Name`, so a panel this head lacks is skipped rather than a compile error.

## Not yet, each named in the file header
Transition choreography and the door height tween (panels snap open and shut), per-tab side effects that reach `App.*` or a service, the bark and EmiDesk hooks, the three keys that are windows rather than tabs (`patreon`, `fyp`, `justdrop`), and an active state on the rail, for which no selector exists on this head yet.

## The check
`--nav-check` constructs the shell headlessly, clicks through `ShowTab`, and asserts exactly one tab is visible and the right door is open, including the alias and unknown-key cases. The render proofs are still frames; this is the one proof that exercises a click.

## Verified
Solution builds, Core guards pass, `--smoke` and `--nav-check` pass, 186/186 views render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351