### PR TITLE
fix(webcam): stop the camera off the UI thread so turning it off cannot wedge the app

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.BlinkTrainer.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.BlinkTrainer.cs
@@ -314,7 +314,10 @@ namespace ConditioningControlPanel
 
             if (svc.IsRunning)
             {
-                svc.Stop();
+                // Teardown joins the capture thread (up to 5s) and disposes the
+                // ONNX sessions, so it never runs on the UI thread (BUG-BRR252E2RM).
+                try { await svc.StopAsync(); }
+                catch (Exception ex) { App.Logger?.Warning(ex, "ToggleWebcamTrackingAsync: StopAsync threw"); }
                 RefreshBlinkTrainerTrackerButton();
                 if (announce)
                     App.Notifications?.Show(Loc.Get("camera_shortcut_toast_stopped"),
@@ -1428,7 +1431,7 @@ namespace ConditioningControlPanel
                 App.ApplyCalibrationScreenPlacement(recalDlg);
                 recalDlg.ShowDialog();
 
-                if (startedHere) svc.Stop();
+                if (startedHere) await svc.StopAsync();
                 RefreshBlinkTrainerWebcamColumn();
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs
@@ -453,14 +453,22 @@ namespace ConditioningControlPanel
             }
         }
 
-        private void WebcamActivePill_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        private async void WebcamActivePill_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             // Click is the panic-stop affordance. Stops every consumer that
             // shares App.Webcam — Webcam Triggers, Focus Gaze, Blink Trainer,
             // Gaze Minigame all release together when the service stops.
             try { App.GazeFocus?.Stop(); } catch { }
             try { App.BlinkTrainer?.Stop(); } catch { }
-            try { App.Webcam?.Stop(); } catch { }
+            // Awaited, never called inline: the webcam teardown joins the capture
+            // thread (up to 5s) and disposes the ONNX sessions, which locked the
+            // UI thread solid on a wedged driver (BUG-BRR252E2RM).
+            try
+            {
+                var svc = App.Webcam;
+                if (svc != null) await svc.StopAsync();
+            }
+            catch (Exception ex) { App.Logger?.Debug("WebcamActivePill_Click stop failed: {Error}", ex.Message); }
         }
 
         internal async void BtnWebcamDebugStart_Click(object sender, RoutedEventArgs e)
@@ -474,9 +482,9 @@ namespace ConditioningControlPanel
 
             if (svc.IsRunning)
             {
-                svc.Stop();
                 AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking";
                 AppendWebcamDebugLog("Stop requested.");
+                await StopWebcamOffUiThreadAsync(svc);
                 RefreshBlinkTrainerTrackerButton();
                 return;
             }
@@ -537,6 +545,23 @@ namespace ConditioningControlPanel
                 App.Logger?.Warning(ex, "MainWindow: webcam Start() threw on worker thread");
                 AppendWebcamDebugLog($"Start() threw: {ex.Message}");
                 return false;
+            }
+        }
+
+        // Mirror of the above for teardown. Stop() joins the capture thread for
+        // up to 5s and then disposes the capture graph plus three ONNX sessions;
+        // run on the UI thread that is a multi-second freeze on any camera whose
+        // driver is slow to release (BUG-BRR252E2RM).
+        private async Task StopWebcamOffUiThreadAsync(WebcamTrackingService svc)
+        {
+            try
+            {
+                await svc.StopAsync();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "MainWindow: webcam Stop() threw on worker thread");
+                AppendWebcamDebugLog($"Stop() threw: {ex.Message}");
             }
         }
 
@@ -756,7 +781,7 @@ namespace ConditioningControlPanel
             // Only auto-stop if calibration was the only reason it's running.
             if (startedHere && result != true)
             {
-                svc.Stop();
+                await StopWebcamOffUiThreadAsync(svc);
                 AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking";
             }
 
@@ -1051,7 +1076,7 @@ namespace ConditioningControlPanel
             if (svc.Calibration == null)
             {
                 AppendWebcamDebugLog("No calibration loaded — run Calibrate (16-point) first.");
-                if (startedHere) { svc.Stop(); AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking"; }
+                if (startedHere) { await StopWebcamOffUiThreadAsync(svc); AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking"; }
                 return;
             }
 
@@ -1066,7 +1091,7 @@ namespace ConditioningControlPanel
             // leave it running.
             if (startedHere)
             {
-                svc.Stop();
+                await StopWebcamOffUiThreadAsync(svc);
                 AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking";
             }
         }
@@ -1108,7 +1133,7 @@ namespace ConditioningControlPanel
             if (svc.Calibration == null)
             {
                 AppendWebcamDebugLog("No calibration loaded — run Calibrate (16-point) first. Quick Recal only nudges an existing calibration.");
-                if (startedHere) { svc.Stop(); AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking"; }
+                if (startedHere) { await StopWebcamOffUiThreadAsync(svc); AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking"; }
                 return;
             }
 
@@ -1122,7 +1147,7 @@ namespace ConditioningControlPanel
 
             if (startedHere)
             {
-                svc.Stop();
+                await StopWebcamOffUiThreadAsync(svc);
                 AppSettingsTab.BtnWebcamDebugStart.Content = "Start tracking";
             }
 

--- a/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
@@ -1072,6 +1072,19 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public Task<bool> StartAsync() => Task.Run(() => Start());
 
+        /// <summary>
+        /// Runs <see cref="Stop"/> on a worker thread, for the same reason
+        /// <see cref="StartAsync"/> exists. Stop() joins the capture thread with
+        /// 2s + 3s timeouts and then disposes the OpenCV capture and the three
+        /// ONNX sessions; on a wedged driver that is a 5s UI freeze followed by a
+        /// native teardown that can take seconds more (BUG-BRR252E2RM: the panel
+        /// "acts as if the system is under a very heavy load", only closable from
+        /// Task Manager). UI callers should await this rather than calling Stop()
+        /// directly. The shutdown path (Dispose) keeps the synchronous Stop(),
+        /// because the process must not exit while the join is still pending.
+        /// </summary>
+        public Task StopAsync() => Task.Run(() => Stop());
+
         public void Stop()
         {
             Thread? thread;
@@ -1105,10 +1118,10 @@ namespace ConditioningControlPanel.Services
             {
                 if (!thread.Join(TimeSpan.FromSeconds(2)))
                 {
-                    App.Logger?.Warning("WebcamTrackingService: capture thread did not exit within 2s — extending wait");
+                    App.Logger?.Warning("WebcamTrackingService: capture thread did not exit within 2s (thread state {ThreadState}) — extending wait", thread.ThreadState);
                     if (!thread.Join(TimeSpan.FromSeconds(3)))
                     {
-                        App.Logger?.Error("WebcamTrackingService: capture thread did not exit within 5s total — leaving native handles alive to avoid disposal race");
+                        App.Logger?.Error("WebcamTrackingService: capture thread did not exit within 5s total (thread state {ThreadState}) — leaving native handles alive to avoid disposal race. The abandoned loop throttles itself and exits once the driver returns.", thread.ThreadState);
                         lock (_stateLock)
                         {
                             SetState(WebcamTrackingState.Error);
@@ -1806,6 +1819,18 @@ namespace ConditioningControlPanel.Services
 
                     if (!capture.Read(frame) || frame.Empty())
                     {
+                        // Read() can sit for seconds on a wedged driver, so a stop
+                        // may have been requested (and even abandoned by Stop()'s
+                        // join) while we were inside it. Back off before looping:
+                        // once Stop() has given up, nothing else throttles this
+                        // thread, and a dead camera fails Read() instantly - that
+                        // is the tight spin that pegs a core and makes the whole
+                        // machine feel loaded (BUG-BRR252E2RM).
+                        if (_stopRequested)
+                        {
+                            Thread.Sleep(100);
+                            break;
+                        }
                         consecutiveReadFails++;
                         if (consecutiveReadFails >= MaxConsecutiveReadFails)
                         {
@@ -1817,6 +1842,12 @@ namespace ConditioningControlPanel.Services
                         continue;
                     }
                     consecutiveReadFails = 0;
+
+                    // Honour a stop request within one frame: skip ~20-30ms of
+                    // inference (and the UI events it raises) for a frame nobody
+                    // is waiting for any more, so Stop()'s join lands inside its
+                    // first timeout instead of leaking the thread.
+                    if (_stopRequested) break;
 
                     // Capture-clock fps watchdog. Ticked HERE — the instant
                     // Read() returned a frame, before any processing and before

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -723,7 +723,12 @@ namespace ConditioningControlPanel.Views.Deeper
 
             if (svc.IsRunning)
             {
-                svc.Stop();
+                // Off the UI thread: the teardown joins the capture thread for up
+                // to 5s and then disposes the capture graph and the ONNX sessions
+                // (BUG-BRR252E2RM - the panel looked hung after turning the camera
+                // off, and had to be killed from Task Manager).
+                try { await svc.StopAsync(); }
+                catch (Exception ex) { App.Logger?.Warning(ex, "EnhancementPlayer: webcam StopAsync threw"); }
                 return;
             }
 


### PR DESCRIPTION
## Bug

`CC-Labs-llc/ccp-bugs#1102` (HIGH, BUG-BRR252E2RM): "Panel freezes and needs to be forced closed when turning off camera... the panel acts as if the system is under a very heavy load with mouse moving extremely slow across the screen. Only way to close the panel is through task manager." Reported for both the title-bar camera pill and the tracking toggle.

## Root cause

`ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs:1075` `Stop()` runs entirely on the caller's thread, and every UI caller called it inline:

- `:1118-1131` joins the capture thread with a 2s then a further 3s timeout.
- `:1137-1138` then calls `ReleaseModels()` / `ReleaseCapture()`, disposing three ONNX `InferenceSession`s and the OpenCV `VideoCapture` graph. Both are native teardowns that can take seconds on a camera whose driver is slow to release.

So the UI thread was blocked for up to 5s of joining plus the native release. Worse, when the capture thread was inside a blocking `VideoCapture.Read()` the joins timed out, `Stop()` deliberately abandoned the thread (`:1124`) and that thread carried on running a full 30fps detect + mesh + iris pipeline: the "system under very heavy load" the reporter describes.

`CaptureLoop` (`:1788`) also only checked `_stopRequested` at the top of the loop, so a stop request arriving during a read cost a whole extra frame of inference before it was seen.

`StartAsync()` at `:1073` already existed for exactly this reason on the start side, along with `MainWindow.LabTab.cs` `StartWebcamOffUiThreadAsync`.

## Fix

- `WebcamTrackingService.StopAsync()`: `Task.Run(() => Stop())`, mirroring `StartAsync()`. The join and both native releases now happen on a thread-pool thread. `Stop()` is unchanged and stays the shutdown path (`Dispose()` at `:1263` keeps calling it, because the process must not exit while a join is pending).
- Every UI caller now awaits it, inside existing `async` handlers, each with a try/catch:
  - `MainWindow.LabTab.cs` `WebcamActivePill_Click` (the title-bar panic-stop, now `async void`), `BtnWebcamDebugStart_Click`, the calibration / tracker-test / quick-recal auto-stops, via a new `StopWebcamOffUiThreadAsync` helper that mirrors the existing start helper.
  - `MainWindow.BlinkTrainer.cs` `ToggleWebcamTrackingAsync` (also the global camera hotkey) and `BtnBlinkTrainerQuickRecal_Click`.
  - `Views/Deeper/EnhancementPlayerWindow.xaml.cs` `BtnEyeTracking_Click`.
- `CaptureLoop` checks `_stopRequested` between `Read()` and `ProcessFrame()`, so a stop is honoured within one frame rather than one full inference pass, which keeps the join inside its first 2s window.
- If a read fails while a stop is pending, the loop sleeps 100ms and exits instead of retrying: once `Stop()` has abandoned the thread nothing else throttles it, and a dead camera fails `Read()` instantly, which is the tight spin that can peg a core.
- Both join-timeout log lines now include `thread.ThreadState` so an abandoned loop is identifiable in `app.log`.

No change to the tracking maths, calibration, or the gaze pipeline.

Not converted on purpose: the webcam auto-stop inside `EnhancementPlayerWindow`'s window-teardown path (`:2141`), which is a synchronous cleanup routine where introducing an await would reorder disposal.

## Verified

- `dotnet build -c Debug`: Build succeeded, 0 errors (344 pre-existing CA1416-style warnings).
- `cd Tests/ConditioningControlPanel.Tests; dotnet test`: **Passed - Failed: 0, Passed: 5169, Skipped: 0**, 53s. There is no webcam or gaze test class in the suite (the service needs a real camera and the ONNX models), so this is a regression check only.
- NOT verified: runtime behaviour. Per the hotfix rules the app was not launched (single instance, would hijack the owner's running app), and no camera was attached, so the actual freeze-on-stop has not been reproduced or observed fixed. The abandoned-thread backoff path in particular is reachable only with a wedging driver.

## Size

77 insertions, 13 deletions across 4 files (`git diff --stat origin/main...HEAD`: 4 files changed, 77 insertions(+), 13 deletions(-)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
