### PR TITLE
fix(arcademy): keep the painted door sign inside the frame on a phone

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
@@ -586,6 +586,28 @@ html.arc-mobile .arm-hot.arm-exit .arm-hot-tag {
   bottom: -40px;
   padding: 6px 16px;
   font-size: 22px;
+
+  /* ...AND IT HANGS OFF THE RIGHT EDGE OF THE PLANE UNLESS IT IS PINNED (owner
+     report 2026-09-03, iPhone portrait: the sign under Homeroom 101's corridor
+     door reads "BACK TO CAMPU"). The tag is centred on its OWN door (the base
+     rule's `left: 50%` + `translateX(-50%)`) and every painted exit in the
+     school is right of centre: Homeroom's rect is [1240, 115, 106, 350], so the
+     centre sits at stage x1293 with 83px of plane left before the frame edge,
+     while 14 tracked caps at 22px measure ~260px and spend ~130 of them to the
+     right. `.arm-root` is `overflow: hidden`, so the tail is cut. It is a
+     phone-only break because it is bought with the doubled type: at the
+     desktop's 13px the same label is ~156px wide and its half still clears
+     1376, which is why a mouse never saw it.
+
+     Pinned to the door's RIGHT edge the sign grows leftwards INTO the room, so
+     it cannot reach the frame however long the localised string runs. Safe for
+     every `.arm-exit` in the building - the three painted class doors sit at
+     x1240, x1028 and x936 and the Records office storeroom at x1175, all of
+     them right of centre, none anywhere near the left edge. The rect under it
+     is unchanged, so the press is the same press. Desktop keeps the centre. */
+  left: auto;
+  right: 0;
+  transform: none;
 }
 
 html.arc-mobile .arm-bar {


### PR DESCRIPTION
## Bug

Discord ticket (no `ccp-bugs` issue). iPhone, Safari, portrait, `app.cclabs.app`
Arcademy: in the Homeroom 101 room scene the "BACK TO CAMPUS" sign under the
painted corridor door hangs off the right edge of the screen and reads
"BACK TO CAMPU". The button under it still works, so this is cosmetic only.

## Root cause

`Resources/web/arcademy/shell/room.js:400-407` builds the painted exit as
`.arm-hot.arm-exit` with an `.arm-hot-tag` label inside it, positioned by
`Resources/web/arcademy/shell/rooms.css:143-150`:

```
.arm-hot .arm-hot-tag { position:absolute; left:50%; bottom:-26px;
                        transform:translateX(-50%); white-space:nowrap; }
```

So the tag is centred on its own door. The geometry, all of it in the fixed
1376x768 stage plane that `fit()` scales to the screen:

- Homeroom's exit rect is `[1240, 115, 106, 350]` (`room.js:91`), so the door
  centres at stage x1293 and the plane's right edge is x1376. That leaves 83
  stage px of room to the right of the anchor.
- On a phone `rooms.css:584-589` doubles the tag ("every number here is a stage
  pixel", the existing note): `font-size: 22px`, `padding: 6px 16px`. Fourteen
  tracked caps at 22px plus 32px of padding measure roughly 260 stage px, so
  about 130 of them fall to the right of the anchor.
- 130 > 83, so ~45 stage px overhang the plane, and `.arm-root` is
  `overflow: hidden` (`rooms.css:17-22`). That is the missing "S" and the right
  half of the plaque, which is exactly what the screenshot shows.

It is phone-only because the overhang is bought with the doubled type: at the
desktop's 13px the label measures about 156px, half of it 78px, which fits the
83px of margin. That is why nobody caught it with a mouse.

Note the overhang is in STAGE pixels, so it is identical in landscape and
portrait - the phone scale factor divides both sides of the comparison. The fix
is therefore in the existing (unqualified) `html.arc-mobile` block, not in a new
portrait-only one.

## Fix

Three declarations added to the block that already exists for this tag on touch,
`rooms.css:584`: `left: auto; right: 0; transform: none;`. The sign is pinned to
the door's right edge instead of centred on it, so it grows leftwards into the
room and cannot reach the frame however long the localised string runs.

Safe for every `.arm-exit` in the building - all four sit right of centre and
none is near the left edge, so nothing gets pushed off the other side:

| where | rect x | file |
|---|---|---|
| Homeroom 101 corridor door | 1240 | `room.js:91` |
| (second scene) | 1028 | `room.js:107` |
| (third scene) | 936 | `room.js:163` |
| Records office storeroom (`quiet: true` -> `.arm-exit` via `scene.js:574`) | 1175 | `recordsroom.js:79` |

Desktop keeps the centred tag, untouched - the existing note in that block
("the desktop rule is untouched, so a mouse still finds the door the way it was
signed off") still holds.

No JS changed. The hotspot rect is untouched, the tag still takes no pointer
events, so the press is the same press.

I checked for a second copy of the plaque: `arm-hot-tag` exists in exactly three
files repo-wide (`shell/room.js`, `shell/scene.js`, `shell/rooms.css`). The
`lite` variant is a class on the same root (`.arm-lite`) served by the same
stylesheet, not a separate build, and `shell/exits.js`'s campus pill / sticky
bar / arrow sign are different elements that never mint an `.arm-hot-tag`. So
this one rule is the whole surface.

## Verified

- No .NET build or test run: the change is one CSS file under
  `Resources/web/arcademy/`, no C# and no JS. `node --check` was not applicable
  for the same reason (no JS touched).
- CSS sanity check against `HEAD`: brace count unchanged at 107/107, comment
  count 50 -> 51, no non-ASCII and no em-dash on any added line, CRLF preserved
  (the diff is 22 insertions and 0 deletions, so there is no line-ending churn).
- **NOT verified by rendering.** I cannot run the Arcademy page or a phone here,
  so the numbers above are reasoned from the authored stage rects and the type
  metrics, not measured off a screen. The text-width figures (~260 stage px at
  22px, ~156 at 13px) are estimates for 14 tracked bold caps; the overhang they
  predict matches the screenshot's cut point (the "S" plus the right padding),
  which is the only empirical check I have. Worth a look on a phone in both
  orientations, and in German, where `Zurueck zum Campus` is the long label.

## Size

22 changed lines (`git diff --stat origin/main...HEAD`: 1 file changed, 22
insertions). Of those, 19 are the explanatory comment the house style asks for
and 3 are declarations.

## After merge

The web sync must be dispatched for this to reach `app.cclabs.app`. Requesting
agent said they will do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
