### PR TITLE
fix(video): don't start a video on top of the previous clip's wedged Stop()

### DIFF
--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -165,6 +165,17 @@ namespace ConditioningControlPanel.Services
         // it treats the player as wedged and quarantines it. Only a real wedge should ever spend a
         // retire from the per-session budget.
         private const int StopStragglerGraceMs = 4000;
+        // Stop() tasks from the LAST teardown that were still running when CloseAll returned, plus
+        // the instance they belong to. The vmem/blur path deliberately never waits for them on the
+        // dispatcher and the VideoView path gives up after ~4.5s, so the NEXT video can start while
+        // a previous Stop() is still inside native code. A Play() that overlaps a wedged Stop() on
+        // the same instance never presents a frame: "fullscreen goes black for 2-3 seconds and then
+        // the video counts as watched" (#1121).
+        private static volatile Task[]? _pendingStopTasks;
+        private static LibVLC? _pendingStopOwner;
+        // How long the next video waits (pumping) for those stragglers before it abandons the owning
+        // instance and builds its players on a fresh one.
+        private const int PendingStopWaitMs = 2000;
 
 #if DEBUG
         // Fault injection for the wedge cluster (#765/#766/#767). Set CCP_FAULT_WEDGE_STOP=1 and the
@@ -2791,6 +2802,12 @@ namespace ConditioningControlPanel.Services
                 StartMaxLengthCapTimer();
                 VideoDiag.Log("VIDEO", $"safety + max-length timers armed +{showSw.ElapsedMilliseconds}ms");
 
+                // A previous teardown's Stop() may still be inside native code right now (#1121):
+                // the vmem/blur path hands its stop tasks straight to the async quarantine without
+                // ever waiting on the dispatcher. Building this video's players on an instance whose
+                // last Stop() has not returned is how a clip ends up black for its whole run.
+                AwaitPendingStops();
+
                 // Ensure LibVLC is initialized (deferred from startup for faster launch).
                 // #616-#623 NOTE: this call runs ON THE UI THREAD and takes _libVLCLock, which a
                 // background rebuild (RetireSharedLibVLC's Task.Run) can hold for the whole duration
@@ -3648,9 +3665,10 @@ namespace ConditioningControlPanel.Services
         ///     fallback safety timer (black and silent for minutes, un-closable in strict mode). The
         ///     retry only moves that skip from ~8s to ~16s, and buys back the runs where the decoder
         ///     was merely slow to come up while three screens spun up at once.
-        ///   * on a SINGLE-surface rig (the majority) the primary is the only surface and gets NO retry
-        ///     rung at all, so that path skips at exactly the ~8s the released build does. The rung is
-        ///     decided by the RIG, not by the role: a lone primary has no siblings to be starved by.
+        ///   * a LONE primary gets that one rung too, as of #1121. Denying it was what left the
+        ///     single-monitor majority with no recovery of any kind: the one surface that could have
+        ///     come back was the one surface not allowed to try. Worst case it costs one more grace
+        ///     window before the same skip.
         ///
         /// See VideoSurfaceHealth.DecideFrameWatchdog / ShouldAbortClip for both rules in pure form.
         /// </summary>
@@ -3686,11 +3704,11 @@ namespace ConditioningControlPanel.Services
                 try
                 {
                     bool tornDown = !_videoPlaying || _isCleaningUp || gen != _teardownGeneration;
-                    // How many surfaces this clip armed. The retry rung is decided by the RIG, not by
-                    // the role (see the ladder note above): a mirror always gets its second chance, and
-                    // so does the audio-bearing surface as soon as it has siblings. A lone primary —
-                    // the single-monitor majority — gets none, which keeps that path's ~8s skip exactly
-                    // where the released build has it.
+                    // How many surfaces this clip armed. Every armed surface now gets its one second
+                    // chance (see the ladder note above and AllowsFrameRetry): a mirror because the
+                    // clip keeps playing while it retries, the audio-bearing surface because a skip
+                    // is otherwise the only outcome - including on the single-monitor rig, which is
+                    // where the #1121 reports come from. Zero armed surfaces still gets none.
                     int armed;
                     lock (_blurFrameWatchLock) { armed = _blurWatches.Count; }
                     switch (VideoSurfaceHealth.DecideFrameWatchdog(tornDown, _gracePaused, surface.HasRendered, watch.RetryUsed,
@@ -3738,7 +3756,7 @@ namespace ConditioningControlPanel.Services
                             VideoSurfaceHealth.Report("libvlc", monitor, primary, -1,
                                 watch.RetryUsed
                                     ? $"no frame within {VoutGraceMs}ms, and none after one retry"
-                                    : $"no frame within {VoutGraceMs}ms, no retry rung on a single-surface rig");
+                                    : $"no frame within {VoutGraceMs}ms, no retry rung available for this surface");
                             if (!VideoSurfaceHealth.ShouldAbortClip(total, dead, primaryDead))
                             {
                                 App.Logger?.Warning("VideoService: giving up on the blurred surface {Surface} ({Dead}/{Total} dead) - the clip keeps playing on the live screen(s)",
@@ -7052,6 +7070,11 @@ namespace ConditioningControlPanel.Services
                 // Snapshot the instance these players belong to, so the (possibly delayed) retire below
                 // can never condemn a FRESH instance that a vout-retry has since built.
                 var owningLibVLC = _libVLC;
+                // Hand the stop tasks to the NEXT video (#1121). Whatever this method decides below -
+                // wait for them, or skip the wait entirely on the vmem path - a straggler that
+                // outlives the teardown must not have the next Play() built on top of it.
+                _pendingStopTasks = stopPairs.Select(p => p.task).ToArray();
+                _pendingStopOwner = owningLibVLC;
 
                 // The waits below exist for ONE reason: detaching a VideoView/HwndHost from a player
                 // that is still presenting is the historic multi-monitor crash (see the detach comment
@@ -7319,6 +7342,49 @@ namespace ConditioningControlPanel.Services
                 // Total UI-thread block for this teardown. Anything past ~1s here is the app being
                 // unresponsive to the user (and to the low-level keyboard hook) — #616-#623.
                 VideoDiag.Log("CLOSE", $"CloseAll end after {closeSw.ElapsedMilliseconds}ms of UI-thread time");
+            }
+        }
+
+        /// <summary>
+        /// Wait for the PREVIOUS teardown's Stop() tasks before this video builds any player (#1121).
+        /// Pumping, so the dispatcher keeps draining exactly as it does during CloseAll's own waits,
+        /// and bounded at <see cref="PendingStopWaitMs"/>.
+        ///
+        /// A Stop() that is still inside native code owns the audio output and the decoder of the
+        /// instance it was created from. Play() on that same instance comes back "playing", presents
+        /// no frame, and the clip is skipped a couple of seconds later with nothing but black on
+        /// screen. If the straggler outlives the wait we do not fight it: the instance is retired
+        /// (quarantined forever - a wedged native call is still inside it, so it is never disposed)
+        /// and EnsureLibVLCInitialized builds a fresh one for this video.
+        /// </summary>
+        private void AwaitPendingStops()
+        {
+            var pending = _pendingStopTasks;
+            var owner = _pendingStopOwner;
+            _pendingStopTasks = null;
+            _pendingStopOwner = null;
+            if (pending == null || pending.Length == 0) return;
+            if (pending.All(t => t.IsCompleted)) return;
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            VideoDiag.Log("VIDEO", $"pre-roll: {pending.Count(t => !t.IsCompleted)} previous Stop() task(s) still running - waiting up to {PendingStopWaitMs}ms");
+            while (sw.ElapsedMilliseconds < PendingStopWaitMs && pending.Any(t => !t.IsCompleted))
+                WaitWithMessagePump(100);
+
+            bool wedged = pending.Any(t => !t.IsCompleted);
+            // One line per overrun, at Warning, carrying the elapsed ms: a report that contains it
+            // says the black screen came from the previous teardown rather than from this clip.
+            App.Logger?.Warning(
+                "VideoService: the previous video's Stop() overran into this one by {Ms}ms - {Outcome} (#1121)",
+                sw.ElapsedMilliseconds,
+                wedged ? "still running, abandoning it and starting this video on a fresh LibVLC instance" : "it finished, playback continues on the same instance");
+            VideoDiag.Log("VIDEO", $"pre-roll: previous Stop() overran {sw.ElapsedMilliseconds}ms, stillRunning={wedged}");
+
+            if (wedged)
+            {
+                // fromCurrentPlayback:false - the clip these players belonged to is already down, so
+                // there is no sibling decoding on this instance to protect.
+                RetireSharedLibVLC(owner, "the previous video's Stop() was still running when the next video started", fromCurrentPlayback: false);
             }
         }
 

--- a/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
+++ b/ConditioningControlPanel/Services/Video/VideoSurfaceHealth.cs
@@ -91,12 +91,21 @@ namespace ConditioningControlPanel.Services
         /// A mirror always may: the clip keeps playing while it retries, so a second grace window
         /// costs the user nothing. The audio-bearing surface may too, as soon as it has siblings -
         /// that is the multi-monitor headline report, where a primary that missed its window used to
-        /// skip the clip on the spot with no recovery rung at all. A LONE primary may not: it is the
-        /// only surface on the rig, a dead primary ends the clip either way, and the rung would be
-        /// nothing but 8 extra seconds of black for the single-monitor majority.
+        /// skip the clip on the spot with no recovery rung at all.
+        ///
+        /// A LONE primary now gets the same single rung (#1121). It used to be withheld to keep the
+        /// single-monitor majority at an ~8s skip instead of ~16s, but that rig is exactly where the
+        /// "black for a couple of seconds and then the video was over" reports come from: the ONE
+        /// surface that could have recovered was the one surface denied a re-Play(). The cost is
+        /// bounded to one extra grace window on a rig whose decoder really is dead; the win is every
+        /// run where it was merely late, which is the common case now that a wedged Stop() from the
+        /// previous clip can still be holding the instance when this one starts.
+        ///
+        /// Zero armed surfaces still means no rung: that is a watch being judged before it was
+        /// registered, and there is nothing there to re-Play.
         /// </summary>
         internal static bool AllowsFrameRetry(bool primarySurface, int armedSurfaces)
-            => !primarySurface || armedSurfaces > 1;
+            => !primarySurface || armedSurfaces > 0;
 
         /// <summary>
         /// Whether a dead surface should take the whole clip with it. This is the #1015/#1035 fix in

--- a/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/MultiMonitorVideoSurfaceTests.cs
@@ -96,12 +96,13 @@ public class MultiMonitorVideoSurfaceTests
     }
 
     [Fact]
-    public void RetryRung_ALonePrimaryGetsNone()
+    public void RetryRung_ALonePrimaryAlsoGetsOne()
     {
-        // The single-monitor majority: nothing else is competing for the decoder, the clip ends
-        // either way, and the rung would be 8 extra seconds of black screen for everyone.
-        Assert.False(AllowsFrameRetry(primarySurface: true, armedSurfaces: 1));
-        // Defensive: a watch judged before it was registered must not read softer than "lone".
+        // #1121: the single-monitor rig used to be the one rig with no recovery at all - the only
+        // surface it has was the only surface denied a re-Play(), so a decoder that came up late
+        // meant a black screen and a skipped clip. One rung, worst case one more grace window.
+        Assert.True(AllowsFrameRetry(primarySurface: true, armedSurfaces: 1));
+        // Defensive: a watch judged before it was registered has nothing to re-Play.
         Assert.False(AllowsFrameRetry(primarySurface: true, armedSurfaces: 0));
     }
 
@@ -151,15 +152,17 @@ public class MultiMonitorVideoSurfaceTests
     }
 
     [Fact]
-    public void SingleMonitorRig_BehavesExactlyLikeTheReleasedBuild()
+    public void SingleMonitorRig_GetsOneRetryAndThenStillAborts()
     {
-        // One screen means one surface and it IS the primary: no retry rung, first missed window ->
-        // GiveUp -> abort. Same ~8s skip the released build does, no added latency. Driven through
-        // AllowsFrameRetry so the rig rule and the ladder cannot drift apart.
+        // One screen means one surface and it IS the primary. #1121 gives it the same single rung
+        // every other surface has: first missed window -> Retry, second -> GiveUp -> abort. Driven
+        // through AllowsFrameRetry so the rig rule and the ladder cannot drift apart.
         bool allowed = AllowsFrameRetry(primarySurface: true, armedSurfaces: 1);
-        Assert.False(allowed);
-        Assert.Equal(FrameWatchdogAction.GiveUp,
+        Assert.True(allowed);
+        Assert.Equal(FrameWatchdogAction.Retry,
             DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: false, retryAllowed: allowed));
+        Assert.Equal(FrameWatchdogAction.GiveUp,
+            DecideFrameWatchdog(tornDown: false, gracePaused: false, hasRendered: false, retryUsed: true, retryAllowed: allowed));
         Assert.True(ShouldAbortClip(totalSurfaces: 1, deadSurfaces: 1, primarySurfaceDead: true));
     }
 


### PR DESCRIPTION
**Stacks on:** `main` (this is PR 1 of a 3-PR stack in `VideoService.cs`; PR 2 bases on this branch).

## Bug
`CC-Labs-llc/ccp-bugs#1121` - fullscreen goes black for 2-3 seconds and then the video is gone, on some rigs for every video. Reporter is single-monitor, 6.8.4 through 6.9.1, survives a reinstall.

## Root cause
A LibVLC `Stop()` can stay inside native code for seconds on a rig whose audio output resolves no device (the wedge cluster #765/#766/#767 already documents 4936ms/4978ms measurements in this file).

- `VideoService.cs:7043-7085` (`CloseAll`): the vmem/blur path - which is the DEFAULT render path - deliberately skips the 500ms + 4s `Stop()` waits and hands the tasks to an async quarantine. The `VideoView` path gives up after ~4.5s. Either way nothing prevented the NEXT video from being built while those tasks were still running.
- `VideoService.cs:3037` (`CreateLibVLCVideoWindow`): the new `MediaPlayer` is constructed from the SAME shared instance the wedged `Stop()` is still inside. `Play()` returns "playing" and no frame is ever presented.
- `VideoSurfaceHealth.cs:98` `AllowsFrameRetry(primary, armed) => !primary || armed > 1`: the blur-frame watchdog (`VideoService.cs:3690-3700`) therefore gave a LONE primary no re-Play rung at all, so the one surface that could have recovered on a single-monitor rig was the only surface denied a retry.

## Fix
- `CloseAll` publishes its outstanding stop tasks plus the owning instance (`_pendingStopTasks` / `_pendingStopOwner`).
- New `AwaitPendingStops()`, called from `StartVideoPlayback` before `EnsureLibVLCInitialized()`: waits up to 2s, pumping (same `WaitWithMessagePump` the teardown already uses, so the dispatcher keeps draining). If the straggler is still running it does not fight it - `RetireSharedLibVLC(..., fromCurrentPlayback: false)` quarantines the instance and a fresh one is built for this clip. The instance is deliberately NOT disposed: this file's `QuarantineNative` contract is that disposing an object with a wedged native call inside it is the #559 poisoning, so "abandon on a background thread" is implemented as the existing quarantine plus the existing background rebuild.
- One `Warning` line per overrun carrying the elapsed ms and the outcome, plus a matching video-diag breadcrumb.
- `AllowsFrameRetry` now grants a lone primary the same single rung (`armedSurfaces > 0`); zero armed surfaces still gets none (a watch judged before it was registered has nothing to re-Play).

Circuit-breaker cap left at 4 as instructed.

## Verified
- `dotnet build -c Debug` in `ConditioningControlPanel/`: **0 errors**, 344 warnings (pre-existing CA1416/CS8602 noise).
- Test run for the whole stack is reported on PR 3 (single run at the end of the stack, as agreed).
- NOT verified: no repro rig. The overlap window is native timing that cannot be reproduced here; the `CCP_FAULT_WEDGE_STOP=1` DEBUG fault injector in this file is the intended way to exercise it, and that needs a real app launch (not allowed for this agent - the app is single-instance and the owner has one running).
- Trade-off to be aware of: on a rig whose decoder really is dead, the lone-primary rung moves the skip from ~8s of black to ~16s. It buys back every run where the decoder was merely late, which is the common case now that a previous clip's `Stop()` can still be holding the instance.

## Size
102 insertions, 24 deletions across 3 files (`git diff --stat origin/main...HEAD` -> `3 files changed, 102 insertions(+), 24 deletions(-)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
