### PR TITLE
fix(gaze): Focus Gaze switch shows the setting, not the engine's running state

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -3588,6 +3588,7 @@
   "label_focus_gaze_description": "Schau 1 Sek. auf eine Blase oder einen Flash, um sie platzen zu lassen.",
   "label_focus_gaze_consent_required": "Kamera-Einwilligung ist erforderlich.",
   "label_focus_gaze_active": "Aktiv — hinschauen und verweilen.",
+  "label_focus_gaze_waiting": "An - warte auf die Kamera.",
   "label_focus_gaze_calibrate_first": "Kalibriere zuerst die Webcam (Deeper-Tab → Webcam-Setup → Kalibrieren).",
   "label_focus_gaze_webcam_failed_format": "Die Webcam konnte nicht gestartet werden (Status: {0}).",
   "btn_open": "Öffnen",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -3739,6 +3739,7 @@
   "label_focus_gaze_description": "Look at a bubble or flash for 1s to pop it.",
   "label_focus_gaze_consent_required": "Camera consent is required.",
   "label_focus_gaze_active": "Active — gaze and dwell.",
+  "label_focus_gaze_waiting": "On - waiting for the camera.",
   "label_focus_gaze_calibrate_first": "Calibrate the webcam first (Deeper tab → Webcam Setup → Calibrate).",
   "label_focus_gaze_webcam_failed_format": "Couldn't start the webcam (state: {0}).",
   "btn_open": "Open",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -3579,6 +3579,7 @@
   "label_focus_gaze_description": "Mira una burbuja o un flash durante 1s para reventarlo.",
   "label_focus_gaze_consent_required": "Se requiere consentimiento de cámara.",
   "label_focus_gaze_active": "Activa — mira y sostén.",
+  "label_focus_gaze_waiting": "Activada - esperando la camara.",
   "label_focus_gaze_calibrate_first": "Calibra primero la webcam (pestaña Deeper → Configuración de Webcam → Calibrar).",
   "label_focus_gaze_webcam_failed_format": "No se pudo iniciar la webcam (estado: {0}).",
   "btn_open": "Abrir",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -3588,6 +3588,7 @@
   "label_focus_gaze_description": "Fixe une bulle ou un flash pendant 1s pour l'éclater.",
   "label_focus_gaze_consent_required": "Le consentement caméra est requis.",
   "label_focus_gaze_active": "Actif — regarde et fixe.",
+  "label_focus_gaze_waiting": "Active - en attente de la camera.",
   "label_focus_gaze_calibrate_first": "Étalonne d'abord la webcam (onglet Deeper → Configuration Webcam → Étalonner).",
   "label_focus_gaze_webcam_failed_format": "Impossible de démarrer la webcam (état : {0}).",
   "btn_open": "Ouvrir",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -3579,6 +3579,7 @@
   "label_focus_gaze_description": "バブルやフラッシュを1秒見つめると割れます。",
   "label_focus_gaze_consent_required": "カメラの同意が必要です。",
   "label_focus_gaze_active": "有効 — 見つめて、留まって。",
+  "label_focus_gaze_waiting": "オン - カメラを待っています。",
   "label_focus_gaze_calibrate_first": "先にウェブカメラをキャリブレーションしてください（Deeperタブ → ウェブカメラ設定 → キャリブレーション）。",
   "label_focus_gaze_webcam_failed_format": "ウェブカメラを開始できませんでした（状態：{0}）。",
   "btn_open": "開く",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -3586,6 +3586,7 @@
   "label_focus_gaze_description": "버블이나 플래시를 1초간 바라보면 터져요.",
   "label_focus_gaze_consent_required": "카메라 동의가 필요해요.",
   "label_focus_gaze_active": "작동 중 — 바라보고 머무르세요.",
+  "label_focus_gaze_waiting": "켜짐 - 카메라를 기다리는 중.",
   "label_focus_gaze_calibrate_first": "웹캠을 먼저 보정하세요 (Deeper 탭 → 웹캠 설정 → 보정).",
   "label_focus_gaze_webcam_failed_format": "웹캠을 시작하지 못했어요 (상태: {0}).",
   "btn_open": "열기",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -3587,6 +3587,7 @@
   "label_focus_gaze_description": "Olhe para uma bolha ou flash por 1s para estourar.",
   "label_focus_gaze_consent_required": "É preciso consentimento para a câmera.",
   "label_focus_gaze_active": "Ativo — olhe e sustente.",
+  "label_focus_gaze_waiting": "Ativado - aguardando a camera.",
   "label_focus_gaze_calibrate_first": "Calibre a webcam primeiro (aba Deeper → Configurar Webcam → Calibrar).",
   "label_focus_gaze_webcam_failed_format": "Não deu para iniciar a webcam (estado: {0}).",
   "btn_open": "Abrir",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -3586,6 +3586,7 @@
   "label_focus_gaze_description": "Посмотри на пузырёк или вспышку 1 с, чтобы лопнуть.",
   "label_focus_gaze_consent_required": "Нужно согласие на камеру.",
   "label_focus_gaze_active": "Активно — смотри и задерживай взгляд.",
+  "label_focus_gaze_waiting": "Включено - ожидание камеры.",
   "label_focus_gaze_calibrate_first": "Сначала откалибруй веб-камеру (вкладка Deeper → Настройка камеры → Калибровка).",
   "label_focus_gaze_webcam_failed_format": "Не удалось запустить веб-камеру (состояние: {0}).",
   "btn_open": "Открыть",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -3421,6 +3421,7 @@
   "label_focus_gaze_description": "注视泡泡或闪图1秒即可戳破",
   "label_focus_gaze_consent_required": "需要摄像头同意",
   "label_focus_gaze_active": "活跃——注视和悬停",
+  "label_focus_gaze_waiting": "已开启 - 正在等待摄像头",
   "label_focus_gaze_calibrate_first": "请先校准摄像头（Deeper标签页→摄像头设置→校准）",
   "label_focus_gaze_webcam_failed_format": "无法启动摄像头（状态：{0}）",
   "btn_open": "打开",

--- a/ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs
@@ -789,29 +789,61 @@ namespace ConditioningControlPanel
             // runs, leaving Webcam.Dispose uncalled and the camera lit.
             Closing += (_, _) => App.GazeFocus?.Stop();
 
-            App.GazeFocus.OnActiveChanged += active =>
+            App.GazeFocus.OnActiveChanged += _ =>
             {
-                // Service may stop itself (e.g., webcam death) — keep the
-                // toggle visually in sync without re-entering the handler.
+                // #1116: the RUNNING state moves on its own (camera off, tracking
+                // lost, service stops itself) and must never touch the switch -
+                // the switch is the user's intent. Only the status line follows
+                // the engine, so the toggle no longer looks self-flipping.
                 if (!Dispatcher.CheckAccess())
                 {
-                    Dispatcher.BeginInvoke(() => SyncFocusGazeToggle(active));
+                    Dispatcher.BeginInvoke(RefreshFocusGazeStatus);
                     return;
                 }
-                SyncFocusGazeToggle(active);
+                RefreshFocusGazeStatus();
             };
+
+            // Restore the saved intent. MasterEnabled only makes the engine
+            // WANTED - EvaluateDesiredState still holds it back until the camera
+            // is running, calibrated and consented, and the status line says which.
+            var enabled = App.Settings?.Current?.FocusGazeEnabled == true;
+            SyncFocusGazeToggle(enabled);
+            if (enabled) App.GazeFocus.MasterEnabled = true;
         }
 
         // PHASE 6: every LabTab.* accessor below became PlayTab.*. There is exactly ONE Focus Gaze
         // switch in the app (Play door, Eyes zone) and this is the code that reads and writes it.
-        private void SyncFocusGazeToggle(bool active)
+        // #1116: the argument is the ENABLED setting (user intent), never GazeFocusService.IsActive.
+        private void SyncFocusGazeToggle(bool enabled)
         {
+            if (App.Settings?.Current != null) App.Settings.Current.FocusGazeEnabled = enabled;
             if (PlayTab?.ChkPlayFocusGaze == null) return;
-            if (PlayTab.ChkPlayFocusGaze.IsChecked == active) return;
-            _focusGazeSyncing = true;
-            try { PlayTab.ChkPlayFocusGaze.IsChecked = active; }
-            finally { _focusGazeSyncing = false; }
-            if (PlayTab.TxtPlayFocusGazeStatus != null && !active) PlayTab.TxtPlayFocusGazeStatus.Text = "";
+            if (PlayTab.ChkPlayFocusGaze.IsChecked != enabled)
+            {
+                _focusGazeSyncing = true;
+                try { PlayTab.ChkPlayFocusGaze.IsChecked = enabled; }
+                finally { _focusGazeSyncing = false; }
+            }
+            RefreshFocusGazeStatus();
+        }
+
+        /// <summary>
+        /// Writes the status line under the Focus Gaze switch. The switch says
+        /// ENABLED, this says RUNNING - they are different things (#1116).
+        /// Callers that have a more specific message (consent, calibration,
+        /// webcam failure) set it AFTER SyncFocusGazeToggle, so theirs wins.
+        /// </summary>
+        private void RefreshFocusGazeStatus()
+        {
+            if (PlayTab?.TxtPlayFocusGazeStatus == null) return;
+            if (App.Settings?.Current?.FocusGazeEnabled != true)
+            {
+                PlayTab.TxtPlayFocusGazeStatus.Text = "";
+                return;
+            }
+            PlayTab.TxtPlayFocusGazeStatus.Text = App.GazeFocus?.IsActive == true
+                ? Loc.Get("label_focus_gaze_active")
+                : Loc.Get("label_focus_gaze_waiting");
         }
 
         internal async void ChkFocusGaze_Changed(object sender, RoutedEventArgs e)
@@ -877,7 +909,8 @@ namespace ConditioningControlPanel
                 App.GazeFocus.MasterEnabled = true;
                 if (App.GazeFocus.IsActive)
                 {
-                    if (PlayTab.TxtPlayFocusGazeStatus != null) PlayTab.TxtPlayFocusGazeStatus.Text = Localization.Loc.Get("label_focus_gaze_active");
+                    // Persist the intent and let the status line report the engine.
+                    SyncFocusGazeToggle(true);
                 }
                 else
                 {
@@ -900,7 +933,7 @@ namespace ConditioningControlPanel
                 // per-feature gaze toggle (Flash pop / linger, Video click) is
                 // still on — those are self-sufficient now.
                 App.GazeFocus.MasterEnabled = false;
-                if (PlayTab.TxtPlayFocusGazeStatus != null) PlayTab.TxtPlayFocusGazeStatus.Text = "";
+                SyncFocusGazeToggle(false);
             }
         }
 

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2236,6 +2236,20 @@ namespace ConditioningControlPanel.Models
             set { _bubbleGazePopEnabled = value; OnPropertyChanged(); }
         }
 
+        // FocusGazeEnabled is the persisted INTENT behind the Play door's
+        // "Focus Gaze" switch (GazeFocusService.MasterEnabled). It is not the
+        // same thing as GazeFocusService.IsActive: the engine pauses whenever
+        // the camera is down, uncalibrated or unconsented, and until v6.9.1 the
+        // switch mirrored IsActive, so it dropped and popped back on its own and
+        // never survived a restart (#1116). The switch now reads this flag and
+        // the status line underneath says whether the engine is actually running.
+        private bool _focusGazeEnabled;
+        public bool FocusGazeEnabled
+        {
+            get => _focusGazeEnabled;
+            set { _focusGazeEnabled = value; OnPropertyChanged(); }
+        }
+
         // VideoGazeClickEnabled gates the gaze-dwell shortcut for the video
         // attention minigame (look at a FloatingText target long enough to
         // fire its onHit callback, same as a mouse click).


### PR DESCRIPTION
## Bug

`CC-Labs-llc/ccp-bugs#1116` (MED). The Focus Gaze switch on the Play door shows ON while the feature is not running, or flips itself, so the user cannot tell whether it is enabled.

The bubble half of that same report (gaze pop not reaching bubbles) was already fixed by PR #460 with `BubbleGazePopEnabled`. This PR does not touch that.

## Root cause

`ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs:792-802` subscribed to `GazeFocusService.OnActiveChanged` and pushed the service's `IsActive` straight onto the switch via `SyncFocusGazeToggle(active)` (`MainWindow.LabTab.cs:807-815`).

`IsActive` is "is the dwell engine running right now", and `GazeFocusService.EvaluateDesiredState` (`ConditioningControlPanel/Services/Tracking/GazeFocusService.cs:259-279`) stops the engine whenever the camera is down, uncalibrated or unconsented, and starts it again when the camera comes back. So every camera blip moved the switch on its own.

The user's actual intent lived in `GazeFocusService.MasterEnabled` (`GazeFocusService.cs:165-174`), which is an in-memory field with no persisted setting behind it, and the switch in `ConditioningControlPanel/Views/Tabs/PlayTabView.xaml:898` was unbound. That is also why the toggle never survived a restart.

## Fix

Enabled and active are now two different surfaces.

- `ConditioningControlPanel/Models/AppSettings.cs`: new persisted `FocusGazeEnabled` (default off), the intent behind `MasterEnabled`. Sits next to `BubbleGazePopEnabled`.
- `SyncFocusGazeToggle` keeps its name and its re-entrancy guard but its argument is now the ENABLED setting, never `IsActive`, and it writes the setting.
- New `RefreshFocusGazeStatus` writes the status line that is already under the switch (`TxtPlayFocusGazeStatus`): `label_focus_gaze_active` when the engine is running, a new `label_focus_gaze_waiting` ("On - waiting for the camera.") when it is enabled but not running, and empty when the switch is off (the switch itself is the off indicator, and the line is styled green, so an "Off" in green would read wrong).
- `OnActiveChanged` now only refreshes that status line. It never touches the switch, so the toggle cannot flip itself any more.
- `HookFocusGazeService` restores the saved intent on window load and re-arms `MasterEnabled`. That only makes the engine WANTED; `EvaluateDesiredState` deliberately never powers the camera on, so nothing lights the webcam at startup. When the camera does come up for another reason, the engine now joins in instead of waiting for a manual off/on of the switch.
- New loc key `label_focus_gaze_waiting` in all 9 language files, one line each, LF preserved, all 9 still parse strictly.

`GazeFocusService` itself is unchanged. `OnSettingsChanged` (`GazeFocusService.cs:210-221`) filters by property name and does not list the new flag, so persisting it is inert on the service side.

## Verified

- `dotnet build -c Debug` in `ConditioningControlPanel/`: 0 errors, 344 warnings (all pre-existing CA1416 / CS8602 noise).
- `dotnet test` in `Tests/ConditioningControlPanel.Tests/`: **Failed: 0, Passed: 5169, Skipped: 0, Total: 5169**. Full suite, no filter.
- All 9 `Localization/Languages/*.json` re-parsed with strict `json.load` after the edit.

**Could NOT verify visually.** The app is single-instance and launching it would hijack the owner's running instance, so the switch, the status line and the restore-on-load path were never seen on screen. The behaviour that most wants a human look:

1. Enable Focus Gaze, then cover the camera or stop tracking. Expected: the switch stays ON and the status line changes from "Active" to "On - waiting for the camera."
2. Restart the app with the switch left on. Expected: the switch comes back ON, the camera does NOT turn itself on, and the status reads "waiting for the camera" until the camera is started.

No new test was added: this is WPF checkbox plus service wiring, which is not reachable without a window and a webcam.

## Size

82 changed lines (`git diff --stat origin/main...HEAD`: 11 files changed, 69 insertions, 13 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
