### PR TITLE
fix(ai): AI audio effect no longer claims it played when it did not

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1710,6 +1710,9 @@ namespace ConditioningControlPanel
             // Create user assets directories in LocalAppData (persists across updates)
             Directory.CreateDirectory(Path.Combine(UserAssetsPath, "images"));
             Directory.CreateDirectory(Path.Combine(UserAssetsPath, "videos"));
+            // AI "audio" effects play from assets/audio. Without the folder the scan finds
+            // nothing and the command silently no-ops, so scaffold it like the rest (#1120).
+            Directory.CreateDirectory(Path.Combine(UserAssetsPath, "audio"));
             Directory.CreateDirectory(Path.Combine(UserAssetsPath, "wallpapers"));
             Directory.CreateDirectory(Path.Combine(UserAssetsPath, "mindwipe"));
             Directory.CreateDirectory(Path.Combine(UserDataPath, "Spirals"));
@@ -4664,7 +4667,7 @@ Application State:
 
         /// <summary>
         /// Ensures a configured custom assets folder and its standard subfolders
-        /// (images/videos/wallpapers) exist. The default UserAssetsPath subdirs are
+        /// (images/videos/audio/wallpapers) exist. The default UserAssetsPath subdirs are
         /// created unconditionally at startup, but a custom path is only known after
         /// settings load — and if its folder is missing, EffectiveAssetsPath silently
         /// falls back to the default location, sending imports/extractions to the wrong
@@ -4680,6 +4683,8 @@ Application State:
                 // CreateDirectory creates the parent customPath too if absent.
                 Directory.CreateDirectory(Path.Combine(customPath, "images"));
                 Directory.CreateDirectory(Path.Combine(customPath, "videos"));
+                // Same reason as the default scaffold: AI audio effects read assets/audio (#1120).
+                Directory.CreateDirectory(Path.Combine(customPath, "audio"));
                 Directory.CreateDirectory(Path.Combine(customPath, "wallpapers"));
                 Logger?.Information("Ensured custom assets directories at {Path}", customPath);
             }

--- a/ConditioningControlPanel/Services/Commands/AiCommandService.cs
+++ b/ConditioningControlPanel/Services/Commands/AiCommandService.cs
@@ -63,7 +63,8 @@ namespace ConditioningControlPanel.Services.Commands
             App.Logger?.Information("AiCommandService: dispatching {Cmd} with data {@Data}",
                 commandData.Command, commandData.Data);
 
-            // Surface a human-readable line in the AI Brain "Live actions" feed.
+            // Surface a human-readable line in the AI Brain "Live actions" feed. This is the
+            // request; a second line follows after execution if the effect did not fire.
             AppendLiveAction(FormatLiveAction(commandData));
 
             var token = commandData.Data.Token;
@@ -82,7 +83,16 @@ namespace ConditioningControlPanel.Services.Commands
                 if (command != null)
                 {
                     App.Logger?.Debug("AiCommandService: executing {Cmd}", commandData.Command);
-                    await command.ExecuteAsync();
+                    var fired = await command.ExecuteAsync();
+                    if (!fired)
+                    {
+                        // The line appended above is the request. Executors return false when
+                        // the effect never happened (empty assets/audio folder, video already
+                        // playing, feature off), so follow up instead of leaving a feed line
+                        // that reads like it played (#1120).
+                        App.Logger?.Warning("AiCommandService: {Cmd} did not fire", commandData.Command);
+                        AppendLiveAction(FormatFailedAction(commandData));
+                    }
                 }
             }
             catch (Exception ex)
@@ -177,6 +187,21 @@ namespace ConditioningControlPanel.Services.Commands
                 default:
                     return $"⚙️ {c.Command}";
             }
+        }
+
+        /// <summary>
+        /// Follow-up feed line for a command whose executor reported failure, so the panel
+        /// never leaves a request line standing as if the effect happened. Audio names the
+        /// usual cause: there are no files in the assets audio folder (#1120).
+        /// </summary>
+        private static string FormatFailedAction(AiCommandData c)
+        {
+            return c.Command switch
+            {
+                AICommandType.audio => "🔇 Audio didn't play - check your assets audio folder",
+                AICommandType.video => "🎬 Video didn't play",
+                _ => $"⚠️ {c.Command} didn't fire"
+            };
         }
 
         private static bool IsEffectAllowed(AICommandType cmd, Models.CompanionPromptSettings s)

--- a/ConditioningControlPanel/Services/Commands/MediaCommand.cs
+++ b/ConditioningControlPanel/Services/Commands/MediaCommand.cs
@@ -79,8 +79,7 @@ namespace ConditioningControlPanel.Services.Commands
 
             if (IsAudio(ext))
             {
-                Application.Current.Dispatcher.Invoke(() => App.Audio?.PlaySound(fullPath, 100));
-                return Task.FromResult(true);
+                return Task.FromResult(PlayFile(fullPath));
             }
 
             App.Logger?.Information("MediaCommand: extension {Ext} not recognized as audio/video — falling back to random {Kind}", ext, _kind);
@@ -132,14 +131,30 @@ namespace ConditioningControlPanel.Services.Commands
 
                 var pick = candidates[new Random().Next(candidates.Length)];
                 App.Logger?.Information("MediaCommand: random audio pick {Path}", pick);
-                Application.Current.Dispatcher.Invoke(() => App.Audio?.PlaySound(pick, 100));
-                return true;
+                return PlayFile(pick);
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "MediaCommand: random audio pick threw");
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Hands one audio file to <see cref="AudioService.PlaySound"/> and reports whether it
+        /// actually started. PlaySound returns the clip duration and 0 when it could not play
+        /// (no audio service yet, unreadable file, no output device), so the caller can tell the
+        /// user "nothing played" instead of claiming success (#1120).
+        /// </summary>
+        private static bool PlayFile(string path)
+        {
+            var seconds = Application.Current.Dispatcher.Invoke(() => App.Audio?.PlaySound(path, 100) ?? 0);
+            if (seconds <= 0)
+            {
+                App.Logger?.Warning("MediaCommand: audio {Path} did not start playing", path);
+                return false;
+            }
+            return true;
         }
 
         private static bool IsVideo(string ext)


### PR DESCRIPTION
## Bug

`CC-Labs-llc/ccp-bugs#1120` (MED) - the companion says it played an audio effect, the AI live-actions feed says it did, nothing plays.

## Root cause

- `ConditioningControlPanel/Services/Commands/MediaCommand.cs:115-125` (`PlayRandomAudio`) scans `<App.EffectiveAssetsPath>/audio`, but the assets scaffold at `ConditioningControlPanel/App.xaml.cs:1710-1715` only created `images`, `videos`, `wallpapers`, `mindwipe`. No content pack ships an `audio` folder either, so the scan came back empty and the command no-opped. Same gap in `EnsureCustomAssetsDirectories` (`App.xaml.cs:4676`) for users with a custom assets folder.
- `ConditioningControlPanel/Services/Commands/AiCommandService.cs:66-67` appended the live-actions line BEFORE executing the command, so the feed claimed success regardless of outcome.
- The explicit-path audio branch (`MediaCommand.cs:80-84`) returned `true` unconditionally, even when `App.Audio` was null or `PlaySound` failed, so there was no truthful signal to report either.
- `Models/CompanionPromptSettings.cs:105` `AllowAiAudio` defaults to false, which is why this went unnoticed.

## Fix

1. Scaffold `<assets>/audio` alongside the existing folders, in both the default path (`App.xaml.cs:1713`) and `EnsureCustomAssetsDirectories` (custom assets path).
2. `MediaCommand` reports real success. `AudioService.PlaySound` returns the clip duration and 0 when it could not play, so the new `PlayFile` helper returns false and logs a Warning naming the file. The empty/missing-folder case already returned false with a Warning naming the folder path, left as is (the log scrubber handles the path).
3. `AiCommandService` keeps the pre-execution line as the request, then appends an outcome line plus a `Log.Warning` when the executor reports the effect did not fire. Audio gets a specific line: `🔇 Audio didn't play - check your assets audio folder`. Appending after execution unconditionally was not an option: `getbacktome` awaits up to 600s inside `ExecuteAsync`, so the request line would be delayed by minutes.

Note on point 4 of the triage (report the failure back to the companion): there is no such channel today. `IAiCommandService.ExecuteCommand` is `void`/`async void` and the two callers (`LocalAiService.cs:553,898`, `OpenAiCompatibleService.cs:655`) discard the outcome; no command reports failure back into the conversation, video included. Wiring one would mean a new feedback path into the AI turn, which is well past a hotfix diff, so the user-visible truth lands in the live-actions feed and the log instead. Happy to file that as a follow-up.

`App.xaml.cs` is also touched by contractor PR #618 - this change is confined to the two directory-scaffold blocks (one added line each, plus a doc-comment word).

## Verified

- `dotnet build -c Debug` in `ConditioningControlPanel/`: 0 errors, 344 warnings (pre-existing CA1416/CS8602 noise).
- `cd Tests/ConditioningControlPanel.Tests; dotnet test` full suite: **5169 passed, 0 failed**. Also ran the narrower `--filter "FullyQualifiedName~Companion|FullyQualifiedName~Prompt|FullyQualifiedName~Audio|FullyQualifiedName~InteractionQueue"` first: 697 passed.
- NOT verified at runtime: the app was not launched (single-instance, would hijack the owner's running app), so the scaffolded folder, the new feed lines and the "did not start playing" path were not observed live. No unit test added: every touched path needs `App` statics, a WPF dispatcher and NAudio output.
- Existing installs only get the folder on next startup (the scaffold runs every launch), and the folder starts empty, so a user with no audio files still gets the honest "didn't play" line rather than silence.

## Size

59 changed lines (52 insertions, 7 deletions) across 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
