### PR TITLE
fix(theme): Studio rack repaints after the mod palette, not before

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -287,6 +287,16 @@ namespace ConditioningControlPanel
             // The header preset dropdown is mod-renamed per item, plus an accent "Save as New" row.
             SweepStep(RefreshPresetsDropdown, "presets dropdown");
 
+            // The Studio rack's captions, art, door icon and accent-mixed chrome. This used to be
+            // its own ModChanged subscription in MainWindow.xaml.cs, wired AHEAD of the palette
+            // handler, so RefreshDots read PinkBrush while it still held the outgoing mod's accent
+            // and the rack's lit state dots (plus their glow) stayed on the old colour until some
+            // unrelated settings write repainted them - ccp-bugs#1100. Riding the sweep is the fix:
+            // Background priority is by construction after every ModChanged handler, palette
+            // included. It rides the LanguageChanged caller too, which is correct - the rack's row
+            // captions are the same mod-aware names a language switch changes.
+            SweepStep(() => StudioTab?.RepaintModAwareChrome(), "studio rack");
+
             // ---- on screen only: these tabs rebuild themselves on their next show ----
 
             if (AchievementsTab?.IsVisible == true)

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2321,7 +2321,17 @@ namespace ConditioningControlPanel
                 res["AccentTintedBgHover"] = tintedBgHover;
                 res["AccentMidGradient"] = midGradient;
 
-                // === ALSO UPDATE BRUSH RESOURCES (in case any are frozen from initial load) ===
+                // === ALSO UPDATE BRUSH RESOURCES - LOAD-BEARING, DO NOT DELETE ===
+                // Resources/Theme/Brushes.xaml declares each of these as a SolidColorBrush whose
+                // Color is a DynamicResource on the key just above, which reads like the block
+                // below is redundant. It is not. A DynamicResource on a Freezable that lives in a
+                // ResourceDictionary resolves ONCE, when the dictionary instantiates it; the brush
+                // has no InheritanceContext to re-resolve through, so a later write to the Color
+                // key never reaches it (verified: writing the Color into either the top-level
+                // Application.Resources or the merged dictionary that owns the key leaves the
+                // brush on its seed colour). Overwriting the brush entry is what actually repaints
+                // every {DynamicResource *Brush} consumer, and it is also the restore path for
+                // MainWindow.Lab.cs ApplyLockdownTheme, which shadows four of these keys.
                 res["PinkBrush"] = new SolidColorBrush(accent);
                 res["DarkPinkBrush"] = new SolidColorBrush(dark);
                 res["PinkButtonHoveredBrush"] = new SolidColorBrush(light);
@@ -3507,9 +3517,12 @@ namespace ConditioningControlPanel
             ApplyModFeatureNames();
             if (App.Mods != null)
             {
+                // Also queues the Background stale-surface sweep, which is where the Studio
+                // rack's repaint lives now - see RefreshModAwareSurfaces in MainWindow.UiUpdates.cs.
+                // The rack used to have its own ModChanged subscription right here, which ran
+                // BEFORE the palette handler below and painted the rack's state dots from the
+                // OUTGOING mod's PinkBrush (ccp-bugs#1100).
                 App.Mods.ModChanged += (_, _) => Dispatcher.Invoke(ApplyModFeatureNames);
-                // The Studio rack's row captions are mod-aware too (Phase 4).
-                App.Mods.ModChanged += (_, _) => Dispatcher.Invoke(() => StudioTab?.RepaintModAwareChrome());
                 // Re-render the Remote Control QR code in the new mod's accent color
                 App.Mods.ModChanged += (_, _) => Dispatcher.Invoke(() =>
                 {

--- a/Tests/ConditioningControlPanel.Tests/ModAwareSurfaceSweepTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModAwareSurfaceSweepTests.cs
@@ -216,6 +216,25 @@ public class ModAwareSurfaceSweepTests
     }
 
     // =====================================================================================
+    //  the Studio rack
+    // =====================================================================================
+
+    [Fact]
+    public void TheStudioRackRepaintsFromTheSweepAndNotFromItsOwnModChangedHook()
+    {
+        // ccp-bugs#1100. RepaintModAwareChrome calls RefreshDots, which reads PinkBrush through
+        // TryFindResource. Its own ModChanged subscription sat AHEAD of the palette handler in
+        // MainWindow.xaml.cs, so the rack's lit state dots (and their glow) were painted from the
+        // OUTGOING mod's accent and stayed there until an unrelated settings write repainted them.
+        // The sweep's Background priority is by construction after every ModChanged handler.
+        Assert.Contains("SweepStep(() => StudioTab?.RepaintModAwareChrome(), \"studio rack\");",
+                        SweepBody(), StringComparison.Ordinal);
+
+        Assert.DoesNotContain("StudioTab?.RepaintModAwareChrome())",
+                              AppFile("MainWindow", "MainWindow.xaml.cs"), StringComparison.Ordinal);
+    }
+
+    // =====================================================================================
     //  the faucet handle
     // =====================================================================================
 


### PR DESCRIPTION
## Bug

`CC-Labs-llc/ccp-bugs#1100` (MED) - after switching mods, parts of the UI keep the previous mod's accent colour; the Studio tab is the worst. Reporter's repro: start a session, go to the Studio, switch mod, not everything follows.

## Root cause

`ConditioningControlPanel/MainWindow/MainWindow.xaml.cs:3512` (origin/main 437c97ca6) subscribed the Studio rack's repaint to `ModChanged`:

```
App.Mods.ModChanged += (_, _) => Dispatcher.Invoke(() => StudioTab?.RepaintModAwareChrome());
```

The handler that rewrites the accent palette, `RefreshThemeAwareElements`, is subscribed **last** in the same block (`MainWindow.xaml.cs:3536`). Handlers run in subscription order, so the rack repainted first.

`StudioTabView.RepaintModAwareChrome` (`ConditioningControlPanel/Views/Tabs/StudioTabView.xaml.cs:313`) calls `RefreshDots`, and `RefreshDots` (`:1403-1405`) reads the palette out of the resource dictionary:

```
var on = (Brush?)TryFindResource("PinkBrush") ?? Brushes.HotPink;
```

so the rack's lit state dots - and `DotGlow`, the halo the same pass mixes - were painted from the **outgoing** mod's accent, and stayed there until an unrelated settings write, selection change or tab show ran `RefreshDots` again. The rest of `RepaintModAwareChrome` is fine: its `Accent` comes from `FxTheme.GlowColor`, and `FxTheme.ApplyForActiveMod` is subscribed at app startup (`App.xaml.cs:1805`), ahead of everything MainWindow wires.

I checked the other three handlers subscribed ahead of the palette one (`RefreshRemoteQrCode`, `LoadFeatureImages`, `ApplyDoorArt`). None of them read a theme resource - the QR code goes to `App.Mods.GetAccentDarkColorHex()` directly - so the Studio rack is the only ordering victim.

## Fix

Deleted the rack's own subscription and added it as a step in the existing `QueueModAwareSurfaceSweep` / `RefreshModAwareSurfaces` pass in `MainWindow/MainWindow.UiUpdates.cs`. That sweep already exists for exactly this bug class, posts at `DispatcherPriority.Background` (which is by construction after every `ModChanged` handler in both raise shapes), and coalesces. Its own doc comment already names this hazard - "a sweep running inline would repaint the presets row from the OUTGOING mod's PinkBrush".

I chose the sweep over swapping the two subscriptions because swapping would make `RefreshThemeAwareElements` no longer the last subscriber, which is the invariant the sweep's Background-priority comment is written against. The sweep also picks up the `LanguageChanged` caller, which is correct here: the rack's row captions are the same mod-aware names a language switch changes.

Added a source-level regression test next to the existing sweep wiring tests.

## Do NOT delete the brush-swap blocks

Triage proposed deleting the `res["...Brush"] = new SolidColorBrush(...)` blocks at `MainWindow.xaml.cs:2284-2290` and `:2325-2337`, on the theory that `Resources/Theme/Brushes.xaml` already binds those brushes with `Color="{DynamicResource <ColorKey>}"` and the swap severs the binding. **That would have broken every mod's theming.** I built a throwaway WPF probe with the same dictionary shape (Colors.xaml + Brushes.xaml merged into `Application.Resources`, a `Border` consuming `{DynamicResource PinkBrush}`):

```
A start             brush=#FFFF69B4 border=#FFFF69B4
B write Color into top-level app dict    brush=#FFFF69B4 border=#FFFF69B4   <- no change
C write Color into the merged dict that owns the key  brush=#FFFF69B4      <- no change
E overwrite the Brush entry              brush=#FFFF0000 border=#FFFF0000  <- this is what works
G remove the Brush entry                 brush=#FFFF69B4 border=#FFFF69B4
```

A `DynamicResource` on a `Freezable` living inside a `ResourceDictionary` resolves once, when the dictionary instantiates the brush; the brush has no `InheritanceContext` to re-resolve through, so later writes to the Color key never reach it. Overwriting the brush entry is the only thing that repaints `{DynamicResource *Brush}` consumers. It is also the restore path for `MainWindow.Lab.cs` `ApplyLockdownTheme` - `RestoreLockdownTheme` (`:1308`) relies on `RefreshThemeAwareElements` to overwrite the four keys lockdown shadows. And `ModAwareSurfaceSweepTests.TheProfileFaucetHandleFollowsTheModAccent` already asserts that exact line exists.

I replaced the misleading "in case any are frozen from initial load" comment with the real reason, so the next triage does not repeat this.

## Other `new SolidColorBrush` writes into theme resource keys (all left alone)

| Site | What | Verdict |
|---|---|---|
| `MainWindow/MainWindow.xaml.cs:2284-2290` | background brushes | load-bearing, see above |
| `MainWindow/MainWindow.xaml.cs:2335-2347` | accent brushes | load-bearing, see above |
| `MainWindow/MainWindow.xaml.cs:2356` | `AccentGradientBrush` anchor swap | not a Color-bound key, correct as is |
| `MainWindow/MainWindow.Lab.cs:1259-1262` | lockdown shadows `PinkBrush`, `DarkPinkBrush`, `TransparentPinkBrush`, `PinkButtonHoveredBrush` | correct, and undone by `RestoreLockdownTheme` -> `RefreshThemeAwareElements`. Note it does NOT write the matching Color keys, so anything reading `PinkColor` during lockdown reads the mod accent, not crimson. Pre-existing, not touched. |
| `Services/FxTheme.cs:58-62` | `Set()` writes both `Fx*Color` and a frozen `Fx*Brush` | correct - it writes both halves |

**Related latent bug, not fixed here:** `Services/RecapTheme.cs:31-47` writes **only** Color keys (`RecapViolet`, `RecapPanel`, ...), while `Resources/Theme/SeasonRecapCard.xaml:42-52` defines 20 `Recap*Brush` entries bound to those keys with `DynamicResource`. By the finding above those brushes can never follow a mod switch. Worth its own ticket - it is a different surface and outside this PR's size budget.

## Verified

- `dotnet build -c Debug` in `ConditioningControlPanel/`: **0 errors**, 344 warnings (all pre-existing CA1416/CS8602/IL3000 noise).
- `dotnet test` in `Tests/ConditioningControlPanel.Tests/`: **5170 passed, 0 failed**, 52s. Full suite, not filtered.
- The new test `TheStudioRackRepaintsFromTheSweepAndNotFromItsOwnModChangedHook` fails on origin/main and passes here.

**NOT verified:** I cannot launch the app (single instance, would hijack the owner's running session), so nothing here is visually confirmed. The claim "the rack's dots now come up in the new mod's accent" is reasoned from the code and from the resource probe above, not seen. Someone should switch mods while parked on the Studio tab and look at the row state dots and their glow.

## Size

3 files changed, 45 insertions(+), 3 deletions(-) - 48 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
