### PR TITLE
fix(video): mute is the player's state, not the media's

### DIFF
--- a/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
@@ -752,7 +752,11 @@ internal static class DtrhHostService
         if (disp == null) return;
         disp.BeginInvoke(() =>
         {
-            try { App.Video?.SetExternalMute(on); }
+            // Apply the CURRENT flag, not the value captured when this was queued (#1103). The
+            // teardown below releases the mute synchronously, so a mute queued just before it
+            // would otherwise land afterwards and leave every video for the rest of the process
+            // silent - with nothing in the log to say why.
+            try { App.Video?.SetExternalMute(_diveMuted); }
             catch (Exception ex) { App.Logger?.Debug("DtrhHost.ApplyDiveMute: {E}", ex.Message); }
         });
     }
@@ -1000,8 +1004,12 @@ internal static class DtrhHostService
         try { Haptics.DtrhHapticDirector.OnClosed(); } catch { }
         // Never leave a video or voiceline wedged paused if the window dies mid-freeze.
         if (_worldFrozen) { _worldFrozen = false; try { App.Video?.PlayPrimary(); } catch { } try { App.AvatarWindow?.ResumeSpokenAudio(); } catch { } }
-        // ...and never leave every video silent because the dive ended while muted.
-        if (_diveMuted) { _diveMuted = false; try { App.Video?.SetExternalMute(false); } catch { } }
+        // ...and never leave every video silent because the dive ended while muted. Unconditional
+        // (#1103): the _diveMuted flag and the VideoService's own mute could get out of step - a
+        // mute applied while Application.Current was already gone set the flag and nothing else,
+        // and this gate then skipped the only release there was, muting every video until restart.
+        _diveMuted = false;
+        try { App.Video?.SetExternalMute(false); } catch { }
         try { _meta?.FlushSave(); } catch { }
         if (_runActive && !_testMode)
         {

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1427,7 +1427,12 @@ namespace ConditioningControlPanel.Services
         /// and the play path force-unmutes, so folding this into GetEffectiveVolume is the
         /// one place that covers every site at once - play-time AND live slider drags.
         /// </summary>
-        private static volatile bool _externalMute;
+        ///
+        /// INSTANCE, not static (#1103). As a static it outlived the VideoService that owned it: a
+        /// dive torn down on an unusual path left it set and every video for the rest of the process
+        /// was created silent, with nothing in the log to say why. Per-instance, a service restart
+        /// clears it, and the only writer is the DtRH host.
+        private volatile bool _externalMute;
 
         /// <summary>Silence (or release) every video for an external owner. Applies live.
         /// MUST be released on teardown - see DtrhHostService.DisposeAll.</summary>
@@ -1448,6 +1453,23 @@ namespace ConditioningControlPanel.Services
             var master = App.Settings.Current.MasterVolume;
             var video = App.Settings.Current.VideoVolume;
             return (int)((master / 100.0) * (video / 100.0) * 100);
+        }
+
+        /// <summary>
+        /// Where the current effective volume comes from, for the one play-time log line (#1103).
+        /// "The video had no sound" reports used to carry nothing that separated "the user's slider
+        /// is at zero" from "a DtRH dive left the external mute set", which are the same silence
+        /// with completely different fixes. Audio ducking is named here only to rule it out: Duck()
+        /// lowers OTHER apps, never this player.
+        /// </summary>
+        private string DescribeVolumeOrigin()
+        {
+            var master = App.Settings.Current.MasterVolume;
+            var video = App.Settings.Current.VideoVolume;
+            if (_externalMute) return $"DtRH dive external mute (user setting is master {master}%, video {video}%)";
+            if (master <= 0) return "user setting: master volume is 0";
+            if (video <= 0) return "user setting: video volume is 0";
+            return $"user setting (master {master}%, video {video}%)";
         }
 
         /// <summary>
@@ -1516,7 +1538,11 @@ namespace ConditioningControlPanel.Services
                     // drags: player.Mute reads true while no audio output exists yet (transient),
                     // so the primary player got skipped. Volume and Mute are independent in
                     // LibVLC - setting Volume never unmutes, and no-audio secondaries ignore it.
+                    // Mute is driven from the same number (#1103): silence is the PLAYER's state
+                    // now, so a drag back up has to clear it or the video stays silent for the rest
+                    // of the clip. Secondaries carry :no-audio and ignore both.
                     player.Volume = effectiveVolume;
+                    player.Mute = effectiveVolume <= 0;
                 }
                 catch (Exception ex)
                 {
@@ -2509,10 +2535,10 @@ namespace ConditioningControlPanel.Services
             // Create media from URL — disposed after Play() (LibVLC ref-counts internally)
             using var media = new Media(_libVLC!, url, FromType.FromLocation);
             // Secondaries skip audio decoding entirely — prevents a parallel WASAPI session
-            // from opening on the same MMDevice and racing the primary's mixer state. Also
-            // skip it when audio is deactivated (effective volume 0), else the async Play()
-            // lets the video blip at 100% before the volume set below lands (see file path).
-            if (!withAudio || GetEffectiveVolume() <= 0) media.AddOption(":no-audio");
+            // from opening on the same MMDevice and racing the primary's mixer state. A zero
+            // effective volume no longer bakes it in: that made the silence permanent for the
+            // whole clip, mute state included (#1103, see the file path for the full note).
+            if (!withAudio) media.AddOption(":no-audio");
 
             // Subscribed BEFORE Play(): a fast start raises Playing inside Play() itself, and this
             // handler owns everything that needs a live aout - the volume re-apply (the set after
@@ -2522,7 +2548,12 @@ namespace ConditioningControlPanel.Services
                 int audioRouted = 0; // Playing can fire again after a seek/restart - route once
                 mediaPlayer.Playing += (s, e) =>
                 {
-                    try { mediaPlayer.Mute = false; mediaPlayer.Volume = GetEffectiveVolume(); }
+                    try
+                    {
+                        var eff = GetEffectiveVolume();
+                        mediaPlayer.Mute = eff <= 0;
+                        mediaPlayer.Volume = eff;
+                    }
                     catch (Exception ex) { App.Logger?.Debug(ex, "VideoService: URL volume apply on Playing failed"); }
 
                     if (System.Threading.Interlocked.Exchange(ref audioRouted, 1) == 0)
@@ -2534,8 +2565,11 @@ namespace ConditioningControlPanel.Services
 
             if (withAudio)
             {
-                mediaPlayer.Mute = false;
-                mediaPlayer.Volume = GetEffectiveVolume();
+                var effective = GetEffectiveVolume();
+                mediaPlayer.Mute = effective <= 0;
+                mediaPlayer.Volume = effective;
+                App.Logger?.Information("VideoService: effective URL video volume {Vol}% (mute={Mute}) - origin: {Origin}",
+                    effective, effective <= 0, DescribeVolumeOrigin());
             }
 
             return win;
@@ -3390,15 +3424,15 @@ namespace ConditioningControlPanel.Services
             // Secondaries skip audio decoding entirely. Setting Mute=true after Play() opened
             // a second WASAPI session on the same MMDevice; Windows collapsed both into one
             // per-app mixer slider and the result was doubled/desynced or zero-volume audio.
-            // Also skip it when audio is deactivated (effective volume 0): Play() is async, so
-            // the Volume=0 set below no-ops until the aout exists and the video would start at
-            // 100% for a beat before the Playing handler cuts it — the audible blip a
-            // "deactivated audio" user hears. :no-audio never decodes audio, so nothing blips.
-            // Same reasoning covers a muted player (dive master-mute or a zeroed slider): it has to
-            // start SILENT, and killing audio at the media level is the only way to beat the aout.
-            // Trade-off: un-muting mid-video won't restore sound - fine for the mandatory dive
-            // video, and any later playback opens a fresh Media that re-evaluates this.
-            if (!withAudio || GetEffectiveVolume() <= 0)
+            // It is NOT baked in for a zero effective volume any more (#1103). ":no-audio" is a
+            // permanent property of the Media: a clip created while the volume happened to be 0 -
+            // a slider at zero, or a DtRH dive holding the external mute - could never make a sound
+            // again, however far the user pushed the slider back up mid-video, and if the mute
+            // state was stale the silence lasted for every video until the app restarted. Mute and
+            // volume are applied through the PLAYER below instead, which a live change can reach.
+            // The cost is the beat between Play() and the aout coming up, where a zero-volume clip
+            // can blip; the Playing handler is the first moment the volume can actually land.
+            if (!withAudio)
             {
                 media.AddOption(":no-audio");
             }
@@ -3426,7 +3460,15 @@ namespace ConditioningControlPanel.Services
                     // with no aout) and the video starts at 100% regardless of the slider. Only
                     // this re-apply lands the Video Volume slider (matches
                     // DualMonitorVideoService/MiniPlayerWindow).
-                    try { mediaPlayer!.Mute = false; mediaPlayer.Volume = GetEffectiveVolume(); }
+                    // Mute follows the CURRENT effective volume rather than being forced off: the
+                    // silence is now the player's state, not the media's, so a later unmute (dive
+                    // released, slider dragged back up) reaches this same live player (#1103).
+                    try
+                    {
+                        var eff = GetEffectiveVolume();
+                        mediaPlayer!.Mute = eff <= 0;
+                        mediaPlayer.Volume = eff;
+                    }
                     catch (Exception ex) { App.Logger?.Debug(ex, "VideoService: volume apply on Playing failed"); }
 
                     // Anything heavier than a property set goes off the LibVLC event thread.
@@ -3446,8 +3488,14 @@ namespace ConditioningControlPanel.Services
             // LibVLC auto-selects the first audio track once the media is parsed.
             if (withAudio)
             {
-                mediaPlayer.Mute = false;
-                mediaPlayer.Volume = GetEffectiveVolume();
+                var effective = GetEffectiveVolume();
+                mediaPlayer.Mute = effective <= 0;
+                mediaPlayer.Volume = effective;
+                // WHY this video is as loud as it is, in one line (#1103). A "no audio" report used
+                // to be unable to tell a zeroed slider from a stale DtRH dive mute - the same
+                // silence, opposite fixes - because nothing ever logged which one was in force.
+                App.Logger?.Information("VideoService: effective video volume {Vol}% (mute={Mute}) - origin: {Origin}",
+                    effective, effective <= 0, DescribeVolumeOrigin());
                 // REQUESTED values only. No aout exists this early, so this line says nothing about
                 // audibility - it read "Volume=99, Mute=false" on both #707 and #708, which were
                 // dead silent. RouteAndProbeAudio logs the RESOLVED routing once the aout is live;


### PR DESCRIPTION
**Stacks on:** `fix/692-video-stop-wedge` (PR 1, #642). Review that one first; this PR's diff is only its own commit. PR 3 bases on this branch.

## Bug
`CC-Labs-llc/ccp-bugs#1103` - "the mandatory video bugged out, no audio and played on one side". The one-side half is unproven and NOT addressed here (see Verified).

## Root cause
`VideoService.cs:3401-3404` baked `:no-audio` into the `Media` whenever `GetEffectiveVolume() <= 0`. That is a permanent property of the Media object, so a clip that happened to start at zero volume could never make a sound again for its whole run, whatever the user did with the slider.

`GetEffectiveVolume()` (`VideoService.cs:1445-1451`) returns 0 while `_externalMute` is set, and `_externalMute` was a **static** field written only by the DtRH dive:
- `DtrhHostService.cs:747-758` `ApplyDiveMute` set the flag, then applied it through `BeginInvoke`. It returned early without applying when `Application.Current` was already gone (flag set, VideoService never told), and a mute queued just before teardown landed AFTER the synchronous release below.
- `DtrhHostService.cs:1008` released it only `if (_diveMuted)` - exactly the flag that had just been desynced.

Either way the static stayed set for the rest of the process, and every video created afterwards got `:no-audio` at construction. Nothing in the log distinguished that from a slider at zero.

## Fix
- `:no-audio` is added only for `!withAudio` (the mirror players, whose reason is a parallel WASAPI session, not a volume). Both LibVLC paths, file and URL.
- Mute/volume are applied through the `MediaPlayer`: in the `Playing` handler (first moment an aout exists), after `Play()`, and in `UpdatePlayingVideosVolume` - which now drives `Mute` from the same number, so a live drag back up actually unmutes the clip on screen.
- `_externalMute` is an instance field. A VideoService restart clears it; the only writer is the DtRH host.
- `DtrhHostService`: the queued apply reads the CURRENT `_diveMuted` instead of the captured value, and the teardown release is unconditional.
- New `DescribeVolumeOrigin()` plus one `Information` line per video: effective volume, mute flag, and whether it is a user setting or the DtRH dive. Ducking is named in that helper's docs only to rule it out - `AudioService.Duck` lowers OTHER apps and is untouched here.

## Verified
- `dotnet build -c Debug`: **0 errors**, 344 warnings (pre-existing).
- Test run for the whole stack is reported on PR 3.
- NOT verified: no runtime repro. Specifically not verified is the one trade-off this makes - with `:no-audio` gone, a clip started at zero volume could in principle blip for the beat between `Play()` and the aout coming up, which is what the old comment at that line was guarding against. The `Playing` handler is the earliest point the volume can land, so that beat cannot be closed further without going back to a permanent media-level mute.
- NOT addressed: "played on one side". No channel/downmix code is involved in this path and the report has no repro; the new volume-origin line is the diagnostic that a follow-up report would need.

## Size
79 insertions, 23 deletions across 2 files (`git diff --stat fix/692-video-stop-wedge...HEAD`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
