### PR TITLE
fix(flash): flash voicelines obey the phrase library and see both content roots

### DIFF
--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -113,6 +113,9 @@ namespace ConditioningControlPanel.Services
         // pool that predates the user's latest selection — see PruneDeselectedFromPools.
         private int _poolDisabledStamp = -1;
         private Queue<string> _soundQueue = new();  // Performance: Changed to Queue for O(1) dequeue
+        // Last flash voice-line pool size written to the log, so BuildVoiceLinePool only speaks up
+        // when the number CHANGES (#1099). Guarded by _lockObj, like _soundQueue.
+        private int _lastLoggedVoicePoolCount = -1;
         private readonly List<string> _tempPackFiles = new();  // Track temp files for cleanup
         private readonly object _lockObj = new();
         private FlashWindow[] _windowsSnapshot = Array.Empty<FlashWindow>(); // Reusable snapshot for heartbeat
@@ -3699,7 +3702,7 @@ namespace ConditioningControlPanel.Services
             {
                 if (_soundQueue.Count == 0)
                 {
-                    var files = GetMediaFiles(SoundsPath, new[] { ".mp3", ".wav", ".ogg" });
+                    var files = BuildVoiceLinePool();
                     if (files.Count == 0) return null;
 
                     // Performance: Shuffle and enqueue all at once
@@ -3708,6 +3711,60 @@ namespace ConditioningControlPanel.Services
 
                 return _soundQueue.Count > 0 ? _soundQueue.Dequeue() : null; // Performance: O(1) instead of O(n)
             }
+        }
+
+        /// <summary>
+        /// The clips a flash may speak (#1099).
+        ///
+        /// <para>Starts from the same list the phrase library shows,
+        /// <see cref="CompanionPhraseService.GetEnabledVoiceLineFiles"/> - the UNION of the bundled
+        /// install dir and the downloaded content pack, already minus the lines the user disabled or
+        /// removed there. Then adds whatever the folder scan finds that the library cannot see: clips
+        /// a user dropped into category subfolders (the scan is recursive, the library is top-level
+        /// only) and packaged-mod folders. Those extras get filtered by the same removed/disabled
+        /// ids, so a line deleted in the library stays deleted wherever it lives.</para>
+        ///
+        /// <para>Until this, the flash path called <see cref="GetMediaFiles"/> on
+        /// <see cref="SoundsPath"/> alone: it honoured no phrase-library toggle at all, and it saw
+        /// only ONE of the two content roots, because <c>ContentLocator.ResolveDirectory</c> stops at
+        /// the first root that exists rather than merging them. That is both halves of the report - a
+        /// reporter deleted the line in the phrase library and still heard it on every flash, and the
+        /// pool that actually played could be a fraction of the list the library showed, small enough
+        /// that one clip came back on every single flash.</para>
+        ///
+        /// <para>Mirrors <c>AvatarTubeWindow.GetRandomVoiceLinePath</c>, which has always taken the
+        /// filtered list with an unfiltered fallback. Caller holds <see cref="_lockObj"/>.</para>
+        /// </summary>
+        private List<string> BuildVoiceLinePool()
+        {
+            var pool = App.CompanionPhrases?.GetEnabledVoiceLineFiles() ?? new List<string>();
+            var libraryCount = pool.Count;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var file in pool) seen.Add(Path.GetFileName(file));
+
+            var settings = App.Settings?.Current;
+            foreach (var file in GetMediaFiles(SoundsPath, new[] { ".mp3", ".wav", ".ogg" }))
+            {
+                if (!seen.Add(Path.GetFileName(file))) continue;
+                var id = CompanionPhraseService.VoiceLineId(file);
+                if (settings?.RemovedPhraseIds?.Contains(id) == true) continue;
+                if (settings?.DisabledPhraseIds?.Contains(id) == true) continue;
+                pool.Add(file);
+            }
+
+            // Says out loud how much variety a flash actually has. A pool of 1 is the shape of
+            // "she says the same line every time", and is invisible from the outside otherwise.
+            // Only on a CHANGE: an empty pool rebuilds on every flash, and this would be spam.
+            if (pool.Count != _lastLoggedVoicePoolCount)
+            {
+                _lastLoggedVoicePoolCount = pool.Count;
+                App.Logger?.Information(
+                    "FlashService: flash voice-line pool = {Count} clip(s) ({LibraryCount} from the phrase library) in {Folder}",
+                    pool.Count, libraryCount, SoundsPath);
+            }
+
+            return pool;
         }
 
         /// <summary>


### PR DESCRIPTION
## Bug

`CC-Labs-llc/ccp-bugs#1099` (BUG-C9AVGQ66LX, v6.8.6, `builtin-bambisleep`) - the companion says
"trigger my brain and make me a bimbo" on every flash image, all session, and turning companion
audio off does not stop it.

The #1099 issue body has an empty crash log, so the evidence is the Discord thread the same
complaint produced. `#support`, 2026-08-23 16:19, **TerrablyFoxy**:

> how do I make it stop saying "Trigger my brain and make me a bimbo" every time a flash image pops
> up? **i deleted the two instances of the phrase under the phrase library**..

and, eight minutes later:

> also, it isnt giving me any other subliminal phrases when those pop...

Wobberjockey answered with Settings > Visuals > "Link to Audio Trigger", which is `FlashAudioEnabled`
(`Features/VisualsFeatureControl.xaml:112-127`), and that silenced it. That pins the source to
`FlashService`'s flash voiceline path, not to the AI companion, not to subliminals.

(The report is TerrablyFoxy + the in-app reporter, not RaleighMac8 - RaleighMac8's messages in the
same window are about remote flash sources and video trigger bubbles.)

## Root cause

`Services/Flash/FlashService.cs:3696` `GetNextSound()` built its pool from
`GetMediaFiles(SoundsPath, ...)` - a plain recursive `Directory.GetFiles` over one folder. Two
consequences, one for each half of the report:

1. **It honoured no phrase-library state.** `DisabledPhraseIds` / `RemovedPhraseIds`
   (`Models/AppSettings.cs:7013,7016`) are applied by
   `CompanionPhraseService.GetEnabledVoiceLineFiles` (`Services/Companion/CompanionPhraseService.cs:615`),
   which every other voice-line consumer goes through - `AvatarTubeWindow.Speech.cs:1608` takes the
   filtered list with an unfiltered fallback. The flash path was the one caller that never did.
   Deleting the line in the library therefore changed nothing, exactly as reported.

2. **It saw only one of the two content roots.** `SoundsPath` is
   `CompanionPhraseService.VoiceLineFolder` (`FlashService.cs:191`), i.e.
   `ContentLocator.ResolveDirectory` (`Services/Content/ContentLocator.cs:78`), which returns the
   install-dir folder as soon as it *exists* and never merges the downloaded content-pack root. The
   library half uses `ContentLocator.EnumerateFiles` and gets the **union** of both roots
   (`CompanionPhraseService.cs:489-503`, and its own doc comment says the folder is split across
   roots). So on a modular install the library can list all 118 baseline clips while playback only
   ever draws from whatever the winning root holds. `GetNextSound`'s shuffled queue is correct in
   itself - it cannot repeat until the pool is exhausted - so "the same line every flash" is a pool
   of one, and this is the only path that can shrink it.

I can prove (1) from the code and the reporter's own words. (2) is the only mechanism that produces
(and the reporter's second message describes) a collapsed pool, but I cannot prove her disk held one
clip: there is no log for it, which is why this PR also adds one.

## Fix

`BuildVoiceLinePool()` replaces the bare scan in `GetNextSound`:

- start from `GetEnabledVoiceLineFiles()` - the two-root union, already minus disabled/removed lines
- add anything only the recursive scan can see (clips a user dropped into category subfolders, and
  packaged-mod folders), deduped by filename, filtered by the same removed/disabled ids
- log the pool size when it CHANGES, naming the folder. A pool of 1 is now a line in the log instead
  of something to infer. Only on change, because an empty pool rebuilds on every flash.

Note: `GetEnabledVoiceLineFiles` also returns the user's own custom phrases in the `VoiceLine`
category that have audio, so those can now play on a flash. That is the same list the avatar already
speaks from, so it is a deliberate widening rather than a surprise.

## Verified

- `dotnet build -c Debug`: **0 errors**, 344 warnings (all pre-existing CA1416/CS8602 noise).
- `dotnet test` full suite: **5169 passed, 0 failed** (29s). Also ran the narrowed
  `--filter "FullyQualifiedName~Flash|FullyQualifiedName~Companion|FullyQualifiedName~Phrase|FullyQualifiedName~ContentLocator"`:
  708 passed, 0 failed.
- **Not verified:** no runtime run - the app is single instance and launching it would hijack the
  owner's session. So the pool-size log line has not been seen firing, and the two-root collapse has
  not been reproduced on a real modular install. No new unit test: `GetNextSound` is private and
  needs `App.Settings` + `App.CompanionPhrases` + disk, which is not reachable without WPF.
- Whether the reporter's pool really was exactly one clip stays unproven until a report comes back
  with the new log line in it.

## Size

`git diff --stat origin/main...HEAD` -> **1 file changed, 58 insertions(+), 1 deletion(-)** = 59
changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
