### PR TITLE
fix(video): say why a refill found no videos, and stop stacking the dialog

### DIFF
--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -176,6 +176,9 @@ namespace ConditioningControlPanel.Services
         // How long the next video waits (pumping) for those stragglers before it abandons the owning
         // instance and builds its players on a fresh one.
         private const int PendingStopWaitMs = 2000;
+        // The "no videos found" guidance dialog is a per-LAUNCH one-off (#1124). Every trigger used
+        // to raise its own modal, so a long session stacked dozens of them on the dispatcher.
+        private static int _noVideosDialogShown;
 
 #if DEBUG
         // Fault injection for the wedge cluster (#765/#766/#767). Set CCP_FAULT_WEDGE_STOP=1 and the
@@ -2139,6 +2142,15 @@ namespace ConditioningControlPanel.Services
                     return;
                 }
 
+                // One dialog per app launch (#1124). A trigger fires every couple of minutes, so a
+                // 33-minute session used to stack dozens of identical modals - each one blocking
+                // this call and pumping a nested message loop on the dispatcher.
+                if (Interlocked.Exchange(ref _noVideosDialogShown, 1) != 0)
+                {
+                    App.Logger?.Information("VideoService: still no videos in {Path}; the guidance dialog was already shown this launch", _videosPath);
+                    return;
+                }
+
                 // Build helpful error message
                 var activePackCount = App.ContentPacks?.GetActivePackIds()?.Count ?? 0;
                 var installedPackCount = App.ContentPacks?.InstalledPacks?.Count ?? 0;
@@ -2156,13 +2168,25 @@ namespace ConditioningControlPanel.Services
 
                 message += Loc.Get("video_add_files_hint");
 
-                System.Windows.MessageBox.Show(message, Loc.Get("video_no_videos_title"));
+                // Posted, not called: MessageBox.Show blocks its caller and pumps a nested message
+                // loop, and this caller is the trigger path. It returns immediately now and the box
+                // opens on the dispatcher's own time (#1124).
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                dispatcher.BeginInvoke(new Action(() =>
+                {
+                    try
+                    {
+                        System.Windows.MessageBox.Show(message, Loc.Get("video_no_videos_title"));
 
-                // AFTER the box closes, never before: MessageBox.Show runs a nested message pump,
-                // so the coaching card's Normal-priority BeginInvoke would be dispatched while the
-                // box is still up and stack a window on a modal. App keeps the one-offer-per-launch
-                // budget, shared with the flash/wallpaper/first-run dead ends.
-                App.OfferRemoteMediaSource("videos");
+                        // AFTER the box closes, never before: MessageBox.Show runs a nested message pump,
+                        // so the coaching card's Normal-priority BeginInvoke would be dispatched while the
+                        // box is still up and stack a window on a modal. App keeps the one-offer-per-launch
+                        // budget, shared with the flash/wallpaper/first-run dead ends.
+                        App.OfferRemoteMediaSource("videos");
+                    }
+                    catch (Exception ex) { App.Logger?.Debug("VideoService: no-videos dialog failed: {Error}", ex.Message); }
+                }));
                 return;
             }
 
@@ -7837,9 +7861,30 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Refills both video queues (regular and pack videos).
         /// </summary>
+        /// <summary>
+        /// Containers the local video walk accepts. Everything here is something LibVLC demuxes and
+        /// the browser engine either plays or hands back to LibVLC, so the cost of a wide list is a
+        /// clip that fails at play time; the cost of a narrow one is a folder that silently scans to
+        /// zero videos and a "no videos" dialog on a folder that visibly has some (#1124).
+        /// </summary>
+        internal static readonly string[] SupportedVideoExtensions =
+        {
+            ".mp4", ".mov", ".avi", ".wmv", ".mkv", ".webm",
+            ".m4v", ".mpg", ".mpeg", ".flv", ".ts"
+        };
+
+        /// <summary>Extension gate of the local video walk, case-insensitive. Pure, so it is unit
+        /// tested (VideoExtensionFilterTests) rather than only exercised through a disk scan.</summary>
+        internal static bool IsSupportedVideoExtension(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            var ext = Path.GetExtension(path);
+            if (string.IsNullOrEmpty(ext)) return false;
+            return SupportedVideoExtensions.Contains(ext.ToLowerInvariant());
+        }
+
         private void RefillVideoQueues()
         {
-            var validExtensions = new[] { ".mp4", ".mov", ".avi", ".wmv", ".mkv", ".webm" };
 
             // Remote injection point. A refill is the moment the pipeline admits it needs more
             // material, so it is where the remote buffer gets topped up too - but ONLY as a
@@ -7853,22 +7898,29 @@ namespace ConditioningControlPanel.Services
 
             App.Logger?.Debug("VideoService: Scanning for videos in {Path}", _videosPath);
 
-            // Load regular videos
+            // Load regular videos.
+            // The counters below are the #1124 funnel: a Release log used to say nothing at all
+            // about WHY a folder full of files scanned to zero videos, because every step here was
+            // Debug-only. One Information line at the end reports the whole ladder.
+            int seen = 0, keptExt = 0, keptSecurity = 0;
+            bool folderMissing = false;
             var files = new List<string>();
             if (Directory.Exists(_videosPath))
             {
                 // Scan subfolders to support user-organized categories
                 var allFiles = Directory.GetFiles(_videosPath, "*.*", SearchOption.AllDirectories);
+                seen = allFiles.Length;
                 App.Logger?.Debug("VideoService: Found {Count} total files in videos folder", allFiles.Length);
 
                 foreach (var file in allFiles)
                 {
                     var ext = Path.GetExtension(file).ToLowerInvariant();
-                    if (!validExtensions.Contains(ext))
+                    if (!IsSupportedVideoExtension(file))
                     {
                         App.Logger?.Debug("VideoService: Skipping non-video file: {Path} (ext: {Ext})", file, ext);
                         continue;
                     }
+                    keptExt++;
 
                     // Security: Validate path is within allowed directories (app dir, user assets, or custom path)
                     var isInAppDir = SecurityHelper.IsPathSafe(file, AppDomain.CurrentDomain.BaseDirectory);
@@ -7891,14 +7943,17 @@ namespace ConditioningControlPanel.Services
                     }
 
                     files.Add(file);
+                    keptSecurity++;
                 }
             }
             else
             {
+                folderMissing = true;
                 App.Logger?.Warning("VideoService: Videos directory does not exist: {Path}", _videosPath);
             }
 
             App.Logger?.Debug("VideoService: {Count} videos passed security checks", files.Count);
+            int keptEnabled = files.Count;
 
             // Filter out disabled assets (blacklist approach).
             // Normalize for case-insensitive, separator-agnostic comparison so saved
@@ -7923,6 +7978,7 @@ namespace ConditioningControlPanel.Services
                 }).ToList();
                 App.Logger?.Debug("VideoService: {Before} -> {After} after disabled filter", beforeCount, files.Count);
             }
+            keptEnabled = files.Count;
 
             // Duration filter (Phase 5). Best-effort: videos with no cached
             // duration are included and parsed lazily — they'll get filtered
@@ -7966,6 +8022,28 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("VideoService: {Before} -> {After} after duration filter [{Min}s, {Max}s]",
                     beforeDur, files.Count, minSec, maxSec);
             }
+            int keptDuration = files.Count;
+
+            // The #1124 funnel line. Information, not Debug: the report that needs it is a Release
+            // log from a user whose folder "has videos" and whose app says it has none, and until
+            // now that log carried the final count and nothing about the ladder that produced it.
+            // The path goes through the same scrubber as every other logged path.
+            var drops = new (int Count, string Reason)[]
+            {
+                (seen - keptExt, $"extension filter ({seen - keptExt} file(s); supported: {string.Join(" ", SupportedVideoExtensions)})"),
+                (keptExt - keptSecurity, $"path/name security checks ({keptExt - keptSecurity} file(s))"),
+                (keptSecurity - keptEnabled, $"the user's disabled-assets list ({keptSecurity - keptEnabled} file(s))"),
+                (keptEnabled - keptDuration, $"duration filter ({keptEnabled - keptDuration} file(s); min {minSec}s max {maxSec}s)")
+            };
+            var worstDrop = drops.OrderByDescending(d => d.Count).First();
+            string biggestDrop =
+                folderMissing ? "the videos folder does not exist"
+                : seen == 0 ? "the folder is empty"
+                : worstDrop.Count <= 0 ? "nothing was dropped"
+                : worstDrop.Reason;
+            App.Logger?.Information(
+                "VideoService: refill funnel for {Path} - {Seen} file(s) seen, {Ext} kept by extension, {Sec} after path/name checks, {Enabled} after the disabled list, {Dur} after the duration filter. Biggest drop: {Drop}",
+                _videosPath, seen, keptExt, keptSecurity, keptEnabled, keptDuration, biggestDrop);
 
             // Shuffle using Fisher-Yates algorithm for reliable randomization
             ShuffleList(files);

--- a/Tests/ConditioningControlPanel.Tests/VideoExtensionFilterTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/VideoExtensionFilterTests.cs
@@ -1,0 +1,72 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The extension gate of the local video walk (#1124: a user whose videos folder produced zero
+/// clips, and a Release log that said nothing about why). Pure, so the ladder that decides whether
+/// a file is even a candidate can be tested without a disk scan.
+/// </summary>
+public class VideoExtensionFilterTests
+{
+    [Theory]
+    [InlineData("clip.mp4")]
+    [InlineData("clip.mov")]
+    [InlineData("clip.avi")]
+    [InlineData("clip.wmv")]
+    [InlineData("clip.mkv")]
+    [InlineData("clip.webm")]
+    public void TheOriginalSixAreStillAccepted(string name)
+    {
+        Assert.True(VideoService.IsSupportedVideoExtension(name));
+    }
+
+    [Theory]
+    [InlineData("clip.m4v")]
+    [InlineData("clip.mpg")]
+    [InlineData("clip.mpeg")]
+    [InlineData("clip.flv")]
+    [InlineData("clip.ts")]
+    public void TheWidenedContainersAreAccepted(string name)
+    {
+        // These are all demuxable, and a folder of them used to scan to zero videos and raise the
+        // "no videos found" dialog on a folder the user could see was full.
+        Assert.True(VideoService.IsSupportedVideoExtension(name));
+    }
+
+    [Theory]
+    [InlineData("CLIP.MP4")]
+    [InlineData("clip.Mkv")]
+    [InlineData("clip.TS")]
+    public void MatchingIsCaseInsensitive(string name)
+    {
+        Assert.True(VideoService.IsSupportedVideoExtension(name));
+    }
+
+    [Theory]
+    [InlineData("notes.txt")]
+    [InlineData("cover.jpg")]
+    [InlineData("audio.mp3")]
+    [InlineData("archive.zip")]
+    public void NonVideoFilesAreRejected(string name)
+    {
+        Assert.False(VideoService.IsSupportedVideoExtension(name));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("no_extension_at_all")]
+    [InlineData("trailing.")]
+    public void MissingOrEmptyExtensionsAreRejected(string name)
+    {
+        Assert.False(VideoService.IsSupportedVideoExtension(name));
+    }
+
+    [Fact]
+    public void AFullPathIsJudgedByItsFileExtension()
+    {
+        Assert.True(VideoService.IsSupportedVideoExtension(@"C:\assets\videos\subfolder\a.name.with.dots.mkv"));
+        Assert.False(VideoService.IsSupportedVideoExtension(@"C:\assets\videos.mp4\readme.md"));
+    }
+}


### PR DESCRIPTION
**Stacks on:** `fix/692-video-mute-origin` (PR 2, #646), which stacks on `fix/692-video-stop-wedge` (PR 1, #642). This PR's own diff is its single commit.

## Bug
`CC-Labs-llc/ccp-bugs#1124` - Russian-locale user, 6.9.1: "doesn't produce video from folder (AppData\Local\ConditioningControlPanel\assets\videos)".

## Root cause
Not one bug, a blind spot. `RefillVideoQueues` (`VideoService.cs:7834+`) walks the folder through four filters and every one of them logs at **Debug**, so a Release log shows only the final "Queues refilled - 0 regular videos" and nothing about which step ate the files:

- extension list at `VideoService.cs:7842` was `.mp4 .mov .avi .wmv .mkv .webm`. Anything else in the folder was dropped silently at Debug level - and `App.xaml.cs:100`, which decides what the app COPIES into that folder, already accepts `.m4v`.
- the duration filter at `VideoService.cs:7940-7960` can empty the list on its own (a min/max the user forgot they set) and also only says so at Debug.

Separately, `ContinueTriggerVideo` (`VideoService.cs:2118-2166`) raised the "no videos found" `MessageBox` on EVERY trigger, blocking the caller and pumping a nested message loop, so a 33-minute session stacked one modal per trigger.

## Fix
- One `Information` funnel line per refill: folder path, files seen, kept after extension, after path/name security checks, after the disabled-assets list, after the duration filter, and which step was the biggest single drop (with the supported-extension list spelled out when that is the one). Path goes through the same scrubber as every other logged path.
- Extension list widened with `.m4v .mpg .mpeg .flv .ts`, moved to `VideoService.SupportedVideoExtensions`, matched through the new pure `IsSupportedVideoExtension` (still case-insensitive).
- The dialog is now once per app launch (`Interlocked.Exchange` guard) and posted with `Dispatcher.BeginInvoke` so it never blocks the trigger path. Subsequent empty triggers log one line instead.
- The extension filter WAS extractable as a pure function, so it has a unit test: `Tests/ConditioningControlPanel.Tests/VideoExtensionFilterTests.cs` (original six, the five new containers, case-insensitivity, non-video and extension-less rejects, full paths).

## Verified
- `dotnet build -c Debug`: **0 errors**, 344 warnings (pre-existing).
- `dotnet test` on the whole stack (this branch, all three PRs applied), full suite, no filter: **Failed: 0, Passed: 5191, Skipped: 0, Duration 31s**.
- NOT verified: the reporter's actual folder. The funnel line is what a follow-up report needs to name the culprit; widening the extension list is a guess at the most likely one and does not depend on being right. Nothing here is locale-specific - no repro that the `ru` locale itself matters, and the walk does not touch culture-sensitive comparisons.
- NOT verified at runtime: the dialog change (no app launch allowed for this agent).

## Size
159 insertions, 9 deletions across 2 files (`git diff --stat fix/692-video-mute-origin...HEAD`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7ZmKyHYMRoErLBhS2x49
