### PR TITLE
refactor(core): move the art-framing table into Core on a Core viewbox type

### DIFF
--- a/CCP.Core/Models/ArtViewbox.cs
+++ b/CCP.Core/Models/ArtViewbox.cs
@@ -1,0 +1,18 @@
+namespace ConditioningControlPanel.Models
+{
+    /// <summary>
+    /// A normalized viewbox: the sub-region of a source image an art surface shows, in 0..1
+    /// units of that image. X and Y are the top-left corner, Width and Height the extent.
+    ///
+    /// <para><b>Why this and not <c>System.Windows.Rect</c>.</b> The framing table and the
+    /// resolve rules are pure data and pure arithmetic, and they belong in Core next to the mod
+    /// manifest that carries them. A bare <c>Rect</c> resolves to <c>System.Windows.Rect</c>,
+    /// which a net8.0 assembly cannot name - the trap CLAUDE.md warns about - and it was the only
+    /// thing keeping the table, and behind it the settings model, in the WPF head.</para>
+    ///
+    /// <para>Deliberately not a geometry type: no operators, no intersection, no union. Nothing
+    /// here needs them. The WPF head converts at its brush boundary with <c>ToRect()</c>, one
+    /// extension in the head; every other consumer only reads Width and Height.</para>
+    /// </summary>
+    public readonly record struct ArtViewbox(double X, double Y, double Width, double Height);
+}

--- a/CCP.Core/Services/ModArtFraming.cs
+++ b/CCP.Core/Services/ModArtFraming.cs
@@ -2,7 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Windows;
+
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Services
 {
@@ -124,7 +125,7 @@ namespace ConditioningControlPanel.Services
     public sealed record ArtSlotBinding(
         string ResourcePath,
         string SurfaceId,
-        Rect ShippedViewbox,
+        ArtViewbox ShippedViewbox,
         bool Framable = true);
 
     /// <summary>
@@ -238,43 +239,43 @@ namespace ConditioningControlPanel.Services
         private static readonly ArtSlotBinding[] _bindings =
         {
             // Rail chips — rects from SettingsTabView.xaml's Art* ImageBrush resources.
-            new("features/takeover.png",       SurfaceRailChip, new Rect(0,    0.06, 1,    0.54)),
-            new("features/awareness.png",      SurfaceRailChip, new Rect(0.02, 0.05, 0.40, 0.43)),
-            new("features/vibe.png",           SurfaceRailChip, new Rect(0,    0.07, 1,    0.61)),
-            new("features/lab_quiz_hero.png",  SurfaceRailChip, new Rect(0.22, 0.04, 0.62, 0.66)),
-            new("features/remote_control.png", SurfaceRailChip, new Rect(0.60, 0.03, 0.35, 0.62)),
-            new("features/fyp.png",            SurfaceRailChip, new Rect(0.20, 0.33, 0.50, 0.545)),
+            new("features/takeover.png",       SurfaceRailChip, new ArtViewbox(0,    0.06, 1,    0.54)),
+            new("features/awareness.png",      SurfaceRailChip, new ArtViewbox(0.02, 0.05, 0.40, 0.43)),
+            new("features/vibe.png",           SurfaceRailChip, new ArtViewbox(0,    0.07, 1,    0.61)),
+            new("features/lab_quiz_hero.png",  SurfaceRailChip, new ArtViewbox(0.22, 0.04, 0.62, 0.66)),
+            new("features/remote_control.png", SurfaceRailChip, new ArtViewbox(0.60, 0.03, 0.35, 0.62)),
+            new("features/fyp.png",            SurfaceRailChip, new ArtViewbox(0.20, 0.33, 0.50, 0.545)),
             // The two taller launchers.
-            new("features/blink_trainer.png",  SurfaceRailCard, new Rect(0.05, 0.06, 0.44, 0.72)),
-            new("lockdown_icon.png",           SurfaceRailCard, new Rect(0.08, 0,    0.25, 1)),
+            new("features/blink_trainer.png",  SurfaceRailCard, new ArtViewbox(0.05, 0.06, 0.44, 0.72)),
+            new("lockdown_icon.png",           SurfaceRailCard, new ArtViewbox(0.08, 0,    0.25, 1)),
 
             // Play door cards — PlayTabView.xaml. Only Goon carried a rect; the rest were a bare
-            // UniformToFill, which is the full-image window and is what Rect(0,0,1,1) means.
+            // UniformToFill, which is the full-image window and is what ArtViewbox(0,0,1,1) means.
             // Goon keeps its rect for OUR art but is not framable: Stretch=Uniform over a plate.
             // Its plate is one of the two overridden to 168, hence playCardTall — the aspect is moot
             // for a non-framable pair (the shipped rect is used verbatim and mod art gets the whole
             // image), but a row that lies about its own shape is a trap for whoever reads it next.
-            new("features/goon_game.png",           SurfacePlayCardTall, new Rect(0.03, 0.22, 0.94, 0.68), Framable: false),
-            new("features/lab_gaze_hero.png",       SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("features/lab_focusgaze_hero.png",  SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("features/lab_quiz_hero.png",       SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("features/blink_trainer.png",       SurfacePlayCard, new Rect(0, 0, 1, 1)),
+            new("features/goon_game.png",           SurfacePlayCardTall, new ArtViewbox(0.03, 0.22, 0.94, 0.68), Framable: false),
+            new("features/lab_gaze_hero.png",       SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
+            new("features/lab_focusgaze_hero.png",  SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
+            new("features/lab_quiz_hero.png",       SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
+            new("features/blink_trainer.png",       SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
             // Remote's plate overrides the style height to 168 (PlayTabView.xaml:645).
-            new("features/remote_control.png",      SurfacePlayCardTall, new Rect(0, 0, 1, 1)),
-            new("features/fyp.png",                 SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("lockdown_icon.png",                SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("features/justdrop.png",            SurfacePlayCard, new Rect(0, 0, 1, 1)),
+            new("features/remote_control.png",      SurfacePlayCardTall, new ArtViewbox(0, 0, 1, 1)),
+            new("features/fyp.png",                 SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
+            new("lockdown_icon.png",                SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
+            new("features/justdrop.png",            SurfacePlayCard, new ArtViewbox(0, 0, 1, 1)),
             // NOT a card plate at all: a fixed 216-wide column in the Loom strip.
-            new("features/loom.png",                SurfaceLoomStrip, new Rect(0, 0, 1, 1)),
+            new("features/loom.png",                SurfaceLoomStrip, new ArtViewbox(0, 0, 1, 1)),
 
             // Play hero banner.
-            new("features/dtrh.png", SurfacePlayHero, new Rect(0, 0, 1, 1)),
+            new("features/dtrh.png", SurfacePlayHero, new ArtViewbox(0, 0, 1, 1)),
 
             // Page headers. lab_quiz_hero paints the narrow Intake strip, NOT the wide permissions
             // plate — the two were one id until the review caught that a single preview cannot be
             // right for a 3.5:1 tile and a 5:1 plate at once.
-            new("features/lab_quiz_hero.png",     SurfaceIntakeStrip, new Rect(0, 0, 1, 1)),
-            new("features/lab_aimemory_hero.png", SurfacePageHeader,  new Rect(0, 0, 1, 1)),
+            new("features/lab_quiz_hero.png",     SurfaceIntakeStrip, new ArtViewbox(0, 0, 1, 1)),
+            new("features/lab_aimemory_hero.png", SurfacePageHeader,  new ArtViewbox(0, 0, 1, 1)),
         };
 
         /// <summary>Every (path, surface) pair the app frames.</summary>
@@ -302,7 +303,7 @@ namespace ConditioningControlPanel.Services
                                && b.SurfaceId == surfaceId && b.Framable);
 
         /// <summary>The shipped rect for a pair, or null when the pair is not in the table.</summary>
-        public static Rect? ShippedViewbox(string resourcePath, string surfaceId) =>
+        public static ArtViewbox? ShippedViewbox(string resourcePath, string surfaceId) =>
             _bindings.FirstOrDefault(b =>
                 string.Equals(b.ResourcePath, resourcePath, StringComparison.OrdinalIgnoreCase)
                 && b.SurfaceId == surfaceId)?.ShippedViewbox;
@@ -323,13 +324,13 @@ namespace ConditioningControlPanel.Services
         /// <param name="framing">The stored centre and zoom. Null yields the full-fill window.</param>
         /// <param name="sourceAspect">Source image width ÷ height, in pixels.</param>
         /// <param name="surfaceAspect">The frame's width ÷ height.</param>
-        public static Rect ToViewbox(ModArtFraming? framing, double sourceAspect, double surfaceAspect)
+        public static ArtViewbox ToViewbox(ModArtFraming? framing, double sourceAspect, double surfaceAspect)
         {
             // A non-finite or absurd aspect (a zero-height decode, a corrupt header) must not
             // produce a NaN rect — WPF renders nothing at all for one, which reads as "the mod's
             // art is missing" rather than "the crop maths broke".
             if (!IsUsable(sourceAspect) || !IsUsable(surfaceAspect))
-                return new Rect(0, 0, 1, 1);
+                return new ArtViewbox(0, 0, 1, 1);
 
             var zoom = framing == null ? 1.0 : framing.Zoom;
             if (double.IsNaN(zoom) || double.IsInfinity(zoom)) zoom = 1.0;
@@ -365,7 +366,7 @@ namespace ConditioningControlPanel.Services
             var x = Math.Clamp(cx - w / 2.0, 0.0, Math.Max(0.0, 1.0 - w));
             var y = Math.Clamp(cy - h / 2.0, 0.0, Math.Max(0.0, 1.0 - h));
 
-            return new Rect(x, y, w, h);
+            return new ArtViewbox(x, y, w, h);
         }
 
         /// <summary>
@@ -388,22 +389,22 @@ namespace ConditioningControlPanel.Services
         /// </param>
         /// <param name="sourceAspect">Source image width ÷ height in pixels.</param>
         /// <param name="framing">The mod's framing for this pair, or null if it supplied none.</param>
-        public static Rect ResolveViewbox(string resourcePath, string surfaceId, bool isModSupplied,
+        public static ArtViewbox ResolveViewbox(string resourcePath, string surfaceId, bool isModSupplied,
                                           double sourceAspect, ModArtFraming? framing)
         {
             if (!isModSupplied)
-                return ShippedViewbox(resourcePath, surfaceId) ?? new Rect(0, 0, 1, 1);
+                return ShippedViewbox(resourcePath, surfaceId) ?? new ArtViewbox(0, 0, 1, 1);
 
             var surface = FindSurface(surfaceId);
             if (surface == null)
-                return new Rect(0, 0, 1, 1);
+                return new ArtViewbox(0, 0, 1, 1);
 
             // A non-framable pair takes the whole image rather than a crop window, whatever a
             // hand-edited mod.json claims: the surface letterboxes onto a plate, so a window would
             // be shrunk inside it instead of filling it. The editor never offers one, so this is
             // purely the guard for a manifest written by hand.
             if (framing != null && !IsFramable(resourcePath, surfaceId))
-                return new Rect(0, 0, 1, 1);
+                return new ArtViewbox(0, 0, 1, 1);
 
             return ToViewbox(framing, sourceAspect, surface.AspectRatio);
         }

--- a/ConditioningControlPanel/Helpers/ArtViewboxExtensions.cs
+++ b/ConditioningControlPanel/Helpers/ArtViewboxExtensions.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Helpers
+{
+    /// <summary>The one place a Core viewbox becomes a WPF rect: at the brush.</summary>
+    internal static class ArtViewboxExtensions
+    {
+        public static Rect ToRect(this ArtViewbox v) => new(v.X, v.Y, v.Width, v.Height);
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2861,7 +2861,7 @@ namespace ConditioningControlPanel
                 }
 
                 brush.Viewbox = ModArtFramingRegistry.ResolveViewbox(
-                    resourcePath, surfaceId, isModSupplied, aspect, framing);
+                    resourcePath, surfaceId, isModSupplied, aspect, framing).ToRect();
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Windows/ModCreatorWindow.ArtFraming.cs
+++ b/ConditioningControlPanel/Windows/ModCreatorWindow.ArtFraming.cs
@@ -1,4 +1,5 @@
 using System;
+using ConditioningControlPanel.Helpers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -360,7 +361,7 @@ namespace ConditioningControlPanel
             var brush = new ImageBrush(bitmap)
             {
                 Stretch = Stretch.Fill,
-                Viewbox = ModArtFramingRegistry.ToViewbox(framing, sourceAspect, surface.AspectRatio),
+                Viewbox = ModArtFramingRegistry.ToViewbox(framing, sourceAspect, surface.AspectRatio).ToRect(),
             };
 
             var holder = new Grid
@@ -440,7 +441,7 @@ namespace ConditioningControlPanel
 
             void Refresh()
             {
-                brush.Viewbox = ModArtFramingRegistry.ToViewbox(framing, sourceAspect, surface.AspectRatio);
+                brush.Viewbox = ModArtFramingRegistry.ToViewbox(framing, sourceAspect, surface.AspectRatio).ToRect();
                 readout.Text = DescribeFraming(framing);
             }
             Refresh();

--- a/Tests/ConditioningControlPanel.Tests/ModArtFramingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModArtFramingTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows;
 using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Models;
 using Xunit;
 
 namespace ConditioningControlPanel.Tests;
@@ -54,7 +55,7 @@ public class ModArtFramingTests
     public void ToViewbox_AtZoomOne_MatchingAspects_IsTheWholeImage()
     {
         var rect = ModArtFramingRegistry.ToViewbox(null, sourceAspect: 1.5, surfaceAspect: 1.5);
-        Assert.Equal(new Rect(0, 0, 1, 1), rect);
+        Assert.Equal(new ArtViewbox(0, 0, 1, 1), rect);
     }
 
     [Fact]
@@ -109,7 +110,7 @@ public class ModArtFramingTests
     public void ToViewbox_ZoomIsClampedBothWays()
     {
         var under = ModArtFramingRegistry.ToViewbox(new ModArtFraming { Zoom = 0.1 }, 2.0, 2.0);
-        Assert.Equal(new Rect(0, 0, 1, 1), under);   // below 1 is meaningless, treated as 1
+        Assert.Equal(new ArtViewbox(0, 0, 1, 1), under);   // below 1 is meaningless, treated as 1
 
         var over = ModArtFramingRegistry.ToViewbox(new ModArtFraming { Zoom = 1e9 }, 2.0, 2.0);
         var atMax = ModArtFramingRegistry.ToViewbox(
@@ -132,7 +133,7 @@ public class ModArtFramingTests
         // missing" rather than "the crop maths broke" — so a corrupt decode must degrade to the
         // full image, not to an empty window.
         var rect = ModArtFramingRegistry.ToViewbox(new ModArtFraming(), sourceAspect, surfaceAspect);
-        Assert.Equal(new Rect(0, 0, 1, 1), rect);
+        Assert.Equal(new ArtViewbox(0, 0, 1, 1), rect);
     }
 
     [Fact]
@@ -173,7 +174,7 @@ public class ModArtFramingTests
             isModSupplied: false, sourceAspect: 1.79,
             framing: new ModArtFraming { CenterX = 0.1, CenterY = 0.9, Zoom = 4.0 });
 
-        Assert.Equal(new Rect(0, 0.06, 1, 0.54), rect);
+        Assert.Equal(new ArtViewbox(0, 0.06, 1, 0.54), rect);
     }
 
     [Fact]
@@ -184,7 +185,7 @@ public class ModArtFramingTests
         // with nothing declared they get an honest centre crop they can predict.
         const string path = "features/takeover.png";
         var shipped = ModArtFramingRegistry.ShippedViewbox(path, ModArtFramingRegistry.SurfaceRailChip);
-        Assert.Equal(new Rect(0, 0.06, 1, 0.54), shipped!.Value);
+        Assert.Equal(new ArtViewbox(0, 0.06, 1, 0.54), shipped!.Value);
 
         var rect = ModArtFramingRegistry.ResolveViewbox(
             path, ModArtFramingRegistry.SurfaceRailChip,
@@ -218,7 +219,7 @@ public class ModArtFramingTests
             "features/fyp.png", "surfaceFromTheFuture",
             isModSupplied: true, sourceAspect: 1.79, framing: new ModArtFraming { Zoom = 3 });
 
-        Assert.Equal(new Rect(0, 0, 1, 1), rect);
+        Assert.Equal(new ArtViewbox(0, 0, 1, 1), rect);
     }
 
     // ── Table guards: catch a typo in the registry rather than on someone's screen ──
@@ -443,7 +444,7 @@ public class ModArtFramingTests
     /// returns null when the element has no Viewbox at all (a bare UniformToFill, which means the
     /// whole image and is not something the registry mirrors).
     /// </summary>
-    private static Rect? ExtractViewbox(string xaml, string anchor)
+    private static ArtViewbox? ExtractViewbox(string xaml, string anchor)
     {
         var at = xaml.IndexOf(anchor, StringComparison.Ordinal);
         if (at < 0) return null;
@@ -455,14 +456,14 @@ public class ModArtFramingTests
         var m = Regex.Match(window, @"Viewbox\s*=\s*""\s*([-\d.]+)\s*,\s*([-\d.]+)\s*,\s*([-\d.]+)\s*,\s*([-\d.]+)\s*""");
         if (!m.Success) return null;
 
-        return new Rect(
+        return new ArtViewbox(
             double.Parse(m.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture),
             double.Parse(m.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture),
             double.Parse(m.Groups[3].Value, System.Globalization.CultureInfo.InvariantCulture),
             double.Parse(m.Groups[4].Value, System.Globalization.CultureInfo.InvariantCulture));
     }
 
-    private static void AssertRectsMatch(Rect registry, Rect xaml, string what)
+    private static void AssertRectsMatch(ArtViewbox registry, ArtViewbox xaml, string what)
     {
         Assert.True(Math.Abs(registry.X - xaml.X) < 1e-9
                     && Math.Abs(registry.Y - xaml.Y) < 1e-9


### PR DESCRIPTION
`ModArtFraming` typed its shipped viewboxes as a bare `Rect`, which resolves to `System.Windows.Rect`: the trap `CLAUDE.md` names. That one type was what kept the framing table, the mod manifest that carries it, and behind them the 8,164-line settings model in the WPF head. This is the first of the layers that unblock the settings move (#618 explains the chain).

## What
- **`ArtViewbox`**, a readonly record struct in Core with the same four members. Deliberately not a geometry type: no operators, no intersection, no union. Nothing needs them.
- **`ModArtFraming.cs` moves to Core** with the type swapped. The table and the resolve rules are pure data and pure arithmetic; the file is otherwise unchanged and its namespace is the same, so no consumer changed a `using`.
- **Every consumer but three only reads `Width` and `Height`**, which the record shares, so they compile untouched. The three that hand a value to a WPF `ImageBrush` convert at that boundary with `ToRect()`, one five-line extension in the head.
- The registry's tests follow: seven literal rects and two helper signatures.

## Verified
Core builds and the guards pass (no `System.Windows` reached Core), the WPF head and the Windows test project build, `--smoke` on both heads, `--nav-check`, 186/186 views render. 87 changed lines plus one rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351