### PR TITLE
feat(core): the settings seams - secrets, change hook, mode name, subreddit rule

### DIFF
--- a/CCP.Core/CoreMods.cs
+++ b/CCP.Core/CoreMods.cs
@@ -56,6 +56,16 @@ namespace ConditioningControlPanel
             get { try { return PetNameOverrideProvider?.Invoke(); } catch { return null; } }
         }
 
+        /// <summary>The active mod's display name for its content mode, or null when no mod layer
+        /// is up. The settings model shows it and falls back to the vanilla label.</summary>
+        public static volatile Func<string?>? ModeDisplayNameProvider;
+
+        /// <summary>Mode display name, or null. Faults are swallowed - see <see cref="ActiveModToken"/>.</summary>
+        public static string? ModeDisplayName
+        {
+            get { try { return ModeDisplayNameProvider?.Invoke(); } catch { return null; } }
+        }
+
         /// <summary>Collective override, or null. Faults are swallowed - see <see cref="ActiveModToken"/>.</summary>
         public static string? CollectiveOverride
         {

--- a/CCP.Core/CoreSecrets.cs
+++ b/CCP.Core/CoreSecrets.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The secret-at-rest seam. The settings model keeps two values out of settings.json - the
+    /// AI API key and the account token - and hands them to a store that encrypts them for the
+    /// current user. On Windows that store is DPAPI (<c>ProtectedData</c>), which the Core
+    /// guards forbid because it throws everywhere else. So the stores stay in the head and the
+    /// model asks here, by name.
+    ///
+    /// <para><b>Unseeded means "no store", never "store in the clear".</b> A head that has not
+    /// attached a provider gets null from <see cref="Retrieve"/> and a silent no-op from
+    /// <see cref="Store"/>. The Linux head is in that state today: it has no secure store yet,
+    /// so on Linux these two values are not persisted at all. That is the honest behaviour until
+    /// a keyring-backed provider exists; writing them to disk unencrypted is not a fallback.</para>
+    ///
+    /// <para>Two delegates, no interface, matching <see cref="CoreMods"/>. Volatile for the same
+    /// reason as there.</para>
+    /// </summary>
+    public static class CoreSecrets
+    {
+        /// <summary>Well-known names. The head maps each to its own store.</summary>
+        public const string ApiKey = "apikey";
+        public const string AuthToken = "authtoken";
+
+        public static volatile Func<string, string?>? RetrieveProvider;
+        public static volatile Action<string, string?>? StoreProvider;
+
+        /// <summary>The stored value, or null when there is none or no store is attached.
+        /// Faults are swallowed: a broken store must not take the settings model down.</summary>
+        public static string? Retrieve(string name)
+        {
+            try { return RetrieveProvider?.Invoke(name); } catch { return null; }
+        }
+
+        /// <summary>Stores the value, or clears it when null. No-op with no store attached.</summary>
+        public static void Store(string name, string? value)
+        {
+            try { StoreProvider?.Invoke(name, value); } catch { /* see Retrieve */ }
+        }
+    }
+}

--- a/CCP.Core/CoreSettingsHooks.cs
+++ b/CCP.Core/CoreSettingsHooks.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// What the settings model tells the outside world, without knowing who listens. Today one
+    /// thing: a property changed by name, which the WPF head forwards to the bark service so a
+    /// companion line can react to a setting flip. The model used to call <c>App.Bark</c> for
+    /// that directly, which is the one reason an 8,000-line pure data class was pinned to WPF.
+    ///
+    /// <para>Fired on every property set, so it is a bare volatile delegate and the invoke is
+    /// wrapped: a slow or throwing listener must never break a settings write. Unseeded is the
+    /// normal state under tests and during startup load, and means nobody is listening.</para>
+    /// </summary>
+    public static class CoreSettingsHooks
+    {
+        public static volatile Action<string?>? SettingChangedSink;
+
+        public static void NotifySettingChanged(string? name)
+        {
+            try { SettingChangedSink?.Invoke(name); } catch { /* never break settings for a listener */ }
+        }
+    }
+}

--- a/CCP.Core/Services/Fyp/SubredditName.cs
+++ b/CCP.Core/Services/Fyp/SubredditName.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+
+namespace ConditioningControlPanel.Services.Fyp
+{
+    /// <summary>
+    /// Normalises what a user typed into a subreddit name: strips a leading "r/" or anything
+    /// up to the last "/r/", keeps the leading run of [A-Za-z0-9_], and accepts 2..40 characters.
+    /// Pure string work, so it lives in Core; the settings model validates with it on every
+    /// edit and the online coordinator delegates here.
+    /// </summary>
+    public static class SubredditName
+    {
+        public static string? Sanitize(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            var s = raw.Trim();
+            int idx = s.LastIndexOf("/r/", StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0) s = s[(idx + 3)..];
+            else if (s.StartsWith("r/", StringComparison.OrdinalIgnoreCase)) s = s[2..];
+            s = new string(s.TakeWhile(ch => char.IsLetterOrDigit(ch) || ch == '_').ToArray());
+            return s.Length is >= 2 and <= 40 ? s : null;
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -46,6 +46,22 @@ namespace ConditioningControlPanel.LinuxSmoke
             Console.WriteLine();
             if (_failures == 0)
             {
+                // The settings seams (wire/06). Unseeded is the documented state here: no head has
+                // attached a secret store or a listener, and the model must behave, not throw.
+                Check("CoreSecrets.Retrieve is null when no store is attached", CoreSecrets.Retrieve(CoreSecrets.ApiKey) == null);
+                CoreSecrets.Store(CoreSecrets.ApiKey, "never-written");
+                Check("CoreSecrets.Store is a no-op when no store is attached", CoreSecrets.Retrieve(CoreSecrets.ApiKey) == null);
+                CoreSettingsHooks.NotifySettingChanged("Anything");
+                Check("CoreSettingsHooks tolerates no listener", true);
+                Check("CoreMods.ModeDisplayName is null when no mod layer is up", CoreMods.ModeDisplayName == null);
+                // The subreddit rule moved from the online coordinator into Core with no test of its own.
+                Check("SubredditName strips r/", Services.Fyp.SubredditName.Sanitize("r/gonewild") == "gonewild");
+                Check("SubredditName keeps the last /r/ segment", Services.Fyp.SubredditName.Sanitize("https://reddit.com/r/Bar_1/") == "Bar_1");
+                Check("SubredditName stops at the first bad char", Services.Fyp.SubredditName.Sanitize("abc def") == "abc");
+                Check("SubredditName rejects one char", Services.Fyp.SubredditName.Sanitize("a") == null);
+                Check("SubredditName rejects 41 chars", Services.Fyp.SubredditName.Sanitize(new string('x', 41)) == null);
+                Check("SubredditName rejects blank", Services.Fyp.SubredditName.Sanitize("   ") == null);
+
                 Console.WriteLine("CCP.Core executed on this platform with all assertions holding.");
                 return 0;
             }

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -273,6 +273,25 @@ namespace ConditioningControlPanel
             CoreMods.ActiveModTokenProvider = () => Mods?.ActiveMod?.Manifest;
             CoreMods.PetNameOverrideProvider = () => Mods?.GetPetNameOverride();
             CoreMods.CollectiveOverrideProvider = () => Mods?.GetCollectiveOverride();
+            CoreMods.ModeDisplayNameProvider = () => Mods?.GetModeDisplayName();
+
+            // The settings model's outward hooks. Bark and the mod service attach later in
+            // startup; the delegates read them lazily, so seeding here is order-safe.
+            CoreSettingsHooks.SettingChangedSink = name => Bark?.NotifySettingChanged(name);
+            CoreSecrets.RetrieveProvider = name => name switch
+            {
+                CoreSecrets.ApiKey    => Services.SecureApiKeyStore.Retrieve(),
+                CoreSecrets.AuthToken => Services.SecureAuthTokenStore.Retrieve(),
+                _ => null,
+            };
+            CoreSecrets.StoreProvider = (name, value) =>
+            {
+                switch (name)
+                {
+                    case CoreSecrets.ApiKey:    Services.SecureApiKeyStore.Store(value); break;
+                    case CoreSecrets.AuthToken: Services.SecureAuthTokenStore.Store(value); break;
+                }
+            };
         }
 
         #region Remote media handoff (Phase 1.5)

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -93,9 +93,9 @@ namespace ConditioningControlPanel.Models
 
     /// <summary>
     /// Legacy content mode enum. Kept for settings deserialization backward compatibility.
-    /// Use App.Mods (ModService) instead.
+    /// Use the mod service (ModService) instead.
     /// </summary>
-    [Obsolete("Use App.Mods (ModService) and ActiveModId instead")]
+    [Obsolete("Use the mod service (ModService) and ActiveModId instead")]
     public enum ContentMode
     {
         BambiSleep,
@@ -142,9 +142,9 @@ namespace ConditioningControlPanel.Models
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
             // Bark hook: surface every numeric/bool setting change as a SettingChanged trigger so
             // the avatar can react to toggles, thresholds and easter-egg values. BarkService reads
-            // the new value off this instance by name and ignores non-numeric props. App.Bark is
+            // the new value off this instance by name and ignores non-numeric props. the bark service is
             // null during startup load, so no spurious barks while settings deserialize.
-            try { ConditioningControlPanel.App.Bark?.NotifySettingChanged(name); } catch { /* never break settings for a bark */ }
+            CoreSettingsHooks.NotifySettingChanged(name);
         }
 
         #region Language
@@ -2099,8 +2099,8 @@ namespace ConditioningControlPanel.Models
         // compatible), -2 = all monitors, 0..N = that specific monitor index
         // (into Screen.AllScreens). An index beyond the current monitor count is
         // NOT clamped here — it falls back to -1 behavior at resolve time (via
-        // App.ResolveScreens) so a temporarily-unplugged monitor's target survives
-        // a reconnect. See App.ResolveScreens for the resolution semantics.
+        // the head's screen resolver) so a temporarily-unplugged monitor's target survives
+        // a reconnect. See the head's screen resolver for the resolution semantics.
         private int _spiralTargetMonitor = -1;
         /// <summary>Monitor target for the Spiral overlay. -1 = follow DualMonitorEnabled,
         /// -2 = all monitors, 0..N = specific monitor index. See <see cref="DualMonitorEnabled"/>.</summary>
@@ -2251,7 +2251,7 @@ namespace ConditioningControlPanel.Models
         // decoupled them — gaze-pop and stare-linger have their own toggles,
         // both default ON. To preserve the intent of existing users who
         // had FlashClickable=false (hands-free / accessibility / deep-trance
-        // configs), App.OnStartup runs RunFlashClickableDecouplingMigration
+        // configs), head startup runs RunFlashClickableDecouplingMigration
         // once: if FlashClickable was off, the new gaze toggles are also
         // turned off. Flag prevents re-migration after the user later
         // configures the new toggles independently.
@@ -2271,7 +2271,7 @@ namespace ConditioningControlPanel.Models
         // Scrapped pre-ship per design call — feature stays in the codebase
         // but is disabled by default and has no UI surface in this release.
         // To revive: flip default to true, re-add the Lab toggle, re-add the
-        // App.OnStartup wiring (see git history for the integration points).
+        // head-startup wiring (see git history for the integration points).
         private bool _attentionCheckEnabled = false;
         public bool AttentionCheckEnabled
         {
@@ -3734,7 +3734,7 @@ namespace ConditioningControlPanel.Models
         /// <summary>True when this name is already kept (case-insensitive, sanitized).</summary>
         public bool LibraryHasSub(string? rawName)
         {
-            var clean = Services.Fyp.Online.FypOnlineCoordinator.SanitizeSub(rawName);
+            var clean = Services.Fyp.SubredditName.Sanitize(rawName);
             if (clean == null) return false;
             foreach (var e in _remoteSubLibrary)
                 if (string.Equals(e?.Name, clean, StringComparison.OrdinalIgnoreCase)) return true;
@@ -3748,7 +3748,7 @@ namespace ConditioningControlPanel.Models
         /// </summary>
         public bool TryAddLibrarySub(string? rawName)
         {
-            var clean = Services.Fyp.Online.FypOnlineCoordinator.SanitizeSub(rawName);
+            var clean = Services.Fyp.SubredditName.Sanitize(rawName);
             if (clean == null) return false;
             if (LibraryHasSub(clean)) return false;
             if (_remoteSubLibrary.Count >= RemoteSubLibraryCap) return false;
@@ -3765,7 +3765,7 @@ namespace ConditioningControlPanel.Models
         /// </summary>
         public bool RemoveLibrarySub(string? rawName)
         {
-            var clean = Services.Fyp.Online.FypOnlineCoordinator.SanitizeSub(rawName) ?? rawName?.Trim();
+            var clean = Services.Fyp.SubredditName.Sanitize(rawName) ?? rawName?.Trim();
             if (string.IsNullOrEmpty(clean)) return false;
 
             bool changed = false;
@@ -3813,7 +3813,7 @@ namespace ConditioningControlPanel.Models
                 {
                     if (_remoteSubLibrary.Count >= RemoteSubLibraryCap) break;
                     if (string.IsNullOrWhiteSpace(name) || LibraryHasSub(name)) continue;
-                    var clean = Services.Fyp.Online.FypOnlineCoordinator.SanitizeSub(name);
+                    var clean = Services.Fyp.SubredditName.Sanitize(name);
                     if (clean == null) continue;
                     // AddedAtUtc backdated by a tick so migrated names sort ahead of anything the
                     // user adds after this load, which is the order they were really added in.
@@ -4694,7 +4694,7 @@ namespace ConditioningControlPanel.Models
         private bool _useCompanionBrain = true;
         /// <summary>
         /// Train 1 kill switch. True routes companion conversation through <c>CompanionBrain</c>
-        /// (<c>App.Brain</c>) — one turn log shared by every provider, so cloud chat finally has
+        /// (the head's brain service) — one turn log shared by every provider, so cloud chat finally has
         /// memory of the current conversation and of previous launches.
         ///
         /// <para>False restores the pre-Train-1 behaviour exactly: each call site goes straight to
@@ -5116,8 +5116,8 @@ namespace ConditioningControlPanel.Models
         [JsonIgnore]
         public string OpenRouterApiKey
         {
-            get => Services.SecureApiKeyStore.Retrieve() ?? "";
-            set { Services.SecureApiKeyStore.Store(string.IsNullOrEmpty(value) ? null : value); OnPropertyChanged(); }
+            get => CoreSecrets.Retrieve(CoreSecrets.ApiKey) ?? "";
+            set { CoreSecrets.Store(CoreSecrets.ApiKey, string.IsNullOrEmpty(value) ? null : value); OnPropertyChanged(); }
         }
 
         /// <summary>
@@ -5131,9 +5131,9 @@ namespace ConditioningControlPanel.Models
             set
             {
                 // Migrate: if there's a plaintext key in settings.json, move it to DPAPI
-                if (!string.IsNullOrEmpty(value) && string.IsNullOrEmpty(Services.SecureApiKeyStore.Retrieve()))
+                if (!string.IsNullOrEmpty(value) && string.IsNullOrEmpty(CoreSecrets.Retrieve(CoreSecrets.ApiKey)))
                 {
-                    Services.SecureApiKeyStore.Store(value);
+                    CoreSecrets.Store(CoreSecrets.ApiKey, value);
                 }
             }
         }
@@ -5243,7 +5243,7 @@ namespace ConditioningControlPanel.Models
         /// Display name for current content mode.
         /// </summary>
         [JsonIgnore]
-        public string ContentModeDisplay => App.Mods?.GetModeDisplayName() ?? "CCP Default";
+        public string ContentModeDisplay => CoreMods.ModeDisplayName ?? "CCP Default";
 
         /// <summary>
         /// Gets/sets the hypnotube links for the currently active content mode.
@@ -6071,8 +6071,8 @@ namespace ConditioningControlPanel.Models
         [JsonIgnore]
         public string? AuthToken
         {
-            get => Services.SecureAuthTokenStore.Retrieve();
-            set { Services.SecureAuthTokenStore.Store(value); OnPropertyChanged(); }
+            get => CoreSecrets.Retrieve(CoreSecrets.AuthToken);
+            set { CoreSecrets.Store(CoreSecrets.AuthToken, value); OnPropertyChanged(); }
         }
 
         private string? _userDisplayName = null;
@@ -7992,7 +7992,7 @@ namespace ConditioningControlPanel.Models
         private string? _installDate = null;
         /// <summary>
         /// Best available evidence of when this install first appeared on this machine, as a UTC
-        /// <c>yyyy-MM-dd</c> string. Written ONCE by <c>App.EnsureInstallDateRecorded</c> on the
+        /// <c>yyyy-MM-dd</c> string. Written ONCE by the head's install-date recorder on the
         /// first launch that finds it absent (see that method for the evidence ordering) and never
         /// touched again — a re-derived value would drift downward as old files are cleaned up.
         ///

--- a/ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
@@ -213,16 +213,7 @@ internal sealed class FypOnlineCoordinator
     }
 
     /// <summary>"r/Name", urls and stray punctuation → bare subreddit name, or null.</summary>
-    public static string? SanitizeSub(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw)) return null;
-        var s = raw.Trim();
-        int idx = s.LastIndexOf("/r/", StringComparison.OrdinalIgnoreCase);
-        if (idx >= 0) s = s[(idx + 3)..];
-        else if (s.StartsWith("r/", StringComparison.OrdinalIgnoreCase)) s = s[2..];
-        s = new string(s.TakeWhile(ch => char.IsLetterOrDigit(ch) || ch == '_').ToArray());
-        return s.Length is >= 2 and <= 40 ? s : null;
-    }
+    public static string? SanitizeSub(string? raw) => SubredditName.Sanitize(raw);   // the rule lives in Core
 
     // There is deliberately NO content filter between the query and the pool: picking the
     // subreddits IS the content control. Scrolller's isNsfw is fetched by the query and read


### PR DESCRIPTION
The 8,164-line settings model reached the WPF head in four ways. Each is now a Core seam, so the model itself can move in the next layer as a pure `git mv`.

| Was | Now |
|---|---|
| `App.Bark?.NotifySettingChanged(name)` | `CoreSettingsHooks.NotifySettingChanged(name)` |
| `App.Mods?.GetModeDisplayName()` | `CoreMods.ModeDisplayName` |
| `SecureApiKeyStore` / `SecureAuthTokenStore` | `CoreSecrets.Retrieve` / `Store`, by name |
| `FypOnlineCoordinator.SanitizeSub` | `Services.Fyp.SubredditName.Sanitize` |

## The one that needs a reviewer's eye: secrets
The two stores stay in the head. They are DPAPI, which the Core guards forbid because it throws off Windows. **Unseeded `CoreSecrets` means "no store"**: `Retrieve` returns null and `Store` is a no-op. It never means "store in the clear". The Linux head is in that state today, so on Linux the API key and account token are not persisted at all, and the seam's doc says so. A keyring-backed provider is a later layer; plaintext on disk is not a fallback.

## The rest
- The subreddit rule is pure string work that lived in the online coordinator by accident. It moves to Core; the coordinator delegates, so its callers are unchanged.
- It had no test of its own, so the Linux smoke runner now checks its six edges, plus the unseeded behaviour of every seam above.
- Comments in the model that named `App.*` are reworded, so the guard that forbids `App.*` in Core has nothing to catch when the file moves.
- The WPF head seeds all four in `App`, next to the existing `CoreMods` seeding. Bark and the mod service attach later in startup; the delegates read them lazily, so the order is safe.

## Verified
Core builds and guards pass, the WPF head and Windows tests build, the Linux Core smoke runner passes with the new checks, `--smoke` and `--nav-check` on the Avalonia head, 186/186 views render. About 180 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351