### PR TITLE
feat(race): Caucus Race 1/9 - contract, consts, track spine

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -34,9 +34,12 @@ import { createSpine } from './spine.js';
 const layout = createSpine({ seed, roomOrder });   // roomOrder: array of room ids from rooms.js
 ```
 Returns a `layout` object that is ALSO a valid argument to `engine/tunnel.js createTunnel(layout)`:
-- `RADIUS`, `totalDepth`, `loopDepth` (= totalDepth), `spine` (a closed `THREE.Curve`), `pointAt(d)`,
-  `frameAt(d)` (tunnel.js compat shape: `{pos, tangent, right, up}`) - tunnel.js only needs `spine`.
-- `frameAtDepth(d)` -> `{pos, tangent, up, right}` (parallel transport, cached per 0.5 m).
+- `RADIUS`, `totalDepth`, `loopDepth` (= totalDepth), `spine` (a closed `THREE.Curve`), `pointAt(t)`,
+  `frameAt(t)` - `t` is the NORMALIZED 0..1 parameter exactly as `buildLoopLayout` (fx.js calls
+  `layout.frameAt(Math.random())` and reads `pos/normal/binormal`); tunnel.js only needs `spine`.
+- `frameAtDepth(d)` -> `{pos, tangent, up, right, normal, binormal}` (`normal`/`binormal` alias
+  `up`/`right`; parallel transport through the wheel, re-levelled to world up elsewhere so the
+  road never stays banked; cached per 0.5 m).
 - `toWorld(d, x, h, out = new THREE.Vector3())` -> `out`.
 - `wrap(d)` -> d folded into `[0, totalDepth)`.
 - `chunks` -> ordered array of `{ id, kind, d0, d1, room, features }`.
@@ -55,6 +58,9 @@ Track shape rules: one Tea Garden start straight, then the rooms in `roomOrder`,
 chunks, exactly one loop somewhere after the first two rooms, at least one ramp per room, the whole
 thing closes back onto the start (closed curve, `spine.closed = true`). The loop must sidestep
 laterally by more than `2*RADIUS` so the tube never self-intersects (see the demo in the pitch).
+Each room's FIRST chunk is its `gate` chunk (the gate feature sits mid-chunk); the Tea Garden gate
+is `chunks[0]` at `d = 0`, so THE BANK fires on every lap crossing, and the start straight follows.
+Every room also carries at least one `itembox`, and a `boost` pad sits on the run-up to the loop.
 
 ### `race/rooms.js` (PR 1)
 ```js

--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -1,0 +1,208 @@
+# The Caucus Race - module contract
+
+Single-player, no-lose kart run through the DtRH tube. Sibling entry to `index.html` / `loom.html`:
+`race.html` + `raceBoot.js` + this `race/` folder. Nothing in `game/chaosRun.js` or `engine/scene.js`
+is touched. Everything below is the agreed interface between modules that are built in parallel.
+If you need to change a signature here, change this file in the same PR and say so in the PR body.
+
+## Coordinate system (track space)
+
+Every gameplay object lives in **track space** `(d, x, h)`:
+
+| axis | meaning | range |
+|------|---------|-------|
+| `d`  | depth along the spine, metres, wraps at `layout.totalDepth` | `0 .. totalDepth` |
+| `x`  | lateral offset on the road, metres, +x = kart's right | `-ROAD_HALF_W .. +ROAD_HALF_W` |
+| `h`  | height above the road surface, metres | `0` on the road, ceiling about `2*RADIUS - ROAD_DROP` |
+
+`layout.toWorld(d, x, h, out)` is the ONLY way to turn track space into a `THREE.Vector3`. Never
+compute world positions yourself. The frames are parallel-transported so the Big Wheel loop inverts
+the world correctly. `layout.frameAtDepth(d)` returns `{pos, tangent, up, right}` (unit vectors, `up`
+points from the road toward the tube centre).
+
+Constants live in `race/consts.js` (import them, do not redeclare).
+
+## Modules and their exports
+
+### `race/consts.js` (PR 1)
+`RADIUS`, `ROAD_DROP`, `ROAD_HALF_W`, `KART_BASE_SPEED`, `KART_MAX_SPEED`, `KART_MIN_SPEED`,
+`GRAVITY`, `POP_HIT_D`, `POP_HIT_X`, `POP_HIT_H`, `MULT_LADDER`, `COMBO_HOLD_SEC`, `INTENSITY_RAMP_SEC`.
+
+### `race/spine.js` (PR 1)
+```js
+import { createSpine } from './spine.js';
+const layout = createSpine({ seed, roomOrder });   // roomOrder: array of room ids from rooms.js
+```
+Returns a `layout` object that is ALSO a valid argument to `engine/tunnel.js createTunnel(layout)`:
+- `RADIUS`, `totalDepth`, `loopDepth` (= totalDepth), `spine` (a closed `THREE.Curve`), `pointAt(d)`,
+  `frameAt(d)` (tunnel.js compat shape: `{pos, tangent, right, up}`) - tunnel.js only needs `spine`.
+- `frameAtDepth(d)` -> `{pos, tangent, up, right}` (parallel transport, cached per 0.5 m).
+- `toWorld(d, x, h, out = new THREE.Vector3())` -> `out`.
+- `wrap(d)` -> d folded into `[0, totalDepth)`.
+- `chunks` -> ordered array of `{ id, kind, d0, d1, room, features }`.
+  `kind` in `straight | bendL | bendR | sCurve | climb | dip | ramp | chicane | loop | gate`.
+  `features` is an array of:
+  - `{ type:'ramp', d, airLen, height }` - lip at `d`, air line from `d` to `d + airLen`, apex `height`
+  - `{ type:'boost', d, x }` - boost pad centre
+  - `{ type:'loop', d0, d1 }` - the Big Wheel occupies `d0..d1`
+  - `{ type:'gate', d, room }` - room boundary; MARQUEE fires here
+  - `{ type:'itembox', d, x }` - sugar cube (item roll)
+- `featuresBetween(d0, d1)` -> features whose `d` (or `d0`) falls in the wrapped range.
+- `roomAtDepth(d)` -> room id.
+- `rampAt(d)` -> the ramp feature whose air line covers `d`, else `null`.
+
+Track shape rules: one Tea Garden start straight, then the rooms in `roomOrder`, each room = 4..7
+chunks, exactly one loop somewhere after the first two rooms, at least one ramp per room, the whole
+thing closes back onto the start (closed curve, `spine.closed = true`). The loop must sidestep
+laterally by more than `2*RADIUS` so the tube never self-intersects (see the demo in the pitch).
+
+### `race/rooms.js` (PR 1)
+```js
+export const ROOMS;          // array of 8 room specs, first is always 'teagarden'
+export function rollRoomOrder(seed) -> id[]     // teagarden first, then shuffled
+export function createRoomDresser({ scene, layout, rooms }) -> { update(d), applyRoom(fx, roomId, fadeSec), dispose }
+```
+Room spec: `{ id, name, tagline, biome, colors:{ road, edge, prop, fog, banner }, propKind,
+bubbleBias:{ [bubbleKindId]: weightMult }, ambient:{ kind, colors } }`. `biome` is a key of
+`game/biomes.js BIOMES_BY_ROOM`; `applyRoom` calls `fx.applyRegionGrade(style, fadeSec)`. Rooms:
+`teagarden, toybox, casino, undertow, mirrors, chapel, greyward, coronation`.
+
+### `race/bubbles.js` (PR 2)
+```js
+export const BUBBLE_KINDS;   // see table below
+export function createBubbleField({ scene, layout, media, getIntensity, getRoom }) -> field
+field.seedChunk(chunk)                  // place lane/air/itembox-adjacent bubbles for a chunk (idempotent per chunk id)
+field.spawnAhead(kartD, n)              // 'spawn' placement: appear 35..60 m ahead on the road
+field.rain(kartD, n)                    // 'rain' placement: fall from the ceiling ahead of the kart
+field.update(dt, t, kart)               // kart = { d, x, h, speed }; runs motion + collision
+field.onPop(cb)                         // cb(popEvent)
+field.onMiss(cb)                        // cb(missEvent) when a bubble passes behind the kart unpopped (treats only)
+field.setDensity(mult)
+field.dispose()
+```
+Pop event: `{ id, kind, payload, strength, points, placement, x, d, worldPos }`.
+`kind` is `'treat'` or `'effect'`. `payload` is the `payloadFx` spec name (`flash`, `subliminal`,
+`overlay`, `glitch`, `bambiFreeze`, `gifCascade`, `video`, or `null` for treats) plus `overlayKind`
+where relevant (`spiral | braindrain | pink_filter`). `strength` is 0..1.
+
+Bubble kinds (mirror `game/variants.js` and `engine/bubbles.js`; sprites from
+`/dtrh/assets/bubbles/effects/*.png` and `https://ccp.art/bubbles/*.png`):
+
+| id | kind | payload | points | notes |
+|----|------|---------|--------|-------|
+| treat | treat | null | 10 | the common bubble, plain sprite |
+| golden | treat | null | 50 | rare, JACKPOT chime |
+| lucky | treat | null | 25 | rolls an item |
+| prism | treat | null | 30 | rainbow, pops neighbours |
+| flash | effect | flash | 15 | flash media from the pool |
+| subliminal | effect | subliminal | 15 | |
+| pink | effect | overlay/pink_filter | 20 | |
+| spiral | effect | overlay/spiral | 20 | |
+| braindrain | effect | overlay/braindrain | 25 | minIntensity 0.4 |
+| glitch | effect | glitch | 20 | |
+| freeze | effect | bambiFreeze | 25 | minIntensity 0.15 |
+| gifrain | effect | gifCascade | 25 | minIntensity 0.45 |
+| video | effect | video | 40 | rare, minIntensity 0.45, host plays it |
+
+Placements: `lane` (rests on the road, h ~0.9, bobbing), `air` (along a ramp air line, h rises
+2..5), `spawn` (materialises ahead, wobbles laterally), `rain` (falls from `h = 9` to the road in
+about 4 s, rests 2 s, then fizzles). Collision is pass-through: pop when
+`|dd| < POP_HIT_D && |dx| < POP_HIT_X && |dh| < POP_HIT_H`.
+
+### `race/score.js` (PR 2)
+```js
+export function createScore() -> { state, pop(points, kindId), miss(), nearMiss(), bank(), jackpot(), tick(dt), onEvent(cb), reset() }
+```
+`state = { score, combo, mult, bank, banked, best, popped, treats, effects, nearMisses }`.
+Multiplier ladder = `MULT_LADDER` from consts (`[[0,1],[5,2],[12,3],[22,4],[36,6],[50,8]]`).
+Combo drops to 0 after `COMBO_HOLD_SEC` without a pop. `bank()` moves `score` into `banked` at the
+Tea Garden gate (THE BANK). Events: `{ type:'pop'|'miss'|'combo'|'mult'|'bank'|'jackpot'|'almost', ... }`.
+
+### `race/kart.js` (PR 3)
+```js
+export function createKart({ scene, layout, reducedMotion }) -> kart
+kart.state           // { d, x, h, vh, speed, steer, drift, airborne, boostSec, slowMult, slowSec, lap }
+kart.update(dt, input, layout)   // input = { steer:-1..1, accel:0..1, brake:0..1, drift:bool }
+kart.applyBoost(sec)             // boost pad / item
+kart.applySlow(mult, sec)        // effect pops slow, never stop (speed floor = KART_MIN_SPEED)
+kart.setMood(id)                 // 'calm' | 'streamed' | 'fraught' | 'smug' | 'shock' | 'jackpot'
+kart.setFraught(v)               // 0..1, drives sweat + antenna kink
+kart.camera(out)                 // out = { pos: Vector3, look: Vector3, roll: number }
+kart.group                       // THREE.Group (cup + EMI back view)
+kart.dispose()
+```
+Speed: cruise `KART_BASE_SPEED`, cap `KART_MAX_SPEED`, floor `KART_MIN_SPEED`. Ramps: when
+`layout.rampAt(d)` matches the lip, give `vh` an upward impulse scaled by speed; `GRAVITY` pulls
+back; `airborne` while `h > 0.05`. Steering moves `x` with inertia, clamped to `ROAD_HALF_W`
+(soft wall, no bounce-off shock). Drift = tighter steer + sparks, no penalty. EMI: CRT body seen
+from behind, gloves on the rim, bead antenna with the six mood states, sweat particles when
+fraught, her face only as a mirrored emoticon in the tea (`:3`, `>_<`, `o_o`, `^_^`, `$_$`). Text
+emoticons only, never a drawn face, never a speech line.
+
+### `race/items.js` (PR 4)
+```js
+export const ITEMS;   // 10 items: { id, name, glyph, desc, durationSec }
+export function createItems({ kart, bubbles, score, fx, hud, payload }) -> { roll(position), current, use(), update(dt), onEvent(cb) }
+```
+Items: `sugar_rush` (boost), `tea_time` (slow-mo 4 s, world slows, kart does not), `magnet`
+(bubbles drift to the lane), `bubble_wand` (rain 12 treats), `lucky_star` (x2 mult 8 s),
+`parasol` (next effect pop is a treat instead), `mirror` (Hall of Mirrors flip 6 s: canvas flips,
+input does not), `spring` (instant ramp), `pocket_watch` (freeze the combo timer 10 s),
+`rabbit_foot` (jackpot chance up). `roll(position)` biases toward catch-up items when the
+multiplier is low (position-aware, Mario Kart style).
+
+### `race/hud.js` + `race/race.css` (PR 4)
+```js
+export function createRaceHud(root) -> hud
+hud.setScore(n) hud.setCombo(combo, mult) hud.setSpeed(ms) hud.setBank(n)
+hud.banner(name, tagline, colorHex)   // MARQUEE, once per gate
+hud.item(glyph | null, name)
+hud.toast(text, kind)                 // kind: 'pop' | 'almost' | 'jackpot' | 'bank' | 'item' | 'effect'
+hud.flicker()                         // Stat Flicker under glitch
+hud.setFraught(v)
+hud.setPaused(bool)
+hud.showEnd(summary) -> Promise<'again' | 'exit'>
+hud.dispose()
+```
+All HUD text is in the DtRH voice: lowercase, short, no em-dashes. `root` is the `.race-hud` div
+that `race.html` provides; `payloadFx` gets its own `.sf-hud` sibling so overlays never clip the HUD.
+
+### `race/run.js` + `raceBoot.js` + `race.html` (PR 5, integration)
+```js
+export function createRace({ root, bridge, media, settings, seed }) -> { start(), setPaused(b), dispose() }
+```
+Composes everything: renderer, `createSpine`, `createTunnel(layout)` from `engine/tunnel.js`,
+`createFx` from `engine/fx.js`, `createRoomDresser`, `createBubbleField`, `createKart`,
+`createScore`, `createItems`, `createRaceHud`, `createPayloadFx` from `game/payloadFx.js`,
+`createScreenShake` from `game/screenShake.js`. Intensity ramps 0..1 over `INTENSITY_RAMP_SEC`
+and gates which bubble kinds may appear. Treat pops go to score; effect pops call
+`payloadFx.applyPayload({ payload, strength }, { durationMult })`, `video`/`audio` go to the host
+through the `fire-payload` bridge message exactly like `chaosRun.js` does today. ESC = Brake
+(pause + end screen). Run end sends `run-ended` (below).
+
+## Host protocol (bridge.js, Protocol v1)
+
+Page -> host (`bridge.send(type, data)`): `ready` (announceReady), `heartbeat`, `pong`, `sfx {name, scale}`,
+`fire-payload {kind:'video'|'audio', strength, durationMult}`, `run-started {seed}`,
+`run-ended {score, banked, durationSec, bestCombo, popped, treats, effects, laps, seed}`,
+`boot-error {message}`, `report-bug {text}`, `fullscreen-set {on}`, `exit`.
+
+Host -> page: `init {protocol, settings:{masterVolume, reducedMotion}, modId, modContent}`,
+`manifest {images:[{name,url}], videos, skipped, truncated}`, `favorites {names}`,
+`payout-result {baseXp, skillMult, finalXp, sparksEarned, previousBest, dryRun}`, `pause {on}`,
+`ping`, `exit-request`.
+
+`sfx` names must exist in `Resources/sounds/chaos/*.mp3` (C# `ChaosSfx.Play(name, scale)`), e.g.
+`tunnel_powerup_collect`, `golden_pop`, `chain_pop`, `streak_milestone`, `pb_fanfare`,
+`rank_up`, `ui_click`, `ui_denied`, `surface`, `depth_change`, `time_slow_in`, `time_slow_out`.
+Bubble pops themselves play in-page from `/dtrh/assets/bubbles/sfx/` via `engine/audioBus.js`.
+
+## Rules for every PR in this stack
+- 600 changed lines max per PR. Split if you are over.
+- Only add files under `Resources/web/dtrh/race/` (plus `race.html`, `raceBoot.js` in PR 5 and the
+  C# host in its own PR). Do not edit `chaosRun.js`, `scene.js`, `tunnel.js`, `fx.js`, `payloadFx.js`.
+- Remote media (Scrolller, CDN) is DOM-only via `hostMedia.drawDom()`. Never a WebGL texture.
+- EMI design is locked: no generated faces, text emoticons only, she never mouths words.
+- No em-dashes anywhere (code comments, HUD copy, PR bodies).
+- Every module gets a small `// self-check` block that can run in node with a THREE stub only if it
+  costs nothing; otherwise `node --check` clean is the bar.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -1,0 +1,55 @@
+// The Caucus Race - shared constants. Import these; never redeclare them in a module.
+// Track space is (d, x, h): depth along the spine, lateral offset, height above the road.
+// See race/CONTRACT.md.
+
+/** Tube radius. Must match engine/tunnel.js RADIUS so createTunnel(layout) lines up. */
+export const RADIUS = 5.5;
+
+/** How far below the spine centre the road surface sits (a flat ribbon on the tube floor). */
+export const ROAD_DROP = RADIUS * 0.82;
+
+/** Half the drivable width. The tube is 11 m across; the road is a 6.4 m ribbon. */
+export const ROAD_HALF_W = 3.2;
+
+/** Ceiling height above the road in track space (where rain bubbles start). */
+export const CEILING_H = RADIUS + ROAD_DROP - 0.6;
+
+// Kart speeds in metres per second. There is no fail state: the floor is never zero.
+export const KART_BASE_SPEED = 22;
+export const KART_MAX_SPEED = 34;
+export const KART_MIN_SPEED = 8;
+export const GRAVITY = 18;
+
+// Pass-through pop box, metres, kart-centred.
+export const POP_HIT_D = 1.4;
+export const POP_HIT_X = 1.0;
+export const POP_HIT_H = 1.1;
+
+/** Combo -> score multiplier ladder: [comboAtLeast, mult]. */
+export const MULT_LADDER = [[0, 1], [5, 2], [12, 3], [22, 4], [36, 6], [50, 8]];
+
+/** Seconds without a pop before the combo lets go. */
+export const COMBO_HOLD_SEC = 3.0;
+
+/** Seconds for the run intensity to ramp from 0 to 1 (gates which bubble kinds may appear). */
+export const INTENSITY_RAMP_SEC = 360;
+
+/** Camera seat behind the cup, track space offsets. */
+export const CAM_BACK = 7.5;
+export const CAM_UP = 3.1;
+export const CAM_LOOK_AHEAD = 9;
+
+/** Room ids in canonical order; teagarden is always the start and the BANK. */
+export const ROOM_IDS = ['teagarden', 'toybox', 'casino', 'undertow', 'mirrors', 'chapel', 'greyward', 'coronation'];
+
+/** Tiny seeded PRNG (mulberry32) so a seed replays the same track. */
+export function makeRng(seed) {
+  let a = (seed >>> 0) || 0x9e3779b9;
+  return function rng() {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/spine.js
@@ -1,0 +1,310 @@
+/* ============================================================================
+ * race/spine.js - The Caucus Race track spine.
+ *
+ * Implements CONTRACT.md section "race/spine.js": createSpine({ seed, roomOrder })
+ * returns a closed CatmullRom layout built from the chunk grammar (straight, bendL,
+ * bendR, sCurve, climb, dip, ramp, chicane, loop, gate), parallel-transported
+ * frames cached every 0.5 m, the track-space (d, x, h) -> world mapping, and the
+ * ordered chunk + feature lists. The object is also a drop-in argument for
+ * engine/tunnel.js createTunnel(layout) (it reads layout.spine) and carries the
+ * buildLoopLayout compat fields fx.js reads (pointAt(t), frameAt(t)).
+ *
+ * Shape: the chunks are laid around one big horizontal ring (the closure is free),
+ * each chunk bending the ring with a bump that returns to zero at its ends, so the
+ * spine is smooth everywhere. THE BIG WHEEL is an 18 m vertical circle spliced in at
+ * one ring angle with a 16 m lateral sidestep (more than 2*RADIUS) that bleeds back
+ * to the ring over the next ~120 m, so the tube never crosses itself. Frames are
+ * parallel-transported (the world inverts through the wheel) and re-levelled toward
+ * world up wherever the tangent is not vertical, so the road never stays banked.
+ *
+ * Contract notes: pointAt(t) / frameAt(t) take the normalized 0..1 parameter exactly
+ * like buildLoopLayout (fx.js calls layout.frameAt(Math.random())) and the frames also
+ * carry normal/binormal aliases for up/right. Each room's first chunk is its gate; the
+ * Tea Garden gate sits at d = 0 and the start straight follows it.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { RADIUS, ROAD_DROP, ROOM_IDS, makeRng } from './consts.js';
+
+const FRAME_STEP = 0.5;                 // metres between cached frames
+const CP_STEP = 6;                      // control-point spacing along the ring, metres
+const LOOP_R = 18;                      // Big Wheel radius (> RADIUS: the road has headroom)
+const LOOP_SIDESTEP = 2 * RADIUS + 5;   // 16 m: the exit runs beside the entry, never through it
+const LOOP_FOOTPRINT = 12;              // ring metres the loop advances (entry -> exit)
+const LOOP_CPS = 24;                    // control points around the wheel (+1 closing point)
+const SIDESTEP_BLEED = 120;             // metres after the loop to ease the sidestep back to 0
+const RING_WAVE = 5;                    // gentle global elevation swell (integer harmonic closes)
+const RELEVEL_TAU = 10;                 // metres: how fast the frame rolls back level after the wheel
+const RELEVEL_MAX = 0.045;              // rad per metre roll-rate cap while re-levelling
+const WORLD_UP = new THREE.Vector3(0, 1, 0);
+
+// Chunk recipes: footprint length range, lateral bump amplitude, elevation bump amplitude.
+// `lat` shapes: bump = one hump (bend), sine = in then out (S), double = two quick alternations.
+// Every shape is windowed by sin^4 so its curvature is zero at the chunk ends: neighbouring
+// chunks never stack their bends, and the amplitudes below keep every bend radius above ~18 m.
+const RECIPES = {
+  straight: { len: [44, 64] },
+  bendL:    { len: [80, 96], lat: 'bump', latAmp: [6, 8],  latSign: 1 },
+  bendR:    { len: [80, 96], lat: 'bump', latAmp: [6, 8],  latSign: -1 },
+  sCurve:   { len: [84, 104], lat: 'sine', latAmp: [4, 5.5] },
+  chicane:  { len: [80, 96], lat: 'double', latAmp: [1.2, 1.6] },
+  climb:    { len: [70, 86], elevAmp: [4.5, 6] },
+  dip:      { len: [70, 86], elevAmp: [-6, -4.5] },
+  ramp:     { len: [60, 64], landingDip: -1.8 },
+  gate:     { len: [18, 18] },
+  loop:     { len: [LOOP_FOOTPRINT, LOOP_FOOTPRINT] },
+};
+
+// Per-room chunk pools (the room's signature shapes from the pitch, weighted by repetition).
+const ROOM_POOLS = {
+  teagarden:  ['straight', 'bendL', 'bendR', 'sCurve', 'dip', 'straight'],
+  toybox:     ['ramp', 'climb', 'dip', 'bendL', 'bendR', 'chicane'],
+  casino:     ['straight', 'bendR', 'bendL', 'sCurve', 'ramp', 'straight'],
+  undertow:   ['sCurve', 'sCurve', 'chicane', 'dip', 'bendL', 'climb'],
+  mirrors:    ['sCurve', 'chicane', 'bendL', 'bendR', 'climb', 'chicane'],
+  chapel:     ['climb', 'dip', 'straight', 'bendL', 'sCurve', 'dip'],
+  greyward:   ['straight', 'straight', 'bendL', 'bendR', 'dip', 'straight'],
+  coronation: ['ramp', 'climb', 'bendR', 'sCurve', 'straight', 'climb'],
+};
+const BOOST_ODDS = { casino: 0.75, toybox: 0.45, coronation: 0.45 };
+
+const bump = (u) => Math.sin(Math.PI * u) ** 4;                    // 0 -> 1 -> 0, flat ends
+const smooth = (u) => u <= 0 ? 0 : u >= 1 ? 1 : u * u * (3 - 2 * u);
+const pick = (rng, arr) => arr[Math.floor(rng() * arr.length) % arr.length];
+const range = (rng, [a, b]) => a + (b - a) * rng();
+
+/** Lay out the chunk plan: one gate per room, the Tea Garden start straight, at least one
+ * ramp per room, exactly one loop in a room at index >= 2 (the casino when it qualifies). */
+function planChunks(rng, roomOrder) {
+  const rooms = roomOrder && roomOrder.length ? roomOrder.slice() : ROOM_IDS.slice();
+  const loopCandidates = rooms.map((r, i) => i).filter((i) => i >= 2);
+  const casinoIdx = rooms.indexOf('casino');
+  const loopRoom = casinoIdx >= 2 ? casinoIdx : pick(rng, loopCandidates);
+  const plan = [];
+  rooms.forEach((room, ri) => {
+    const pool = ROOM_POOLS[room] || ROOM_POOLS.teagarden;
+    const hasLoop = ri === loopRoom;
+    let n = 4 + Math.floor(rng() * 4);                    // 4..7 chunks incl. the gate
+    if (hasLoop) n = Math.max(n, 5);
+    const kinds = new Array(n).fill(null);
+    kinds[0] = 'gate';
+    if (ri === 0) kinds[1] = 'start';                     // the Tea Garden start straight
+    const free = () => kinds.map((k, i) => (k ? -1 : i)).filter((i) => i >= 0);
+    if (hasLoop) kinds[pick(rng, free().filter((i) => i <= n - 3))] = 'loop';
+    kinds[pick(rng, free())] = 'ramp';
+    for (const i of free()) {
+      let k = pick(rng, pool);
+      if (k === 'ramp' && kinds.includes('ramp') && rng() < 0.6) k = 'straight';
+      if (k === kinds[i - 1] && k !== 'straight') k = pick(rng, pool); // avoid stutters
+      kinds[i] = k;
+    }
+    kinds.forEach((kind, ci) => {
+      const isStart = kind === 'start';
+      const recipe = RECIPES[isStart ? 'straight' : kind];
+      const c = { kind: isStart ? 'straight' : kind, room, roomIndex: ri, indexInRoom: ci,
+        len: isStart ? 96 : range(rng, recipe.len), latAmp: 0, elevAmp: 0, lat: recipe.lat || null,
+        landingDip: recipe.landingDip || 0 };
+      if (recipe.latAmp) c.latAmp = range(rng, recipe.latAmp) * (recipe.latSign || (rng() < 0.5 ? -1 : 1));
+      if (recipe.elevAmp) c.elevAmp = range(rng, recipe.elevAmp);
+      plan.push(c);
+    });
+  });
+  return plan;
+}
+
+/** Turn the plan into control points on the ring (+ the spliced wheel). Fills c.cp0/c.cp1. */
+function buildControlPoints(plan) {
+  const footprint = plan.reduce((s, c) => s + c.len, 0);
+  const ringR = footprint / (2 * Math.PI);
+  const pts = [];
+  let theta = 0, sidestepFrom = -1;     // ring metres where the sidestep bleed started
+  const ringPoint = (m, radial, elev) => {   // m = metres along the ring
+    const a = m / ringR;
+    const r = ringR + radial;
+    return new THREE.Vector3(Math.cos(a) * r, RING_WAVE * Math.sin(2 * a) + elev, Math.sin(a) * r);
+  };
+  const carry = (m) => (sidestepFrom < 0 ? 0
+    : -LOOP_SIDESTEP * (1 - smooth((m - sidestepFrom) / SIDESTEP_BLEED)));
+  for (const c of plan) {
+    c.cp0 = pts.length;
+    if (c.kind === 'loop') {
+      // local frame at the wheel's foot: T along the ring, n = world up, b = right (inward)
+      const P0 = ringPoint(theta, carry(theta), 0);
+      const T = ringPoint(theta + 0.5, 0, 0).sub(ringPoint(theta - 0.5, 0, 0)).normalize();
+      const n = WORLD_UP.clone().addScaledVector(T, -T.dot(WORLD_UP)).normalize();
+      const b = new THREE.Vector3().crossVectors(T, n).normalize();
+      for (let k = 0; k <= LOOP_CPS; k++) {
+        const th = (k / LOOP_CPS) * Math.PI * 2;
+        pts.push(P0.clone().addScaledVector(T, LOOP_R * Math.sin(th))
+          .addScaledVector(n, LOOP_R * (1 - Math.cos(th)))
+          .addScaledVector(b, LOOP_SIDESTEP * (k / LOOP_CPS)));
+      }
+      theta += c.len;
+      sidestepFrom = theta;
+      c.cp1 = pts.length;                // exclusive; the next chunk's first point closes the wheel
+      continue;
+    }
+    const n = Math.max(2, Math.round(c.len / CP_STEP));
+    for (let k = 0; k < n; k++) {
+      const u = k / n, m = theta + u * c.len;
+      let lat = 0, elev = 0;
+      if (c.lat === 'bump') lat = c.latAmp * bump(u);
+      else if (c.lat === 'sine') lat = c.latAmp * Math.sin(Math.PI * 2 * u) * bump(u);
+      else if (c.lat === 'double') lat = c.latAmp * Math.sin(Math.PI * 4 * u) * bump(u);
+      if (c.elevAmp) elev = c.elevAmp * bump(u);
+      if (c.landingDip && u > 0.35) elev = c.landingDip * bump((u - 0.35) / 0.65);
+      pts.push(ringPoint(m, lat + carry(m), elev));
+    }
+    theta += c.len;
+    c.cp1 = pts.length;
+  }
+  return pts;
+}
+
+export function createSpine({ seed = 1, roomOrder } = {}) {
+  const rng = makeRng(seed | 0);
+  const plan = planChunks(rng, roomOrder);
+  const pts = buildControlPoints(plan);
+  const spine = new THREE.CatmullRomCurve3(pts, true, 'centripetal', 0.5);
+  spine.arcLengthDivisions = pts.length * 16;
+  const lengths = spine.getLengths(spine.arcLengthDivisions);
+  const totalDepth = lengths[lengths.length - 1];
+  const wrap = (d) => ((d % totalDepth) + totalDepth) % totalDepth;
+  const cpDepth = (i) => lengths[Math.round((i / pts.length) * spine.arcLengthDivisions)];
+
+  // ---- chunks + features (depths are read off the finished curve) ----------------
+  const chunks = plan.map((c, i) => {
+    const d0 = cpDepth(c.cp0), d1 = i === plan.length - 1 ? totalDepth : cpDepth(c.cp1);
+    const len = d1 - d0, features = [];
+    const boostOdds = BOOST_ODDS[c.room] || 0.35;
+    if (c.kind === 'gate') features.push({ type: 'gate', d: d0 + len * 0.5, room: c.room });
+    else if (c.kind === 'loop') features.push({ type: 'loop', d0, d1 });
+    else if (c.kind === 'ramp') {
+      features.push({ type: 'ramp', d: d0 + 14, airLen: range(rng, [22, 30]), height: range(rng, [3, 4]) });
+    } else {
+      if (rng() < boostOdds) features.push({ type: 'boost', d: d0 + len * 0.5, x: range(rng, [-1.2, 1.2]) });
+      if (rng() < 0.5) features.push({ type: 'itembox', d: d0 + len * (rng() < 0.5 ? 0.28 : 0.76), x: range(rng, [-1.8, 1.8]) });
+    }
+    return { id: i, kind: c.kind, d0, d1, room: c.room, features };
+  });
+  // a boost pad on the run-up to the wheel, and one sugar cube per room at least
+  chunks.forEach((ch, i) => {
+    if (ch.kind !== 'loop' || i === 0) return;
+    const prev = chunks[i - 1];
+    prev.features.push({ type: 'boost', d: prev.d1 - 12, x: 0 });
+  });
+  for (const room of new Set(chunks.map((c) => c.room))) {
+    const mine = chunks.filter((c) => c.room === room);
+    if (mine.some((c) => c.features.some((f) => f.type === 'itembox'))) continue;
+    const host = mine.find((c) => c.kind !== 'gate' && c.kind !== 'loop' && c.kind !== 'ramp') || mine[1] || mine[0];
+    host.features.push({ type: 'itembox', d: host.d0 + (host.d1 - host.d0) * 0.6, x: 0 });
+  }
+  chunks.forEach((c) => c.features.sort((a, b) => (a.d ?? a.d0) - (b.d ?? b.d0)));
+  const allFeatures = chunks.flatMap((c) => c.features);
+  const ramps = allFeatures.filter((f) => f.type === 'ramp');
+
+  // ---- frames, cached every FRAME_STEP metres -------------------------------------
+  // Parallel transport carries `up` through the wheel so the world inverts at the top.
+  // A helical loop leaves the transported frame rolled on exit (about 1 rad for a 16 m
+  // sidestep), so wherever the tangent is not vertical the frame also eases back toward
+  // the nearest of +/- world up: a no-op on the ring, and a short settle after the wheel.
+  const N = Math.ceil(totalDepth / FRAME_STEP);
+  const P = new Float32Array(N * 3), Tn = new Float32Array(N * 3), Up = new Float32Array(N * 3);
+  {
+    const tans = [], ups = [], axis = new THREE.Vector3(), ref = new THREE.Vector3();
+    const relax = 1 - Math.exp(-FRAME_STEP / RELEVEL_TAU), cap = RELEVEL_MAX * FRAME_STEP;
+    for (let i = 0; i < N; i++) {
+      const u = (i * FRAME_STEP) / totalDepth;
+      const p = spine.getPointAt(u), t = spine.getTangentAt(u).normalize();
+      tans.push(t); P[i * 3] = p.x; P[i * 3 + 1] = p.y; P[i * 3 + 2] = p.z;
+    }
+    ups[0] = WORLD_UP.clone().addScaledVector(tans[0], -tans[0].dot(WORLD_UP)).normalize();
+    for (let i = 1; i < N; i++) {
+      const up = ups[i - 1].clone(), t = tans[i];
+      axis.crossVectors(tans[i - 1], t);
+      if (axis.lengthSq() > 1e-12) {
+        const ang = Math.acos(THREE.MathUtils.clamp(tans[i - 1].dot(t), -1, 1));
+        up.applyAxisAngle(axis.normalize(), ang);
+      }
+      up.addScaledVector(t, -up.dot(t)).normalize();
+      const gain = (1 - Math.abs(t.y)) ** 2;
+      ref.copy(WORLD_UP).addScaledVector(t, -t.y);
+      if (gain > 1e-4 && ref.lengthSq() > 1e-6) {
+        ref.normalize();
+        if (up.dot(ref) < 0) ref.negate();
+        let roll = Math.atan2(axis.crossVectors(up, ref).dot(t), up.dot(ref));
+        roll = THREE.MathUtils.clamp(roll * relax, -cap, cap) * gain;
+        up.applyAxisAngle(t, roll);
+      }
+      ups[i] = up;
+    }
+    // closure: transport one more step back onto sample 0 and spread the residual twist
+    const upEnd = ups[N - 1].clone();
+    axis.crossVectors(tans[N - 1], tans[0]);
+    if (axis.lengthSq() > 1e-12) upEnd.applyAxisAngle(axis.normalize(), Math.acos(THREE.MathUtils.clamp(tans[N - 1].dot(tans[0]), -1, 1)));
+    upEnd.addScaledVector(tans[0], -upEnd.dot(tans[0])).normalize();
+    let twist = Math.acos(THREE.MathUtils.clamp(upEnd.dot(ups[0]), -1, 1));
+    if (tans[0].dot(axis.crossVectors(upEnd, ups[0])) < 0) twist = -twist;
+    for (let i = 0; i < N; i++) {
+      const up = ups[i].applyAxisAngle(tans[i], (twist * i) / N);
+      Tn[i * 3] = tans[i].x; Tn[i * 3 + 1] = tans[i].y; Tn[i * 3 + 2] = tans[i].z;
+      Up[i * 3] = up.x; Up[i * 3 + 1] = up.y; Up[i * 3 + 2] = up.z;
+    }
+  }
+  const _p = new THREE.Vector3(), _t = new THREE.Vector3(), _u = new THREE.Vector3(), _r = new THREE.Vector3();
+  const _a = new THREE.Vector3(), _b = new THREE.Vector3();
+  const lerp3 = (arr, i0, i1, k, out) => {
+    _a.fromArray(arr, i0 * 3); _b.fromArray(arr, i1 * 3);
+    return out.copy(_a).lerp(_b, k);
+  };
+  /** Fill the scratch frame at depth d (no allocation). */
+  function frameInto(d) {
+    const f = wrap(d) / FRAME_STEP, i0 = Math.floor(f) % N, i1 = (i0 + 1) % N, k = f - Math.floor(f);
+    lerp3(P, i0, i1, k, _p);
+    lerp3(Tn, i0, i1, k, _t).normalize();
+    lerp3(Up, i0, i1, k, _u);
+    _u.addScaledVector(_t, -_u.dot(_t)).normalize();
+    _r.crossVectors(_t, _u).normalize();
+  }
+  function frameAtDepth(d) {
+    frameInto(d);
+    const pos = _p.clone(), tangent = _t.clone(), up = _u.clone(), right = _r.clone();
+    return { pos, tangent, up, right, normal: up, binormal: right };
+  }
+  function toWorld(d, x, h, out = new THREE.Vector3()) {
+    frameInto(d);
+    return out.copy(_p).addScaledVector(_u, h - ROAD_DROP).addScaledVector(_r, x);
+  }
+
+  // ---- queries ------------------------------------------------------------------
+  function chunkAtDepth(d) {
+    const w = wrap(d);
+    let lo = 0, hi = chunks.length - 1;
+    while (lo < hi) { const mid = (lo + hi + 1) >> 1; if (chunks[mid].d0 <= w) lo = mid; else hi = mid - 1; }
+    return chunks[lo];
+  }
+  const roomAtDepth = (d) => chunkAtDepth(d).room;
+  function featuresBetween(d0, d1) {
+    const a = wrap(d0), b = wrap(d1);
+    const inRange = (fd) => (a <= b ? fd >= a && fd < b : fd >= a || fd < b);
+    const key = (f) => (f.d != null ? f.d : f.d0);
+    return allFeatures.filter((f) => inRange(key(f)))
+      .sort((f, g) => wrap(key(f) - a) - wrap(key(g) - a));
+  }
+  function rampAt(d) {
+    const w = wrap(d);
+    for (const r of ramps) if (w >= r.d && w <= r.d + r.airLen) return r;
+    return null;
+  }
+
+  // ---- tunnel.js / fx.js compat (normalized t in 0..1, as buildLoopLayout) ---------
+  const wrap01 = (t) => ((t % 1) + 1) % 1;
+  const pointAt = (t, out) => spine.getPointAt(wrap01(t), out);
+  const frameAt = (t) => frameAtDepth(wrap01(t) * totalDepth);
+
+  return {
+    RADIUS, totalDepth, loopDepth: totalDepth, spine, pointAt, frameAt,
+    frameAtDepth, toWorld, wrap, chunks, featuresBetween, roomAtDepth, rampAt,
+    seed, roomOrder: [...new Set(chunks.map((c) => c.room))],
+  };
+}


### PR DESCRIPTION
## What
Base of The Caucus Race stack: the module contract every race module is built against (race/CONTRACT.md), shared constants (race/consts.js) and the track spine (race/spine.js).

## Spine
- Closed CatmullRom spine with a chunk grammar (straight, bends, S-curve, climb, dip, ramp, chicane, loop, gate), Tea Garden start straight, 4..7 chunks per room, one ramp and one item box per room, THE BIG WHEEL (18 m vertical loop with a 16 m lateral sidestep so the tube never self-intersects) after the second room.
- Parallel-transported frames through the wheel, re-levelled to world up elsewhere so the road never stays banked. Frames cached every 0.5 m; toWorld(d, x, h) is allocation-free.
- The layout is a drop-in argument for engine/tunnel.js createTunnel(layout): the race gets the whole biome tunnel shader for free.

## Verified
node against the vendored three r169 over six seeds: closed spine, every room 4..7 chunks with gate first, ramp + item box per room, exactly one loop, minimum non-adjacent tube separation 14.6 m, bend radius >= 15 m, up.y = -1 at the wheel top, deterministic per seed.

## Not verified
Nothing rendered in a browser on this PR alone; the integration PR carries the headless boot check.

---
Part of The Caucus Race stack (DtRH as a no-lose kart run with the CCP/DtRH effect bubbles as the pickup layer). Stack order: 1-track > 1b-rooms > 2-bubbles > 3-kart > 4-hud > 4b-items > 6-run > 7-boot; the host PR is independent. Each PR is under the 600 changed-line cap. Nothing in this stack edits chaosRun.js, scene.js, tunnel.js, fx.js or payloadFx.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
