### PR TITLE
feat(race): Caucus Race 3/9 - bubble pickup layer + score

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbleKinds.js
@@ -1,0 +1,63 @@
+/* ============================================================================
+ * race/bubbleKinds.js - The Caucus Race bubble table, data only (no three.js)
+ * so score.js and the HUD can read it without pulling the renderer in.
+ * Implements the "Bubble kinds" table of CONTRACT.md section `race/bubbles.js`;
+ * bubbles.js re-exports BUBBLE_KINDS from here.
+ *
+ * Every row mirrors game/variants.js + engine/bubbles.js: same sprites, same
+ * tints, same payload names, so the race bubbles read as THE SAME bubbles the
+ * player pops in DtRH and on the desktop. Sprites come from the two locally
+ * mapped hosts (installer tree + ccp.art = assets/Chaos/bubbles/<id>.png).
+ * ==========================================================================*/
+
+const SPRITE_BASE = '/dtrh/assets/bubbles/effects/';
+const ART_BASE = 'https://ccp.art/bubbles/';
+const PLAIN_SPRITE = '/dtrh/assets/bubbles/bubble.png';   // the classic soap bubble
+
+// kind: 'treat' pops for points only; 'effect' also fires a payloadFx spec.
+// payload / overlayKind are the game/payloadFx.js applyPayload names.
+// strength: the base 0..1 power of the effect (intensity nudges it up at pop).
+// weight: spawn odds; minIntensity gates the kind until the run is that deep.
+export const BUBBLE_KINDS = [
+  { id: 'treat',      label: '',  kind: 'treat',  payload: null,         overlayKind: null,
+    strength: 0,    points: 10, weight: 22,  minIntensity: 0,    tint: 'rgb(184,222,255)', sprite: PLAIN_SPRITE },
+  { id: 'golden',     label: '🍀', kind: 'treat',  payload: null,         overlayKind: null,
+    strength: 0,    points: 50, weight: 1.2, minIntensity: 0,    tint: 'rgb(255,215,0)',   sprite: SPRITE_BASE + 'golden.png' },
+  { id: 'lucky',      label: '✧', kind: 'treat',  payload: null,         overlayKind: null,
+    strength: 0,    points: 25, weight: 1.6, minIntensity: 0,    tint: 'rgb(255,215,0)',   sprite: ART_BASE + 'gold_droplet.png' },
+  { id: 'prism',      label: '❂', kind: 'treat',  payload: null,         overlayKind: null,
+    strength: 0,    points: 30, weight: 1.4, minIntensity: 0.1,  tint: 'rgb(200,168,255)', sprite: SPRITE_BASE + 'prism.png' },
+  { id: 'flash',      label: '',  kind: 'effect', payload: 'flash',      overlayKind: null,
+    strength: 0.45, points: 15, weight: 6,   minIntensity: 0,    tint: 'rgb(255,208,232)', sprite: SPRITE_BASE + 'flash.png' },
+  { id: 'subliminal', label: '♥', kind: 'effect', payload: 'subliminal', overlayKind: null,
+    strength: 0.45, points: 15, weight: 5,   minIntensity: 0,    tint: 'rgb(176,128,255)', sprite: SPRITE_BASE + 'subliminal.png' },
+  { id: 'pink',       label: '◑', kind: 'effect', payload: 'overlay',    overlayKind: 'pink_filter',
+    strength: 0.5,  points: 20, weight: 4,   minIntensity: 0.1,  tint: 'rgb(255,61,165)',  sprite: SPRITE_BASE + 'pinkfilter.png' },
+  { id: 'spiral',     label: '◎', kind: 'effect', payload: 'overlay',    overlayKind: 'spiral',
+    strength: 0.5,  points: 20, weight: 4,   minIntensity: 0.15, tint: 'rgb(64,208,192)',  sprite: SPRITE_BASE + 'spiral.png' },
+  { id: 'braindrain', label: '☁', kind: 'effect', payload: 'overlay',    overlayKind: 'braindrain',
+    strength: 0.55, points: 25, weight: 2.4, minIntensity: 0.4,  tint: 'rgb(64,96,192)',   sprite: SPRITE_BASE + 'braindrain.png' },
+  { id: 'glitch',     label: '▚', kind: 'effect', payload: 'glitch',     overlayKind: null,
+    strength: 0.5,  points: 20, weight: 3,   minIntensity: 0.2,  tint: 'rgb(120,255,190)', sprite: SPRITE_BASE + 'glitch.png' },
+  { id: 'freeze',     label: '❄', kind: 'effect', payload: 'bambiFreeze', overlayKind: null,
+    strength: 0.6,  points: 25, weight: 1,   minIntensity: 0.15, tint: 'rgb(138,230,255)', sprite: ART_BASE + 'bambifreeze.png' },
+  { id: 'gifrain',    label: '▼', kind: 'effect', payload: 'gifCascade', overlayKind: null,
+    strength: 0.6,  points: 25, weight: 1.2, minIntensity: 0.45, tint: 'rgb(255,200,61)',  sprite: ART_BASE + 'htlink.png' },
+  { id: 'video',      label: '▶', kind: 'effect', payload: 'video',      overlayKind: null,
+    strength: 0.7,  points: 40, weight: 0.35, minIntensity: 0.45, tint: 'rgb(224,64,77)',  sprite: ART_BASE + 'video.png' },
+];
+
+export const KIND_BY_ID = Object.fromEntries(BUBBLE_KINDS.map((k) => [k.id, k]));
+export const TREAT_IDS = BUBBLE_KINDS.filter((k) => k.kind === 'treat').map((k) => k.id);
+
+/** Weighted roll over the kinds allowed at this intensity, in this room.
+ *  `bias` is the room's bubbleBias map; `extra(kind)` is an optional per-call
+ *  multiplier (air lines favour gold, etc). rng defaults to Math.random. */
+export function rollKind(intensity, bias = null, extra = null, rng = Math.random) {
+  let pool = BUBBLE_KINDS.filter((k) => k.minIntensity <= intensity);
+  if (!pool.length) pool = [BUBBLE_KINDS[0]];
+  const w = pool.map((k) => k.weight * ((bias && bias[k.id]) || 1) * (extra ? extra(k) : 1));
+  let r = rng() * w.reduce((s, v) => s + v, 0);
+  for (let i = 0; i < pool.length; i++) { r -= w[i]; if (r <= 0) return pool[i]; }
+  return pool[pool.length - 1];
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -1,0 +1,314 @@
+/* ============================================================================
+ * race/bubbles.js - The Caucus Race pickup layer: the bubbles on the road.
+ * Implements CONTRACT.md section `race/bubbles.js` (createBubbleField + the
+ * BUBBLE_KINDS table, which lives in bubbleKinds.js and is re-exported here).
+ *
+ * Every bubble is a pooled THREE.Sprite in track space (d, x, h), placed
+ * through layout.toWorld only. Four placements: lane (rests on the road and
+ * bobs), air (threads a ramp's air line), spawn (materialises ahead and
+ * wobbles), rain (falls from the ceiling, rests, fizzles). Pops are pass-
+ * through against the kart box; a pop plays the DtRH pop/chime in-page
+ * (engine/audioBus) and throws a few sparkle shards, the WPF BubbleService way.
+ * Sprite textures come from the two locally mapped hosts (never remote media).
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H } from './consts.js';
+import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
+import { makeSfxPlayer } from '../engine/audioBus.js';
+import { getLevel } from '../engine/audioLevels.js';
+
+export { BUBBLE_KINDS };
+
+const SFX_BASE = '/dtrh/assets/bubbles/sfx/';
+const POP_SFX = ['Pop.mp3', 'Pop2.mp3', 'Pop3.mp3'];
+const CHIME_SFX = ['chime1.mp3', 'chime2.mp3', 'chime3.mp3'];
+const BURST_SFX = 'Burst.mp3';
+
+const CAP = 160;              // live bubbles, recycled farthest-first when full
+const SHARD_CAP = 64;
+const LANE_H = 0.9;
+const LANE_STEP = 3.2;        // metres between bubbles in a lane line
+const VIEW_AHEAD = 150;       // sprites beyond this are hidden, not freed
+const MISS_BEHIND = 6;        // a treat this far behind the kart unpopped = miss
+const DROP_BEHIND = 12;       // freed once this far behind
+const RAIN_FALL = 4, RAIN_REST = 2, RAIN_FIZZLE = 0.5;
+const POP_ANIM = 0.14;
+const PRISM_REACH = 8;        // prism chain-pops neighbours within this many metres
+
+const rand = (a, b) => a + Math.random() * (b - a);
+const pick = (arr) => arr[(Math.random() * arr.length) | 0];
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+const sizeOf = (id) => (id === 'video' || id === 'gifrain') ? 1.5 : id === 'golden' ? 0.95 : id === 'lucky' ? 0.8 : 1.15;
+
+/** Soft radial dot: the fallback face while a sprite loads, and the shard face. */
+function makeDotTex() {
+  try {
+    const c = document.createElement('canvas'); c.width = c.height = 64;
+    const g = c.getContext('2d');
+    const grad = g.createRadialGradient(32, 32, 4, 32, 32, 30);
+    grad.addColorStop(0, 'rgba(255,255,255,1)'); grad.addColorStop(0.6, 'rgba(255,255,255,0.55)'); grad.addColorStop(1, 'rgba(255,255,255,0)');
+    g.fillStyle = grad; g.fillRect(0, 0, 64, 64);
+    const t = new THREE.CanvasTexture(c); t.colorSpace = THREE.SRGBColorSpace; return t;
+  } catch (e) { return null; }
+}
+
+export function createBubbleField({ scene, layout, media, getIntensity, getRoom }) {
+  void media;   // reserved: flash media is drawn by payloadFx at pop time, never here
+  const T = layout.totalDepth;
+  /** Signed depth from `from` to `d`, folded into (-T/2, T/2] so the start line is nothing special. */
+  const relD = (d, from) => { let r = (d - from) % T; if (r > T / 2) r -= T; else if (r <= -T / 2) r += T; return r; };
+  const intensity = () => clamp(getIntensity ? getIntensity() : 0, 0, 1);
+  const roomBias = () => { const r = getRoom && getRoom(); return (r && r.bubbleBias) || null; };
+
+  const audio = makeSfxPlayer();
+  audio.preload([...POP_SFX, ...CHIME_SFX, BURST_SFX].map((f) => SFX_BASE + f));
+  const sfx = (file, vol) => audio.play(SFX_BASE + file, vol * getLevel('fx'));
+
+  // ---- textures: one per kind, fallback dot until the PNG lands --------------
+  const dotTex = makeDotTex();
+  const texOf = {};
+  const loader = new THREE.TextureLoader();
+  let disposed = false;
+  for (const k of BUBBLE_KINDS) {
+    texOf[k.id] = dotTex;
+    loader.load(k.sprite, (tex) => {
+      if (disposed) { tex.dispose(); return; }
+      tex.colorSpace = THREE.SRGBColorSpace;
+      texOf[k.id] = tex;
+      for (const s of pool) if (s.alive && s.kindId === k.id) { s.mat.map = tex; s.mat.needsUpdate = true; }
+    }, undefined, () => { /* keep the dot */ });
+  }
+
+  // ---- pools ---------------------------------------------------------------
+  const group = new THREE.Group();
+  group.name = 'race-bubbles';
+  scene.add(group);
+  const pool = [];
+  for (let i = 0; i < CAP; i++) {
+    const mat = new THREE.SpriteMaterial({ transparent: true, depthWrite: false, opacity: 1 });
+    const sprite = new THREE.Sprite(mat);
+    sprite.visible = false;
+    group.add(sprite);
+    pool.push({ sprite, mat, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
+      x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false });
+  }
+  const shards = [];
+  for (let i = 0; i < SHARD_CAP; i++) {
+    const mat = new THREE.SpriteMaterial({ map: dotTex, transparent: true, depthWrite: false, opacity: 0 });
+    const sprite = new THREE.Sprite(mat);
+    sprite.visible = false;
+    group.add(sprite);
+    shards.push({ sprite, mat, alive: false, age: 0, life: 0.5, p0: new THREE.Vector3(), r: null, u: null, vr: 0, vu: 0, size: 0.2 });
+  }
+  let liveCount = 0;
+  let lastKartD = 0;
+  let density = 1;
+  const popCbs = [], missCbs = [];
+  const emit = (cbs, ev) => { for (const cb of cbs) { try { cb(ev); } catch (e) { /* listener bug, not ours */ } } };
+
+  function freeSlot(s) { if (!s.alive) return; s.alive = false; s.sprite.visible = false; liveCount--; }
+  function takeSlot() {
+    let s = pool.find((p) => !p.alive);
+    if (!s) {   // full: recycle the bubble farthest from the kart
+      let far = -1;
+      for (const p of pool) { const a = Math.abs(relD(p.d, lastKartD)); if (a > far) { far = a; s = p; } }
+      freeSlot(s);
+    }
+    s.alive = true; liveCount++;
+    return s;
+  }
+
+  const liveOf = (id) => { let n = 0; for (const p of pool) if (p.alive && p.kindId === id) n++; return n; };
+  /** Weighted kind roll: room bias, intensity gate, and a per-placement nudge. */
+  function roll(placement) {
+    const extra = (k) => {
+      if (k.id === 'video' && liveOf('video') > 0) return 0;      // one video on the road at a time
+      if (k.id === 'freeze' && liveOf('freeze') > 1) return 0;
+      if (placement === 'air' && k.id === 'golden') return 3;     // gold favours the air line
+      if (placement === 'rain' && k.kind === 'effect') return 0.5;
+      return 1;
+    };
+    return rollKind(intensity(), roomBias(), extra).id;
+  }
+
+  function place(kindId, placement, d, x, h) {
+    const k = KIND_BY_ID[kindId] || KIND_BY_ID.treat;
+    const s = takeSlot();
+    s.kindId = k.id; s.placement = placement;
+    s.d = layout.wrap(d); s.x = clamp(x, -ROAD_HALF_W + 0.4, ROAD_HALF_W - 0.4); s.x0 = s.x;
+    s.h = h; s.baseH = h; s.phase = Math.random() * Math.PI * 2; s.age = 0;
+    s.size = sizeOf(k.id); s.scale = placement === 'spawn' ? 0 : 1; s.popT = -1; s.missed = false;
+    s.mat.map = texOf[k.id]; s.mat.color.set(k.tint); s.mat.opacity = 1; s.mat.needsUpdate = true;
+    s.sprite.scale.setScalar(s.size * s.scale);
+    layout.toWorld(s.d, s.x, s.h, s.sprite.position);
+    s.sprite.visible = true;
+    return s;
+  }
+
+  // ---- placements ----------------------------------------------------------
+  const seeded = new Set();
+  const chunkRecs = [];
+  const LANES = [-2.2, -1.1, 0, 1.1, 2.2];
+
+  /** Lane lines the kart can thread, ramp air lines, and a pair flanking each sugar cube. */
+  function seedChunk(chunk) {
+    if (!chunk || seeded.has(chunk.id)) return;
+    seeded.add(chunk.id);
+    chunkRecs.push({ id: chunk.id, d0: chunk.d0, d1: chunk.d1 });
+    const len = Math.max(0, chunk.d1 - chunk.d0);
+    if (chunk.kind !== 'gate' && len > 8) {
+      const lines = Math.max(1, Math.round((len / 26) * density));
+      for (let l = 0; l < lines; l++) {
+        const count = 3 + ((Math.random() * 4) | 0);
+        const x = pick(LANES) + rand(-0.3, 0.3);
+        const drift = rand(-0.22, 0.22);
+        const d0 = chunk.d0 + rand(2, Math.max(2, len - count * LANE_STEP - 2));
+        const lineKind = roll('lane');
+        for (let i = 0; i < count; i++) {
+          place(Math.random() < 0.7 ? lineKind : roll('lane'), 'lane', d0 + i * LANE_STEP, x + drift * i, LANE_H);
+        }
+      }
+    }
+    for (const f of chunk.features || []) {
+      if (f.type === 'ramp') {
+        const n = 5, x = rand(-0.6, 0.6);
+        for (let i = 0; i < n; i++) {
+          const u = (i + 0.5) / n;
+          place(roll('air'), 'air', f.d + f.airLen * u, x, 2 + 3 * (4 * u * (1 - u)));
+        }
+      } else if (f.type === 'itembox') {
+        place(roll('lane'), 'lane', f.d, f.x - 1.5, LANE_H);
+        place(roll('lane'), 'lane', f.d, f.x + 1.5, LANE_H);
+      }
+    }
+  }
+
+  function spawnAhead(kartD, n = 1) {
+    for (let i = 0; i < n; i++) place(roll('spawn'), 'spawn', kartD + rand(35, 60), rand(-ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6), LANE_H);
+  }
+  function rain(kartD, n = 1) {
+    for (let i = 0; i < n; i++) place(roll('rain'), 'rain', kartD + rand(18, 44), rand(-ROAD_HALF_W + 0.6, ROAD_HALF_W - 0.6), CEILING_H);
+  }
+
+  // ---- pop -----------------------------------------------------------------
+  const _r = new THREE.Vector3(), _u = new THREE.Vector3();
+  function burst(s, golden) {
+    const f = layout.frameAtDepth(s.d);
+    const dirs = { r: f.right.clone(), u: f.up.clone() };   // one pair per burst, shared by its shards
+    const n = golden ? 12 : 7;
+    for (let i = 0; i < n; i++) {
+      const sh = shards.find((p) => !p.alive) || shards[(Math.random() * SHARD_CAP) | 0];
+      const ang = (Math.PI * 2 * i) / n + rand(-0.35, 0.35);
+      const v = rand(2.2, 4.6) * (golden ? 1.3 : 1);
+      sh.alive = true; sh.age = 0; sh.life = rand(0.35, 0.6);
+      sh.p0.copy(s.sprite.position); sh.r = dirs.r; sh.u = dirs.u;
+      sh.vr = Math.cos(ang) * v; sh.vu = Math.sin(ang) * v + 1.2;
+      sh.size = rand(0.14, 0.26) * (golden ? 1.3 : 1);
+      sh.mat.color.set(golden ? '#ffe27a' : '#ffd9ef'); sh.mat.opacity = 1;
+      sh.sprite.position.copy(sh.p0); sh.sprite.scale.setScalar(sh.size); sh.sprite.visible = true;
+    }
+  }
+
+  function pop(s, chained = false) {
+    if (s.popT >= 0) return;
+    const k = KIND_BY_ID[s.kindId];
+    s.popT = 0;
+    const golden = k.id === 'golden';
+    if (golden) sfx(pick(CHIME_SFX), 0.4);
+    else if (k.id === 'prism') sfx(BURST_SFX, 0.35);
+    else sfx(pick(POP_SFX), 0.28);
+    burst(s, golden);
+    const strength = k.strength > 0 ? clamp(k.strength + 0.35 * intensity() + Math.random() * 0.1, 0, 1) : 0;
+    emit(popCbs, { id: k.id, kind: k.kind, payload: k.payload, overlayKind: k.overlayKind, strength,
+      points: k.points, placement: s.placement, x: s.x, d: s.d, worldPos: s.sprite.position.clone() });
+    if (k.id === 'prism' && !chained) {
+      for (const o of pool) {
+        if (!o.alive || o === s || o.popT >= 0 || o.kindId === 'video') continue;
+        const dd = relD(o.d, s.d);
+        if (dd > -2 && dd < PRISM_REACH) pop(o, true);
+      }
+    }
+  }
+
+  // ---- per frame -----------------------------------------------------------
+  function update(dt, t, kart) {
+    lastKartD = kart.d;
+    for (const s of pool) {
+      if (!s.alive) continue;
+      s.age += dt;
+      const rel = relD(s.d, kart.d);
+      if (s.popT >= 0) {   // pop flash: swell + fade, then free
+        s.popT += dt;
+        const f = Math.min(1, s.popT / POP_ANIM);
+        s.scale = 1 + 0.55 * f; s.mat.opacity = 1 - f;
+        if (f >= 1) { freeSlot(s); continue; }
+      } else {
+        const bob = 0.12 * Math.sin(t * 2.2 + s.phase);
+        if (s.placement === 'lane') { s.h = s.baseH + bob; }
+        else if (s.placement === 'air') { s.h = s.baseH + 0.08 * Math.sin(t * 2.6 + s.phase); }
+        else if (s.placement === 'spawn') {
+          const a = Math.min(1, s.age / 0.45);
+          s.scale = 1 - (1 - a) * (1 - a);
+          s.x = clamp(s.x0 + 0.55 * Math.sin(t * 1.7 + s.phase), -ROAD_HALF_W + 0.4, ROAD_HALF_W - 0.4);
+          s.h = LANE_H + bob;
+        } else if (s.placement === 'rain') {
+          if (s.age < RAIN_FALL) { const k = s.age / RAIN_FALL; s.h = CEILING_H - (CEILING_H - LANE_H) * k * k; }
+          else if (s.age < RAIN_FALL + RAIN_REST) { s.h = LANE_H + bob; }
+          else {
+            const f = (s.age - RAIN_FALL - RAIN_REST) / RAIN_FIZZLE;
+            s.h = LANE_H + bob; s.scale = 1 - 0.4 * f; s.mat.opacity = 1 - f;
+            if (f >= 1) { freeSlot(s); continue; }
+          }
+        }
+        // behind the kart: a treat that slipped by is a miss, further back it is gone
+        if (rel < -MISS_BEHIND && rel > -DROP_BEHIND - 40 && !s.missed) {
+          s.missed = true;
+          const k = KIND_BY_ID[s.kindId];
+          if (k.kind === 'treat') emit(missCbs, { id: k.id, points: k.points, d: s.d });
+        }
+        if (rel < -DROP_BEHIND && rel > -DROP_BEHIND - 40) { freeSlot(s); continue; }
+        if (Math.abs(rel) < POP_HIT_D && Math.abs(s.x - kart.x) < POP_HIT_X && Math.abs(s.h - kart.h) < POP_HIT_H) pop(s);
+      }
+      s.sprite.visible = rel > -DROP_BEHIND && rel < VIEW_AHEAD;
+      if (s.sprite.visible) {
+        layout.toWorld(s.d, s.x, s.h, s.sprite.position);
+        s.sprite.scale.setScalar(s.size * s.scale);
+      }
+    }
+    for (const sh of shards) {
+      if (!sh.alive) continue;
+      sh.age += dt;
+      const f = sh.age / sh.life;
+      if (f >= 1) { sh.alive = false; sh.sprite.visible = false; continue; }
+      _r.copy(sh.r).multiplyScalar(sh.vr * sh.age);
+      _u.copy(sh.u).multiplyScalar(sh.vu * sh.age - 4.5 * sh.age * sh.age);
+      sh.sprite.position.copy(sh.p0).add(_r).add(_u);
+      sh.sprite.scale.setScalar(sh.size * (1 - 0.7 * f));
+      sh.mat.opacity = 1 - f * f;
+    }
+    // a chunk the kart has just cleared may seed again next lap
+    for (let i = chunkRecs.length - 1; i >= 0; i--) {
+      const r = relD(chunkRecs[i].d1, kart.d);
+      if (r < -30 && r > -80) { seeded.delete(chunkRecs[i].id); chunkRecs.splice(i, 1); }
+    }
+  }
+
+  function dispose() {
+    disposed = true;
+    scene.remove(group);
+    for (const s of pool) s.mat.dispose();
+    for (const sh of shards) sh.mat.dispose();
+    for (const id of Object.keys(texOf)) if (texOf[id] && texOf[id] !== dotTex) texOf[id].dispose();
+    if (dotTex) dotTex.dispose();
+    popCbs.length = 0; missCbs.length = 0; seeded.clear(); chunkRecs.length = 0;
+  }
+
+  return {
+    seedChunk, spawnAhead, rain, update, dispose,
+    onPop(cb) { if (typeof cb === 'function') popCbs.push(cb); },
+    onMiss(cb) { if (typeof cb === 'function') missCbs.push(cb); },
+    setDensity(mult) { density = clamp(Number(mult) || 1, 0.25, 3); },
+    get liveCount() { return liveCount; },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/score.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/score.js
@@ -1,0 +1,128 @@
+/* ============================================================================
+ * race/score.js - The Caucus Race ledger: score, combo, the multiplier ladder,
+ * THE BANK at the Tea Garden, near-miss ALMOSTs and the jackpot ladder.
+ * Implements CONTRACT.md section `race/score.js`.
+ *
+ * No renderer, no DOM: pure state plus an event stream a HUD reacts to.
+ * Nothing here ever subtracts: a miss or a timeout only lets the combo go
+ * (mult back to x1), the score never moves down (no-lose contract).
+ * ==========================================================================*/
+
+import { MULT_LADDER, COMBO_HOLD_SEC } from './consts.js';
+import { KIND_BY_ID } from './bubbleKinds.js';
+
+const BEST_KEY = 'race.best';
+const NEAR_MISS_POINTS = 25;
+const JACKPOT_COMBOS = [25, 50, 100];           // combo rungs that fire a major jackpot on their own
+const JACKPOT_BONUS = { minor: 100, major: 250, royal: 1000 };
+
+const ladderMult = (combo) => { let m = 1; for (const [at, mult] of MULT_LADDER) if (combo >= at) m = mult; return m; };
+const ladderStep = (combo) => MULT_LADDER.some(([at]) => at === combo && at > 0);
+function loadBest() { try { const v = Number(localStorage.getItem(BEST_KEY)); return isFinite(v) && v > 0 ? v : 0; } catch (e) { return 0; } }
+function saveBest(v) { try { localStorage.setItem(BEST_KEY, String(v)); } catch (e) { /* private mode */ } }
+
+export function createScore() {
+  const state = { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, best: loadBest(),
+    popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0 };
+  let hold = 0;          // seconds of combo left before it lets go
+  let freezeSec = 0;     // pocket_watch: the hold timer stands still
+  let boost = 1, boostSec = 0;   // lucky_star: a temporary multiplier on top of the ladder
+  const cbs = [];
+  const emit = (ev) => { for (const cb of cbs) { try { cb(ev); } catch (e) { /* listener bug, not ours */ } } };
+
+  function touchBest() {
+    const total = state.banked + state.score;
+    if (total > state.best) { state.best = total; saveBest(total); }
+  }
+  /** Recompute the effective multiplier; emits `mult` when it changes. */
+  function setMult() {
+    const to = ladderMult(state.combo) * boost;
+    if (to === state.mult) return false;
+    const from = state.mult; state.mult = to;
+    emit({ type: 'mult', from, to, combo: state.combo });
+    return true;
+  }
+  function release(reason) {
+    const lost = state.combo;
+    state.combo = 0; hold = 0;
+    emit({ type: 'combo', combo: 0, step: false, lost, reason });
+    setMult();
+    return lost;
+  }
+
+  function pop(points, kindId) {
+    const k = KIND_BY_ID[kindId];
+    state.combo++; hold = COMBO_HOLD_SEC;
+    if (state.combo > state.bestCombo) state.bestCombo = state.combo;
+    const step = setMult() || ladderStep(state.combo);
+    const gain = Math.round((Number(points) || 0) * state.mult);
+    state.score += gain; state.popped++;
+    if (k && k.kind === 'effect') state.effects++; else state.treats++;
+    emit({ type: 'pop', kindId, points, gain, combo: state.combo, mult: state.mult, score: state.score });
+    emit({ type: 'combo', combo: state.combo, step, mult: state.mult, hold });
+    if (JACKPOT_COMBOS.includes(state.combo)) jackpot('major');
+    return gain;
+  }
+  /** A treat slipped behind the kart: the streak gets a shiver, the score does not move. */
+  function miss() {
+    const from = state.mult;
+    const lost = state.combo > 0 ? release('miss') : 0;
+    emit({ type: 'miss', comboLost: lost, multFrom: from, mult: state.mult });
+  }
+  function nearMiss() {
+    const gain = Math.round(NEAR_MISS_POINTS * state.mult);
+    state.score += gain; state.nearMisses++;
+    emit({ type: 'almost', gain, nearMisses: state.nearMisses, score: state.score });
+    return gain;
+  }
+  /** THE BANK: the run's score leaves the road and lands in `banked` (Tea Garden gate). */
+  function bank() {
+    const amount = state.score;
+    state.banked += amount; state.bank = amount; state.score = 0;
+    touchBest();
+    emit({ type: 'bank', amount, banked: state.banked, combo: state.combo, best: state.best });
+    return amount;
+  }
+  function jackpot(tier = 'minor') {
+    const gain = Math.round((JACKPOT_BONUS[tier] || JACKPOT_BONUS.minor) * state.mult);
+    state.score += gain;
+    emit({ type: 'jackpot', tier, gain, combo: state.combo, mult: state.mult, score: state.score });
+    return gain;
+  }
+  function tick(dt) {
+    if (boostSec > 0) { boostSec -= dt; if (boostSec <= 0) { boost = 1; boostSec = 0; setMult(); } }
+    if (state.combo <= 0) return;
+    if (freezeSec > 0) { freezeSec -= dt; return; }
+    hold -= dt;
+    if (hold <= 0) release('timeout');
+  }
+  function reset() {
+    touchBest();
+    Object.assign(state, { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0 });
+    hold = 0; freezeSec = 0; boost = 1; boostSec = 0;
+  }
+
+  return {
+    state, pop, miss, nearMiss, bank, jackpot, tick, reset,
+    onEvent(cb) { if (typeof cb === 'function') cbs.push(cb); },
+    // items.js hooks (additive to the contract): pocket_watch + lucky_star
+    freezeCombo(sec) { freezeSec = Math.max(freezeSec, Number(sec) || 0); },
+    boostMult(mult, sec) { boost = Math.max(1, Number(mult) || 1); boostSec = Number(sec) || 0; setMult(); },
+    /** 0..1 fraction of the combo hold still left, for a HUD ring. */
+    holdLeft() { return state.combo > 0 ? Math.max(0, hold / COMBO_HOLD_SEC) : 0; },
+  };
+}
+
+// self-check (node only): `RACE_SELFCHECK=1 node --input-type=module -e "import './score.js'"`
+if (typeof process !== 'undefined' && process.env && process.env.RACE_SELFCHECK) {
+  const s = createScore(); const ev = [];
+  s.onEvent((e) => ev.push(e.type));
+  for (let i = 0; i < 5; i++) s.pop(10, 'treat');
+  console.assert(s.state.combo === 5 && s.state.mult === 2 && s.state.score === 60, 'ladder x2 at 5');
+  s.tick(COMBO_HOLD_SEC + 0.01);
+  console.assert(s.state.combo === 0 && s.state.mult === 1, 'combo lets go');
+  s.pop(15, 'flash'); console.assert(s.state.effects === 1 && s.state.treats === 5, 'kind tally');
+  const b = s.bank(); console.assert(b === 75 && s.state.score === 0 && s.state.banked === 75, 'bank');
+  console.assert(ev.includes('mult') && ev.includes('bank') && ev.includes('combo'), 'events');
+  console.log('score.js self-check ok', s.state);
+}


### PR DESCRIPTION
## What
The pickup layer and the score ledger.

## Bubbles (race/bubbleKinds.js + race/bubbles.js)
The same bubbles the player knows from DtRH and the desktop CCP: treat, golden, lucky, prism, flash, subliminal, pink, spiral, braindrain, glitch, freeze, gif rain and the rare video, with the existing sprites, tints and payload names. Four placements: lane (resting on the road), air (threaded along a ramp's air line), spawn (materialise 35..60 m ahead and wobble) and rain (fall from the tube ceiling, rest, fizzle). Driving through pops them; treats score, effects hand a payload spec to the run brain. Kind roll is weighted per room and gated by run intensity (braindrain, gif rain and video only at higher intensity). Pooled sprites capped at 160, pop shards, in-page pop sounds from assets/bubbles/sfx.

## Score (race/score.js)
Score, combo, the multiplier ladder from consts (x1/2/3/4/6/8 at combo 0/5/12/22/36/50), near-miss ALMOST, THE BANK at the Tea Garden gate, JACKPOT tiers at combo 25/50/100, personal best in localStorage. Nothing ever subtracts score. freezeCombo and boostMult exist for the items PR.

## Verified
node smoke test with a THREE stub: a chunk straddling the start line seeds and pops, pops on lane/air/spawn, misses fire behind the kart, the cap holds, rain fizzles to zero, intensity 0 never rolls braindrain/gifrain/video, every event shape checked; the score self-check covers the ladder, release after the hold and bank.

## Not verified
Sprite look, tint strength and draw cost in a real renderer.

---
Part of The Caucus Race stack (DtRH as a no-lose kart run with the CCP/DtRH effect bubbles as the pickup layer). Stack order: 1-track > 1b-rooms > 2-bubbles > 3-kart > 4-hud > 4b-items > 6-run > 7-boot; the host PR is independent. Each PR is under the 600 changed-line cap. Nothing in this stack edits chaosRun.js, scene.js, tunnel.js, fx.js or payloadFx.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
