### PR TITLE
feat(race): Caucus Race 4/9 - kart physics + EMI in the cup

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/CONTRACT.md
@@ -138,7 +138,8 @@ kart.applyBoost(sec)             // boost pad / item
 kart.applySlow(mult, sec)        // effect pops slow, never stop (speed floor = KART_MIN_SPEED)
 kart.setMood(id)                 // 'calm' | 'streamed' | 'fraught' | 'smug' | 'shock' | 'jackpot'
 kart.setFraught(v)               // 0..1, drives sweat + antenna kink
-kart.camera(out)                 // out = { pos: Vector3, look: Vector3, roll: number }
+kart.camera(out)                 // out = { pos: Vector3, look: Vector3, up: Vector3, roll: number }; up follows the
+                                 // transported frame (inverts through the loop); level + roll 0 under reducedMotion
 kart.group                       // THREE.Group (cup + EMI back view)
 kart.dispose()
 ```

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -1,0 +1,238 @@
+// race/emi.js - The Caucus Race: the teacup rig with EMI riding in it, seen from behind.
+// Visual half of CONTRACT.md "race/kart.js (PR 3)": saucer + cup + handle + tea surface, EMI as a
+// CRT body with vents, two glove arms on the rim, a bead antenna with the six mood poses, pooled
+// sweat drops, drift sparks, and the tea reflection. Canon lock: her face is ONLY a text emoticon
+// drawn on a canvas and mirrored in the tea. No drawn face, no generated face, no mouthed words.
+// Ported from the approved pitch demo (C:\wt-race-ref\pitch-demo.html) into ESM; poses now blend
+// on a spring (House Book Law XI), never a linear tween, and always return to the breath.
+
+import * as THREE from 'three';
+
+const PINK = 0xff69b4, GOLD = 0xF2C14E, PALE = 0xB3C7FF, PORCELAIN = 0xF6E7C8;
+const BREATH_SEC = 3.9;      // the one breath on screen (Law III)
+const SWEAT_N = 28, SPARK_N = 32;
+
+/** Antenna poses per mood. antX pitches the whole stem (negative = streamed back), kinkX/Z bend
+ *  the joint, wind = how much speed is allowed to stream the stem, w = spring speed (rad/s). */
+export const MOODS = {
+  calm:     { face: 'o_o', antX: 0,    kinkX: 0,    kinkZ: 0,    bead: PINK, scale: 1,   sway: 1,   wind: 1,   w: 8,  zeta: 0.65 },
+  streamed: { face: ':3',  antX: -1.0, kinkX: -0.3, kinkZ: 0,    bead: PINK, scale: 1,   sway: 0,   wind: 1,   w: 14, zeta: 0.7 },
+  fraught:  { face: ';_;', antX: 0.25, kinkX: 1.4,  kinkZ: 0,    bead: PALE, scale: 0.9, sway: 0.4, wind: 0.3, w: 10, zeta: 0.6 },
+  smug:     { face: '^_^', antX: 0,    kinkX: 0,    kinkZ: 0.55, bead: PINK, scale: 1,   sway: 1,   wind: 0.6, w: 7,  zeta: 0.6 },
+  shock:    { face: '>_<', antX: 0.1,  kinkX: 0,    kinkZ: 0,    bead: PINK, scale: 1.6, sway: 0,   wind: 0,   w: 22, zeta: 0.45 },
+  jackpot:  { face: '$_$', antX: 0,    kinkX: 0,    kinkZ: 0.2,  bead: GOLD, scale: 1.3, sway: 1,   wind: 0.6, w: 12, zeta: 0.5 },
+};
+
+/** Damped spring toward a target; zeta < 1 overshoots a little, which is the point. */
+class Spring {
+  constructor(x = 0) { this.x = x; this.v = 0; }
+  step(target, dt, w, zeta = 0.65) {
+    this.v += (w * w * (target - this.x) - 2 * zeta * w * this.v) * dt;
+    this.x += this.v * dt;
+    return this.x;
+  }
+}
+
+const _m = new THREE.Matrix4(), _q = new THREE.Quaternion(), _s = new THREE.Vector3(), _p = new THREE.Vector3();
+const _g = new THREE.Vector3(), _c = new THREE.Color();
+
+/** Tiny pooled particle system in WORLD space (drops fall toward the road, not with the cup). */
+function makePool(n, geo, mat) {
+  const mesh = new THREE.InstancedMesh(geo, mat, n);
+  mesh.frustumCulled = false;
+  const items = [];
+  for (let i = 0; i < n; i++) {
+    items.push({ life: 0, ttl: 1, size: 1, p: new THREE.Vector3(), v: new THREE.Vector3() });
+    mesh.setMatrixAt(i, _m.compose(_p.set(0, -999, 0), _q, _s.setScalar(0.0001)));
+  }
+  let cursor = 0;
+  return {
+    mesh,
+    spawn(p, v, ttl, size) {
+      const it = items[cursor]; cursor = (cursor + 1) % n;
+      it.life = it.ttl = ttl; it.size = size; it.p.copy(p); it.v.copy(v);
+    },
+    update(dt, gravity) {
+      for (let i = 0; i < n; i++) {
+        const it = items[i];
+        if (it.life <= 0) continue;
+        it.life -= dt;
+        it.v.addScaledVector(gravity, dt);
+        it.p.addScaledVector(it.v, dt);
+        const k = it.life > 0 ? it.size * (0.55 + 0.45 * it.life / it.ttl) : 0.0001;
+        mesh.setMatrixAt(i, _m.compose(it.life > 0 ? it.p : _p.set(0, -999, 0), _q, _s.setScalar(k)));
+      }
+      mesh.instanceMatrix.needsUpdate = true;
+    },
+  };
+}
+
+function ventTexture() {
+  const c = document.createElement('canvas'); c.width = c.height = 64;
+  const g = c.getContext('2d');
+  g.fillStyle = '#1B1A33'; g.fillRect(0, 0, 64, 64);
+  g.fillStyle = '#0F0E22'; for (let y = 10; y < 44; y += 6) g.fillRect(10, y, 44, 2);
+  g.fillStyle = '#F2C14E'; g.beginPath(); g.arc(50, 54, 3.2, 0, 7); g.fill();
+  g.fillStyle = '#FF69B4'; g.fillRect(10, 52, 14, 4);
+  const t = new THREE.CanvasTexture(c); t.magFilter = THREE.NearestFilter; t.minFilter = THREE.LinearFilter;
+  return t;
+}
+
+/**
+ * createEmiRig({ scene, reducedMotion }) -> { group, update(dt, ctx), setMood, setFraught, squash, dispose }
+ * ctx = { t, up, right, tangent, speedNorm, airborne, steerVel, drift, driftSide }  (world-space frame)
+ * `group` is the whole rig; the caller positions and orients it. Particles are added to `scene`.
+ */
+export function createEmiRig({ scene, reducedMotion = false }) {
+  const group = new THREE.Group(); group.name = 'kart';
+  const root = new THREE.Group(); group.add(root);          // squash scales this, not the frame
+  const porcelain = new THREE.MeshStandardMaterial({ color: PORCELAIN, roughness: 0.35, metalness: 0.05 });
+  const pinkGlow = new THREE.MeshStandardMaterial({ color: PINK, emissive: PINK, emissiveIntensity: 1.2, roughness: 0.4 });
+  const navy = new THREE.MeshStandardMaterial({ color: 0x252542, roughness: 0.6 });
+  const navyDark = new THREE.MeshStandardMaterial({ color: 0x1B1A33, roughness: 0.7 });
+  const stemMat = new THREE.MeshStandardMaterial({ color: 0x2C2B4A, roughness: 0.5 });
+  const glove = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.5 });
+
+  // ---- saucer ----
+  const saucer = new THREE.Group(); root.add(saucer);
+  const sc = new THREE.Mesh(new THREE.CylinderGeometry(0.95, 0.7, 0.09, 40), porcelain); sc.position.y = 0.05; saucer.add(sc);
+  const saucerRim = new THREE.Mesh(new THREE.TorusGeometry(0.93, 0.03, 8, 48), pinkGlow); saucerRim.rotation.x = Math.PI / 2; saucerRim.position.y = 0.09; saucer.add(saucerRim);
+  const saucerMark = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.02, 0.08), pinkGlow); saucerMark.position.set(0.7, 0.1, 0); saucer.add(saucerMark);
+
+  // ---- cup ----
+  const body = new THREE.Group(); root.add(body);
+  const prof = [[0.001, 0], [0.28, 0], [0.34, 0.06], [0.44, 0.3], [0.52, 0.58], [0.55, 0.66], [0.5, 0.68], [0.47, 0.6], [0.4, 0.3], [0.3, 0.1], [0.001, 0.08]]
+    .map(([x, y]) => new THREE.Vector2(x, y));
+  const cupMat = new THREE.MeshStandardMaterial({ color: PORCELAIN, roughness: 0.35, metalness: 0.05, side: THREE.DoubleSide });
+  const cupMesh = new THREE.Mesh(new THREE.LatheGeometry(prof, 40), cupMat); cupMesh.position.y = 0.09; body.add(cupMesh);
+  const rim = new THREE.Mesh(new THREE.TorusGeometry(0.53, 0.025, 8, 48), pinkGlow); rim.rotation.x = Math.PI / 2; rim.position.y = 0.75; body.add(rim);
+  const handle = new THREE.Mesh(new THREE.TorusGeometry(0.19, 0.045, 10, 24, Math.PI), porcelain); handle.position.set(0.62, 0.42, 0); handle.rotation.z = -Math.PI / 2; body.add(handle);
+
+  // ---- the tea: the only mirror she has. Her face shows in it, reversed. ----
+  const teaCanvas = document.createElement('canvas'); teaCanvas.width = teaCanvas.height = 96;
+  const teaTex = new THREE.CanvasTexture(teaCanvas); teaTex.magFilter = THREE.NearestFilter; teaTex.minFilter = THREE.LinearFilter;
+  let faceDrawn = '';
+  function drawTea(face) {
+    if (face === faceDrawn) return; faceDrawn = face;
+    const g = teaCanvas.getContext('2d'); g.setTransform(1, 0, 0, 1, 0, 0);
+    g.fillStyle = '#B23282'; g.fillRect(0, 0, 96, 96);
+    const rg = g.createRadialGradient(48, 48, 6, 48, 48, 50); rg.addColorStop(0, 'rgba(255,140,200,.55)'); rg.addColorStop(1, 'rgba(120,20,80,.3)');
+    g.fillStyle = rg; g.fillRect(0, 0, 96, 96);
+    g.translate(96, 0); g.scale(-1, 1);                        // mirrored: it is a reflection
+    g.fillStyle = '#FF9BD0'; g.font = '600 ' + (face.length > 4 ? 15 : 24) + 'px "Noto Sans Mono", "JetBrains Mono", Consolas, monospace';
+    g.textAlign = 'center'; g.textBaseline = 'middle'; g.fillText(face, 48, 50);
+    teaTex.needsUpdate = true;
+  }
+  drawTea(MOODS.calm.face);
+  const reflection = new THREE.Mesh(new THREE.CircleGeometry(0.46, 32), new THREE.MeshBasicMaterial({ map: teaTex }));
+  reflection.rotation.set(-Math.PI / 2, 0, Math.PI); reflection.position.y = 0.655; body.add(reflection);
+  const teaMat = new THREE.MeshStandardMaterial({ color: 0xC94A9A, roughness: 0.15, metalness: 0.2, transparent: true, opacity: 0.35 });
+  const tea = new THREE.Mesh(new THREE.CircleGeometry(0.47, 32), teaMat);
+  tea.rotation.set(-Math.PI / 2, 0, Math.PI); tea.position.y = 0.66; body.add(tea);
+
+  // ---- EMI: a living pixel CRT seen from behind, gripping the rim ----
+  const emi = new THREE.Group(); emi.position.y = 0.8; emi.scale.setScalar(1.25); body.add(emi);
+  const crt = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.42, 0.34), navy); emi.add(crt);
+  const ventMat = new THREE.MeshStandardMaterial({ map: ventTexture(), roughness: 0.8 });
+  const back = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.34, 0.06), ventMat); back.position.z = -0.19; emi.add(back);
+  const shoulderL = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.22, 0.26), navyDark); shoulderL.position.set(-0.29, -0.06, 0); emi.add(shoulderL);
+  const shoulderR = shoulderL.clone(); shoulderR.position.x = 0.29; emi.add(shoulderR);
+  const screenMat = new THREE.MeshBasicMaterial({ color: PINK, transparent: true, opacity: 0.85 });
+  const screenGlow = new THREE.Mesh(new THREE.PlaneGeometry(0.4, 0.3), screenMat); screenGlow.position.z = 0.172; emi.add(screenGlow);
+  const screenLight = new THREE.PointLight(PINK, 0.9, 3); screenLight.position.set(0, 0, 0.5); emi.add(screenLight);
+  const armGeo = new THREE.CylinderGeometry(0.035, 0.03, 0.42, 8), handGeo = new THREE.SphereGeometry(0.06, 10, 8);
+  for (const sd of [-1, 1]) {
+    const arm = new THREE.Mesh(armGeo, navyDark); arm.position.set(sd * 0.3, -0.1, 0.25); arm.rotation.set(-0.9, 0, sd * 0.35); emi.add(arm);
+    const hand = new THREE.Mesh(handGeo, glove); hand.position.set(sd * 0.36, -0.22, 0.44); emi.add(hand);
+  }
+  const antenna = new THREE.Group(); antenna.position.y = 0.21; emi.add(antenna);
+  const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.022, 0.22, 8), stemMat); stem.position.y = 0.11; antenna.add(stem);
+  const kink = new THREE.Group(); kink.position.y = 0.22; antenna.add(kink);
+  const stem2 = new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.018, 0.16, 8), stemMat); stem2.position.y = 0.08; kink.add(stem2);
+  const beadMat = new THREE.MeshStandardMaterial({ color: PINK, emissive: PINK, emissiveIntensity: 0.9, roughness: 0.3 });
+  const bead = new THREE.Mesh(new THREE.SphereGeometry(0.06, 12, 10), beadMat); bead.position.y = 0.17; kink.add(bead);
+  const beadLight = new THREE.PointLight(PINK, 0.5, 2); bead.add(beadLight);
+  const cupLight = new THREE.PointLight(PINK, 1.4, 14); cupLight.position.y = 1.2; group.add(cupLight);
+
+  // ---- sweat (pale blue drops) and drift sparks, both world-space pools ----
+  const sweat = makePool(SWEAT_N, new THREE.SphereGeometry(0.04, 8, 6), new THREE.MeshBasicMaterial({ color: 0xCFF6FF }));
+  const sparks = makePool(SPARK_N, new THREE.BoxGeometry(0.07, 0.07, 0.07), new THREE.MeshBasicMaterial({ color: 0xFFD27A }));
+  scene.add(sweat.mesh); scene.add(sparks.mesh);
+
+  // ---- state ----
+  let mood = MOODS.calm, fraught = 0, sweatAcc = 0, sparkAcc = 0, blinkAt = 0;
+  const sAnt = new Spring(0), sKinkX = new Spring(0), sKinkZ = new Spring(0), sBead = new Spring(1), sSquash = new Spring(0);
+  const beadTarget = new THREE.Color(PINK);
+
+  function setMood(id) { mood = MOODS[id] || MOODS.calm; }
+  function setFraught(v) { fraught = Math.max(0, Math.min(1, +v || 0)); }
+  function squash(amount) { sSquash.x = Math.max(sSquash.x, Math.min(1, amount)); sSquash.v = 0; }
+
+  function emitFrom(obj, lx, ly, lz, ctx, pool, ttl, size, spread, upSpeed, backSpeed) {
+    _p.set(lx, ly, lz); obj.localToWorld(_p);
+    _g.copy(ctx.up).multiplyScalar(upSpeed).addScaledVector(ctx.right, (Math.random() - 0.5) * spread).addScaledVector(ctx.tangent, backSpeed);
+    pool.spawn(_p, _g, ttl, size);
+  }
+
+  function update(dt, ctx) {
+    dt = Math.min(dt, 0.05);
+    const t = ctx.t || 0, m = mood;
+    const wind = Math.max(0, Math.min(1, (ctx.speedNorm - 0.55) / 0.45)) * 0.8 + (ctx.airborne ? 0.5 : 0);
+    const antTarget = m.antX - Math.min(1, wind) * m.wind + (fraught > 0.4 ? 0.25 * fraught : 0);
+    const kinkXT = m.kinkX + 1.7 * fraught * (m === MOODS.fraught ? 0.3 : 1);
+    const hush = ctx.airborne || m.sway === 0 ? 0 : m.sway * (1 - 0.6 * fraught);
+    const sway = hush * 0.14 * Math.sin(t * (Math.PI * 2) / BREATH_SEC);
+    antenna.rotation.set(sAnt.step(antTarget, dt, m.w, m.zeta), 0, sway - (ctx.steerVel || 0) * 0.06);
+    kink.rotation.set(sKinkX.step(kinkXT, dt, m.w, m.zeta), 0, sKinkZ.step(m.kinkZ, dt, m.w, m.zeta));
+    bead.scale.setScalar(Math.max(0.3, sBead.step(m.scale, dt, m.w, m.zeta)));
+    beadTarget.setHex(m.bead); if (m !== MOODS.jackpot) beadTarget.lerp(_c.setHex(PALE), fraught);
+    beadMat.color.lerp(beadTarget, Math.min(1, dt * 6)); beadMat.emissive.copy(beadMat.color); beadLight.color.copy(beadMat.color);
+    beadMat.emissiveIntensity = m === MOODS.jackpot ? 1.4 : 0.9;
+    screenMat.opacity = 0.6 + 0.25 * Math.sin(t * 4);
+
+    // the tea swirls; the face in it is text and nothing else
+    tea.rotation.z = reflection.rotation.z = Math.PI + Math.sin(t * 1.3) * 0.05;
+    let face = fraught > 0.6 && (m === MOODS.calm || m === MOODS.smug) ? MOODS.fraught.face : m.face;
+    if (face === MOODS.calm.face) { if (t > blinkAt) blinkAt = t + 5.2; else if (t > blinkAt - 0.11) face = '-_-'; }
+    drawTea(face);
+
+    // landing squash with overshoot (Law XI)
+    const sq = sSquash.step(0, dt, 9, 0.45);
+    root.scale.set(1 + sq * 0.18, 1 - sq * 0.28, 1 + sq * 0.18);
+    saucer.rotation.y += (0.7 + ctx.speedNorm * 2.5) * dt;
+
+    // sweat off the bead and the CRT's top corners; a Bambi-scale anime sweat, not a rain
+    if (!reducedMotion) {
+      const rate = fraught > 0.3 || m === MOODS.fraught ? 4 + 6 * Math.max(fraught, m === MOODS.fraught ? 0.5 : 0) : 0;
+      sweatAcc += dt * rate;
+      while (sweatAcc >= 1) {
+        sweatAcc -= 1;
+        const src = Math.random() < 0.5 ? bead : crt, sd = Math.random() < 0.5 ? -1 : 1;
+        if (src === bead) emitFrom(bead, 0, 0, 0, ctx, sweat, 0.7, 1, 2.2, 1.4 + Math.random() * 1.2, -0.6);
+        else emitFrom(crt, sd * 0.25, 0.21, 0, ctx, sweat, 0.7, 0.9, 2.6, 1.2 + Math.random(), -0.5);
+      }
+      const drifting = ctx.drift && !ctx.airborne ? 1 : 0;
+      sparkAcc += dt * 40 * drifting;
+      while (sparkAcc >= 1) {
+        sparkAcc -= 1;
+        const side = -(ctx.driftSide || 1);
+        emitFrom(saucer, side * 0.8, 0.04, -0.5 + Math.random() * 0.3, ctx, sparks, 0.3 + Math.random() * 0.15, 0.6 + Math.random() * 0.8, 2.5,
+          0.8 + Math.random() * 2, -(3 + Math.random() * 4));
+      }
+      if (!drifting) sparkAcc = 0;
+    }
+    _g.copy(ctx.up).multiplyScalar(-5); sweat.update(dt, _g);
+    _g.copy(ctx.up).multiplyScalar(-12); sparks.update(dt, _g);
+  }
+
+  function dispose() {
+    scene.remove(sweat.mesh); scene.remove(sparks.mesh);
+    for (const o of [group, sweat.mesh, sparks.mesh]) o.traverse((n) => {
+      if (n.geometry) n.geometry.dispose();
+      const mats = Array.isArray(n.material) ? n.material : n.material ? [n.material] : [];
+      for (const mt of mats) { if (mt.map) mt.map.dispose(); mt.dispose(); }
+    });
+  }
+
+  return { group, update, setMood, setFraught, squash, dispose };
+}

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -1,0 +1,183 @@
+// race/kart.js - The Caucus Race: the kart (the teacup) in track space, its placement on the road,
+// and the chase camera. Implements CONTRACT.md "race/kart.js (PR 3)". The cup + EMI meshes,
+// antenna moods, sweat and sparks live in race/emi.js; this file owns speed, steering, drift,
+// ramps, the lap counter and the camera seat. There is no fail state: speed never drops below
+// KART_MIN_SPEED and the road walls are soft.
+
+import * as THREE from 'three';
+import {
+  KART_BASE_SPEED, KART_MAX_SPEED, KART_MIN_SPEED, GRAVITY, ROAD_HALF_W,
+  CAM_BACK, CAM_UP, CAM_LOOK_AHEAD,
+} from './consts.js';
+import { createEmiRig } from './emi.js';
+
+const STEER_VMAX = 6.5;       // lateral m/s at full lock, cruise speed, no drift
+const DRIFT_STEER = 1.45;     // drift tightens the steer
+const WALL_SOFT = 0.7;        // metres from the road edge where the soft wall starts easing you back
+const WORLD_UP = new THREE.Vector3(0, 1, 0), ZERO = new THREE.Vector3();
+const _m = new THREE.Matrix4(), _q = new THREE.Quaternion(), _v = new THREE.Vector3();
+const _fwd = new THREE.Vector3(), _up = new THREE.Vector3(), _right = new THREE.Vector3(), _lvl = new THREE.Vector3();
+const AX_X = new THREE.Vector3(1, 0, 0), AX_Z = new THREE.Vector3(0, 0, 1);
+
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const ease = (k, dt) => 1 - Math.exp(-k * dt);
+
+/**
+ * createKart({ scene, layout, reducedMotion }) -> kart
+ * kart.update(dt, input, layout)  input = { steer:-1..1, accel:0..1, brake:0..1, drift:bool }
+ * kart.camera(out)                out = { pos: Vector3, look: Vector3, up?: Vector3, roll: number }
+ */
+export function createKart({ scene, layout, reducedMotion = false }) {
+  const state = {
+    d: 0, x: 0, h: 0, vh: 0, speed: KART_BASE_SPEED, steer: 0, drift: false, airborne: false,
+    boostSec: 0, slowMult: 1, slowSec: 0, lap: 0,
+  };
+  const rig = createEmiRig({ scene, reducedMotion });
+  const group = rig.group;
+  scene.add(group);
+
+  let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
+  const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
+  const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1 };
+
+  function applyBoost(sec) { state.boostSec = Math.max(state.boostSec, +sec || 0); }
+  function applySlow(mult, sec) {
+    state.slowMult = clamp(+mult || 1, 0.2, 1);
+    state.slowSec = Math.max(state.slowSec, +sec || 0);
+  }
+
+  function launch(ramp) {
+    const height = Math.max(0.5, +ramp.height || 2.4);
+    const scale = clamp(state.speed / KART_BASE_SPEED, 0.7, 1.3);   // faster = higher, never a fail
+    state.vh = Math.sqrt(2 * GRAVITY * height * scale);
+    state.airborne = true;
+    lastRampD = ramp.d;
+  }
+
+  function stepSpeed(dt, input) {
+    if (state.boostSec > 0) state.boostSec = Math.max(0, state.boostSec - dt);
+    if (state.slowSec > 0) { state.slowSec = Math.max(0, state.slowSec - dt); if (state.slowSec === 0) state.slowMult = 1; }
+    const cap = state.boostSec > 0 ? KART_MAX_SPEED : KART_BASE_SPEED;
+    // accel holds cruise, letting go coasts a touch under it, boost pins the cap
+    let target = state.boostSec > 0 ? cap : cap * (0.88 + 0.12 * input.accel);
+    if (state.drift) target *= 1.04;                                   // small speed keep while drifting
+    target = target * (1 - input.brake) + KART_MIN_SPEED * input.brake;
+    if (state.slowSec > 0) target *= state.slowMult;
+    target = clamp(target, KART_MIN_SPEED, KART_MAX_SPEED);
+    const rising = target > state.speed;
+    const k = rising ? (state.boostSec > 0 ? 6 : 2.5) : (input.brake > 0 ? 3 : state.drift ? 0.8 : 1.5);
+    state.speed += (target - state.speed) * ease(k, dt);
+    state.speed = clamp(state.speed, KART_MIN_SPEED, KART_MAX_SPEED);
+  }
+
+  function stepSteer(dt, input) {
+    state.steer = clamp(input.steer, -1, 1);
+    state.drift = !!input.drift && !state.airborne && Math.abs(state.steer) > 0.15;
+    if (state.drift) driftSide = state.steer > 0 ? 1 : -1;
+    // speed-dependent authority: the faster you go the wider the sweep, drift claws it back
+    let auth = 0.72 + 0.28 * Math.min(1, KART_BASE_SPEED / state.speed);
+    if (state.drift) auth *= DRIFT_STEER;
+    if (state.airborne) auth *= 0.35;
+    let vTarget = state.steer * STEER_VMAX * auth;
+    // soft wall: the last WALL_SOFT metres bleed the outward push away, no bounce shock
+    const edge = ROAD_HALF_W - Math.abs(state.x);
+    if (edge < WALL_SOFT && Math.sign(vTarget) === Math.sign(state.x)) vTarget *= clamp(edge / WALL_SOFT, 0, 1);
+    vx += (vTarget - vx) * ease(state.drift ? 9 : 6, dt);
+    state.x += vx * dt;
+    if (Math.abs(state.x) > ROAD_HALF_W) {
+      state.x = Math.sign(state.x) * ROAD_HALF_W;
+      if (Math.sign(vx) === Math.sign(state.x)) vx *= 0.25;
+    }
+    const leanT = -vx * 0.07 - (state.drift ? state.steer * 0.1 : 0);
+    lean += (leanT - lean) * ease(8, dt);
+  }
+
+  function stepRamps(dt, lay, prevD) {
+    if (!state.airborne) {
+      const here = lay.rampAt ? lay.rampAt(state.d) : null;
+      if (!here) lastRampD = -1;                                        // past the air line: re-arm for next lap
+      let hit = null;
+      const feats = lay.featuresBetween ? lay.featuresBetween(prevD, state.d) : null;
+      if (feats) for (const f of feats) if (f.type === 'ramp' && Math.abs(f.d - lastRampD) > 0.01) { hit = f; break; }
+      if (!hit && here && Math.abs(here.d - lastRampD) > 0.01) hit = here;
+      if (hit) launch(hit);
+    }
+    if (state.airborne || state.h > 0) {
+      state.vh -= GRAVITY * dt;
+      state.h += state.vh * dt;
+      if (state.h <= 0) {                                              // THUD: land, squash, spring back
+        rig.squash(clamp(-state.vh / 12, 0.25, 1));
+        state.h = 0; state.vh = 0; state.airborne = false;
+      }
+    }
+    state.airborne = state.h > 0.05 || (state.airborne && state.h > 0);
+    const pitchT = state.airborne ? -clamp(state.vh / 12, -1, 1) * 0.35 : 0;
+    pitch += (pitchT - pitch) * ease(6, dt);
+  }
+
+  function place(lay) {
+    lay.toWorld(state.d, state.x, state.h, group.position);
+    const f = lay.frameAtDepth(state.d);
+    _fwd.copy(f.tangent); _up.copy(f.up); _right.copy(f.right || _v.crossVectors(_up, _fwd));
+    _m.lookAt(_fwd, ZERO, _up);                                        // +z faces down the road
+    group.quaternion.setFromRotationMatrix(_m);
+    group.quaternion.multiply(_q.setFromAxisAngle(AX_Z, lean)).multiply(_q.setFromAxisAngle(AX_X, pitch));
+    group.updateMatrixWorld(true);
+  }
+
+  function stepCamera(dt, lay) {
+    // the seat rides the track frame exactly CAM_BACK behind the cup; only the lateral / height
+    // offsets and the up vector are smoothed, so there is no lag and nothing to snap at the wrap
+    camX += (state.x - camX) * ease(6, dt);
+    camH += (state.h - camH) * ease(8, dt);
+    const camD = lay.wrap(state.d - CAM_BACK), lookD = lay.wrap(state.d + CAM_LOOK_AHEAD);
+    lay.toWorld(camD, camX * 0.45, CAM_UP + camH * 0.4, cam.pos);
+    lay.toWorld(lookD, camX * 0.3, 0.9 + camH * 0.5, cam.look);
+    const cf = lay.frameAtDepth(camD);
+    let rollT = 0;
+    if (reducedMotion) {
+      // comfort: hold the camera level and let the world turn through the Wheel
+      _v.subVectors(cam.look, cam.pos).normalize();
+      _lvl.copy(WORLD_UP).addScaledVector(_v, -WORLD_UP.dot(_v));
+      if (_lvl.lengthSq() < 0.09) _lvl.copy(cf.up); else _lvl.normalize();
+    } else {
+      rollT = -camX * 0.04 + lean * 0.35;
+      _lvl.copy(cf.up).applyAxisAngle(cf.tangent, rollT);
+    }
+    if (!camReady) { cam.up.copy(_lvl); cam.roll = rollT; camReady = true; return; }
+    cam.up.lerp(_lvl, ease(reducedMotion ? 4 : 10, dt)).normalize();
+    cam.roll += (rollT - cam.roll) * ease(8, dt);
+  }
+
+  function update(dt, input, lay) {
+    lay = lay || layout;
+    dt = clamp(+dt || 0, 0, 0.1);
+    input = input || {};
+    const inp = { steer: +input.steer || 0, accel: clamp(+input.accel || 0, 0, 1), brake: clamp(+input.brake || 0, 0, 1), drift: !!input.drift };
+    elapsed += dt;
+    stepSpeed(dt, inp);
+    stepSteer(dt, inp);
+    const prevD = state.d;
+    let d = state.d + state.speed * dt;
+    if (d >= lay.totalDepth) state.lap += 1;
+    d = lay.wrap(d);
+    state.d = d;
+    stepRamps(dt, lay, prevD);
+    place(lay);
+    stepCamera(dt, lay);
+    ctx.t = elapsed; ctx.speedNorm = state.speed / KART_MAX_SPEED; ctx.airborne = state.airborne;
+    ctx.steerVel = vx; ctx.drift = state.drift; ctx.driftSide = driftSide;
+    rig.update(dt, ctx);
+  }
+
+  function camera(out) {
+    out.pos.copy(cam.pos); out.look.copy(cam.look);
+    if (out.up && out.up.copy) out.up.copy(cam.up);
+    out.roll = reducedMotion ? 0 : cam.roll;
+    return out;
+  }
+
+  function dispose() { scene.remove(group); rig.dispose(); }
+
+  return { state, update, applyBoost, applySlow, setMood: rig.setMood, setFraught: rig.setFraught, camera, group, dispose };
+}


### PR DESCRIPTION
## What
race/kart.js (physics + chase camera) and race/emi.js (the cup and EMI riding in it).

## Kart
Track-space physics: cruise 22 m/s, boost cap 34, floor 8 (there is no fail state, the cup never stops). Steering with inertia and speed-dependent authority, soft wall at the road edge with no bounce shock, drift keeps speed and throws sparks. Ramps launch the cup with an impulse tuned so the apex lands on the ramp height at cruise; gravity brings it back with a landing squash. The camera rides the parallel-transported frame so the view inverts through the Big Wheel; reduced motion keeps the camera level and reports roll 0.

## EMI
Seen only from behind: CRT body with vents, gloves on the rim, bead antenna with six mood poses on a damped spring (calm breath sway, streamed back at speed, fraught kink-down with a pale bead and sweat, smug lazy kink, shock, gold jackpot bead). Her face exists only as a text emoticon mirrored in the tea. Design lock respected: no drawn face, no speech.

## Verified
node against the vendored three r169 on straight and circular stub layouts: ramp apex 2.39 m for a 2.4 m ramp, five launches over four laps, lap counter on wrap, speed pinned to [8, 34] through boost/slow/brake, x clamped, camera step under 0.6 m per frame across the wrap, no NaNs, dispose leaves the scene empty.

## Not verified
Look of the loop inversion, lighting, emoticon legibility in the tea.

---
Part of The Caucus Race stack (DtRH as a no-lose kart run with the CCP/DtRH effect bubbles as the pickup layer). Stack order: 1-track > 1b-rooms > 2-bubbles > 3-kart > 4-hud > 4b-items > 6-run > 7-boot; the host PR is independent. Each PR is under the 600 changed-line cap. Nothing in this stack edits chaosRun.js, scene.js, tunnel.js, fx.js or payloadFx.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
