### PR TITLE
feat(race): Caucus Race 8/9 - race.html + boot

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/race.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>the caucus race</title>
+    <!-- race.html - The Caucus Race page. Implements CONTRACT.md "race/run.js + raceBoot.js + race.html".
+         Same import map as index.html: three.js from the fork's own vendored ESM, no bundler. -->
+    <link rel="stylesheet" href="./styles.css">
+    <link rel="stylesheet" href="./race/race.css">
+    <script type="importmap">
+    {
+      "imports": {
+        "three": "/dtrh/vendor/three/three.module.min.js",
+        "three/addons/": "/dtrh/vendor/three/addons/"
+      }
+    }
+    </script>
+    <style>
+      /* the root is the screen-shake target (game/screenShake.js transforms it); the canvas alone
+         takes the mirror flip, so the two never share one style.transform */
+      #race-root { position: fixed; inset: 0; overflow: hidden; background: #12261f; }
+      #race-root > canvas { display: block; width: 100%; height: 100%; }
+      /* boot splash, z30: above the HUD chrome (z3) and every payload layer (z4 / z9), below the loader */
+      .race-splash {
+        position: fixed; inset: 0; z-index: 30; display: flex; flex-direction: column;
+        align-items: center; justify-content: center; gap: .6rem; text-align: center;
+        font-family: var(--rh-font); color: #fff; background: radial-gradient(ellipse at 50% 60%, rgba(18,38,31,.55), rgba(10,8,18,.92));
+        transition: opacity .5s ease-out; cursor: pointer;
+      }
+      .race-splash.is-off { opacity: 0; pointer-events: none; }
+      .race-splash .rs-cup { font-size: 3.2rem; line-height: 1; letter-spacing: .04em; color: #ffb6d9; }
+      .race-splash .rs-title { font-size: clamp(2rem, 6vw, 3.6rem); font-weight: 700; letter-spacing: .06em; color: #ff69b4; text-shadow: 0 0 24px rgba(255,105,180,.55); }
+      .race-splash .rs-sub { font-size: clamp(1rem, 2.4vw, 1.4rem); letter-spacing: .18em; color: #f6e7c8; }
+      .race-splash .rs-press { margin-top: 1.6rem; font-size: .95rem; letter-spacing: .22em; color: #fff; animation: rs-blink 1.6s ease-in-out infinite; }
+      .race-splash .rs-keys { font-size: .78rem; letter-spacing: .12em; color: rgba(255,255,255,.55); }
+      .race-splash .rs-wait { font-size: .78rem; letter-spacing: .12em; color: rgba(255,255,255,.4); min-height: 1.2em; }
+      @keyframes rs-blink { 0%, 100% { opacity: .35; } 50% { opacity: 1; } }
+      @media (prefers-reduced-motion: reduce) { .race-splash .rs-press { animation: none; } }
+    </style>
+</head>
+<body>
+    <div id="race-root">
+        <canvas id="sf-canvas" aria-hidden="true"></canvas>
+        <!-- payloadFx draws its .sf-pfx / .sf-pfx-front layers inside this one (styles.css: fixed, z10) -->
+        <div id="sf-hud" class="sf-hud"></div>
+        <!-- the race HUD chrome, Brake and End screens are built in here by race/hud.js -->
+        <div class="race-hud"></div>
+        <div id="race-splash" class="race-splash">
+            <div class="rs-cup" aria-hidden="true">(^_^)</div>
+            <div class="rs-title">the caucus race</div>
+            <div class="rs-sub">steer. pop. never stop.</div>
+            <div class="rs-press" id="race-press">press any key</div>
+            <div class="rs-keys">arrows or wasd steer · shift drift · e item · esc brake</div>
+            <div class="rs-wait" id="race-wait"></div>
+        </div>
+    </div>
+    <script type="module" src="./raceBoot.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -1,0 +1,141 @@
+/* ============================================================================
+ * raceBoot.js - boots The Caucus Race page. Implements CONTRACT.md
+ * "race/run.js + raceBoot.js + race.html (PR 5, integration)".
+ *
+ * Order: capability detect -> quality tier -> bridge handlers -> announceReady
+ * -> wait for `init` (+ `manifest`, `favorites`) with a 4 s timeout -> hostMedia
+ * -> createRace -> start on the first key / pointer / gamepad press.
+ *
+ * Host messages owned here: init, manifest, favorites, ping, exit-request,
+ * fullscreen (run.js owns pause + payout-result). Sent here: pong, boot-error,
+ * fullscreen-set, exit + exit-done on a host exit-request.
+ *
+ * STANDALONE DEV MODE (no WebView2): `bridge.isHosted` is false, so `init` is
+ * synthesised (masterVolume 60, reducedMotion from matchMedia, empty manifest)
+ * and every would-be host message is logged to the console with a
+ * `[race->host]` prefix. `?autostart=1` skips the splash.
+ * ==========================================================================*/
+
+import * as bridge from './bridge.js';
+import { detectMode } from './shared/capability.js';
+import { setQuality } from './shared/quality.js';
+import { createHostMediaSource } from './hostMedia.js';
+
+const INIT_TIMEOUT_MS = 4000;
+const params = new URLSearchParams(location.search);
+const hosted = bridge.isHosted;
+const host = hosted ? bridge : {
+  on: bridge.on,
+  send: (m) => { try { console.log('[race->host]', JSON.stringify(m)); } catch (e) { console.log('[race->host]', m); } },
+  log: (m) => console.log('[race->host] log', String(m)),
+  announceReady: () => console.log('[race->host] ready (standalone)'),
+};
+
+const root = document.getElementById('race-root');
+const splash = document.getElementById('race-splash');
+const waitEl = document.getElementById('race-wait');
+const media = createHostMediaSource();
+let initMsg = null, haveManifest = false, race = null, booted = false, started = false, exiting = false;
+
+const note = (t) => { if (waitEl) waitEl.textContent = t || ''; };
+function fail(err) {
+  const msg = String((err && (err.stack || err.message)) || err || 'unknown').slice(0, 600);
+  console.error('[race] boot-error', msg);
+  note('something broke. the host has the log.');
+  host.send({ type: 'boot-error', msg, message: msg });
+}
+window.addEventListener('error', (e) => {
+  const src = e.filename ? ` @ ${String(e.filename).split('/').pop()}:${e.lineno}` : '';
+  if (!started) fail((e.message || 'script error') + src);
+  else host.log('error: ' + (e.message || 'script error') + src);
+});
+window.addEventListener('unhandledrejection', (e) => {
+  const r = e.reason;
+  const msg = (r && (r.stack || r.message)) || r || 'unknown';
+  if (!started) fail('promise: ' + msg); else host.log('promise: ' + msg);
+});
+
+// ---- capability -> quality tier ----
+const mode = detectMode();
+if (mode.hardBlock || !mode.canTry3d) {
+  fail('no webgl here: ' + (mode.reason || mode.mode));
+} else {
+  setQuality(mode.tier);
+}
+
+// ---- host wiring ----
+bridge.on('init', (m) => { initMsg = m; maybeBoot(); });
+bridge.on('manifest', (m) => { try { media.setManifest(m); } catch (e) { host.log('manifest: ' + e); } haveManifest = true; maybeBoot(); });
+bridge.on('favorites', (m) => { try { media.setFavorites(m && m.names || []); } catch (e) { host.log('favorites: ' + e); } });
+bridge.on('ping', (m) => host.send({ type: 'pong', t: m && m.t }));
+bridge.on('fullscreen', (m) => host.send({ type: 'fullscreen-set', on: !!(m && m.on) }));
+bridge.on('exit-request', () => {
+  if (exiting) return;
+  exiting = true;
+  try { if (race) race.dispose(); } catch (e) { host.log('exit dispose: ' + e); }
+  host.send({ type: 'exit' });
+  host.send({ type: 'exit-done' });
+});
+
+function synthInit() {
+  return {
+    type: 'init', protocol: 1, modId: null, modContent: null,
+    settings: { masterVolume: 60, reducedMotion: !!(matchMedia && matchMedia('(prefers-reduced-motion: reduce)').matches) },
+  };
+}
+
+function maybeBoot() {
+  if (booted || !initMsg || !haveManifest) return;
+  boot();
+}
+
+async function boot() {
+  if (booted) return;
+  booted = true;
+  try {
+    const settings = (initMsg && initMsg.settings) || {};
+    const seed = (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
+    note('the road is drawing');
+    const { createRace } = await import('./race/run.js');
+    race = createRace({ root, bridge: host, media, settings, seed });
+    note('');
+    host.log(`race booted: seed ${seed}, tier ${mode.tier}, hosted ${hosted}, manifest ${haveManifest}`);
+    if (params.get('autostart') === '1') startRace();
+  } catch (err) {
+    fail(err);
+  }
+}
+
+function startRace() {
+  if (started || !race) return;
+  started = true;
+  splash.classList.add('is-off');
+  setTimeout(() => { splash.hidden = true; }, 600);
+  race.start();
+}
+// "press any key": keyboard, pointer, or a gamepad button (polled while the splash is up)
+window.addEventListener('keydown', (e) => { if (!e.repeat && race && !started) startRace(); });
+splash.addEventListener('pointerdown', () => { if (race && !started) startRace(); });
+(function pollPad() {
+  if (started) return;
+  const pads = navigator.getGamepads ? navigator.getGamepads() : null;
+  if (pads && race) for (const g of pads) if (g && g.buttons.some((b) => b && b.pressed)) { startRace(); return; }
+  requestAnimationFrame(pollPad);
+})();
+
+// ---- go ----
+bridge.announceReady();
+host.log('race: ready posted, waiting for init + manifest');
+if (!hosted) {
+  initMsg = synthInit();
+  media.setManifest({ images: [], videos: [], skipped: 0, truncated: false });
+  haveManifest = true;
+  maybeBoot();
+} else {
+  setTimeout(() => {
+    if (booted) return;
+    host.log('race: init timeout, booting with ' + (initMsg ? 'init' : 'defaults') + (haveManifest ? '' : ', no manifest'));
+    if (!initMsg) initMsg = synthInit();
+    boot();
+  }, INIT_TIMEOUT_MS);
+}


### PR DESCRIPTION
## What
race.html and raceBoot.js: the page and its boot. This is the PR that makes the race reachable from the C# host (feat/race-5-host opens https://ccp.game/dtrh/race.html).

- race.html: same import map as index.html, the canvas, the .race-hud root, the .sf-hud and .sf-pfx layers payloadFx expects, styles.css + race/race.css, and a splash in the DtRH voice ("the caucus race / steer. pop. never stop. / press any key").
- raceBoot.js: capability detect to a quality tier, bridge init, waits for init (+ manifest, favorites) with a 4 s timeout, hostMedia setup, seed, createRace, start on first input, routes ping / fullscreen / exit-request, reports boot-error on any throw before the run starts (after that, errors go to bridge.log so a stray runtime error cannot make the host close a live run).
- Standalone dev mode: when not hosted, it synthesises init and boots anyway, logging every would-be host message with a [race->host] prefix. That is what the headless check drives.

## Verified
Headless Chrome against a local static server: splash renders over the dimmed scene with the HUD beneath; ?autostart=1 renders the running scene; zero uncaught errors.

## Not verified
Real WebView2 host round trips (init, manifest, payout-result, pause, exit-request).

---
Part of The Caucus Race stack (DtRH as a no-lose kart run with the CCP/DtRH effect bubbles as the pickup layer). Stack order: 1-track > 1b-rooms > 2-bubbles > 3-kart > 4-hud > 4b-items > 6-run > 7-boot; the host PR is independent. Each PR is under the 600 changed-line cap. Nothing in this stack edits chaosRun.js, scene.js, tunnel.js, fx.js or payloadFx.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
