### PR TITLE
feat(core): audio and AI seams; the keyword-preset service moves to Core

### DIFF
--- a/CCP.Core/CoreAi.cs
+++ b/CCP.Core/CoreAi.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The AI-availability seam. Engine code that shapes content by whether an AI provider is
+    /// usable (the keyword-preset installer marks AI-only triggers) asks here. The providers
+    /// themselves, cloud identity and Patreon access stay in the head. Unseeded is "no AI".
+    /// </summary>
+    public static class CoreAi
+    {
+        public static volatile Func<bool>? IsAvailableProvider;
+
+        public static bool IsAvailable
+        {
+            get { try { return IsAvailableProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+    }
+}

--- a/CCP.Core/CoreAudio.cs
+++ b/CCP.Core/CoreAudio.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The audio seam: the four things ported views ask of the audio service. The service itself
+    /// is NAudio and LibVLC on Windows and stays in the head; a Linux backend is a later layer.
+    ///
+    /// <para>Unseeded means "no audio on this head": <see cref="PlayOneShot"/> fires the finished
+    /// callback at once and returns, which is exactly what the service does when disposed, so a
+    /// view that sequences on the sound still proceeds; ducking is a no-op and the generation
+    /// never advances.</para>
+    ///
+    /// <para><c>ApplyPreferredDevice</c> is deliberately not here: it takes an NAudio or LibVLC
+    /// player object, which is the head's business. A view that needs it keeps its note.</para>
+    /// </summary>
+    public static class CoreAudio
+    {
+        public static volatile Action<string, float, string, Action<TimeSpan>?, Action?>? PlayOneShotProvider;
+        public static volatile Action<int>? DuckProvider;
+        public static volatile Action<long>? UnduckProvider;
+        public static volatile Func<long>? DuckGenerationProvider;
+
+        public static void PlayOneShot(string path, float volume, string tag = "audio",
+                                       Action<TimeSpan>? onStarted = null, Action? onFinished = null)
+        {
+            var p = PlayOneShotProvider;
+            if (p is null) { try { onFinished?.Invoke(); } catch { } return; }
+            try { p(path, volume, tag, onStarted, onFinished); }
+            catch { try { onFinished?.Invoke(); } catch { } }
+        }
+
+        public static void Duck(int strength = 80) { try { DuckProvider?.Invoke(strength); } catch { } }
+        public static void Unduck(long generation = -1) { try { UnduckProvider?.Invoke(generation); } catch { } }
+        public static long DuckGeneration { get { try { return DuckGenerationProvider?.Invoke() ?? 0; } catch { return 0; } } }
+    }
+}

--- a/CCP.Core/Services/KeywordTriggerPresetService.cs
+++ b/CCP.Core/Services/KeywordTriggerPresetService.cs
@@ -1,4 +1,5 @@
 using System;
+using Serilog;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -31,7 +32,7 @@ namespace ConditioningControlPanel.Services
         {
             get
             {
-                var list = App.Settings?.Current?.KeywordTriggerPresets;
+                var list = CoreSettings.Current?.KeywordTriggerPresets;
                 if (list == null || list.Count == 0) return Array.Empty<KeywordTriggerPreset>();
                 return list.ToList();
             }
@@ -40,7 +41,7 @@ namespace ConditioningControlPanel.Services
         public KeywordTriggerPreset? GetPreset(string presetId)
         {
             if (string.IsNullOrEmpty(presetId)) return null;
-            return App.Settings?.Current?.KeywordTriggerPresets
+            return CoreSettings.Current?.KeywordTriggerPresets
                 .FirstOrDefault(p => p.Id == presetId);
         }
 
@@ -57,13 +58,13 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public bool InstallPreset(string presetId)
         {
-            var settings = App.Settings?.Current;
+            var settings = CoreSettings.Current;
             var preset = GetPreset(presetId);
             if (settings == null || preset == null) return false;
 
             if (preset.MasterEnabled)
             {
-                App.Logger?.Debug("InstallPreset: {Id} already installed", presetId);
+                Log.Debug("InstallPreset: {Id} already installed", presetId);
                 return true;
             }
 
@@ -72,7 +73,7 @@ namespace ConditioningControlPanel.Services
             // Remove any stale clones from previous installs (defensive).
             settings.KeywordTriggers.RemoveAll(t => t.Id?.StartsWith(prefix, StringComparison.Ordinal) == true);
 
-            var aiAvailable = App.Ai?.IsAvailable == true;
+            var aiAvailable = CoreAi.IsAvailable;
 
             foreach (var source in preset.Triggers)
             {
@@ -93,7 +94,7 @@ namespace ConditioningControlPanel.Services
                 }
                 else
                 {
-                    KeywordTriggerService.RebuildActionsFromFlatFields(clone);
+                    clone.RebuildActionsFromFlatFields();
                 }
 
                 settings.KeywordTriggers.Add(clone);
@@ -102,8 +103,8 @@ namespace ConditioningControlPanel.Services
             InstallCannedPhrases(preset);
 
             preset.MasterEnabled = true;
-            App.Settings?.Save();
-            App.Logger?.Information("InstallPreset: {Id} installed ({Count} triggers)",
+            CoreSettings.Save();
+            Log.Information("InstallPreset: {Id} installed ({Count} triggers)",
                 presetId, preset.Triggers?.Count ?? 0);
 
             PresetsChanged?.Invoke(this, EventArgs.Empty);
@@ -116,7 +117,7 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public bool UninstallPreset(string presetId)
         {
-            var settings = App.Settings?.Current;
+            var settings = CoreSettings.Current;
             var preset = GetPreset(presetId);
             if (settings == null || preset == null) return false;
 
@@ -127,8 +128,8 @@ namespace ConditioningControlPanel.Services
             RemoveCannedPhrases(preset);
 
             preset.MasterEnabled = false;
-            App.Settings?.Save();
-            App.Logger?.Information("UninstallPreset: {Id} uninstalled ({Count} triggers removed)",
+            CoreSettings.Save();
+            Log.Information("UninstallPreset: {Id} uninstalled ({Count} triggers removed)",
                 presetId, removed);
 
             PresetsChanged?.Invoke(this, EventArgs.Empty);
@@ -146,7 +147,7 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public KeywordTriggerPreset? CloneToCustom(string presetId)
         {
-            var settings = App.Settings?.Current;
+            var settings = CoreSettings.Current;
             var source = GetPreset(presetId);
             if (settings == null || source == null) return null;
 
@@ -177,13 +178,13 @@ namespace ConditioningControlPanel.Services
                 clone.Id = Guid.NewGuid().ToString("N")[..8];
                 clone.LastTriggeredAt = DateTime.MinValue;
                 if (clone.Actions == null || clone.Actions.Count == 0)
-                    KeywordTriggerService.RebuildActionsFromFlatFields(clone);
+                    clone.RebuildActionsFromFlatFields();
                 copy.Triggers.Add(clone);
             }
 
             settings.KeywordTriggerPresets.Add(copy);
-            App.Settings?.Save();
-            App.Logger?.Information("CloneToCustom: created {NewId} from {SourceId} ({Count} triggers)",
+            CoreSettings.Save();
+            Log.Information("CloneToCustom: created {NewId} from {SourceId} ({Count} triggers)",
                 copy.Id, presetId, copy.Triggers.Count);
 
             PresetsChanged?.Invoke(this, EventArgs.Empty);
@@ -213,10 +214,10 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void RefreshAiGating()
         {
-            var settings = App.Settings?.Current;
+            var settings = CoreSettings.Current;
             if (settings == null) return;
 
-            var aiAvailable = App.Ai?.IsAvailable == true;
+            var aiAvailable = CoreAi.IsAvailable;
             int touched = 0;
 
             foreach (var trigger in settings.KeywordTriggers)
@@ -240,8 +241,8 @@ namespace ConditioningControlPanel.Services
 
             if (touched > 0)
             {
-                App.Settings?.Save();
-                App.Logger?.Information("RefreshAiGating: adjusted {Count} avatar-comment actions (aiAvailable={Ai})",
+                CoreSettings.Save();
+                Log.Information("RefreshAiGating: adjusted {Count} avatar-comment actions (aiAvailable={Ai})",
                     touched, aiAvailable);
             }
         }
@@ -253,7 +254,7 @@ namespace ConditioningControlPanel.Services
 
         private static void InstallCannedPhrases(KeywordTriggerPreset preset)
         {
-            var settings = App.Settings?.Current;
+            var settings = CoreSettings.Current;
             if (settings == null || preset.CannedPhrases == null || preset.CannedPhrases.Count == 0) return;
 
             // Defensive: strip any previously-injected phrases for this preset.
@@ -282,7 +283,7 @@ namespace ConditioningControlPanel.Services
 
         private static void RemoveCannedPhrases(KeywordTriggerPreset preset)
         {
-            var settings = App.Settings?.Current;
+            var settings = CoreSettings.Current;
             if (settings == null) return;
 
             var marker = $"preset:{preset.Id}:phrase:";

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -72,6 +72,12 @@ namespace ConditioningControlPanel.LinuxSmoke
                 Check("CoreMods.AccentColorHex is the built-in default manifest's", CoreMods.AccentColorHex == Models.BuiltInMods.CCPDefault.Theme?.AccentColor, CoreMods.AccentColorHex);
                 Check("CoreMods.Affirmation is the built-in default manifest's", CoreMods.Affirmation == Models.BuiltInMods.CCPDefault.Identity?.Affirmation, CoreMods.Affirmation);
                 Check("CoreMods.GetPhrases is null with no mod layer", CoreMods.GetPhrases("BubbleCountMercy") == null);
+                var finished = false;
+                CoreAudio.PlayOneShot("/nowhere.mp3", 1f, "smoke", onFinished: () => finished = true);
+                Check("CoreAudio.PlayOneShot fires onFinished at once with no audio", finished);
+                CoreAudio.Duck(95); CoreAudio.Unduck();
+                Check("CoreAudio ducking is a no-op with no audio", CoreAudio.DuckGeneration == 0);
+                Check("CoreAi.IsAvailable is false with no head", !CoreAi.IsAvailable);
                 Check("CoreReleaseContent answers null with no pack service", CoreReleaseContent.GetPackInfo("mod-bambi") == null && CoreReleaseContent.GetStampFor("mod-bambi") == null);
                 Check("AwarenessIntensity.Current reads the ship default unseeded", Services.Awareness.AwarenessIntensityProfile.Current == Services.Awareness.AwarenessIntensity.Chatty);
                 // The subreddit rule moved from the online coordinator into Core with no test of its own.

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -294,6 +294,13 @@ namespace ConditioningControlPanel
             // The downloadable packs: the pack service seeds what the mod service reads.
             CoreReleaseContent.StampProvider = ReleaseContentService.GetStampFor;
             CoreReleaseContent.PackInfoProvider = id => ReleaseContent?.GetPackInfo(id);
+            // Audio and AI availability, for the views that only need to play a sound or duck,
+            // and for the engine code that shapes content by whether an AI provider is usable.
+            CoreAudio.PlayOneShotProvider = (path, volume, tag, onStarted, onFinished) => Audio?.PlayOneShot(path, volume, tag, onStarted, onFinished);
+            CoreAudio.DuckProvider = strength => Audio?.Duck(strength);
+            CoreAudio.UnduckProvider = generation => Audio?.Unduck(generation);
+            CoreAudio.DuckGenerationProvider = () => Audio?.DuckGeneration ?? 0;
+            CoreAi.IsAvailableProvider = () => Ai?.IsAvailable == true;
             CoreSettingsHooks.CloudBackup = () =>
                 HasCloudIdentity && ProfileSync != null ? ProfileSync.BackupSettingsAsync() : Task.CompletedTask;
 


### PR DESCRIPTION
Two small seams and one clean move.

- **`CoreAudio`**: one-shot play, duck, unduck and the duck generation, which is everything the ported views ask of the audio service. The service is NAudio and LibVLC and stays in the head. Unseeded, a one-shot fires its finished callback at once, which is exactly what the service does when disposed, so a view that sequences on a sound still proceeds. `ApplyPreferredDevice` takes a player object and is deliberately not seamed; a view that needs it keeps its note.
- **`CoreAi`**: whether an AI provider is usable. The providers, cloud identity and Patreon access stay in the head. Unseeded is "no AI".
- **`KeywordTriggerPresetService` moves to Core** as-is: it needed only settings, logging, that flag, and the trigger rebuild the model already owns.

The Linux smoke runner checks each unseeded behaviour. Verified: Core builds, guards pass, both heads and the Windows tests build, smoke on both heads, `--nav-check`, 186/186 views render. 52 changed lines plus one rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351