### PR TITLE
feat(avalonia): restore settings logic in the General, Performance and Notifications sections

### DIFF
--- a/CCP.Avalonia/Views/Controls/AppSettings/GeneralSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/GeneralSettingsSection.axaml.cs
@@ -1,6 +1,8 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
 {
@@ -8,8 +10,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
     /// SETTINGS ▸ GENERAL, ported from the WPF head. Language, startup, window/tray, Deeper switch.
     ///
     /// The language combo is populated for real from <see cref="LocalizationManager.AvailableLanguages"/>
-    /// (Core). Every handler on the WPF side forwards to MainWindow or writes <c>App.Settings</c>,
-    /// neither of which exists on this head yet, so they are stubs with the x:Names preserved.
+    /// (Core). The settings logic is restored against <see cref="CoreSettings"/>: the live editors
+    /// compare before writing, as on WPF, because the section is seeded from outside and an echo
+    /// must not save. What still needs the head is named at each handler: the Windows startup
+    /// shortcut, the start-hidden warning dialog, the file picker, the shell's Deeper door.
     /// <c>IAppSettingsSection</c> lives in the WPF head's AppSettingsTabView; <see cref="OnSectionShown"/>
     /// keeps the shape so the host can pick it up when it is ported.
     /// </summary>
@@ -38,52 +42,112 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             ChkEnableDeeper.IsCheckedChanged += ChkEnableDeeper_Changed;
             BtnSelectStartupVideo.Click += BtnSelectStartupVideo_Click;
             BtnClearStartupVideo.Click += BtnClearStartupVideo_Click;
+
+            OnSectionShown();   // seed from settings; every handler above compares before writing
         }
 
         /// <summary>Re-reads the OS startup registration and the startup-video filename.</summary>
         public void OnSectionShown()
         {
-            // ponytail: needs App.Settings + StartupManager, wired when they move to Core
+            try
+            {
+                var s = CoreSettings.Current;
+                // ponytail: WPF reconciles RunOnStartup against the Windows startup shortcut here
+                // (StartupManager). No equivalent on this head; the box shows the stored value.
+                Set(ChkWinStart, s.RunOnStartup);
+                // Assign only on a real difference: these raise IsCheckedChanged, and their
+                // handlers are live editors.
+                Set(ChkStartHidden, s.StartMinimized);
+                Set(ChkAutoRun, s.AutoStartEngine);
+                Set(ChkVidLaunch, s.ForceVideoOnLaunch);
+                Set(ChkEnableDeeper, s.EnableDeeper);
+                TxtStartupVideo.Text = string.IsNullOrEmpty(s.StartupVideoPath)
+                    ? Loc.Get("label_random")
+                    : System.IO.Path.GetFileName(s.StartupVideoPath);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("GeneralSettingsSection.OnSectionShown: {E}", ex.Message);
+            }
+
+            static void Set(CheckBox box, bool value)
+            {
+                if ((box.IsChecked ?? false) != value) box.IsChecked = value;
+            }
         }
 
         private void CmbLanguageSetting_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
-            // ponytail: needs MainWindow.ApplyLanguageSelection, wired when it moves to Core
+            if (CmbLanguageSetting.SelectedItem is not ComboBoxItem selected) return;
+            var code = string.IsNullOrWhiteSpace(selected.Tag as string) ? "en" : (string)selected.Tag!;
+            var s = CoreSettings.Current;
+            if (s.Language == code) return;   // the seed's echo, or the pill re-selecting us
+            s.Language = code;
+            LocalizationManager.Instance.SetLanguage(code);
+            CoreSettings.Save();
+            // ponytail: WPF also re-selects the chrome pill and shows the "restart to apply" banner
+            // through MainWindow; those live in the shell.
         }
 
         private void ChkWinStart_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs StartupManager, wired when it moves to Core
+            // ponytail: needs StartupManager (a Windows Startup-folder shortcut); no equivalent on this head yet
         }
 
         private void ChkStartHidden_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.Settings (StartMinimized), wired when it moves to Core
+            // ponytail: WPF first warns (a Yes/No dialog) when hidden is enabled while startup is
+            // on, and may revert the box; no dialog on this head yet, so the write is direct.
+            var s = CoreSettings.Current;
+            var want = ChkStartHidden.IsChecked ?? false;
+            if (s.StartMinimized == want) return;
+            s.StartMinimized = want;
+            CoreSettings.Save();
+            Log.Information("Start minimized set to {Enabled} (Settings/General)", want);
         }
 
         private void BtnSelectStartupVideo_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs a file picker + App.Settings (StartupVideoPath), wired when it moves to Core
+            // ponytail: needs a file picker (Avalonia StorageProvider), not wired on this head yet
         }
 
         private void BtnClearStartupVideo_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.Settings (StartupVideoPath), wired when it moves to Core
+            CoreSettings.Current.StartupVideoPath = null;
+            TxtStartupVideo.Text = Loc.Get("label_random");
+            CoreSettings.Save();
+            Log.Information("Startup video cleared - will use random");
         }
 
         private void ChkAutoRun_Changed(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.Settings (AutoStartEngine), wired when it moves to Core
+            var s = CoreSettings.Current;
+            var want = ChkAutoRun.IsChecked ?? false;
+            if (s.AutoStartEngine == want) return;   // seeding echo, not a user edit
+            s.AutoStartEngine = want;
+            CoreSettings.Save();
+            Log.Information("Auto-start engine set to {Enabled} (Settings/General)", want);
         }
 
         private void ChkVidLaunch_Changed(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.Settings (ForceVideoOnLaunch), wired when it moves to Core
+            var s = CoreSettings.Current;
+            var want = ChkVidLaunch.IsChecked ?? false;
+            if (s.ForceVideoOnLaunch == want) return;
+            s.ForceVideoOnLaunch = want;
+            CoreSettings.Save();
+            Log.Information("Force video on launch set to {Enabled} (Settings/General)", want);
         }
 
         private void ChkEnableDeeper_Changed(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs MainWindow.ChkEnableDeeper_Changed (EnableDeeper + BtnDeeper visibility), wired when it moves to Core
+            var s = CoreSettings.Current;
+            var enabled = ChkEnableDeeper.IsChecked ?? true;
+            if (s.EnableDeeper == enabled) return;
+            s.EnableDeeper = enabled;
+            CoreSettings.Save();
+            // ponytail: WPF also hides the shell's Deeper door and falls back to Settings if Deeper
+            // is the active tab (MainWindow.DeeperTab.cs); that is the shell's, not this section's.
         }
     }
 }

--- a/CCP.Avalonia/Views/Controls/AppSettings/NotificationsSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/NotificationsSettingsSection.axaml.cs
@@ -6,7 +6,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
     /// <summary>
     /// SETTINGS · NOTIFICATIONS, ported from the WPF head. <c>ChkIntakeNudge</c> has no handler on
     /// purpose (read at launch, round-trips through Load/SaveSettings). <c>ChkSuppressPerkNotifications</c>
-    /// is a live editor on WPF; here it is a stub until a settings surface exists on this head.
+    /// is a live editor: painted from <see cref="CoreSettings"/> and written back on a real edit.
     /// </summary>
     public partial class NotificationsSettingsSection : UserControl
     {
@@ -25,7 +25,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             _isLoading = true;
             try
             {
-                // ponytail: needs App.Settings (SuppressPerkNotifications), wired when it moves to Core
+                ChkSuppressPerkNotifications.IsChecked = CoreSettings.Current.SuppressPerkNotifications;
             }
             finally { _isLoading = false; }
         }
@@ -33,7 +33,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         private void ChkSuppressPerkNotifications_Changed(object? sender, RoutedEventArgs e)
         {
             if (_isLoading) return;
-            // ponytail: needs App.Settings (SuppressPerkNotifications) + Save, wired when it moves to Core
+            CoreSettings.Current.SuppressPerkNotifications = ChkSuppressPerkNotifications.IsChecked ?? false;
+            CoreSettings.Save();
         }
     }
 }

--- a/CCP.Avalonia/Views/Controls/AppSettings/PerformanceSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/PerformanceSettingsSection.axaml.cs
@@ -1,38 +1,149 @@
+using System;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.UI;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
 {
     /// <summary>
-    /// SETTINGS ▸ PERFORMANCE, ported from the WPF head.
+    /// SETTINGS ▸ PERFORMANCE, ported from the WPF head, settings logic restored against
+    /// <see cref="CoreSettings"/>. Five forwards that on WPF hop through MainWindow only to write
+    /// a setting write it here directly; the do-not-disturb rows are the same live editors they
+    /// were. The <c>_isLoading</c> seed guard is kept: Avalonia raises IsCheckedChanged on a
+    /// programmatic set exactly as WPF raised Checked, and a seed without it saves defaults over
+    /// the user's file.
     ///
-    /// Every handler on the WPF control either forwards to <c>MainWindow</c> or writes
-    /// <c>App.Settings.Current</c> and saves; the DND picker enumerates windowed processes through
-    /// <c>Services/UI/DoNotDisturbGuard</c> (Win32). None of that exists on this head yet, so the
-    /// handlers are stubs and the view is a rendering proof. The WPF <c>_isLoading</c> seed guard
-    /// is omitted for the same reason: there is nothing to seed from and nothing to guard.
+    /// Still a stub, named: the motion-level change on WPF also stops the ambient loops through
+    /// MainWindow (they are FX partials, not on this head), and the DND app picker enumerates
+    /// windows through Win32.
     /// </summary>
     public partial class PerformanceSettingsSection : UserControl
     {
+        private bool _isLoading = true;
+
         public PerformanceSettingsSection()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields, and the seed below reads them.
+            InitializeComponent();
+            SyncFromSettings();
         }
 
-        // ponytail: needs App.Settings + MainWindow.Chk*_Changed forwards, wired when they move to Core
-        private void ChkPerformanceMode_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkAutoPerformance_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkUnifiedOverlay_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkVideoHwDecode_Changed(object? sender, RoutedEventArgs e) { }
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            SyncFromSettings();
+        }
 
-        // ponytail: needs MainWindow.CmbMotionLevel_SelectionChanged (stops ambient loops), wired when it moves to Core
-        private void CmbMotionLevel_SelectionChanged(object? sender, SelectionChangedEventArgs e) { }
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            base.OnDetachedFromVisualTree(e);
+        }
 
-        // ponytail: needs App.Settings + DoNotDisturbGuard.Parse/FormatProcessList, wired when they move to Core
-        private void TxtDndProcesses_LostFocus(object? sender, RoutedEventArgs e) { }
-        private void ChkDndSuppressVideos_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkDndSuppressFlashes_Changed(object? sender, RoutedEventArgs e) { }
+        // A cloud restore or a factory reset swaps the instance; repaint from it, on the UI thread.
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(SyncFromSettings);
+
+        internal void SyncFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkPerformanceMode.IsChecked = s.PerformanceMode;
+                ChkAutoPerformance.IsChecked = s.AutoPerformanceMode;
+                ChkUnifiedOverlay.IsChecked = s.UnifiedOverlayHost;
+                ChkVideoHwDecode.IsChecked = s.VideoForceHardwareDecoding;
+                // MotionLevel's ordinal IS the item index (Full=0, Reduced=1, Off=2). Clamped rather
+                // than trusted so a settings file from a future build cannot throw here.
+                var index = (int)s.MotionLevel;
+                CmbMotionLevel.SelectedIndex = index >= 0 && index < CmbMotionLevel.ItemCount ? index : 0;
+                // The textbox is a VIEW of the normalised list, repainted from settings rather than
+                // left holding whatever was last typed.
+                TxtDndProcesses.Text = DndProcessList.Format(s.DndProcessList);
+                ChkDndSuppressVideos.IsChecked = s.DndSuppressVideos;
+                ChkDndSuppressFlashes.IsChecked = s.DndSuppressFlashes;
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void ChkPerformanceMode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.PerformanceMode = ChkPerformanceMode.IsChecked ?? false;
+            Log.Information("Performance mode set to {Enabled}", CoreSettings.Current.PerformanceMode);
+            CoreSettings.Save();
+        }
+
+        private void ChkAutoPerformance_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.AutoPerformanceMode = ChkAutoPerformance.IsChecked ?? true;
+            Log.Information("Auto performance mode set to {Enabled}", CoreSettings.Current.AutoPerformanceMode);
+            CoreSettings.Save();
+        }
+
+        private void ChkUnifiedOverlay_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.UnifiedOverlayHost = ChkUnifiedOverlay.IsChecked ?? true;
+            Log.Information("Unified overlay renderer set to {Enabled}", CoreSettings.Current.UnifiedOverlayHost);
+            CoreSettings.Save();
+        }
+
+        private void ChkVideoHwDecode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.VideoForceHardwareDecoding = ChkVideoHwDecode.IsChecked ?? false;
+            Log.Information("Force video hardware decoding set to {Enabled}", CoreSettings.Current.VideoForceHardwareDecoding);
+            CoreSettings.Save();
+        }
+
+        private void CmbMotionLevel_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var level = CmbMotionLevel.SelectedIndex switch
+            {
+                1 => MotionLevel.Reduced,
+                2 => MotionLevel.Off,
+                _ => MotionLevel.Full,
+            };
+            CoreSettings.Current.MotionLevel = level;
+            Log.Information("Motion level set to {Level}", level);
+            // ponytail: WPF also stops the ambient loops here (season shimmer, skill tree, program
+            // banner) through MainWindow's FX partials, which are not on this head.
+            CoreSettings.Save();
+        }
+
+        private void TxtDndProcesses_LostFocus(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var parsed = DndProcessList.Parse(TxtDndProcesses.Text);
+            CoreSettings.Current.DndProcessList = parsed;
+            CoreSettings.Save();
+            _isLoading = true;
+            try { TxtDndProcesses.Text = DndProcessList.Format(parsed); }
+            finally { _isLoading = false; }
+        }
+
+        private void ChkDndSuppressVideos_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.DndSuppressVideos = ChkDndSuppressVideos.IsChecked == true;
+            CoreSettings.Save();
+        }
+
+        private void ChkDndSuppressFlashes_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.DndSuppressFlashes = ChkDndSuppressFlashes.IsChecked == true;
+            CoreSettings.Save();
+        }
 
         // ponytail: needs DoNotDisturbGuard.RunningWindowedProcesses (Win32 window enumeration); per-platform in the head
         private void BtnDndPickApp_Click(object? sender, RoutedEventArgs e) { }

--- a/CCP.Core/Services/UI/DndProcessList.cs
+++ b/CCP.Core/Services/UI/DndProcessList.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel.Services.UI
+{
+    /// <summary>
+    /// The do-not-disturb process list as text: how one entry is cleaned, how the settings
+    /// textbox parses into the stored list, and how the list renders back. Pure string work,
+    /// pulled out of <c>DoNotDisturbGuard</c> (which stays in the head: the guard itself
+    /// enumerates windows through Win32) so the Settings page can edit the list on any head.
+    /// </summary>
+    public static class DndProcessList
+    {
+        /// <summary>One list entry, cleaned: trimmed, lower-cased, a trailing ".exe" removed,
+        /// surrounding quotes dropped. "VLC.exe" and " vlc " are the same app and must compare equal.</summary>
+        public static string Normalize(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return "";
+            var name = raw.Trim().Trim('"').Trim();
+            if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+                name = name.Substring(0, name.Length - 4);
+            return name.Trim().ToLowerInvariant();
+        }
+
+        /// <summary>Parses the settings textbox into the stored list. Accepts one process per line,
+        /// commas, semicolons or any mix. Entries are normalised, blanks dropped, duplicates
+        /// collapsed, order preserved so the box reads back the way it was typed.</summary>
+        public static List<string> Parse(string? raw)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(raw)) return result;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var piece in raw.Split(new[] { '\r', '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var name = Normalize(piece);
+                if (name.Length == 0) continue;
+                if (seen.Add(name)) result.Add(name);
+            }
+            return result;
+        }
+
+        /// <summary>Renders the stored list back into the textbox, one process per line.</summary>
+        public static string Format(IEnumerable<string>? list)
+            => list == null ? "" : string.Join(Environment.NewLine, list);
+    }
+}

--- a/ConditioningControlPanel/Services/UI/DoNotDisturbGuard.cs
+++ b/ConditioningControlPanel/Services/UI/DoNotDisturbGuard.cs
@@ -167,39 +167,9 @@ namespace ConditioningControlPanel.Services.UI
         /// One list entry, cleaned: trimmed, lower-cased, a trailing ".exe" removed, surrounding
         /// quotes dropped. "VLC.exe" and " vlc " are the same app and must compare equal.
         /// </summary>
-        public static string Normalize(string? raw)
-        {
-            if (string.IsNullOrWhiteSpace(raw)) return "";
-            var name = raw.Trim().Trim('"').Trim();
-            if (name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-                name = name.Substring(0, name.Length - 4);
-            return name.Trim().ToLowerInvariant();
-        }
-
-        /// <summary>
-        /// Parses the settings textbox into the stored list. Accepts one process per line, commas,
-        /// semicolons or any mix of the three, because users will type all of them. Entries are
-        /// <see cref="Normalize"/>d, blanks dropped and duplicates collapsed, order preserved so the
-        /// box reads back the way it was typed.
-        /// </summary>
-        public static List<string> ParseProcessList(string? raw)
-        {
-            var result = new List<string>();
-            if (string.IsNullOrWhiteSpace(raw)) return result;
-
-            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var piece in raw.Split(new[] { '\r', '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
-            {
-                var name = Normalize(piece);
-                if (name.Length == 0) continue;
-                if (seen.Add(name)) result.Add(name);
-            }
-            return result;
-        }
-
-        /// <summary>Renders the stored list back into the textbox, one process per line.</summary>
-        public static string FormatProcessList(IEnumerable<string>? list)
-            => list == null ? "" : string.Join(Environment.NewLine, list);
+        public static string Normalize(string? raw) => DndProcessList.Normalize(raw);          // the rule lives in Core
+        public static List<string> ParseProcessList(string? raw) => DndProcessList.Parse(raw);
+        public static string FormatProcessList(IEnumerable<string>? list) => DndProcessList.Format(list);
 
         /// <summary>
         /// Process names of everything that currently owns a visible top-level window, de-duplicated


### PR DESCRIPTION
The first views whose settings logic comes back, against `CoreSettings`. From this layer, toggles on these three Settings pages read the user's file and write it back on the Linux app.

## How each handler was restored
Its WPF original, with `App.Settings?.Current` + `App.Settings?.Save()` replaced by the seam and `App.Logger` by Serilog's static `Log`. The live editors keep the compare-before-write and `_isLoading` guards on purpose: Avalonia raises `IsCheckedChanged` on a programmatic set exactly as WPF raised `Checked`, and a seed without them saves defaults over the user's file.

| Section | Restored | Still a note, narrowed to what is missing |
|---|---|---|
| General | language (settings + `LocalizationManager` + save), start hidden, auto-run, video on launch, Deeper, clear startup video, the seed on show | the Windows startup shortcut, the start-hidden warning dialog, the startup-video file picker, the shell's Deeper door and tab fallback, the chrome pill re-select |
| Performance | the four mode toggles, motion level, the do-not-disturb list and its two toggles, repaint on settings-instance replaced | the ambient-loop stop on motion change (FX partials), the running-app picker (Win32) |
| Notifications | the perk-popup toggle | none |
| Devices | untouched | every handler is a webcam, speech or panic-key forward |

The do-not-disturb list's normalise/parse/format rules move to Core as `DndProcessList`; the Win32 guard delegates to them, so its callers are unchanged.

## What the renders show
The three PNGs draw with real strings, and the toggles now reflect the model's defaults rather than the XAML's (Deeper on, auto performance on, unified overlay on, hold mandatory videos on). That difference is the seed working. One trap found on the way: a section that loads its XAML through `AvaloniaXamlLoader.Load` gets no `x:Name` fields assigned, and the seed dereferenced them; it now uses the generated `InitializeComponent` like its siblings.

## Verified
Core and both heads build, Windows tests build, guards pass, `--smoke`, `--nav-check`, the three views rendered and read, 186/186 views render. 273 changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C78Y31SNNgbxtyMyPm351