### PR TITLE
feat(race): Caucus Race 10/21 - low chase camera, speed sense, big-pixel toggle, effect budget

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race.html
+++ b/ConditioningControlPanel/Resources/web/dtrh/race.html
@@ -51,7 +51,7 @@
             <div class="rs-title">the caucus race</div>
             <div class="rs-sub">steer. pop. never stop.</div>
             <div class="rs-press" id="race-press">press any key</div>
-            <div class="rs-keys">arrows or wasd steer · shift drift · e item · esc brake</div>
+            <div class="rs-keys">arrows or wasd steer · shift drift · e item · p pixels · esc brake</div>
             <div class="rs-wait" id="race-wait"></div>
         </div>
     </div>

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -13,7 +13,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H } from './consts.js';
+import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H } from './consts.js';
 import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
 import { makeSfxPlayer } from '../engine/audioBus.js';
 import { getLevel } from '../engine/audioLevels.js';
@@ -27,11 +27,11 @@ const BURST_SFX = 'Burst.mp3';
 
 const CAP = 160;              // live bubbles, recycled farthest-first when full
 const SHARD_CAP = 64;
-const LANE_H = 0.9;
 const LANE_STEP = 3.2;        // metres between bubbles in a lane line
 const VIEW_AHEAD = 150;       // sprites beyond this are hidden, not freed
 const MISS_BEHIND = 6;        // a treat this far behind the kart unpopped = miss
 const DROP_BEHIND = 12;       // freed once this far behind
+const PASS_FADE_M = 2.4;      // metres behind the pop box over which a passed bubble fades away
 const RAIN_FALL = 4, RAIN_REST = 2, RAIN_FIZZLE = 0.5;
 const POP_ANIM = 0.14;
 const PRISM_REACH = 8;        // prism chain-pops neighbours within this many metres
@@ -273,7 +273,11 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom 
       s.sprite.visible = rel > -DROP_BEHIND && rel < VIEW_AHEAD;
       if (s.sprite.visible) {
         layout.toWorld(s.d, s.x, s.h, s.sprite.position);
-        s.sprite.scale.setScalar(s.size * s.scale);
+        // a bubble that slipped past the pop box fades and shrinks before it can balloon into the
+        // low chase camera (the seat is only ~6 m back)
+        const gone = s.popT < 0 && rel < -POP_HIT_D ? clamp(1 + (rel + POP_HIT_D) / PASS_FADE_M, 0, 1) : 1;
+        if (gone < 1) s.mat.opacity = Math.min(s.mat.opacity, gone);
+        s.sprite.scale.setScalar(s.size * s.scale * (0.6 + 0.4 * gone));
       }
     }
     for (const sh of shards) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -53,7 +53,7 @@ function makeDotTex() {
   } catch (e) { return null; }
 }
 
-export function createBubbleField({ scene, layout, media, getIntensity, getRoom }) {
+export function createBubbleField({ scene, layout, media, getIntensity, getRoom, onTexture }) {
   void media;   // reserved: flash media is drawn by payloadFx at pop time, never here
   const T = layout.totalDepth;
   /** Signed depth from `from` to `d`, folded into (-T/2, T/2] so the start line is nothing special. */
@@ -75,6 +75,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom 
     loader.load(k.sprite, (tex) => {
       if (disposed) { tex.dispose(); return; }
       tex.colorSpace = THREE.SRGBColorSpace;
+      if (onTexture) { try { onTexture(tex); } catch (e) { /* the look never breaks the field */ } }
       texOf[k.id] = tex;
       for (const s of pool) if (s.alive && s.kindId === k.id) { s.mat.map = tex; s.mat.needsUpdate = true; }
     }, undefined, () => { /* keep the dot */ });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -13,7 +13,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H } from './consts.js';
+import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, TREATS_ONLY_SEC } from './consts.js';
 import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
 import { makeSfxPlayer } from '../engine/audioBus.js';
 import { getLevel } from '../engine/audioLevels.js';
@@ -53,13 +53,15 @@ function makeDotTex() {
   } catch (e) { return null; }
 }
 
-export function createBubbleField({ scene, layout, media, getIntensity, getRoom, onTexture }) {
+export function createBubbleField({ scene, layout, media, getIntensity, getRoom, getElapsed, onTexture }) {
   void media;   // reserved: flash media is drawn by payloadFx at pop time, never here
   const T = layout.totalDepth;
   /** Signed depth from `from` to `d`, folded into (-T/2, T/2] so the start line is nothing special. */
   const relD = (d, from) => { let r = (d - from) % T; if (r > T / 2) r -= T; else if (r <= -T / 2) r += T; return r; };
   const intensity = () => clamp(getIntensity ? getIntensity() : 0, 0, 1);
   const roomBias = () => { const r = getRoom && getRoom(); return (r && r.bubbleBias) || null; };
+  /** 0 while the opening is treats only, then a ramp to 1 over the next minute. */
+  const effectGate = () => { const el = getElapsed ? getElapsed() : Infinity; return el < TREATS_ONLY_SEC ? 0 : clamp((el - TREATS_ONLY_SEC) / 60, 0.15, 1); };
 
   const audio = makeSfxPlayer();
   audio.preload([...POP_SFX, ...CHIME_SFX, BURST_SFX].map((f) => SFX_BASE + f));
@@ -105,6 +107,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   let liveCount = 0;
   let lastKartD = 0;
   let density = 1;
+  let reachX = POP_HIT_X, reachH = POP_HIT_H;   // the pop box, widened by the magnet item (setReach)
   const popCbs = [], missCbs = [];
   const emit = (cbs, ev) => { for (const cb of cbs) { try { cb(ev); } catch (e) { /* listener bug, not ours */ } } };
 
@@ -121,9 +124,11 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   }
 
   const liveOf = (id) => { let n = 0; for (const p of pool) if (p.alive && p.kindId === id) n++; return n; };
-  /** Weighted kind roll: room bias, intensity gate, and a per-placement nudge. */
+  /** Weighted kind roll: room bias, intensity gate, the treats-only opening, and a per-placement nudge. */
   function roll(placement) {
+    const gate = effectGate();
     const extra = (k) => {
+      if (k.kind === 'effect' && gate < 1) { if (gate <= 0) return 0; return gate * (placement === 'rain' ? 0.5 : 1); }
       if (k.id === 'video' && liveOf('video') > 0) return 0;      // one video on the road at a time
       if (k.id === 'freeze' && liveOf('freeze') > 1) return 0;
       if (placement === 'air' && k.id === 'golden') return 3;     // gold favours the air line
@@ -152,13 +157,27 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   const chunkRecs = [];
   const LANES = [-2.2, -1.1, 0, 1.1, 2.2];
 
+  /** The Tea Garden start straight: a run-up of three, a slow zigzag of treats the whole length,
+   *  a chevron (tip forward) every 4th beat, and one golden at the end. Readable at the first lap. */
+  function seedStartStraight(chunk) {
+    for (let i = 0; i < 3; i++) place('treat', 'lane', chunk.d0 - 8 + i * LANE_STEP, 0, LANE_H);
+    const n = Math.floor((chunk.d1 - chunk.d0 - 6) / LANE_STEP);
+    for (let i = 0; i < n; i++) {
+      const d = chunk.d0 + 2 + i * LANE_STEP, x = 1.6 * Math.sin(i * Math.PI / 8);
+      place('treat', 'lane', d, x, LANE_H);
+      if (i % 4 === 3) { place('treat', 'lane', d - 1.3, x - 1.3, LANE_H); place('treat', 'lane', d - 1.3, x + 1.3, LANE_H); }
+    }
+    place('golden', 'lane', chunk.d1 - 2.5, 0, LANE_H);
+  }
+
   /** Lane lines the kart can thread, ramp air lines, and a pair flanking each sugar cube. */
   function seedChunk(chunk) {
     if (!chunk || seeded.has(chunk.id)) return;
     seeded.add(chunk.id);
     chunkRecs.push({ id: chunk.id, d0: chunk.d0, d1: chunk.d1 });
     const len = Math.max(0, chunk.d1 - chunk.d0);
-    if (chunk.kind !== 'gate' && len > 8) {
+    if (chunk.id === 1 && chunk.room === 'teagarden' && chunk.kind === 'straight') seedStartStraight(chunk);
+    else if (chunk.kind !== 'gate' && len > 8) {
       const lines = Math.max(1, Math.round((len / 26) * density));
       for (let l = 0; l < lines; l++) {
         const count = 3 + ((Math.random() * 4) | 0);
@@ -269,7 +288,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
           if (k.kind === 'treat') emit(missCbs, { id: k.id, points: k.points, d: s.d, x: s.x, h: s.h });
         }
         if (rel < -DROP_BEHIND && rel > -DROP_BEHIND - 40) { freeSlot(s); continue; }
-        if (Math.abs(rel) < POP_HIT_D && Math.abs(s.x - kart.x) < POP_HIT_X && Math.abs(s.h - kart.h) < POP_HIT_H) pop(s);
+        if (Math.abs(rel) < POP_HIT_D && Math.abs(s.x - kart.x) < reachX && Math.abs(s.h - kart.h) < reachH) pop(s);
       }
       s.sprite.visible = rel > -DROP_BEHIND && rel < VIEW_AHEAD;
       if (s.sprite.visible) {
@@ -314,6 +333,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     onPop(cb) { if (typeof cb === 'function') popCbs.push(cb); },
     onMiss(cb) { if (typeof cb === 'function') missCbs.push(cb); },
     setDensity(mult) { density = clamp(Number(mult) || 1, 0.25, 3); },
+    /** Magnet: widen the pop box (X and H) by mult; 1 restores it. */
+    setReach(mult) { const m = clamp(Number(mult) || 1, 0.5, 3); reachX = POP_HIT_X * m; reachH = POP_HIT_H * m; },
     get liveCount() { return liveCount; },
   };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -38,6 +38,9 @@ export const COMBO_HOLD_SEC = 4.0;
 /** Seconds for the run intensity to ramp from 0 to 1 (gates which bubble kinds may appear). */
 export const INTENSITY_RAMP_SEC = 360;
 
+/** The opening is treats only: no effect bubble rolls before this, then they trickle in over the next minute. */
+export const TREATS_ONLY_SEC = 45;
+
 /** The cup + EMI rig scale (the pitch demo cup read tiny at the chase camera). */
 export const KART_SCALE = 1.35;
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -20,24 +20,33 @@ export const KART_MAX_SPEED = 34;
 export const KART_MIN_SPEED = 8;
 export const GRAVITY = 18;
 
-// Pass-through pop box, metres, kart-centred.
+// Pass-through pop box, metres, kart-centred. Sized for the 1.35x cup (KART_SCALE below);
+// bubbles.js field.setReach(mult) widens X/H for the magnet item.
 export const POP_HIT_D = 1.4;
-export const POP_HIT_X = 1.0;
-export const POP_HIT_H = 1.1;
+export const POP_HIT_X = 1.15;
+export const POP_HIT_H = 1.25;
 
-/** Combo -> score multiplier ladder: [comboAtLeast, mult]. */
-export const MULT_LADDER = [[0, 1], [5, 2], [12, 3], [22, 4], [36, 6], [50, 8]];
+/** Height of a lane bubble above the road (bubbles.js), and where the pop ring sits (kart.js). */
+export const LANE_H = 0.9;
+
+/** Combo -> score multiplier ladder: [comboAtLeast, mult]. The first rung is three pops away. */
+export const MULT_LADDER = [[0, 1], [3, 2], [8, 3], [15, 4], [25, 6], [40, 8]];
 
 /** Seconds without a pop before the combo lets go. */
-export const COMBO_HOLD_SEC = 3.0;
+export const COMBO_HOLD_SEC = 4.0;
 
 /** Seconds for the run intensity to ramp from 0 to 1 (gates which bubble kinds may appear). */
 export const INTENSITY_RAMP_SEC = 360;
 
-/** Camera seat behind the cup, track space offsets. */
-export const CAM_BACK = 7.5;
-export const CAM_UP = 3.1;
-export const CAM_LOOK_AHEAD = 9;
+/** The cup + EMI rig scale (the pitch demo cup read tiny at the chase camera). */
+export const KART_SCALE = 1.35;
+
+/** Camera seat behind the cup, track space offsets: low and close, the road fills the frame. */
+export const CAM_BACK = 5.8;
+export const CAM_UP = 2.45;
+export const CAM_LOOK_AHEAD = 7;
+/** Extra metres of look-ahead at the speed cap (grows with speed so boost reads as reach). */
+export const CAM_LOOK_SPEED = 5;
 
 /** Room ids in canonical order; teagarden is always the start and the BANK. */
 export const ROOM_IDS = ['teagarden', 'toybox', 'casino', 'undertow', 'mirrors', 'chapel', 'greyward', 'coronation'];

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -109,29 +109,41 @@ export function createEmiRig({ scene, reducedMotion = false }) {
   const handle = new THREE.Mesh(new THREE.TorusGeometry(0.19, 0.045, 10, 24, Math.PI), porcelain); handle.position.set(0.62, 0.42, 0); handle.rotation.z = -Math.PI / 2; body.add(handle);
 
   // ---- the tea: the only mirror she has. Her face shows in it, reversed. ----
-  const teaCanvas = document.createElement('canvas'); teaCanvas.width = teaCanvas.height = 96;
+  // The chase camera sits low and ~6 m back, so a flat surface is a sliver. The reflection is the
+  // NEAR half of the tea only: it pivots at the near rim and leans up toward EMI (the tea looks up
+  // at you), which turns the band between the rim and her body toward the camera. The far half
+  // stays flat under her. The emoticon is drawn in that band; canvas bottom = the near (camera) side.
+  const TEA_PX = 128, TEA_TILT = 0.5, TEA_R = 0.46;   // rad: near edge at the rim, chord lifted
+  const teaCanvas = document.createElement('canvas'); teaCanvas.width = teaCanvas.height = TEA_PX;
   const teaTex = new THREE.CanvasTexture(teaCanvas); teaTex.magFilter = THREE.NearestFilter; teaTex.minFilter = THREE.LinearFilter;
   let faceDrawn = '';
   function drawTea(face) {
     if (face === faceDrawn) return; faceDrawn = face;
     const g = teaCanvas.getContext('2d'); g.setTransform(1, 0, 0, 1, 0, 0);
-    g.fillStyle = '#B23282'; g.fillRect(0, 0, 96, 96);
-    const rg = g.createRadialGradient(48, 48, 6, 48, 48, 50); rg.addColorStop(0, 'rgba(255,140,200,.55)'); rg.addColorStop(1, 'rgba(120,20,80,.3)');
-    g.fillStyle = rg; g.fillRect(0, 0, 96, 96);
-    g.translate(96, 0); g.scale(-1, 1);                        // mirrored: it is a reflection
-    g.fillStyle = '#FF9BD0'; g.font = '600 ' + (face.length > 4 ? 15 : 24) + 'px "Noto Sans Mono", "JetBrains Mono", Consolas, monospace';
-    g.textAlign = 'center'; g.textBaseline = 'middle'; g.fillText(face, 48, 50);
+    const c = TEA_PX / 2;
+    g.fillStyle = '#B23282'; g.fillRect(0, 0, TEA_PX, TEA_PX);
+    const rg = g.createRadialGradient(c, c * 1.4, 6, c, c * 1.4, c * 1.1); rg.addColorStop(0, 'rgba(255,140,200,.6)'); rg.addColorStop(1, 'rgba(120,20,80,.3)');
+    g.fillStyle = rg; g.fillRect(0, 0, TEA_PX, TEA_PX);
+    g.translate(TEA_PX, 0); g.scale(-1, 1);                    // mirrored: it is a reflection
+    g.font = '700 ' + (face.length > 4 ? 22 : 34) + 'px "Noto Sans Mono", "JetBrains Mono", Consolas, monospace';
+    g.textAlign = 'center'; g.textBaseline = 'middle';
+    g.lineWidth = 5; g.strokeStyle = 'rgba(70,10,50,.85)'; g.strokeText(face, c, c * 1.44);
+    g.fillStyle = '#FFE3F3'; g.fillText(face, c, c * 1.44);
     teaTex.needsUpdate = true;
   }
   drawTea(MOODS.calm.face);
-  const reflection = new THREE.Mesh(new THREE.CircleGeometry(0.46, 32), new THREE.MeshBasicMaterial({ map: teaTex }));
-  reflection.rotation.set(-Math.PI / 2, 0, Math.PI); reflection.position.y = 0.655; body.add(reflection);
+  const teaTilt = new THREE.Group(); teaTilt.position.set(0, 0.69, -TEA_R); teaTilt.rotation.x = -TEA_TILT; body.add(teaTilt);
+  // geometry y < 0 is the canvas bottom = the near half (thetaStart PI); the partial circle keeps full-disc UVs
+  const reflection = new THREE.Mesh(new THREE.CircleGeometry(TEA_R, 32, Math.PI, Math.PI), new THREE.MeshBasicMaterial({ map: teaTex, side: THREE.DoubleSide }));
+  reflection.rotation.set(-Math.PI / 2, 0, Math.PI); reflection.position.set(0, 0, TEA_R); teaTilt.add(reflection);
   const teaMat = new THREE.MeshStandardMaterial({ color: 0xC94A9A, roughness: 0.15, metalness: 0.2, transparent: true, opacity: 0.35 });
-  const tea = new THREE.Mesh(new THREE.CircleGeometry(0.47, 32), teaMat);
+  const tea = new THREE.Mesh(new THREE.CircleGeometry(TEA_R + 0.01, 32), teaMat);
   tea.rotation.set(-Math.PI / 2, 0, Math.PI); tea.position.y = 0.66; body.add(tea);
 
   // ---- EMI: a living pixel CRT seen from behind, gripping the rim ----
-  const emi = new THREE.Group(); emi.position.y = 0.8; emi.scale.setScalar(1.25); body.add(emi);
+  // she sits a little forward in the cup so the near band of tea is wide enough to hold her face
+  const EMI_Z = 0.12;
+  const emi = new THREE.Group(); emi.position.set(0, 0.82, EMI_Z); emi.scale.setScalar(1.25); body.add(emi);
   const crt = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.42, 0.34), navy); emi.add(crt);
   const ventMat = new THREE.MeshStandardMaterial({ map: ventTexture(), roughness: 0.8 });
   const back = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.34, 0.06), ventMat); back.position.z = -0.19; emi.add(back);
@@ -142,8 +154,8 @@ export function createEmiRig({ scene, reducedMotion = false }) {
   const screenLight = new THREE.PointLight(PINK, 0.9, 3); screenLight.position.set(0, 0, 0.5); emi.add(screenLight);
   const armGeo = new THREE.CylinderGeometry(0.035, 0.03, 0.42, 8), handGeo = new THREE.SphereGeometry(0.06, 10, 8);
   for (const sd of [-1, 1]) {
-    const arm = new THREE.Mesh(armGeo, navyDark); arm.position.set(sd * 0.3, -0.1, 0.25); arm.rotation.set(-0.9, 0, sd * 0.35); emi.add(arm);
-    const hand = new THREE.Mesh(handGeo, glove); hand.position.set(sd * 0.36, -0.22, 0.44); emi.add(hand);
+    const arm = new THREE.Mesh(armGeo, navyDark); arm.position.set(sd * 0.3, -0.1, 0.25 - EMI_Z / 1.25); arm.rotation.set(-0.9, 0, sd * 0.35); emi.add(arm);
+    const hand = new THREE.Mesh(handGeo, glove); hand.position.set(sd * 0.36, -0.22, 0.44 - EMI_Z / 1.25); emi.add(hand);
   }
   const antenna = new THREE.Group(); antenna.position.y = 0.21; emi.add(antenna);
   const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.022, 0.22, 8), stemMat); stem.position.y = 0.11; antenna.add(stem);
@@ -190,8 +202,9 @@ export function createEmiRig({ scene, reducedMotion = false }) {
     beadMat.emissiveIntensity = m === MOODS.jackpot ? 1.4 : 0.9;
     screenMat.opacity = 0.6 + 0.25 * Math.sin(t * 4);
 
-    // the tea swirls; the face in it is text and nothing else
+    // the tea swirls and leans up a touch more the faster the cup goes; the face in it is text and nothing else
     tea.rotation.z = reflection.rotation.z = Math.PI + Math.sin(t * 1.3) * 0.05;
+    teaTilt.rotation.x = -(TEA_TILT + 0.1 * Math.max(0, ctx.speedNorm - 0.65) / 0.35);
     let face = fraught > 0.6 && (m === MOODS.calm || m === MOODS.smug) ? MOODS.fraught.face : m.face;
     if (face === MOODS.calm.face) { if (t > blinkAt) blinkAt = t + 5.2; else if (t > blinkAt - 0.11) face = '-_-'; }
     drawTea(face);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/input.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/input.js
@@ -2,12 +2,13 @@
  * race/input.js - the wheel. Implements CONTRACT.md "race/run.js + raceBoot.js"
  * (PR 5, integration): the one place keyboard and gamepad are read.
  *
- * Keyboard: arrows / WASD steer + accel + brake, Shift drift, E item, Esc brake.
+ * Keyboard: arrows / WASD steer + accel + brake, Shift drift, E item, Esc brake,
+ * P cycles the pixel look.
  * Gamepad (navigator.getGamepads, standard map): left stick steer, RT accel,
  * LT brake, A drift, X item, Start brake.
  *
  *   read() -> { steer:-1..1, accel:0..1, brake:0..1, drift:bool }
- *   onAction(cb)   cb('item' | 'brake'), edge-triggered, never repeats on hold
+ *   onAction(cb)   cb('item' | 'brake' | 'pixel'), edge-triggered, never repeats on hold
  *   dispose()
  *
  * Law II (input honesty): nothing here ever remaps an axis. accel defaults to 1
@@ -41,6 +42,7 @@ export function createInput({ target = window } = {}) {
       if (e.repeat) { if (KEYS[code]) e.preventDefault(); return; }
       if (code === 'KeyE') { fire('item'); return; }
       if (code === 'Escape') { fire('brake'); return; }
+      if (code === 'KeyP') { fire('pixel'); return; }
       if (!KEYS[code]) return;
       down.add(KEYS[code]);
       e.preventDefault();

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -7,13 +7,18 @@
 import * as THREE from 'three';
 import {
   KART_BASE_SPEED, KART_MAX_SPEED, KART_MIN_SPEED, GRAVITY, ROAD_HALF_W,
-  CAM_BACK, CAM_UP, CAM_LOOK_AHEAD,
+  CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, CAM_LOOK_SPEED, KART_SCALE,
+  POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H,
 } from './consts.js';
 import { createEmiRig } from './emi.js';
 
 const STEER_VMAX = 6.5;       // lateral m/s at full lock, cruise speed, no drift
 const DRIFT_STEER = 1.45;     // drift tightens the steer
 const WALL_SOFT = 0.7;        // metres from the road edge where the soft wall starts easing you back
+const TARGET_AHEAD = POP_HIT_D * 0.5;   // the pop ring floats this far in front of the cup
+const TARGET_H = LANE_H - 0.15;         // ring centre: between the road box centre and a lane bubble
+const RING_ALPHA = 0.14;                // resting alpha; a pop pulses it up
+const CAM_BOOST_BACK = 0.7;             // the seat slides back a touch under boost
 const WORLD_UP = new THREE.Vector3(0, 1, 0), ZERO = new THREE.Vector3();
 const _m = new THREE.Matrix4(), _q = new THREE.Quaternion(), _v = new THREE.Vector3();
 const _fwd = new THREE.Vector3(), _up = new THREE.Vector3(), _right = new THREE.Vector3(), _lvl = new THREE.Vector3();
@@ -34,9 +39,20 @@ export function createKart({ scene, layout, reducedMotion = false }) {
   };
   const rig = createEmiRig({ scene, reducedMotion });
   const group = rig.group;
+  group.scale.setScalar(KART_SCALE);
   scene.add(group);
 
+  // the pop target: a faint ring at the pop box, just ahead of the cup, that pulses on a pop.
+  // Its own object (not a child of the scaled rig) so it stays in honest pop-box metres.
+  const ringMat = new THREE.MeshBasicMaterial({ color: 0xff9bd0, transparent: true, opacity: RING_ALPHA,
+    blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide });
+  const ring = new THREE.Mesh(new THREE.RingGeometry(0.88, 1, 48), ringMat);
+  ring.frustumCulled = false; ring.renderOrder = 2;
+  scene.add(ring);
+  let pulse = 0, reach = 1;
+
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
+  let camBoost = 0, steerS = 0;
   const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
   const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1 };
 
@@ -121,18 +137,31 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     _fwd.copy(f.tangent); _up.copy(f.up); _right.copy(f.right || _v.crossVectors(_up, _fwd));
     _m.lookAt(_fwd, ZERO, _up);                                        // +z faces down the road
     group.quaternion.setFromRotationMatrix(_m);
+    ring.quaternion.copy(group.quaternion);                            // the ring never leans
     group.quaternion.multiply(_q.setFromAxisAngle(AX_Z, lean)).multiply(_q.setFromAxisAngle(AX_X, pitch));
     group.updateMatrixWorld(true);
+    lay.toWorld(lay.wrap(state.d + TARGET_AHEAD), state.x, state.h + TARGET_H, ring.position);
+    const swell = 1 + 0.22 * pulse;
+    ring.scale.set(POP_HIT_X * reach * swell, POP_HIT_H * reach * swell, 1);
+    ringMat.opacity = RING_ALPHA + 0.5 * pulse;
   }
 
   function stepCamera(dt, lay) {
-    // the seat rides the track frame exactly CAM_BACK behind the cup; only the lateral / height
-    // offsets and the up vector are smoothed, so there is no lag and nothing to snap at the wrap
+    // the seat rides the track frame CAM_BACK behind the cup (a touch further under boost); only
+    // the lateral / height offsets and the up vector are smoothed, so there is no lag and nothing
+    // to snap at the wrap. Look-ahead grows with speed; the look point leans into the turn.
     camX += (state.x - camX) * ease(6, dt);
     camH += (state.h - camH) * ease(8, dt);
-    const camD = lay.wrap(state.d - CAM_BACK), lookD = lay.wrap(state.d + CAM_LOOK_AHEAD);
+    steerS += (state.steer - steerS) * ease(5, dt);
+    const boostT = state.boostSec > 0 ? 1 : 0;
+    camBoost += (boostT - camBoost) * ease(boostT ? 5 : 1.5, dt);
+    const spd = clamp((state.speed - KART_BASE_SPEED) / (KART_MAX_SPEED - KART_BASE_SPEED), 0, 1);
+    const back = CAM_BACK + CAM_BOOST_BACK * camBoost;
+    const lookAhead = CAM_LOOK_AHEAD + CAM_LOOK_SPEED * Math.max(spd, camBoost * 0.6);
+    const turnLook = reducedMotion ? 0 : steerS * 0.7;
+    const camD = lay.wrap(state.d - back), lookD = lay.wrap(state.d + lookAhead);
     lay.toWorld(camD, camX * 0.45, CAM_UP + camH * 0.4, cam.pos);
-    lay.toWorld(lookD, camX * 0.3, 0.9 + camH * 0.5, cam.look);
+    lay.toWorld(lookD, camX * 0.3 + turnLook, LANE_H + camH * 0.5, cam.look);
     const cf = lay.frameAtDepth(camD);
     let rollT = 0;
     if (reducedMotion) {
@@ -141,7 +170,8 @@ export function createKart({ scene, layout, reducedMotion = false }) {
       _lvl.copy(WORLD_UP).addScaledVector(_v, -WORLD_UP.dot(_v));
       if (_lvl.lengthSq() < 0.09) _lvl.copy(cf.up); else _lvl.normalize();
     } else {
-      rollT = -camX * 0.04 + lean * 0.35;
+      // a small lean into the steer on top of the lateral-offset roll and the cup's own lean
+      rollT = -camX * 0.04 + lean * 0.35 - steerS * 0.045 * (state.drift ? 1.5 : 1);
       _lvl.copy(cf.up).applyAxisAngle(cf.tangent, rollT);
     }
     if (!camReady) { cam.up.copy(_lvl); cam.roll = rollT; camReady = true; return; }
@@ -155,6 +185,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     input = input || {};
     const inp = { steer: +input.steer || 0, accel: clamp(+input.accel || 0, 0, 1), brake: clamp(+input.brake || 0, 0, 1), drift: !!input.drift };
     elapsed += dt;
+    if (pulse > 0) pulse = Math.max(0, pulse - pulse * ease(7, dt) - 0.2 * dt);
     stepSpeed(dt, inp);
     stepSteer(dt, inp);
     const prevD = state.d;
@@ -177,7 +208,17 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     return out;
   }
 
-  function dispose() { scene.remove(group); rig.dispose(); }
+  /** A pop landed: the target ring swells and brightens, then settles (run.js onPop). */
+  function pulseTarget() { pulse = 1; }
+  /** Magnet: the ring grows with the field's reach so the wider pop box is visible. */
+  function setReach(mult) { reach = clamp(+mult || 1, 0.5, 3); }
 
-  return { state, update, applyBoost, applySlow, setMood: rig.setMood, setFraught: rig.setFraught, camera, group, dispose };
+  function dispose() {
+    scene.remove(group); scene.remove(ring);
+    ring.geometry.dispose(); ringMat.dispose();
+    rig.dispose();
+  }
+
+  return { state, update, applyBoost, applySlow, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
+    pulseTarget, setReach, dispose };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -1,0 +1,85 @@
+/* ============================================================================
+ * race/pixel.js - the big-pixel look for The Caucus Race.
+ *
+ * Renders the 3D scene at a low internal resolution and lets the browser
+ * upscale it with nearest neighbour: `renderer.setPixelRatio(1 / block)` plus
+ * `renderer.setSize(w, h, false)` keeps the canvas CSS size untouched, and
+ * `image-rendering: pixelated` on the canvas does the blocky upscale. The DOM
+ * HUD and the payloadFx media layers sit above the canvas, so they stay crisp.
+ *
+ * Textures in the scene get NearestFilter + no mipmaps while a block is on
+ * (walk the scene once after build with retexture(scene); textures that load
+ * later go through filterTexture(tex)); OFF restores what each texture had.
+ *
+ *   createPixelizer({ renderer, canvas, block }) ->
+ *     { block, setBlock(n), cycle(), resize(w, h), filterTexture(tex), retexture(scene), label() }
+ *
+ * PIXEL_STEPS is the P-key cycle: off, 2, 3, 4, 6 screen pixels per block.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { Q } from '../shared/quality.js';
+
+export const PIXEL_STEPS = [0, 2, 3, 4, 6];
+export const PIXEL_DEFAULT = 3;
+const MAP_KEYS = ['map', 'emissiveMap', 'alphaMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap'];
+
+/** Snap any input to a step: 0 (off) or the nearest listed block size. */
+export function normalizeBlock(n) {
+  const v = Number(n);
+  if (!isFinite(v) || v <= 1) return 0;
+  let best = PIXEL_STEPS[1];
+  for (const s of PIXEL_STEPS) if (s > 0 && Math.abs(s - v) < Math.abs(best - v)) best = s;
+  return best;
+}
+
+export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT }) {
+  let cur = normalizeBlock(block);
+  let w = 1, h = 1;
+  const nativeDpr = () => Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5);
+
+  function apply() {
+    renderer.setPixelRatio(cur > 0 ? 1 / cur : nativeDpr());
+    renderer.setSize(w, h, false);
+    if (canvas) canvas.style.imageRendering = cur > 0 ? 'pixelated' : '';
+  }
+  function resize(width, height) { w = Math.max(1, width | 0); h = Math.max(1, height | 0); apply(); }
+  function setBlock(n) { cur = normalizeBlock(n); apply(); return cur; }
+  function cycle() {
+    const i = PIXEL_STEPS.indexOf(cur);
+    return setBlock(PIXEL_STEPS[(i + 1) % PIXEL_STEPS.length]);
+  }
+
+  /** Apply the current mode to one texture (remembers its original filters the first time). */
+  function filterTexture(tex) {
+    if (!tex || !tex.isTexture) return;
+    const ud = tex.userData || (tex.userData = {});
+    if (!ud.pxOrig) ud.pxOrig = { mag: tex.magFilter, min: tex.minFilter, mip: tex.generateMipmaps };
+    const o = ud.pxOrig;
+    const mag = cur > 0 ? THREE.NearestFilter : o.mag;
+    const min = cur > 0 ? THREE.NearestFilter : o.min;
+    const mip = cur > 0 ? false : o.mip;
+    if (tex.magFilter === mag && tex.minFilter === min && tex.generateMipmaps === mip) return;
+    tex.magFilter = mag; tex.minFilter = min; tex.generateMipmaps = mip;
+    tex.needsUpdate = true;
+  }
+  /** Walk every material in the scene (maps + shader sampler uniforms). */
+  function retexture(scene) {
+    if (!scene || !scene.traverse) return;
+    scene.traverse((o) => {
+      const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
+      for (const m of mats) {
+        for (const k of MAP_KEYS) if (m[k]) filterTexture(m[k]);
+        if (m.uniforms) for (const u of Object.values(m.uniforms)) if (u && u.value && u.value.isTexture) filterTexture(u.value);
+      }
+    });
+  }
+
+  return {
+    get block() { return cur; },
+    setBlock, cycle, resize, filterTexture, retexture,
+    label() { return cur > 0 ? `pixels ${cur}` : 'pixels off'; },
+  };
+}
+
+// self-check: node --check is the bar; normalizeBlock(2.6) -> 3, normalizeBlock('0') -> 0, normalizeBlock(9) -> 6.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -29,6 +29,8 @@ import { createScore } from './score.js';
 import { createRaceHud } from './hud.js';
 import { createItems } from './items.js';
 import { createInput } from './input.js';
+import { createPixelizer, PIXEL_DEFAULT } from './pixel.js';
+import { createSpeedFx } from './speed.js';
 
 const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.6, FOV_BASE = 72;
 const EFFECT_SEC = { flash: 1.5, subliminal: 3, overlay: 6, glitch: 3, bambiFreeze: 1.6, gifCascade: 5, video: 9 };
@@ -47,7 +49,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
   // ---- renderer / scene / camera (engine/scene.js pattern, pitch-demo look) ----
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: Q.antialias, alpha: false, powerPreference: 'high-performance' });
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5));
+  // the big-pixel look: low internal resolution, nearest upscale; host settings.pixel / ?pixel=N override, 0 = off
+  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? PIXEL_DEFAULT : settings.pixel });
   if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x12261f);
@@ -58,7 +61,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   scene.add(cupLight);
   function resize() {
     const w = root.clientWidth || window.innerWidth, h = root.clientHeight || window.innerHeight;
-    renderer.setSize(w, h, false); camera.aspect = w / h; camera.updateProjectionMatrix();
+    pixel.resize(w, h); camera.aspect = w / h; camera.updateProjectionMatrix();
   }
   window.addEventListener('resize', resize); resize();
 
@@ -69,6 +72,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const shake = createScreenShake({ el: root });
   if (reducedMotion) shake.setEnabled(false);
   const input = createInput();
+  const speedFx = createSpeedFx({ scene, camera, root, reducedMotion });
   const camOut = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
   const _v = new THREE.Vector3();
 
@@ -108,13 +112,14 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       if (!r || S.jackpotBias === 1) return r;
       return { ...r, bubbleBias: { ...r.bubbleBias, golden: (r.bubbleBias.golden == null ? 1 : r.bubbleBias.golden) * S.jackpotBias } };
     };
-    const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom });
+    const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, onTexture: pixel.filterTexture });
     const items = createItems({ kart, bubbles: field, score, fx, hud, payload: payloadFx, rng });
     const w = { layout, tunnel, fx, dresser, kart, score, field, items, rng };
     field.onPop((p) => onPop(w, p));
     field.onMiss((m) => onMiss(w, m));
     score.onEvent((e) => onScore(w, e));
     items.onEvent((e) => onItem(w, e));
+    pixel.retexture(scene);
     return w;
   }
   function teardown() {
@@ -258,6 +263,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const fovT = FOV_BASE + (reducedMotion ? 5 : 12) * S.fovBoost + (ks.drift && !reducedMotion ? 3 : 0) - (S.timeScale < 1 ? 4 : 0);
     if (Math.abs(fovT - S.fov) > 0.05) { S.fov += (fovT - S.fov) * Math.min(1, dt * 6); camera.fov = S.fov; camera.updateProjectionMatrix(); }
     cupLight.position.copy(k.group.position).addScaledVector(_v.copy(camOut.up), 1.6);
+    speedFx.update(dt, ks, lay);
 
     // EMI: calm cruise, streamed on boost, fraught under a stack, pokes on top
     if (S.moodHold > 0) { S.moodHold -= dt; if (S.moodHold <= 0) S.moodHeld = null; }
@@ -330,7 +336,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   // ---- host + input wiring ----
   bridge.on('pause', (m) => setPaused(!!(m && m.on)));
   bridge.on('payout-result', (m) => { if (payoutResolve) payoutResolve(m); });
-  input.onAction((a) => { if (a === 'item') { if (W && S.running && !S.paused) W.items.use(); } else if (a === 'brake') brake(); });
+  function cyclePixel() { pixel.cycle(); pixel.retexture(scene); hud.toast(pixel.label(), 'item'); }
+  input.onAction((a) => { if (a === 'item') { if (W && S.running && !S.paused) W.items.use(); } else if (a === 'brake') brake(); else if (a === 'pixel') cyclePixel(); });
   const onVis = () => { last = 0; };
   document.addEventListener('visibilitychange', onVis);
 
@@ -354,7 +361,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     document.removeEventListener('visibilitychange', onVis);
     if (payoutResolve) payoutResolve(null);
     teardown();
-    input.dispose(); hud.dispose(); shake.dispose(); payloadFx.dispose();
+    input.dispose(); hud.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose();
     scene.clear(); renderer.dispose();
     setFlip(false);
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -19,7 +19,7 @@ import { createTunnel, FOG_DENSITY } from '../engine/tunnel.js';
 import { createFx } from '../engine/fx.js';
 import { createPayloadFx } from '../game/payloadFx.js';
 import { createScreenShake } from '../game/screenShake.js';
-import { INTENSITY_RAMP_SEC, KART_BASE_SPEED, makeRng } from './consts.js';
+import { INTENSITY_RAMP_SEC, TREATS_ONLY_SEC, KART_BASE_SPEED, makeRng } from './consts.js';
 import { createSpine } from './spine.js';
 import { roomById, rollRoomOrder, createRoomDresser } from './rooms.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
@@ -33,7 +33,11 @@ import { createPixelizer, PIXEL_DEFAULT } from './pixel.js';
 import { createSpeedFx } from './speed.js';
 
 const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.6, FOV_BASE = 72;
-const EFFECT_SEC = { flash: 1.5, subliminal: 3, overlay: 6, glitch: 3, bambiFreeze: 1.6, gifCascade: 5, video: 9 };
+// how long each payload paints over the road: scaled ones follow payloadFx's durationMult, fixed ones do not
+// (subliminal and bambiFreeze are fixed in payloadFx; the host's video length is its own, 9 s is the budget)
+const EFFECT_SEC = { flash: 2.6, overlay: 4.5, glitch: 4.5, gifCascade: 6 };
+const EFFECT_FIXED_SEC = { subliminal: 0.5, bambiFreeze: 1.7, video: 9 };
+const SPAWN_T0 = 2.5, RAIN_T0 = 20, EARLY_SLOW = 1.5;   // the opening drips slower (TREATS_ONLY_SEC)
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const hex = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
 
@@ -80,7 +84,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const S = {
     started: false, running: false, paused: false, hostPaused: false, ended: false, disposed: false,
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
-    flip: false, spawnT: 1.5, rainT: 8, tunnelTime: 0, rush: 0, fov: 72, fovBoost: 0, gates: 0, room: null,
+    flip: false, spawnT: SPAWN_T0, rainT: RAIN_T0, tunnelTime: 0, rush: 0, fov: 72, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed,
   };
   let W = null;                       // the world: everything that is rebuilt on "again"
@@ -112,7 +116,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       if (!r || S.jackpotBias === 1) return r;
       return { ...r, bubbleBias: { ...r.bubbleBias, golden: (r.bubbleBias.golden == null ? 1 : r.bubbleBias.golden) * S.jackpotBias } };
     };
-    const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, onTexture: pixel.filterTexture });
+    const field = createBubbleField({ scene, layout, media, getIntensity: () => S.intensity, getRoom, getElapsed: () => S.elapsed, onTexture: pixel.filterTexture });
     const items = createItems({ kart, bubbles: field, score, fx, hud, payload: payloadFx, rng });
     const w = { layout, tunnel, fx, dresser, kart, score, field, items, rng };
     field.onPop((p) => onPop(w, p));
@@ -130,7 +134,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function resetRunState(runSeed) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
-      jackpotBias: 1, parasol: false, magnet: false, spawnT: 1.5, rainT: 8, rush: 0, fovBoost: 0, gates: 0, room: null,
+      jackpotBias: 1, parasol: false, magnet: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed });
     setFlip(false); trail.length = 0;
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.item(null, 'no item yet');
@@ -164,15 +168,17 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     w.kart.pulseTarget();
     if (p.kind === 'treat') return treat(w, p);
     if (S.parasol) { S.parasol = false; hud.toast('parasol', 'item'); return treat(w, p); }
+    // effect budget: one screen-level effect at a time (video included); the rest score as treats
+    if (S.effects.length > 0) { w.score.pop(p.points, 'treat'); hud.toast('held', 'effect'); return; }
     w.score.pop(p.points, p.id);
     const strength = Math.round(clamp(p.strength, 0, 1) * 100);
-    const durationMult = 0.6 + 0.6 * S.intensity;
+    const durationMult = 0.5 + 0.5 * S.intensity;
     if (p.payload === 'video') send({ type: 'fire-payload', kind: 'video', strength, durationMult });
     else payloadFx.applyPayload({ payload: { kind: p.payload, overlay: p.overlayKind }, strength }, { durationMult });
-    w.kart.applySlow(0.85, 2.5);
+    w.kart.applySlow(0.92, 2.0);
     hud.toast((KIND_BY_ID[p.id] || {}).label || p.id, 'effect');
     if (p.payload === 'glitch') hud.flicker();
-    S.effects.push((EFFECT_SEC[p.payload] || 3) * durationMult);
+    S.effects.push(EFFECT_FIXED_SEC[p.payload] || (EFFECT_SEC[p.payload] || 3) * durationMult);
     shake.shake(p.payload === 'video' ? 0.9 : 0.5, 300);
     poke('shock', 0.9);
   }
@@ -199,7 +205,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       case 'itemArm': sfx('ui_click', 0.4); break;
       case 'itemUse': sfx('tunnel_powerup_collect', 0.7); poke('smug', 0.8); break;
       case 'timeScale': S.timeScale = e.value; sfx('time_slow_in', 0.8); break;
-      case 'magnet': S.magnet = true; break;                       // no field API for the hit box yet (CONTRACT.md gap)
+      case 'magnet': S.magnet = true; w.field.setReach(2.2); w.kart.setReach(2.2); break;
       case 'multBoost': w.score.boostMult(e.mult, e.sec); break;
       case 'parasol': S.parasol = true; break;
       case 'flip': setFlip(true); break;
@@ -210,7 +216,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
         if (e.id === 'tea_time') { S.timeScale = 1; sfx('time_slow_out', 0.8); }
         else if (e.id === 'mirror') setFlip(false);
         else if (e.id === 'rabbit_foot') S.jackpotBias = 1;
-        else if (e.id === 'magnet') S.magnet = false;
+        else if (e.id === 'magnet') { S.magnet = false; w.field.setReach(1); w.kart.setReach(1); }
         break;
     }
   }
@@ -230,10 +236,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
     // bubbles: seed the chunks ahead, drip spawns, rain bursts
     for (const c of lay.chunks) { const rel = lay.wrap(c.d0 - ks.d + lay.totalDepth / 2) - lay.totalDepth / 2; if (rel > -20 && rel < 250) w.field.seedChunk(c); }
+    const early = S.elapsed < TREATS_ONLY_SEC ? EARLY_SLOW : 1;
     S.spawnT -= wdt;
-    if (S.spawnT <= 0) { w.field.spawnAhead(ks.d, 1 + Math.round(S.intensity * 2)); S.spawnT = 3.4 - 1.8 * S.intensity; }
+    if (S.spawnT <= 0) { w.field.spawnAhead(ks.d, 1 + Math.round(S.intensity * 2)); S.spawnT = (3.4 - 1.8 * S.intensity) * early; }
     S.rainT -= wdt;
-    if (S.rainT <= 0) { w.field.rain(ks.d, 3 + Math.round(S.intensity * 4)); S.rainT = (S.room && S.room.loud ? 9 : 14) * (1 - 0.5 * S.intensity); }
+    if (S.rainT <= 0) { w.field.rain(ks.d, 3 + Math.round(S.intensity * 4)); S.rainT = (S.room && S.room.loud ? 9 : 14) * (1 - 0.5 * S.intensity) * early; }
     w.field.update(wdt, S.t, ks);
 
     // track features crossed this frame

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -30,7 +30,7 @@ import { createRaceHud } from './hud.js';
 import { createItems } from './items.js';
 import { createInput } from './input.js';
 
-const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.6;
+const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.6, FOV_BASE = 72;
 const EFFECT_SEC = { flash: 1.5, subliminal: 3, overlay: 6, glitch: 3, bambiFreeze: 1.6, gifCascade: 5, video: 9 };
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const hex = (n) => '#' + ((n >>> 0) & 0xffffff).toString(16).padStart(6, '0');
@@ -52,7 +52,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x12261f);
   scene.fog = new THREE.FogExp2(0x12261f, FOG_DENSITY);
-  const camera = new THREE.PerspectiveCamera(72, 1, 0.1, 400);
+  const camera = new THREE.PerspectiveCamera(FOV_BASE, 1, 0.1, 400);
   scene.add(new THREE.AmbientLight(0x8a70a8, 1.0));
   const cupLight = new THREE.PointLight(0xff69b4, 1.4, 14);
   scene.add(cupLight);
@@ -76,7 +76,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const S = {
     started: false, running: false, paused: false, hostPaused: false, ended: false, disposed: false,
     elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1, jackpotBias: 1, parasol: false, magnet: false,
-    flip: false, spawnT: 1.5, rainT: 8, tunnelTime: 0, rush: 0, fov: 72, gates: 0, room: null,
+    flip: false, spawnT: 1.5, rainT: 8, tunnelTime: 0, rush: 0, fov: 72, fovBoost: 0, gates: 0, room: null,
     wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', bestAtStart: 0, seed,
   };
   let W = null;                       // the world: everything that is rebuilt on "again"
@@ -125,7 +125,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   }
   function resetRunState(runSeed) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
-      jackpotBias: 1, parasol: false, magnet: false, spawnT: 1.5, rainT: 8, rush: 0, gates: 0, room: null,
+      jackpotBias: 1, parasol: false, magnet: false, spawnT: 1.5, rainT: 8, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed });
     setFlip(false); trail.length = 0;
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.item(null, 'no item yet');
@@ -156,6 +156,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
   }
   function onPop(w, p) {
+    w.kart.pulseTarget();
     if (p.kind === 'treat') return treat(w, p);
     if (S.parasol) { S.parasol = false; hud.toast('parasol', 'item'); return treat(w, p); }
     w.score.pop(p.points, p.id);
@@ -251,9 +252,12 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // camera + the cup light
     k.camera(camOut);
     camera.position.copy(camOut.pos); camera.up.copy(camOut.up); camera.lookAt(camOut.look);
-    const fovT = 72 + (ks.boostSec > 0 ? 6 : 0) - (S.timeScale < 1 ? 4 : 0);
-    if (Math.abs(fovT - S.fov) > 0.05) { S.fov += (fovT - S.fov) * Math.min(1, dt * 4); camera.fov = S.fov; camera.updateProjectionMatrix(); }
-    cupLight.position.copy(k.group.position).addScaledVector(_v.copy(camOut.up), 1.2);
+    // FOV kick: boost snaps wide (to ~84) and eases back slowly; drift adds a smaller one; tea_time narrows
+    const boostT = ks.boostSec > 0 ? 1 : 0;
+    S.fovBoost += (boostT - S.fovBoost) * Math.min(1, dt * (boostT ? 9 : 2.2));
+    const fovT = FOV_BASE + (reducedMotion ? 5 : 12) * S.fovBoost + (ks.drift && !reducedMotion ? 3 : 0) - (S.timeScale < 1 ? 4 : 0);
+    if (Math.abs(fovT - S.fov) > 0.05) { S.fov += (fovT - S.fov) * Math.min(1, dt * 6); camera.fov = S.fov; camera.updateProjectionMatrix(); }
+    cupLight.position.copy(k.group.position).addScaledVector(_v.copy(camOut.up), 1.6);
 
     // EMI: calm cruise, streamed on boost, fraught under a stack, pokes on top
     if (S.moodHold > 0) { S.moodHold -= dt; if (S.moodHold <= 0) S.moodHeld = null; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/score.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/score.js
@@ -117,12 +117,15 @@ export function createScore() {
 if (typeof process !== 'undefined' && process.env && process.env.RACE_SELFCHECK) {
   const s = createScore(); const ev = [];
   s.onEvent((e) => ev.push(e.type));
+  // ladder [[0,1],[3,2],[8,3],[15,4],[25,6],[40,8]]: pops 1-2 at x1, 3-7 at x2, 8+ at x3
   for (let i = 0; i < 5; i++) s.pop(10, 'treat');
-  console.assert(s.state.combo === 5 && s.state.mult === 2 && s.state.score === 60, 'ladder x2 at 5');
+  console.assert(s.state.combo === 5 && s.state.mult === 2 && s.state.score === 80, 'ladder x2 at 3');
+  for (let i = 0; i < 3; i++) s.pop(10, 'treat');
+  console.assert(s.state.combo === 8 && s.state.mult === 3 && s.state.score === 80 + 20 + 20 + 30, 'ladder x3 at 8');
   s.tick(COMBO_HOLD_SEC + 0.01);
   console.assert(s.state.combo === 0 && s.state.mult === 1, 'combo lets go');
-  s.pop(15, 'flash'); console.assert(s.state.effects === 1 && s.state.treats === 5, 'kind tally');
-  const b = s.bank(); console.assert(b === 75 && s.state.score === 0 && s.state.banked === 75, 'bank');
+  s.pop(15, 'flash'); console.assert(s.state.effects === 1 && s.state.treats === 8, 'kind tally');
+  const b = s.bank(); console.assert(b === 165 && s.state.score === 0 && s.state.banked === 165, 'bank');
   console.assert(ev.includes('mult') && ev.includes('bank') && ev.includes('combo'), 'events');
   console.log('score.js self-check ok', s.state);
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/speed.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/speed.js
@@ -1,0 +1,138 @@
+/* ============================================================================
+ * race/speed.js - the sense of speed for The Caucus Race.
+ *
+ * Three cheap layers, all additive, none of them paint over the road:
+ *  - streaks: short lines around the camera edge (a child of the camera) that
+ *    scroll outward and lengthen with speed, brightest under boost
+ *  - wind: a stream of thin segments in track space past the cup; the kart
+ *    moves through them at its true speed so they never lie about it
+ *  - vignette: an optional mild pink radial pulse (a DOM layer under the HUD)
+ *    that comes up fast on boost and fades slowly
+ * The ground rush itself is the rooms' scrolling road texture, not ours.
+ *
+ *   createSpeedFx({ scene, camera, root, reducedMotion }) -> { update(dt, kartState, layout), dispose }
+ *
+ * Reduced motion: no streaks, no vignette, the wind at half strength.
+ * ==========================================================================*/
+
+import * as THREE from 'three';
+import { KART_BASE_SPEED, KART_MAX_SPEED, ROAD_HALF_W } from './consts.js';
+
+const STREAK_N = 56, WIND_N = 90;
+const STREAK_Z = 2;                 // camera-space depth of the streak plane
+const DEG = Math.PI / 180;
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const rand = (a, b) => a + Math.random() * (b - a);
+
+export function createSpeedFx({ scene, camera, root, reducedMotion = false }) {
+  // ---- streaks (camera space) ----
+  const streaks = [];
+  for (let i = 0; i < STREAK_N; i++) streaks.push({ a: rand(0, Math.PI * 2), r0: rand(0.5, 0.95), p: Math.random(), spin: rand(0.6, 1.4) });
+  const sGeo = new THREE.BufferGeometry();
+  const sPos = new Float32Array(STREAK_N * 6), sCol = new Float32Array(STREAK_N * 6);
+  sGeo.setAttribute('position', new THREE.BufferAttribute(sPos, 3));
+  sGeo.setAttribute('color', new THREE.BufferAttribute(sCol, 3));
+  const sMat = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0, blending: THREE.AdditiveBlending, depthTest: false, depthWrite: false, fog: false });
+  const sLines = new THREE.LineSegments(sGeo, sMat);
+  sLines.frustumCulled = false; sLines.renderOrder = 5; sLines.visible = false;
+  let cameraAdded = false;
+  if (!reducedMotion) {
+    if (!camera.parent) { scene.add(camera); cameraAdded = true; }
+    camera.add(sLines);
+  }
+
+  // ---- wind (track space) ----
+  const wind = [];
+  for (let i = 0; i < WIND_N; i++) wind.push({ d: 0, x: 0, h: 0, len: 0.6, live: false });
+  const wGeo = new THREE.BufferGeometry();
+  const wPos = new Float32Array(WIND_N * 6);
+  wGeo.setAttribute('position', new THREE.BufferAttribute(wPos, 3));
+  const wMat = new THREE.LineBasicMaterial({ color: 0xffd9ef, transparent: true, opacity: 0, blending: THREE.AdditiveBlending, depthWrite: false, fog: true });
+  const wLines = new THREE.LineSegments(wGeo, wMat);
+  wLines.frustumCulled = false; wLines.renderOrder = 4;
+  scene.add(wLines);
+  const _a = new THREE.Vector3(), _b = new THREE.Vector3();
+
+  // ---- vignette (DOM, under the HUD chrome at z3) ----
+  let vig = null;
+  if (!reducedMotion && root) {
+    vig = document.createElement('div');
+    vig.className = 'race-speed-vignette';
+    vig.setAttribute('aria-hidden', 'true');
+    vig.style.cssText = 'position:absolute;inset:0;pointer-events:none;z-index:2;opacity:0;'
+      + 'background:radial-gradient(ellipse at center, rgba(255,105,180,0) 52%, rgba(255,105,180,.42) 100%);';
+    root.appendChild(vig);
+  }
+
+  let boost = 0, rush = 0;
+
+  function update(dt, ks, layout) {
+    if (!(dt > 0) || !ks) return;
+    const boostT = ks.boostSec > 0 ? 1 : 0;
+    boost += (boostT - boost) * Math.min(1, dt * (boostT ? 8 : 1.6));
+    // 0 a touch under cruise, 1 at the cap: cruise shows a whisper, boost the full streak
+    const rushT = clamp((ks.speed - KART_BASE_SPEED * 0.85) / (KART_MAX_SPEED - KART_BASE_SPEED * 0.85), 0, 1);
+    rush += (rushT - rush) * Math.min(1, dt * 4);
+    const heat = clamp(rush * 0.7 + boost * 0.5, 0, 1);
+
+    // streaks
+    if (!reducedMotion) {
+      sLines.visible = heat > 0.02;
+      if (sLines.visible) {
+        const th = Math.tan(camera.fov * 0.5 * DEG) * STREAK_Z, tw = th * camera.aspect;
+        const scroll = (0.35 + 1.6 * heat) * dt, len = 0.03 + 0.22 * heat;
+        for (let i = 0; i < STREAK_N; i++) {
+          const s = streaks[i];
+          s.p += scroll * s.spin; if (s.p >= 1) s.p -= 1;
+          const r = s.r0 + s.p * 0.45, r2 = r + len;
+          const c = Math.cos(s.a), sn = Math.sin(s.a);
+          const o = i * 6;
+          sPos[o] = c * r * tw; sPos[o + 1] = sn * r * th; sPos[o + 2] = -STREAK_Z;
+          sPos[o + 3] = c * r2 * tw; sPos[o + 4] = sn * r2 * th; sPos[o + 5] = -STREAK_Z;
+          const k = (1 - s.p) * (0.4 + 0.6 * clamp((r - 0.5) / 0.6, 0, 1));
+          sCol[o] = 0.35 * k; sCol[o + 1] = 0.2 * k; sCol[o + 2] = 0.3 * k;
+          sCol[o + 3] = k; sCol[o + 4] = 0.55 * k + 0.3 * boost; sCol[o + 5] = 0.8 * k;
+        }
+        sGeo.attributes.position.needsUpdate = true; sGeo.attributes.color.needsUpdate = true;
+        sMat.opacity = 0.12 + 0.6 * heat;
+      }
+    }
+
+    // wind: segments live in track space; respawn ahead once the cup is past them
+    if (layout) {
+      const T = layout.totalDepth;
+      const rel = (d) => { let r = (d - ks.d) % T; if (r > T / 2) r -= T; else if (r <= -T / 2) r += T; return r; };
+      const segLen = clamp(ks.speed * 0.045, 0.35, 1.7);
+      for (let i = 0; i < WIND_N; i++) {
+        const p = wind[i];
+        if (!p.live || rel(p.d) < -2.5) {
+          p.live = true;
+          p.d = layout.wrap(ks.d + rand(8, 34)); p.x = rand(-4.6, 4.6);
+          // over the road it stays high (the ribbon keeps its own texture); in the gutters it can skim low
+          p.h = Math.abs(p.x) < ROAD_HALF_W + 0.3 ? rand(1.5, 4.8) : rand(0.25, 4.8);
+          p.len = segLen * rand(0.6, 1.2);
+        }
+        layout.toWorld(p.d, p.x, p.h, _a); layout.toWorld(layout.wrap(p.d + p.len), p.x, p.h, _b);
+        const o = i * 6;
+        wPos[o] = _a.x; wPos[o + 1] = _a.y; wPos[o + 2] = _a.z;
+        wPos[o + 3] = _b.x; wPos[o + 4] = _b.y; wPos[o + 5] = _b.z;
+      }
+      wGeo.attributes.position.needsUpdate = true;
+      wMat.opacity = (0.1 + 0.45 * heat) * (reducedMotion ? 0.5 : 1);
+    }
+
+    if (vig) vig.style.opacity = String((0.85 * boost).toFixed(3));
+  }
+
+  function dispose() {
+    if (sLines.parent) sLines.parent.remove(sLines);
+    if (cameraAdded && camera.parent === scene) scene.remove(camera);
+    scene.remove(wLines);
+    sGeo.dispose(); sMat.dispose(); wGeo.dispose(); wMat.dispose();
+    if (vig) vig.remove();
+  }
+
+  return { update, dispose };
+}
+
+// self-check: node --check is the bar (the DOM vignette and the camera are only touched inside createSpeedFx).

--- a/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/raceBoot.js
@@ -13,7 +13,8 @@
  * STANDALONE DEV MODE (no WebView2): `bridge.isHosted` is false, so `init` is
  * synthesised (masterVolume 60, reducedMotion from matchMedia, empty manifest)
  * and every would-be host message is logged to the console with a
- * `[race->host]` prefix. `?autostart=1` skips the splash.
+ * `[race->host]` prefix. `?autostart=1` skips the splash; `?pixel=N` (0 = off)
+ * overrides the pixel look, as does `settings.pixel` from the host init.
  * ==========================================================================*/
 
 import * as bridge from './bridge.js';
@@ -93,7 +94,8 @@ async function boot() {
   if (booted) return;
   booted = true;
   try {
-    const settings = (initMsg && initMsg.settings) || {};
+    const settings = { ...((initMsg && initMsg.settings) || {}) };
+    if (params.has('pixel') && params.get('pixel') !== '') settings.pixel = Number(params.get('pixel'));
     const seed = (Date.now() ^ Math.floor(Math.random() * 0x7fffffff)) >>> 0;
     note('the road is drawing');
     const { createRace } = await import('./race/run.js');


### PR DESCRIPTION
Pass 2, feel. Camera sits lower and closer behind a 1.35x cup, the tea looks up at the road, a pop target ring shows what the next bubble will hit, and the multiplier ladder starts at 3 pops. speed.js adds the sense of speed (FOV push, streaks) and pixel.js the big-pixel Minecraft-style render the owner asked to try (P key cycles the block size, ?pixel=N, settings.pixel). One screen effect at a time with an alpha cap, treats-only opening, start-straight zigzag, magnet reach.

Stacked on #658 (feat/race-7-boot). Merge in order.

---
Verification: node syntax check on every race module, headless Chrome (swiftshader) run of race.html?autostart=1 with zero Uncaught/TypeError/ReferenceError/404, and the WebView2 play build (--race) booted with the whole chain merged. No new binary assets. Each commit stays under the 600-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
