### PR TITLE
feat(race): Caucus Race 17/21 - crisp layer, EMI faces forward, far tunnel point

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -9,7 +9,8 @@
  * wobbles), rain (falls from the ceiling, rests, fizzles). Pops are pass-
  * through against the kart box; a pop plays the DtRH pop/chime in-page
  * (engine/audioBus) and throws a few sparkle shards, the WPF BubbleService way.
- * Sprite textures come from the two locally mapped hosts (never remote media).
+ * Sprite textures come from the two locally mapped hosts (never remote media). Every sprite
+ * (bubbles and shards) sits on pixel.js's CRISP_LAYER: full resolution over the blocky world.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -17,6 +18,7 @@ import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, TREATS
 import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
 import { makeSfxPlayer } from '../engine/audioBus.js';
 import { getLevel } from '../engine/audioLevels.js';
+import { CRISP_LAYER } from './pixel.js';
 
 export { BUBBLE_KINDS };
 
@@ -55,6 +57,7 @@ function makeDotTex() {
 
 export function createBubbleField({ scene, layout, media, getIntensity, getRoom, getElapsed, onTexture }) {
   void media;   // reserved: flash media is drawn by payloadFx at pop time, never here
+  void onTexture;   // see the loader below: crisp-layer sprites keep their own filters
   const T = layout.totalDepth;
   /** Signed depth from `from` to `d`, folded into (-T/2, T/2] so the start line is nothing special. */
   const relD = (d, from) => { let r = (d - from) % T; if (r > T / 2) r -= T; else if (r <= -T / 2) r += T; return r; };
@@ -77,7 +80,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     loader.load(k.sprite, (tex) => {
       if (disposed) { tex.dispose(); return; }
       tex.colorSpace = THREE.SRGBColorSpace;
-      if (onTexture) { try { onTexture(tex); } catch (e) { /* the look never breaks the field */ } }
+      // onTexture (the pixel look's nearest-filter hook) is accepted for the contract but no longer
+      // applied: the sprites draw on the crisp layer at full resolution and keep their own filters
       texOf[k.id] = tex;
       for (const s of pool) if (s.alive && s.kindId === k.id) { s.mat.map = tex; s.mat.needsUpdate = true; }
     }, undefined, () => { /* keep the dot */ });
@@ -91,7 +95,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   for (let i = 0; i < CAP; i++) {
     const mat = new THREE.SpriteMaterial({ transparent: true, depthWrite: false, opacity: 1 });
     const sprite = new THREE.Sprite(mat);
-    sprite.visible = false;
+    sprite.visible = false; sprite.layers.set(CRISP_LAYER);
     group.add(sprite);
     pool.push({ sprite, mat, alive: false, kindId: 'treat', placement: 'lane', d: 0, x: 0, h: LANE_H,
       x0: 0, baseH: LANE_H, phase: 0, age: 0, size: 1, scale: 1, popT: -1, missed: false });
@@ -100,7 +104,7 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   for (let i = 0; i < SHARD_CAP; i++) {
     const mat = new THREE.SpriteMaterial({ map: dotTex, transparent: true, depthWrite: false, opacity: 0 });
     const sprite = new THREE.Sprite(mat);
-    sprite.visible = false;
+    sprite.visible = false; sprite.layers.set(CRISP_LAYER);
     group.add(sprite);
     shards.push({ sprite, mat, alive: false, age: 0, life: 0.5, p0: new THREE.Vector3(), r: null, u: null, vr: 0, vu: 0, size: 0.2 });
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -30,7 +30,8 @@ const BURST_SFX = 'Burst.mp3';
 const CAP = 160;              // live bubbles, recycled farthest-first when full
 const SHARD_CAP = 64;
 const LANE_STEP = 3.2;        // metres between bubbles in a lane line
-const VIEW_AHEAD = 150;       // sprites beyond this are hidden, not freed
+const VIEW_AHEAD = 110;       // sprites beyond this are hidden, not freed (every visible sprite is a draw call,
+                              // and past ~80 m the world has folded into fog anyway)
 const MISS_BEHIND = 6;        // a treat this far behind the kart unpopped = miss
 const DROP_BEHIND = 12;       // freed once this far behind
 const PASS_FADE_M = 1.6;      // metres behind the pop box over which a passed bubble fades away (before it balloons into the seat)
@@ -117,7 +118,8 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
 
   function freeSlot(s) { if (!s.alive) return; s.alive = false; s.sprite.visible = false; liveCount--; }
   function takeSlot() {
-    let s = pool.find((p) => !p.alive);
+    let s = null;
+    for (let i = 0; i < pool.length; i++) if (!pool[i].alive) { s = pool[i]; break; }
     if (!s) {   // full: recycle the bubble farthest from the kart
       let far = -1;
       for (const p of pool) { const a = Math.abs(relD(p.d, lastKartD)); if (a > far) { far = a; s = p; } }
@@ -217,12 +219,21 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
 
   // ---- pop -----------------------------------------------------------------
   const _r = new THREE.Vector3(), _u = new THREE.Vector3();
+  // burst frames come from a fixed ring (no per-pop allocation): one right/up pair per burst,
+  // shared by its shards; 16 pairs outlive any shard (life <= 0.6 s, 64 shards, 7..12 per burst)
+  const DIR_RING = 16, dirRing = [];
+  for (let i = 0; i < DIR_RING; i++) dirRing.push({ r: new THREE.Vector3(), u: new THREE.Vector3() });
+  let dirNext = 0, shardNext = 0;
   function burst(s, golden) {
     const f = layout.frameAtDepth(s.d);
-    const dirs = { r: f.right.clone(), u: f.up.clone() };   // one pair per burst, shared by its shards
+    const dirs = dirRing[dirNext]; dirNext = (dirNext + 1) % DIR_RING;
+    dirs.r.copy(f.right); dirs.u.copy(f.up);
     const n = golden ? 12 : 7;
     for (let i = 0; i < n; i++) {
-      const sh = shards.find((p) => !p.alive) || shards[(Math.random() * SHARD_CAP) | 0];
+      // next free shard scanning from where the last burst stopped; a full ring steals the oldest slot
+      let sh = null;
+      for (let j = 0; j < SHARD_CAP; j++) { const c = shards[(shardNext + j) % SHARD_CAP]; if (!c.alive) { sh = c; shardNext = (shardNext + j + 1) % SHARD_CAP; break; } }
+      if (!sh) { sh = shards[shardNext]; shardNext = (shardNext + 1) % SHARD_CAP; }
       const ang = (Math.PI * 2 * i) / n + rand(-0.35, 0.35);
       const v = rand(2.2, 4.6) * (golden ? 1.3 : 1);
       sh.alive = true; sh.age = 0; sh.life = rand(0.35, 0.6);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -33,7 +33,7 @@ const LANE_STEP = 3.2;        // metres between bubbles in a lane line
 const VIEW_AHEAD = 150;       // sprites beyond this are hidden, not freed
 const MISS_BEHIND = 6;        // a treat this far behind the kart unpopped = miss
 const DROP_BEHIND = 12;       // freed once this far behind
-const PASS_FADE_M = 2.4;      // metres behind the pop box over which a passed bubble fades away
+const PASS_FADE_M = 1.6;      // metres behind the pop box over which a passed bubble fades away (before it balloons into the seat)
 const RAIN_FALL = 4, RAIN_REST = 2, RAIN_FIZZLE = 0.5;
 const POP_ANIM = 0.14;
 const PRISM_REACH = 8;        // prism chain-pops neighbours within this many metres

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -1,8 +1,9 @@
 // race/emi.js - The Caucus Race: the teacup rig with EMI riding in it, seen from behind.
 // Visual half of CONTRACT.md "race/kart.js (PR 3)": saucer + cup + handle + tea surface, EMI as a
 // CRT body with vents, two glove arms on the rim, a bead antenna with the six mood poses, pooled
-// sweat drops, drift sparks, and the tea reflection. Canon lock: her face is ONLY a text emoticon
-// drawn on a canvas and mirrored in the tea. No drawn face, no generated face, no mouthed words.
+// sweat drops, drift sparks, and a plain disc of tea. Canon lock: EMI faces forward, away from the
+// camera, so no face is ever visible. No drawn face, no reflection of one, no generated face, no
+// mouthed words. The moods live in the antenna and the bead alone.
 // Ported from the approved pitch demo (C:\wt-race-ref\pitch-demo.html) into ESM; poses now blend
 // on a spring (House Book Law XI), never a linear tween, and always return to the breath.
 
@@ -13,14 +14,15 @@ const BREATH_SEC = 3.9;      // the one breath on screen (Law III)
 const SWEAT_N = 28, SPARK_N = 32;
 
 /** Antenna poses per mood. antX pitches the whole stem (negative = streamed back), kinkX/Z bend
- *  the joint, wind = how much speed is allowed to stream the stem, w = spring speed (rad/s). */
+ *  the joint, wind = how much speed is allowed to stream the stem, w = spring speed (rad/s).
+ *  There is no face field on purpose: the antenna is the whole expression. */
 export const MOODS = {
-  calm:     { face: 'o_o', antX: 0,    kinkX: 0,    kinkZ: 0,    bead: PINK, scale: 1,   sway: 1,   wind: 1,   w: 8,  zeta: 0.65 },
-  streamed: { face: ':3',  antX: -1.0, kinkX: -0.3, kinkZ: 0,    bead: PINK, scale: 1,   sway: 0,   wind: 1,   w: 14, zeta: 0.7 },
-  fraught:  { face: ';_;', antX: 0.25, kinkX: 1.4,  kinkZ: 0,    bead: PALE, scale: 0.9, sway: 0.4, wind: 0.3, w: 10, zeta: 0.6 },
-  smug:     { face: '^_^', antX: 0,    kinkX: 0,    kinkZ: 0.55, bead: PINK, scale: 1,   sway: 1,   wind: 0.6, w: 7,  zeta: 0.6 },
-  shock:    { face: '>_<', antX: 0.1,  kinkX: 0,    kinkZ: 0,    bead: PINK, scale: 1.6, sway: 0,   wind: 0,   w: 22, zeta: 0.45 },
-  jackpot:  { face: '$_$', antX: 0,    kinkX: 0,    kinkZ: 0.2,  bead: GOLD, scale: 1.3, sway: 1,   wind: 0.6, w: 12, zeta: 0.5 },
+  calm:     { antX: 0,    kinkX: 0,    kinkZ: 0,    bead: PINK, scale: 1,   sway: 1,   wind: 1,   w: 8,  zeta: 0.65 },
+  streamed: { antX: -1.0, kinkX: -0.3, kinkZ: 0,    bead: PINK, scale: 1,   sway: 0,   wind: 1,   w: 14, zeta: 0.7 },
+  fraught:  { antX: 0.25, kinkX: 1.4,  kinkZ: 0,    bead: PALE, scale: 0.9, sway: 0.4, wind: 0.3, w: 10, zeta: 0.6 },
+  smug:     { antX: 0,    kinkX: 0,    kinkZ: 0.55, bead: PINK, scale: 1,   sway: 1,   wind: 0.6, w: 7,  zeta: 0.6 },
+  shock:    { antX: 0.1,  kinkX: 0,    kinkZ: 0,    bead: PINK, scale: 1.6, sway: 0,   wind: 0,   w: 22, zeta: 0.45 },
+  jackpot:  { antX: 0,    kinkX: 0,    kinkZ: 0.2,  bead: GOLD, scale: 1.3, sway: 1,   wind: 0.6, w: 12, zeta: 0.5 },
 };
 
 /** Damped spring toward a target; zeta < 1 overshoots a little, which is the point. */
@@ -108,40 +110,17 @@ export function createEmiRig({ scene, reducedMotion = false }) {
   const rim = new THREE.Mesh(new THREE.TorusGeometry(0.53, 0.025, 8, 48), pinkGlow); rim.rotation.x = Math.PI / 2; rim.position.y = 0.75; body.add(rim);
   const handle = new THREE.Mesh(new THREE.TorusGeometry(0.19, 0.045, 10, 24, Math.PI), porcelain); handle.position.set(0.62, 0.42, 0); handle.rotation.z = -Math.PI / 2; body.add(handle);
 
-  // ---- the tea: the only mirror she has. Her face shows in it, reversed. ----
-  // The chase camera sits low and ~6 m back, so a flat surface is a sliver. The reflection is the
-  // NEAR half of the tea only: it pivots at the near rim and leans up toward EMI (the tea looks up
-  // at you), which turns the band between the rim and her body toward the camera. The far half
-  // stays flat under her. The emoticon is drawn in that band; canvas bottom = the near (camera) side.
-  const TEA_PX = 128, TEA_TILT = 0.5, TEA_R = 0.46;   // rad: near edge at the rim, chord lifted
-  const teaCanvas = document.createElement('canvas'); teaCanvas.width = teaCanvas.height = TEA_PX;
-  const teaTex = new THREE.CanvasTexture(teaCanvas); teaTex.magFilter = THREE.NearestFilter; teaTex.minFilter = THREE.LinearFilter;
-  let faceDrawn = '';
-  function drawTea(face) {
-    if (face === faceDrawn) return; faceDrawn = face;
-    const g = teaCanvas.getContext('2d'); g.setTransform(1, 0, 0, 1, 0, 0);
-    const c = TEA_PX / 2;
-    g.fillStyle = '#B23282'; g.fillRect(0, 0, TEA_PX, TEA_PX);
-    const rg = g.createRadialGradient(c, c * 1.4, 6, c, c * 1.4, c * 1.1); rg.addColorStop(0, 'rgba(255,140,200,.6)'); rg.addColorStop(1, 'rgba(120,20,80,.3)');
-    g.fillStyle = rg; g.fillRect(0, 0, TEA_PX, TEA_PX);
-    g.translate(TEA_PX, 0); g.scale(-1, 1);                    // mirrored: it is a reflection
-    g.font = '700 ' + (face.length > 4 ? 22 : 34) + 'px "Noto Sans Mono", "JetBrains Mono", Consolas, monospace';
-    g.textAlign = 'center'; g.textBaseline = 'middle';
-    g.lineWidth = 5; g.strokeStyle = 'rgba(70,10,50,.85)'; g.strokeText(face, c, c * 1.44);
-    g.fillStyle = '#FFE3F3'; g.fillText(face, c, c * 1.44);
-    teaTex.needsUpdate = true;
-  }
-  drawTea(MOODS.calm.face);
-  const teaTilt = new THREE.Group(); teaTilt.position.set(0, 0.69, -TEA_R); teaTilt.rotation.x = -TEA_TILT; body.add(teaTilt);
-  // geometry y < 0 is the canvas bottom = the near half (thetaStart PI); the partial circle keeps full-disc UVs
-  const reflection = new THREE.Mesh(new THREE.CircleGeometry(TEA_R, 32, Math.PI, Math.PI), new THREE.MeshBasicMaterial({ map: teaTex, side: THREE.DoubleSide }));
-  reflection.rotation.set(-Math.PI / 2, 0, Math.PI); reflection.position.set(0, 0, TEA_R); teaTilt.add(reflection);
-  const teaMat = new THREE.MeshStandardMaterial({ color: 0xC94A9A, roughness: 0.15, metalness: 0.2, transparent: true, opacity: 0.35 });
+  // ---- the tea: a plain tinted liquid disc, nothing drawn in it. It takes the room's colour
+  // (the scene fog hue, which fx grades per room) and ripples a little. EMI faces forward, away
+  // from the camera, so there is no face to reflect and none is ever painted here.
+  const TEA_R = 0.46, TEA_Y = 0.66;
+  const teaMat = new THREE.MeshStandardMaterial({ color: 0xC94A9A, emissive: 0x3c1630, roughness: 0.12, metalness: 0.25, transparent: true, opacity: 0.9 });
   const tea = new THREE.Mesh(new THREE.CircleGeometry(TEA_R + 0.01, 32), teaMat);
-  tea.rotation.set(-Math.PI / 2, 0, Math.PI); tea.position.y = 0.66; body.add(tea);
+  tea.rotation.set(-Math.PI / 2, 0, Math.PI); tea.position.y = TEA_Y; body.add(tea);
+  const teaTarget = new THREE.Color(0xC94A9A), teaHsl = { h: 0, s: 0, l: 0 };
 
   // ---- EMI: a living pixel CRT seen from behind, gripping the rim ----
-  // she sits a little forward in the cup so the near band of tea is wide enough to hold her face
+  // she sits a little forward in the cup, hands on the far rim
   const EMI_Z = 0.12;
   const emi = new THREE.Group(); emi.position.set(0, 0.82, EMI_Z); emi.scale.setScalar(1.25); body.add(emi);
   const crt = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.42, 0.34), navy); emi.add(crt);
@@ -172,7 +151,7 @@ export function createEmiRig({ scene, reducedMotion = false }) {
   scene.add(sweat.mesh); scene.add(sparks.mesh);
 
   // ---- state ----
-  let mood = MOODS.calm, fraught = 0, sweatAcc = 0, sparkAcc = 0, blinkAt = 0;
+  let mood = MOODS.calm, fraught = 0, sweatAcc = 0, sparkAcc = 0;
   const sAnt = new Spring(0), sKinkX = new Spring(0), sKinkZ = new Spring(0), sBead = new Spring(1), sSquash = new Spring(0);
   const beadTarget = new THREE.Color(PINK);
 
@@ -202,12 +181,17 @@ export function createEmiRig({ scene, reducedMotion = false }) {
     beadMat.emissiveIntensity = m === MOODS.jackpot ? 1.4 : 0.9;
     screenMat.opacity = 0.6 + 0.25 * Math.sin(t * 4);
 
-    // the tea swirls and leans up a touch more the faster the cup goes; the face in it is text and nothing else
-    tea.rotation.z = reflection.rotation.z = Math.PI + Math.sin(t * 1.3) * 0.05;
-    teaTilt.rotation.x = -(TEA_TILT + 0.1 * Math.max(0, ctx.speedNorm - 0.65) / 0.35);
-    let face = fraught > 0.6 && (m === MOODS.calm || m === MOODS.smug) ? MOODS.fraught.face : m.face;
-    if (face === MOODS.calm.face) { if (t > blinkAt) blinkAt = t + 5.2; else if (t > blinkAt - 0.11) face = '-_-'; }
-    drawTea(face);
+    // the tea swirls, bobs and settles lower at speed; its colour follows the room (fog hue) with a
+    // floor on saturation and lightness so it always reads as a liquid, never as a hole in the cup
+    tea.rotation.z = Math.PI + Math.sin(t * 1.3) * 0.05;
+    tea.position.y = TEA_Y + 0.006 * Math.sin(t * 2.7) - 0.02 * Math.max(0, ctx.speedNorm - 0.65) / 0.35;
+    tea.scale.set(1 + 0.02 * Math.sin(t * 1.9), 1 + 0.02 * Math.cos(t * 2.3), 1);
+    if (scene.fog && scene.fog.color) {
+      scene.fog.color.getHSL(teaHsl);
+      teaTarget.setHSL(teaHsl.h, Math.max(0.3, teaHsl.s), 0.42);
+      teaMat.color.lerp(teaTarget, Math.min(1, dt * 1.5));
+      teaMat.emissive.copy(teaMat.color).multiplyScalar(0.28);
+    }
 
     // landing squash with overshoot (Law XI)
     const sq = sSquash.step(0, dt, 9, 0.45);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -1,20 +1,31 @@
 /* ============================================================================
- * race/pixel.js - the big-pixel look for The Caucus Race.
+ * race/pixel.js - the big-pixel look for The Caucus Race, with a crisp layer.
  *
- * Renders the 3D scene at a low internal resolution and lets the browser
- * upscale it with nearest neighbour: `renderer.setPixelRatio(1 / block)` plus
- * `renderer.setSize(w, h, false)` keeps the canvas CSS size untouched, and
- * `image-rendering: pixelated` on the canvas does the blocky upscale. The DOM
+ * Two-pass render while a block size is on:
+ *   (a) the WORLD (THREE layer 0) renders into a low-resolution render target
+ *       sized canvas / block (nearest filtering, no mipmaps, a depth texture);
+ *   (b) a fullscreen blit upscales it onto the full-resolution canvas with
+ *       nearest sampling and writes gl_FragDepth from the depth texture, so
+ *       whatever draws next still occludes correctly; the blit also fades the
+ *       far tunnel to the fog colour past FAR_FADE metres (a vanishing point,
+ *       not a ring tangle);
+ *   (c) the CRISP layer (THREE layer 1: bubble sprites, pop shards, the wall
+ *       media posters) renders on top at full resolution, autoClear off.
+ * Off (block 0) is one ordinary full-res render with every layer on. The DOM
  * HUD and the payloadFx media layers sit above the canvas, so they stay crisp.
  *
  * Textures in the scene get NearestFilter + no mipmaps while a block is on
  * (walk the scene once after build with retexture(scene); textures that load
  * later go through filterTexture(tex)); OFF restores what each texture had.
  *
- *   createPixelizer({ renderer, canvas, block }) ->
- *     { block, setBlock(n), cycle(), resize(w, h), filterTexture(tex), retexture(scene), label() }
+ *   createPixelizer({ renderer, canvas, block, log }) ->
+ *     { block, setBlock(n), cycle(), resize(w, h), render(scene, camera),
+ *       filterTexture(tex), retexture(scene), label(), stats }
  *
  * PIXEL_STEPS is the P-key cycle: off, 2, 3, 4, 6 screen pixels per block.
+ * Put an object on the crisp layer with `obj.layers.set(CRISP_LAYER)`.
+ * `stats` is last frame's draw calls + triangles summed over the passes; with
+ * `log` given, a line goes out every PERF_LOG_SEC seconds.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -22,7 +33,11 @@ import { Q } from '../shared/quality.js';
 
 export const PIXEL_STEPS = [0, 2, 3, 4, 6];
 export const PIXEL_DEFAULT = 3;
+export const CRISP_LAYER = 1;
+const WORLD_MASK = 1 << 0, CRISP_MASK = 1 << CRISP_LAYER, ALL_MASK = WORLD_MASK | CRISP_MASK;
 const MAP_KEYS = ['map', 'emissiveMap', 'alphaMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap'];
+const FAR_FADE = [42, 80];     // metres: the world pass fades to the fog colour across this band
+const PERF_LOG_SEC = 5;
 
 /** Snap any input to a step: 0 (off) or the nearest listed block size. */
 export function normalizeBlock(n) {
@@ -33,15 +48,81 @@ export function normalizeBlock(n) {
   return best;
 }
 
-export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT }) {
+// The blit: one triangle over the whole canvas. Colour is nearest-sampled from the low-res
+// target; depth comes back out through gl_FragDepth (WebGL2 only) so the crisp pass can
+// depth-test against the world. <colorspace_fragment> encodes for the canvas the way every
+// three material does (the target stores sRGB, sampling hands back linear).
+const BLIT_VERT = `
+  varying vec2 vUv;
+  void main() { vUv = position.xy * 0.5 + 0.5; gl_Position = vec4(position.xy, 0.0, 1.0); }`;
+const BLIT_FRAG = `
+  #include <packing>
+  uniform sampler2D tDiffuse;
+  uniform sampler2D tDepth;
+  uniform vec3 uFogColor;
+  uniform vec2 uFade;
+  uniform float uNear, uFar;
+  varying vec2 vUv;
+  void main() {
+    vec4 c = texture2D(tDiffuse, vUv);
+    #ifdef WRITE_DEPTH
+      float z = texture2D(tDepth, vUv).r;
+      gl_FragDepth = z;
+      float dist = -perspectiveDepthToViewZ(z, uNear, uFar);
+      c.rgb = mix(c.rgb, uFogColor, smoothstep(uFade.x, uFade.y, dist));
+    #endif
+    gl_FragColor = vec4(c.rgb, 1.0);
+    #include <colorspace_fragment>
+  }`;
+
+export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT, log = null }) {
   let cur = normalizeBlock(block);
   let w = 1, h = 1;
   const nativeDpr = () => Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5);
+  const caps = renderer.capabilities || {};
+  const depthOk = caps.isWebGL2 !== false;   // r163+ is WebGL2 only; the guard keeps an older fork honest
+
+  // ---- the low-res target + the blit ------------------------------------------------------
+  let rt = null, rtW = 0, rtH = 0;
+  const blitGeo = new THREE.BufferGeometry();
+  blitGeo.setAttribute('position', new THREE.Float32BufferAttribute([-1, -1, 0, 3, -1, 0, -1, 3, 0], 3));
+  const blitMat = new THREE.ShaderMaterial({
+    uniforms: { tDiffuse: { value: null }, tDepth: { value: null }, uFogColor: { value: new THREE.Color(0) },
+      uFade: { value: new THREE.Vector2(FAR_FADE[0], FAR_FADE[1]) }, uNear: { value: 0.1 }, uFar: { value: 400 } },
+    vertexShader: BLIT_VERT, fragmentShader: BLIT_FRAG,
+    depthTest: true, depthWrite: true, depthFunc: THREE.AlwaysDepth, fog: false, lights: false,
+  });
+  if (depthOk) blitMat.defines.WRITE_DEPTH = 1;
+  const blitScene = new THREE.Scene();
+  const blitMesh = new THREE.Mesh(blitGeo, blitMat);
+  blitMesh.frustumCulled = false;
+  blitScene.add(blitMesh);
+  const blitCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+  function dropTarget() {
+    if (!rt) return;
+    if (rt.depthTexture) rt.depthTexture.dispose();
+    rt.dispose(); rt = null; rtW = rtH = 0;
+  }
+  function ensureTarget() {
+    const tw = Math.max(1, Math.ceil(w / cur)), th = Math.max(1, Math.ceil(h / cur));
+    if (rt && tw === rtW && th === rtH) return;
+    dropTarget();
+    rtW = tw; rtH = th;
+    const depthTexture = depthOk ? new THREE.DepthTexture(tw, th, THREE.UnsignedIntType) : null;
+    rt = new THREE.WebGLRenderTarget(tw, th, {
+      minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, generateMipmaps: false,
+      depthBuffer: true, stencilBuffer: false, depthTexture, colorSpace: THREE.SRGBColorSpace,
+    });
+    blitMat.uniforms.tDiffuse.value = rt.texture;
+    blitMat.uniforms.tDepth.value = depthTexture;
+  }
 
   function apply() {
-    renderer.setPixelRatio(cur > 0 ? 1 / cur : nativeDpr());
+    renderer.setPixelRatio(nativeDpr());
     renderer.setSize(w, h, false);
-    if (canvas) canvas.style.imageRendering = cur > 0 ? 'pixelated' : '';
+    if (canvas) canvas.style.imageRendering = '';   // the blit does the nearest upscale now
+    if (cur > 0) ensureTarget(); else dropTarget();
   }
   function resize(width, height) { w = Math.max(1, width | 0); h = Math.max(1, height | 0); apply(); }
   function setBlock(n) { cur = normalizeBlock(n); apply(); return cur; }
@@ -50,6 +131,54 @@ export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT }) {
     return setBlock(PIXEL_STEPS[(i + 1) % PIXEL_STEPS.length]);
   }
 
+  // ---- the frame ---------------------------------------------------------------------------
+  const stats = { calls: 0, triangles: 0, passes: 0 };
+  let fCalls = 0, fTris = 0, fPasses = 0, perfLast = 0;
+  const info = renderer.info;
+  function tally() { if (!info || !info.render) return; fCalls += info.render.calls; fTris += info.render.triangles; fPasses++; }
+  function closeFrame() {
+    stats.calls = fCalls; stats.triangles = fTris; stats.passes = fPasses;
+    fCalls = fTris = fPasses = 0;
+    if (!log) return;
+    const now = performance.now() / 1000;
+    if (!perfLast) perfLast = now;
+    if (now - perfLast < PERF_LOG_SEC) return;
+    perfLast = now;
+    try { log(`[race-perf] t+${Math.round(now)}s calls ${stats.calls} tris ${stats.triangles} ${label()}${rt ? ` rt ${rtW}x${rtH}` : ''}`); } catch (e) { /* host gone */ }
+  }
+
+  function render(scene, camera) {
+    if (cur === 0 || !rt) {
+      camera.layers.mask = ALL_MASK;
+      renderer.setRenderTarget(null); renderer.autoClear = true;
+      renderer.render(scene, camera); tally();
+      closeFrame();
+      return;
+    }
+    // (a) the world, low-res
+    camera.layers.mask = WORLD_MASK;
+    renderer.setRenderTarget(rt); renderer.autoClear = true;
+    renderer.render(scene, camera); tally();
+    // (b) the blit: colour + depth up to the canvas, the far end folded into the fog
+    renderer.setRenderTarget(null);
+    const u = blitMat.uniforms;
+    if (scene.fog && scene.fog.color) u.uFogColor.value.copy(scene.fog.color);
+    else if (scene.background && scene.background.isColor) u.uFogColor.value.copy(scene.background);
+    u.uNear.value = camera.near; u.uFar.value = camera.far;
+    renderer.render(blitScene, blitCam); tally();
+    // (c) the crisp layer on top, full-res; a Color background would force a clear, so it steps aside
+    const bg = scene.background;
+    scene.background = null;
+    renderer.autoClear = false;
+    camera.layers.mask = CRISP_MASK;
+    renderer.render(scene, camera); tally();
+    renderer.autoClear = true;
+    scene.background = bg;
+    camera.layers.mask = ALL_MASK;
+    closeFrame();
+  }
+
+  // ---- textures ----------------------------------------------------------------------------
   /** Apply the current mode to one texture (remembers its original filters the first time). */
   function filterTexture(tex) {
     if (!tex || !tex.isTexture) return;
@@ -63,10 +192,11 @@ export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT }) {
     tex.magFilter = mag; tex.minFilter = min; tex.generateMipmaps = mip;
     tex.needsUpdate = true;
   }
-  /** Walk every material in the scene (maps + shader sampler uniforms). */
+  /** Walk every material in the scene (maps + shader sampler uniforms). Crisp-layer objects keep theirs. */
   function retexture(scene) {
     if (!scene || !scene.traverse) return;
     scene.traverse((o) => {
+      if (o.layers && (o.layers.mask & CRISP_MASK) && !(o.layers.mask & WORLD_MASK)) return;
       const mats = Array.isArray(o.material) ? o.material : o.material ? [o.material] : [];
       for (const m of mats) {
         for (const k of MAP_KEYS) if (m[k]) filterTexture(m[k]);
@@ -75,10 +205,11 @@ export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT }) {
     });
   }
 
+  function label() { return cur > 0 ? `pixels ${cur}` : 'pixels off'; }
+
   return {
     get block() { return cur; },
-    setBlock, cycle, resize, filterTexture, retexture,
-    label() { return cur > 0 ? `pixels ${cur}` : 'pixels off'; },
+    setBlock, cycle, resize, render, filterTexture, retexture, label, stats,
   };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -20,7 +20,7 @@
  *
  *   createPixelizer({ renderer, canvas, block, log }) ->
  *     { block, setBlock(n), cycle(), resize(w, h), render(scene, camera),
- *       filterTexture(tex), retexture(scene), label(), stats }
+ *       filterTexture(tex), retexture(scene), label(), stats, dispose() }
  *
  * PIXEL_STEPS is the P-key cycle: off, 2, 3, 4, 6 screen pixels per block.
  * Put an object on the crisp layer with `obj.layers.set(CRISP_LAYER)`.
@@ -207,9 +207,12 @@ export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT, log =
 
   function label() { return cur > 0 ? `pixels ${cur}` : 'pixels off'; }
 
+  /** Free the render target and the blit material (call from the race's dispose). */
+  function dispose() { dropTarget(); blitMat.dispose(); blitGeo.dispose(); }
+
   return {
     get block() { return cur; },
-    setBlock, cycle, resize, render, filterTexture, retexture, label, stats,
+    setBlock, cycle, resize, render, filterTexture, retexture, label, stats, dispose,
   };
 }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -19,7 +19,7 @@
  * ==========================================================================*/
 
 import * as THREE from 'three';
-import { makeRng } from './consts.js';
+import { makeRng, CAM_BACK } from './consts.js';
 import { biomeById } from '../game/biomes.js';
 import { createRoomProps, pixelTex } from './roomProps.js';
 
@@ -242,8 +242,12 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   const wedgeMat = mat(new THREE.MeshLambertMaterial({ map: wedgeTex, color: wedgeTex ? 0xffffff : 0xf6e7c8 }));
   const pinkGlow = mat(new THREE.MeshLambertMaterial({ color: 0xff69b4, emissive: 0xff69b4, emissiveIntensity: 0.9 }));
   const gold = mat(new THREE.MeshLambertMaterial({ color: 0xf2c14e, emissive: 0xf2c14e, emissiveIntensity: 0.6 }));
-  // the air line is marked by PAIRS of gold cubes either side of the arc (never on the camera seat)
+  // the air line is marked by PAIRS of gold cubes either side of the arc. A dot hides while it would
+  // sit between the camera seat and the cup (from DOT_BEHIND to DOT_NEAR of the kart) and fades back
+  // in over DOT_NEAR..DOT_FAR ahead, so the low chase camera never has gold in its face mid-jump.
   const AIR_DOTS = 10, AIR_X = 2.4;
+  const DOT_NEAR = 6, DOT_FAR = 11, DOT_BEHIND = -(CAM_BACK + 2.5);
+  const airBase = [], airD = [];   // per dot: its resting matrix and wrapped depth
   const wedges = new THREE.InstancedMesh(track(wedgeGeometry(KERB_OUT, 4, 0.8)), wedgeMat, Math.max(1, ramps.length));
   const lips = new THREE.InstancedMesh(track(new THREE.BoxGeometry(KERB_OUT * 2 + 0.1, 0.2, 0.3)), pinkGlow, Math.max(1, ramps.length));
   const airDots = new THREE.InstancedMesh(track(new THREE.BoxGeometry(0.3, 0.3, 0.3)), gold, Math.max(1, ramps.length * AIR_DOTS));
@@ -253,10 +257,13 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
     lips.setMatrixAt(i, roadMatrix(r.d, 0, 0.85, 0, 1, _m));
     for (let k = 0; k < AIR_DOTS; k++) {
       const prog = (Math.floor(k / 2) + 1) / (AIR_DOTS / 2 + 1), side = k & 1 ? AIR_X : -AIR_X;
-      airDots.setMatrixAt(i * AIR_DOTS + k, roadMatrix(r.d + prog * r.airLen, side, 0.5 + r.height * Math.sin(Math.PI * prog), prog * 2, 1, _m));
+      const dd = r.d + prog * r.airLen;
+      airDots.setMatrixAt(i * AIR_DOTS + k, roadMatrix(dd, side, 0.5 + r.height * Math.sin(Math.PI * prog), prog * 2, 1, _m));
+      airBase.push(_m.clone()); airD.push(layout.wrap(dd));
     }
   });
   wedges.count = ramps.length; lips.count = ramps.length; airDots.count = ramps.length * AIR_DOTS;
+  const airK = new Float32Array(airBase.length).fill(1);   // each dot's current scale (1 = resting)
   // boost pad: full lane width, 3 m long, chevrons that run forward (texture offset), cyan glow
   const PAD_W = 2.4, PAD_L = 3.0;
   const padTex = pixelTex(24, 30, (c, w, h) => {
@@ -313,6 +320,18 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
       dirty = true;
     });
     if (dirty) cubeMesh.instanceMatrix.needsUpdate = true;
+    // air-line dots: gone while they would sit between the seat and the cup, back over DOT_NEAR..DOT_FAR
+    let adirty = false;
+    for (let i = 0; i < airD.length; i++) {
+      const rel = layout.wrap(airD[i] - d + total / 2) - total / 2;   // signed, kart-relative metres
+      let k = 1;
+      if (rel > DOT_BEHIND && rel < DOT_FAR) k = rel < DOT_NEAR ? 0 : (rel - DOT_NEAR) / (DOT_FAR - DOT_NEAR);
+      if (k === airK[i]) continue;
+      airK[i] = k;
+      airDots.setMatrixAt(i, _m.copy(airBase[i]).scale(_s.setScalar(Math.max(k, 0.0001))));
+      adirty = true;
+    }
+    if (adirty) airDots.instanceMatrix.needsUpdate = true;
     cubeMat.emissiveIntensity = 0.25 + 0.2 * (0.5 + 0.5 * Math.sin(t * 3));
     if (padTex) padTex.offset.y = (t * 1.6) % 1;          // the chevrons run forward
     padMat.color.setScalar(0.85 + 0.15 * Math.sin(t * 6));

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -110,8 +110,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const tunnel = createTunnel(layout);
     Q.tubeSegMult = segBase;
     const u = tunnel.material.uniforms;
-    u.uRings.value = Math.round(layout.totalDepth / 8);
-    u.uSpiralTurns.value = Math.round(layout.totalDepth / 22);
+    u.uRings.value = Math.round(layout.totalDepth / 12);        // a ring every 12 m (the descent's 8 m tangles at the far end)
+    u.uSpiralTurns.value = Math.round(layout.totalDepth / 36);  // and a lazier spiral, so the tube ends in a point, not a knot
     scene.add(tunnel.mesh);
     const fx = createFx({ scene, layout, tunnelMat: tunnel.material, particleFog: false });
     const dresser = createRoomDresser({ scene, layout });

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -56,8 +56,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
 
   // ---- renderer / scene / camera (engine/scene.js pattern, pitch-demo look) ----
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: Q.antialias, alpha: false, powerPreference: 'high-performance' });
-  // the big-pixel look: low internal resolution, nearest upscale; host settings.pixel / ?pixel=N override, 0 = off
-  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? PIXEL_DEFAULT : settings.pixel });
+  // the big-pixel look: the world at low resolution, bubbles + wall media crisp on top (race/pixel.js);
+  // host settings.pixel / ?pixel=N override, 0 = off; draw-call stats go to the host log every ~5 s
+  const pixel = createPixelizer({ renderer, canvas, block: settings.pixel == null ? PIXEL_DEFAULT : settings.pixel, log: (m) => { if (bridge.log) bridge.log(m); } });
   if ('outputColorSpace' in renderer) renderer.outputColorSpace = THREE.SRGBColorSpace;
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x12261f);
@@ -369,7 +370,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     if (S.running && !S.paused && !S.hostPaused) {
       try { step(W, dt); } catch (e) { bridge.log && bridge.log('race step: ' + (e && e.stack || e)); }
     }
-    renderer.render(scene, camera);
+    pixel.render(scene, camera);
   }
 
   // ---- brake / end / again / exit ----

--- a/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/walls.js
@@ -20,7 +20,8 @@
  * of room words in the room's colours. A sparse "base" set is always up (diegetic
  * placards); the "fill" set only draws while media.hasUserMedia() is false, via
  * geometry drawRange, so an empty library still gets a dressed wall. 8 meshes, only
- * the rooms in view visible (2..3 draw calls at a time).
+ * the rooms in view visible (2..3 draw calls at a time). The media posters live on
+ * pixel.js's CRISP_LAYER (full resolution); the painted signs stay in the pixel world.
  *
  * createWalls({ scene, layout, media, renderer, camera, rng }) -> { update(d, dt), setRoom(id), dispose }
  * ==========================================================================*/
@@ -30,6 +31,7 @@ import { createWallPosters } from '../engine/wallPosters.js';
 import { RADIUS } from './consts.js';
 import { ROOMS, roomById } from './rooms.js';
 import { pixelTex } from './roomProps.js';
+import { CRISP_LAYER } from './pixel.js';
 
 const BAND_LO = 0.32, BAND_HI = 1.27;   // radians from the ceiling: the upper-wall poster band
 const SIGN_INSET = 0.16;                // signs sit just inside the wall, like the posters
@@ -87,12 +89,20 @@ export function createWalls({ scene, layout, media, renderer, camera, rng }) {
 
   // ---- the posters (engine/wallPosters.js, adapted) --------------------------------------
   const posters = createWallPosters({ scene, layout, media, renderer, camera });
+  // createWallPosters adds its (unnamed) group to the scene first thing; keeping a handle lets the
+  // per-frame walk below read the children in place instead of building getPickables' array
+  const posterGroup = scene.children[scene.children.length - 1];
+  const posterMeshes = posterGroup && posterGroup.isGroup ? posterGroup.children : null;
   const seen = new Map();          // slot -> depth we last aimed it at
   let odometer = 0, lastW = null;  // unwrapped camera depth for the one-way poster logic
   function aimNewSlots() {
-    for (const mesh of posters.getPickables()) {
+    const list = posterMeshes || posters.getPickables();
+    for (let i = 0; i < list.length; i++) {
+      const mesh = list[i];
       const slot = mesh.userData && mesh.userData.slot;
-      if (!slot || seen.get(slot) === slot.depth) continue;
+      if (!slot) continue;
+      if (mesh.layers.mask !== (1 << CRISP_LAYER)) mesh.layers.set(CRISP_LAYER);   // media posters render crisp, full-res
+      if (!slot.active || !mesh.visible || slot.melt || seen.get(slot) === slot.depth) continue;
       seen.set(slot, slot.depth);
       const side = rng() < 0.5 ? -1 : 1;
       slot.angle = side * (BAND_LO + rng() * (BAND_HI - BAND_LO));


### PR DESCRIPTION
Pass 3, crisp. pixel.js becomes a two-pass renderer: the world renders to a low-res target and is blitted with depth, while bubbles and wall media render full-res on THREE layer 1 so they stay unpixelated as the owner asked. The tea emoticon "face" is removed (EMI faces forward, no face ever), the far tunnel ends in a point instead of a ring tangle, air dots clear the seat. Fewer far sprites and no per-pop allocation in the bubble field.

Stacked on #674 (feat/race-p3-mix). Merge in order.

---
Verification: node syntax check on every race module, headless Chrome (swiftshader) run of race.html?autostart=1 with zero Uncaught/TypeError/ReferenceError/404, and the WebView2 play build (--race) booted with the whole chain merged. No new binary assets. Each commit stays under the 600-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
