### PR TITLE
feat(race): Caucus Race 20/21 - drift turbo, tricks, inverted pops, lap clock, item beats

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/consts.js
@@ -20,6 +20,13 @@ export const KART_MAX_SPEED = 34;
 export const KART_MIN_SPEED = 8;
 export const GRAVITY = 18;
 
+// Drift mini-turbo (kart.js): hold drift while steering; the charge crosses these seconds to reach
+// tier 1/2/3 (blue / orange / purple sparks) and releasing hands out that many seconds of boost.
+export const DRIFT_TIER_SEC = [0.8, 1.6, 2.6];
+export const DRIFT_BOOST_SEC = [0, 1.15, 1.35, 1.6];
+/** Seconds of scrubbing the road edge before the soft wall costs a little speed (never a stop). */
+export const WALL_SCRUB_SEC = 0.5;
+
 // Pass-through pop box, metres, kart-centred. Sized for the 1.35x cup (KART_SCALE below);
 // bubbles.js field.setReach(mult) widens X/H for the magnet item.
 export const POP_HIT_D = 1.4;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/input.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/input.js
@@ -8,19 +8,28 @@
  * LT brake, A drift, X item, Start brake.
  *
  *   read() -> { steer:-1..1, accel:0..1, brake:0..1, drift:bool }
- *   onAction(cb)   cb('item' | 'brake' | 'pixel' | 'mute'), edge-triggered, never repeats on hold
+ *   onAction(cb)   cb(action) for the ACTIONS table below ('item' | 'brake' | 'pixel' | 'mute'), edge-triggered, never repeats on hold
  *   dispose()
  *
  * Law II (input honesty): nothing here ever remaps an axis. accel defaults to 1
  * when nothing is pressed, so a player who only ever steers still cruises.
  * Digital steer is eased over ~80 ms so the cup leans on the first frame
- * (Law VIII) without a hard snap.
+ * (Law VIII) without a hard snap. The mirror item flips the picture, never
+ * the hand: there is no flip/mirror API here and none may be added (the
+ * owner's law: left stays left).
  * ==========================================================================*/
 
 const KEYS = {
   ArrowLeft: 'left', KeyA: 'left', ArrowRight: 'right', KeyD: 'right',
   ArrowUp: 'accel', KeyW: 'accel', ArrowDown: 'brake', KeyS: 'brake',
   ShiftLeft: 'drift', ShiftRight: 'drift',
+};
+/** Edge-triggered actions by key code; append a line here to add one (fired once per press, never on hold). */
+const ACTIONS = {
+  KeyE: 'item',
+  Escape: 'brake',
+  KeyP: 'pixel',
+  KeyM: 'mute',   // race/audio.js listens
 };
 const DEADZONE = 0.16;
 const PAD = { steer: 0, accelBtn: 7, brakeBtn: 6, drift: 0, item: 2, start: 9 };
@@ -40,10 +49,7 @@ export function createInput({ target = window } = {}) {
     const code = e.code || '';
     if (e.type === 'keydown') {
       if (e.repeat) { if (KEYS[code]) e.preventDefault(); return; }
-      if (code === 'KeyE') { fire('item'); return; }
-      if (code === 'Escape') { fire('brake'); return; }
-      if (code === 'KeyP') { fire('pixel'); return; }
-      if (code === 'KeyM') { fire('mute'); return; }   // race/audio.js listens
+      if (ACTIONS[code]) { fire(ACTIONS[code]); return; }
       if (!KEYS[code]) return;
       down.add(KEYS[code]);
       e.preventDefault();

--- a/ConditioningControlPanel/Resources/web/dtrh/race/items.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/items.js
@@ -6,7 +6,9 @@
  * multiplier leans the pool toward catch-up items, a high one toward
  * risk/reward. The cube rolls for ROLL_SEC (the roll is decided before the
  * animation starts: Fake Shuffle), then arms; E uses it, or the cup uses it
- * for you after AUTO_USE_SEC so autopilot players never touch a key.
+ * for you after AUTO_USE_SEC so autopilot players never touch a key. Every item
+ * gets a visible beat on use (`beat`) and, for the quiet timed ones, one when it
+ * runs out (`over`), so nothing ever fires into silence.
  *
  * Effects go through the contract APIs only (kart.applyBoost, bubbles.rain,
  * bubbles.setDensity, hud.*). Anything that needs the run brain's hands is
@@ -30,16 +32,16 @@ const AUTO_USE_SEC = 1.5;
 const USED_FLASH_SEC = 0.8;
 
 export const ITEMS = [
-  { id: 'sugar_rush',   name: 'sugar rush',   glyph: '▲', desc: 'boost 2.6 s. the big word.',                 durationSec: 2.6, pool: 'catch' },
-  { id: 'tea_time',     name: 'tea time',     glyph: '◷', desc: 'the world slows for 4 s. you do not.',      durationSec: 4,   pool: 'mid' },
-  { id: 'magnet',       name: 'the wand',     glyph: '✦', desc: 'treats bend to the cup for 7 s.',            durationSec: 7,   pool: 'catch' },
-  { id: 'bubble_wand',  name: 'bubble wand',  glyph: '○', desc: 'twelve treats rain in ahead of you.',        durationSec: 0,   pool: 'catch' },
-  { id: 'lucky_star',   name: 'lucky star',   glyph: '★', desc: 'x2 on top of the ladder for 8 s.',          durationSec: 8,   pool: 'risk' },
-  { id: 'parasol',      name: 'parasol',      glyph: '☂', desc: 'the next effect pops as a treat instead.',   durationSec: 0,   pool: 'mid' },
-  { id: 'mirror',       name: 'mirror',       glyph: '◫', desc: 'the picture flips for 6 s. left is still left.', durationSec: 6, pool: 'risk' },
-  { id: 'spring',       name: 'spring',       glyph: '⤴', desc: 'a ramp, right here, right now.',            durationSec: 0,   pool: 'mid' },
-  { id: 'pocket_watch', name: 'pocket watch', glyph: '◔', desc: 'the combo timer stops for 10 s.',            durationSec: 10,  pool: 'mid' },
-  { id: 'rabbit_foot',  name: 'rabbit foot',  glyph: '♣', desc: 'jackpots come easier for 12 s.',             durationSec: 12,  pool: 'risk' },
+  { id: 'sugar_rush',   name: 'sugar rush',   glyph: '▲', desc: 'boost 2.6 s. the big word.',                 durationSec: 2.6, pool: 'catch', beat: 'sugar rush' },
+  { id: 'tea_time',     name: 'tea time',     glyph: '◷', desc: 'the world slows for 4 s. you do not.',      durationSec: 4,   pool: 'mid',   beat: 'tea time. the world slows, you do not', over: 'tea is over' },
+  { id: 'magnet',       name: 'the wand',     glyph: '✦', desc: 'treats bend to the cup for 7 s.',            durationSec: 7,   pool: 'catch', beat: 'the wand. treats come to you', over: 'wand down' },
+  { id: 'bubble_wand',  name: 'bubble wand',  glyph: '○', desc: 'twelve treats rain in ahead of you.',        durationSec: 0,   pool: 'catch', beat: 'twelve, incoming' },
+  { id: 'lucky_star',   name: 'lucky star',   glyph: '★', desc: 'x2 on top of the ladder for 8 s.',          durationSec: 8,   pool: 'risk',  beat: 'lucky star. x2 on top', over: 'star fell' },
+  { id: 'parasol',      name: 'parasol',      glyph: '☂', desc: 'the next effect pops as a treat instead.',   durationSec: 0,   pool: 'mid',   beat: 'parasol up. next effect is a treat' },
+  { id: 'mirror',       name: 'mirror',       glyph: '◫', desc: 'the picture flips for 6 s. left is still left.', durationSec: 6, pool: 'risk', beat: 'mirror. left is still left', over: 'mirror gone' },
+  { id: 'spring',       name: 'spring',       glyph: '⤴', desc: 'a ramp, right here, right now.',            durationSec: 0,   pool: 'mid',   beat: 'spring' },
+  { id: 'pocket_watch', name: 'pocket watch', glyph: '◔', desc: 'the combo timer stops for 10 s.',            durationSec: 10,  pool: 'mid',   beat: 'pocket watch. the combo waits', over: 'the watch ticks again' },
+  { id: 'rabbit_foot',  name: 'rabbit foot',  glyph: '♣', desc: 'jackpots come easier for 12 s.',             durationSec: 12,  pool: 'risk',  beat: 'rabbit foot. jackpots lean in', over: 'foot wore off' },
 ];
 const BY_ID = Object.fromEntries(ITEMS.map((it) => [it.id, it]));
 
@@ -107,7 +109,7 @@ export function createItems({ kart, bubbles, score, fx, hud, payload, rng, autoU
       armed = null; armedFor = 0;
       emit({ type: 'itemUse', id: it.id });
       apply(it);
-      if (hud) { hud.item(it.glyph, `${it.name} used`); hud.toast(it.name, 'item'); }
+      if (hud) { hud.item(it.glyph, `${it.name} used`); hud.toast(it.beat || it.name, 'item'); }
       usedFlash = USED_FLASH_SEC;
       return true;
     },
@@ -133,6 +135,7 @@ export function createItems({ kart, bubbles, score, fx, hud, payload, rng, autoU
         if (next > 0) { active.set(id, next); continue; }
         active.delete(id);
         emit({ type: 'itemEnd', id });
+        if (hud && BY_ID[id] && BY_ID[id].over) hud.toast(BY_ID[id].over, 'item');
       }
     },
     onEvent(cb) { if (typeof cb === 'function') listeners.push(cb); return () => { const i = listeners.indexOf(cb); if (i >= 0) listeners.splice(i, 1); }; },

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -8,6 +8,9 @@
 //   { type:'driftTier', tier }        the drift charge crossed a tier (1 blue, 2 orange, 3 purple)
 //   { type:'driftBoost', tier, sec }  drift released with a charge: that many seconds of boost
 //   { type:'scrub', sec }             the road edge has been scrubbed for WALL_SCRUB_SEC (speed eases off a touch)
+//   { type:'trick', name, points, streak }   a ramp trick was thrown (one per launch): 'spin left' | 'spin right' | 'backflip'
+//   { type:'landing', clean, trick, streak } touched down; clean = not on the kerb; a clean trick landing boosts
+//   { type:'inverted', on }           roll past 120 degrees (inside THE BIG WHEEL) began / ended; state.inverted mirrors it
 
 import * as THREE from 'three';
 import {
@@ -23,6 +26,12 @@ const DRIFT_SNAP = 1.6;       // m/s of counter-steer kick when a drift lets go 
 const WALL_SOFT = 0.7;        // metres from the road edge where the soft wall starts easing you back
 const WALL_SCRUB_MULT = 0.9;  // speed target while scrubbing the edge past WALL_SCRUB_SEC; the floor still holds
 const HOP_SEC = 0.28, HOP_H = 0.3;      // the drift-press hop: cosmetic, the pop box never leaves the road
+const TRICK_SEC = 0.62;                 // one full rotation of the cup (spin about up, backflip about right)
+const TRICK_POINTS = { spin: 150, flip: 250 };
+const TRICK_STREAK_MAX = 4;             // consecutive clean trick landings scale trick points by 1 + 0.5 * streak
+const LAND_BOOST_SEC = 0.7;             // a clean landing after a trick
+const LAND_CLEAN_M = 0.45;              // metres inside the road edge that still count as clean
+const INVERT_DEG = 120;                 // roll past this = upside down (pops count double, score.js)
 const TIER_COLORS = [0xFFD27A, 0x5BB8FF, 0xFF8A3D, 0xC46BFF];   // tier 0 (gold) is emi.js's own sparks
 const TARGET_AHEAD = POP_HIT_D * 0.5;   // the pop ring floats this far in front of the cup
 const TARGET_H = LANE_H - 0.15;         // ring centre: between the road box centre and a lane bubble
@@ -31,7 +40,7 @@ const CAM_BOOST_BACK = 0.7;             // the seat slides back a touch under bo
 const WORLD_UP = new THREE.Vector3(0, 1, 0), ZERO = new THREE.Vector3();
 const _m = new THREE.Matrix4(), _q = new THREE.Quaternion(), _v = new THREE.Vector3();
 const _fwd = new THREE.Vector3(), _up = new THREE.Vector3(), _right = new THREE.Vector3(), _lvl = new THREE.Vector3();
-const AX_X = new THREE.Vector3(1, 0, 0), AX_Z = new THREE.Vector3(0, 0, 1);
+const AX_X = new THREE.Vector3(1, 0, 0), AX_Y = new THREE.Vector3(0, 1, 0), AX_Z = new THREE.Vector3(0, 0, 1);
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const ease = (k, dt) => 1 - Math.exp(-k * dt);
@@ -75,6 +84,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     d: 0, x: 0, h: 0, vh: 0, speed: KART_BASE_SPEED, steer: 0, drift: false, airborne: false,
     boostSec: 0, slowMult: 1, slowSec: 0, lap: 0,
     driftSec: 0, driftTier: 0, scrub: false,
+    inverted: false, roll: 0, trick: null, trickStreak: 0,
   };
   const rig = createEmiRig({ scene, reducedMotion });
   const group = rig.group;
@@ -93,6 +103,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
 
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
   let camBoost = 0, steerS = 0, hopT = 0, scrubSec = 0, sparkAcc = 0, driftWas = false;
+  let airWas = false, steerWas = 0, trickArmed = false, trickKind = null, trickDir = 1, trickT = 1;
   const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
   const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1, driftTier: 0 };
   const listeners = [];
@@ -212,6 +223,31 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     return HOP_H * Math.sin(Math.PI * (1 - hopT / HOP_SEC));
   }
 
+  /** Airborne input: a fresh drift press backflips, a fresh steer past half lock spins. One per launch. */
+  function stepTricks(dt, inp, driftPress) {
+    if (trickT < 1) trickT = Math.min(1, trickT + dt / TRICK_SEC);
+    if (state.airborne && !airWas) { trickArmed = true; state.trick = null; }
+    if (state.airborne && trickArmed) {
+      let kind = null, dir = 1;
+      if (driftPress) kind = 'flip';
+      else if (Math.abs(inp.steer) > 0.5 && Math.abs(steerWas) <= 0.5) { kind = 'spin'; dir = inp.steer > 0 ? 1 : -1; }
+      if (kind) {
+        trickArmed = false; trickKind = kind; trickDir = dir; trickT = 0;
+        state.trick = kind === 'flip' ? 'backflip' : dir > 0 ? 'spin right' : 'spin left';
+        const points = Math.round(TRICK_POINTS[kind] * (1 + 0.5 * Math.min(state.trickStreak, TRICK_STREAK_MAX)));
+        emit({ type: 'trick', name: state.trick, points, streak: state.trickStreak });
+      }
+    }
+    if (!state.airborne && airWas) {
+      const clean = Math.abs(state.x) < ROAD_HALF_W - LAND_CLEAN_M, trick = state.trick;
+      if (trick && clean) { applyBoost(LAND_BOOST_SEC); state.trickStreak = Math.min(state.trickStreak + 1, TRICK_STREAK_MAX + 1); }
+      else state.trickStreak = 0;
+      emit({ type: 'landing', clean, trick, streak: state.trickStreak });
+      state.trick = null; trickArmed = false;
+    }
+    airWas = state.airborne; steerWas = inp.steer;
+  }
+
   function stepTierSparks(dt) {
     if (!tierSparks) return;
     const on = state.drift && state.driftTier > 0 && !state.airborne;
@@ -234,7 +270,15 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     group.quaternion.setFromRotationMatrix(_m);
     ring.quaternion.copy(group.quaternion);                            // the ring never leans
     group.quaternion.multiply(_q.setFromAxisAngle(AX_Z, lean)).multiply(_q.setFromAxisAngle(AX_X, pitch));
+    if (trickT < 1) {                                                  // the trick: one full turn, eased
+      const ang = Math.PI * 2 * smooth(trickT);
+      group.quaternion.multiply(trickKind === 'flip' ? _q.setFromAxisAngle(AX_X, -ang) : _q.setFromAxisAngle(AX_Y, ang * trickDir));
+    }
     group.updateMatrixWorld(true);
+    // upside down: how far the road's up has rolled from the world's (THE BIG WHEEL)
+    state.roll = Math.acos(clamp(_up.dot(WORLD_UP), -1, 1)) * 180 / Math.PI;
+    const inv = state.roll > INVERT_DEG;
+    if (inv !== state.inverted) { state.inverted = inv; emit({ type: 'inverted', on: inv }); }
     lay.toWorld(lay.wrap(state.d + TARGET_AHEAD), state.x, state.h + TARGET_H, ring.position);
     const swell = 1 + 0.22 * pulse;
     ring.scale.set(POP_HIT_X * reach * swell, POP_HIT_H * reach * swell, 1);
@@ -281,6 +325,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     const inp = { steer: +input.steer || 0, accel: clamp(+input.accel || 0, 0, 1), brake: clamp(+input.brake || 0, 0, 1), drift: !!input.drift };
     elapsed += dt;
     if (pulse > 0) pulse = Math.max(0, pulse - pulse * ease(7, dt) - 0.2 * dt);
+    const driftPress = inp.drift && !driftWas;
     stepSpeed(dt, inp);
     stepSteer(dt, inp);
     const prevD = state.d;
@@ -289,6 +334,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     d = lay.wrap(d);
     state.d = d;
     stepRamps(dt, lay, prevD);
+    stepTricks(dt, inp, driftPress);
     place(lay, stepHop(dt));
     stepCamera(dt, lay);
     stepTierSparks(dt);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -11,6 +11,8 @@
 //   { type:'trick', name, points, streak }   a ramp trick was thrown (one per launch): 'spin left' | 'spin right' | 'backflip'
 //   { type:'landing', clean, trick, streak } touched down; clean = not on the kerb; a clean trick landing boosts
 //   { type:'inverted', on }           roll past 120 degrees (inside THE BIG WHEEL) began / ended; state.inverted mirrors it
+//   { type:'lap', lap, sec }          the Tea Garden gate crossed again: a timed lap (the first crossing only starts the clock)
+//   { type:'split', frac, sec }       a quarter mark of the lap (0.25 / 0.5 / 0.75) passed at `sec` into the lap
 
 import * as THREE from 'three';
 import {
@@ -85,6 +87,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     boostSec: 0, slowMult: 1, slowSec: 0, lap: 0,
     driftSec: 0, driftTier: 0, scrub: false,
     inverted: false, roll: 0, trick: null, trickStreak: 0,
+    lapSec: 0, lapsTimed: 0,
   };
   const rig = createEmiRig({ scene, reducedMotion });
   const group = rig.group;
@@ -104,6 +107,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
   let camBoost = 0, steerS = 0, hopT = 0, scrubSec = 0, sparkAcc = 0, driftWas = false;
   let airWas = false, steerWas = 0, trickArmed = false, trickKind = null, trickDir = 1, trickT = 1;
+  let gateLay = null, gateD = 0, lapTimed = false, lapMark = 0;
   const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
   const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1, driftTier: 0 };
   const listeners = [];
@@ -248,6 +252,29 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     airWas = state.airborne; steerWas = inp.steer;
   }
 
+  /** The lap clock runs gate to gate (the Tea Garden gate in chunk 0; d = 0 when a layout has none). */
+  function gateFor(lay, atD) {
+    if (lay !== gateLay) {
+      const c = lay.chunks && lay.chunks[0], g = c && c.features && c.features.find((f) => f.type === 'gate');
+      gateLay = lay; gateD = g ? g.d : 0;
+      if (Math.abs(atD - gateD) < 1e-6) { lapTimed = true; state.lapSec = 0; lapMark = 0; }   // spawned on the gate: the clock runs from here
+    }
+    return gateD;
+  }
+  function stepLaps(dt, lay, prevD) {
+    const g = gateFor(lay, prevD);
+    if (lapTimed) state.lapSec += dt;
+    const crossed = prevD <= state.d ? (g > prevD && g <= state.d) : (g > prevD || g <= state.d);
+    if (crossed) {
+      if (lapTimed) { state.lapsTimed++; emit({ type: 'lap', lap: state.lapsTimed, sec: state.lapSec }); }
+      lapTimed = true; state.lapSec = 0; lapMark = 0;
+      return;
+    }
+    if (!lapTimed) return;
+    const prog = lay.wrap(state.d - g) / lay.totalDepth;
+    for (const f of [0.25, 0.5, 0.75]) if (prog >= f && lapMark < f) { lapMark = f; emit({ type: 'split', frac: f, sec: state.lapSec }); }
+  }
+
   function stepTierSparks(dt) {
     if (!tierSparks) return;
     const on = state.drift && state.driftTier > 0 && !state.airborne;
@@ -335,6 +362,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     state.d = d;
     stepRamps(dt, lay, prevD);
     stepTricks(dt, inp, driftPress);
+    stepLaps(dt, lay, prevD);
     place(lay, stepHop(dt));
     stepCamera(dt, lay);
     stepTierSparks(dt);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/kart.js
@@ -1,20 +1,29 @@
 // race/kart.js - The Caucus Race: the kart (the teacup) in track space, its placement on the road,
 // and the chase camera. Implements CONTRACT.md "race/kart.js (PR 3)". The cup + EMI meshes,
 // antenna moods, sweat and sparks live in race/emi.js; this file owns speed, steering, drift,
-// ramps, the lap counter and the camera seat. There is no fail state: speed never drops below
-// KART_MIN_SPEED and the road walls are soft.
+// the drift mini-turbo, ramps, the lap counter and the camera seat. There is no fail state: speed
+// never drops below KART_MIN_SPEED and the road walls are soft.
+//
+// Events (kart.onEvent(cb)), all fired from inside update():
+//   { type:'driftTier', tier }        the drift charge crossed a tier (1 blue, 2 orange, 3 purple)
+//   { type:'driftBoost', tier, sec }  drift released with a charge: that many seconds of boost
+//   { type:'scrub', sec }             the road edge has been scrubbed for WALL_SCRUB_SEC (speed eases off a touch)
 
 import * as THREE from 'three';
 import {
   KART_BASE_SPEED, KART_MAX_SPEED, KART_MIN_SPEED, GRAVITY, ROAD_HALF_W,
   CAM_BACK, CAM_UP, CAM_LOOK_AHEAD, CAM_LOOK_SPEED, KART_SCALE,
-  POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H,
+  POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, DRIFT_TIER_SEC, DRIFT_BOOST_SEC, WALL_SCRUB_SEC,
 } from './consts.js';
 import { createEmiRig } from './emi.js';
 
 const STEER_VMAX = 6.5;       // lateral m/s at full lock, cruise speed, no drift
 const DRIFT_STEER = 1.45;     // drift tightens the steer
+const DRIFT_SNAP = 1.6;       // m/s of counter-steer kick when a drift lets go (the cup straightens with a snap)
 const WALL_SOFT = 0.7;        // metres from the road edge where the soft wall starts easing you back
+const WALL_SCRUB_MULT = 0.9;  // speed target while scrubbing the edge past WALL_SCRUB_SEC; the floor still holds
+const HOP_SEC = 0.28, HOP_H = 0.3;      // the drift-press hop: cosmetic, the pop box never leaves the road
+const TIER_COLORS = [0xFFD27A, 0x5BB8FF, 0xFF8A3D, 0xC46BFF];   // tier 0 (gold) is emi.js's own sparks
 const TARGET_AHEAD = POP_HIT_D * 0.5;   // the pop ring floats this far in front of the cup
 const TARGET_H = LANE_H - 0.15;         // ring centre: between the road box centre and a lane bubble
 const RING_ALPHA = 0.14;                // resting alpha; a pop pulses it up
@@ -26,6 +35,35 @@ const AX_X = new THREE.Vector3(1, 0, 0), AX_Z = new THREE.Vector3(0, 0, 1);
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const ease = (k, dt) => 1 - Math.exp(-k * dt);
+const smooth = (u) => u <= 0 ? 0 : u >= 1 ? 1 : u * u * (3 - 2 * u);
+const tierFor = (sec) => { let t = 0; for (const at of DRIFT_TIER_SEC) if (sec >= at) t++; return t; };
+
+/** Tier sparks: a small world-space point pool that takes the tier colour (emi.js keeps the gold tier 0). */
+function makeTierSparks(scene, n) {
+  const pos = new Float32Array(n * 3), vel = new Float32Array(n * 3), life = new Float32Array(n);
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  const mat = new THREE.PointsMaterial({ color: TIER_COLORS[1], size: 0.2, sizeAttenuation: true, transparent: true, opacity: 0.95, depthWrite: false });
+  const pts = new THREE.Points(geo, mat); pts.frustumCulled = false; pts.visible = false;
+  scene.add(pts);
+  let head = 0;
+  return {
+    setTier(t) { mat.color.setHex(TIER_COLORS[clamp(t | 0, 0, 3)]); },
+    spawn(p, v, ttl) { const i = head; head = (head + 1) % n; pos.set([p.x, p.y, p.z], i * 3); vel.set([v.x, v.y, v.z], i * 3); life[i] = ttl; },
+    update(dt, g) {
+      let alive = 0;
+      for (let i = 0; i < n; i++) {
+        if (life[i] <= 0) continue;
+        life[i] -= dt; alive++;
+        vel[i * 3] += g.x * dt; vel[i * 3 + 1] += g.y * dt; vel[i * 3 + 2] += g.z * dt;
+        pos[i * 3] += vel[i * 3] * dt; pos[i * 3 + 1] += vel[i * 3 + 1] * dt; pos[i * 3 + 2] += vel[i * 3 + 2] * dt;
+        if (life[i] <= 0) pos[i * 3 + 1] = -1e4;
+      }
+      pts.visible = alive > 0; geo.attributes.position.needsUpdate = true;
+    },
+    dispose() { scene.remove(pts); geo.dispose(); mat.dispose(); },
+  };
+}
 
 /**
  * createKart({ scene, layout, reducedMotion }) -> kart
@@ -36,11 +74,13 @@ export function createKart({ scene, layout, reducedMotion = false }) {
   const state = {
     d: 0, x: 0, h: 0, vh: 0, speed: KART_BASE_SPEED, steer: 0, drift: false, airborne: false,
     boostSec: 0, slowMult: 1, slowSec: 0, lap: 0,
+    driftSec: 0, driftTier: 0, scrub: false,
   };
   const rig = createEmiRig({ scene, reducedMotion });
   const group = rig.group;
   group.scale.setScalar(KART_SCALE);
   scene.add(group);
+  const tierSparks = reducedMotion ? null : makeTierSparks(scene, 48);
 
   // the pop target: a faint ring at the pop box, just ahead of the cup, that pulses on a pop.
   // Its own object (not a child of the scaled rig) so it stays in honest pop-box metres.
@@ -52,9 +92,11 @@ export function createKart({ scene, layout, reducedMotion = false }) {
   let pulse = 0, reach = 1;
 
   let vx = 0, lean = 0, pitch = 0, elapsed = 0, lastRampD = -1, driftSide = 1, camReady = false, camX = 0, camH = 0;
-  let camBoost = 0, steerS = 0;
+  let camBoost = 0, steerS = 0, hopT = 0, scrubSec = 0, sparkAcc = 0, driftWas = false;
   const cam = { pos: new THREE.Vector3(), look: new THREE.Vector3(), up: new THREE.Vector3(0, 1, 0), roll: 0 };
-  const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1 };
+  const ctx = { t: 0, up: _up, right: _right, tangent: _fwd, speedNorm: 0, airborne: false, steerVel: 0, drift: false, driftSide: 1, driftTier: 0 };
+  const listeners = [];
+  const emit = (ev) => { for (const cb of listeners) { try { cb(ev); } catch (e) { /* a listener never breaks the kart */ } } };
 
   function applyBoost(sec) { state.boostSec = Math.max(state.boostSec, +sec || 0); }
   function applySlow(mult, sec) {
@@ -79,6 +121,7 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     if (state.drift) target *= 1.04;                                   // small speed keep while drifting
     target = target * (1 - input.brake) + KART_MIN_SPEED * input.brake;
     if (state.slowSec > 0) target *= state.slowMult;
+    if (state.scrub) target *= WALL_SCRUB_MULT;                         // scrubbing the kerb costs a touch, never a stop
     target = clamp(target, KART_MIN_SPEED, KART_MAX_SPEED);
     const rising = target > state.speed;
     const k = rising ? (state.boostSec > 0 ? 6 : 2.5) : (input.brake > 0 ? 3 : state.drift ? 0.8 : 1.5);
@@ -86,24 +129,55 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     state.speed = clamp(state.speed, KART_MIN_SPEED, KART_MAX_SPEED);
   }
 
+  /** Drift let go: the charge becomes boost by tier, and the cup straightens with a counter-steer snap. */
+  function releaseDrift() {
+    const tier = state.driftTier;
+    state.driftSec = 0; state.driftTier = 0; ctx.driftTier = 0;
+    if (state.airborne) return;                                        // a ramp mid-drift: the charge just fizzles
+    vx -= driftSide * DRIFT_SNAP;
+    lean += driftSide * 0.08;
+    if (tier > 0) {
+      const sec = DRIFT_BOOST_SEC[tier] || 0;
+      applyBoost(sec);
+      emit({ type: 'driftBoost', tier, sec });
+    }
+  }
+
   function stepSteer(dt, input) {
     state.steer = clamp(input.steer, -1, 1);
+    const wasDrift = state.drift;
     state.drift = !!input.drift && !state.airborne && Math.abs(state.steer) > 0.15;
-    if (state.drift) driftSide = state.steer > 0 ? 1 : -1;
-    // speed-dependent authority: the faster you go the wider the sweep, drift claws it back
-    let auth = 0.72 + 0.28 * Math.min(1, KART_BASE_SPEED / state.speed);
+    // the hop: a fresh press of drift on the road bounces the cup (cosmetic; state.h stays put)
+    if (input.drift && !driftWas && !state.airborne && hopT <= 0) hopT = HOP_SEC;
+    driftWas = !!input.drift;
+    if (state.drift) {
+      driftSide = state.steer > 0 ? 1 : -1;
+      state.driftSec += dt;
+      const tier = tierFor(state.driftSec);
+      if (tier > state.driftTier) { state.driftTier = tier; ctx.driftTier = tier; if (tierSparks) tierSparks.setTier(tier); emit({ type: 'driftTier', tier }); }
+    } else if (wasDrift) releaseDrift();
+    // speed-dependent authority: nimble at the floor, planted under boost; drift claws it back
+    const sn = clamp((state.speed - KART_MIN_SPEED) / (KART_MAX_SPEED - KART_MIN_SPEED), 0, 1);
+    let auth = 1.15 - 0.4 * smooth(sn);
     if (state.drift) auth *= DRIFT_STEER;
     if (state.airborne) auth *= 0.35;
     let vTarget = state.steer * STEER_VMAX * auth;
     // soft wall: the last WALL_SOFT metres bleed the outward push away, no bounce shock
     const edge = ROAD_HALF_W - Math.abs(state.x);
-    if (edge < WALL_SOFT && Math.sign(vTarget) === Math.sign(state.x)) vTarget *= clamp(edge / WALL_SOFT, 0, 1);
+    const outward = state.steer !== 0 && Math.sign(state.steer) === Math.sign(state.x);
+    if (edge < WALL_SOFT && outward) vTarget *= clamp(edge / WALL_SOFT, 0, 1);
     vx += (vTarget - vx) * ease(state.drift ? 9 : 6, dt);
     state.x += vx * dt;
     if (Math.abs(state.x) > ROAD_HALF_W) {
       state.x = Math.sign(state.x) * ROAD_HALF_W;
       if (Math.sign(vx) === Math.sign(state.x)) vx *= 0.25;
     }
+    // the kerb: leaning on the edge for WALL_SCRUB_SEC eases the speed target off a little (stepSpeed)
+    const scrubbing = edge < 0.12 && outward && Math.abs(state.steer) > 0.3 && !state.airborne;
+    scrubSec = scrubbing ? scrubSec + dt : 0;
+    const scrub = scrubSec >= WALL_SCRUB_SEC;
+    if (scrub && !state.scrub) emit({ type: 'scrub', sec: scrubSec });
+    state.scrub = scrub;
     const leanT = -vx * 0.07 - (state.drift ? state.steer * 0.1 : 0);
     lean += (leanT - lean) * ease(8, dt);
   }
@@ -131,10 +205,31 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     pitch += (pitchT - pitch) * ease(6, dt);
   }
 
-  function place(lay) {
+  function stepHop(dt) {
+    if (hopT <= 0) return 0;
+    hopT -= dt;
+    if (hopT <= 0) { hopT = 0; rig.squash(0.3); return 0; }
+    return HOP_H * Math.sin(Math.PI * (1 - hopT / HOP_SEC));
+  }
+
+  function stepTierSparks(dt) {
+    if (!tierSparks) return;
+    const on = state.drift && state.driftTier > 0 && !state.airborne;
+    sparkAcc = on ? sparkAcc + dt * (30 + 20 * state.driftTier) : 0;
+    while (sparkAcc >= 1) {
+      sparkAcc -= 1;
+      _v.copy(group.position).addScaledVector(_right, -driftSide * 0.85 * KART_SCALE).addScaledVector(_fwd, -0.4).addScaledVector(_up, 0.05);
+      const vel = _lvl.copy(_up).multiplyScalar(1 + Math.random() * 2.5).addScaledVector(_right, -driftSide * (0.5 + Math.random() * 2)).addScaledVector(_fwd, -(3 + Math.random() * 4));
+      tierSparks.spawn(_v, vel, 0.28 + Math.random() * 0.18);
+    }
+    tierSparks.update(dt, _lvl.copy(_up).multiplyScalar(-12));
+  }
+
+  function place(lay, hopH) {
     lay.toWorld(state.d, state.x, state.h, group.position);
     const f = lay.frameAtDepth(state.d);
     _fwd.copy(f.tangent); _up.copy(f.up); _right.copy(f.right || _v.crossVectors(_up, _fwd));
+    if (hopH > 0) group.position.addScaledVector(_up, hopH);
     _m.lookAt(_fwd, ZERO, _up);                                        // +z faces down the road
     group.quaternion.setFromRotationMatrix(_m);
     ring.quaternion.copy(group.quaternion);                            // the ring never leans
@@ -194,8 +289,9 @@ export function createKart({ scene, layout, reducedMotion = false }) {
     d = lay.wrap(d);
     state.d = d;
     stepRamps(dt, lay, prevD);
-    place(lay);
+    place(lay, stepHop(dt));
     stepCamera(dt, lay);
+    stepTierSparks(dt);
     ctx.t = elapsed; ctx.speedNorm = state.speed / KART_MAX_SPEED; ctx.airborne = state.airborne;
     ctx.steerVel = vx; ctx.drift = state.drift; ctx.driftSide = driftSide;
     rig.update(dt, ctx);
@@ -212,13 +308,19 @@ export function createKart({ scene, layout, reducedMotion = false }) {
   function pulseTarget() { pulse = 1; }
   /** Magnet: the ring grows with the field's reach so the wider pop box is visible. */
   function setReach(mult) { reach = clamp(+mult || 1, 0.5, 3); }
+  function onEvent(cb) { if (typeof cb === 'function') listeners.push(cb); return () => { const i = listeners.indexOf(cb); if (i >= 0) listeners.splice(i, 1); }; }
 
   function dispose() {
     scene.remove(group); scene.remove(ring);
     ring.geometry.dispose(); ringMat.dispose();
+    if (tierSparks) tierSparks.dispose();
     rig.dispose();
+    listeners.length = 0;
   }
 
   return { state, update, applyBoost, applySlow, setMood: rig.setMood, setFraught: rig.setFraught, camera, group,
-    pulseTarget, setReach, dispose };
+    pulseTarget, setReach, onEvent, dispose };
 }
+
+// self-check: node --check is the bar; the stub-layout drift/ramp/lap tests live in the pass-three
+// harness (straight + circular layouts against the vendored three) and are not committed.

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -130,6 +130,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const w = { layout, tunnel, fx, dresser, walls, kart, score, field, items, rng };
     field.onPop((p) => onPop(w, p));
     field.onMiss((m) => onMiss(w, m));
+    kart.onEvent((e) => onKart(w, e));
     score.onEvent((e) => onScore(w, e));
     items.onEvent((e) => onItem(w, e));
     pixel.retexture(scene);
@@ -294,6 +295,15 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
         else if (e.id === 'rabbit_foot') S.jackpotBias = 1;
         else if (e.id === 'magnet') { S.magnet = false; w.field.setReach(1); w.kart.setReach(1); }
         break;
+    }
+  }
+
+  // ---- kart events (drift turbo, tricks, the wheel, laps) ----
+  const TURBO = ['', 'mini turbo', 'super turbo', 'ultra turbo'];
+  function onKart(w, e) {
+    switch (e.type) {
+      case 'driftTier': sfx('ui_click', 0.3 + 0.15 * e.tier); break;
+      case 'driftBoost': hud.toast(TURBO[e.tier] || 'turbo', 'pop'); sfx('tunnel_powerup_collect', 0.5 + 0.15 * e.tier); if (e.tier >= 2) shake.shake(0.12 * e.tier, 160); poke(e.tier >= 3 ? 'smug' : 'streamed', 1.0); break;
     }
   }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -307,6 +307,8 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
       case 'trick': { const g = w.score.trick(e.points, e.name); hud.toast(`${e.name} +${g}`, 'pop'); sfx('chain_pop', 0.8); poke('smug', 0.6); break; }
       case 'landing': if (e.trick) { hud.toast(e.clean ? (e.streak >= 3 ? 'hat trick, clean' : 'clean') : 'kerbed it', e.clean ? 'pop' : 'almost'); if (e.clean) sfx('surface', 0.5); } break;
       case 'inverted': w.score.setInverted(e.on); if (e.on) { hud.toast('upside down', 'effect'); poke('shock', 0.8); } break;
+      case 'lap': { const r = w.score.lap(e.sec); hud.toast(`lap ${r.text}`, 'item'); if (r.pb && r.prevBest > 0) { hud.toast('pb!', 'jackpot'); sfx('pb_fanfare', 0.9); poke('jackpot', 1.5); } break; }
+      case 'split': w.score.pace(e.frac, e.sec); break;
     }
   }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -304,6 +304,9 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     switch (e.type) {
       case 'driftTier': sfx('ui_click', 0.3 + 0.15 * e.tier); break;
       case 'driftBoost': hud.toast(TURBO[e.tier] || 'turbo', 'pop'); sfx('tunnel_powerup_collect', 0.5 + 0.15 * e.tier); if (e.tier >= 2) shake.shake(0.12 * e.tier, 160); poke(e.tier >= 3 ? 'smug' : 'streamed', 1.0); break;
+      case 'trick': { const g = w.score.trick(e.points, e.name); hud.toast(`${e.name} +${g}`, 'pop'); sfx('chain_pop', 0.8); poke('smug', 0.6); break; }
+      case 'landing': if (e.trick) { hud.toast(e.clean ? (e.streak >= 3 ? 'hat trick, clean' : 'clean') : 'kerbed it', e.clean ? 'pop' : 'almost'); if (e.clean) sfx('surface', 0.5); } break;
+      case 'inverted': w.score.setInverted(e.on); if (e.on) { hud.toast('upside down', 'effect'); poke('shock', 0.8); } break;
     }
   }
 
@@ -340,6 +343,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     }
     if (S.wasAirborne && !ks.airborne) { shake.shake(0.8, 300); poke('smug', 0.7); }
     S.wasAirborne = ks.airborne;
+    for (const n of w.score.drainNotes()) { hud.toast(n.text, n.kind); if (n.mood) poke(n.mood, 1.2); if (n.sfx) sfx(n.sfx, 0.9); }   // upside down, full circle, hot lap
 
     // tube + fx + rooms
     S.tunnelTime += wdt * (0.5 + ks.speed / 12);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/score.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/score.js
@@ -6,6 +6,14 @@
  * No renderer, no DOM: pure state plus an event stream a HUD reacts to.
  * Nothing here ever subtracts: a miss or a timeout only lets the combo go
  * (mult back to x1), the score never moves down (no-lose contract).
+ *
+ * Pass three additions (all additive):
+ *   pop(points, kindId, { inverted })  upside down (THE BIG WHEEL) pops count double; the `pop`
+ *                                      event carries the base `gain` plus `bonus`, and a note says so
+ *   setInverted(on)                    kart.js `inverted` events land here; leaving the wheel with
+ *                                      FULL_CIRCLE_POPS or more inverted pops pays the "full circle"
+ *   trick(points, name)                a ramp trick: points * mult, emits `trick`
+ *   drainNotes()                       the HUD lines onScore cannot phrase itself ([{text, kind, mood, sfx}])
  * ==========================================================================*/
 
 import { MULT_LADDER, COMBO_HOLD_SEC } from './consts.js';
@@ -15,6 +23,7 @@ const BEST_KEY = 'race.best';
 const NEAR_MISS_POINTS = 25;
 const JACKPOT_COMBOS = [25, 50, 100];           // combo rungs that fire a major jackpot on their own
 const JACKPOT_BONUS = { minor: 100, major: 250, royal: 1000 };
+const FULL_CIRCLE_POPS = 3, FULL_CIRCLE_BONUS = 300;
 
 const ladderMult = (combo) => { let m = 1; for (const [at, mult] of MULT_LADDER) if (combo >= at) m = mult; return m; };
 const ladderStep = (combo) => MULT_LADDER.some(([at]) => at === combo && at > 0);
@@ -23,7 +32,10 @@ function saveBest(v) { try { localStorage.setItem(BEST_KEY, String(v)); } catch 
 
 export function createScore() {
   const state = { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, best: loadBest(),
-    popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0 };
+    popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0,
+    inverted: false, invertedPops: 0, tricks: 0, trickPoints: 0 };
+  const notes = [];
+  const note = (text, kind = 'pop', mood = null, sfx = null) => { notes.push({ text, kind, mood, sfx }); };
   let hold = 0;          // seconds of combo left before it lets go
   let freezeSec = 0;     // pocket_watch: the hold timer stands still
   let boost = 1, boostSec = 0;   // lucky_star: a temporary multiplier on top of the ladder
@@ -50,17 +62,40 @@ export function createScore() {
     return lost;
   }
 
-  function pop(points, kindId) {
+  function pop(points, kindId, opts) {
     const k = KIND_BY_ID[kindId];
+    const inverted = opts && 'inverted' in opts ? !!opts.inverted : state.inverted;
     state.combo++; hold = COMBO_HOLD_SEC;
     if (state.combo > state.bestCombo) state.bestCombo = state.combo;
     const step = setMult() || ladderStep(state.combo);
     const gain = Math.round((Number(points) || 0) * state.mult);
-    state.score += gain; state.popped++;
+    const bonus = inverted ? gain : 0;                     // upside down: the pop counts twice
+    state.score += gain + bonus; state.popped++;
     if (k && k.kind === 'effect') state.effects++; else state.treats++;
-    emit({ type: 'pop', kindId, points, gain, combo: state.combo, mult: state.mult, score: state.score });
+    if (inverted) { state.invertedPops++; if (bonus > 0) note(`upside down +${bonus}`, 'pop'); }
+    emit({ type: 'pop', kindId, points, gain, bonus, inverted, combo: state.combo, mult: state.mult, score: state.score });
     emit({ type: 'combo', combo: state.combo, step, mult: state.mult, hold });
     if (JACKPOT_COMBOS.includes(state.combo)) jackpot('major');
+    return gain + bonus;
+  }
+  /** kart.js says the road rolled past 120 degrees (on) or back (off). Off pays the full circle. */
+  function setInverted(on) {
+    on = !!on;
+    if (on === state.inverted) return;
+    state.inverted = on;
+    if (on) { state.invertedPops = 0; return; }
+    if (state.invertedPops >= FULL_CIRCLE_POPS) {
+      const gain = Math.round(FULL_CIRCLE_BONUS * state.mult);
+      state.score += gain;
+      note(`full circle +${gain}`, 'jackpot', 'jackpot', 'golden_pop');
+      emit({ type: 'fullCircle', gain, pops: state.invertedPops, score: state.score });
+    }
+  }
+  /** A ramp trick landed in the ledger: points * mult, never a combo step (the pops own the ladder). */
+  function trick(points, name) {
+    const gain = Math.round((Number(points) || 0) * state.mult);
+    state.score += gain; state.tricks++; state.trickPoints += gain;
+    emit({ type: 'trick', name, gain, mult: state.mult, score: state.score });
     return gain;
   }
   /** A treat slipped behind the kart: the streak gets a shiver, the score does not move. */
@@ -98,13 +133,16 @@ export function createScore() {
   }
   function reset() {
     touchBest();
-    Object.assign(state, { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0 });
-    hold = 0; freezeSec = 0; boost = 1; boostSec = 0;
+    Object.assign(state, { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0,
+      inverted: false, invertedPops: 0, tricks: 0, trickPoints: 0 });
+    hold = 0; freezeSec = 0; boost = 1; boostSec = 0; notes.length = 0;
   }
 
   return {
-    state, pop, miss, nearMiss, bank, jackpot, tick, reset,
+    state, pop, miss, nearMiss, bank, jackpot, tick, reset, setInverted, trick,
     onEvent(cb) { if (typeof cb === 'function') cbs.push(cb); },
+    /** Pending HUD notes (upside down, full circle, ...), oldest first; the queue empties. */
+    drainNotes() { return notes.splice(0, notes.length); },
     // items.js hooks (additive to the contract): pocket_watch + lucky_star
     freezeCombo(sec) { freezeSec = Math.max(freezeSec, Number(sec) || 0); },
     boostMult(mult, sec) { boost = Math.max(1, Number(mult) || 1); boostSec = Number(sec) || 0; setMult(); },
@@ -127,5 +165,12 @@ if (typeof process !== 'undefined' && process.env && process.env.RACE_SELFCHECK)
   s.pop(15, 'flash'); console.assert(s.state.effects === 1 && s.state.treats === 8, 'kind tally');
   const b = s.bank(); console.assert(b === 165 && s.state.score === 0 && s.state.banked === 165, 'bank');
   console.assert(ev.includes('mult') && ev.includes('bank') && ev.includes('combo'), 'events');
+  // upside down: pops double, three of them in one wheel pass pay the full circle on the way out
+  s.setInverted(true); const g = s.pop(10, 'treat'); console.assert(g === 20 && s.state.score === 20, 'inverted pop doubles');
+  s.pop(10, 'treat'); s.pop(10, 'treat'); s.setInverted(false);
+  console.assert(s.state.score === 20 + 40 + 40 + 300 * 2 && ev.includes('fullCircle'), 'full circle');
+  console.assert(s.drainNotes().map((n) => n.text).join('|') === 'upside down +20|upside down +40|upside down +40|full circle +600' && s.drainNotes().length === 0, 'notes drain once');
+  console.assert(s.pop(10, 'treat', { inverted: true }) === 40 && s.pop(10, 'treat') === 20, 'opts.inverted overrides');
+  console.assert(s.trick(150, 'spin left') === 300 && s.state.tricks === 1, 'trick pays points * mult');
   console.log('score.js self-check ok', s.state);
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/score.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/score.js
@@ -14,12 +14,17 @@
  *                                      FULL_CIRCLE_POPS or more inverted pops pays the "full circle"
  *   trick(points, name)                a ramp trick: points * mult, emits `trick`
  *   drainNotes()                       the HUD lines onScore cannot phrase itself ([{text, kind, mood, sfx}])
+ *   lap(sec) -> {sec, text, pb, best, prevBest}   a timed lap from kart.js; best lap kept in localStorage
+ *   pace(frac, sec)                    a quarter split; on best-lap pace state.hotlap goes true, and the
+ *                                      first golden popped while hot pays "hot lap" (once a lap)
  * ==========================================================================*/
 
 import { MULT_LADDER, COMBO_HOLD_SEC } from './consts.js';
 import { KIND_BY_ID } from './bubbleKinds.js';
 
 const BEST_KEY = 'race.best';
+const BEST_LAP_KEY = 'race.bestLap';
+const HOT_LAP_BONUS = 100, HOT_LAP_SLACK_SEC = 0.15;
 const NEAR_MISS_POINTS = 25;
 const JACKPOT_COMBOS = [25, 50, 100];           // combo rungs that fire a major jackpot on their own
 const JACKPOT_BONUS = { minor: 100, major: 250, royal: 1000 };
@@ -29,11 +34,21 @@ const ladderMult = (combo) => { let m = 1; for (const [at, mult] of MULT_LADDER)
 const ladderStep = (combo) => MULT_LADDER.some(([at]) => at === combo && at > 0);
 function loadBest() { try { const v = Number(localStorage.getItem(BEST_KEY)); return isFinite(v) && v > 0 ? v : 0; } catch (e) { return 0; } }
 function saveBest(v) { try { localStorage.setItem(BEST_KEY, String(v)); } catch (e) { /* private mode */ } }
+function loadBestLap() { try { const v = Number(localStorage.getItem(BEST_LAP_KEY)); return isFinite(v) && v > 0 ? v : 0; } catch (e) { return 0; } }
+function saveBestLap(v) { try { localStorage.setItem(BEST_LAP_KEY, String(v)); } catch (e) { /* private mode */ } }
+/** "1:42.3" (minutes only when there are any). */
+export function fmtLap(sec) {
+  sec = Math.max(0, Number(sec) || 0);
+  const m = Math.floor(sec / 60), s = sec - m * 60;
+  return m > 0 ? `${m}:${s.toFixed(1).padStart(4, '0')}` : s.toFixed(1);
+}
 
 export function createScore() {
   const state = { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, best: loadBest(),
     popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0,
-    inverted: false, invertedPops: 0, tricks: 0, trickPoints: 0 };
+    inverted: false, invertedPops: 0, tricks: 0, trickPoints: 0,
+    laps: 0, lastLap: 0, bestLap: loadBestLap(), hotlap: false };
+  let hotPaid = false;   // the hot lap note, once a lap
   const notes = [];
   const note = (text, kind = 'pop', mood = null, sfx = null) => { notes.push({ text, kind, mood, sfx }); };
   let hold = 0;          // seconds of combo left before it lets go
@@ -73,6 +88,12 @@ export function createScore() {
     state.score += gain + bonus; state.popped++;
     if (k && k.kind === 'effect') state.effects++; else state.treats++;
     if (inverted) { state.invertedPops++; if (bonus > 0) note(`upside down +${bonus}`, 'pop'); }
+    if (state.hotlap && !hotPaid && kindId === 'golden') {
+      hotPaid = true;
+      const hot = Math.round(HOT_LAP_BONUS * state.mult);
+      state.score += hot;
+      note(`hot lap +${hot}`, 'jackpot', 'smug', 'streak_milestone');
+    }
     emit({ type: 'pop', kindId, points, gain, bonus, inverted, combo: state.combo, mult: state.mult, score: state.score });
     emit({ type: 'combo', combo: state.combo, step, mult: state.mult, hold });
     if (JACKPOT_COMBOS.includes(state.combo)) jackpot('major');
@@ -90,6 +111,23 @@ export function createScore() {
       note(`full circle +${gain}`, 'jackpot', 'jackpot', 'golden_pop');
       emit({ type: 'fullCircle', gain, pops: state.invertedPops, score: state.score });
     }
+  }
+  /** A timed lap: the best lap lives next to the best score. Never a penalty for a slow one. */
+  function lap(sec) {
+    sec = Number(sec) || 0;
+    const prevBest = state.bestLap;
+    const pb = sec > 0 && (prevBest === 0 || sec < prevBest);
+    if (pb) { state.bestLap = sec; saveBestLap(sec); }
+    state.laps++; state.lastLap = sec; state.hotlap = false; hotPaid = false;
+    const r = { sec, text: fmtLap(sec), pb, best: state.bestLap, prevBest };
+    emit({ type: 'lap', lap: state.laps, ...r });
+    return r;
+  }
+  /** A quarter split at `frac` of the lap, `sec` in: hot when on best-lap pace. */
+  function pace(frac, sec) {
+    frac = Number(frac) || 0; sec = Number(sec) || 0;
+    state.hotlap = state.bestLap > 0 && frac > 0 && sec <= state.bestLap * frac + HOT_LAP_SLACK_SEC;
+    return state.hotlap;
   }
   /** A ramp trick landed in the ledger: points * mult, never a combo step (the pops own the ladder). */
   function trick(points, name) {
@@ -134,12 +172,12 @@ export function createScore() {
   function reset() {
     touchBest();
     Object.assign(state, { score: 0, combo: 0, mult: 1, bank: 0, banked: 0, popped: 0, treats: 0, effects: 0, nearMisses: 0, bestCombo: 0,
-      inverted: false, invertedPops: 0, tricks: 0, trickPoints: 0 });
-    hold = 0; freezeSec = 0; boost = 1; boostSec = 0; notes.length = 0;
+      inverted: false, invertedPops: 0, tricks: 0, trickPoints: 0, laps: 0, lastLap: 0, hotlap: false });
+    hold = 0; freezeSec = 0; boost = 1; boostSec = 0; notes.length = 0; hotPaid = false;
   }
 
   return {
-    state, pop, miss, nearMiss, bank, jackpot, tick, reset, setInverted, trick,
+    state, pop, miss, nearMiss, bank, jackpot, tick, reset, setInverted, trick, lap, pace,
     onEvent(cb) { if (typeof cb === 'function') cbs.push(cb); },
     /** Pending HUD notes (upside down, full circle, ...), oldest first; the queue empties. */
     drainNotes() { return notes.splice(0, notes.length); },
@@ -169,8 +207,14 @@ if (typeof process !== 'undefined' && process.env && process.env.RACE_SELFCHECK)
   s.setInverted(true); const g = s.pop(10, 'treat'); console.assert(g === 20 && s.state.score === 20, 'inverted pop doubles');
   s.pop(10, 'treat'); s.pop(10, 'treat'); s.setInverted(false);
   console.assert(s.state.score === 20 + 40 + 40 + 300 * 2 && ev.includes('fullCircle'), 'full circle');
-  console.assert(s.drainNotes().map((n) => n.text).join('|') === 'upside down +20|upside down +40|upside down +40|full circle +600' && s.drainNotes().length === 0, 'notes drain once');
+  console.assert(s.drainNotes().map((n) => n.text).join('|') === 'upside down +10|upside down +20|upside down +20|full circle +600' && s.drainNotes().length === 0, 'notes drain once');
   console.assert(s.pop(10, 'treat', { inverted: true }) === 40 && s.pop(10, 'treat') === 20, 'opts.inverted overrides');
   console.assert(s.trick(150, 'spin left') === 300 && s.state.tricks === 1, 'trick pays points * mult');
+  // laps: the first is a pb by definition, a faster one is a pb, a slower one is not; hot lap pays once
+  const l1 = s.lap(102.3), l2 = s.lap(101.0), l3 = s.lap(140);
+  console.assert(l1.pb && l1.prevBest === 0 && l2.pb && !l3.pb && s.state.bestLap === 101 && l1.text === '1:42.3' && fmtLap(59.96) === '60.0', 'laps + pb');
+  console.assert(s.pace(0.5, 50.5) === true && s.state.hotlap && s.pace(0.75, 80) === false, 'pace: hot at half, cold at three quarters');
+  s.pace(0.75, 75.5); s.drainNotes(); const sc = s.state.score; s.pop(50, 'golden'); s.pop(50, 'golden');
+  console.assert(s.drainNotes().filter((n) => n.text.startsWith('hot lap')).length === 1 && s.state.score >= sc + 300, 'hot lap once a lap');
   console.log('score.js self-check ok', s.state);
 }


### PR DESCRIPTION
Pass 3, fun. Drift mini-turbo tiers, hop, kerb scrub and a kart event bus; ramp tricks with a clean-landing boost; upside-down double pops and the "full circle" in the Big Wheel; a lap clock with personal best and hot laps; every item gets its own beat.

Stacked on #677 (feat/race-p3-audio). Merge in order.

---
Verification: node syntax check on every race module, headless Chrome (swiftshader) run of race.html?autostart=1 with zero Uncaught/TypeError/ReferenceError/404, and the WebView2 play build (--race) booted with the whole chain merged. No new binary assets. Each commit stays under the 600-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
