### PR TITLE
feat(race): Caucus Race 21/21 - box shatter, Burst/GG cut, toast runs, cup handle, perf governor

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/AUDIO.md
@@ -17,7 +17,9 @@ per-frame edges (airborne, boost, drift, the Big Wheel span, the room).
 - Master = host `init.settings.masterVolume / 100` (60 standalone). `M` toggles the dive's shared
   mute (`shared/audioMute.js`, persisted in localStorage as `rh-audio-muted`) with a HUD toast;
   a persisted mute is announced on boot. Muted = no in-page voices AND no host legs.
-- One-shots are capped at **6 voices**; the 7th drops the quietest (logged, rate-limited 5 s).
+- One-shots are capped at **8 voices**; the 9th drops the quietest (logged, rate-limited 5 s).
+  Two pops inside 28 ms are one pop (a chain, not a machine gun); the near-miss whisper fires
+  at most every 260 ms. `Burst.mp3` and `GG.mp3` are not loaded: the owner cut both.
   Loops (music, the speed bed, drift sparks) do not count.
 - Pops climb with the combo: **+1 semitone per 4 combo, capped at +7**, plus +-20 cents of jitter
   so a chain never machine-guns. Rungs climb the chime ladder: x2 chime1, x3 chime2, x4 chime3,
@@ -47,9 +49,9 @@ on the ground, 0 otherwise (that is the crackle). Nothing here is built while mu
 |------|--------|--------------------|-----------------------|
 | treat pop | `field.onPop` treat | Pop / Pop2 / Pop3 round-robin, combo pitch, panned, 0.34 | - |
 | lucky pop | `field.onPop` lucky | Pop2 + chime1 at +5 (item incoming) | - |
-| prism pop | `field.onPop` prism | Burst at +3 (its chained pops sound themselves) | - |
-| golden pop | `field.onPop` golden | Burst 0.5 | `golden_pop` 0.9 |
-| jackpot | `score` jackpot | GG 0.5 (minor 0.35), 120 ms after the Burst | - |
+| prism pop | `field.onPop` prism | Pop2 at +3 + chime1 at +5 (its chained pops sound themselves) | - |
+| golden pop | `field.onPop` golden | Pop3 at +2, chime3 at +7 (50 ms), chime3 at +12 (140 ms) | swallowed (`golden_pop` 0.9) |
+| jackpot | `score` jackpot | chime1-2-3 arpeggio 80 ms (minor 0.7), major adds chime3 at +12 (300 ms) | - |
 | effect pop | `field.onPop` effect (not "held") | Pop at -5 semis through a 1.1 kHz lowpass + 140>50 Hz sine thud | - |
 | near miss | `score` almost | Pop2 at -4, 0.10 (the whisper) | - |
 | rung up | `score` mult (to > from) | chime ladder (above) | swallowed (`streak_milestone` 0.6) |

--- a/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/audio.js
@@ -31,19 +31,24 @@ import { audioUrl, altAudioUrl } from '../shared/audioSrc.js';
 import { ROAD_HALF_W, KART_MIN_SPEED, KART_MAX_SPEED, makeRng } from './consts.js';
 
 export const SFX_BASE = '/dtrh/assets/bubbles/sfx/';
-export const MAX_VOICES = 6;            // one-shots at once; the quietest is dropped for the 7th
+export const MAX_VOICES = 8;            // one-shots at once; the quietest is dropped for the 9th
+export const POP_GAP_MS = 28;           // two pops closer than this are one pop (a chain, not a machine gun)
+export const ALMOST_GAP_MS = 260;       // the near-miss whisper at most this often
 export const PITCH_CAP_SEMIS = 7;       // the combo ladder tops out here
 export const PITCH_STEP_COMBO = 4;      // +1 semitone per this many combo
 
 /** Host catalogue names this page may send (verified against Resources/sounds/chaos/). */
 export const HOST_SFX = new Set([
   'depth_change', 'pb_fanfare', 'streak_milestone', 'golden_pop', 'ui_click',
-  'tunnel_powerup_collect', 'time_slow_in', 'time_slow_out', 'surface', 'thud',
+  'tunnel_powerup_collect', 'time_slow_in', 'time_slow_out', 'surface', 'thud', 'chain_pop',
 ]);
 
-const FILES = { pop: 'Pop.mp3', pop2: 'Pop2.mp3', pop3: 'Pop3.mp3', chime1: 'chime1.mp3', chime2: 'chime2.mp3', chime3: 'chime3.mp3', burst: 'Burst.mp3', gg: 'GG.mp3' };
+// Burst.mp3 and GG.mp3 are deliberately NOT here: the owner cut both (they read as random
+// stingers on a bubble pop). Golden, prism and the jackpot are pops + chimes now.
+const FILES = { pop: 'Pop.mp3', pop2: 'Pop2.mp3', pop3: 'Pop3.mp3', chime1: 'chime1.mp3', chime2: 'chime2.mp3', chime3: 'chime3.mp3' };
 const POPS = ['pop', 'pop2', 'pop3'];
-const LEVELS = { sfx: 1, pop: 0.34, effect: 0.42, whisper: 0.1, chime: 0.36, burst: 0.5, gg: 0.5, tick: 0.16, thud: 0.55 };
+const POP_KEYS = new Set(POPS);
+const LEVELS = { sfx: 1, pop: 0.34, effect: 0.42, whisper: 0.1, chime: 0.36, tick: 0.16, thud: 0.55 };
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 const semisToRate = (s) => Math.pow(2, s / 12);
 
@@ -130,6 +135,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
   const live = { world: null, run: null, kart: null };   // what update() last saw (run/kart are live objects)
   const edge = { room: null, airborne: false, boost: 0, d: null, drift: false };
   let ctx = null, master = null, sfxBus = null, noise = null, popRR = 0, disposed = false, dropped = 0, dropLogT = 0;
+  let lastPopAt = -1e9, lastAlmostAt = -1e9;   // performance.now() ms: the pop gap and the whisper gap
   let lastScorePop = null;       // the score 'pop' event that ran just before the field pop reaches us
   // music: the chain is duck -> lowpass (fraught / Undertow / tea time) -> highpass (Grey Ward) -> level -> master
   let musicDuck = null, musicLp = null, musicHp = null, musicLevelNode = null, elementMode = false;
@@ -327,6 +333,11 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     const buf = buffers.get(key);
     if (!buf || buf === 'pending' || buf === 'failed') return null;
     const level = clamp(opts.level == null ? 0.3 : opts.level, 0, 1);
+    if (POP_KEYS.has(key) && !opts.at) {   // a chain of pops inside POP_GAP_MS is one pop
+      const nowMs = performance.now();
+      if (nowMs - lastPopAt < POP_GAP_MS) return null;
+      lastPopAt = nowMs;
+    }
     admit(level);
     try {
       const t = ctx.currentTime + Math.max(0, opts.at || 0);
@@ -373,18 +384,18 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     const semis = pitchSemis(combo()), pan = panOf(p.x);
     const asEffect = p.kind === 'effect' && (!scored || scored.kindId !== 'treat');
     if (asEffect) { play('pop', { level: LEVELS.effect, semis: semis - 5, pan, lowpass: 1100 }); synth({ kind: 'sine', f0: 140, f1: 50, sec: 0.16, level: 0.28 }); return; }
-    if (p.id === 'golden') { play('burst', { level: LEVELS.burst, semis: 0, pan }); return; }
-    if (p.id === 'prism') { play('burst', { level: LEVELS.burst * 0.6, semis: 3 + semis, pan }); return; }
+    if (p.id === 'golden') { play('pop3', { level: LEVELS.pop, semis: semis + 2, pan }); play('chime3', { level: LEVELS.chime * 0.8, semis: 7, pan, at: 0.05 }); play('chime3', { level: LEVELS.chime * 0.6, semis: 12, pan, at: 0.14 }); return; }
+    if (p.id === 'prism') { play('pop2', { level: LEVELS.pop, semis: 3 + semis, pan }); play('chime1', { level: LEVELS.chime * 0.45, semis: 5 + semis, pan, at: 0.04 }); return; }
     if (p.id === 'lucky') { play('pop2', { level: LEVELS.pop, semis, pan }); play('chime1', { level: LEVELS.chime * 0.5, semis: 5, pan, at: 0.05 }); return; }
     play(POPS[popRR++ % POPS.length], { level: LEVELS.pop, semis, pan });
   }
   function onScore(e) {
     switch (e.type) {
       case 'pop': lastScorePop = e; break;
-      case 'almost': play('pop2', { level: LEVELS.whisper, semis: -4 }); break;
+      case 'almost': { const nowMs = performance.now(); if (nowMs - lastAlmostAt >= ALMOST_GAP_MS) { lastAlmostAt = nowMs; play('pop2', { level: LEVELS.whisper, semis: -4 }); } break; }
       case 'mult': if (e.to > e.from) { const c = chimeFor(e.to); play(c.file, { level: LEVELS.chime, semis: c.semis }); } break;
       case 'bank': bankThud(); arpeggio(LEVELS.chime * 0.8, 0.09); break;
-      case 'jackpot': play('gg', { level: e.tier === 'major' ? LEVELS.gg : LEVELS.gg * 0.7, at: 0.12 }); break;
+      case 'jackpot': arpeggio(e.tier === 'major' ? LEVELS.chime : LEVELS.chime * 0.7, 0.08); if (e.tier === 'major') play('chime3', { level: LEVELS.chime * 0.8, semis: 12, at: 0.3 }); break;
     }
   }
   function onItem(e) {
@@ -408,6 +419,7 @@ export function createRaceAudio({ bridge, hud, settings = {}, input } = {}) {
     if (!HOST_SFX.has(name)) { log('unknown host sfx dropped: ' + name); return; }
     const paused = !!(live.run && live.run.paused);
     if (name === 'streak_milestone' && scale < 0.8) return;   // the rung: the ladder above owns it
+    if (name === 'golden_pop') return;                        // the golden pop: the chime stack above owns it
     if (name === 'ui_click' && !paused) return;               // item roll / arm: the ticks own it
     if (name === 'surface') endSting();
     if (isMuted()) return;

--- a/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/bubbles.js
@@ -7,7 +7,7 @@
  * through layout.toWorld only. Four placements: lane (rests on the road and
  * bobs), air (threads a ramp's air line), spawn (materialises ahead and
  * wobbles), rain (falls from the ceiling, rests, fizzles). Pops are pass-
- * through against the kart box; a pop plays the DtRH pop/chime in-page
+ * through against the kart box; a pop is SILENT here (race/audio.js sounds it)
  * (engine/audioBus) and throws a few sparkle shards, the WPF BubbleService way.
  * Sprite textures come from the two locally mapped hosts (never remote media). Every sprite
  * (bubbles and shards) sits on pixel.js's CRISP_LAYER: full resolution over the blocky world.
@@ -16,16 +16,10 @@
 import * as THREE from 'three';
 import { ROAD_HALF_W, CEILING_H, POP_HIT_D, POP_HIT_X, POP_HIT_H, LANE_H, TREATS_ONLY_SEC } from './consts.js';
 import { BUBBLE_KINDS, KIND_BY_ID, rollKind } from './bubbleKinds.js';
-import { makeSfxPlayer } from '../engine/audioBus.js';
-import { getLevel } from '../engine/audioLevels.js';
 import { CRISP_LAYER } from './pixel.js';
 
 export { BUBBLE_KINDS };
 
-const SFX_BASE = '/dtrh/assets/bubbles/sfx/';
-const POP_SFX = ['Pop.mp3', 'Pop2.mp3', 'Pop3.mp3'];
-const CHIME_SFX = ['chime1.mp3', 'chime2.mp3', 'chime3.mp3'];
-const BURST_SFX = 'Burst.mp3';
 
 const CAP = 160;              // live bubbles, recycled farthest-first when full
 const SHARD_CAP = 64;
@@ -67,9 +61,6 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
   /** 0 while the opening is treats only, then a ramp to 1 over the next minute. */
   const effectGate = () => { const el = getElapsed ? getElapsed() : Infinity; return el < TREATS_ONLY_SEC ? 0 : clamp((el - TREATS_ONLY_SEC) / 60, 0.15, 1); };
 
-  const audio = makeSfxPlayer();
-  audio.preload([...POP_SFX, ...CHIME_SFX, BURST_SFX].map((f) => SFX_BASE + f));
-  const sfx = (file, vol) => audio.play(SFX_BASE + file, vol * getLevel('fx'));
 
   // ---- textures: one per kind, fallback dot until the PNG lands --------------
   const dotTex = makeDotTex();
@@ -250,9 +241,6 @@ export function createBubbleField({ scene, layout, media, getIntensity, getRoom,
     const k = KIND_BY_ID[s.kindId];
     s.popT = 0;
     const golden = k.id === 'golden';
-    if (golden) sfx(pick(CHIME_SFX), 0.4);
-    else if (k.id === 'prism') sfx(BURST_SFX, 0.35);
-    else sfx(pick(POP_SFX), 0.28);
     burst(s, golden);
     const strength = k.strength > 0 ? clamp(k.strength + 0.35 * intensity() + Math.random() * 0.1, 0, 1) : 0;
     emit(popCbs, { id: k.id, kind: k.kind, payload: k.payload, overlayKind: k.overlayKind, strength,

--- a/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/emi.js
@@ -108,7 +108,13 @@ export function createEmiRig({ scene, reducedMotion = false }) {
   const cupMat = new THREE.MeshStandardMaterial({ color: PORCELAIN, roughness: 0.35, metalness: 0.05, side: THREE.DoubleSide });
   const cupMesh = new THREE.Mesh(new THREE.LatheGeometry(prof, 40), cupMat); cupMesh.position.y = 0.09; body.add(cupMesh);
   const rim = new THREE.Mesh(new THREE.TorusGeometry(0.53, 0.025, 8, 48), pinkGlow); rim.rotation.x = Math.PI / 2; rim.position.y = 0.75; body.add(rim);
-  const handle = new THREE.Mesh(new THREE.TorusGeometry(0.19, 0.045, 10, 24, Math.PI), porcelain); handle.position.set(0.62, 0.42, 0); handle.rotation.z = -Math.PI / 2; body.add(handle);
+  // the handle: a C along a bezier whose two ends start INSIDE the cup wall (the wall radius is
+  // ~0.37 at the low root and ~0.51 at the high root, so 0.33 and 0.46 sit 4-5 cm inside it),
+  // bows out to 0.86 and comes back. Same material as the cup so the retexture tints them alike.
+  const handleCurve = new THREE.CubicBezierCurve3(
+    new THREE.Vector3(0.33, 0.24, 0), new THREE.Vector3(0.86, 0.14, 0),
+    new THREE.Vector3(0.86, 0.74, 0), new THREE.Vector3(0.46, 0.63, 0));
+  const handle = new THREE.Mesh(new THREE.TubeGeometry(handleCurve, 18, 0.048, 8, false), cupMat); body.add(handle);
 
   // ---- the tea: a plain tinted liquid disc, nothing drawn in it. It takes the room's colour
   // (the scene fog hue, which fx grades per room) and ripples a little. EMI faces forward, away
@@ -136,12 +142,15 @@ export function createEmiRig({ scene, reducedMotion = false }) {
     const arm = new THREE.Mesh(armGeo, navyDark); arm.position.set(sd * 0.3, -0.1, 0.25 - EMI_Z / 1.25); arm.rotation.set(-0.9, 0, sd * 0.35); emi.add(arm);
     const hand = new THREE.Mesh(handGeo, glove); hand.position.set(sd * 0.36, -0.22, 0.44 - EMI_Z / 1.25); emi.add(hand);
   }
+  // the antenna: a short stem, a kink joint and the bead, about half the reach of the first
+  // draft (STEM_L + KINK_L). The moods read through the kink angle, not the length.
+  const STEM_L = 0.11, KINK_L = 0.08;
   const antenna = new THREE.Group(); antenna.position.y = 0.21; emi.add(antenna);
-  const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.022, 0.22, 8), stemMat); stem.position.y = 0.11; antenna.add(stem);
-  const kink = new THREE.Group(); kink.position.y = 0.22; antenna.add(kink);
-  const stem2 = new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.018, 0.16, 8), stemMat); stem2.position.y = 0.08; kink.add(stem2);
+  const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.022, STEM_L, 8), stemMat); stem.position.y = STEM_L / 2; antenna.add(stem);
+  const kink = new THREE.Group(); kink.position.y = STEM_L; antenna.add(kink);
+  const stem2 = new THREE.Mesh(new THREE.CylinderGeometry(0.016, 0.018, KINK_L, 8), stemMat); stem2.position.y = KINK_L / 2; kink.add(stem2);
   const beadMat = new THREE.MeshStandardMaterial({ color: PINK, emissive: PINK, emissiveIntensity: 0.9, roughness: 0.3 });
-  const bead = new THREE.Mesh(new THREE.SphereGeometry(0.06, 12, 10), beadMat); bead.position.y = 0.17; kink.add(bead);
+  const bead = new THREE.Mesh(new THREE.SphereGeometry(0.055, 12, 10), beadMat); bead.position.y = KINK_L + 0.01; kink.add(bead);
   const beadLight = new THREE.PointLight(PINK, 0.5, 2); bead.add(beadLight);
   const cupLight = new THREE.PointLight(PINK, 1.4, 14); cupLight.position.y = 1.2; group.add(cupLight);
 

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -424,7 +424,7 @@ export function createRaceHud(root) {
     },
     dispose() {
       disposed = true;
-      popRun = { el: null, at: 0, sum: 0, n: 0, kill: 0 };
+      for (const k of Object.keys(runs)) Object.assign(runs[k], { el: null, at: 0, sum: 0, n: 0, kill: 0 });
       settleBrake('resume');
       settleEnd('exit');
       for (const t of timers) clearTimeout(t);

--- a/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/hud.js
@@ -24,6 +24,10 @@ const FLICK_MS = 450;
 const TOAST_HOLD = { pop: 1100, almost: 1300, jackpot: 1800, bank: 1600, item: 1400, effect: 1400, recipe: 1700 };
 /** Two "+N" pops inside this window merge into one counting toast ("+30 x3"). */
 const POP_MERGE_MS = 600;
+/** Two "almost +N" inside this window merge the same way ("almost +50 x2"). */
+const ALMOST_MERGE_MS = 900;
+/** Chatter kinds (pop, almost) may not open a NEW toast more often than this. */
+const CHATTER_GAP_MS = 180;
 
 /** The second-pass rung ladder. consts.js MULT_LADDER is the source of truth;
  * this is the documented fallback for when the import is missing or malformed. */
@@ -171,8 +175,26 @@ export function createRaceHud(root) {
   const wake = () => { if (!raf && !disposed) raf = requestAnimationFrame(tick); };
 
   let lastMult = 1, lastCombo = 0;
-  // the open "+N" run: the live toast, when it was last hit, and its running total
-  let popRun = { el: null, at: 0, sum: 0, n: 0, kill: 0 };
+  // the open runs: a live "+N" / "almost +N" toast, when it was last hit, and its running total
+  const RUN_OF = {
+    pop: { re: /^\+(\d+)$/, merge: POP_MERGE_MS, text: (s, n) => `+${fmt(s)} x${n}` },
+    almost: { re: /^almost \+(\d+)$/, merge: ALMOST_MERGE_MS, text: (s, n) => `almost +${fmt(s)} x${n}` },
+  };
+  const runs = {};
+  for (const k of Object.keys(RUN_OF)) runs[k] = { kind: k, ...RUN_OF[k], el: null, at: 0, sum: 0, n: 0, kill: 0 };
+  let lastChatterAt = -1e9;
+  function fold(run, gain, now) {
+    run.at = now; run.sum += gain; run.n += 1;
+    const node = run.el;
+    node.textContent = run.text(run.sum, run.n);
+    node.classList.toggle('is-run', run.n > 1);
+    // restart the toast's own hold animation so the merged toast re-pops
+    node.style.animation = 'none';
+    void node.offsetWidth;
+    node.style.animation = '';
+    if (run.kill) { clearTimeout(run.kill); timers.delete(run.kill); }
+    run.kill = later(() => { node.remove(); if (run.el === node) run.el = null; }, TOAST_HOLD[run.kind] + 60);
+  }
 
   // ---- BANK: tokens fly from low centre into the score; the counter ticks per landing ----
   function bankTokens(text) {
@@ -293,33 +315,27 @@ export function createRaceHud(root) {
     toast(text, kind) {
       kind = TOAST_HOLD[kind] ? kind : 'pop';
       let body = String(text == null ? '' : text);
-      // COALESCE: a dense run of "+10" pops used to stack four toasts on one
-      // spot and read as flicker. Inside POP_MERGE_MS they become one counting
-      // toast ("+30 x3") that re-pops on every hit. Only bare "+N" merges, so
-      // "x4" rung toasts and every other kind still stand alone.
-      const gain = kind === 'pop' ? /^\+(\d+)$/.exec(body) : null;
+      // COALESCE: dense chatter used to stack toasts on one spot and read as
+      // flicker (the owner counted ~10 a second). Inside its merge window a
+      // "+N" pop or an "almost +N" folds into one counting toast ("+30 x3",
+      // "almost +50 x2") that re-pops on every hit. Rung toasts ("x4") and every
+      // other kind still stand alone. A chatter kind also may not open a NEW
+      // toast more often than CHATTER_GAP_MS: a blocked one folds into its live
+      // run or is dropped (the score plate already moved).
+      const run = runs[kind] || null;
+      const m = run ? run.re.exec(body) : null;
       const now = typeof performance === 'object' ? performance.now() : Date.now();
-      if (gain && popRun.el && popRun.el.parentNode && now - popRun.at < POP_MERGE_MS) {
-        popRun.at = now;
-        popRun.sum += +gain[1];
-        popRun.n += 1;
-        popRun.el.textContent = `+${fmt(popRun.sum)} x${popRun.n}`;
-        popRun.el.classList.toggle('is-run', popRun.n > 1);
-        // restart the toast's own hold animation so the merged toast re-pops
-        popRun.el.style.animation = 'none';
-        void popRun.el.offsetWidth;
-        popRun.el.style.animation = '';
-        if (popRun.kill) { clearTimeout(popRun.kill); timers.delete(popRun.kill); }
-        popRun.kill = later(() => { if (popRun.el) popRun.el.remove(); popRun.el = null; }, TOAST_HOLD.pop + 60);
-        return;
-      }
+      const liveRun = !!(m && run.el && run.el.parentNode);
+      if (liveRun && now - run.at < run.merge) { fold(run, +m[1], now); return; }
+      if (run && now - lastChatterAt < CHATTER_GAP_MS) { if (liveRun) fold(run, +m[1], now); return; }
       if (kind === 'bank') body = bankTokens(body);
       if (kind === 'jackpot') hit(gold, 'is-on');
       const t = el(`rh-toast rh-toast--${kind}`, toasts, body);
       t.style.setProperty('--rh-hold', `${TOAST_HOLD[kind]}ms`);
       while (toasts.children.length > 3) toasts.firstChild.remove();
-      const kill = later(() => { t.remove(); if (popRun.el === t) popRun.el = null; }, TOAST_HOLD[kind] + 60);
-      if (gain) popRun = { el: t, at: now, sum: +gain[1], n: 1, kill };
+      const kill = later(() => { t.remove(); for (const k of Object.keys(runs)) if (runs[k].el === t) runs[k].el = null; }, TOAST_HOLD[kind] + 60);
+      if (run) lastChatterAt = now;
+      if (m) Object.assign(run, { el: t, at: now, sum: +m[1], n: 1, kill });
     },
     /** THE MIXER: `state` is cocktail.state(): { live: [slot...], recipe }. Cheap to call every frame. */
     mixer(state) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/pixel.js
@@ -24,8 +24,11 @@
  *
  * PIXEL_STEPS is the P-key cycle: off, 2, 3, 4, 6 screen pixels per block.
  * Put an object on the crisp layer with `obj.layers.set(CRISP_LAYER)`.
- * `stats` is last frame's draw calls + triangles summed over the passes; with
- * `log` given, a line goes out every PERF_LOG_SEC seconds.
+ * `stats` is last frame's draw calls + triangles summed over the passes plus
+ * the frame time (avg + p95 ms over the last FRAME_WIN frames); with `log`
+ * given, a line goes out every PERF_LOG_SEC seconds. THE GOVERNOR: on a
+ * high-DPI screen an average frame above SLOW_MS drops the canvas to one
+ * device pixel per CSS pixel, and one under FAST_MS restores the native ratio.
  * ==========================================================================*/
 
 import * as THREE from 'three';
@@ -38,6 +41,8 @@ const WORLD_MASK = 1 << 0, CRISP_MASK = 1 << CRISP_LAYER, ALL_MASK = WORLD_MASK 
 const MAP_KEYS = ['map', 'emissiveMap', 'alphaMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap'];
 const FAR_FADE = [42, 80];     // metres: the world pass fades to the fog colour across this band
 const PERF_LOG_SEC = 5;
+const FRAME_WIN = 300;         // frames kept for the avg / p95
+const SLOW_MS = 24, FAST_MS = 13;   // governor thresholds on the avg frame (about 42 and 77 fps)
 
 /** Snap any input to a step: 0 (off) or the nearest listed block size. */
 export function normalizeBlock(n) {
@@ -78,7 +83,9 @@ const BLIT_FRAG = `
 export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT, log = null }) {
   let cur = normalizeBlock(block);
   let w = 1, h = 1;
-  const nativeDpr = () => Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5);
+  let dprCap = Infinity;         // the governor's lid on the device pixel ratio (1 while slow)
+  const screenDpr = () => Math.min(window.devicePixelRatio || 1, Q.maxDpr, 1.5);
+  const nativeDpr = () => Math.min(screenDpr(), dprCap);
   const caps = renderer.capabilities || {};
   const depthOk = caps.isWebGL2 !== false;   // r163+ is WebGL2 only; the guard keeps an older fork honest
 
@@ -132,19 +139,42 @@ export function createPixelizer({ renderer, canvas, block = PIXEL_DEFAULT, log =
   }
 
   // ---- the frame ---------------------------------------------------------------------------
-  const stats = { calls: 0, triangles: 0, passes: 0 };
+  const stats = { calls: 0, triangles: 0, passes: 0, frameMs: 0, frameP95: 0 };
   let fCalls = 0, fTris = 0, fPasses = 0, perfLast = 0;
   const info = renderer.info;
   function tally() { if (!info || !info.render) return; fCalls += info.render.calls; fTris += info.render.triangles; fPasses++; }
+  // frame gaps in a ring; a gap over 250 ms is a tab switch or a hitch, not a frame
+  const gaps = new Float32Array(FRAME_WIN);
+  let gapN = 0, gapI = 0, lastFrameAt = 0;
+  const sorted = new Float32Array(FRAME_WIN);
+  function frameStats() {
+    if (!gapN) return { avg: 0, p95: 0 };
+    let sum = 0;
+    for (let i = 0; i < gapN; i++) { sum += gaps[i]; sorted[i] = gaps[i]; }
+    const view = sorted.subarray(0, gapN); view.sort();
+    return { avg: sum / gapN, p95: view[Math.min(gapN - 1, Math.floor(gapN * 0.95))] };
+  }
+  function govern(avg) {
+    if (gapN < 60) return;
+    const native = screenDpr();
+    if (avg > SLOW_MS && dprCap > 1 && native > 1) { dprCap = 1; apply(); if (log) log(`[race-perf] governor: dpr 1 (avg frame ${avg.toFixed(1)} ms)`); }
+    else if (avg < FAST_MS && dprCap < native) { dprCap = Infinity; apply(); if (log) log(`[race-perf] governor: dpr native (avg frame ${avg.toFixed(1)} ms)`); }
+  }
   function closeFrame() {
     stats.calls = fCalls; stats.triangles = fTris; stats.passes = fPasses;
     fCalls = fTris = fPasses = 0;
-    if (!log) return;
-    const now = performance.now() / 1000;
+    const nowMs = performance.now();
+    if (lastFrameAt) { const g = nowMs - lastFrameAt; if (g < 250) { gaps[gapI] = g; gapI = (gapI + 1) % FRAME_WIN; if (gapN < FRAME_WIN) gapN++; } }
+    lastFrameAt = nowMs;
+    const now = nowMs / 1000;
     if (!perfLast) perfLast = now;
     if (now - perfLast < PERF_LOG_SEC) return;
     perfLast = now;
-    try { log(`[race-perf] t+${Math.round(now)}s calls ${stats.calls} tris ${stats.triangles} ${label()}${rt ? ` rt ${rtW}x${rtH}` : ''}`); } catch (e) { /* host gone */ }
+    const { avg, p95 } = frameStats();
+    stats.frameMs = avg; stats.frameP95 = p95;
+    govern(avg);
+    if (!log) return;
+    try { log(`[race-perf] t+${Math.round(now)}s calls ${stats.calls} tris ${stats.triangles} frame ${avg.toFixed(1)}ms p95 ${p95.toFixed(1)} dpr ${renderer.getPixelRatio().toFixed(2)} ${label()}${rt ? ` rt ${rtW}x${rtH}` : ''}`); } catch (e) { /* host gone */ }
   }
 
   function render(scene, camera) {

--- a/ConditioningControlPanel/Resources/web/dtrh/race/race.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/race.css
@@ -181,6 +181,7 @@
 /* a merged run of pops ("+30 x3"): one toast, one spot, and it grows with the run */
 .race-hud .rh-toast--pop.is-run { font-size: 1.4rem; color: #fff0b8; text-shadow: 0 0 20px rgba(255, 212, 94, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); }
 .race-hud .rh-toast--almost { font-size: 1.5rem; color: #bfe9ff; animation: rhShiver 0.34s linear, rhToastPop 1.3s ease-out forwards; text-shadow: 0 0 18px rgba(150, 210, 255, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); }
+.race-hud .rh-toast--almost.is-run { font-size: 1.8rem; color: #e2f5ff; }
 .race-hud .rh-toast--jackpot { font-size: 2.4rem; color: #fff0b8; text-shadow: 0 0 26px rgba(242, 193, 78, 1), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhReveal 1.8s cubic-bezier(0.2, 1.4, 0.4, 1) forwards; }
 .race-hud .rh-toast--bank { font-size: 1.3rem; color: #ffe082; text-shadow: 0 0 18px rgba(255, 200, 60, 0.9), 0 2px 4px rgba(0, 0, 0, 0.85); animation: rhToastPop 1.6s ease-out forwards; }
 .race-hud .rh-toast--item { font-size: 1.6rem; color: #ffd6ea; animation: rhBounce 0.36s cubic-bezier(0.2, 1.6, 0.4, 1), rhToastPop 1.4s ease-out forwards; }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/rooms.js
@@ -10,7 +10,8 @@
  * with running chevrons, bobbing sugar-cube item boxes, and the diegetic props from
  * race/roomProps.js. update(d) culls rooms out of sight and animates what is near
  * the kart; applyRoom(fx, roomId, fadeSec) hands the room's biome style to
- * fx.applyRegionGrade; dispose() tears it all down.
+ * fx.applyRegionGrade; breakItemBox(feature) smashes a crossed sugar cube (pooled
+ * shards, a white flash, regrowth after RESPAWN_SEC); dispose() tears it all down.
  *
  * Every position goes through layout.toWorld(d, x, h) and every orientation through
  * layout.frameAtDepth(d). Draw calls: 6 for the furniture + 21 for the props (27).
@@ -294,7 +295,75 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
   const cubeMesh = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE, CUBE, CUBE)), cubeMat, Math.max(1, cubes.length));
   cubes.forEach((c, i) => cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75, 0, 1, _m)));
   cubeMesh.count = cubes.length;
-  for (const m of [wedges, lips, airDots, padMesh, cubeMesh]) { m.frustumCulled = false; m.instanceMatrix.needsUpdate = true; group.add(m); }
+  // a crossed cube BREAKS: it hides, throws SHARDS_PER pieces of itself (pooled, world space,
+  // gravity along the local up) with a white flash on its spot, and grows back after RESPAWN_SEC.
+  const cubeIndex = new Map(cubes.map((c, i) => [c, i]));
+  const cubeBrokenAt = new Float64Array(Math.max(1, cubes.length)).fill(-1);   // -1 = intact
+  const RESPAWN_SEC = 8, REGROW_SEC = 0.5, SHARD_TTL = 0.65, SHARDS_PER = 8, SHARD_N = 48, FLASH_N = 4, FLASH_SEC = 0.22;
+  const shards = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE * 0.24, CUBE * 0.24, CUBE * 0.24)), cubeMat, SHARD_N);
+  const shard = []; for (let i = 0; i < SHARD_N; i++) shard.push({ life: 0, age: 0, spin: 0, p: new THREE.Vector3(), v: new THREE.Vector3(), g: new THREE.Vector3(), axis: new THREE.Vector3(0, 1, 0) });
+  let shardCursor = 0, shardsLive = 0;
+  const flashMat = mat(new THREE.MeshBasicMaterial({ color: 0xffffff }));
+  const flashes = new THREE.InstancedMesh(track(new THREE.BoxGeometry(CUBE, CUBE, CUBE)), flashMat, FLASH_N);
+  const flash = []; for (let i = 0; i < FLASH_N; i++) flash.push({ life: 0, m: new THREE.Matrix4() });
+  let flashCursor = 0, flashesLive = 0;
+  const _q = new THREE.Quaternion(), _up = new THREE.Vector3(), _hide = new THREE.Vector3(0, -999, 0);
+  const hideAll = (mesh, n) => { for (let i = 0; i < n; i++) mesh.setMatrixAt(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); };
+  hideAll(shards, SHARD_N); hideAll(flashes, FLASH_N);
+  let lastT = -1;
+  /** Break the cube for feature f (or its index). Returns true when it was intact, false when
+   *  it was already broken (the run brain hands out an item only on true). */
+  function breakItemBox(f) {
+    const i = typeof f === 'number' ? f : cubeIndex.get(f);
+    if (i == null || cubeBrokenAt[i] >= 0) return false;
+    const c = cubes[i];
+    cubeBrokenAt[i] = now() - t0;
+    cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75, 0, 0.0001, _m)); cubeMesh.instanceMatrix.needsUpdate = true;
+    const fr = layout.frameAtDepth(c.d); _up.copy(fr.up);
+    layout.toWorld(c.d, c.x, CUBE * 0.75, _p);
+    for (let k = 0; k < SHARDS_PER; k++) {
+      const s = shard[shardCursor]; shardCursor = (shardCursor + 1) % SHARD_N;
+      if (s.life <= 0) shardsLive++;
+      s.life = SHARD_TTL; s.age = 0;
+      s.p.copy(_p).addScaledVector(fr.right, (rng() - 0.5) * CUBE * 0.6).addScaledVector(_up, (rng() - 0.5) * CUBE * 0.6).addScaledVector(fr.tangent, (rng() - 0.5) * CUBE * 0.6);
+      s.v.copy(fr.right).multiplyScalar((rng() - 0.5) * 7).addScaledVector(_up, 2.5 + rng() * 4).addScaledVector(fr.tangent, 1 + rng() * 5);
+      s.g.copy(_up).multiplyScalar(-14);
+      s.axis.set(rng() - 0.5, rng() - 0.5, rng() - 0.5).normalize(); s.spin = (rng() - 0.5) * 24;
+    }
+    const fl = flash[flashCursor]; flashCursor = (flashCursor + 1) % FLASH_N;
+    if (fl.life <= 0) flashesLive++;
+    fl.life = FLASH_SEC; roadMatrix(c.d, c.x, CUBE * 0.75, 0, 1, fl.m);
+    return true;
+  }
+  function updateBreaks(t) {
+    const dt = lastT < 0 ? 0 : Math.min(0.05, t - lastT); lastT = t;
+    if (shardsLive > 0) {                   // shards fly, spin and shrink out
+      let live = 0;
+      for (let i = 0; i < SHARD_N; i++) {
+        const s = shard[i];
+        if (s.life <= 0) continue;
+        s.life -= dt; s.age += dt;
+        if (s.life <= 0) { shards.setMatrixAt(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); continue; }
+        live++;
+        s.v.addScaledVector(s.g, dt); s.p.addScaledVector(s.v, dt);
+        shards.setMatrixAt(i, _m.compose(s.p, _q.setFromAxisAngle(s.axis, s.spin * s.age), _s.setScalar(0.4 + 0.6 * (s.life / SHARD_TTL))));
+      }
+      shardsLive = live; shards.instanceMatrix.needsUpdate = true;
+    }
+    if (flashesLive > 0) {                  // the flash: a white cube on the spot that swells and vanishes
+      let live = 0;
+      for (let i = 0; i < FLASH_N; i++) {
+        const fl = flash[i];
+        if (fl.life <= 0) continue;
+        fl.life -= dt;
+        if (fl.life <= 0) { flashes.setMatrixAt(i, _m.compose(_hide, _q.identity(), _s.setScalar(0.0001))); continue; }
+        live++;
+        flashes.setMatrixAt(i, _m.copy(fl.m).scale(_s.setScalar(1.15 + 0.9 * (1 - fl.life / FLASH_SEC))));
+      }
+      flashesLive = live; flashes.instanceMatrix.needsUpdate = true;
+    }
+  }
+  for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards, flashes]) { m.frustumCulled = false; m.instanceMatrix.needsUpdate = true; group.add(m); }
   if (wedges.instanceColor) wedges.instanceColor.needsUpdate = true;
 
   // ---- diegetic props: grounded, voxel, animated near the kart (race/roomProps.js) ------
@@ -314,12 +383,20 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
     const t = now() - t0;
     props.update(d, t);
     let dirty = false;
-    cubes.forEach((c, i) => {
-      if (wrapDist(c.d, d) > ANIM) return;
-      cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75 + 0.18 * Math.sin(t * 2 + i), t * 1.1 + i, 1, _m));
+    for (let i = 0; i < cubes.length; i++) {
+      const c = cubes[i], since = cubeBrokenAt[i] >= 0 ? t - cubeBrokenAt[i] : -1;
+      if (since >= 0 && since < RESPAWN_SEC) continue;                       // hidden, matrix already written
+      let scale = 1;
+      if (since >= 0) {                                                       // growing back
+        const u = Math.min(1, (since - RESPAWN_SEC) / REGROW_SEC);
+        scale = u < 1 ? Math.max(0.0001, 1.12 * Math.sin(u * Math.PI * 0.5)) : 1;
+        if (u >= 1) cubeBrokenAt[i] = -1;
+      } else if (wrapDist(c.d, d) > ANIM) continue;
+      cubeMesh.setMatrixAt(i, roadMatrix(c.d, c.x, CUBE * 0.75 + 0.18 * Math.sin(t * 2 + i), t * 1.1 + i, scale, _m));
       dirty = true;
-    });
+    }
     if (dirty) cubeMesh.instanceMatrix.needsUpdate = true;
+    updateBreaks(t);
     // air-line dots: gone while they would sit between the seat and the cup, back over DOT_NEAR..DOT_FAR
     let adirty = false;
     for (let i = 0; i < airD.length; i++) {
@@ -352,8 +429,8 @@ export function createRoomDresser({ scene, layout, rooms = ROOMS }) {
     for (const m of mats) m.dispose();
     for (const t of texes) t.dispose();
     props.dispose();
-    for (const m of [wedges, lips, airDots, padMesh, cubeMesh]) m.dispose();
+    for (const m of [wedges, lips, airDots, padMesh, cubeMesh, shards, flashes]) m.dispose();
   }
 
-  return { update, applyRoom, dispose, group, spans, rooms: specs };
+  return { update, applyRoom, breakItemBox, dispose, group, spans, rooms: specs };
 }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -97,7 +97,11 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   const mix = createCocktail({ now: () => S.elapsed });   // THE MIX: one live effect per category (cocktail.js); S.effects mirrors its live slots
   let W = null;                       // the world: everything that is rebuilt on "again"
   let raf = 0, last = 0, lastBeat = 0, payoutResolve = null;
-  const trail = [];                   // last ~1 s of kart {d,x,h}, for the ALMOST on a miss
+  // last ~1 s of kart {d,x,h} for the ALMOST on a miss: a fixed ring, no per-frame objects
+  const TRAIL_N = 70, trail = [];
+  for (let i = 0; i < TRAIL_N; i++) trail.push({ d: 0, x: 0, h: 0, ok: false });
+  let trailI = 0;
+  const trailClear = () => { for (const s of trail) s.ok = false; trailI = 0; };
 
   function poke(mood, sec) { S.moodHeld = mood; S.moodHold = sec; }
   function setFlip(on) { S.flip = !!on; canvas.style.transform = on ? 'scaleX(-1)' : ''; }
@@ -146,7 +150,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     Object.assign(S, { running: false, paused: false, ended: false, elapsed: 0, t: 0, intensity: intensityFloor, timeScale: 1,
       jackpotBias: 1, parasol: false, magnet: false, spawnT: SPAWN_T0, rainT: RAIN_T0, rush: 0, fovBoost: 0, gates: 0, room: null,
       wasAirborne: false, effects: [], moodHeld: null, moodHold: 0, mood: 'calm', seed: runSeed });
-    setFlip(false); trail.length = 0;
+    setFlip(false); trailClear();
     mix.reset(); S.wobble = 0; clearMixChrome();
     hud.setScore(0); hud.setCombo(0, 1); hud.setBank(0); hud.setSpeed(0); hud.setFraught(0); hud.item(null, 'no item yet');
   }
@@ -262,7 +266,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
   function onMiss(w, m) {
     // ALMOST: the treat slid past inside NEAR_MISS_M but outside the hit box; else the streak lets go
     let best = null, bestGap = Infinity;
-    for (const s of trail) { const g = Math.abs(w.layout.wrap(s.d - m.d + w.layout.totalDepth / 2) - w.layout.totalDepth / 2); if (g < bestGap) { bestGap = g; best = s; } }
+    for (const s of trail) { if (!s.ok) continue; const g = Math.abs(w.layout.wrap(s.d - m.d + w.layout.totalDepth / 2) - w.layout.totalDepth / 2); if (g < bestGap) { bestGap = g; best = s; } }
     const near = best && m.x != null && Math.abs(m.x - best.x) < NEAR_MISS_M && Math.abs((m.h || 0) - best.h) < NEAR_MISS_M;
     if (near) w.score.nearMiss(); else w.score.miss();
   }
@@ -322,11 +326,14 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     const prevD = ks.d;
     k.update(dt, input.read(), lay);
     w.score.tick(dt); w.items.update(dt);
-    trail.push({ d: ks.d, x: ks.x, h: ks.h }); if (trail.length > 70) trail.shift();
+    { const tr = trail[trailI]; tr.d = ks.d; tr.x = ks.x; tr.h = ks.h; tr.ok = true; trailI = (trailI + 1) % TRAIL_N; }
     for (const e of mix.tick(dt)) onMix(w, e);
     if (S.wobble > 0) { S.wobble -= dt; if (S.wobble <= 0 && S.timeScale === WOBBLE_SCALE) S.timeScale = 1; }
     const mixed = mix.state(); S.effects = mixed.live;
-    if (hud.mixer) hud.mixer(mixed);
+    // the mixer rail only needs a frame while something is live (or just went dark)
+    const mixOn = mixed.live.length > 0 || !!mixed.recipe;
+    if (hud.mixer && (mixOn || S.mixWasOn)) hud.mixer(mixed);
+    S.mixWasOn = mixOn;
 
     // bubbles: seed the chunks ahead, drip spawns, rain bursts
     for (const c of lay.chunks) { const rel = lay.wrap(c.d0 - ks.d + lay.totalDepth / 2) - lay.totalDepth / 2; if (rel > -20 && rel < 250) w.field.seedChunk(c); }
@@ -470,6 +477,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     teardown();
     audio.dispose();
     input.dispose(); hud.dispose(); shake.dispose(); payloadFx.dispose(); speedFx.dispose(); lane.dispose();
+    pixel.dispose();
     scene.clear(); renderer.dispose();
     setFlip(false);
   }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -340,7 +340,7 @@ export function createRace({ root, bridge, media, settings = {}, seed = 1 }) {
     // track features crossed this frame
     for (const f of lay.featuresBetween(prevD, ks.d)) {
       if (f.type === 'boost' && !ks.airborne && Math.abs(f.x - ks.x) <= 1.2) { k.applyBoost(1.6); sfx('tunnel_powerup_collect', 0.8); shake.shake(0.25, 200); poke('streamed', 1.2); }
-      else if (f.type === 'itembox' && Math.abs(f.x - ks.x) <= 1.2) { if (w.items.roll(w.score.state.mult)) sfx('ui_click', 0.5); }
+      else if (f.type === 'itembox' && Math.abs(f.x - ks.x) <= 1.2 && w.dresser.breakItemBox(f)) { shake.shake(0.2, 120); if (w.items.roll(w.score.state.mult)) sfx('ui_click', 0.5); }
       else if (f.type === 'gate') enterRoom(w, f.room);
     }
     if (S.wasAirborne && !ks.airborne) { shake.shake(0.8, 300); poke('smug', 0.7); }

--- a/ConditioningControlPanel/Resources/web/dtrh/race/run.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/race/run.js
@@ -36,7 +36,7 @@ import { createPixelizer, PIXEL_DEFAULT } from './pixel.js';
 import { createSpeedFx } from './speed.js';
 import { createRaceAudio } from './audio.js';
 
-const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.6, FOV_BASE = 72;
+const HEARTBEAT_MS = 2000, PAYOUT_WAIT_MS = 2000, NEAR_MISS_M = 1.15, FOV_BASE = 72;   // 1.6 read as ALMOST spam: the next lane over qualified
 // effect lives are cocktail.js CATEGORIES (scaled by the pop's durationMult); a glitch re-pop wobbles
 // the world clock this hard, this long (only when tea_time is not already holding it)
 const WOBBLE_SCALE = 0.82, WOBBLE_SEC = 0.3;


### PR DESCRIPTION
Pass 4, the owner's fix list. Item boxes break on impact (pooled shards and a flash, regrow after 8 s) and the item roll only fires on a real break. Burst.mp3 and GG.mp3 are no longer loaded, every pop was being sounded twice and is now sounded once (bubbles.js is silent, audio.js owns it), golden/prism/jackpot are pop and chime stacks. ALMOST and score toasts fold into counting runs and the near-miss lane is tightened so the next lane over no longer qualifies. The teacup handle is a bezier tube rooted inside the cup wall and EMI's antenna is half as long. The perf line reports frame avg and p95 and a DPR governor drops to 1x on slow high-DPI frames; trail ring and mixer rail no longer allocate per frame; the pixel target is freed on dispose.

Stacked on #678 (feat/race-p3-fun). Merge in order.

---
Verification: node syntax check on every race module, headless Chrome (swiftshader) run of race.html?autostart=1 with zero Uncaught/TypeError/ReferenceError/404, and the WebView2 play build (--race) booted with the whole chain merged. No new binary assets. Each commit stays under the 600-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134ga9XjUzgFrLPF6B12pzj
