### PR TITLE
feat(avalonia): consent dialogs persist what the user agreed to

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/AwarenessConsentDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessConsentDialog.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -11,27 +12,38 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// </summary>
     public partial class AwarenessConsentDialog : Window
     {
-        /// <summary>Matches <c>AppSettings.AwarenessRetentionDays</c>'s default; used only headlessly.</summary>
-        private const int AppSettingsRetentionFallback = 30;
-
         public AwarenessConsentDialog()
         {
             AvaloniaXamlLoader.Load(this);
 
-            // ponytail: needs AppSettings (UseAwarenessV2, AwarenessRetentionDays), wired when it moves to Core.
-            // Until then the WPF null-settings fallbacks apply: v2 on, 30 days.
-            const bool v2 = true;
+            var settings = CoreSettings.Current;
+
+            // The "what leaves your PC" sentence is the one claim the v2 kill switch can invalidate:
+            // with UseAwarenessV2 off the legacy pipeline runs and it does send the page title.
+            bool v2 = settings.UseAwarenessV2;
             this.FindControl<TextBlock>("TxtLeavesBody")!.Text = Loc.Get(v2
                 ? "awareness_consent_leaves_body"
                 : "awareness_consent_leaves_body_legacy");
+
             this.FindControl<TextBlock>("TxtRetention")!.Text =
-                Loc.GetF("awareness_consent_retention_fmt", AppSettingsRetentionFallback);
+                Loc.GetF("awareness_consent_retention_fmt", settings.AwarenessRetentionDays);
 
             this.FindControl<Button>("BtnAccept")!.Click += (_, _) => Close(true);
             this.FindControl<Button>("BtnDecline")!.Click += (_, _) => Close(false);
         }
 
-        // ponytail: IsRequired/EnsureConsent need AppSettings, AwarenessPrivacyRules and
-        // AwarenessIntensityMigration (all head-only); ported when they move to Core.
+        /// <summary>
+        /// True when the dialog must be raised before awareness may be switched on: v2's consent has
+        /// never been accepted. Null settings read as "ask", because the only thing worse than an extra
+        /// dialog is a silent one.
+        /// </summary>
+        public static bool IsRequired(AppSettings? settings) => settings?.AwarenessConsentShownV2 != true;
+
+        // ponytail: EnsureConsent needs AwarenessPrivacyRules.EnsureSeeded
+        // (ConditioningControlPanel/Services/Awareness/AwarenessPrivacyRules.cs) and
+        // AwarenessIntensityMigration.EnsureMigrated
+        // (ConditioningControlPanel/Services/Awareness/AwarenessIntensityMigration.cs), both still
+        // in the WPF head. Accepting consent without seeding the recommended deny groups would
+        // change what awareness observes, so this stays unported rather than half-ported.
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/ExplicitContentAcknowledgementDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ExplicitContentAcknowledgementDialog.axaml.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -23,8 +26,26 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                 // Defense-in-depth: IsEnabled already prevents this, but a harness may invoke it.
                 if (chk.IsChecked != true) return;
 
-                // ponytail: needs AppSettings.CompanionPrompt (ExplicitAcknowledgedAt/Locale audit stamp),
-                // wired when AppSettings moves to Core.
+                // P2 C3: stamp the audit-trail fields BEFORE the caller's MarkAcknowledged call
+                // flips ExplicitContentAcknowledged + ExplicitAcknowledgedVersion. These two
+                // properties capture WHEN and in WHICH locale the affirmation happened. The
+                // dialog never saves — the caller's MarkAcknowledged + Save persists both.
+                try
+                {
+                    var promptSettings = CoreSettings.Current.CompanionPrompt;
+                    if (promptSettings != null)
+                    {
+                        promptSettings.ExplicitAcknowledgedAt =
+                            DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+                        promptSettings.ExplicitAcknowledgedLocale = CultureInfo.CurrentCulture.Name;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Best-effort capture; the gate itself still functions if this fails.
+                    Log.Warning(ex, "ExplicitContentAcknowledgementDialog: failed to capture ack timestamp/locale");
+                }
+
                 Close(true);
             };
             this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);

--- a/CCP.Avalonia/Views/Dialogs/MicConsentDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/MicConsentDialog.axaml.cs
@@ -130,8 +130,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void Enable()
         {
-            // ponytail: needs AppSettings (MicConsentGiven) + SettingsService.Save, wired when they move to Core.
-            // The mic stays closed - it only opens during an explicit listen window while Takeover runs.
+            // Persist consent. The mic stays closed — it only opens during an explicit listen
+            // window while Takeover is running.
+            CoreSettings.Current.MicConsentGiven = true;
+            CoreSettings.Save();
+
             Log.Information("Mic consent granted at {Time}", System.DateTime.UtcNow);
 
             ConsentGiven = true;

--- a/CCP.Avalonia/Views/Dialogs/WebcamConsentDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WebcamConsentDialog.axaml.cs
@@ -155,8 +155,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void Enable()
         {
-            // ponytail: needs AppSettings (WebcamConsentGiven/Version/Date), SettingsService.Save and
-            // WebcamTrackingService.ConsentVersion, wired when they move to Core. Camera stays closed.
+            // Persist consent. Camera stays closed — the user must explicitly enable a feature
+            // toggle in the Lab card to actually start tracking.
+            // ponytail: needs WebcamTrackingService.ConsentVersion
+            // (ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs:98), still in the
+            // WPF head — there is no Webcam directory in Core. Until it moves, WebcamConsentVersion
+            // is left unstamped and the log line omits {Version}. That fails safe: IsConsentCurrent
+            // compares the stored version against the contract version, so a Given=true record with
+            // an empty version re-prompts rather than silently granting.
+            var s = CoreSettings.Current;
+            s.WebcamConsentGiven = true;
+            s.WebcamConsentDate = System.DateTime.UtcNow;
+            CoreSettings.Save();
+
             Log.Information("Webcam consent granted at {Time}", System.DateTime.UtcNow);
 
             ConsentGiven = true;

--- a/CCP.Avalonia/Views/Dialogs/WelcomeDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/WelcomeDialog.axaml.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using ConditioningControlPanel.Localization;
@@ -9,8 +10,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/WelcomeDialog.xaml.cs. Deviations:
     ///  - WPF's <c>DialogResult</c> becomes <c>Close(true)</c>.
-    ///  - <c>App.Mods.GetAffirmation()</c> and <c>App.Settings</c> are head services; both are
-    ///    ponytail stubs below.
+    ///  - <c>App.Mods.GetAffirmation() ?? "Subject"</c> becomes <see cref="CoreMods.Affirmation"/>,
+    ///    which carries the same fallback.
+    ///  - <see cref="ShowIfNeeded"/> takes an owner and is async: Avalonia's <c>ShowDialog</c> needs
+    ///    a non-null owner Window and returns a Task, so the parameterless synchronous WPF static
+    ///    cannot be ported one for one.
     /// </summary>
     public partial class WelcomeDialog : Window
     {
@@ -18,8 +22,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         {
             AvaloniaXamlLoader.Load(this);
 
-            // ponytail: needs App.Mods.GetAffirmation(), wired when it moves to Core
-            this.FindControl<TextBlock>("TxtWelcomeHeading")!.Text = Loc.GetF("label_welcome", "Subject");
+            this.FindControl<TextBlock>("TxtWelcomeHeading")!.Text =
+                Loc.GetF("label_welcome", CoreMods.Affirmation);
 
             this.FindControl<Button>("BtnBegin")!.Click += (_, _) => Close(true);
         }
@@ -28,12 +32,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// Show welcome dialog if user hasn't been welcomed yet.
         /// </summary>
         /// <returns>True if welcome was shown (first launch), false otherwise</returns>
-        public static bool ShowIfNeeded()
+        public static async Task<bool> ShowIfNeeded(Window owner)
         {
-            // ponytail: needs App.Settings (Welcomed flag + Save), wired when it moves to Core.
-            // Until then this never fires, so first launch shows nothing rather than showing it
-            // on every launch.
-            return false;
+            if (CoreSettings.Current.Welcomed) return false;
+
+            await new WelcomeDialog().ShowDialog(owner);
+
+            // WPF latched Welcomed whatever the dialog returned — dismissing it still counts as
+            // having seen it, otherwise the dialog reappears on every launch.
+            CoreSettings.Current.Welcomed = true;
+            CoreSettings.Save();
+            return true;
         }
     }
 }


### PR DESCRIPTION
The five consent gates stopped being read-only screens. Each one's persistence
body comes back against CoreSettings, which is what the stale notes were waiting
for — AppSettings, CompanionPromptSettings and every flag named below have been in
Core since the earlier layers.

ExplicitContentAcknowledgementDialog: the P2 C3 audit stamp. Accept writes
ExplicitAcknowledgedAt (UTC round-trip, invariant) and ExplicitAcknowledgedLocale
onto CompanionPrompt inside the WPF try/catch, before returning true, so the
caller's MarkAcknowledged still flips the flag and version afterwards. The dialog
deliberately does not save; the caller owns that, as on WPF. A failed stamp warns
and lets the gate through, since the audit field must never block consent.

WelcomeDialog: the heading interpolates the active mod's affirmation through
CoreMods.Affirmation, whose fallback is the same "Subject" the WPF null-coalesce
produced. ShowIfNeeded is ported as `Task<bool> ShowIfNeeded(Window owner)` —
Avalonia's ShowDialog is async and needs a non-null owner, so the parameterless
synchronous static could not survive as-is. It latches Welcomed and saves whatever
the dialog returned, matching WPF. It has no caller yet on either head:
FirstRunWizard.ShouldRunAndClaim took over the latch and the WPF original is dead
code too. Ported for parity, not because anything calls it.

MicConsentDialog: Enable now writes MicConsentGiven and saves before logging. The
mic still stays closed — it only opens during an explicit listen window under
Takeover.

WebcamConsentDialog: Enable writes WebcamConsentGiven and WebcamConsentDate and
saves. The camera stays closed. WebcamConsentVersion is NOT stamped, see below;
that fails safe rather than open, because IsConsentCurrent compares the stored
version against the contract version, so a Given=true record carrying an empty
version re-prompts from screen 1 instead of silently counting as consent.

AwarenessConsentDialog: the two live substitutions read real settings —
UseAwarenessV2 picks the "what leaves your PC" sentence between the v2 and legacy
copy, and AwarenessRetentionDays fills the retention line, so the number cannot go
stale against the setting. IsRequired ports verbatim; it is pure over AppSettings.
The local retention fallback constant is gone: Core's default AppSettings already
carries the real default under the headless render.

Still blocked:
- WebcamTrackingService.ConsentVersion ("1.0") is at
  ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs:98 and there is
  no Webcam directory in Core. Copying the literal would drift silently the moment
  the WPF side bumps it — which is the one thing the version field exists to
  prevent — so WebcamConsentVersion is left unwritten and the log line omits its
  {Version} argument until the service moves.
- AwarenessConsentDialog.EnsureConsent needs AwarenessPrivacyRules.EnsureSeeded and
  AwarenessIntensityMigration.EnsureMigrated, both still in
  ConditioningControlPanel/Services/Awareness/. Accepting consent without seeding
  the recommended deny groups would change what awareness observes, so it stays
  unported rather than half-ported.

Verified: CCP.Core and CCP.Avalonia build clean, and all five dialogs render
headless with real strings.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU