### PR TITLE
feat(avalonia): the Scheduler, Flash and System Lab cards read and write real settings

### DIFF
--- a/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml.cs
@@ -1,27 +1,272 @@
+using System;
+using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Flash Images panel, ported from the WPF head. Slider read-outs are real; every toggle and
-    /// slider also writes App.Settings on WPF (and ChkEnable / SliderFrequency poke FlashService),
-    /// which is not portable yet.
+    /// Flash Images panel, ported from the WPF head, settings logic restored against
+    /// <see cref="CoreSettings"/>. Every toggle and slider round-trips the AppSettings property
+    /// the WPF original wrote and saves, and the slider read-outs are repainted the same way.
+    ///
+    /// <para>The WPF <c>SettingsHook</c>/<c>ISettingsRebindable</c> pair is inlined: a cloud
+    /// restore SWAPS the settings instance, so the PropertyChanged subscription is tracked by
+    /// instance and re-pointed on <c>SettingsService.CurrentReplaced</c>.</para>
+    ///
+    /// <para>What is still head-side is named at each handler: the FlashService live-apply
+    /// (start/stop and RefreshSchedule) and the mod-art repaint.</para>
     /// </summary>
     public partial class FlashFeatureControl : UserControl
     {
+        private bool _isLoading = true;
+
         public FlashFeatureControl()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields, and everything below reads them.
+            InitializeComponent();
 
-            SliderLabel.Wire(this, "SliderFrequency", "TxtFrequency", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderImages", "TxtImages", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderMaxOnScreen", "TxtMaxOnScreen", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderCenterExclusion", "TxtCenterExclusion", v => $"{(int)v}%");
-            SliderLabel.Wire(this, "SliderFlashLingerMs", "TxtFlashLingerMs", v => $"{(int)v} ms");
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderFrequency.ValueChanged += SliderFrequency_Changed;
+            SliderImages.ValueChanged += SliderImages_Changed;
+            SliderMaxOnScreen.ValueChanged += SliderMaxOnScreen_Changed;
+            ChkClickable.IsCheckedChanged += ChkClickable_Changed;
+            ChkCorruption.IsCheckedChanged += ChkCorruption_Changed;
+            ChkHydraLinked.IsCheckedChanged += ChkHydraLinked_Changed;
+            ChkGlow.IsCheckedChanged += ChkGlow_Changed;
+            ChkSolidMode.IsCheckedChanged += ChkSolidMode_Changed;
+            ChkFlashAvoidCenter.IsCheckedChanged += ChkFlashAvoidCenter_Changed;
+            SliderCenterExclusion.ValueChanged += SliderCenterExclusion_Changed;
+            ChkFlashGazePop.IsCheckedChanged += ChkFlashGazePop_Changed;
+            ChkFlashGazeLinger.IsCheckedChanged += ChkFlashGazeLinger_Changed;
+            SliderFlashLingerMs.ValueChanged += SliderFlashLingerMs_Changed;
 
-            // ponytail: needs App.Settings / App.Flash, wired when they move to Core. The ten Chk*
-            // toggles are settings writes only.
+            LoadFromSettings();
+
+            // ponytail: WPF also repaints the hero and side art plates here (ApplyFeatureArt +
+            // App.Mods.ModChanged). Needs Services.ModResourceResolver.ResolveImageDecoded
+            // (ConditioningControlPanel/Services/, still in the WPF head) AND a named ImageBrush
+            // in the .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port
+            // draws a static wash instead, so there is nothing here to repaint.
+        }
+
+        // ---- settings instance tracking (WPF: SettingsHook + ISettingsRebindable) --------------
+
+        private AppSettings? _hooked;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            RebindToCurrentSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(RebindToCurrentSettings);
+
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = s.FlashEnabled;
+                SliderFrequency.Value = s.FlashFrequency;
+                TxtFrequency.Text = s.FlashFrequency.ToString();
+                SliderImages.Value = s.SimultaneousImages;
+                TxtImages.Text = s.SimultaneousImages.ToString();
+                SliderMaxOnScreen.Value = s.HydraLimit;
+                TxtMaxOnScreen.Text = s.HydraLimit.ToString();
+                ChkClickable.IsChecked = s.FlashClickable;
+                ChkCorruption.IsChecked = s.CorruptionMode;
+                ChkHydraLinked.IsChecked = s.HydraLinkedTiming;
+                ChkGlow.IsChecked = s.FlashGlowEnabled;
+                ChkSolidMode.IsChecked = s.FlashSolidMode;
+                ChkFlashGazePop.IsChecked = s.FlashGazePopEnabled;
+                ChkFlashGazeLinger.IsChecked = s.FlashGazeLingerEnabled;
+                SliderFlashLingerMs.Value = s.FlashGazeLingerExtensionMs;
+                TxtFlashLingerMs.Text = $"{s.FlashGazeLingerExtensionMs} ms";
+                ChkFlashAvoidCenter.IsChecked = s.FlashAvoidCenter;
+                SliderCenterExclusion.Value = s.FlashCenterExclusionPercent;
+                TxtCenterExclusion.Text = $"{s.FlashCenterExclusionPercent}%";
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            // Reload on any flash-related property; the set is small.
+            if (e.PropertyName == nameof(AppSettings.FlashEnabled) ||
+                e.PropertyName == nameof(AppSettings.FlashFrequency) ||
+                e.PropertyName == nameof(AppSettings.SimultaneousImages) ||
+                e.PropertyName == nameof(AppSettings.HydraLimit) ||
+                e.PropertyName == nameof(AppSettings.FlashClickable) ||
+                e.PropertyName == nameof(AppSettings.CorruptionMode) ||
+                e.PropertyName == nameof(AppSettings.HydraLinkedTiming) ||
+                e.PropertyName == nameof(AppSettings.FlashGlowEnabled) ||
+                e.PropertyName == nameof(AppSettings.FlashSolidMode) ||
+                e.PropertyName == nameof(AppSettings.FlashGazePopEnabled) ||
+                e.PropertyName == nameof(AppSettings.FlashGazeLingerEnabled) ||
+                e.PropertyName == nameof(AppSettings.FlashGazeLingerExtensionMs) ||
+                e.PropertyName == nameof(AppSettings.FlashAvoidCenter) ||
+                e.PropertyName == nameof(AppSettings.FlashCenterExclusionPercent))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        private void ChkFlashGazePop_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FlashGazePopEnabled = ChkFlashGazePop.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkFlashGazeLinger_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FlashGazeLingerEnabled = ChkFlashGazeLinger.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void SliderFlashLingerMs_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtFlashLingerMs.Text = $"{v} ms";
+            CoreSettings.Current.FlashGazeLingerExtensionMs = v;
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// #770/#859 — keeps flashes out of a centered square on every monitor so they never
+        /// cover a game's crosshair. Global user preference: sessions and presets never touch
+        /// it, and this control is its only UI surface.
+        /// </summary>
+        private void ChkFlashAvoidCenter_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkFlashAvoidCenter.IsChecked ?? false;
+            s.FlashAvoidCenter = on;
+            Log.Information("Flash avoid-center toggled: {Enabled} ({Pct}%)",
+                on, s.FlashCenterExclusionPercent);
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// #770 — size of the centered no-flash square, as a % of the shorter monitor edge.
+        /// AppSettings clamps to 5-60; the slider carries the same range.
+        /// </summary>
+        private void SliderCenterExclusion_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtCenterExclusion.Text = $"{v}%";
+            CoreSettings.Current.FlashCenterExclusionPercent = v;
+            CoreSettings.Save();
+        }
+
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FlashEnabled = ChkEnable.IsChecked ?? false;
+            CoreSettings.Save();
+            // ponytail: WPF also live-applies here - App.Flash.Start()/Stop() when
+            // App.IsEngineRunning. Needs FlashService (ConditioningControlPanel/Services/) and the
+            // engine-running flag off App, both still in the WPF head.
+        }
+
+        private void SliderFrequency_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtFrequency.Text = v.ToString();
+            CoreSettings.Current.FlashFrequency = v;
+            // ponytail: WPF also calls App.Flash.RefreshSchedule() here. Needs FlashService
+            // (ConditioningControlPanel/Services/), still in the WPF head.
+            CoreSettings.Save();
+        }
+
+        private void SliderImages_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtImages.Text = v.ToString();
+            CoreSettings.Current.SimultaneousImages = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderMaxOnScreen_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtMaxOnScreen.Text = v.ToString();
+            CoreSettings.Current.HydraLimit = v;
+            CoreSettings.Save();
+        }
+
+        private void ChkClickable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FlashClickable = ChkClickable.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkCorruption_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.CorruptionMode = ChkCorruption.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkHydraLinked_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.HydraLinkedTiming = ChkHydraLinked.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkGlow_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FlashGlowEnabled = ChkGlow.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkSolidMode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FlashSolidMode = ChkSolidMode.IsChecked ?? false;
+            CoreSettings.Save();
+            // No service bounce needed: each spawn reads the setting, so the next flash uses the
+            // new mode. Live flashes finish out on whichever renderer spawned them.
         }
     }
 }

--- a/CCP.Avalonia/Views/Features/SchedulerFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SchedulerFeatureControl.axaml.cs
@@ -1,22 +1,140 @@
+using System;
+using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Scheduler panel, ported from the WPF head. On WPF every handler round-trips
-    /// App.Settings.Current.Scheduler* and the SettingsHook/ISettingsRebindable pair keeps the
-    /// panel following a cloud-restored settings instance. AppSettings still lives in the WPF
-    /// head, so this port renders the markup defaults and persists nothing.
+    /// Scheduler panel, ported from the WPF head, settings logic restored against
+    /// <see cref="CoreSettings"/>. Every handler round-trips <c>CoreSettings.Current.Scheduler*</c>
+    /// and saves, exactly as the WPF original round-tripped <c>App.Settings</c>.
+    ///
+    /// <para>The WPF <c>SettingsHook</c>/<c>ISettingsRebindable</c> pair is inlined here: a cloud
+    /// restore or a factory reset SWAPS the settings instance rather than mutating it, so the
+    /// PropertyChanged subscription is tracked by instance and re-pointed on
+    /// <c>SettingsService.CurrentReplaced</c>. Without that this permanently-mounted rack panel
+    /// would keep showing, and writing to, the discarded object.</para>
+    ///
+    /// <para>The <c>_isLoading</c> guard is not optional: Avalonia raises
+    /// <c>IsCheckedChanged</c> on a programmatic set exactly as WPF raised <c>Checked</c>, so a
+    /// seed without it saves the markup defaults over the user's file.</para>
     /// </summary>
     public partial class SchedulerFeatureControl : UserControl
     {
+        private bool _isLoading = true;
+
         public SchedulerFeatureControl()
         {
-            AvaloniaXamlLoader.Load(this);
-            // ponytail: needs App.Settings (Scheduler* fields) + SettingsHook, wired when they move to Core.
-            // The ChkEnabled / TxtStart / TxtEnd / Day* handlers are pure settings writes; nothing
-            // view-side is left for them to do, so they are not stubbed one by one.
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields, and everything below reads them.
+            InitializeComponent();
+
+            ChkEnabled.IsCheckedChanged += ChkEnabled_Changed;
+            TxtStart.LostFocus += TxtTime_LostFocus;
+            TxtEnd.LostFocus += TxtTime_LostFocus;
+            DayMon.IsCheckedChanged += Day_Changed;
+            DayTue.IsCheckedChanged += Day_Changed;
+            DayWed.IsCheckedChanged += Day_Changed;
+            DayThu.IsCheckedChanged += Day_Changed;
+            DayFri.IsCheckedChanged += Day_Changed;
+            DaySat.IsCheckedChanged += Day_Changed;
+            DaySun.IsCheckedChanged += Day_Changed;
+
+            LoadFromSettings();
+        }
+
+        // ---- settings instance tracking (WPF: SettingsHook + ISettingsRebindable) --------------
+
+        private AppSettings? _hooked;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            RebindToCurrentSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(RebindToCurrentSettings);
+
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkEnabled.IsChecked = s.SchedulerEnabled;
+                TxtStart.Text = s.SchedulerStartTime ?? "00:00";
+                TxtEnd.Text = s.SchedulerEndTime ?? "22:00";
+                DayMon.IsChecked = s.SchedulerMonday;
+                DayTue.IsChecked = s.SchedulerTuesday;
+                DayWed.IsChecked = s.SchedulerWednesday;
+                DayThu.IsChecked = s.SchedulerThursday;
+                DayFri.IsChecked = s.SchedulerFriday;
+                DaySat.IsChecked = s.SchedulerSaturday;
+                DaySun.IsChecked = s.SchedulerSunday;
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName?.StartsWith("Scheduler", StringComparison.Ordinal) == true)
+                Dispatcher.UIThread.Post(LoadFromSettings);
+        }
+
+        private void ChkEnabled_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.SchedulerEnabled = ChkEnabled.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void TxtTime_LostFocus(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.SchedulerStartTime = TxtStart.Text ?? string.Empty;
+            s.SchedulerEndTime = TxtEnd.Text ?? string.Empty;
+            CoreSettings.Save();
+        }
+
+        private void Day_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.SchedulerMonday = DayMon.IsChecked ?? true;
+            s.SchedulerTuesday = DayTue.IsChecked ?? true;
+            s.SchedulerWednesday = DayWed.IsChecked ?? true;
+            s.SchedulerThursday = DayThu.IsChecked ?? true;
+            s.SchedulerFriday = DayFri.IsChecked ?? true;
+            s.SchedulerSaturday = DaySat.IsChecked ?? true;
+            s.SchedulerSunday = DaySun.IsChecked ?? true;
+            CoreSettings.Save();
         }
     }
 }

--- a/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml
+++ b/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml
@@ -7,7 +7,11 @@
        Image of an emoji (EmojiToImageSource) -> TextBlock with the emoji
        Content="{loc:Str ...}" on Button ->  a <TextBlock> child (trap 1: "_" is an access key)
        feat:AdaptiveSideArt.CollapseBelow -> dropped (attached behaviour lives in the WPF head)
-       Click/Checked handlers            ->  wired in code-behind (porting convention) -->
+       Click/Checked handlers            ->  wired in code-behind (porting convention)
+       TxtNoPanicState / TxtOfflineModeState / TxtStartupVideo lost their {loc:Str} default.
+       LoadFromSettings chooses the key and sets .Text, and an Avalonia {loc:Str} is a live
+       OneWay binding that survives a local value and overwrites it on the next language
+       change - so the read-out has to own the property outright. -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
@@ -129,7 +133,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="{loc:Str setting_no_panic}" Foreground="#FF6B6B"
                                            FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" x:Name="TxtNoPanicState" Text="{loc:Str set2_chip_off}"
+                                <TextBlock Grid.Column="1" x:Name="TxtNoPanicState" Text=""
                                            Foreground="{StaticResource TextMutedBrush}" FontSize="11"
                                            TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
                                            HorizontalAlignment="Right" Margin="10,0,10,0"/>
@@ -149,7 +153,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="{loc:Str setting_offline_mode}" FontSize="13" FontWeight="SemiBold"
                                            Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" x:Name="TxtOfflineModeState" Text="{loc:Str set2_chip_off}"
+                                <TextBlock Grid.Column="1" x:Name="TxtOfflineModeState" Text=""
                                            Foreground="{StaticResource TextMutedBrush}" FontSize="11"
                                            TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
                                            HorizontalAlignment="Right" Margin="10,0,10,0"/>
@@ -169,7 +173,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0" Text="{loc:Str label_startup_video}" FontSize="13" FontWeight="SemiBold"
                                            Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="1" x:Name="TxtStartupVideo" Text="{loc:Str label_random}"
+                                <TextBlock Grid.Column="1" x:Name="TxtStartupVideo" Text=""
                                            Foreground="{DynamicResource PinkBrush}" FontSize="12"
                                            TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
                                            HorizontalAlignment="Right" Margin="10,0,10,0"/>

--- a/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SystemFeatureControl.axaml.cs
@@ -1,36 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// System panel, ported from the WPF head. Five live toggles plus five read-out rows that
-    /// LoadFromSettings paints from App.Settings. AppSettings, StartupManager and MainWindow's
-    /// navigation (OpenAppSettingsSection / OpenDeviceSettings / RequestPickAssetsFolder) are all
-    /// still in the WPF head, so the read-outs show the "nothing set" defaults and the buttons
-    /// are inert.
+    /// System panel, ported from the WPF head, settings logic restored against
+    /// <see cref="CoreSettings"/>. The five live toggles write and save exactly as WPF's did, and
+    /// the five read-out rows are painted by <see cref="LoadFromSettings"/> from the real settings
+    /// and kept current by the PropertyChanged subscription, as on WPF.
+    ///
+    /// <para>The read-outs are read-only by design since Phase 2 of the UX restructure: Settings ▸
+    /// General owns the startup four and the startup video, Settings ▸ Devices owns the panic key,
+    /// Settings ▸ Data owns offline mode. This panel shows them and links there.</para>
+    ///
+    /// <para>What is still head-side is named at each handler: the four "configure in settings"
+    /// buttons and the assets-folder picker need the shell's navigation, which is stubbed in
+    /// <c>MainShellWindow</c> on this head too. Opening the assets folder works: it is
+    /// <see cref="CorePaths.EffectiveAssets"/> plus the platform launcher.</para>
     /// </summary>
     public partial class SystemFeatureControl : UserControl
     {
+        private bool _isLoading = true;
+
         public SystemFeatureControl()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields, and everything below reads them.
+            InitializeComponent();
+
+            ChkMultiMon.IsCheckedChanged += ChkMultiMon_Changed;
+            ChkFillAllMon.IsCheckedChanged += ChkFillAllMon_Changed;
+            ChkVideoGpuDecode.IsCheckedChanged += ChkVideoGpuDecode_Changed;
+            ChkVideoBlurBg.IsCheckedChanged += ChkVideoBlurBg_Changed;
+            ChkBrowserVideoEngine.IsCheckedChanged += ChkBrowserVideoEngine_Changed;
+
+            BtnOpenGeneralSettings.Click += BtnOpenGeneralSettings_Click;
+            BtnOpenGeneralSettingsVideo.Click += BtnOpenGeneralSettings_Click;
+            BtnOpenDeviceSettingsNoPanic.Click += BtnOpenDeviceSettings_Click;
+            BtnOpenDataSettings.Click += BtnOpenDataSettings_Click;
+            BtnPickAssets.Click += BtnPickAssets_Click;
+            BtnOpenAssets.Click += BtnOpenAssets_Click;
+
             LoadFromSettings();
-            // ponytail: needs App.Settings + MainWindow navigation, wired when they move to Core.
-            // ChkMultiMon / ChkFillAllMon / ChkVideoGpuDecode / ChkVideoBlurBg / ChkBrowserVideoEngine
-            // are pure settings writes; BtnOpen* / BtnPickAssets / BtnOpenAssets call MainWindow.
+        }
+
+        // ---- settings instance tracking (WPF hooked App.Settings.Current directly here) --------
+
+        private AppSettings? _hooked;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            RebindToCurrentSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(RebindToCurrentSettings);
+
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkMultiMon.IsChecked = s.DualMonitorEnabled;
+                ChkFillAllMon.IsChecked = s.FillAllMonitorsWithVideo;
+                ChkVideoGpuDecode.IsChecked = s.VideoForceHardwareDecoding;
+                ChkVideoBlurBg.IsChecked = s.VideoBlurredBackgroundEnabled;
+                ChkBrowserVideoEngine.IsChecked = s.BrowserVideoEngineEnabled;
+                // Startup group + offline mode: read-only mirrors since Phase 2 of the UX
+                // restructure. Both were second live editors of settings whose real owner is the
+                // Settings door. Painting is all that is left; the PropertyChanged subscription
+                // keeps it current while the panel is mounted.
+                TxtStartupGroupState.Text = DescribeStartupGroup(s);
+                TxtOfflineModeState.Text = Loc.Get(s.OfflineMode ? "set2_chip_on" : "set2_chip_off");
+
+                TxtStartupVideo.Text = string.IsNullOrEmpty(s.StartupVideoPath)
+                    ? Loc.Get("label_random")
+                    : Path.GetFileName(s.StartupVideoPath);
+
+                // Panic key: read-only mirror for the same reason. Settings ▸ Devices owns the
+                // toggle, the rebind and the keyboard hook.
+                TxtPanicKeyState.Text = $"🔑 {s.PanicKey}";
+                TxtNoPanicState.Text = Loc.Get(s.PanicKeyEnabled ? "set2_chip_off" : "set2_chip_on");
+            }
+            finally { _isLoading = false; }
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.DualMonitorEnabled) ||
+                e.PropertyName == nameof(AppSettings.FillAllMonitorsWithVideo) ||
+                e.PropertyName == nameof(AppSettings.VideoForceHardwareDecoding) ||
+                e.PropertyName == nameof(AppSettings.VideoBlurredBackgroundEnabled) ||
+                e.PropertyName == nameof(AppSettings.BrowserVideoEngineEnabled) ||
+                e.PropertyName == nameof(AppSettings.ForceVideoOnLaunch) ||
+                e.PropertyName == nameof(AppSettings.AutoStartEngine) ||
+                e.PropertyName == nameof(AppSettings.StartMinimized) ||
+                e.PropertyName == nameof(AppSettings.PanicKeyEnabled) ||
+                e.PropertyName == nameof(AppSettings.PanicKey) ||
+                e.PropertyName == nameof(AppSettings.OfflineMode) ||
+                e.PropertyName == nameof(AppSettings.StartupVideoPath) ||
+                e.PropertyName == nameof(AppSettings.RunOnStartup))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        // ---- Simple local toggles (write directly to settings) ----
+
+        private void ChkMultiMon_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.DualMonitorEnabled = ChkMultiMon.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkFillAllMon_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.FillAllMonitorsWithVideo = ChkFillAllMon.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkVideoGpuDecode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.VideoForceHardwareDecoding = ChkVideoGpuDecode.IsChecked ?? false;
+            CoreSettings.Save();
+            Log.Information("Force video GPU decode set to {Enabled} (System popup)", s.VideoForceHardwareDecoding);
+        }
+
+        private void ChkVideoBlurBg_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.VideoBlurredBackgroundEnabled = ChkVideoBlurBg.IsChecked ?? true;
+            CoreSettings.Save();
+            Log.Information("Blurred video background set to {Enabled} (System popup)", s.VideoBlurredBackgroundEnabled);
+        }
+
+        private void ChkBrowserVideoEngine_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.BrowserVideoEngineEnabled = ChkBrowserVideoEngine.IsChecked ?? false;
+            CoreSettings.Save();
+            Log.Information("Browser video engine set to {Enabled} (System popup)", s.BrowserVideoEngineEnabled);
         }
 
         /// <summary>
-        /// Placeholder mirror of the WPF LoadFromSettings: same keys, "nothing configured" values.
-        /// TxtNoPanicState / TxtOfflineModeState / TxtStartupVideo keep their markup defaults
-        /// (set2_chip_off / label_random), exactly what WPF paints for a fresh settings file.
+        /// One line summarising the four startup switches for the read-only row. Each is named only
+        /// when it is ON, so the common "nothing special" case reads as a single calm phrase instead
+        /// of four "Off"s.
         /// </summary>
-        private void LoadFromSettings()
+        private static string DescribeStartupGroup(AppSettings s)
         {
-            this.FindControl<TextBlock>("TxtStartupGroupState")!.Text = Loc.Get("set2_startup_group_none");
-            this.FindControl<TextBlock>("TxtPanicKeyState")!.Text = "🔑 —"; // WPF: $"🔑 {s.PanicKey}"
+            var parts = new List<string>();
+            // ponytail: WPF asks Services.StartupManager.IsRegistered() (a Windows Startup-folder
+            // shortcut) rather than the stored flag. No equivalent on this head; the stored value
+            // stands in, exactly as GeneralSettingsSection does for the same switch.
+            if (s.RunOnStartup) parts.Add(Loc.Get("setting_win_start"));
+            if (s.StartMinimized) parts.Add(Loc.Get("setting_start_hidden"));
+            if (s.AutoStartEngine) parts.Add(Loc.Get("setting_auto_run"));
+            if (s.ForceVideoOnLaunch) parts.Add(Loc.Get("setting_vid_launch"));
+            return parts.Count == 0
+                ? Loc.Get("set2_startup_group_none")
+                : string.Join(" · ", parts);
+        }
+
+        // ponytail: the four navigation buttons need the shell's OpenAppSettingsSection /
+        // OpenDeviceSettings / RequestPickAssetsFolder. Both heads still owe them: they are
+        // commented-out stubs in CCP.Avalonia/Views/Windows/MainShellWindow.Settings.cs,
+        // .LabTab.cs and .axaml.cs, and live methods on MainWindow in the WPF head.
+        private void BtnOpenDeviceSettings_Click(object? sender, RoutedEventArgs e) { }
+
+        private void BtnOpenGeneralSettings_Click(object? sender, RoutedEventArgs e) { }
+
+        private void BtnOpenDataSettings_Click(object? sender, RoutedEventArgs e) { }
+
+        private void BtnPickAssets_Click(object? sender, RoutedEventArgs e) { }
+
+        private void BtnOpenAssets_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var path = CorePaths.EffectiveAssets;
+                if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+                {
+                    // UseShellExecute hands the folder to the platform's file manager - xdg-open
+                    // on Linux, Explorer on Windows. Same call the WPF original made.
+                    Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to open assets folder from popup");
+            }
         }
     }
 }


### PR DESCRIPTION
Split from a single feature-card layer to keep each layer reviewable; the Video and
Bubble Pop halves follow in the next layer.

All three were markup with their logic cut out. They now round-trip CoreSettings.Current
and save on every change, exactly as their WPF originals round-tripped App.Settings, with
the _isLoading seed guard that keeps a programmatic IsChecked from writing the markup
defaults over the user's file. Each inlines the WPF SettingsHook/ISettingsRebindable pair:
the PropertyChanged subscription is tracked by instance and re-pointed on
SettingsService.CurrentReplaced, so a cloud restore or factory reset - which swaps the
settings object rather than mutating it - does not leave a permanently-mounted rack panel
showing and writing the discarded one.

Scheduler: enable, both time boxes on LostFocus and the seven day checkboxes. Nothing
left blocked.

Flash Images: the enable switch, the three count sliders, click/hydra/linked/glow/solid
mode, the avoid-center pair (with its log line) and the three gaze rows.

System: the five monitor/video toggles with their log lines, and the five read-out rows
painted from real settings and kept current by the PropertyChanged filter. TxtNoPanicState,
TxtOfflineModeState and TxtStartupVideo lose their {loc:Str} defaults in the .axaml -
LoadFromSettings picks the key, and an Avalonia {loc:Str} is a live OneWay binding that
would overwrite a code-set value on the next language change. Opening the assets folder
works off CorePaths.EffectiveAssets.

Still blocked, each note rewritten to name the exact symbol:
- FlashService start, stop and RefreshSchedule, plus App.IsEngineRunning
  (ConditioningControlPanel/Services/, WPF head)
- ModResourceResolver.ResolveImageDecoded, and a named ImageBrush the .axaml cannot
  declare (x:Name on a brush is AVLN2000) - the art plates draw a static wash
- StartupManager.IsRegistered(); the stored RunOnStartup stands in, as in
  GeneralSettingsSection
- MainShellWindow.OpenAppSettingsSection / OpenDeviceSettings / RequestPickAssetsFolder,
  commented-out stubs on this head

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU