### PR TITLE
feat(avalonia): the Bubble Pop and Mandatory Video Lab cards read and write real settings

### DIFF
--- a/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml.cs
@@ -1,37 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Bubble Pop panel, ported from the WPF head. The slider read-outs, the trigger-options
-    /// reveal and the two formatted lines are real; the settings writes, the BubbleService
-    /// start/stop and the persona lookup (App.Mods.ActiveModId) are WPF-head services.
+    /// Bubble Pop panel, ported from the WPF head, settings logic restored against
+    /// <see cref="CoreSettings"/>. Every toggle and slider round-trips the AppSettings property
+    /// the WPF original wrote and saves; the trigger-options reveal and the seven trigger-type
+    /// checkboxes drive <c>BubbleTriggerVariants</c> the same way.
+    ///
+    /// <para>The WPF <c>SettingsHook</c>/<c>ISettingsRebindable</c> pair is inlined: a cloud
+    /// restore SWAPS the settings instance, so the PropertyChanged subscription is tracked by
+    /// instance and re-pointed on <c>SettingsService.CurrentReplaced</c>.</para>
+    ///
+    /// <para>The easter-egg hint names the active persona from <see cref="CoreMods.ActiveModId"/>,
+    /// and <see cref="CoreMods.ModChanged"/> repaints it - the rack hosts this control
+    /// permanently, so a mod switch has to be followed.</para>
     /// </summary>
     public partial class BubblePopFeatureControl : UserControl
     {
+        private bool _isLoading = true;
+
         public BubblePopFeatureControl()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields, and everything below reads them.
+            InitializeComponent();
 
-            SliderLabel.Wire(this, "SliderFreq", "TxtFreq", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderVolume", "TxtVolume", v => $"{(int)v}%");
-            SliderLabel.Wire(this, "SliderSize", "TxtSize", v => $"{(int)v}%");
-            SliderLabel.Wire(this, "SliderSpeed", "TxtSpeed", v => $"+{(int)v}%");
-            SliderLabel.Wire(this, "SliderTriggerChance", "TxtTriggerChance", v => $"{(int)v}%");
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderFreq.ValueChanged += SliderFreq_Changed;
+            SliderVolume.ValueChanged += SliderVolume_Changed;
+            SliderSize.ValueChanged += SliderSize_Changed;
+            SliderSpeed.ValueChanged += SliderSpeed_Changed;
+            ChkSolidMode.IsCheckedChanged += ChkSolidMode_Changed;
+            ChkTriggers.IsCheckedChanged += ChkTriggers_Changed;
+            SliderTriggerChance.ValueChanged += SliderTriggerChance_Changed;
+            foreach (var box in TriggerTypeBoxes()) box.IsCheckedChanged += TriggerType_Changed;
 
-            var triggers = this.FindControl<CheckBox>("ChkTriggers")!;
-            var options = this.FindControl<StackPanel>("TriggerOptionsPanel")!;
-            triggers.IsCheckedChanged += (_, _) => options.IsVisible = triggers.IsChecked ?? false;
+            LoadFromSettings();
 
-            // WPF: persona from App.Mods.ActiveModId; "your companion" is its fallback arm.
-            this.FindControl<TextBlock>("TxtTriggerEggHint")!.Text = "careful — your companion loves these…";
-            // WPF: BubbleService.AmbientBubbleXpPaidToday() / AmbientBubbleDailyXpCap (300).
-            this.FindControl<TextBlock>("TxtAmbientXpBudget")!.Text = Loc.GetF("label_ambient_bubble_xp_budget", 0, 300);
-
-            // ponytail: needs App.Settings / App.Bubbles / App.Mods, wired when they move to Core.
-            // ChkEnable, ChkSolidMode and the ChkType* effect checkboxes are settings writes only.
+            // ponytail: WPF also repaints the hero and side art plates here (ApplyFeatureArt).
+            // Needs Services.ModResourceResolver.ResolveImageDecoded
+            // (ConditioningControlPanel/Services/, still in the WPF head) AND a named ImageBrush
+            // in the .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port
+            // draws a static wash instead, so there is nothing here to repaint.
         }
+
+        /// <summary>The seven effect boxes, each carrying its variant id in <c>Tag</c>.</summary>
+        private IEnumerable<CheckBox> TriggerTypeBoxes()
+        {
+            yield return ChkTypeFlash;
+            yield return ChkTypeSubliminal;
+            yield return ChkTypePink;
+            yield return ChkTypeSpiral;
+            yield return ChkTypeGlitch;
+            yield return ChkTypeCascade;
+            yield return ChkTypeVideo;
+        }
+
+        // ---- settings instance tracking (WPF: SettingsHook + ISettingsRebindable) --------------
+
+        private AppSettings? _hooked;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            CoreMods.ModChanged += OnModChanged;
+            RebindToCurrentSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            CoreMods.ModChanged -= OnModChanged;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(RebindToCurrentSettings);
+
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        /// <summary>
+        /// ModChanged can be raised off the UI thread, so the repaint is marshalled. The persona
+        /// line is the only thing here that changes answer on a mod switch (WPF also repainted the
+        /// two art plates, which this head does not draw).
+        /// </summary>
+        private void OnModChanged(object? sender, ModPackage mod) =>
+            Dispatcher.UIThread.Post(LoadFromSettings);
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = s.BubblesEnabled;
+                SliderFreq.Value = s.BubblesFrequency;
+                TxtFreq.Text = s.BubblesFrequency.ToString();
+                SliderVolume.Value = s.BubblesVolume;
+                TxtVolume.Text = $"{s.BubblesVolume}%";
+                SliderSize.Value = s.BubblesSize;
+                TxtSize.Text = $"{s.BubblesSize}%";
+                SliderSpeed.Value = s.BubbleSpeedBoost;
+                TxtSpeed.Text = $"+{s.BubbleSpeedBoost}%";
+                ChkSolidMode.IsChecked = s.BubbleSharedHost;
+
+                // Easter-egg hint (companion auto-pops a lingering effect bubble) — name the active persona.
+                var persona = CoreMods.ActiveModId switch
+                {
+                    "builtin-bambisleep" => "Bambi",
+                    "builtin-sissyhypno" => "your bimbo",
+                    "builtin-locked" => "Circe",
+                    _ => "your companion"
+                };
+                TxtTriggerEggHint.Text = $"careful — {persona} loves these…";
+
+                ChkTriggers.IsChecked = s.BubbleTriggersEnabled;
+                TriggerOptionsPanel.IsVisible = s.BubbleTriggersEnabled;
+                SliderTriggerChance.Value = s.BubbleTriggerChance;
+                TxtTriggerChance.Text = $"{s.BubbleTriggerChance}%";
+                var ids = s.BubbleTriggerVariants ?? new List<string>();
+                foreach (var box in TriggerTypeBoxes())
+                    box.IsChecked = box.Tag is string id && ids.Contains(id);
+                UpdateAmbientXpBudgetLine();
+            }
+            finally { _isLoading = false; }
+        }
+
+        /// <summary>
+        /// "Ambient bubble XP: N/300 today" (#1019/#1026). Ambient pops stop paying once the daily
+        /// bucket is spent; before this line the ceiling was completely invisible.
+        /// </summary>
+        private void UpdateAmbientXpBudgetLine()
+        {
+            // ponytail: needs Services.BubbleService.AmbientBubbleDailyXpCap and
+            // AmbientBubbleXpPaidToday() (ConditioningControlPanel/Services/BubbleService.cs, still
+            // in the WPF head) - the paid-today counter is on AppSettings in Core, but the 300 cap
+            // and the clamp are not, and duplicating the constant here would put it in two places.
+            // WPF also repaints this from BubbleService.AmbientXpBudgetChanged, which is the same
+            // head-side class.
+            TxtAmbientXpBudget.Text = Loc.GetF("label_ambient_bubble_xp_budget", 0, 300);
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.BubblesEnabled) ||
+                e.PropertyName == nameof(AppSettings.BubblesFrequency) ||
+                e.PropertyName == nameof(AppSettings.BubblesVolume) ||
+                e.PropertyName == nameof(AppSettings.BubblesSize) ||
+                e.PropertyName == nameof(AppSettings.BubbleSpeedBoost) ||
+                e.PropertyName == nameof(AppSettings.BubbleGazePopEnabled) ||
+                e.PropertyName == nameof(AppSettings.BubbleTriggersEnabled) ||
+                e.PropertyName == nameof(AppSettings.BubbleTriggerChance) ||
+                e.PropertyName == nameof(AppSettings.BubbleTriggerVariants))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.BubblesEnabled = ChkEnable.IsChecked ?? false;
+            CoreSettings.Save();
+            // ponytail: WPF also live-applies here - App.Bubbles.Start()/Stop() when
+            // App.IsEngineRunning. Needs BubbleService (ConditioningControlPanel/Services/) and the
+            // engine-running flag off App, both still in the WPF head.
+        }
+
+        private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtFreq.Text = v.ToString();
+            CoreSettings.Current.BubblesFrequency = v;
+            // ponytail: WPF also calls App.Bubbles.RefreshFrequency() here. Needs BubbleService
+            // (ConditioningControlPanel/Services/), still in the WPF head.
+            CoreSettings.Save();
+        }
+
+        private void SliderVolume_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtVolume.Text = $"{v}%";
+            CoreSettings.Current.BubblesVolume = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderSize_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtSize.Text = $"{v}%";
+            CoreSettings.Current.BubblesSize = v;
+            CoreSettings.Save();
+            // No live-apply hook: size is read when each bubble is CONSTRUCTED, so the change
+            // shows on the next spawn without disturbing the ones already drifting. Restarting the
+            // service to resize mid-flight would pop the field out from under the user.
+        }
+
+        private void SliderSpeed_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtSpeed.Text = $"+{v}%";
+            CoreSettings.Current.BubbleSpeedBoost = v;
+            CoreSettings.Save();
+        }
+
+        private void ChkSolidMode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.BubbleSharedHost = ChkSolidMode.IsChecked ?? false;
+            CoreSettings.Save();
+            // ponytail: the render path is latched per Start->Stop session, so WPF bounces a live
+            // bubble service here to pick up the new mode. Needs BubbleService
+            // (ConditioningControlPanel/Services/) and App.IsEngineRunning, still in the WPF head.
+        }
+
+        private void ChkTriggers_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var on = ChkTriggers.IsChecked ?? false;
+            CoreSettings.Current.BubbleTriggersEnabled = on;
+            TriggerOptionsPanel.IsVisible = on;
+            CoreSettings.Save();
+        }
+
+        private void SliderTriggerChance_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtTriggerChance.Text = $"{v}%";
+            CoreSettings.Current.BubbleTriggerChance = v;
+            CoreSettings.Save();
+        }
+
+        private void TriggerType_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            if (sender is not CheckBox cb || cb.Tag is not string id) return;
+
+            var s = CoreSettings.Current;
+            var ids = new List<string>(s.BubbleTriggerVariants ?? new List<string>());
+            if (cb.IsChecked ?? false) { if (!ids.Contains(id)) ids.Add(id); }
+            else ids.Remove(id);
+            s.BubbleTriggerVariants = ids;   // reassign so the setter fires change notification
+            CoreSettings.Save();
+        }
+
+        // ponytail: WPF also carries the "stare to pop" row here - ChkBubbleGazePop_Changed
+        // (BubbleGazePopEnabled, which is in Core) plus TxtBubbleGazeHint, whose visibility asks
+        // App.Webcam.IsRunning / .Calibration and Services.WebcamTrackingService.IsConsentCurrent()
+        // in the WPF head. Neither control exists in this port's .axaml, so there is nothing to
+        // wire until that card is ported.
     }
 }

--- a/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml.cs
@@ -1,35 +1,126 @@
+using System;
+using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Mandatory Video panel, ported from the WPF head. The read-outs and the min/max duration
-    /// clamp are real; the settings writes, VideoService start/stop/test, the strict-lock
-    /// double-confirm (WarningDialog) and the two editor dialogs (TextEditorDialog over
-    /// s.AttentionPool, AttentionTargetEditorDialog) are WPF-head services or need App.Settings.
+    /// Mandatory Video panel, ported from the WPF head, settings logic restored against
+    /// <see cref="CoreSettings"/>. Every toggle and slider round-trips the AppSettings property
+    /// the WPF original wrote and saves, including the min/max duration clamp that keeps the
+    /// queue from being trapped empty.
+    ///
+    /// <para>The WPF <c>SettingsHook</c>/<c>ISettingsRebindable</c> pair is inlined: a cloud
+    /// restore SWAPS the settings instance, so the PropertyChanged subscription is tracked by
+    /// instance and re-pointed on <c>SettingsService.CurrentReplaced</c>.</para>
+    ///
+    /// <para>The three dialogs are real, against this head's ports: the strict-lock double
+    /// confirm (<see cref="WarningDialog.ShowDoubleWarningAsync"/>), the attention-pool editor
+    /// (<see cref="TextEditorDialog"/>) and the target-style editor
+    /// (<see cref="AttentionTargetEditorDialog"/>). Avalonia's ShowDialog is async and needs an
+    /// owner Window, so the two handlers that show one are <c>async void</c> and no-op when the
+    /// control has no window (the headless render path).</para>
     /// </summary>
     public partial class VideoFeatureControl : UserControl
     {
+        private bool _isLoading = true;
+
         public VideoFeatureControl()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields, and everything below reads them.
+            InitializeComponent();
 
-            SliderLabel.Wire(this, "SliderPerHour", "TxtPerHour", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderTargets", "TxtTargets", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderDuration", "TxtDuration", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderTargetSize", "TxtTargetSize", v => ((int)v).ToString());
-            var min = SliderLabel.Wire(this, "SliderVideoMinDur", "TxtVideoMinDur", v => FormatDuration((int)v));
-            var max = SliderLabel.Wire(this, "SliderVideoMaxDur", "TxtVideoMaxDur", v => FormatDuration((int)v));
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderPerHour.ValueChanged += SliderPerHour_Changed;
+            ChkStrict.IsCheckedChanged += ChkStrict_Changed;
+            SliderVideoMinDur.ValueChanged += SliderVideoMinDur_Changed;
+            SliderVideoMaxDur.ValueChanged += SliderVideoMaxDur_Changed;
+            ChkMiniGame.IsCheckedChanged += ChkMiniGame_Changed;
+            SliderTargets.ValueChanged += SliderTargets_Changed;
+            ChkRandomize.IsCheckedChanged += ChkRandomize_Changed;
+            SliderDuration.ValueChanged += SliderDuration_Changed;
+            SliderTargetSize.ValueChanged += SliderTargetSize_Changed;
+            ChkVideoGazeClick.IsCheckedChanged += ChkVideoGazeClick_Changed;
+            BtnManageAttention.Click += BtnManageAttention_Click;
+            BtnAttentionStyle.Click += BtnAttentionStyle_Click;
+            BtnTestVideo.Click += BtnTestVideo_Click;
 
-            // Keep max >= min (and min <= max) when both are non-zero, so the user can't trap the
-            // queue empty. Same rule as WPF; the paired slider's own ValueChanged repaints its label.
-            min.ValueChanged += (_, e) => { if (max.Value > 0 && e.NewValue > 0 && max.Value < e.NewValue) max.Value = e.NewValue; };
-            max.ValueChanged += (_, e) => { if (min.Value > 0 && e.NewValue > 0 && min.Value > e.NewValue) min.Value = e.NewValue; };
+            LoadFromSettings();
 
-            // ponytail: needs App.Settings / App.Video / WarningDialog / AttentionTargetEditorDialog,
-            // wired when they move to Core. ChkEnable, ChkStrict, ChkMiniGame, ChkRandomize,
-            // ChkVideoGazeClick, BtnManageAttention, BtnAttentionStyle, BtnTestVideo are inert.
+            // ponytail: WPF also repaints the hero and side art plates here (ApplyFeatureArt +
+            // App.Mods.ModChanged). Needs Services.ModResourceResolver.ResolveImageDecoded
+            // (ConditioningControlPanel/Services/, still in the WPF head) AND a named ImageBrush
+            // in the .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port
+            // draws a static wash instead, so there is nothing here to repaint.
+        }
+
+        // ---- settings instance tracking (WPF: SettingsHook + ISettingsRebindable) --------------
+
+        private AppSettings? _hooked;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            RebindToCurrentSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(RebindToCurrentSettings);
+
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = s.MandatoryVideosEnabled;
+                SliderPerHour.Value = s.VideosPerHour;
+                TxtPerHour.Text = s.VideosPerHour.ToString();
+                ChkStrict.IsChecked = s.StrictLockEnabled;
+                SliderVideoMinDur.Value = s.VideoMinDurationSeconds;
+                TxtVideoMinDur.Text = FormatDuration(s.VideoMinDurationSeconds);
+                SliderVideoMaxDur.Value = s.VideoMaxDurationSeconds;
+                TxtVideoMaxDur.Text = FormatDuration(s.VideoMaxDurationSeconds);
+                ChkMiniGame.IsChecked = s.AttentionChecksEnabled;
+                SliderTargets.Value = s.AttentionDensity;
+                TxtTargets.Text = s.AttentionDensity.ToString();
+                ChkRandomize.IsChecked = s.RandomizeAttentionTargets;
+                SliderDuration.Value = s.AttentionLifespan;
+                TxtDuration.Text = s.AttentionLifespan.ToString();
+                SliderTargetSize.Value = s.AttentionSize;
+                TxtTargetSize.Text = s.AttentionSize.ToString();
+                ChkVideoGazeClick.IsChecked = s.VideoGazeClickEnabled;
+            }
+            finally { _isLoading = false; }
         }
 
         private static string FormatDuration(int seconds)
@@ -39,6 +130,184 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             var m = seconds / 60;
             var rem = seconds % 60;
             return rem == 0 ? $"{m}m" : $"{m}m {rem}s";
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.MandatoryVideosEnabled) ||
+                e.PropertyName == nameof(AppSettings.VideosPerHour) ||
+                e.PropertyName == nameof(AppSettings.StrictLockEnabled) ||
+                e.PropertyName == nameof(AppSettings.VideoMinDurationSeconds) ||
+                e.PropertyName == nameof(AppSettings.VideoMaxDurationSeconds) ||
+                e.PropertyName == nameof(AppSettings.AttentionChecksEnabled) ||
+                e.PropertyName == nameof(AppSettings.AttentionDensity) ||
+                e.PropertyName == nameof(AppSettings.RandomizeAttentionTargets) ||
+                e.PropertyName == nameof(AppSettings.AttentionLifespan) ||
+                e.PropertyName == nameof(AppSettings.AttentionSize) ||
+                e.PropertyName == nameof(AppSettings.VideoGazeClickEnabled))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        private void ChkVideoGazeClick_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.VideoGazeClickEnabled = ChkVideoGazeClick.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void SliderVideoMinDur_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtVideoMinDur.Text = FormatDuration(v);
+            s.VideoMinDurationSeconds = v;
+            // Keep max >= min when both are non-zero, so the user can't trap the queue empty.
+            if (s.VideoMaxDurationSeconds > 0 && v > 0 && s.VideoMaxDurationSeconds < v)
+            {
+                s.VideoMaxDurationSeconds = v;
+                SliderVideoMaxDur.Value = v;
+                TxtVideoMaxDur.Text = FormatDuration(v);
+            }
+            CoreSettings.Save();
+        }
+
+        private void SliderVideoMaxDur_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtVideoMaxDur.Text = FormatDuration(v);
+            s.VideoMaxDurationSeconds = v;
+            // Keep min <= max when both are non-zero.
+            if (s.VideoMinDurationSeconds > 0 && v > 0 && s.VideoMinDurationSeconds > v)
+            {
+                s.VideoMinDurationSeconds = v;
+                SliderVideoMinDur.Value = v;
+                TxtVideoMinDur.Text = FormatDuration(v);
+            }
+            CoreSettings.Save();
+        }
+
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.MandatoryVideosEnabled = ChkEnable.IsChecked ?? false;
+            CoreSettings.Save();
+            // ponytail: WPF also live-applies here - App.Video.Start()/Stop() when
+            // App.IsEngineRunning. Needs VideoService (ConditioningControlPanel/Services/) and the
+            // engine-running flag off App, both still in the WPF head.
+        }
+
+        private void SliderPerHour_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtPerHour.Text = v.ToString();
+            CoreSettings.Current.VideosPerHour = v;
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// Strict lock is the one setting on this panel that can trap the user, so enabling it
+        /// costs a double confirm. A refusal reverts the box under the loading guard, as on WPF -
+        /// the revert is itself a programmatic set and must not re-enter this handler.
+        /// </summary>
+        private async void ChkStrict_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var on = ChkStrict.IsChecked ?? false;
+            if (on && TopLevel.GetTopLevel(this) is Window owner)
+            {
+                var confirmed = await WarningDialog.ShowDoubleWarningAsync(owner,
+                    "Strict Lock",
+                    "• You will NOT be able to skip or close videos\n" +
+                    "• Videos MUST be watched to completion\n" +
+                    "• The only way out is the panic key (if enabled)\n" +
+                    "• This can be very intense and restrictive");
+
+                if (!confirmed)
+                {
+                    _isLoading = true;
+                    ChkStrict.IsChecked = false;
+                    _isLoading = false;
+                    return;
+                }
+            }
+
+            CoreSettings.Current.StrictLockEnabled = on;
+            CoreSettings.Save();
+        }
+
+        private void ChkMiniGame_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.AttentionChecksEnabled = ChkMiniGame.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void SliderTargets_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtTargets.Text = v.ToString();
+            CoreSettings.Current.AttentionDensity = v;
+            CoreSettings.Save();
+        }
+
+        private void ChkRandomize_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.RandomizeAttentionTargets = ChkRandomize.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void SliderDuration_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtDuration.Text = v.ToString();
+            CoreSettings.Current.AttentionLifespan = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderTargetSize_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtTargetSize.Text = v.ToString();
+            CoreSettings.Current.AttentionSize = v;
+            CoreSettings.Save();
+        }
+
+        private async void BtnManageAttention_Click(object? sender, RoutedEventArgs e)
+        {
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
+            var s = CoreSettings.Current;
+            var dialog = new TextEditorDialog("Attention Targets", s.AttentionPool);
+            if (await dialog.ShowDialog<bool?>(owner) == true && dialog.ResultData != null)
+            {
+                s.AttentionPool = dialog.ResultData;
+                CoreSettings.Save();
+                Log.Information("Attention pool updated: {Count} items", dialog.ResultData.Count);
+            }
+        }
+
+        private async void BtnAttentionStyle_Click(object? sender, RoutedEventArgs e)
+        {
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
+            await new AttentionTargetEditorDialog().ShowDialog(owner);
+        }
+
+        private void BtnTestVideo_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs VideoService (IsPlaying / ForceCleanup / TriggerVideo),
+            // InteractionQueue (CanStart / CurrentInteraction / ForceReset) and
+            // AutonomyService.ForceEndWebVideoTakeover, all under
+            // ConditioningControlPanel/Services/ and still in the WPF head. The two "looks stuck,
+            // force reset?" prompts around them go with it.
         }
     }
 }


### PR DESCRIPTION
The second half of the feature-card layer; same inline SettingsHook/ISettingsRebindable
pattern and the same _isLoading seed guard as the Scheduler/Flash/System layer below it.

Bubble Pop: the enable switch, four sliders, solid mode, the trigger reveal and the seven
trigger-type boxes writing BubbleTriggerVariants. The easter-egg hint names the active
persona from CoreMods.ActiveModId and repaints on CoreMods.ModChanged.

Mandatory Video: every toggle and slider including the min/max duration clamp, plus all
three dialogs against this head's ports - the strict-lock double confirm
(WarningDialog.ShowDoubleWarningAsync), the attention-pool editor (TextEditorDialog) and
the target-style editor. ShowDialog is async here, so those handlers take the owner window
and no-op without one.

Still blocked, each note rewritten to name the exact symbol:
- BubbleService and VideoService start, stop and refresh, plus App.IsEngineRunning
  (ConditioningControlPanel/Services/, WPF head)
- BubbleService.AmbientBubbleDailyXpCap and AmbientBubbleXpPaidToday() - AppSettings
  carries the paid-today counter but not the 300 cap, so the line still reads 0/300
- InteractionQueue and AutonomyService.ForceEndWebVideoTakeover behind the Test button

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU