### PR TITLE
feat(avalonia): the Bouncing Text and Pink Filter cards edit real settings

### DIFF
--- a/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
@@ -1,51 +1,420 @@
+using System;
+using System.ComponentModel;
 using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Bouncing Text panel, ported from the WPF head. Slider read-outs, the fixed-colour row
-    /// reveal and the font list are real; settings writes, BouncingTextService refresh/restart,
-    /// the WinForms ColorDialog and the phrase editor over s.BouncingTextPool are not portable yet.
+    /// Bouncing Text panel, ported from the WPF head, against <see cref="CoreSettings"/>.
+    ///
+    /// <para>WPF's <c>ISettingsRebindable</c> + <c>SettingsHook</c> pair is reproduced inline: a
+    /// cloud restore SWAPS the AppSettings instance, so the PropertyChanged subscription is
+    /// tracked per instance and re-pointed on <c>SettingsService.CurrentReplaced</c>.</para>
+    ///
+    /// <para>The phrase editor is the ported <see cref="TextEditorDialog"/>, so it is real here;
+    /// Avalonia's ShowDialog is async and needs an owner Window, which is the only shape change
+    /// from the WPF handler. The live-apply calls into BouncingTextService are named at each
+    /// handler - that service draws Win32 layered windows and has no port.</para>
     /// </summary>
     public partial class BouncingTextFeatureControl : UserControl
     {
+        /// <summary>WPF's <c>FontPickerHelper.Populate</c> fallback family. Kept verbatim so a
+        /// settings file written on either head selects the same row.</summary>
+        private const string FontFallback = "Segoe UI";
+
+        private bool _isLoading = true;
+        private bool _fontsPopulated;
+        private AppSettings? _hooked;
+
         public BouncingTextFeatureControl()
         {
-            AvaloniaXamlLoader.Load(this);
+            InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            SliderLabel.Wire(this, "SliderSpeed", "TxtSpeed", v => ((int)v).ToString());
-            SliderLabel.Wire(this, "SliderSize", "TxtSize", v => $"{(int)v}%");
-            SliderLabel.Wire(this, "SliderOpacity", "TxtOpacity", v => $"{(int)v}%");
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderSpeed.ValueChanged += SliderSpeed_Changed;
+            SliderSize.ValueChanged += SliderSize_Changed;
+            SliderOpacity.ValueChanged += SliderOpacity_Changed;
+            CmbColorMode.SelectionChanged += CmbColorMode_Changed;
+            CmbFont.SelectionChanged += CmbFont_Changed;
+            BtnChooseColor.Click += (_, _) =>
+            {
+                // ponytail: needs a colour picker. WPF opens System.Windows.Forms.ColorDialog;
+                // Avalonia's equivalent is the Avalonia.Controls.ColorPicker package, which is
+                // NOT referenced by CCP.Avalonia.csproj (a csproj edit is the coordinator's call).
+            };
+            BtnResetColor.Click += BtnResetColor_Click;
+            ChkFxBreathing.IsCheckedChanged += FxToggle_Changed;
+            ChkFxWobble.IsCheckedChanged += FxToggle_Changed;
+            ChkFxSpin.IsCheckedChanged += FxToggle_Changed;
+            ChkFxVelocityTilt.IsCheckedChanged += FxToggle_Changed;
+            ChkFxSquash.IsCheckedChanged += FxToggle_Changed;
+            ChkFxCornerBurst.IsCheckedChanged += FxToggle_Changed;
+            ChkOutline.IsCheckedChanged += ChkOutline_Changed;
+            ChkSecondText.IsCheckedChanged += ChkSecondText_Changed;
+            ChkAlwaysOnTop.IsCheckedChanged += ChkAlwaysOnTop_Changed;
+            BtnEditPhrases.Click += BtnEditPhrases_Click;
 
-            var mode = this.FindControl<ComboBox>("CmbColorMode")!;
-            var fixedRow = this.FindControl<Grid>("PanelFixedColor")!;
-            mode.SelectedIndex = 0; // placeholder: AppSettings.BouncingTextColorMode default
-            mode.SelectionChanged += (_, _) => fixedRow.IsVisible = mode.SelectedIndex == 1;
+            LoadFromSettings();
+        }
 
-            PopulateFonts();
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += RebindToCurrentSettings;
+            RebindToCurrentSettings();
+        }
 
-            // ponytail: needs App.Settings / App.BouncingText / a colour picker / TextEditorDialog over
-            // the pool, wired when they move to Core. ChkEnable, ChkSecondText, ChkAlwaysOnTop, the
-            // ChkFx* toggles, BtnChooseColor, BtnResetColor, BtnEditPhrases are inert.
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= RebindToCurrentSettings;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>WPF's <c>ISettingsRebindable.RebindToCurrentSettings</c>: detach from whichever
+        /// instance we were on, attach to the live one, repaint from it.</summary>
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                ChkEnable.IsChecked = s.BouncingTextEnabled;
+                SliderSpeed.Value = s.BouncingTextSpeed;
+                TxtSpeed.Text = s.BouncingTextSpeed.ToString();
+                SliderSize.Value = s.BouncingTextSize;
+                TxtSize.Text = $"{s.BouncingTextSize}%";
+                SliderOpacity.Value = Math.Max(10, s.BouncingTextOpacity);
+                TxtOpacity.Text = $"{s.BouncingTextOpacity}%";
+                CmbColorMode.SelectedIndex = s.BouncingTextColorMode;
+                ChkFxBreathing.IsChecked = s.BouncingTextFxBreathing;
+                ChkFxWobble.IsChecked = s.BouncingTextFxWobble;
+                ChkFxSpin.IsChecked = s.BouncingTextFxSpin;
+                ChkFxVelocityTilt.IsChecked = s.BouncingTextFxVelocityTilt;
+                ChkFxSquash.IsChecked = s.BouncingTextFxSquashStretch;
+                ChkFxCornerBurst.IsChecked = s.BouncingTextFxCornerBurst;
+                ChkOutline.IsChecked = s.BouncingTextOutline;
+                ChkSecondText.IsChecked = s.BouncingTextSecondText;
+                ChkAlwaysOnTop.IsChecked = s.BouncingTextAlwaysOnTop;
+                PopulateFonts(s.BouncingTextFont);
+                UpdateSwatch();
+                UpdateFixedColorPanel();
+            }
+            finally { _isLoading = false; }
+        }
+
+        /// <summary>Reflects external writes (Ramp, presets, the session engine) back into the
+        /// panel. Marshalled: those writers are not all on the UI thread.</summary>
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.BouncingTextEnabled) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextSpeed) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextSize) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextOpacity) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextColorMode) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFixedColor) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFont) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFxBreathing) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFxWobble) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFxSpin) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFxVelocityTilt) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFxSquashStretch) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextFxCornerBurst) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextOutline) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextSecondText) ||
+                e.PropertyName == nameof(AppSettings.BouncingTextAlwaysOnTop))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        // =====================================================================================
+        //  handlers
+        // =====================================================================================
+
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var want = ChkEnable.IsChecked ?? false;
+            if (s.BouncingTextEnabled == want) return;   // an echo of the seed must not save
+            s.BouncingTextEnabled = want;
+            CoreSettings.Save();
+            // ponytail: WPF then live-applies through App.BouncingText.Start()/Stop() while
+            // App.IsEngineRunning (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs),
+            // still in the WPF head - it draws Win32 layered windows.
+        }
+
+        private void SliderSpeed_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtSpeed.Text = v.ToString();
+            CoreSettings.Current.BouncingTextSpeed = v;
+            SafeRefresh();
+            CoreSettings.Save();
+        }
+
+        private void SliderSize_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtSize.Text = $"{v}%";
+            CoreSettings.Current.BouncingTextSize = v;
+            SafeRefresh();
+            CoreSettings.Save();
+        }
+
+        private void SliderOpacity_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtOpacity.Text = $"{v}%";
+            CoreSettings.Current.BouncingTextOpacity = v;
+            SafeRefresh();
+            CoreSettings.Save();
+        }
+
+        private void CmbColorMode_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var mode = CmbColorMode.SelectedIndex;
+            var s = CoreSettings.Current;
+            if (mode < 0 || s.BouncingTextColorMode == mode) return;
+            s.BouncingTextColorMode = mode;
+            CoreSettings.Save();
+            UpdateFixedColorPanel();
+            SafeRefresh();
+        }
+
+        /// <summary>The service re-measures and pushes the family into the live windows on Refresh,
+        /// so the pick applies mid-run without a restart (unlike the outline toggle, which swaps
+        /// element types).</summary>
+        private void CmbFont_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var name = (CmbFont.SelectedItem as ComboBoxItem)?.Tag as string;
+            var s = CoreSettings.Current;
+            if (string.IsNullOrWhiteSpace(name) || s.BouncingTextFont == name) return;
+            s.BouncingTextFont = name!;
+            CoreSettings.Save();
+            SafeRefresh();
+        }
+
+        private void BtnResetColor_Click(object? sender, RoutedEventArgs e)
+        {
+            CoreSettings.Current.BouncingTextFixedColor = ""; // empty = hot pink default
+            CoreSettings.Save();
+            UpdateSwatch();
+            SafeRefresh();
+        }
+
+        /// <summary>The transform effects are read per-frame by the service, so writing the setting
+        /// is all a live apply needs. One handler for all six, as on WPF.</summary>
+        private void FxToggle_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            // Compare before writing: every AppSettings setter raises PropertyChanged whether or
+            // not the value moved, and this handler fires for all six boxes on any one of them.
+            bool changed =
+                Set(ChkFxBreathing, s.BouncingTextFxBreathing, v => s.BouncingTextFxBreathing = v) |
+                Set(ChkFxWobble, s.BouncingTextFxWobble, v => s.BouncingTextFxWobble = v) |
+                Set(ChkFxSpin, s.BouncingTextFxSpin, v => s.BouncingTextFxSpin = v) |
+                Set(ChkFxVelocityTilt, s.BouncingTextFxVelocityTilt, v => s.BouncingTextFxVelocityTilt = v) |
+                Set(ChkFxSquash, s.BouncingTextFxSquashStretch, v => s.BouncingTextFxSquashStretch = v) |
+                Set(ChkFxCornerBurst, s.BouncingTextFxCornerBurst, v => s.BouncingTextFxCornerBurst = v);
+            if (changed) CoreSettings.Save();
+
+            static bool Set(CheckBox box, bool stored, Action<bool> write)
+            {
+                var want = box.IsChecked ?? false;
+                if (stored == want) return false;
+                write(want);
+                return true;
+            }
+        }
+
+        /// <summary>Outlined style swaps the rendered element type, so a running instance restarts.</summary>
+        private void ChkOutline_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var want = ChkOutline.IsChecked ?? false;
+            if (s.BouncingTextOutline == want) return;
+            s.BouncingTextOutline = want;
+            CoreSettings.Save();
+            SafeRestart();
+        }
+
+        /// <summary>The second logo needs its own window visuals, so a running instance restarts.</summary>
+        private void ChkSecondText_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var want = ChkSecondText.IsChecked ?? false;
+            if (s.BouncingTextSecondText == want) return;
+            s.BouncingTextSecondText = want;
+            CoreSettings.Save();
+            SafeRestart();
+        }
+
+        private void ChkAlwaysOnTop_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var want = ChkAlwaysOnTop.IsChecked ?? false;
+            if (s.BouncingTextAlwaysOnTop == want) return;
+            s.BouncingTextAlwaysOnTop = want;
+            CoreSettings.Save();
+            SafeRefresh(); // applies mid-video (pause/resume the loop accordingly)
         }
 
         /// <summary>
-        /// WPF: Helpers.FontPickerHelper.Populate(CmbFont, s.BouncingTextFont, "Segoe UI") - installed
-        /// families plus the bundled Fredoka. FontManager is cross-platform, so the installed half
-        /// is real here; a headless run may enumerate nothing, hence the fallback.
+        /// The phrase pool editor. Avalonia's ShowDialog is async and needs a non-null owner, so
+        /// this awaits where WPF blocked; the write-back afterwards is the WPF handler unchanged.
+        /// The dialog title is the WPF literal, not a loc key - the original hard-codes it.
         /// </summary>
-        private void PopulateFonts()
+        private async void BtnEditPhrases_Click(object? sender, RoutedEventArgs e)
         {
-            var cmb = this.FindControl<ComboBox>("CmbFont")!;
-            string[] names;
-            try { names = FontManager.Current.SystemFonts.Select(f => f.Name).OrderBy(n => n).ToArray(); }
-            catch { names = System.Array.Empty<string>(); }
-            if (names.Length == 0) names = new[] { "Segoe UI" };
-            foreach (var n in names) cmb.Items.Add(new ComboBoxItem { Content = n });
-            cmb.SelectedIndex = 0;
+            var owner = TopLevel.GetTopLevel(this) as Window;
+            if (owner is null) return;   // detached, or a headless render: nothing to own the modal
+
+            var s = CoreSettings.Current;
+            var editor = new TextEditorDialog("Bouncing Text Phrases", s.BouncingTextPool);
+            try
+            {
+                if (await editor.ShowDialog<bool?>(owner) == true && editor.ResultData != null)
+                {
+                    s.BouncingTextPool = editor.ResultData;
+                    CoreSettings.Save();
+                    Log.Information("Bouncing text phrases updated: {Count} items", editor.ResultData.Count);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Bouncing text phrase editor failed");
+            }
+        }
+
+        // ponytail: both need App.BouncingText
+        // (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs), still in the WPF
+        // head. Kept as named no-ops so the call ORDER around them stays the WPF one.
+        private static void SafeRefresh() { }
+
+        private static void SafeRestart() { }
+
+        // =====================================================================================
+        //  view state
+        // =====================================================================================
+
+        private void UpdateFixedColorPanel()
+            => PanelFixedColor.IsVisible = CmbColorMode.SelectedIndex == 1;
+
+        private void UpdateSwatch()
+        {
+            var (r, g, b) = EffectiveColor();
+            ColorSwatch.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
+        }
+
+        /// <summary>The colour Fixed mode renders: the user's pick if set, else hot pink.
+        /// Mirrors BouncingTextService.GetFixedColor.</summary>
+        private static (byte R, byte G, byte B) EffectiveColor()
+        {
+            if (TryParseHex(CoreSettings.Current.BouncingTextFixedColor, out var rgb)) return rgb;
+            return (255, 105, 180);
+        }
+
+        private static bool TryParseHex(string? hex, out (byte R, byte G, byte B) rgb)
+        {
+            rgb = (255, 105, 180);
+            if (string.IsNullOrWhiteSpace(hex)) return false;
+            hex = hex.Trim().TrimStart('#');
+            if (hex.Length != 6) return false;
+            try
+            {
+                rgb = (Convert.ToByte(hex.Substring(0, 2), 16),
+                       Convert.ToByte(hex.Substring(2, 2), 16),
+                       Convert.ToByte(hex.Substring(4, 2), 16));
+                return true;
+            }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// WPF calls <c>Helpers.FontPickerHelper.Populate(CmbFont, s.BouncingTextFont, "Segoe UI")</c>
+        /// - a WinForms-era enumeration of installed families plus the bundled Fredoka pack:// face.
+        /// <see cref="FontManager"/> is cross-platform, so the installed half is real here; the
+        /// Fredoka sentinel is not, because that face ships as a WPF pack resource.
+        ///
+        /// <para>Built once, as WPF's cheap path is: <see cref="LoadFromSettings"/> re-runs on every
+        /// property in the chain (a slider drag included), and rebuilding several hundred items each
+        /// time would stutter. After that only the selection moves.</para>
+        ///
+        /// <para>Each row carries the stored value in <c>Tag</c> and its own face, so the list reads
+        /// as a real preview. A headless run may enumerate nothing, hence the fallback row.</para>
+        /// </summary>
+        private void PopulateFonts(string? current)
+        {
+            var wanted = string.IsNullOrWhiteSpace(current) ? FontFallback : current!.Trim();
+
+            if (!_fontsPopulated)
+            {
+                string[] names;
+                try
+                {
+                    names = FontManager.Current.SystemFonts
+                        .Select(f => f.Name)
+                        .Where(n => !string.IsNullOrWhiteSpace(n))
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "BouncingText: font enumeration failed, using the fallback row");
+                    names = Array.Empty<string>();
+                }
+                if (names.Length == 0) names = new[] { FontFallback };
+
+                foreach (var n in names)
+                    CmbFont.Items.Add(new ComboBoxItem { Content = n, Tag = n, FontFamily = new FontFamily(n), FontSize = 14 });
+                _fontsPopulated = true;
+            }
+
+            // Selection, WPF's order: the stored pick, else the fallback family, else the first row.
+            ComboBoxItem? match = null, fallback = null;
+            foreach (var obj in CmbFont.Items)
+            {
+                if (obj is not ComboBoxItem item || item.Tag is not string name) continue;
+                if (match == null && string.Equals(name, wanted, StringComparison.OrdinalIgnoreCase)) match = item;
+                if (fallback == null && string.Equals(name, FontFallback, StringComparison.OrdinalIgnoreCase)) fallback = item;
+            }
+            CmbFont.SelectedItem = match ?? fallback;
+            if (CmbFont.SelectedItem == null && CmbFont.Items.Count > 0) CmbFont.SelectedIndex = 0;
         }
     }
 }

--- a/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
@@ -1,72 +1,152 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Platform;
+using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Pink Filter settings panel, ported from the WPF head. <see cref="PinkFilterSettings"/>
-    /// stands in for <c>App.Settings.Current</c>. Save, the overlay refresh, the mod colour/art
-    /// repaint, the WinForms ColorDialog and the screen enumeration are stubbed: the monitor combo
-    /// carries the two fixed entries plus one placeholder monitor line built with the same loc keys
-    /// and format the WPF code-behind uses.
+    /// Pink Filter settings panel, ported from the WPF head, against <see cref="CoreSettings"/>.
+    ///
+    /// <para>WPF's <c>ISettingsRebindable</c> + <c>SettingsHook</c> pair is reproduced inline: a
+    /// cloud restore SWAPS the AppSettings instance, so the PropertyChanged subscription is
+    /// tracked per instance and re-pointed on <c>SettingsService.CurrentReplaced</c>.</para>
+    ///
+    /// <para>The monitor picker enumerates real displays through <c>TopLevel.Screens</c>, which is
+    /// cross-platform, so it needs no head service. It is filled on attach rather than in the
+    /// constructor: a detached control has no TopLevel and therefore no screen list.</para>
     /// </summary>
     public partial class PinkFilterFeatureControl : UserControl
     {
-        // ponytail: local copy of App.ScreenResolver's sentinels, reuse when they move to Core
+        // ponytail: local copy of App.MonitorTargetFollowGlobal / App.MonitorTargetAll
+        // (ConditioningControlPanel/App.ScreenResolver.cs), still in the WPF head. They are the
+        // sentinels persisted in AppSettings.PinkFilterTargetMonitor, so both heads must agree.
         private const int MonitorTargetFollowGlobal = -1;
         private const int MonitorTargetAll = -2;
 
         private bool _isLoading = true;
         private bool _monitorPopulating;
-        private readonly PinkFilterSettings _s = new();
+        private AppSettings? _hooked;
 
         public PinkFilterFeatureControl()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: needs App.Overlay.RefreshOverlays / RefreshFilterColor, wired when it moves to Core
-            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.PinkFilterEnabled = ChkEnable.IsChecked ?? false; Save(); };
-            SliderOpacity.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtOpacity.Text = $"{v}%"; _s.PinkFilterOpacity = v; Save(); };
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderOpacity.ValueChanged += SliderOpacity_Changed;
             CmbMonitor.DropDownOpened += (_, _) => PopulateMonitors();
-            CmbMonitor.SelectionChanged += (_, _) =>
+            CmbMonitor.SelectionChanged += CmbMonitor_Changed;
+            BtnChooseColor.Click += (_, _) =>
             {
-                if (_monitorPopulating || _isLoading) return;
-                if (CmbMonitor.SelectedItem is not ComboBoxItem item || item.Tag is not int target) return;
-                if (_s.PinkFilterTargetMonitor == target) return;
-                _s.PinkFilterTargetMonitor = target;
-                Save();
+                // ponytail: needs a colour picker. WPF opens System.Windows.Forms.ColorDialog;
+                // Avalonia's equivalent is the Avalonia.Controls.ColorPicker package, which is
+                // NOT referenced by CCP.Avalonia.csproj (a csproj edit is the coordinator's call).
             };
-            // ponytail: needs a colour picker (WinForms ColorDialog on WPF); no cross-platform picker yet
-            BtnChooseColor.Click += (_, _) => { };
-            BtnResetColor.Click += (_, _) =>
-            {
-                _s.PinkFilterColor = ""; // empty = default (mod / hot pink)
-                Save();
-                UpdateSwatch();
-            };
+            BtnResetColor.Click += BtnResetColor_Click;
 
             LoadFromSettings();
         }
 
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += RebindToCurrentSettings;
+            RebindToCurrentSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= RebindToCurrentSettings;
+            Unhook();
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>WPF's <c>ISettingsRebindable.RebindToCurrentSettings</c>: detach from whichever
+        /// instance we were on, attach to the live one, repaint from it.</summary>
+        private void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
         private void LoadFromSettings()
         {
+            var s = CoreSettings.Current;
             _isLoading = true;
             try
             {
-                ChkEnable.IsChecked = _s.PinkFilterEnabled;
-                SliderOpacity.Value = _s.PinkFilterOpacity;
-                TxtOpacity.Text = $"{_s.PinkFilterOpacity}%";
+                ChkEnable.IsChecked = s.PinkFilterEnabled;
+                SliderOpacity.Value = s.PinkFilterOpacity;
+                TxtOpacity.Text = $"{s.PinkFilterOpacity}%";
                 UpdateSwatch();
                 PopulateMonitors();
             }
             finally { _isLoading = false; }
         }
 
+        /// <summary>Reflects external writes (Ramp, presets, the session engine) back into the
+        /// panel. Marshalled: those writers are not all on the UI thread.</summary>
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.PinkFilterEnabled) ||
+                e.PropertyName == nameof(AppSettings.PinkFilterOpacity) ||
+                e.PropertyName == nameof(AppSettings.PinkFilterColor) ||
+                e.PropertyName == nameof(AppSettings.PinkFilterTargetMonitor))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var want = ChkEnable.IsChecked ?? false;
+            if (s.PinkFilterEnabled == want) return;   // an echo of the seed must not save
+            s.PinkFilterEnabled = want;
+            CoreSettings.Save();
+            // ponytail: WPF then calls App.Overlay.RefreshOverlays()
+            // (ConditioningControlPanel/Services/Notifications/OverlayService.cs), still in the WPF
+            // head - the tint windows are Win32 layered windows with no port yet.
+        }
+
+        private void SliderOpacity_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var v = (int)e.NewValue;
+            TxtOpacity.Text = $"{v}%";
+            CoreSettings.Current.PinkFilterOpacity = v;
+            CoreSettings.Save();
+            // ponytail: WPF then calls App.Overlay.RefreshOverlays() - see ChkEnable_Changed.
+        }
+
+        // ── Display monitor picker (#639) ─────────────────────────────────
+
+        /// <summary>Rebuild the monitor dropdown from the current display topology and select the
+        /// entry matching the saved <see cref="AppSettings.PinkFilterTargetMonitor"/>. A saved index
+        /// that no longer exists (unplugged monitor) matches nothing and shows "Default" WITHOUT
+        /// writing back (the populate guard blocks SelectionChanged), so the target survives a
+        /// reconnect.</summary>
         private void PopulateMonitors()
         {
-            int saved = _s.PinkFilterTargetMonitor;
+            int saved = CoreSettings.Current.PinkFilterTargetMonitor;
             _monitorPopulating = true;
             try
             {
@@ -74,11 +154,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
                 CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = MonitorTargetFollowGlobal });
                 CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = MonitorTargetAll });
 
-                // ponytail: needs the screen list (App.GetAllScreensCached on WPF); one placeholder
-                // monitor in the exact WPF format so the row renders with a real string.
+                var screens = ScreenList.Enumerate(this);
                 string monitorLabel = Loc.Get("monitor_label");
                 string primaryMarker = Loc.Get("monitor_primary_marker");
-                CmbMonitor.Items.Add(new ComboBoxItem { Content = $"{monitorLabel} 1 ({primaryMarker}, 1920x1080)", Tag = 0 });
+                for (int i = 0; i < screens.Count; i++)
+                {
+                    var b = screens[i].Bounds;
+                    string prefix = screens[i].IsPrimary ? primaryMarker + ", " : "";
+                    CmbMonitor.Items.Add(new ComboBoxItem
+                    {
+                        Content = $"{monitorLabel} {i + 1} ({prefix}{b.Width}x{b.Height})",
+                        Tag = i,
+                    });
+                }
 
                 ComboBoxItem? match = null;
                 foreach (var obj in CmbMonitor.Items)
@@ -88,22 +176,47 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             finally { _monitorPopulating = false; }
         }
 
+        private void CmbMonitor_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_monitorPopulating || _isLoading) return;
+            if (CmbMonitor.SelectedItem is not ComboBoxItem item || item.Tag is not int target) return;
+
+            var s = CoreSettings.Current;
+            if (s.PinkFilterTargetMonitor == target) return;
+
+            s.PinkFilterTargetMonitor = target;
+            CoreSettings.Save();
+            // ponytail: WPF then calls App.Overlay.RefreshOverlays() - see ChkEnable_Changed.
+        }
+
+        private void BtnResetColor_Click(object? sender, RoutedEventArgs e)
+        {
+            CoreSettings.Current.PinkFilterColor = ""; // empty = default (mod / hot pink)
+            CoreSettings.Save();
+            UpdateSwatch();
+            // ponytail: WPF then calls App.Overlay.RefreshFilterColor() + RefreshOverlays() to push
+            // the colour into a tint already on screen - see ChkEnable_Changed.
+        }
+
         private void UpdateSwatch()
         {
             var (r, g, b) = EffectiveColor();
             ColorSwatch.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
         }
 
-        // The colour the tint renders: the user's pick if set, else hot pink.
-        // ponytail: the mod fallback (App.Mods.GetFilterColorRgb) is skipped until ModService moves to Core.
-        private (byte R, byte G, byte B) EffectiveColor()
+        /// <summary>The colour the tint renders: the user's pick if set, else hot pink.</summary>
+        // ponytail: WPF's middle link is App.Mods.GetFilterColorRgb()
+        // (ModService.GetFilterColorRgb, ConditioningControlPanel/Services/ModService.cs); CoreMods
+        // exposes AccentColorHex/SecondaryColorHex but no filter colour, so the mod fallback is skipped.
+        private static (byte R, byte G, byte B) EffectiveColor()
         {
-            if (TryParseHex(_s.PinkFilterColor, out var rgb)) return rgb;
+            if (TryParseHex(CoreSettings.Current.PinkFilterColor, out var rgb)) return rgb;
             return (255, 105, 180);
         }
 
-        // ponytail: third copy of the hex->RGB parse (WPF PinkFilterFeatureControl, ModService.ParseHexColor);
-        // hoist to CCP.Core and call it from both heads when AppSettings crosses. Not done here: this PR adds no shared files.
+        // ponytail: third copy of the hex->RGB parse (WPF PinkFilterFeatureControl,
+        // ModService.ParseHexColor); hoist to CCP.Core and call it from both heads. Not done here:
+        // this layer adds no shared files.
         private static bool TryParseHex(string? hex, out (byte R, byte G, byte B) rgb)
         {
             rgb = (255, 105, 180);
@@ -119,18 +232,32 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             }
             catch { return false; }
         }
-
-        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
-        private static void Save() { }
     }
 
-    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
-    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
-    public sealed class PinkFilterSettings
+    /// <summary>
+    /// The display topology, the Avalonia way. WPF reads <c>App.GetAllScreensCached()</c> (a
+    /// WinForms <c>Screen[]</c> behind a cache); here it is <c>TopLevel.Screens</c>, which is
+    /// cross-platform and already cached by the windowing backend, so the cache-plus-invalidate
+    /// pair the WPF head carries has nothing left to do.
+    ///
+    /// <para>Empty is a normal answer: a control that is not attached yet, and a headless render,
+    /// both have no TopLevel. The picker then shows only its two fixed entries, which is what WPF
+    /// shows on a machine reporting no displays.</para>
+    /// </summary>
+    internal static class ScreenList
     {
-        public bool PinkFilterEnabled { get; set; }
-        public int PinkFilterOpacity { get; set; } = 10;
-        public string PinkFilterColor { get; set; } = "";
-        public int PinkFilterTargetMonitor { get; set; } = -1;
+        public static IReadOnlyList<Screen> Enumerate(Visual host)
+        {
+            try
+            {
+                var screens = TopLevel.GetTopLevel(host)?.Screens;
+                if (screens?.All is { } all) return all;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("ScreenList.Enumerate: {E}", ex.Message);
+            }
+            return Array.Empty<Screen>();
+        }
     }
 }


### PR DESCRIPTION
The second half of the visual feature-card layer; same inline SettingsHook /
ISettingsRebindable follow-the-live-instance pattern as the Spiral/Visuals layer below it.

Bouncing Text: enable, all three sliders, colour mode with its fixed-colour row reveal, the
font pick, the colour reset and all nine toggles persist. The phrase editor is real - the
ported TextEditorDialog over BouncingTextPool, awaited with an owner window because
Avalonia's ShowDialog is async. The font list is FontManager.Current.SystemFonts with the
stored pick selected, built once so a slider drag does not rebuild several hundred rows.

Pink Filter: enable, opacity, colour reset and the monitor target all persist. The monitor
picker enumerates real displays through TopLevel.Screens instead of showing a hard-coded
"Monitor 1 (Primary, 1920x1080)" line that was fiction; it fills on attach, because a
detached control has no TopLevel. The saved-target reconnect rule is unchanged - an
unplugged monitor matches nothing, shows Default, and is not written back.

Still blocked:
- OverlayService.RefreshFilterColor (Notifications/) - the tint is a Win32 layered window
- BouncingTextService.Refresh / Restart (Services/Subliminal/) and App.IsEngineRunning
- A colour picker for both Choose colour buttons. WPF opens System.Windows.Forms
  .ColorDialog; Avalonia's twin is the Avalonia.Controls.ColorPicker package, which
  CCP.Avalonia.csproj does not reference and this layer may not edit
- ModService.GetFilterColorRgb - CoreMods carries accent and secondary, not the filter
  colour, so the Pink Filter swatch falls straight through to hot pink
- LoomHostService.Launch and DtrhLoomStore.Changed (Services/Chaos/)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU