### PR TITLE
feat(avalonia): the Subliminal and Intensity Ramp cards edit and persist real settings

### DIFF
--- a/CCP.Avalonia/Views/Features/IntensityRampFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/IntensityRampFeatureControl.axaml.cs
@@ -1,117 +1,319 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 using ConditioningControlPanel.Helpers;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Intensity Ramp panel, ported from the WPF head. The mode/row visibility, the slider
-    /// read-outs and the live curve preview are real and driven by the controls themselves;
-    /// on WPF they are driven by App.Settings, which is what the preview reads there.
+    /// Intensity Ramp panel, ported from the WPF head. Every editor now reads and writes
+    /// <see cref="CoreSettings.Current"/> and persists through <see cref="CoreSettings.Save"/>,
+    /// and the live curve preview is driven by the SAME
+    /// <see cref="RampMath.ResolveFactor(AppSettings, double)"/> the runtime tick calls - so the
+    /// preview cannot drift from the ramp, which is the whole point of it on WPF too.
+    ///
+    /// <para>The settings hook is inlined for the reason spelled out in
+    /// <see cref="BubbleCountFeatureControl"/>. Nothing else here touches a service: the global
+    /// ramp runs on MainWindow's own timer and the per-session ramp is SessionEngine's, and both
+    /// read the settings this panel writes.</para>
     /// </summary>
     public partial class IntensityRampFeatureControl : UserControl
     {
+        private bool _isLoading = true;
+        private AppSettings? _hooked;
+
+        private readonly CheckBox _enabled;
+        private readonly CheckBox _endAt;
         private readonly ComboBox _mode;
         private readonly ComboBox _curve;
+        private readonly Slider _duration;
         private readonly Slider _multiplier;
         private readonly Slider _rangeStart;
         private readonly Slider _rangeEnd;
         private readonly Canvas _canvas;
         private readonly Polyline _line;
+        private readonly CheckBox[] _links;
 
         public IntensityRampFeatureControl()
         {
             AvaloniaXamlLoader.Load(this);
 
-            SliderLabel.Wire(this, "SliderDuration", "TxtDuration", v => $"{(int)v} min");
+            _duration = SliderLabel.Wire(this, "SliderDuration", "TxtDuration", v => $"{(int)v} min");
             _multiplier = SliderLabel.Wire(this, "SliderMultiplier", "TxtMultiplier", v => $"{v:F1}x");
             _rangeStart = SliderLabel.Wire(this, "SliderRangeStart", "TxtRangeStart", v => $"{(int)v}%");
             _rangeEnd = SliderLabel.Wire(this, "SliderRangeEnd", "TxtRangeEnd", v => $"{(int)v}%");
+            _enabled = this.FindControl<CheckBox>("ChkEnabled")!;
+            _endAt = this.FindControl<CheckBox>("ChkEndAt")!;
             _mode = this.FindControl<ComboBox>("CmbRampMode")!;
             _curve = this.FindControl<ComboBox>("CmbRampCurve")!;
             _canvas = this.FindControl<Canvas>("CurvePreviewCanvas")!;
             _line = this.FindControl<Polyline>("CurvePreviewLine")!;
 
-            // Placeholder defaults = a fresh AppSettings: Multiplier mode, Linear curve.
-            _mode.SelectedIndex = 0;
-            _curve.SelectedIndex = 0;
+            // Six toggles, one setting group, one handler - as on WPF, where Link_Changed writes
+            // all six every time whichever one moved.
+            _links = new[]
+            {
+                this.FindControl<CheckBox>("ChkLinkFlash")!,
+                this.FindControl<CheckBox>("ChkLinkSpiral")!,
+                this.FindControl<CheckBox>("ChkLinkPink")!,
+                this.FindControl<CheckBox>("ChkLinkMaster")!,
+                this.FindControl<CheckBox>("ChkLinkSub")!,
+                this.FindControl<CheckBox>("ChkLinkBrainDrain")!,
+            };
 
-            _mode.SelectionChanged += (_, _) => { ApplyModeVisibility(); RedrawPreview(); };
-            _curve.SelectionChanged += (_, _) => RedrawPreview();
-            _multiplier.ValueChanged += (_, _) => RedrawPreview();
-            _rangeStart.ValueChanged += (_, _) => RedrawPreview();
-            _rangeEnd.ValueChanged += (_, _) => RedrawPreview();
+            _enabled.IsCheckedChanged += (_, _) => ChkEnabled_Changed();
+            _endAt.IsCheckedChanged += (_, _) => ChkEndAt_Changed();
+            _mode.SelectionChanged += (_, _) => CmbRampMode_Changed();
+            _curve.SelectionChanged += (_, _) => CmbRampCurve_Changed();
+            _duration.ValueChanged += (_, e) => SliderDuration_Changed(e.NewValue);
+            _multiplier.ValueChanged += (_, e) => SliderMultiplier_Changed(e.NewValue);
+            _rangeStart.ValueChanged += (_, e) => SliderRangeStart_Changed(e.NewValue);
+            _rangeEnd.ValueChanged += (_, e) => SliderRangeEnd_Changed(e.NewValue);
+            foreach (var link in _links) link.IsCheckedChanged += (_, _) => Link_Changed();
             _canvas.SizeChanged += (_, _) => RedrawPreview();
 
+            Loaded += (_, _) => RebindToCurrentSettings();
+            Unloaded += (_, _) => Unhook();
+
+            RebindToCurrentSettings();
+        }
+
+        /// <summary>Re-points the settings hook at the live instance and repaints from it.</summary>
+        public void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
+            LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        private void LoadFromSettings()
+        {
+            var s = CoreSettings.Current;
+            _isLoading = true;
+            try
+            {
+                _enabled.IsChecked = s.IntensityRampEnabled;
+                _duration.Value = s.RampDurationMinutes;
+                _multiplier.Value = s.SchedulerMultiplier;
+                _mode.SelectedIndex = s.RampMode == RampMode.Range ? 1 : 0;
+                _rangeStart.Value = s.RampStartPercent;
+                _rangeEnd.Value = s.RampEndPercent;
+                _endAt.IsChecked = s.EndSessionOnRampComplete;
+                _curve.SelectedIndex = s.RampCurve switch
+                {
+                    RampCurve.EaseIn => 1,
+                    RampCurve.EaseOut => 2,
+                    RampCurve.SCurve => 3,
+                    RampCurve.Exponential => 4,
+                    _ => 0,
+                };
+                _links[0].IsChecked = s.RampLinkFlashOpacity;
+                _links[1].IsChecked = s.RampLinkSpiralOpacity;
+                _links[2].IsChecked = s.RampLinkPinkFilterOpacity;
+                _links[3].IsChecked = s.RampLinkMasterAudio;
+                _links[4].IsChecked = s.RampLinkSubliminalAudio;
+                _links[5].IsChecked = s.RampLinkBrainDrain;
+            }
+            finally { _isLoading = false; }
+
             ApplyModeVisibility();
-            // ponytail: needs App.Settings, wired when it moves to Core. ChkEnabled, ChkEndAt and the
-            // six ChkLink* toggles are settings writes only.
+            RedrawPreview();
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.IntensityRampEnabled) ||
+                e.PropertyName == nameof(AppSettings.RampDurationMinutes) ||
+                e.PropertyName == nameof(AppSettings.SchedulerMultiplier) ||
+                e.PropertyName == nameof(AppSettings.EndSessionOnRampComplete) ||
+                e.PropertyName == nameof(AppSettings.RampCurve) ||
+                e.PropertyName == nameof(AppSettings.RampMode) ||
+                e.PropertyName == nameof(AppSettings.RampStartPercent) ||
+                e.PropertyName == nameof(AppSettings.RampEndPercent) ||
+                e.PropertyName == nameof(AppSettings.RampLinkFlashOpacity) ||
+                e.PropertyName == nameof(AppSettings.RampLinkSpiralOpacity) ||
+                e.PropertyName == nameof(AppSettings.RampLinkPinkFilterOpacity) ||
+                e.PropertyName == nameof(AppSettings.RampLinkMasterAudio) ||
+                e.PropertyName == nameof(AppSettings.RampLinkSubliminalAudio) ||
+                e.PropertyName == nameof(AppSettings.RampLinkBrainDrain))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        private void ChkEnabled_Changed()
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = _enabled.IsChecked ?? false;
+            if (s.IntensityRampEnabled == on) return;
+            s.IntensityRampEnabled = on;
+            CoreSettings.Save();
+        }
+
+        private void SliderDuration_Changed(double value)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)value;
+            if (s.RampDurationMinutes == v) return;
+            s.RampDurationMinutes = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderMultiplier_Changed(double value)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            if (Math.Abs(s.SchedulerMultiplier - value) < 0.0001) return;
+            s.SchedulerMultiplier = value;
+            CoreSettings.Save();
+            RedrawPreview();
+        }
+
+        private void CmbRampMode_Changed()
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var mode = _mode.SelectedIndex == 1 ? RampMode.Range : RampMode.Multiplier;
+            if (s.RampMode == mode) return;
+            s.RampMode = mode;
+            CoreSettings.Save();
+            ApplyModeVisibility();
+            RedrawPreview();
+        }
+
+        private void SliderRangeStart_Changed(double value)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)value;
+            if (s.RampStartPercent == v) return;
+            s.RampStartPercent = v;
+            CoreSettings.Save();
+            RedrawPreview();
+        }
+
+        private void SliderRangeEnd_Changed(double value)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)value;
+            if (s.RampEndPercent == v) return;
+            s.RampEndPercent = v;
+            CoreSettings.Save();
+            RedrawPreview();
+        }
+
+        private void CmbRampCurve_Changed()
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var curve = _curve.SelectedIndex switch
+            {
+                1 => RampCurve.EaseIn,
+                2 => RampCurve.EaseOut,
+                3 => RampCurve.SCurve,
+                4 => RampCurve.Exponential,
+                _ => RampCurve.Linear,
+            };
+            if (s.RampCurve == curve) return;
+            s.RampCurve = curve;
+            CoreSettings.Save();
+            RedrawPreview();
+        }
+
+        private void ChkEndAt_Changed()
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = _endAt.IsChecked ?? false;
+            if (s.EndSessionOnRampComplete == on) return;
+            s.EndSessionOnRampComplete = on;
+            CoreSettings.Save();
+        }
+
+        /// <summary>All six link toggles write together, as on WPF: one handler, one save.</summary>
+        private void Link_Changed()
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.RampLinkFlashOpacity = _links[0].IsChecked ?? false;
+            s.RampLinkSpiralOpacity = _links[1].IsChecked ?? false;
+            s.RampLinkPinkFilterOpacity = _links[2].IsChecked ?? false;
+            s.RampLinkMasterAudio = _links[3].IsChecked ?? false;
+            s.RampLinkSubliminalAudio = _links[4].IsChecked ?? false;
+            s.RampLinkBrainDrain = _links[5].IsChecked ?? false;
+            CoreSettings.Save();
         }
 
         /// <summary>
         /// Multiplier mode shows the single "up to Nx" dial; Range mode shows the start/end pair
-        /// instead. Never both.
+        /// instead. Never both: they are two spellings of the same factor and showing the inert one
+        /// is exactly the "dial that quietly does nothing" this panel already argues against.
         /// </summary>
         private void ApplyModeVisibility()
         {
-            var isRange = _mode.SelectedIndex == 1;
+            var isRange = CoreSettings.Current.RampMode == RampMode.Range;
             this.FindControl<Grid>("RowMultiplier")!.IsVisible = !isRange;
             this.FindControl<Grid>("RowRangeStart")!.IsVisible = isRange;
             this.FindControl<Grid>("RowRangeEnd")!.IsVisible = isRange;
         }
 
-        private RampCurve SelectedCurve => _curve.SelectedIndex switch
-        {
-            1 => RampCurve.EaseIn,
-            2 => RampCurve.EaseOut,
-            3 => RampCurve.SCurve,
-            4 => RampCurve.Exponential,
-            _ => RampCurve.Linear,
-        };
-
         /// <summary>
-        /// Repaints the factor-over-time polyline. The vertical axis is normalised to whatever
-        /// span the curve covers (a flat 100 -> 100 draws a centred straight line rather than
+        /// Repaints the factor-over-time polyline from the same
+        /// <see cref="RampMath.ResolveFactor(AppSettings, double)"/> the runtime tick calls, so the
+        /// preview cannot drift from the ramp. The vertical axis is normalised to whatever span the
+        /// curve actually covers (a flat 100 -> 100 draws a centred straight line rather than
         /// dividing by zero), because the shape is the point here, not absolute values.
         /// </summary>
         private void RedrawPreview()
         {
-            var w = _canvas.Bounds.Width;
-            var h = _canvas.Bounds.Height;
-            if (w <= 1 || h <= 1) return; // not laid out yet - SizeChanged calls back
-
-            var isRange = _mode.SelectedIndex == 1;
-            var curve = SelectedCurve;
-            var mult = _multiplier.Value;
-            var start = Math.Clamp(_rangeStart.Value, 0, 300);
-            var end = Math.Clamp(_rangeEnd.Value, 0, 300);
-
-            const int steps = 48;
-            var values = new double[steps + 1];
-            double min = double.MaxValue, max = double.MinValue;
-            for (var i = 0; i <= steps; i++)
+            try
             {
-                // ponytail: mirrors Helpers/RampMath.ResolveFactor (WPF head, RampMode lives there);
-                // delete when RampMath moves to Core.
-                var eased = RampCurves.ApplyCurve((double)i / steps, curve);
-                var f = isRange ? (start + (end - start) * eased) / 100.0 : 1.0 + (mult - 1.0) * eased;
-                values[i] = f;
-                if (f < min) min = f;
-                if (f > max) max = f;
+                var w = _canvas.Bounds.Width;
+                var h = _canvas.Bounds.Height;
+                if (w <= 1 || h <= 1) return; // not laid out yet - SizeChanged calls back
+
+                var s = CoreSettings.Current;
+
+                const int steps = 48;
+                var values = new double[steps + 1];
+                double min = double.MaxValue, max = double.MinValue;
+                for (var i = 0; i <= steps; i++)
+                {
+                    var f = RampMath.ResolveFactor(s, (double)i / steps);
+                    values[i] = f;
+                    if (f < min) min = f;
+                    if (f > max) max = f;
+                }
+
+                var span = max - min;
+                if (span < 0.0001) { min -= 0.5; span = 1.0; }
+
+                var points = new List<Point>(steps + 1);
+                for (var i = 0; i <= steps; i++)
+                    points.Add(new Point(w * i / steps, h - (values[i] - min) / span * h));
+                _line.Points = points;
             }
-
-            var span = max - min;
-            if (span < 0.0001) { min -= 0.5; span = 1.0; }
-
-            var points = new List<Point>(steps + 1);
-            for (var i = 0; i <= steps; i++)
-                points.Add(new Point(w * i / steps, h - (values[i] - min) / span * h));
-            _line.Points = points;
+            catch (Exception ex)
+            {
+                Log.Debug("Ramp preview redraw failed: {E}", ex.Message);
+            }
         }
     }
 }

--- a/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
@@ -1,85 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Subliminal settings panel, ported from the WPF head. <see cref="SubliminalSettings"/>
-    /// stands in for <c>App.Settings.Current</c>. Save, SubliminalService.SetEnabled, the pool
-    /// editor write-back (with its user-added / removed-default bookkeeping), ColorEditorDialog,
-    /// FontPickerHelper and the mod-art repaint are stubbed; the font combo carries two
-    /// placeholder families.
+    /// Subliminal settings panel, ported from the WPF head. Every editor reads and writes
+    /// <see cref="CoreSettings.Current"/> and persists through <see cref="CoreSettings.Save"/>,
+    /// and the settings hook is inlined for the reason spelled out in
+    /// <see cref="BubbleCountFeatureControl"/>.
+    ///
+    /// <para>The font combo is real rather than two placeholders:
+    /// <c>FontManager.Current.SystemFonts</c> is the cross-platform half of the WPF
+    /// <c>Helpers.FontPickerHelper</c>, and each row previews in its own face exactly as
+    /// <c>Populate</c> did. What does not carry over is that helper's <c>Fredoka (bundled)</c>
+    /// sentinel: the face ships as a WPF <c>pack://</c> Resource and is not packed on this head,
+    /// so offering it would name a font nothing can resolve.</para>
+    ///
+    /// <para>Still head-side: SubliminalService (the flash loop) and the mod-aware feature art.</para>
     /// </summary>
     public partial class SubliminalFeatureControl : UserControl
     {
+        /// <summary>What the picker falls back to when the stored family is gone - the WPF
+        /// <c>Populate(CmbFont, s.SubliminalFont, "Arial")</c> fallback, unchanged.</summary>
+        private const string FontFallback = "Arial";
+
         private bool _isLoading = true;
-        private readonly SubliminalSettings _s = new();
+        private AppSettings? _hooked;
 
         public SubliminalFeatureControl()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: needs App.Subliminal.SetEnabled (the single authority on WPF), wired when it moves to Core
-            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.SubliminalEnabled = ChkEnable.IsChecked ?? false; Save(); };
-            SliderPerMin.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtPerMin.Text = v.ToString(); _s.SubliminalFrequency = v; Save(); };
-            SliderFrames.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFrames.Text = v.ToString(); _s.SubliminalDuration = v; Save(); };
-            SliderOpacity.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtOpacity.Text = $"{v}%"; _s.SubliminalOpacity = v; Save(); };
-            ChkWhispers.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.SubAudioEnabled = ChkWhispers.IsChecked ?? false; Save(); };
-            SliderWhisperVol.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtWhisperVol.Text = $"{v}%"; _s.SubAudioVolume = v; Save(); };
-            ChkSolidMode.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.SubliminalSolidMode = ChkSolidMode.IsChecked ?? false; Save(); };
-            CmbFont.SelectionChanged += (_, _) =>
-            {
-                if (_isLoading) return;
-                var name = CmbFont.SelectedItem as string;
-                if (string.IsNullOrWhiteSpace(name) || _s.SubliminalFont == name) return;
-                _s.SubliminalFont = name;
-                Save();
-            };
-            // ponytail: Views/Dialogs/TextEditorDialog is ported, but the pool bookkeeping is App.Settings/App.Mods; wired with them
-            BtnManageMessages.Click += (_, _) => { };
-            // ponytail: needs ColorEditorDialog, ported separately
-            BtnAdvanced.Click += (_, _) => { };
+            PopulateFonts();
 
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderPerMin.ValueChanged += SliderPerMin_Changed;
+            SliderFrames.ValueChanged += SliderFrames_Changed;
+            SliderOpacity.ValueChanged += SliderOpacity_Changed;
+            ChkWhispers.IsCheckedChanged += ChkWhispers_Changed;
+            SliderWhisperVol.ValueChanged += SliderWhisperVol_Changed;
+            ChkSolidMode.IsCheckedChanged += ChkSolidMode_Changed;
+            CmbFont.SelectionChanged += CmbFont_Changed;
+            BtnManageMessages.Click += BtnManageMessages_Click;
+            BtnAdvanced.Click += BtnAdvanced_Click;
+
+            Loaded += (_, _) => RebindToCurrentSettings();
+            Unloaded += (_, _) => Unhook();
+
+            // ponytail: WPF also repaints the hero and side plates on ModChanged through
+            // Services/ModResourceResolver.cs (WPF head) from Resources/features/subliminal.png.
+            // The Avalonia .axaml drops both plates deliberately, so nothing here to repaint yet.
+
+            RebindToCurrentSettings();
+        }
+
+        /// <summary>Re-points the settings hook at the live instance and repaints from it.</summary>
+        public void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
             LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
+        }
+
+        /// <summary>
+        /// Built once, in the constructor. The settings hook re-runs
+        /// <see cref="LoadFromSettings"/> on every property in this feature's chain - a slider drag
+        /// included - and rebuilding several hundred rows each time would stutter, which is the
+        /// same reason WPF's Populate keeps a "already filled" marker. Only the selection moves.
+        /// </summary>
+        private void PopulateFonts()
+        {
+            string[] names;
+            try { names = FontManager.Current.SystemFonts.Select(f => f.Name).OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToArray(); }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Subliminal font enumeration failed, using the fallback list");
+                names = Array.Empty<string>();
+            }
+            if (names.Length == 0) names = new[] { FontFallback };
+
+            foreach (var name in names)
+            {
+                // Tag carries the value that gets stored; Content is what the row shows. Each row
+                // renders in its own face, so the list reads as a real preview, as on WPF.
+                CmbFont.Items.Add(new ComboBoxItem
+                {
+                    Content = name,
+                    Tag = name,
+                    FontFamily = new FontFamily($"{name}, {FontFallback}"),
+                    FontSize = 14,
+                });
+            }
+        }
+
+        /// <summary>
+        /// Moves the selection to the stored family, else to the fallback, else row 0 - WPF's
+        /// <c>match ?? fallbackItem</c> chain.
+        ///
+        /// <para>WPF's <c>ApplySelectedFamily</c> (repainting the CLOSED box in the picked face) is
+        /// deliberately not ported: setting the ComboBox's own FontFamily shifts which face
+        /// Avalonia's fallback chain picks for the emoji on the sibling buttons, and a render
+        /// proved it turns the colour glyphs monochrome. The per-row preview below is the part
+        /// that carries the information.</para>
+        /// </summary>
+        private void SelectFont(string? wanted)
+        {
+            if (string.IsNullOrWhiteSpace(wanted)) wanted = FontFallback;
+            ComboBoxItem? fallbackItem = null;
+            foreach (var obj in CmbFont.Items)
+            {
+                if (obj is not ComboBoxItem item || item.Tag is not string name) continue;
+                if (string.Equals(name, wanted, StringComparison.OrdinalIgnoreCase))
+                {
+                    CmbFont.SelectedItem = item;
+                    return;
+                }
+                if (fallbackItem == null && string.Equals(name, FontFallback, StringComparison.OrdinalIgnoreCase))
+                    fallbackItem = item;
+            }
+            if (fallbackItem != null) CmbFont.SelectedItem = fallbackItem;
+            else if (CmbFont.SelectedItem == null && CmbFont.ItemCount > 0) CmbFont.SelectedIndex = 0;
         }
 
         private void LoadFromSettings()
         {
+            var s = CoreSettings.Current;
             _isLoading = true;
             try
             {
-                ChkEnable.IsChecked = _s.SubliminalEnabled;
-                SliderPerMin.Value = _s.SubliminalFrequency;
-                TxtPerMin.Text = _s.SubliminalFrequency.ToString();
-                SliderFrames.Value = _s.SubliminalDuration;
-                TxtFrames.Text = _s.SubliminalDuration.ToString();
-                SliderOpacity.Value = _s.SubliminalOpacity;
-                TxtOpacity.Text = $"{_s.SubliminalOpacity}%";
-                ChkWhispers.IsChecked = _s.SubAudioEnabled;
-                SliderWhisperVol.Value = _s.SubAudioVolume;
-                TxtWhisperVol.Text = $"{_s.SubAudioVolume}%";
-                ChkSolidMode.IsChecked = _s.SubliminalSolidMode;
-                // ponytail: needs Helpers.FontPickerHelper (system font enumeration); two placeholders, selection by name as on WPF
-                CmbFont.ItemsSource = new[] { "Arial", "Fredoka" };
-                CmbFont.SelectedItem = _s.SubliminalFont;
+                ChkEnable.IsChecked = s.SubliminalEnabled;
+                SliderPerMin.Value = s.SubliminalFrequency;
+                TxtPerMin.Text = s.SubliminalFrequency.ToString();
+                SliderFrames.Value = s.SubliminalDuration;
+                TxtFrames.Text = s.SubliminalDuration.ToString();
+                SliderOpacity.Value = s.SubliminalOpacity;
+                TxtOpacity.Text = $"{s.SubliminalOpacity}%";
+                ChkWhispers.IsChecked = s.SubAudioEnabled;
+                SliderWhisperVol.Value = s.SubAudioVolume;
+                TxtWhisperVol.Text = $"{s.SubAudioVolume}%";
+                ChkSolidMode.IsChecked = s.SubliminalSolidMode;
+                SelectFont(s.SubliminalFont);
             }
             finally { _isLoading = false; }
         }
 
-        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
-        private static void Save() { }
-    }
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.SubliminalEnabled) ||
+                e.PropertyName == nameof(AppSettings.SubliminalFrequency) ||
+                e.PropertyName == nameof(AppSettings.SubliminalDuration) ||
+                e.PropertyName == nameof(AppSettings.SubliminalOpacity) ||
+                e.PropertyName == nameof(AppSettings.SubAudioEnabled) ||
+                e.PropertyName == nameof(AppSettings.SubAudioVolume) ||
+                e.PropertyName == nameof(AppSettings.SubliminalSolidMode) ||
+                e.PropertyName == nameof(AppSettings.SubliminalFont))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
 
-    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
-    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
-    public sealed class SubliminalSettings
-    {
-        public bool SubliminalEnabled { get; set; }
-        public int SubliminalFrequency { get; set; } = 5;
-        public int SubliminalDuration { get; set; } = 2;
-        public int SubliminalOpacity { get; set; } = 80;
-        public bool SubAudioEnabled { get; set; }
-        public int SubAudioVolume { get; set; } = 50;
-        public bool SubliminalSolidMode { get; set; }
-        public string SubliminalFont { get; set; } = "Arial";
+        /// <summary>
+        /// WPF hands the whole toggle to <c>App.Subliminal.SetEnabled</c>, which is the single
+        /// authority. Its settings half - compare, write, save, log - is restored here verbatim;
+        /// only the idempotent Start/Stop it also does still needs the service.
+        /// </summary>
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkEnable.IsChecked ?? false;
+            if (s.SubliminalEnabled == on) return;
+            s.SubliminalEnabled = on;
+            // ponytail: SubliminalService.SetEnabled also does the live Start()/Stop() gated on
+            // App.IsEngineRunning - ConditioningControlPanel/Services/Subliminal/SubliminalService.cs,
+            // still in the WPF head. Route this whole handler back through it when it moves.
+            CoreSettings.Save();
+            Log.Information("Subliminals toggled: {Enabled}", on);
+        }
+
+        private void SliderPerMin_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtPerMin.Text = v.ToString();
+            if (s.SubliminalFrequency == v) return;
+            s.SubliminalFrequency = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderFrames_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtFrames.Text = v.ToString();
+            if (s.SubliminalDuration == v) return;
+            s.SubliminalDuration = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderOpacity_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtOpacity.Text = $"{v}%";
+            if (s.SubliminalOpacity == v) return;
+            s.SubliminalOpacity = v;
+            CoreSettings.Save();
+        }
+
+        private void ChkWhispers_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkWhispers.IsChecked ?? false;
+            if (s.SubAudioEnabled == on) return;
+            s.SubAudioEnabled = on;
+            CoreSettings.Save();
+        }
+
+        private void SliderWhisperVol_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtWhisperVol.Text = $"{v}%";
+            if (s.SubAudioVolume == v) return;
+            s.SubAudioVolume = v;
+            CoreSettings.Save();
+        }
+
+        private void ChkSolidMode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkSolidMode.IsChecked ?? false;
+            if (s.SubliminalSolidMode == on) return;
+            s.SubliminalSolidMode = on;
+            CoreSettings.Save();
+            // No service bounce needed: each show reads the setting, so the next subliminal
+            // uses the new renderer. An in-flight card finishes out on whichever spawned it.
+        }
+
+        // No service bounce: the text blocks are built per flash, so the next subliminal picks
+        // the new face up on its own.
+        private void CmbFont_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var name = (CmbFont.SelectedItem as ComboBoxItem)?.Tag as string;
+            if (string.IsNullOrWhiteSpace(name) || s.SubliminalFont == name) return;
+            s.SubliminalFont = name;
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// The pool editor, plus the bookkeeping that keeps a mod's top-up honest: phrases the
+        /// user added by hand are remembered so a cross-mod prune never deletes them, and a
+        /// DELETED DEFAULT is recorded so ModService's top-up does not put it straight back on the
+        /// next launch (#892).
+        /// </summary>
+        private async void BtnManageMessages_Click(object? sender, RoutedEventArgs e)
+        {
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
+            var s = CoreSettings.Current;
+
+            var oldKeys = new HashSet<string>(s.SubliminalPool.Keys);
+            // OrdinalIgnoreCase: the removed-set and ModService's top-up compare
+            // case-insensitively, so detection must too or modded defaults slip through.
+            // ponytail: WPF asks App.Mods.GetDefaultSubliminalPool() first
+            // (ConditioningControlPanel/Services/ModService.cs:1113, no Core seam yet) and only
+            // falls back to BuiltInMods. With no mod layer on this head the fallback IS the
+            // answer, which is the branch WPF takes for a null App.Mods too.
+            var defaults = new HashSet<string>(
+                (BuiltInMods.BambiSleep.SubliminalPool ?? new Dictionary<string, bool>()).Keys,
+                StringComparer.OrdinalIgnoreCase);
+
+            var dialog = new Dialogs.TextEditorDialog("Subliminal Messages", s.SubliminalPool);
+            if (await dialog.ShowDialog<bool?>(owner) != true || dialog.ResultData == null) return;
+
+            // Remember hand-added phrases (and forget removed ones) so the cross-mod prune
+            // never silently deletes a custom phrase that collides with another mod's default.
+            var newKeys = new HashSet<string>(dialog.ResultData.Keys);
+            foreach (var key in newKeys)
+                if (!oldKeys.Contains(key)) s.UserAddedSubliminals.Add(key);
+            foreach (var key in oldKeys)
+                if (!newKeys.Contains(key)) s.UserAddedSubliminals.Remove(key);
+
+            // Record deleted DEFAULTS, or ModService's top-up puts them straight back on the
+            // next launch — the phrase the user deliberately deleted returns forever (#892).
+            foreach (var key in oldKeys)
+                if (!newKeys.Contains(key) && defaults.Contains(key))
+                    s.RemovedDefaultSubliminals.Add(key);
+            // A default they added back is no longer "removed".
+            foreach (var key in newKeys)
+                s.RemovedDefaultSubliminals.Remove(key);
+
+            s.SubliminalPool = dialog.ResultData;
+            CoreSettings.Save();
+            Log.Information("Subliminal pool updated: {Count} items", dialog.ResultData.Count);
+        }
+
+        private async void BtnAdvanced_Click(object? sender, RoutedEventArgs e)
+        {
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
+            await new Dialogs.ColorEditorDialog().ShowDialog(owner);
+        }
     }
 }


### PR DESCRIPTION
Every editor on both cards now reads and writes CoreSettings.Current and persists through
CoreSettings.Save(), so a change survives a restart instead of dying in a per-control
placeholder object. Both placeholder *Settings classes are gone. Each card inlines the WPF
SettingsHook / ISettingsRebindable pair - subscribe to the live AppSettings' PropertyChanged,
repaint through Dispatcher.UIThread.Post, and re-point the hook on Loaded - so a cloud
restore, which swaps the settings instance under these permanently rack-mounted panels, is
followed rather than silently edited past. Every handler is guarded by _isLoading and
compares before writing, because Avalonia raises IsCheckedChanged on a programmatic set.

Intensity Ramp: the whole panel is live - enable, duration, multiplier, mode, range
start/end, curve, end-at-complete and all six link toggles write settings, and the curve
preview is redrawn from Helpers.RampMath.ResolveFactor (which is in Core now) instead of a
copy of its formula, so the preview cannot drift from the runtime ramp. It has no notes
left.

Subliminal: frequency, frame count, opacity, whispers, whisper volume, solid mode and font
persist, and the font combo is a real picker over FontManager.Current.SystemFonts with each
row previewing in its own face. Manage Messages opens the ported TextEditorDialog and
restores the full pool bookkeeping - user-added phrases remembered, removed defaults
recorded so a mod top-up cannot resurrect them (#892) - and Advanced opens the ported
ColorEditorDialog.

Still blocked:
- SubliminalService's live Start/Stop/RefreshSchedule half, plus App.IsEngineRunning - still
  in the WPF head. The settings half of each handler is restored; only the live apply is a
  note.
- ModService.GetDefaultSubliminalPool has no Core seam; the pool bookkeeping takes WPF's own
  null-App.Mods branch and falls back to BuiltInMods.BambiSleep.SubliminalPool, in Core.
- The mod-aware hero/side art plates are dropped from these .axaml files by design
  (ModResourceResolver and Resources/features/*.png are still head-side), so ApplyFeatureArt
  and its ModChanged subscription have nothing to repaint.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU