### PR TITLE
feat(avalonia): the Lock Card, Mind Wipe and Bubble Count cards edit and persist real settings

### DIFF
--- a/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs
@@ -1,73 +1,190 @@
+using System;
+using System.ComponentModel;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Bubble Count settings panel, ported from the WPF head. <see cref="BubbleCountSettings"/>
-    /// stands in for <c>App.Settings.Current</c>. Save, SettingsHook, the mod-art repaint and the
-    /// BubbleCountService calls are stubbed; the strict-lock double warning writes through.
+    /// Bubble Count settings panel, ported from the WPF head. Every editor reads and writes
+    /// <see cref="CoreSettings.Current"/> and persists through <see cref="CoreSettings.Save"/>,
+    /// which is the <c>App.Settings.Current</c> / <c>App.Settings.Save()</c> pair the WPF
+    /// code-behind used, one for one.
+    ///
+    /// <para>The WPF <c>SettingsHook</c> / <c>ISettingsRebindable</c> pair is inlined here rather
+    /// than shared: that interface lives in the WPF head and minting a twin is not this file's
+    /// job. It buys the same thing it bought there - a cloud restore SWAPS the settings instance,
+    /// and this control is rack-mounted for the whole session, so the hook must follow the swap or
+    /// the panel edits a discarded object. <see cref="RebindToCurrentSettings"/> stays public so
+    /// the rack can fan a restore out over it.</para>
+    ///
+    /// <para>Still head-side: the BubbleCount service (start/stop/reschedule/trigger) and the
+    /// mod-aware feature art. Both are named at their call sites.</para>
     /// </summary>
     public partial class BubbleCountFeatureControl : UserControl
     {
         private bool _isLoading = true;
-        private readonly BubbleCountSettings _s = new();
+        private AppSettings? _hooked;
 
         public BubbleCountFeatureControl()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: needs App.BubbleCount Start/Stop/RefreshSchedule/TriggerGame, wired when it moves to Core
-            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.BubbleCountEnabled = ChkEnable.IsChecked ?? false; Save(); };
-            SliderFreq.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFreq.Text = v.ToString(); _s.BubbleCountFrequency = v; Save(); };
-            CmbDifficulty.SelectionChanged += (_, _) =>
-            {
-                if (_isLoading) return;
-                if (CmbDifficulty.SelectedItem is ComboBoxItem item && item.Tag is string tag && int.TryParse(tag, out var difficulty))
-                {
-                    _s.BubbleCountDifficulty = difficulty;
-                    Save();
-                }
-            };
-            // ponytail: needs WarningDialog.ShowDoubleWarning (WPF head); writes through without the confirm
-            ChkStrict.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.BubbleCountStrictLock = ChkStrict.IsChecked ?? false; Save(); };
-            BtnTest.Click += (_, _) => { };
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderFreq.ValueChanged += SliderFreq_Changed;
+            CmbDifficulty.SelectionChanged += CmbDifficulty_Changed;
+            ChkStrict.IsCheckedChanged += ChkStrict_Changed;
+            BtnTest.Click += BtnTest_Click;
 
+            Loaded += (_, _) => RebindToCurrentSettings();
+            Unloaded += (_, _) => Unhook();
+
+            // ponytail: WPF also repaints the hero and side plates on ModChanged through
+            // Services/ModResourceResolver.cs (WPF head) from Resources/features/Bubble_count.png.
+            // The Avalonia .axaml drops both plates deliberately, so nothing here to repaint yet.
+
+            RebindToCurrentSettings();
+        }
+
+        /// <summary>Re-points the settings hook at the live instance and repaints from it.</summary>
+        public void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
             LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
         }
 
         private void LoadFromSettings()
         {
+            var s = CoreSettings.Current;
             _isLoading = true;
             try
             {
-                ChkEnable.IsChecked = _s.BubbleCountEnabled;
-                SliderFreq.Value = _s.BubbleCountFrequency;
-                TxtFreq.Text = _s.BubbleCountFrequency.ToString();
+                ChkEnable.IsChecked = s.BubbleCountEnabled;
+                SliderFreq.Value = s.BubbleCountFrequency;
+                TxtFreq.Text = s.BubbleCountFrequency.ToString();
                 // Select matching ComboBoxItem by Tag
                 foreach (var obj in CmbDifficulty.Items)
                 {
-                    if (obj is ComboBoxItem item && item.Tag is string tag && int.TryParse(tag, out var val) && val == _s.BubbleCountDifficulty)
+                    if (obj is ComboBoxItem item && item.Tag is string tag &&
+                        int.TryParse(tag, out var val) && val == s.BubbleCountDifficulty)
                     {
                         CmbDifficulty.SelectedItem = item;
                         break;
                     }
                 }
-                ChkStrict.IsChecked = _s.BubbleCountStrictLock;
+                ChkStrict.IsChecked = s.BubbleCountStrictLock;
             }
             finally { _isLoading = false; }
         }
 
-        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
-        private static void Save() { }
-    }
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.BubbleCountEnabled) ||
+                e.PropertyName == nameof(AppSettings.BubbleCountFrequency) ||
+                e.PropertyName == nameof(AppSettings.BubbleCountDifficulty) ||
+                e.PropertyName == nameof(AppSettings.BubbleCountStrictLock))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
 
-    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
-    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
-    public sealed class BubbleCountSettings
-    {
-        public bool BubbleCountEnabled { get; set; }
-        public int BubbleCountFrequency { get; set; } = 2;
-        public int BubbleCountDifficulty { get; set; } = 1;
-        public bool BubbleCountStrictLock { get; set; }
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkEnable.IsChecked ?? false;
+            if (s.BubbleCountEnabled == on) return;   // a seeding echo, not a user edit
+            s.BubbleCountEnabled = on;
+            CoreSettings.Save();
+
+            // ponytail: WPF live-applies here - App.BubbleCount.Start()/Stop(), gated on
+            // App.IsEngineRunning. BubbleCountService (ConditioningControlPanel/Services/) and
+            // App.IsEngineRunning (ConditioningControlPanel/App.xaml.cs) are both still head-side.
+        }
+
+        private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtFreq.Text = v.ToString();
+            if (s.BubbleCountFrequency == v) return;
+            s.BubbleCountFrequency = v;
+            // ponytail: WPF then calls App.BubbleCount.RefreshSchedule() so a live schedule picks
+            // the new frequency up - BubbleCountService, still in the WPF head.
+            CoreSettings.Save();
+        }
+
+        private void CmbDifficulty_Changed(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            if (CmbDifficulty.SelectedItem is ComboBoxItem item &&
+                item.Tag is string tag && int.TryParse(tag, out var difficulty))
+            {
+                var s = CoreSettings.Current;
+                if (s.BubbleCountDifficulty == difficulty) return;
+                s.BubbleCountDifficulty = difficulty;
+                CoreSettings.Save();
+            }
+        }
+
+        /// <summary>
+        /// Strict mode is one of the restrictive locks, so switching it ON has to clear the
+        /// acknowledgement-gated double warning first. A decline puts the box back rather than
+        /// leaving it visually on while the setting says off.
+        /// </summary>
+        private async void ChkStrict_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkStrict.IsChecked ?? false;
+            if (s.BubbleCountStrictLock == on) return;
+
+            if (on)
+            {
+                // Avalonia's ShowDialog is async and needs a real owner Window. With no owner the
+                // honest answer is "not confirmed", so the box reverts rather than arming a lock
+                // the user never acknowledged.
+                var owner = TopLevel.GetTopLevel(this) as Window;
+                var confirmed = owner != null && await Dialogs.WarningDialog.ShowDoubleWarningAsync(owner,
+                    "Strict Bubble Count",
+                    "• You will NOT be able to skip the bubble count challenge\n" +
+                    "• You MUST answer correctly to dismiss\n" +
+                    "• Wrong answers force you to REWATCH the video\n" +
+                    "• Mercy system grants escape after 3 retries (if enabled)\n" +
+                    "• This can be very restrictive!");
+
+                if (!confirmed)
+                {
+                    // Back on the UI thread after the await, so WPF's BeginInvoke hop is gone.
+                    _isLoading = true;
+                    ChkStrict.IsChecked = false;
+                    _isLoading = false;
+                    return;
+                }
+            }
+
+            s.BubbleCountStrictLock = on;
+            CoreSettings.Save();
+            Log.Information("Bubble count strict lock set to {Enabled}", on);
+        }
+
+        private void BtnTest_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.BubbleCount.TriggerGame(forceTest: true) - BubbleCountService
+            // (ConditioningControlPanel/Services/), still in the WPF head.
+        }
     }
 }

--- a/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
@@ -1,55 +1,209 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Lock Card settings panel, ported from the WPF head. <see cref="LockCardSettings"/> stands
-    /// in for <c>App.Settings.Current</c>. Save, the LockCardService calls, the strict-lock double
-    /// warning, MicConsentDialog, the phrase editor write-back, LockCardColorDialog, MessageBox and
-    /// the mod-art repaint are stubbed. The voice hint keeps the WPF literals; with no speech
-    /// service the "on" branch lands on "No microphone detected", which is the honest answer here.
+    /// Lock Card settings panel, ported from the WPF head. Every editor reads and writes
+    /// <see cref="CoreSettings.Current"/> and persists through <see cref="CoreSettings.Save"/>,
+    /// and the settings hook is inlined for the reason spelled out in
+    /// <see cref="BubbleCountFeatureControl"/>.
+    ///
+    /// <para>Both gates are real: strict mode still has to clear the acknowledgement-gated double
+    /// warning, and voice mode still has to clear the mic consent flow before it is written. Both
+    /// dialogs are awaited rather than blocking, and a decline reverts the box.</para>
+    ///
+    /// <para>Still head-side: LockCardService (start/stop/test) and the mod-aware feature art. The
+    /// voice hint keeps the WPF literals; with no speech service on this head the "on" branch
+    /// lands on "No microphone detected", which is the honest answer here.</para>
     /// </summary>
     public partial class LockCardFeatureControl : UserControl
     {
-        private bool _isLoading = true;
-        private readonly LockCardSettings _s = new();
+        private bool _isLoading = true; // stops the XAML defaults overwriting settings while loading
+        private AppSettings? _hooked;
 
         public LockCardFeatureControl()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: needs App.LockCard Start/Stop/TestLockCard, wired when it moves to Core
-            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.LockCardEnabled = ChkEnable.IsChecked ?? false; Save(); };
-            SliderFreq.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFreq.Text = v.ToString(); _s.LockCardFrequency = v; Save(); };
-            SliderRepeats.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtRepeats.Text = $"{v}x"; _s.LockCardRepeats = v; Save(); };
-            // ponytail: needs WarningDialog.ShowDoubleWarning (WPF head); writes through without the confirm
-            ChkStrict.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.LockCardStrict = ChkStrict.IsChecked ?? false; Save(); };
-            // ponytail: needs MicConsentDialog (WPF head); writes through without the consent gate
-            ChkVoiceMode.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.LockCardVoiceMode = ChkVoiceMode.IsChecked ?? false; Save(); UpdateVoiceHint(); };
-            // ponytail: Views/Dialogs/TextEditorDialog is ported, but the write-back is App.Settings; wired with it
-            BtnManagePhrases.Click += (_, _) => { };
-            BtnTest.Click += (_, _) => { };
-            // ponytail: needs LockCardColorDialog, ported separately
-            BtnColorSettings.Click += (_, _) => { };
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderFreq.ValueChanged += SliderFreq_Changed;
+            SliderRepeats.ValueChanged += SliderRepeats_Changed;
+            ChkStrict.IsCheckedChanged += ChkStrict_Changed;
+            ChkVoiceMode.IsCheckedChanged += ChkVoiceMode_Changed;
+            BtnManagePhrases.Click += BtnManagePhrases_Click;
+            BtnTest.Click += BtnTest_Click;
+            BtnColorSettings.Click += BtnColorSettings_Click;
 
+            Loaded += (_, _) => RebindToCurrentSettings();
+            Unloaded += (_, _) => Unhook();
+
+            // ponytail: WPF also repaints the hero and side plates on ModChanged through
+            // Services/ModResourceResolver.cs (WPF head) from Resources/features/Phrase_Lock.png.
+            // The Avalonia .axaml drops both plates deliberately, so nothing here to repaint yet.
+
+            RebindToCurrentSettings();
+        }
+
+        /// <summary>Re-points the settings hook at the live instance and repaints from it.</summary>
+        public void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
             LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
         }
 
         private void LoadFromSettings()
         {
+            var s = CoreSettings.Current;
             _isLoading = true;
             try
             {
-                ChkEnable.IsChecked = _s.LockCardEnabled;
-                SliderFreq.Value = _s.LockCardFrequency;
-                TxtFreq.Text = _s.LockCardFrequency.ToString();
-                SliderRepeats.Value = _s.LockCardRepeats;
-                TxtRepeats.Text = $"{_s.LockCardRepeats}x";
-                ChkStrict.IsChecked = _s.LockCardStrict;
-                ChkVoiceMode.IsChecked = _s.LockCardVoiceMode && _s.MicConsentGiven;
+                ChkEnable.IsChecked = s.LockCardEnabled;
+                SliderFreq.Value = s.LockCardFrequency;
+                TxtFreq.Text = s.LockCardFrequency.ToString();
+                SliderRepeats.Value = s.LockCardRepeats;
+                TxtRepeats.Text = $"{s.LockCardRepeats}x";
+                ChkStrict.IsChecked = s.LockCardStrict;
+                ChkVoiceMode.IsChecked = s.LockCardVoiceMode && s.MicConsentGiven;
                 UpdateVoiceHint();
             }
             finally { _isLoading = false; }
+        }
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.LockCardEnabled) ||
+                e.PropertyName == nameof(AppSettings.LockCardFrequency) ||
+                e.PropertyName == nameof(AppSettings.LockCardRepeats) ||
+                e.PropertyName == nameof(AppSettings.LockCardStrict) ||
+                e.PropertyName == nameof(AppSettings.LockCardVoiceMode))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
+
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkEnable.IsChecked ?? false;
+            if (s.LockCardEnabled == on) return;
+            s.LockCardEnabled = on;
+            CoreSettings.Save();
+
+            // ponytail: WPF live-applies here - App.LockCard.Start()/Stop(), gated on
+            // App.IsEngineRunning. LockCardService (ConditioningControlPanel/Services/) and
+            // App.IsEngineRunning (ConditioningControlPanel/App.xaml.cs) are both still head-side.
+        }
+
+        private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtFreq.Text = v.ToString();
+            if (s.LockCardFrequency == v) return;
+            s.LockCardFrequency = v;
+            CoreSettings.Save();
+        }
+
+        private void SliderRepeats_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtRepeats.Text = $"{v}x";
+            if (s.LockCardRepeats == v) return;
+            s.LockCardRepeats = v;
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// Strict mode removes the ESC escape, so switching it ON has to clear the
+        /// acknowledgement-gated double warning first. A decline puts the box back.
+        /// </summary>
+        private async void ChkStrict_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkStrict.IsChecked ?? false;
+            if (s.LockCardStrict == on) return;
+
+            if (on)
+            {
+                // No owner Window means no dialog, and an unacknowledged lock must not arm - so
+                // "not confirmed" is the honest answer and the box reverts.
+                var owner = TopLevel.GetTopLevel(this) as Window;
+                var confirmed = owner != null && await Dialogs.WarningDialog.ShowDoubleWarningAsync(owner,
+                    "Strict Lock Card",
+                    "• You will NOT be able to escape lock cards with ESC\n" +
+                    "• You MUST type the phrase the required number of times\n" +
+                    "• This can be very restrictive!");
+
+                if (!confirmed)
+                {
+                    // Back on the UI thread after the await, so WPF's BeginInvoke hop is gone.
+                    _isLoading = true;
+                    ChkStrict.IsChecked = false;
+                    _isLoading = false;
+                    return;
+                }
+            }
+
+            s.LockCardStrict = on;
+            CoreSettings.Save();
+            Log.Information("Lock card strict mode set to {Enabled}", on);
+        }
+
+        /// <summary>
+        /// First time on, voice mode requires mic consent (the shared offline-audio contract).
+        /// Decline reverts the box and nothing is written.
+        /// </summary>
+        private async void ChkVoiceMode_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkVoiceMode.IsChecked ?? false;
+            if (s.LockCardVoiceMode == on) return;
+
+            if (on && !s.MicConsentGiven)
+            {
+                var owner = TopLevel.GetTopLevel(this) as Window;
+                var dlg = new Dialogs.MicConsentDialog();
+                var ok = owner != null && await dlg.ShowDialog<bool?>(owner) == true && dlg.ConsentGiven;
+                if (!ok)
+                {
+                    _isLoading = true;
+                    ChkVoiceMode.IsChecked = false;
+                    _isLoading = false;
+                    return;
+                }
+                // ponytail: on WPF the consent dialog itself flips AppSettings.MicConsentGiven and
+                // saves; the ported one does not yet (CCP.Avalonia/Views/Dialogs/MicConsentDialog
+                // .axaml.cs, Enable()). Until it does, LoadFromSettings' "LockCardVoiceMode &&
+                // MicConsentGiven" clears this box again on the next repaint. Fixing it belongs in
+                // that dialog, not here - this control never wrote the consent flag on WPF either.
+            }
+
+            s.LockCardVoiceMode = on;
+            CoreSettings.Save();
+            UpdateVoiceHint();
         }
 
         /// <summary>Refresh the grey hint under the voice toggle to reflect mic availability.</summary>
@@ -61,23 +215,50 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
                 TxtVoiceHint.Text = "Say the phrase out loud instead of typing it (offline mic). Falls back to typing if no mic.";
                 return;
             }
-            // ponytail: needs App.Speech (IsAvailable / HasCaptureDevice / ModelStatus); no service means no mic
+            // ponytail: WPF picks one of four hints from App.Speech (IsAvailable /
+            // HasCaptureDevice / ModelStatus) - ConditioningControlPanel/Services/Speech/
+            // SpeechService.cs, still in the WPF head. No service means no mic, which is this one.
             TxtVoiceHint.Text = "No microphone detected — lock cards will use typing until one is connected.";
         }
 
-        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
-        private static void Save() { }
-    }
+        private async void BtnManagePhrases_Click(object? sender, RoutedEventArgs e)
+        {
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
+            var s = CoreSettings.Current;
 
-    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
-    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
-    public sealed class LockCardSettings
-    {
-        public bool LockCardEnabled { get; set; }
-        public int LockCardFrequency { get; set; } = 2;
-        public int LockCardRepeats { get; set; } = 3;
-        public bool LockCardStrict { get; set; }
-        public bool LockCardVoiceMode { get; set; }
-        public bool MicConsentGiven { get; set; }
+            var editor = new Dialogs.TextEditorDialog("Lock Card Phrases", s.LockCardPhrases);
+            if (await editor.ShowDialog<bool?>(owner) != true || editor.ResultData == null) return;
+
+            s.LockCardPhrases = editor.ResultData;
+            CoreSettings.Save();
+            Log.Information("Lock card phrases updated: {Count} items", editor.ResultData.Count);
+        }
+
+        /// <summary>
+        /// The "no enabled phrases" guard is settings-backed, so it is real here; what it guards
+        /// is not, yet.
+        /// </summary>
+        private void BtnTest_Click(object? sender, RoutedEventArgs e)
+        {
+            var s = CoreSettings.Current;
+
+            var enabledPhrases = s.LockCardPhrases.Where(p => p.Value).Select(p => p.Key).ToList();
+            if (enabledPhrases.Count == 0)
+            {
+                // ponytail: WPF says so in a MessageBox (Loc key
+                // "msg_no_phrases_enabled_add_some_phrases_first"); this head has no styled
+                // message dialog yet, so the refusal is logged rather than shown.
+                Log.Warning("Lock card test refused: {Msg}", Loc.Get("msg_no_phrases_enabled_add_some_phrases_first"));
+                return;
+            }
+            // ponytail: needs App.LockCard.TestLockCard() - LockCardService
+            // (ConditioningControlPanel/Services/), still in the WPF head.
+        }
+
+        private async void BtnColorSettings_Click(object? sender, RoutedEventArgs e)
+        {
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
+            await new Dialogs.LockCardColorDialog().ShowDialog(owner);
+        }
     }
 }

--- a/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml.cs
@@ -1,77 +1,215 @@
+using System;
+using System.ComponentModel;
 using System.IO;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
 {
     /// <summary>
-    /// Mind Wipe settings panel, ported from the WPF head. <see cref="MindWipeSettings"/> stands
-    /// in for <c>App.Settings.Current</c>. Save, the MindWipeService calls, the Win32
-    /// OpenFileDialog and the mod-art repaint are stubbed.
+    /// Mind Wipe settings panel, ported from the WPF head. Every editor reads and writes
+    /// <see cref="CoreSettings.Current"/> and persists through <see cref="CoreSettings.Save"/>,
+    /// the one-for-one port of <c>App.Settings.Current</c> / <c>App.Settings.Save()</c>.
+    ///
+    /// <para>The settings hook is inlined for the reason spelled out in
+    /// <see cref="BubbleCountFeatureControl"/>: a cloud restore swaps the settings instance under
+    /// a permanently rack-mounted panel.</para>
+    ///
+    /// <para>Win32's <c>OpenFileDialog</c> becomes Avalonia's <c>StorageProvider</c>, which is
+    /// async and needs a TopLevel - so the handler is <c>async void</c> and the title and filter
+    /// carry over verbatim. Still head-side: MindWipeService (the audio loop itself) and the
+    /// mod-aware feature art.</para>
     /// </summary>
     public partial class MindWipeFeatureControl : UserControl
     {
         private bool _isLoading = true;
-        private readonly MindWipeSettings _s = new();
+        private AppSettings? _hooked;
 
         public MindWipeFeatureControl()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: needs App.MindWipe UpdateSettings/StartLoop/StopLoop/TriggerOnce/ReloadAudioFiles, wired when it moves to Core
-            ChkEnable.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.MindWipeEnabled = ChkEnable.IsChecked ?? false; Save(); };
-            SliderFreq.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtFreq.Text = $"{v}/h"; _s.MindWipeFrequency = v; Save(); };
-            SliderVolume.ValueChanged += (_, e) => { if (_isLoading) return; var v = (int)e.NewValue; TxtVolume.Text = $"{v}%"; _s.MindWipeVolume = v; Save(); };
-            ChkLoop.IsCheckedChanged += (_, _) => { if (_isLoading) return; _s.MindWipeLoop = ChkLoop.IsChecked ?? false; Save(); };
-            BtnTest.Click += (_, _) => { };
-            // ponytail: needs a file picker (Win32 OpenFileDialog on WPF); StorageProvider needs a TopLevel, wired with the host
-            BtnSelectAudio.Click += (_, _) => { };
-            BtnClearAudio.Click += (_, _) =>
-            {
-                if (string.IsNullOrEmpty(_s.MindWipeAudioPath)) return;
-                _s.MindWipeAudioPath = "";
-                Save();
-                UpdateAudioFileLabel();
-            };
+            ChkEnable.IsCheckedChanged += ChkEnable_Changed;
+            SliderFreq.ValueChanged += SliderFreq_Changed;
+            SliderVolume.ValueChanged += SliderVolume_Changed;
+            ChkLoop.IsCheckedChanged += ChkLoop_Changed;
+            BtnTest.Click += BtnTest_Click;
+            BtnSelectAudio.Click += BtnSelectAudio_Click;
+            BtnClearAudio.Click += BtnClearAudio_Click;
 
+            Loaded += (_, _) => RebindToCurrentSettings();
+            Unloaded += (_, _) => Unhook();
+
+            // ponytail: WPF also repaints the hero and side plates on ModChanged through
+            // Services/ModResourceResolver.cs (WPF head) from Resources/features/Mind_Wipers.png.
+            // The Avalonia .axaml drops both plates deliberately, so nothing here to repaint yet.
+
+            RebindToCurrentSettings();
+        }
+
+        /// <summary>Re-points the settings hook at the live instance and repaints from it.</summary>
+        public void RebindToCurrentSettings()
+        {
+            Unhook();
+            _hooked = CoreSettings.Current;
+            _hooked.PropertyChanged += OnSettingsPropertyChanged;
             LoadFromSettings();
+        }
+
+        private void Unhook()
+        {
+            if (_hooked != null) _hooked.PropertyChanged -= OnSettingsPropertyChanged;
+            _hooked = null;
         }
 
         private void LoadFromSettings()
         {
+            var s = CoreSettings.Current;
             _isLoading = true;
             try
             {
-                ChkEnable.IsChecked = _s.MindWipeEnabled;
-                SliderFreq.Value = _s.MindWipeFrequency;
-                TxtFreq.Text = $"{_s.MindWipeFrequency}/h";
-                SliderVolume.Value = _s.MindWipeVolume;
-                TxtVolume.Text = $"{_s.MindWipeVolume}%";
-                ChkLoop.IsChecked = _s.MindWipeLoop;
-                UpdateAudioFileLabel();
+                ChkEnable.IsChecked = s.MindWipeEnabled;
+                SliderFreq.Value = s.MindWipeFrequency;
+                TxtFreq.Text = $"{s.MindWipeFrequency}/h";
+                SliderVolume.Value = s.MindWipeVolume;
+                TxtVolume.Text = $"{s.MindWipeVolume}%";
+                ChkLoop.IsChecked = s.MindWipeLoop;
+                UpdateAudioFileLabel(s);
             }
             finally { _isLoading = false; }
         }
 
-        private void UpdateAudioFileLabel()
+        private void UpdateAudioFileLabel(AppSettings s)
         {
-            var path = _s.MindWipeAudioPath;
+            var path = s.MindWipeAudioPath;
             TxtAudioFile.Text = !string.IsNullOrWhiteSpace(path) && File.Exists(path)
                 ? Path.GetFileName(path)
                 : "Default (built-in clips)";
         }
 
-        // ponytail: needs App.Settings.Save(), wired when AppSettings moves to Core
-        private static void Save() { }
-    }
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppSettings.MindWipeEnabled) ||
+                e.PropertyName == nameof(AppSettings.MindWipeFrequency) ||
+                e.PropertyName == nameof(AppSettings.MindWipeVolume) ||
+                e.PropertyName == nameof(AppSettings.MindWipeLoop) ||
+                e.PropertyName == nameof(AppSettings.MindWipeAudioPath))
+            {
+                Dispatcher.UIThread.Post(LoadFromSettings);
+            }
+        }
 
-    /// <summary>Placeholder for the AppSettings slice this panel reads. Property names match
-    /// Models.AppSettings; values are the WPF XAML defaults.</summary>
-    public sealed class MindWipeSettings
-    {
-        public bool MindWipeEnabled { get; set; }
-        public int MindWipeFrequency { get; set; } = 6;
-        public int MindWipeVolume { get; set; } = 50;
-        public bool MindWipeLoop { get; set; }
-        public string MindWipeAudioPath { get; set; } = "";
+        private void ChkEnable_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkEnable.IsChecked ?? false;
+            if (s.MindWipeEnabled == on) return;
+            s.MindWipeEnabled = on;
+            CoreSettings.Save();
+        }
+
+        private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtFreq.Text = $"{v}/h";
+            if (s.MindWipeFrequency == v) return;
+            s.MindWipeFrequency = v;
+            // ponytail: WPF pushes the pair through App.MindWipe.UpdateSettings(frequency,
+            // volume/100) - MindWipeService (ConditioningControlPanel/Services/), still head-side.
+            CoreSettings.Save();
+        }
+
+        private void SliderVolume_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var v = (int)e.NewValue;
+            TxtVolume.Text = $"{v}%";
+            if (s.MindWipeVolume == v) return;
+            s.MindWipeVolume = v;
+            // ponytail: same App.MindWipe.UpdateSettings call as SliderFreq_Changed.
+            CoreSettings.Save();
+        }
+
+        private void ChkLoop_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var looping = ChkLoop.IsChecked ?? false;
+            if (s.MindWipeLoop == looping) return;
+            s.MindWipeLoop = looping;
+            // ponytail: WPF starts or stops the background loop here -
+            // App.MindWipe.StartLoop(volume/100) / StopLoop(), MindWipeService in the WPF head.
+            CoreSettings.Save();
+        }
+
+        private void BtnTest_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs App.MindWipe.TriggerOnce() - MindWipeService
+            // (ConditioningControlPanel/Services/), still in the WPF head.
+        }
+
+        /// <summary>
+        /// Win32's <c>OpenFileDialog</c> in Avalonia terms. Same title, same extensions, and the
+        /// current pick's folder is still where the picker opens.
+        /// </summary>
+        private async void BtnSelectAudio_Click(object? sender, RoutedEventArgs e)
+        {
+            var storage = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storage == null) return;
+            var s = CoreSettings.Current;
+
+            var options = new FilePickerOpenOptions
+            {
+                Title = "Select mind-wipe audio (short clip, ~2 sec recommended)",
+                AllowMultiple = false,
+                FileTypeFilter = new[]
+                {
+                    new FilePickerFileType("Audio Files") { Patterns = new[] { "*.mp3", "*.wav", "*.ogg" } },
+                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } },
+                },
+            };
+
+            var current = s.MindWipeAudioPath;
+            if (!string.IsNullOrWhiteSpace(current) && File.Exists(current) &&
+                Path.GetDirectoryName(current) is { Length: > 0 } dir)
+            {
+                try { options.SuggestedStartLocation = await storage.TryGetFolderFromPathAsync(dir); }
+                catch (Exception ex) { Log.Debug("MindWipe audio picker start folder: {E}", ex.Message); }
+            }
+
+            var files = await storage.OpenFilePickerAsync(options);
+            if (files.Count != 1 || files[0].TryGetLocalPath() is not { } path) return;
+
+            s.MindWipeAudioPath = path;
+            CoreSettings.Save();
+            ApplyAudioChange(s);
+        }
+
+        private void BtnClearAudio_Click(object? sender, RoutedEventArgs e)
+        {
+            var s = CoreSettings.Current;
+            if (string.IsNullOrEmpty(s.MindWipeAudioPath)) return;
+
+            s.MindWipeAudioPath = "";
+            CoreSettings.Save();
+            ApplyAudioChange(s);
+        }
+
+        private void ApplyAudioChange(AppSettings s)
+        {
+            UpdateAudioFileLabel(s);
+            // ponytail: WPF then calls App.MindWipe.ReloadAudioFiles() and, when MindWipeLoop is
+            // on and IsLooping, restarts the loop so the new clip takes effect - MindWipeService
+            // (ConditioningControlPanel/Services/), still in the WPF head.
+        }
     }
 }


### PR DESCRIPTION
The second half of the session feature-card layer; same inline SettingsHook /
ISettingsRebindable pattern, the same _isLoading compare-before-write guard, and the same
three placeholder *Settings classes deleted.

Bubble Count: enable, per-hour frequency, difficulty and strict lock all persist. Strict
lock is gated again on WarningDialog.ShowDoubleWarningAsync with the WPF bullet list
verbatim; a decline (or no owner Window) reverts the toggle rather than arming an
unacknowledged lock.

Mind Wipe: enable, frequency, volume, loop and the custom-audio path persist. The Win32
OpenFileDialog is restored as Avalonia's StorageProvider picker with the same title and the
same mp3/wav/ogg filter, opening in the current clip's folder; Reset clears the path and
repaints the label.

Lock Card: frequency, repeats, strict mode and voice mode persist. Strict mode is gated on
the double warning and voice mode on MicConsentDialog, both awaited, both reverting the
toggle on a decline - and that dialog persists MicConsentGiven as of the consent layer at
the bottom of this chain, so voice mode is asked once rather than on every repaint. Manage
Phrases writes the edited pool back through TextEditorDialog, the colour button opens
LockCardColorDialog, and Test's "no enabled phrases" guard is real again.

Still blocked:
- BubbleCountService, MindWipeService and LockCardService's live Start / Stop /
  RefreshSchedule / Trigger / UpdateSettings halves, plus App.IsEngineRunning - all still in
  the WPF head. The settings half of each handler is restored; only the live apply is a note.
- App.Speech (SpeechService.IsAvailable / HasCaptureDevice / ModelStatus) - the lock-card
  voice hint keeps the WPF literals and lands on "no microphone detected".
- The mod-aware hero/side art plates are dropped from these .axaml files by design
  (ModResourceResolver and Resources/features/*.png are still head-side).
- No styled message dialog on this head, so Lock Card's "add some phrases first" refusal is
  logged rather than shown.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU