### PR TITLE
feat(core): views can ask whether speech input is usable

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -58,6 +58,10 @@ namespace ConditioningControlPanel.Avalonia
                 var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
                 CoreReleaseContent.AppVersionProvider = () =>
                     version is null ? null : $"{version.Major}.{version.Minor}.{version.Build}";
+                // CoreSpeech is deliberately left unseeded: there is no speech engine on this head
+                // yet, and the seam's unseeded answers (no mic, empty device list, NotProbed) are
+                // exactly what that is. Seeding it with anything else would be a lie.
+
                 desktop.MainWindow = new Views.Windows.MainShellWindow();
             }
             base.OnFrameworkInitializationCompleted();

--- a/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
@@ -29,6 +29,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
     public partial class DevicesSettingsSection : UserControl
     {
         private bool _loading = true;
+        private bool _micPopulating;   // Items.Clear()/SelectedItem raise SelectionChanged
 
         public DevicesSettingsSection()
         {
@@ -45,8 +46,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             ChkPanicOverridesAll.IsCheckedChanged += ChkPanicOverridesAll_Changed;
             ChkNoPanic.IsCheckedChanged += ChkNoPanic_Changed;
             TxtSpeechWakeWords.LostFocus += TxtSpeechWakeWords_LostFocus;
+            CmbMicDevice.SelectionChanged += CmbMicDevice_SelectionChanged;
+            BtnMicRefresh.Click += BtnMicRefresh_Click;
 
             SyncFromSettings();
+            PopulateMicDevices();
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -55,8 +59,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
             // The WPF section implements IAppSettingsSection.OnSectionShown because device lists go
             // stale the moment someone plugs a headset in. Attach is this head's equivalent reveal
-            // hook; there is nothing to re-enumerate yet (see the mic note below).
+            // hook, so the mic list is re-enumerated here too.
             SyncFromSettings();
+            PopulateMicDevices();
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
@@ -152,10 +157,53 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             // (MainWindow.RefreshSheListeningDeviceChips); no such host on this head.
         }
 
-        // ponytail: CmbMicDevice / BtnMicRefresh need SpeechService.EnumerateInputDevices
-        // (ConditioningControlPanel/Services/Speech/SpeechService.cs, NAudio/WASAPI), still in the
-        // WPF head. Without an enumeration there is no device to select and nothing honest to
-        // write to SpeechInputDeviceIndex / SpeechInputDeviceName, so both stay unwired.
+        /// <summary>
+        /// The WPF PopulateMicDevices, against <see cref="CoreSpeech"/> instead of SpeechService.
+        /// An empty enumeration means no head has seeded the seam, and clearing on that would
+        /// leave a blank ComboBox where the XAML's "System default" placeholder sits - so the
+        /// list is only replaced when there is a real one to replace it with.
+        /// </summary>
+        private void PopulateMicDevices()
+        {
+            var devices = CoreSpeech.EnumerateInputDevices();
+            if (devices.Count == 0) return;   // no speech head attached; keep the placeholder
+
+            int saved = CoreSettings.Current.SpeechInputDeviceIndex;
+            _micPopulating = true;   // Clear() raises SelectionChanged here as it does on WPF
+            try
+            {
+                CmbMicDevice.Items.Clear();
+                ComboBoxItem? toSelect = null;
+                foreach (var dev in devices)
+                {
+                    var item = new ComboBoxItem { Content = dev.Name, Tag = dev.Index };
+                    CmbMicDevice.Items.Add(item);
+                    if (dev.Index == saved) toSelect = item;
+                }
+                // Fall back to the first entry (the OS default) if the saved device is gone.
+                CmbMicDevice.SelectedItem = toSelect ?? (CmbMicDevice.Items.Count > 0 ? CmbMicDevice.Items[0] : null);
+            }
+            finally { _micPopulating = false; }
+        }
+
+        private void CmbMicDevice_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (_micPopulating || _loading) return;
+            if (CmbMicDevice.SelectedItem is not ComboBoxItem item || item.Tag is not int idx) return;
+
+            var s = CoreSettings.Current;
+            var name = idx < 0 ? "" : (item.Content?.ToString() ?? "");
+            if (s.SpeechInputDeviceIndex == idx && s.SpeechInputDeviceName == name) return;
+            s.SpeechInputDeviceIndex = idx;
+            s.SpeechInputDeviceName = name; // matched by name on reopen - robust to ordinal reshuffle (#441b)
+            CoreSettings.Save();
+            // ponytail: WPF also cuts the open capture so the wake loop reopens on the new device
+            // (App.Speech.StopListening + App.Autonomy.RefreshVoiceInputModes) and re-quotes the
+            // device on the She's Listening chip. The seam carries capability only, and neither
+            // the autonomy service nor that chip exists on this head.
+        }
+
+        private void BtnMicRefresh_Click(object? sender, RoutedEventArgs e) => PopulateMicDevices();
 
         // =====================================================================================
         //  webcam

--- a/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
@@ -22,8 +22,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
     /// dialogs are awaited rather than blocking, and a decline reverts the box.</para>
     ///
     /// <para>Still head-side: LockCardService (start/stop/test) and the mod-aware feature art. The
-    /// voice hint keeps the WPF literals; with no speech service on this head the "on" branch
-    /// lands on "No microphone detected", which is the honest answer here.</para>
+    /// voice hint asks <see cref="CoreSpeech"/> for all four of its branches; with no speech
+    /// service seeded on this head it reports no capture device, so the "on" branch lands on
+    /// "No microphone detected", which is the honest answer here.</para>
     /// </summary>
     public partial class LockCardFeatureControl : UserControl
     {
@@ -215,10 +216,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
                 TxtVoiceHint.Text = "Say the phrase out loud instead of typing it (offline mic). Falls back to typing if no mic.";
                 return;
             }
-            // ponytail: WPF picks one of four hints from App.Speech (IsAvailable /
-            // HasCaptureDevice / ModelStatus) - ConditioningControlPanel/Services/Speech/
-            // SpeechService.cs, still in the WPF head. No service means no mic, which is this one.
-            TxtVoiceHint.Text = "No microphone detected — lock cards will use typing until one is connected.";
+            // The same four hints WPF picks, now from CoreSpeech rather than App.Speech. With no
+            // speech service seeded (this head) HasCaptureDevice is false, so it lands on the
+            // second branch - which is the honest answer, not a placeholder.
+            if (CoreSpeech.IsAvailable)
+                TxtVoiceHint.Text = "On — speak the phrase to dismiss the card. Typing stays available if the mic can't hear you.";
+            else if (!CoreSpeech.HasCaptureDevice)
+                TxtVoiceHint.Text = "No microphone detected — lock cards will use typing until one is connected.";
+            else if (CoreSpeech.ModelStatus == CoreSpeechModelStatus.LoadFailed)
+                TxtVoiceHint.Text = "Speech model found but it would not load — remove any extra model you added under Resources\\Models\\vosk, then restart.";
+            else
+                TxtVoiceHint.Text = "Speech model not installed yet — lock cards will use typing until it is.";
         }
 
         private async void BtnManagePhrases_Click(object? sender, RoutedEventArgs e)

--- a/CCP.Core/CoreSpeech.cs
+++ b/CCP.Core/CoreSpeech.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// Why the offline speech model is or is not usable, mirrored into Core for the views that
+    /// report it. The head's own <c>SpeechService.ModelStatus</c> maps onto this one for one:
+    /// "there is no model" and "there IS a model and it refused to load" have to read differently,
+    /// or users get told to install what they already installed.
+    /// </summary>
+    public enum CoreSpeechModelStatus
+    {
+        /// <summary>Not probed yet - nothing has asked for speech this run, or no head is attached.</summary>
+        NotProbed,
+        /// <summary>A model loaded; speech can run.</summary>
+        Ok,
+        /// <summary>Nothing under the model root looks like a speech model.</summary>
+        NoModelFound,
+        /// <summary>A model directory was found, but the engine refused to load it.</summary>
+        LoadFailed,
+    }
+
+    /// <summary>A selectable microphone. Index -1 = the OS default capture device.</summary>
+    public readonly record struct SpeechInputDevice(int Index, string Name);
+
+    /// <summary>
+    /// The speech-capability seam: the four things ported views ask before offering voice input.
+    /// The service itself is Vosk over NAudio/WASAPI on Windows and stays in the head - it owns a
+    /// capture device - so this carries capability only, never a listen call.
+    ///
+    /// <para>Unseeded means "no speech on this head", answered honestly rather than optimistically:
+    /// no engine, no capture device, an empty device list, and
+    /// <see cref="CoreSpeechModelStatus.NotProbed"/> - which is also what the Windows service
+    /// reports once disposed. Never <c>Ok</c>, never null. A view that asks lands on its real
+    /// "no microphone detected" branch instead of offering voice it cannot deliver.</para>
+    /// </summary>
+    public static class CoreSpeech
+    {
+        public static volatile Func<bool>? IsAvailableProvider;
+        public static volatile Func<bool>? HasCaptureDeviceProvider;
+        public static volatile Func<CoreSpeechModelStatus>? ModelStatusProvider;
+        public static volatile Func<IReadOnlyList<SpeechInputDevice>>? EnumerateInputDevicesProvider;
+
+        /// <summary>True when recognition can actually run: a model is loaded and a mic exists.
+        /// Says nothing about consent - callers gate on that themselves.</summary>
+        public static bool IsAvailable
+        {
+            get { try { return IsAvailableProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+
+        /// <summary>Whether the OS reports at least one audio capture device.</summary>
+        public static bool HasCaptureDevice
+        {
+            get { try { return HasCaptureDeviceProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+
+        /// <summary>Why the model half of <see cref="IsAvailable"/> is where it is. Deliberately
+        /// says nothing about the microphone - ask <see cref="HasCaptureDevice"/> and report a
+        /// missing mic first, since it makes the model question moot.</summary>
+        public static CoreSpeechModelStatus ModelStatus
+        {
+            get
+            {
+                try { return ModelStatusProvider?.Invoke() ?? CoreSpeechModelStatus.NotProbed; }
+                catch { return CoreSpeechModelStatus.NotProbed; }
+            }
+        }
+
+        /// <summary>The microphones a picker can offer, OS default first. Empty with no head,
+        /// which is the truth: nothing here can open a device.</summary>
+        public static IReadOnlyList<SpeechInputDevice> EnumerateInputDevices()
+        {
+            try { return EnumerateInputDevicesProvider?.Invoke() ?? Array.Empty<SpeechInputDevice>(); }
+            catch { return Array.Empty<SpeechInputDevice>(); }
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -78,6 +78,12 @@ namespace ConditioningControlPanel.LinuxSmoke
                 CoreAudio.Duck(95); CoreAudio.Unduck();
                 Check("CoreAudio ducking is a no-op with no audio", CoreAudio.DuckGeneration == 0);
                 Check("CoreAi.IsAvailable is false with no head", !CoreAi.IsAvailable);
+                // The speech seam (wire/21). Unseeded must be honest, never optimistic: a view
+                // that believed "available" here would offer voice input nothing can deliver.
+                Check("CoreSpeech.IsAvailable is false with no speech service", !CoreSpeech.IsAvailable);
+                Check("CoreSpeech.HasCaptureDevice is false with no speech service", !CoreSpeech.HasCaptureDevice);
+                Check("CoreSpeech.ModelStatus is NotProbed with no speech service", CoreSpeech.ModelStatus == CoreSpeechModelStatus.NotProbed);
+                Check("CoreSpeech.EnumerateInputDevices is empty with no speech service", CoreSpeech.EnumerateInputDevices().Count == 0);
                 Check("CoreReleaseContent answers null with no pack service", CoreReleaseContent.GetPackInfo("mod-bambi") == null && CoreReleaseContent.GetStampFor("mod-bambi") == null);
                 Check("AwarenessIntensity.Current reads the ship default unseeded", Services.Awareness.AwarenessIntensityProfile.Current == Services.Awareness.AwarenessIntensity.Chatty);
                 // The subreddit rule moved from the online coordinator into Core with no test of its own.

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -308,6 +308,21 @@ namespace ConditioningControlPanel
             CoreAudio.UnduckProvider = generation => Audio?.Unduck(generation);
             CoreAudio.DuckGenerationProvider = () => Audio?.DuckGeneration ?? 0;
             CoreAi.IsAvailableProvider = () => Ai?.IsAvailable == true;
+            // Speech capability, for the views that ask whether voice input is worth offering.
+            // SpeechService itself stays here - it owns a capture device. Reading ModelStatus
+            // lazily probes the model exactly as the WPF views already did.
+            CoreSpeech.IsAvailableProvider = () => Speech?.IsAvailable == true;
+            CoreSpeech.HasCaptureDeviceProvider = () => Services.Speech.SpeechService.HasCaptureDevice;
+            CoreSpeech.ModelStatusProvider = () => Speech?.ModelStatus switch
+            {
+                Services.Speech.SpeechModelStatus.Ok           => CoreSpeechModelStatus.Ok,
+                Services.Speech.SpeechModelStatus.NoModelFound => CoreSpeechModelStatus.NoModelFound,
+                Services.Speech.SpeechModelStatus.LoadFailed   => CoreSpeechModelStatus.LoadFailed,
+                _ => CoreSpeechModelStatus.NotProbed,
+            };
+            CoreSpeech.EnumerateInputDevicesProvider = () =>
+                Services.Speech.SpeechService.EnumerateInputDevices()
+                    .Select(d => new SpeechInputDevice(d.Index, d.Name)).ToList();
             CoreSettingsHooks.CloudBackup = () =>
                 HasCloudIdentity && ProfileSync != null ? ProfileSync.BackupSettingsAsync() : Task.CompletedTask;
 


### PR DESCRIPTION
CoreSpeech is the speech-capability seam: IsAvailable, HasCaptureDevice,
ModelStatus and EnumerateInputDevices, in the house delegate style. The service
itself owns a capture device and stays in the Windows head, which seeds all four
from SpeechService; CoreSpeechModelStatus mirrors the head enum one for one so
"no model" and "the model would not load" keep reading differently. Unseeded
answers honestly rather than optimistically - no engine, no mic, an empty device
list, NotProbed - which is what a head with no speech service must report, and
CCP.LinuxSmoke now asserts each of those four.

The Lock Card voice hint picks all four of WPF's branches from the seam instead
of the single hardcoded literal it carried; with nothing seeded it still lands
on "No microphone detected", now because the seam says so. Settings > Devices
gains the WPF mic picker: PopulateMicDevices on construction and on reveal, a
selection handler writing SpeechInputDeviceIndex/Name, and the refresh button.
An empty enumeration leaves the XAML's "System default" placeholder alone rather
than clearing the ComboBox to nothing. The Avalonia head deliberately seeds
nothing.

Still blocked:
- selecting a device cannot cut the open capture or re-quote the She's Listening
  chip (App.Speech.StopListening, App.Autonomy.RefreshVoiceInputModes,
  MainWindow.RefreshSheListeningDeviceChips), all still in the WPF head.
- Devices' other notes are untouched and out of this layer: TierGate.DemandPremium
  for the two voice-mode toggles, MainWindow's global keyboard hook for the panic
  and PTT key capture, WebcamTrackingService for the webcam bar, and
  AvatarTubeWindow + GlobalHotkeyService for the shortcut buttons.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU