### PR TITLE
feat(avalonia): the Takeover tab saves again, and the Play wall navigates

### DIFF
--- a/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml.cs
@@ -11,8 +11,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
     /// PORTED from ConditioningControlPanel/Views/Deeper/NewEnhancementDialog.xaml.cs. Deviations:
     ///  - DialogResult becomes Close(bool); callers use ShowDialog&lt;bool&gt;.
     ///  - OpenFileDialog becomes the StorageProvider file picker.
-    ///  - The three interactive tutorials and the last-directory memory are stubs: TutorialService,
-    ///    TutorialOverlay, EnhancementLibrary and AppSettings all still live in the WPF head.
+    ///  - The three interactive tutorials and the last-directory memory are stubs:
+    ///    ConditioningControlPanel/Services/TutorialService.cs (TutorialType, TutorialEventBus),
+    ///    ConditioningControlPanel/TutorialOverlay and
+    ///    ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs all still live in the WPF
+    ///    head. AppSettings does NOT: the HypnoTube flow's one settings write is restored below.
     /// </summary>
     public partial class NewEnhancementDialog : Window
     {
@@ -44,7 +47,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         private async System.Threading.Tasks.Task BrowseAsync()
         {
             var isVideo = _rbVideo.IsChecked == true;
-            // ponytail: needs EnhancementLibrary.LastDirectory for SuggestedStartLocation, wired when it moves to Core
+            // ponytail: WPF seeds InitialDirectory from App.EnhancementLibrary.LastDirectory;
+            // ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs is still head-only, so
+            // there is no SuggestedStartLocation and the picker opens where the OS last left it.
             var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
             {
                 Title = Loc.Get(isVideo ? "deeper_dialog_pick_video" : "deeper_dialog_pick_audio"),
@@ -63,15 +68,31 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
 
         private void BtnTryHypnoTubeTutorial_Click()
         {
-            // ponytail: needs AvatarTubeWindow.KnownVideoLinks and AppSettings.HasSeenDeeperHTInteractiveTutorial, wired when they move to Core
+            // ponytail: WPF prefers the first TikTok entry of
+            // ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs KnownVideoLinks and
+            // falls back to this literal; that window is WebView2-hosted and not on this head, so
+            // only the fallback is available - which is the value WPF ships when the lookup misses.
             _rbVideo.IsChecked = true;
             _txtSource.Text = "https://hypnotube.com/video/bambis-naughty-tiktok-collection-117314.html";
+
+            // Mark the flag so a future first-time hint does not double up. Same write WPF makes,
+            // and it lands here for the same reason: the user has now seen the walkthrough offer.
+            try
+            {
+                CoreSettings.Current.HasSeenDeeperHTInteractiveTutorial = true;
+                CoreSettings.Save();
+            }
+            catch { /* a settings write must never take the dialog down */ }
+
             StartInteractiveTutorial();
         }
 
         private void StartInteractiveTutorial()
         {
-            // ponytail: needs TutorialService + TutorialOverlay + TutorialEventBus.PendingPart2Tutorial, wired when they move to Core
+            // ponytail: needs ConditioningControlPanel/Services/TutorialService.cs (TutorialType,
+            // TutorialEventBus.PendingPart2Tutorial) and ConditioningControlPanel/TutorialOverlay,
+            // both still in the WPF head. Without them the three "walk me through" buttons still
+            // pick the media type and pre-fill the source, which is Part 1's whole visible effect.
         }
 
         private void BtnCreate_Click()

--- a/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml.cs
@@ -1,65 +1,80 @@
 using System;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
     /// <summary>
     /// "Bambi Takeover" - the autonomy Exclusive, PORTED from
-    /// ConditioningControlPanel/Views/Tabs/BambiTakeoverTabView.xaml.cs.
+    /// ConditioningControlPanel/Views/Tabs/BambiTakeoverTabView.xaml.cs with its settings logic
+    /// restored against <see cref="CoreSettings"/>.
     ///
-    /// <para><b>Almost every handler on the WPF head is a one-line shim</b> - it looks up the
-    /// hosting MainWindow and forwards to a MainWindow.Autonomy partial
-    /// (BtnAutonomyStartStop_Click, BtnForceStartAutonomy_Click, BtnGateUnlock_Click,
-    /// BtnTestAutonomy_Click, BtnTestVoice_Click, ChkAutonomyVoice_Changed,
-    /// ChkAutonomyResume_Changed, ChkShowTakeoverCountdown_Changed, OpenDeviceSettings,
-    /// ChkAutonomyBehavior_Changed, BtnWallpaperFolder_Click, ChkWallpaperKeep_Changed,
-    /// SliderWallpaperDuration_Changed, ChkAutonomyEnabled_Changed, ChkAutonomyIdle_Changed,
-    /// ChkAutonomyRandom_Changed, ChkAutonomyTimeAware_Changed, and the four
-    /// SliderAutonomy*_Changed). None of those partials is on this head, so each is a stub with
-    /// the same name so the eventual wiring diffs cleanly.</para>
+    /// <para><b>Where the logic came from.</b> On WPF this view is almost all one-line shims into
+    /// <c>MainWindow.Autonomy.cs</c>, and the seed lives in <c>MainWindow.Settings.cs</c>
+    /// (LoadSettingsIntoUI, lines 155-207). Every one of those bodies that is a pure
+    /// <c>App.Settings.Current.X = …; App.Settings.Save();</c> pair is here directly now - the four
+    /// autonomy bars, the three trigger toggles, the fourteen-box behaviour grid, resume-on-startup,
+    /// the countdown bar, the whole wallpaper block and Mantra Chant. What is left is only what
+    /// needs a service, a device or a Win32 dialog, and each of those is named where it sits.</para>
     ///
-    /// <para>The six value readouts beside the sliders ARE ported: painting a number next to its
-    /// slider is pure view state, and the formats are copied verbatim from
-    /// MainWindow.Autonomy.cs (253/261/269/438/447) and this view's own LoadMantraChant, so the
-    /// truncating cast and the "s"/"%" suffixes match. Only the settings write and the service
-    /// call each handler also does are the stubbed half. Same split SheListeningTabView made for
-    /// the mic-sensitivity readout.</para>
+    /// <para><b>_isLoading starts true</b> and the seed runs inside it, exactly as WPF's
+    /// <c>_isLoading</c> gate does: Avalonia raises <c>IsCheckedChanged</c> and <c>ValueChanged</c>
+    /// on a PROGRAMMATIC set, so without the guard the seed would write itself back over the user's
+    /// file. Each bar paints its readout BEFORE the guard returns, which is why the numbers are
+    /// honest on the first frame (#485).</para>
+    ///
+    /// <para><b>Re-read on every show.</b> WPF hooked <c>IsVisibleChanged</c> for Mantra Chant
+    /// because panic clears <c>MantraChantEnabled</c> behind this tab's back (#685). The shell here
+    /// shows a tab by flipping <c>IsVisible</c> and never re-attaches, so the whole seed re-runs on
+    /// the IsVisible edge as well as on attach and on a settings-instance swap.</para>
     ///
     /// <para><b>Dropped:</b> the mod-aware feature art (ModService.ModChanged -&gt;
     /// ModResourceResolver repainting the hero and side takeover.png plates, including the
     /// BambiSleep "bambi takeover.png" fork). Both plates are art-less on this head - see the
-    /// .axaml header - so there is nothing to repaint yet. ponytail: needs ModService +
-    /// ModResourceResolver, restore together with the plates when Resources/features ships here.
-    /// The Mantra Chant load/save (App.Settings + App.MantraChant) is the same story.</para>
+    /// .axaml header - so there is nothing to repaint yet. ponytail: needs
+    /// ConditioningControlPanel/Helpers/ModResourceResolver.cs; restore together with the plates
+    /// when Resources/features ships here.</para>
     /// </summary>
     public partial class BambiTakeoverTabView : UserControl
     {
+        /// <summary>True while the seed writes the controls, so no handler mistakes the echo for a
+        /// user edit. Starts true: the .axaml gives every Slider a Value, which raises ValueChanged
+        /// during InitializeComponent, before settings are read.</summary>
+        private bool _isLoading = true;
+
         public BambiTakeoverTabView()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: needs MainWindow.Autonomy (AutonomyService, the premium gate, the wallpaper
-            // folder picker, Settings → Devices); wired when they move to Core.
+            // ponytail: needs ConditioningControlPanel/Services/AutonomyService.cs (start/stop,
+            // TestTrigger, TestVoiceCommand) and the premium gate behind the unlock button.
             BtnAutonomyStartStop.Click += (_, _) => { };   // mw.BtnAutonomyStartStop_Click(...)
             BtnForceStartAutonomy.Click += (_, _) => { };  // mw.BtnForceStartAutonomy_Click(...)
             BtnGateUnlock.Click += (_, _) => { };          // mw.BtnGateUnlock_Click(...)
             BtnTestAutonomy.Click += (_, _) => { };        // mw.BtnTestAutonomy_Click(...)
             BtnTestVoice.Click += (_, _) => { };           // mw.BtnTestVoice_Click(...)
-            BtnOpenDeviceSettings.Click += (_, _) => { };  // mw.OpenDeviceSettings()
-            BtnWallpaperFolder.Click += (_, _) => { };     // mw.BtnWallpaperFolder_Click(...)
+            BtnOpenDeviceSettings.Click += BtnOpenDeviceSettings_Click;
+            BtnWallpaperFolder.Click += BtnWallpaperFolder_Click;
 
             // Triggers + session toggles. WPF split these across Checked/Unchecked; Avalonia 11
             // raises one IsCheckedChanged for both edges.
-            ChkAutonomyIdle.IsCheckedChanged += (_, _) => { };              // mw.ChkAutonomyIdle_Changed(...)
-            ChkAutonomyRandom.IsCheckedChanged += (_, _) => { };            // mw.ChkAutonomyRandom_Changed(...)
-            ChkAutonomyTimeAware.IsCheckedChanged += (_, _) => { };         // mw.ChkAutonomyTimeAware_Changed(...)
-            ChkAutonomyResumeOnStartup.IsCheckedChanged += (_, _) => { };   // mw.ChkAutonomyResume_Changed(...)
-            ChkAutonomyVoice.IsCheckedChanged += (_, _) => { };             // mw.ChkAutonomyVoice_Changed(...)
-            ChkShowTakeoverCountdown.IsCheckedChanged += (_, _) => { };     // mw.ChkShowTakeoverCountdown_Changed(...)
-            ChkWallpaperKeep.IsCheckedChanged += (_, _) => { };             // mw.ChkWallpaperKeep_Changed(...)
-            ChkAutonomyEnabled.IsCheckedChanged += (_, _) => { };           // mw.ChkAutonomyEnabled_Changed(...)
+            ChkAutonomyIdle.IsCheckedChanged += ChkAutonomyIdle_Changed;
+            ChkAutonomyRandom.IsCheckedChanged += ChkAutonomyRandom_Changed;
+            ChkAutonomyTimeAware.IsCheckedChanged += ChkAutonomyTimeAware_Changed;
+            ChkAutonomyResumeOnStartup.IsCheckedChanged += ChkAutonomyResume_Changed;
+            ChkAutonomyVoice.IsCheckedChanged += ChkAutonomyVoice_Changed;
+            ChkShowTakeoverCountdown.IsCheckedChanged += ChkShowTakeoverCountdown_Changed;
+            ChkWallpaperKeep.IsCheckedChanged += ChkWallpaperKeep_Changed;
+            ChkAutonomyEnabled.IsCheckedChanged += ChkAutonomyEnabled_Changed;
 
-            // The behaviour grid: eleven toggles that all route to the SAME handler on WPF.
+            // The behaviour grid: fourteen toggles that all route to the SAME handler on WPF,
+            // which rewrites every one of them on any change. Kept that way.
             foreach (var chk in new[]
                      {
                          ChkAutonomyFlash, ChkAutonomyVideo, ChkAutonomyWebVideo, ChkProtectBrowserVideo,
@@ -67,31 +82,412 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                          ChkAutonomyLockCard, ChkAutonomyBouncingText, ChkAutonomyMindWipe, ChkAutonomyWallpaper,
                          ChkAutonomySpiral, ChkAutonomyBubbleCount,
                      })
-                chk.IsCheckedChanged += (_, _) => { };  // mw.ChkAutonomyBehavior_Changed(...)
+                chk.IsCheckedChanged += ChkAutonomyBehavior_Changed;
 
-            // View-only half of the five slider handlers: the readout beside each one. Formats
-            // copied verbatim - a truncating (int) cast, not Math.Round, so 59.9 reads 59 the way
-            // it does on WPF. The settings write + RefreshRandomTimer() are the stubbed half.
-            SliderAutonomyInterval.ValueChanged += (_, e) => TxtAutonomyInterval.Text = $"{(int)e.NewValue}s";
-            SliderAutonomyCooldown.ValueChanged += (_, e) => TxtAutonomyCooldown.Text = $"{(int)e.NewValue}s";
-            SliderAutonomyIntensity.ValueChanged += (_, e) => TxtAutonomyIntensity.Text = $"{(int)e.NewValue}";
-            SliderAutonomyAnnounce.ValueChanged += (_, e) => TxtAutonomyAnnounce.Text = $"{(int)e.NewValue}%";
-            SliderWallpaperDuration.ValueChanged += (_, e) => TxtWallpaperDuration.Text = $"{(int)e.NewValue}s";
+            // Each bar paints its readout first and writes second. Formats verbatim from
+            // MainWindow.Autonomy.cs - a truncating (int) cast, not Math.Round, so 59.9 reads 59.
+            SliderAutonomyInterval.ValueChanged += SliderAutonomyInterval_Changed;
+            SliderAutonomyCooldown.ValueChanged += SliderAutonomyCooldown_Changed;
+            SliderAutonomyIntensity.ValueChanged += SliderAutonomyIntensity_Changed;
+            SliderAutonomyAnnounce.ValueChanged += SliderAutonomyAnnounce_Changed;
+            SliderWallpaperDuration.ValueChanged += SliderWallpaperDuration_Changed;
 
-            // Mantra Chant (#653) is the one block whose handlers really live in this view. The
-            // settings read/write and App.MantraChant.Start/Stop/ApplyVolume are stubbed; the two
-            // readouts are real, with LoadMantraChant's Math.Round formats
-            // (BambiTakeoverTabView.xaml.cs:118/120) rather than the sliders' truncating cast.
-            // ponytail: needs App.Settings + MantraChantService, wired when they move to Core.
-            SldMantraChantVolume.ValueChanged += (_, e) => TxtMantraChantVolume.Text = $"{(int)Math.Round(e.NewValue)}%";
-            SldMantraChantGap.ValueChanged += (_, e) => TxtMantraChantGap.Text = $"{(int)Math.Round(e.NewValue)}s";
-            ChkMantraChant.IsCheckedChanged += (_, _) => { };
+            // Mantra Chant (#653) is the one block whose handlers really live in this view on WPF
+            // too. Its two readouts use LoadMantraChant's Math.Round format, not the bars' cast.
+            SldMantraChantVolume.ValueChanged += SldMantraChantVolume_Changed;
+            SldMantraChantGap.ValueChanged += SldMantraChantGap_Changed;
+            ChkMantraChant.IsCheckedChanged += ChkMantraChant_Changed;
 
-            // Placeholder start values; the real ones come from settings when the services land.
-            // These fire the two handlers above, so the em-dash placeholders in the XAML are
-            // replaced by real readings in --render-all rather than staying "—".
-            SldMantraChantVolume.Value = 70;
-            SldMantraChantGap.Value = 8;
+            SyncFromSettings();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            SyncFromSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>The shell shows a tab by flipping IsVisible, never by re-attaching. This is the
+        /// Avalonia twin of WPF's <c>IsVisibleChanged -&gt; LoadMantraChant()</c>: re-read on every
+        /// show, or the toggles lie after panic disarmed something behind our back (#685).</summary>
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+            if (change.Property == IsVisibleProperty && change.GetNewValue<bool>()) SyncFromSettings();
+        }
+
+        // A cloud restore or a factory reset swaps the instance; repaint from it, on the UI thread.
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(SyncFromSettings);
+
+        // =====================================================================================
+        //  seed - MainWindow.Settings.cs LoadSettingsIntoUI, the Autonomy Mode block
+        // =====================================================================================
+
+        internal void SyncFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                var s = CoreSettings.Current;
+
+                ChkAutonomyEnabled.IsChecked = s.AutonomyModeEnabled;
+                // ponytail: WPF also calls UpdateAutonomyButtonState here (MainWindow.Autonomy.cs);
+                // it reads AutonomyService's live state, which is not on this head.
+
+                // Clamp persisted values into the bars' ranges BEFORE assigning: an out-of-range
+                // stored value (old-version scale, cloud-restored settings) would silently snap the
+                // bar while the label kept its XAML default (#485). Write the clamped value back so
+                // the setting and the UI agree.
+                s.AutonomyIntensity = Math.Clamp(s.AutonomyIntensity,
+                    (int)SliderAutonomyIntensity.Minimum, (int)SliderAutonomyIntensity.Maximum);
+                s.AutonomyCooldownSeconds = Math.Clamp(s.AutonomyCooldownSeconds,
+                    (int)SliderAutonomyCooldown.Minimum, (int)SliderAutonomyCooldown.Maximum);
+                s.AutonomyRandomIntervalSeconds = Math.Clamp(s.AutonomyRandomIntervalSeconds,
+                    (int)SliderAutonomyInterval.Minimum, (int)SliderAutonomyInterval.Maximum);
+                s.AutonomyAnnouncementChance = Math.Clamp(s.AutonomyAnnouncementChance, 0, 100);
+
+                SliderAutonomyIntensity.Value = s.AutonomyIntensity;
+                SliderAutonomyCooldown.Value = s.AutonomyCooldownSeconds;
+                SliderAutonomyInterval.Value = s.AutonomyRandomIntervalSeconds;
+                SliderAutonomyAnnounce.Value = s.AutonomyAnnouncementChance;
+
+                ChkAutonomyIdle.IsChecked = s.AutonomyIdleTriggerEnabled;
+                ChkAutonomyRandom.IsChecked = s.AutonomyRandomTriggerEnabled;
+                ChkAutonomyTimeAware.IsChecked = s.AutonomyTimeAwareEnabled;
+
+                ChkAutonomyFlash.IsChecked = s.AutonomyCanTriggerFlash;
+                ChkAutonomyVideo.IsChecked = s.AutonomyCanTriggerVideo;
+                ChkAutonomyWebVideo.IsChecked = s.AutonomyCanTriggerWebVideo;
+                ChkProtectBrowserVideo.IsChecked = s.ProtectBrowserVideoPlayback;
+                ChkAutonomySubliminal.IsChecked = s.AutonomyCanTriggerSubliminal;
+                ChkAutonomyBubbles.IsChecked = s.AutonomyCanTriggerBubbles;
+                ChkAutonomyComment.IsChecked = s.AutonomyCanComment;
+                ChkAutonomyMindWipe.IsChecked = s.AutonomyCanTriggerMindWipe;
+                ChkAutonomyLockCard.IsChecked = s.AutonomyCanTriggerLockCard;
+                ChkAutonomySpiral.IsChecked = s.AutonomyCanTriggerSpiral;
+                ChkAutonomyPinkFilter.IsChecked = s.AutonomyCanTriggerPinkFilter;
+                ChkAutonomyBouncingText.IsChecked = s.AutonomyCanTriggerBouncingText;
+                ChkAutonomyBubbleCount.IsChecked = s.AutonomyCanTriggerBubbleCount;
+                ChkAutonomyWallpaper.IsChecked = s.AutonomyCanTriggerWallpaper;
+
+                RefreshWallpaperBlock(s);
+
+                // The mic gate is part of the seed on WPF too: an armed voice toggle with no
+                // consent on file reads OFF rather than claiming a microphone it may not open.
+                ChkAutonomyVoice.IsChecked = s.AutonomyCanTriggerVoiceCommand && s.MicConsentGiven;
+                ChkAutonomyResumeOnStartup.IsChecked = s.AutonomyResumeOnStartup;
+                ChkShowTakeoverCountdown.IsChecked = s.ShowTakeoverCountdownBar;
+
+                // The bars' handlers paint their labels themselves, but only for a value that
+                // actually changed; set all four explicitly so a seed that lands on the current
+                // value still leaves the number and the bar agreeing (#485).
+                TxtAutonomyIntensity.Text = $"{s.AutonomyIntensity}";
+                TxtAutonomyCooldown.Text = $"{s.AutonomyCooldownSeconds}s";
+                TxtAutonomyInterval.Text = $"{s.AutonomyRandomIntervalSeconds}s";
+                TxtAutonomyAnnounce.Text = $"{s.AutonomyAnnouncementChance}%";
+
+                // Mantra Chant, WPF's LoadMantraChant.
+                ChkMantraChant.IsChecked = s.MantraChantEnabled;
+                SldMantraChantVolume.Value = s.MantraChantVolume;
+                TxtMantraChantVolume.Text = $"{(int)Math.Round(s.MantraChantVolume)}%";
+                SldMantraChantGap.Value = s.MantraChantGapSeconds;
+                TxtMantraChantGap.Text = $"{s.MantraChantGapSeconds}s";
+                // ponytail: WPF's RefreshMantraChantHint swaps TxtMantraChantHint between
+                // desc_mantra_chant and desc_mantra_chant_none on App.MantraChant.CanChant().
+                // Needs ConditioningControlPanel/Services/MantraChantService.cs. The hint keeps its
+                // {loc:Str desc_mantra_chant} binding meanwhile - a .Text write here would be undone
+                // by the next language change anyway.
+
+                // ponytail: WPF also calls RefreshAutonomyVoiceHint (MainWindow.Autonomy.cs) to
+                // amber TxtAutonomyVoiceHint while the mic is being driven by wake word / PTT or the
+                // speech model is missing. Needs ConditioningControlPanel/Services/Speech/SpeechService.cs.
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("BambiTakeoverTabView.SyncFromSettings: {E}", ex.Message);
+            }
+            finally { _isLoading = false; }
+        }
+
+        /// <summary>WPF's RefreshWallpaperFolderLabel + RefreshWallpaperDurationVisibility.</summary>
+        private void RefreshWallpaperBlock(Models.AppSettings s)
+        {
+            TxtWallpaperFolder.Text = string.IsNullOrWhiteSpace(s.WallpaperSourceFolder)
+                ? Loc.Get("label_wallpaper_folder_default")
+                : s.WallpaperSourceFolder;
+
+            ChkWallpaperKeep.IsChecked = s.WallpaperEnabled;
+            // Clamp before assigning, like the other Takeover bars (#485).
+            s.WallpaperPulseSeconds = Math.Clamp(s.WallpaperPulseSeconds,
+                (int)SliderWallpaperDuration.Minimum, (int)SliderWallpaperDuration.Maximum);
+            SliderWallpaperDuration.Value = s.WallpaperPulseSeconds;
+            TxtWallpaperDuration.Text = $"{s.WallpaperPulseSeconds}s";
+
+            // The pulse duration is meaningless while "keep it" is on - hide it rather than lie.
+            PanelWallpaperDuration.IsVisible = !s.WallpaperEnabled;
+        }
+
+        // =====================================================================================
+        //  bars
+        // =====================================================================================
+
+        private void SliderAutonomyIntensity_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtAutonomyIntensity.Text = $"{(int)e.NewValue}";
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyIntensity = (int)e.NewValue;
+            CoreSettings.Save();
+        }
+
+        private void SliderAutonomyCooldown_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtAutonomyCooldown.Text = $"{(int)e.NewValue}s";
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyCooldownSeconds = (int)e.NewValue;
+            CoreSettings.Save();
+        }
+
+        private void SliderAutonomyInterval_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtAutonomyInterval.Text = $"{(int)e.NewValue}s";
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyRandomIntervalSeconds = (int)e.NewValue;
+            // ponytail: WPF also calls App.Autonomy.RefreshRandomTimer() so a running takeover picks
+            // the new interval up mid-session. Needs ConditioningControlPanel/Services/AutonomyService.cs.
+            CoreSettings.Save();
+        }
+
+        private void SliderAutonomyAnnounce_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtAutonomyAnnounce.Text = $"{(int)e.NewValue}%";
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyAnnouncementChance = (int)e.NewValue;
+            CoreSettings.Save();
+        }
+
+        private void SliderWallpaperDuration_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtWallpaperDuration.Text = $"{(int)e.NewValue}s";
+            if (_isLoading) return;
+            CoreSettings.Current.WallpaperPulseSeconds = (int)e.NewValue;
+            CoreSettings.Save();
+        }
+
+        // =====================================================================================
+        //  triggers and session toggles
+        // =====================================================================================
+
+        private void ChkAutonomyIdle_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyIdleTriggerEnabled = ChkAutonomyIdle.IsChecked ?? false;
+            // ponytail: WPF also calls App.Autonomy.RefreshIdleTimer() (Services/AutonomyService.cs).
+            CoreSettings.Save();
+        }
+
+        private void ChkAutonomyRandom_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyRandomTriggerEnabled = ChkAutonomyRandom.IsChecked ?? false;
+            // ponytail: WPF also calls App.Autonomy.RefreshRandomTimer() (Services/AutonomyService.cs).
+            CoreSettings.Save();
+        }
+
+        private void ChkAutonomyTimeAware_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyTimeAwareEnabled = ChkAutonomyTimeAware.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        private void ChkAutonomyResume_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.AutonomyResumeOnStartup = ChkAutonomyResumeOnStartup.IsChecked == true;
+            CoreSettings.Save();
+        }
+
+        private void ChkShowTakeoverCountdown_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            CoreSettings.Current.ShowTakeoverCountdownBar = ChkShowTakeoverCountdown.IsChecked == true;
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// One handler, every box, exactly as WPF does it: the grid is rewritten whole on any
+        /// change, so a box set from somewhere else can never be left behind.
+        /// </summary>
+        private void ChkAutonomyBehavior_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            s.AutonomyCanTriggerFlash = ChkAutonomyFlash.IsChecked ?? false;
+            s.AutonomyCanTriggerVideo = ChkAutonomyVideo.IsChecked ?? false;
+            s.AutonomyCanTriggerWebVideo = ChkAutonomyWebVideo.IsChecked ?? false;
+            s.ProtectBrowserVideoPlayback = ChkProtectBrowserVideo.IsChecked ?? false;
+            // Takeover has no strictness toggle of its own: a Takeover video is a plain mandatory
+            // video and follows the global StrictLockEnabled flag, which carries its own warning.
+            s.AutonomyCanTriggerSubliminal = ChkAutonomySubliminal.IsChecked ?? false;
+            s.AutonomyCanTriggerBubbles = ChkAutonomyBubbles.IsChecked ?? false;
+            s.AutonomyCanComment = ChkAutonomyComment.IsChecked ?? false;
+            s.AutonomyCanTriggerMindWipe = ChkAutonomyMindWipe.IsChecked ?? false;
+            s.AutonomyCanTriggerLockCard = ChkAutonomyLockCard.IsChecked ?? false;
+            s.AutonomyCanTriggerSpiral = ChkAutonomySpiral.IsChecked ?? false;
+            s.AutonomyCanTriggerPinkFilter = ChkAutonomyPinkFilter.IsChecked ?? false;
+            s.AutonomyCanTriggerBouncingText = ChkAutonomyBouncingText.IsChecked ?? false;
+            s.AutonomyCanTriggerBubbleCount = ChkAutonomyBubbleCount.IsChecked ?? false;
+            s.AutonomyCanTriggerWallpaper = ChkAutonomyWallpaper.IsChecked ?? false;
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// The master switch. WPF gates it on a consent dialog, the Patreon check and the lockdown
+        /// refusal before it starts AutonomyService. None of those is on this head, so only the
+        /// half that cannot arm anything the user has not already agreed to is restored: turning it
+        /// OFF always writes, turning it ON writes only when consent is already on file.
+        /// </summary>
+        private void ChkAutonomyEnabled_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var enabled = ChkAutonomyEnabled.IsChecked ?? false;
+            if (s.AutonomyModeEnabled == enabled) return;
+
+            if (enabled && !s.AutonomyConsentGiven)
+            {
+                // ponytail: WPF shows the Autonomy consent MessageBox here and writes
+                // AutonomyConsentGiven on Yes (MainWindow.Autonomy.cs:55). No ported dialog exists
+                // for it, and arming her without consent is not a safe default, so the box reverts.
+                _isLoading = true;
+                ChkAutonomyEnabled.IsChecked = false;
+                _isLoading = false;
+                Log.Information("Takeover master switch refused: no consent on file and no consent dialog on this head");
+                return;
+            }
+
+            s.AutonomyModeEnabled = enabled;
+            CoreSettings.Save();
+            // ponytail: WPF then starts or stops App.Autonomy behind the Patreon / daily-free check,
+            // and refuses a stop while Lockdown is active (#514). Needs Services/AutonomyService.cs
+            // and Services/LockdownService.cs, neither on this head.
+            Log.Information("Autonomy Mode toggled: {Enabled} (setting only - no service on this head)", enabled);
+        }
+
+        /// <summary>
+        /// First time on, the surprise-mantra prompt needs mic consent - the shared offline-audio
+        /// contract, the same flow LockCardFeatureControl uses. Decline reverts the box and writes
+        /// nothing.
+        /// </summary>
+        private async void ChkAutonomyVoice_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkAutonomyVoice.IsChecked == true;
+            if (s.AutonomyCanTriggerVoiceCommand == on) return;
+
+            if (on && !s.MicConsentGiven)
+            {
+                var owner = TopLevel.GetTopLevel(this) as Window;
+                var dlg = new Dialogs.MicConsentDialog();
+                var ok = owner != null && await dlg.ShowDialog<bool?>(owner) == true && dlg.ConsentGiven;
+                if (!ok)
+                {
+                    _isLoading = true;
+                    ChkAutonomyVoice.IsChecked = false;
+                    _isLoading = false;
+                    return;
+                }
+                // ponytail: on WPF the consent dialog itself flips AppSettings.MicConsentGiven and
+                // saves; the ported one does not yet (CCP.Avalonia/Views/Dialogs/MicConsentDialog
+                // .axaml.cs, Enable()). Until it does, the seed's "&& MicConsentGiven" clears this
+                // box again on the next repaint. Fixing it belongs in that dialog, not here.
+            }
+
+            s.AutonomyCanTriggerVoiceCommand = on;
+            CoreSettings.Save();
+        }
+
+        // =====================================================================================
+        //  wallpaper
+        // =====================================================================================
+
+        /// <summary>
+        /// "Keep the wallpaper": her changes stay on the desktop instead of reverting after a few
+        /// seconds (#694). The pulse bar is meaningless while it is on, so it hides.
+        /// </summary>
+        private void ChkWallpaperKeep_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var keep = ChkWallpaperKeep.IsChecked ?? false;
+            if (s.WallpaperEnabled == keep) return;
+
+            s.WallpaperEnabled = keep;
+            CoreSettings.Save();
+            PanelWallpaperDuration.IsVisible = !keep;
+            // ponytail: WPF also puts the original wallpaper straight back when this goes off
+            // (App.Wallpaper.Deactivate) and warns on an empty library when it goes on
+            // (MainWindow.StartStop.cs WarnIfWallpaperLibraryEmpty). Needs
+            // ConditioningControlPanel/Services/WallpaperService.cs, which is Win32.
+        }
+
+        private void BtnWallpaperFolder_Click(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: needs a folder picker AND the refusal that makes it safe -
+            // ConditioningControlPanel/Services/Auth/SecurityHelper.cs IsPersonalFolderRoot (#1053).
+            // Every top-level image in the chosen folder becomes a wallpaper she can put on screen,
+            // so this stays shut rather than opening a picker with no personal-folder guard.
+        }
+
+        private void BtnOpenDeviceSettings_Click(object? sender, RoutedEventArgs e)
+        {
+            // WPF: mw.OpenDeviceSettings() = ShowTab("appsettings") + AppSettingsTab.FocusSection("devices").
+            // ponytail: the second half is the shell's helper, and MainShellWindow has no
+            // OpenDeviceSettings yet (CCP.Avalonia/Views/Windows/MainShellWindow.Presets.cs lists
+            // the stubbed navigation helpers), so this lands on the Settings door's first section.
+            (TopLevel.GetTopLevel(this) as Windows.MainShellWindow)?.ShowTab("appsettings");
+        }
+
+        // =====================================================================================
+        //  Mantra Chant (#653) - the one block whose handlers live in this view on WPF too
+        // =====================================================================================
+
+        private void ChkMantraChant_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = CoreSettings.Current;
+            var on = ChkMantraChant.IsChecked == true;
+            if (s.MantraChantEnabled == on) return;
+            s.MantraChantEnabled = on;
+            CoreSettings.Save();
+            // ponytail: WPF then calls App.MantraChant.Start()/Stop() and re-reads the hint. Needs
+            // ConditioningControlPanel/Services/MantraChantService.cs.
+        }
+
+        private void SldMantraChantVolume_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            TxtMantraChantVolume.Text = $"{(int)Math.Round(e.NewValue)}%";
+            if (_isLoading) return;
+            CoreSettings.Current.MantraChantVolume = e.NewValue;
+            CoreSettings.Save();
+            // ponytail: WPF also live-applies to a clip already playing (App.MantraChant.ApplyVolume).
+        }
+
+        private void SldMantraChantGap_Changed(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            var seconds = (int)Math.Round(e.NewValue);
+            TxtMantraChantGap.Text = $"{seconds}s";
+            if (_isLoading) return;
+            CoreSettings.Current.MantraChantGapSeconds = seconds;
+            CoreSettings.Save();
         }
     }
 }

--- a/CCP.Avalonia/Views/Tabs/EnhancementsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/EnhancementsTabView.axaml.cs
@@ -22,7 +22,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// <c>App.SkillTree</c> and <c>Models.SkillDefinition.All</c>, neither of which is on this head.
     /// This file paints a SAMPLE of each instead, with the real loc keys, so the 460dip board and
     /// the 90dip rail do not render as two unexplained blanks in the render proof.
-    /// ponytail: needs SkillTreeService + SkillDefinition, wired when they move to Core.</para>
+    /// ponytail: needs ConditioningControlPanel/Services/SkillTreeService.cs and
+    /// ConditioningControlPanel/Models/SkillTree.cs (SkillDefinition.All), both still in the WPF
+    /// head. The one number that IS live is the sparkle-point count, which is a plain setting.</para>
     /// </summary>
     public partial class EnhancementsTabView : UserControl
     {
@@ -138,8 +140,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             });
             var info = new StackPanel();
             info.Children.Add(Text(Loc.Get("label_sparkle_points"), Color.FromRgb(0xB0, 0xB0, 0xB0), 10));
-            // ponytail: the real count is settings.SkillPoints; needs SettingsService.
-            info.Children.Add(Text("0", Color.FromRgb(0xFF, 0x69, 0xB4), 24, bold: true));
+            // The live count, as CreateSkillTreeHeader reads it. Spending is what needs
+            // SkillTreeService; the balance is a plain setting and reads correctly today.
+            info.Children.Add(Text($"{CoreSettings.Current.SkillPoints}", Color.FromRgb(0xFF, 0x69, 0xB4), 24, bold: true));
             points.Children.Add(info);
 
             stack.Children.Add(new Border

--- a/CCP.Avalonia/Views/Tabs/PlayTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/PlayTabView.axaml.cs
@@ -2,27 +2,33 @@ using System;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.VisualTree;
 using ConditioningControlPanel.Avalonia.Controls;
+using ConditioningControlPanel.Avalonia.Views.Windows;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
     /// <summary>
-    /// PORTED from ConditioningControlPanel/Views/Tabs/PlayTabView.xaml.cs.
+    /// PORTED from ConditioningControlPanel/Views/Tabs/PlayTabView.xaml.cs (the host) and
+    /// PlayTabView.Cards.cs (the shims).
     ///
-    /// The Play door (tab key <c>play</c>): a card wall over the game-shaped features.
+    /// <para>The Play door (tab key <c>play</c>): a card wall over the game-shaped features.</para>
     ///
-    /// <para><b>This file is the host only.</b> It owns the page frame and the one ambient loop.
-    /// It owns no card content, no launch, and no tier decision. On WPF every card's click is a
-    /// one-line shim in a <c>PlayTabView.&lt;Area&gt;.cs</c> partial that forwards to the
-    /// MainWindow handler of the same name; MainWindow is a WPF type, so on this head every shim
-    /// is a stub instead. The handler NAMES are kept verbatim - they are the launch-parity
-    /// contract, and the wiring is a rename away once those handlers reach Core.</para>
+    /// <para><b>This file is the host plus the shims.</b> It owns the page frame and the one
+    /// ambient loop; it owns no card content, no launch, and no tier decision. On WPF every card's
+    /// click is a one-line passthrough to the MainWindow handler of the same name. That pattern
+    /// ports: <see cref="Owner"/> is <c>Window.GetWindow(this) as MainWindow</c> written for
+    /// Avalonia, and every click that WPF answers with <c>ShowTab</c> is answered with the shell's
+    /// <c>ShowTab</c> here, so the Play wall navigates for real. The clicks that WPF answers with a
+    /// host service (Chaos, Goon, Arcademy, the gaze minigame, the blink trainer) have no service on
+    /// this head and each one names what it is waiting for.</para>
     ///
-    /// <para><b>The one loop.</b> <c>RabbitHoleFx</c> is this surface's single focal ambient
-    /// canvas (FX_OVERHAUL_PLAN: one per surface). It is composed once, on first attach, and on
-    /// WPF is then handed to <c>MainWindow.RegisterTabFx("play", …)</c> - simultaneously the
-    /// park/resume hook and the motion kill-switch's reach. Starting the layers is portable and
-    /// carried over for real; the registration is the stub.</para>
+    /// <para><b>The one loop.</b> <c>RabbitHoleFx</c> is this surface's single focal ambient canvas
+    /// (FX_OVERHAUL_PLAN: one per surface). It is composed once, on first attach, and on WPF is then
+    /// handed to <c>MainWindow.RegisterTabFx("play", …)</c> - simultaneously the park/resume hook
+    /// and the motion kill-switch's reach. Starting the layers is portable and carried over for
+    /// real; the registration is what is still missing.</para>
     /// </summary>
     public partial class PlayTabView : UserControl
     {
@@ -40,9 +46,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private bool _fxComposed;
 
         // The compiled-XAML x:Name fields are only populated by a generated InitializeComponent();
-        // this head loads its views with AvaloniaXamlLoader.Load, so the one control the code
-        // touches is resolved by name here, as in LockdownTabView and AdornedAvatar.
+        // this view loads with AvaloniaXamlLoader.Load, so the one control the code touches is
+        // resolved by name here, as in LockdownTabView and AdornedAvatar.
         private readonly AmbientFxCanvas? _rabbitHoleFx;
+
+        /// <summary>The one cast every shim makes - the port of WPF's
+        /// <c>Window.GetWindow(this) as MainWindow</c>. Null while the view is being built and under
+        /// <c>--render-view</c>, where a card that fires simply does nothing, exactly as WPF's
+        /// designer case does.</summary>
+        private MainShellWindow? Owner => TopLevel.GetTopLevel(this) as MainShellWindow;
 
         public PlayTabView()
         {
@@ -73,72 +85,97 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                     Intensity = RabbitHoleFxIntensity,
                 });
 
-                // ponytail: needs MainWindow.RegisterTabFx(TabKey, _rabbitHoleFx) - the park/resume
-                // hook and the motion kill-switch's reach. MainWindow is a WPF type; wired when
-                // the ambient registry moves to Core. Until then the canvas parks itself on
-                // detach (AmbientFxCanvas.Evaluate), which is why running it here is safe.
+                // ponytail: needs RegisterTabFx(TabKey, _rabbitHoleFx) - the park/resume hook and
+                // the motion kill-switch's reach. It is one of the four members stubbed out of
+                // CCP.Avalonia/Views/Windows/MainShellWindow.AmbientFx.cs. Until it exists the
+                // canvas parks itself on detach (AmbientFxCanvas.Evaluate), which is why running
+                // it here is safe.
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // ponytail: needs App.Logger. Swallowed rather than crashing the tab, same as WPF.
+                Log.Debug("PlayTabView FX compose: {E}", ex.Message);
             }
         }
 
         // ==================================================================================
-        // Launch shims. Every name below is the MainWindow handler the WPF card forwards to -
-        // `if (Window.GetWindow(this) is MainWindow mw) mw.<Handler>(sender, e);` - and launch
-        // parity is the contract, so the names are kept even though the bodies are empty here.
-        // Nothing on this surface may re-implement a launch, and nothing here decides a tier:
-        // the lockbands are decoration and TierGate does the refusing inside the handler.
+        // Launch shims. Every name below is the MainWindow handler the WPF card forwards to,
+        // and launch parity is the contract, so the names are kept. Nothing on this surface
+        // re-implements a launch, and nothing here decides a tier: the lockbands are
+        // decoration and TierGate does the refusing inside the handler.
         // ==================================================================================
 
-        /// <summary>ponytail: needs MainWindow.BtnStartChaos_Click (TierGate.DemandLab + the hub).</summary>
+        // ---- DESCENT ---------------------------------------------------------------------
+
+        /// <summary>ponytail: needs the Chaos slot picker behind MainWindow.BtnStartChaos_Click
+        /// (TierGate.DemandLab + ChaosHostService); neither is on this head.</summary>
         private void BtnStartChaos_Click(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.BtnQuickStartChaos_Click (straight into a saved run).</summary>
+        /// <summary>ponytail: needs MainWindow.BtnQuickStartChaos_Click (straight into a saved run,
+        /// same ChaosHostService).</summary>
         private void BtnQuickStartChaos_Click(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.BtnStartGoon_Click (GoonHostService).</summary>
+        // ---- TOGETHER --------------------------------------------------------------------
+
+        /// <summary>ponytail: needs ConditioningControlPanel/Services/Goon/GoonHostService.cs.</summary>
         private void BtnStartGoon_Click(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("remotecontrol").</summary>
-        private void BtnPlayRemoteControl_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnPlayRemoteControl_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("remotecontrol");
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("settings") + the Devices section.</summary>
-        private void BtnOpenDeviceSettings_Click(object? sender, RoutedEventArgs e) { }
+        // ---- EYES ------------------------------------------------------------------------
 
-        /// <summary>ponytail: needs MainWindow.BtnGazeMinigame_Click.</summary>
+        /// <summary>WPF: <c>mw.OpenDeviceSettings()</c> = ShowTab("appsettings") +
+        /// AppSettingsTab.FocusSection("devices"). ponytail: the focus half is the shell's helper and
+        /// MainShellWindow has no OpenDeviceSettings yet, so this lands on the door's first
+        /// section.</summary>
+        private void BtnOpenDeviceSettings_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("appsettings");
+
+        /// <summary>ponytail: needs MainWindow.BtnGazeMinigame_Click - the gaze minigame window plus
+        /// Services/Webcam/WebcamTrackingService.cs and its consent flow.</summary>
         private void BtnGazeMinigame_Click(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.ChkFocusGaze_Changed - it reads ChkPlayFocusGaze and
-        /// writes TxtPlayFocusGazeStatus. WPF's Checked + Unchecked pair is one event here.</summary>
+        /// <summary>The only Focus Gaze switch in the app. ponytail: needs
+        /// ConditioningControlPanel/Services/Webcam/GazeFocusService.cs, WebcamTrackingService and
+        /// TierGate - MainWindow.LabTab.cs:817 gates the ON edge on Tier 2 and on webcam consent
+        /// before it arms anything, and there is nothing safe to write without them. Turning the box
+        /// OFF is never gated on WPF either, but there is no consumer here to release.</summary>
         private void ChkFocusGaze_Changed(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.BtnLabBlinkTrainerOpenNew_Click.</summary>
+        /// <summary>ponytail: needs MainWindow.BtnLabBlinkTrainerOpenNew_Click; the Blink Trainer
+        /// page exists here but its host service does not.</summary>
         private void BtnLabBlinkTrainerOpenNew_Click(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("gradedintake") - every gate state navigates.</summary>
-        private void BtnPlayGradedIntake_Click(object? sender, RoutedEventArgs e) { }
+        // ---- SESSIONS --------------------------------------------------------------------
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("home") - the pass comes from the logo tile.</summary>
-        private void BtnPlayIntakePassHome_Click(object? sender, RoutedEventArgs e) { }
+        // All four pass states navigate: the page's own gate is what explains a spent week or a
+        // missing login, so a locked click has to ARRIVE somewhere rather than be swallowed.
+        private void BtnPlayGradedIntake_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("gradedintake");
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("fyp"), which intercepts into OpenFypFeed.
-        /// Never FypHostService.Launch() - that would be a second, ungated launch path.</summary>
-        private void BtnPlayFyp_Click(object? sender, RoutedEventArgs e) { }
+        /// <summary>"Where does a pass come from?" - the Home logo tile's flip ceremony hands them
+        /// out, and "settings" is Home's tab key (the Settings DOOR is "appsettings").</summary>
+        private void BtnPlayIntakePassHome_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("settings");
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("justdrop"), which owns the withheld refusal.</summary>
-        private void BtnPlayJustDrop_Click(object? sender, RoutedEventArgs e) { }
+        /// <summary>ShowTab("fyp"), never FypHostService.Launch() - that would be a second, ungated
+        /// launch path. ponytail: "fyp" is one of the shell's WindowKeys, so the call is a
+        /// documented no-op until OpenFypFeed exists (MainShellWindow.TabNavigation.cs).</summary>
+        private void BtnPlayFyp_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("fyp");
 
-        /// <summary>ponytail: needs MainWindow.ShowTab("lockdown").</summary>
-        private void BtnPlayLockdown_Click(object? sender, RoutedEventArgs e) { }
+        /// <summary>ShowTab("justdrop"), which owns the withheld refusal. ponytail: also a
+        /// WindowKey on this head, so it no-ops until the shop host lands.</summary>
+        private void BtnPlayJustDrop_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("justdrop");
 
-        /// <summary>ponytail: needs MainWindow.BtnStartArcademy_Click (ArcademyHostService.Launch,
-        /// which owns the door, the T2 check and the AudioOnlySession refusal).</summary>
+        private void BtnPlayLockdown_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("lockdown");
+
+        // ---- MORE ------------------------------------------------------------------------
+
+        /// <summary>ponytail: needs ArcademyHostService.Launch, which owns the door, the T2 check
+        /// and the AudioOnlySession refusal. A launch, not navigation - the Arcademy has no tab.</summary>
         private void BtnStartArcademy_Click(object? sender, RoutedEventArgs e) { }
 
-        /// <summary>ponytail: needs MainWindow.OpenStudioModule("spiral") - ShowTab("studio") plus
-        /// FocusRackEntry("spiral"). Loom NAVIGATES; a Launch() here would be a second editor.</summary>
-        private void BtnPlayLoom_Click(object? sender, RoutedEventArgs e) { }
+        /// <summary>Loom NAVIGATES; a Launch() here would be a second editor. WPF calls
+        /// <c>OpenStudioModule("spiral")</c> = ShowTab("studio") + StudioTab.FocusRackEntry("spiral").
+        /// ponytail: OpenStudioModule is one of the helpers stubbed out of
+        /// CCP.Avalonia/Views/Windows/MainShellWindow.Presets.cs, so this lands on the Studio rack's
+        /// default module instead of the Spiral one.</summary>
+        private void BtnPlayLoom_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("studio");
     }
 }


### PR DESCRIPTION
Bambi Takeover is a live editor once more. The seed from MainWindow.Settings.cs
(LoadSettingsIntoUI's Autonomy block, clamp-before-assign and all) and every handler
in MainWindow.Autonomy.cs whose body was a pure settings write now sit in the view
itself, against CoreSettings: the four autonomy bars, the three triggers, the
fourteen-box behaviour grid, resume-on-startup, the countdown bar, the whole
wallpaper block and Mantra Chant. _isLoading starts true so the seed's own echo is
never saved, and the seed re-runs on the IsVisible edge as well as on attach and on
CurrentReplaced - the shell shows a tab by flipping IsVisible and never re-attaches,
and panic clears MantraChantEnabled behind this tab's back (#685). The two
placeholder writes that used to paint the chant readouts are gone; with the handlers
restored they would have saved 70/8 over the user's values on every construction.
The master switch and the voice toggle keep their gates: enabling Takeover without
consent on file reverts instead of arming, and the voice toggle runs the same
MicConsentDialog flow LockCardFeatureControl uses.

The Play wall's shims are shims again. Owner is TopLevel.GetTopLevel(this) as
MainShellWindow - the port of WPF's Window.GetWindow(this) as MainWindow - so every
card WPF answers with ShowTab navigates for real (Remote Control, Graded Intake, the
Home pass, Lockdown, Studio), and the FX compose logs through Serilog instead of
swallowing into a note about App.Logger.

Enhancements shows the real sparkle-point balance, and the New Enhancement dialog
makes the HypnoTube walkthrough's one settings write again.

Still blocked:
- AutonomyService, LockdownService and the Patreon gate: start/stop, force start,
  test trigger, test voice, RefreshIdleTimer/RefreshRandomTimer, the lockdown stop
  refusal (#514) and the Autonomy consent dialog.
- WallpaperService and Services/Auth/SecurityHelper.IsPersonalFolderRoot: the
  wallpaper folder picker stays shut rather than opening one with no personal-folder
  guard (#1053), and "keep it" cannot put the original wallpaper back.
- MantraChantService (Start/Stop/ApplyVolume/CanChant) and SpeechService: the chant
  hint and the voice hint keep their authored text.
- MicConsentDialog on this head still does not write MicConsentGiven, so an armed
  voice toggle clears itself on the next seed. That fix belongs in the dialog.
- MainShellWindow.RegisterTabFx, OpenStudioModule and OpenDeviceSettings are still
  stubbed, so the Play FX canvas is unregistered and Loom/Devices land on their
  door's default entry.
- GazeFocusService + WebcamTrackingService + TierGate: Focus Gaze has no safe half
  to restore - its ON edge is a Tier-2 and consent gate before anything is armed.
- SkillTreeService and Models/SkillTree.cs: the tree and secret rail stay samples.
- TutorialService/TutorialOverlay and EnhancementLibrary.LastDirectory.

Note for the next language-change pass: TxtAutonomyInterval and TxtAutonomyCooldown
carry {loc:Str label_60s/label_30s} in the .axaml, so a language switch resets those
two readouts until the bar moves. The .axaml is not this layer's file.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU