### PR TITLE
feat(avalonia): the Lockdown and Awareness tabs edit their settings for real

### DIFF
--- a/CCP.Avalonia/Views/Tabs/AwarenessTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AwarenessTabView.axaml.cs
@@ -3,91 +3,83 @@ using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
-using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
     /// <summary>
     /// PORTED from ConditioningControlPanel/Views/Tabs/AwarenessTabView.xaml.cs.
     ///
-    /// <para>The WPF code-behind is pure re-hosting: every one of its eighteen handlers is a
-    /// three-line thunk that finds the owning <c>MainWindow</c> and forwards. Those MainWindow
-    /// bodies read <c>App.Settings</c>, <c>App.KeywordTriggers</c>, <c>App.ScreenOcr</c>,
-    /// <c>App.KeywordHighlight</c> and <c>TutorialService</c>, none of which are in Core, so
-    /// they are stubs here.</para>
+    /// <para>The WPF code-behind is pure re-hosting - eighteen three-line thunks into
+    /// <c>MainWindow</c> - so the bodies ported here are MainWindow.Awareness.cs's and
+    /// MainWindow.KeywordTriggers.cs's, not the tab's. Their settings half is restored against
+    /// <see cref="CoreSettings"/>: the seed (SyncAwarenessTabUI), the two cooldown sliders, the
+    /// master switch and its sub-toggle, OCR, ignore-own-UI, loop protection, highlight on/off,
+    /// capture visibility, ignore-own-focus, the app scope mode and the highlight colour all read
+    /// and write <c>AppSettings</c> for real and save.</para>
     ///
-    /// <para>What is NOT stubbed is the view-only half of those same bodies, lifted from
-    /// MainWindow.Awareness.cs and MainWindow.KeywordTriggers.cs so the tab is honest on its
-    /// own: the two cooldown sliders write their own <c>{v}s</c> labels (the format string is
-    /// MainWindow.KeywordTriggers.cs:65/82), the master switch drives the status dot and its
-    /// Live/Off label (MainWindow.Awareness.cs:376-384), the app-scope combo shows and hides the
-    /// app list (MainWindow.Awareness.cs:548-554), and the swatch row paints its selected
-    /// outline and mirrors the hex box (SyncAwarenessHighlightSwatchUi, :795-816).</para>
+    /// <para>What is NOT restored is the runtime: nothing here starts or stops an engine. The
+    /// Patreon gate (<c>KeywordTriggerService.HasAccess</c>), the keyboard hook, ScreenOcr,
+    /// KeywordHighlight's overlay windows, the recently-seen-app ring, the tutorial and the preset
+    /// editor are all head-side, and each stub below names the one it wants.</para>
     /// </summary>
     public partial class AwarenessTabView : UserControl
     {
-        // The compiled-XAML x:Name fields are only populated by the generated
-        // InitializeComponent(); this head loads its views with AvaloniaXamlLoader.Load, so every
-        // control the code touches is resolved by name here, as LockdownTabView does.
-        private readonly Slider _sliderGlobalCooldown;
-        private readonly TextBlock _txtGlobalCooldown;
-        private readonly Slider _sliderSameWordCooldown;
-        private readonly TextBlock _txtSameWordCooldown;
-        private readonly CheckBox _chkMaster;
-        private readonly Ellipse _statusDot;
-        private readonly TextBlock _txtStatus;
-        private readonly ComboBox _cmbAppScope;
-        private readonly StackPanel _appListPanel;
-        private readonly TextBox _txtHighlightHex;
-        private readonly Border[] _swatches;
+        /// <summary>
+        /// True while the seed is writing the controls, so the live editors do not save the value
+        /// they were just handed. Starts true because the XAML wires <c>IsCheckedChanged</c>
+        /// itself and two boxes carry <c>IsChecked="True"</c>, i.e. a handler fires from inside
+        /// InitializeComponent, before the seed has run. MainWindow's <c>_isLoading</c>, scoped to
+        /// the one view that uses it.
+        /// </summary>
+        private bool _isLoading = true;
 
         /// <summary>The off-state dot fill, straight out of the WPF XAML (Fill="#606060").</summary>
         private static readonly IBrush OffDot = new SolidColorBrush(Color.FromRgb(0x60, 0x60, 0x60));
 
+        /// <summary>The off-state status label colour (UpdateAwarenessStatusIndicator, "#A0A0A0").</summary>
+        private static readonly IBrush OffLabel = new SolidColorBrush(Color.FromRgb(0xA0, 0xA0, 0xA0));
+
         /// <summary>Unselected swatch outline, from SyncAwarenessHighlightSwatchUi.</summary>
         private static readonly IBrush SwatchIdle = new SolidColorBrush(Color.FromRgb(0x3A, 0x3A, 0x5A));
 
+        private Border[] Swatches => new[]
+        {
+            SwatchHighlightPink, SwatchHighlightCyan, SwatchHighlightLime,
+            SwatchHighlightOrange, SwatchHighlightViolet, SwatchHighlightWhite,
+        };
+
         public AwarenessTabView()
         {
-            AvaloniaXamlLoader.Load(this);
-
-            _sliderGlobalCooldown = this.FindControl<Slider>("SliderAwarenessGlobalCooldown")!;
-            _txtGlobalCooldown = this.FindControl<TextBlock>("TxtAwarenessGlobalCooldown")!;
-            _sliderSameWordCooldown = this.FindControl<Slider>("SliderAwarenessSameWordCooldown")!;
-            _txtSameWordCooldown = this.FindControl<TextBlock>("TxtAwarenessSameWordCooldown")!;
-            _chkMaster = this.FindControl<CheckBox>("ChkAwarenessMaster")!;
-            _statusDot = this.FindControl<Ellipse>("AwarenessStatusDot")!;
-            _txtStatus = this.FindControl<TextBlock>("TxtAwarenessStatus")!;
-            _cmbAppScope = this.FindControl<ComboBox>("CmbAwarenessAppScope")!;
-            _appListPanel = this.FindControl<StackPanel>("AwarenessAppListPanel")!;
-            _txtHighlightHex = this.FindControl<TextBox>("TxtAwarenessHighlightHex")!;
-            _swatches = new[]
-            {
-                this.FindControl<Border>("SwatchHighlightPink")!,
-                this.FindControl<Border>("SwatchHighlightCyan")!,
-                this.FindControl<Border>("SwatchHighlightLime")!,
-                this.FindControl<Border>("SwatchHighlightOrange")!,
-                this.FindControl<Border>("SwatchHighlightViolet")!,
-                this.FindControl<Border>("SwatchHighlightWhite")!,
-            };
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields this code-behind reads.
+            InitializeComponent();
 
             // WPF's Slider.ValueChanged forwards to MainWindow, which writes the setting AND the
-            // label. Only the label half is view-local, so it is wired here instead of in XAML -
-            // same split KeywordTriggersPanel already makes for its four sliders.
-            _sliderGlobalCooldown.PropertyChanged += (_, e) =>
+            // label. Wired here rather than in XAML so the seed below can move the sliders before
+            // the handler exists to react to it.
+            SliderAwarenessGlobalCooldown.PropertyChanged += (_, e) =>
             {
-                if (e.Property == RangeBase.ValueProperty)
-                    _txtGlobalCooldown.Text = $"{(int)_sliderGlobalCooldown.Value}s";
+                if (e.Property != RangeBase.ValueProperty) return;
+                var value = (int)SliderAwarenessGlobalCooldown.Value;
+                TxtAwarenessGlobalCooldown.Text = $"{value}s";
+                if (_isLoading) return;
+                CoreSettings.Current.KeywordGlobalCooldownSeconds = value;
+                CoreSettings.Save();
             };
-            _sliderSameWordCooldown.PropertyChanged += (_, e) =>
+            SliderAwarenessSameWordCooldown.PropertyChanged += (_, e) =>
             {
-                if (e.Property == RangeBase.ValueProperty)
-                    _txtSameWordCooldown.Text = $"{(int)_sliderSameWordCooldown.Value}s";
+                if (e.Property != RangeBase.ValueProperty) return;
+                var value = (int)SliderAwarenessSameWordCooldown.Value;
+                TxtAwarenessSameWordCooldown.Text = $"{value}s";
+                if (_isLoading) return;
+                CoreSettings.Current.KeywordPerKeywordCooldownSeconds = value;
+                CoreSettings.Save();
             };
 
             // The drawer ships shut on WPF (IsExpanded="False"); the Avalonia panel ships open so
@@ -97,28 +89,196 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                 if (ex.Name == "KeywordTriggersExpander")
                     ex.SetCurrentValue(Expander.IsExpandedProperty, false);
 
-            // Everywhere is the default mode, as the WPF item's IsSelected="True" says. Set here,
-            // not in XAML: a SelectedIndex there fires SelectionChanged mid-populate.
-            _cmbAppScope.SelectedIndex = 0;
+            SyncAwarenessTabUi();
 
-            SyncHighlightSwatchUi(_txtHighlightHex.Text ?? "#FF69B4");
+            // Tabs are shown and hidden rather than rebuilt, so re-read on every show: the master
+            // switch is [JsonIgnore] session state and the app list can be edited elsewhere.
+            AttachedToVisualTree += (_, _) => SyncAwarenessTabUi();
+            PropertyChanged += (_, e) =>
+            {
+                if (e.Property == IsVisibleProperty && IsVisible) SyncAwarenessTabUi();
+            };
         }
 
-        // ------------------------------------------------------------------ view-only behaviour
+        // ------------------------------------------------------------------ seed
 
         /// <summary>
-        /// Master switch. The settings write and the engine start/stop are MainWindow's; the dot
-        /// and the Live/Off label beside it are this view's, so they stay real.
+        /// The settings half of MainWindow.SyncAwarenessTabUI, plus RefreshAwarenessAppScopeUi and
+        /// SyncAwarenessHighlightSwatchUi, which it calls. Paints, never writes back.
+        /// </summary>
+        private void SyncAwarenessTabUi()
+        {
+            try
+            {
+                var s = CoreSettings.Current;
+                _isLoading = true;
+
+                var masterOn = s.KeywordTriggersEnabled;
+                Set(ChkAwarenessMaster, masterOn);
+                Set(ChkAwarenessOcr, s.ScreenOcrEnabled);
+                // The keyboard sub-toggle mirrors the master, as on WPF: it is one signal source,
+                // and the master is what actually arms it.
+                Set(ChkAwarenessKeyboard, masterOn);
+                Set(ChkAwarenessIgnoreOwnUi, s.AwarenessIgnoreOwnUi);
+                Set(ChkAwarenessLoopProtection, s.AwarenessLoopProtectionEnabled);
+                Set(ChkAwarenessHighlight, s.KeywordHighlightEnabled);
+                Set(ChkAwarenessHighlightVisibleInCapture, s.OcrHighlightVisibleInCapture);
+                Set(ChkAwarenessIgnoreOwnFocus, s.KeywordTriggerIgnoreOwnFocus);
+
+                SyncHighlightSwatchUi(s.KeywordHighlightColor);
+
+                // Clamped to the slider's own range: the settings clamp is wider (1-300 / 1-600)
+                // and a value past Maximum would be silently coerced back and then saved.
+                SliderAwarenessGlobalCooldown.Value = Math.Clamp(s.KeywordGlobalCooldownSeconds, 1, 180);
+                SliderAwarenessSameWordCooldown.Value = Math.Clamp(s.KeywordPerKeywordCooldownSeconds, 1, 180);
+
+                // Matched on Tag rather than index so reordering the XAML items cannot silently
+                // remap a saved setting onto the wrong mode.
+                var wanted = s.KeywordTriggerAppScope.ToString();
+                foreach (var item in CmbAwarenessAppScope.Items.OfType<ComboBoxItem>())
+                    if (string.Equals(item.Tag as string, wanted, StringComparison.Ordinal))
+                        CmbAwarenessAppScope.SelectedItem = item;
+
+                TxtAwarenessAppList.Text = string.Join(", ", s.KeywordTriggerApps ?? new());
+                AwarenessAppListPanel.IsVisible = s.KeywordTriggerAppScope != AwarenessAppScope.Everywhere;
+
+                UpdateStatusIndicator(masterOn);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Awareness tab: failed to load settings");
+            }
+            finally
+            {
+                _isLoading = false;
+            }
+
+            // Assign only on a real difference: Avalonia raises IsCheckedChanged on a programmatic
+            // set too, and every handler below is a live editor.
+            static void Set(CheckBox box, bool value)
+            {
+                if ((box.IsChecked ?? false) != value) box.IsChecked = value;
+            }
+        }
+
+        /// <summary>The dot and the Live/Off label beside the master switch.</summary>
+        private void UpdateStatusIndicator(bool on)
+        {
+            var pink = this.FindResource("PinkBrush") as IBrush;
+            AwarenessStatusDot.Fill = on ? pink ?? Brushes.HotPink : OffDot;
+            TxtAwarenessStatus.Text = on ? "Live" : "Off";
+            TxtAwarenessStatus.Foreground = on ? pink ?? Brushes.HotPink : OffLabel;
+
+            // ponytail: WPF also breathes the dot while the engine is genuinely live
+            // (SetAwarenessStatusPulse). Cosmetic, and it belongs with the engine seam.
+        }
+
+        // ------------------------------------------------------------------ live editors
+
+        /// <summary>
+        /// Master switch. Writes the setting, keeps the keyboard sub-toggle and the status
+        /// indicator in step, and saves - the whole of ChkAwarenessMaster_Changed except starting
+        /// anything.
         /// </summary>
         private void ChkAwarenessMaster_Changed(object? sender, RoutedEventArgs e)
         {
-            var on = _chkMaster.IsChecked == true;
-            _statusDot.Fill = on ? this.FindResource("PinkBrush") as IBrush : OffDot;
-            _txtStatus.Text = on ? "Live" : "Off";
+            if (_isLoading) return;
+            try
+            {
+                var on = ChkAwarenessMaster.IsChecked == true;
 
-            // ponytail: needs App.Settings + App.KeywordTriggers to actually arm the engine,
-            // wired when they move to Core.
+                // ponytail: WPF gates ON behind KeywordTriggerService.HasAccess() and bounces the
+                // box with a Patreon message box. Both are head-side (cloud identity + a dialog);
+                // no Core seam, so this head lets the toggle through.
+
+                CoreSettings.Current.KeywordTriggersEnabled = on;
+
+                // ponytail: this is where WPF starts/stops App.KeywordTriggers, the keyboard hook
+                // and App.ScreenOcr. All three are Win32 on that head; nothing arms here.
+
+                _isLoading = true;
+                try { if ((ChkAwarenessKeyboard.IsChecked ?? false) != on) ChkAwarenessKeyboard.IsChecked = on; }
+                finally { _isLoading = false; }
+
+                UpdateStatusIndicator(on);
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Awareness tab: failed to write KeywordTriggersEnabled");
+            }
         }
+
+        /// <summary>
+        /// Keyboard is one signal source, toggled independently - but turning it on with the master
+        /// off turns the master on, which is what actually arms it. Turning it off leaves the
+        /// master alone: OCR may still want the engine.
+        /// </summary>
+        private void ChkAwarenessKeyboard_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            if (ChkAwarenessKeyboard.IsChecked == true && ChkAwarenessMaster.IsChecked != true)
+                ChkAwarenessMaster.IsChecked = true;   // deliberately outside the guard: routes through the master handler
+
+            // ponytail: turning it OFF drops the keyboard hook on WPF when nothing else needs it
+            // (the panic key, OCR). The hook is Win32 and head-side.
+        }
+
+        private void ChkAwarenessOcr_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: WPF gates ON behind KeywordTriggerService.HasAccess() with a Patreon
+            // message box, starts/stops App.ScreenOcr, and calls SyncKeywordRescuePanelUi() to
+            // show the scan-interval / confirmation rows. The OCR engine is head-side, and the
+            // rescue rows live in KeywordTriggersPanel.
+            WriteFlag(v => CoreSettings.Current.ScreenOcrEnabled = v, ChkAwarenessOcr, "ScreenOcrEnabled");
+        }
+
+        private void ChkAwarenessIgnoreOwnUi_Changed(object? sender, RoutedEventArgs e)
+            => WriteFlag(v => CoreSettings.Current.AwarenessIgnoreOwnUi = v,
+                         ChkAwarenessIgnoreOwnUi, "AwarenessIgnoreOwnUi");
+
+        private void ChkAwarenessLoopProtection_Changed(object? sender, RoutedEventArgs e)
+            => WriteFlag(v => CoreSettings.Current.AwarenessLoopProtectionEnabled = v,
+                         ChkAwarenessLoopProtection, "AwarenessLoopProtectionEnabled");
+
+        private void ChkAwarenessIgnoreOwnFocus_Changed(object? sender, RoutedEventArgs e)
+            => WriteFlag(v => CoreSettings.Current.KeywordTriggerIgnoreOwnFocus = v,
+                         ChkAwarenessIgnoreOwnFocus, "KeywordTriggerIgnoreOwnFocus");
+
+        private void ChkAwarenessHighlight_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: WPF also calls SyncKeywordRescuePanelUi() here for the highlight mode +
+            // duration rows, which live in KeywordTriggersPanel (not this layer's file).
+            WriteFlag(v => CoreSettings.Current.KeywordHighlightEnabled = v,
+                      ChkAwarenessHighlight, "KeywordHighlightEnabled");
+            SyncHighlightSwatchUi(CoreSettings.Current.KeywordHighlightColor);
+        }
+
+        private void ChkAwarenessHighlightVisibleInCapture_Changed(object? sender, RoutedEventArgs e)
+        {
+            // ponytail: WPF then flips display affinity on the live overlay windows
+            // (App.KeywordHighlight.RefreshCaptureVisibility) - WDA_EXCLUDEFROMCAPTURE, Win32,
+            // head-side. The setting is stored either way, so a later head reads the right value.
+            WriteFlag(v => CoreSettings.Current.OcrHighlightVisibleInCapture = v,
+                      ChkAwarenessHighlightVisibleInCapture, "OcrHighlightVisibleInCapture");
+        }
+
+        /// <summary>One box, one flag, one save - the shape most of these toggles share.</summary>
+        private void WriteFlag(Action<bool> write, CheckBox box, string name)
+        {
+            if (_isLoading) return;
+            try
+            {
+                write(box.IsChecked == true);
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Awareness tab: failed to write {Setting}", name);
+            }
+        }
+
+        // ------------------------------------------------------------------ app scope
 
         /// <summary>
         /// The list of apps is meaningless in Everywhere mode, and leaving it visible invites
@@ -127,44 +287,106 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// </summary>
         private void CmbAwarenessAppScope_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
-            if (_appListPanel is null) return;   // a selection raised from inside XAML populate
-            var tag = (_cmbAppScope.SelectedItem as ComboBoxItem)?.Tag as string;
-            _appListPanel.IsVisible = !string.Equals(tag, "Everywhere", StringComparison.Ordinal);
+            var tag = (CmbAwarenessAppScope.SelectedItem as ComboBoxItem)?.Tag as string;
+            if (!Enum.TryParse<AwarenessAppScope>(tag, out var scope)) return;
 
-            // ponytail: needs App.Settings (KeywordTriggerAppScope) + KeywordTriggerService's
-            // recent-foreground-app ring for the chips, wired when they move to Core.
+            AwarenessAppListPanel.IsVisible = scope != AwarenessAppScope.Everywhere;
+
+            if (_isLoading) return;
+            try
+            {
+                CoreSettings.Current.KeywordTriggerAppScope = scope;
+                CoreSettings.Save();
+                Log.Information("Awareness app scope set to {Mode} ({Count} apps listed)",
+                    scope, CoreSettings.Current.KeywordTriggerApps?.Count ?? 0);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Awareness tab: failed to write KeywordTriggerAppScope");
+            }
+
+            // ponytail: WPF also rebuilds the "recently focused" chips from
+            // KeywordTriggerService.GetRecentForegroundApps(). That ring is fed by a foreground-
+            // window poll (Win32) and lives with the service, so the chip row stays empty here.
         }
 
+        private void TxtAwarenessAppList_LostFocus(object? sender, RoutedEventArgs e) => CommitAppList();
+
+        private void TxtAwarenessAppList_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter) CommitAppList();
+        }
+
+        private void CommitAppList()
+        {
+            // ponytail: BLOCKED on KeywordTriggerService.ParseAppList, which canonicalises the box
+            // (split on , ; newline, strip a trailing ".exe", de-duplicate case-insensitively).
+            // That is a pure static with no platform dependency and belongs in Core, but the
+            // service is not this layer's file and copying the parse here would give the two heads
+            // two definitions of what "chrome.exe" means. The box is seeded and readable; commit
+            // lands with the service.
+        }
+
+        // ------------------------------------------------------------------ highlight colour
+
         /// <summary>
-        /// Swatch click. MainWindow persists the colour and repaints the live highlight overlay;
-        /// the hex box and the selected outline are view state and are ported.
+        /// Swatch click. Writes the colour and repaints the row, as ApplyAwarenessHighlightColor
+        /// does; the live overlay repaint is head-side.
         /// </summary>
         private void AwarenessHighlightSwatch_Click(object? sender, PointerPressedEventArgs e)
         {
-            if (sender is not Border b || b.Tag is not string hex) return;
-            _txtHighlightHex.Text = hex;
-            SyncHighlightSwatchUi(hex);
-
-            // ponytail: needs App.Settings (KeywordHighlightColor) + App.KeywordHighlight to
-            // repaint the on-screen overlay, wired when they move to Core.
+            if (sender is Border b && b.Tag is string hex) ApplyHighlightColour(hex);
         }
 
         private void TxtAwarenessHighlightHex_LostFocus(object? sender, RoutedEventArgs e)
-            => SyncHighlightSwatchUi(_txtHighlightHex.Text ?? "");
+            => ApplyHighlightColour(TxtAwarenessHighlightHex.Text);
 
         private void TxtAwarenessHighlightHex_KeyDown(object? sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Enter) SyncHighlightSwatchUi(_txtHighlightHex.Text ?? "");
+            if (e.Key != Key.Enter) return;
+            ApplyHighlightColour(TxtAwarenessHighlightHex.Text);
+            e.Handled = true;
+        }
+
+        /// <summary>
+        /// Validates a hex colour and writes it to settings. Silently no-ops on malformed input so
+        /// a half-typed value in the textbox does not wipe the user's colour.
+        /// </summary>
+        private void ApplyHighlightColour(string? hex)
+        {
+            if (_isLoading || string.IsNullOrWhiteSpace(hex)) return;
+
+            var trimmed = hex.Trim();
+            if (!trimmed.StartsWith('#')) trimmed = "#" + trimmed;
+            if (!Color.TryParse(trimmed, out _)) return;   // Avalonia's twin of WPF's ColorConverter
+
+            try
+            {
+                CoreSettings.Current.KeywordHighlightColor = trimmed;
+                CoreSettings.Save();
+                SyncHighlightSwatchUi(CoreSettings.Current.KeywordHighlightColor);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Awareness tab: failed to write KeywordHighlightColor");
+            }
+
+            // ponytail: WPF then repaints the live highlight overlay through App.KeywordHighlight -
+            // click-through layered windows, head-side.
         }
 
         /// <summary>
         /// Dims every swatch then re-outlines the one matching the current colour, so the user can
-        /// see which preset (if any) their colour is. Ported from SyncAwarenessHighlightSwatchUi.
+        /// see which preset (if any) their colour is. Ported from SyncAwarenessHighlightSwatchUi,
+        /// which also rewrites the hex box.
         /// </summary>
-        private void SyncHighlightSwatchUi(string colour)
+        private void SyncHighlightSwatchUi(string? colour)
         {
-            var selected = colour.ToUpperInvariant();
-            foreach (var swatch in _swatches)
+            var selected = (colour ?? "").ToUpperInvariant();
+            if (!string.Equals(TxtAwarenessHighlightHex.Text, colour, StringComparison.Ordinal))
+                TxtAwarenessHighlightHex.Text = colour;
+
+            foreach (var swatch in Swatches)
             {
                 var match = string.Equals(swatch.Tag?.ToString()?.ToUpperInvariant(), selected, StringComparison.Ordinal);
                 swatch.BorderBrush = match ? Brushes.White : SwatchIdle;
@@ -172,68 +394,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             }
         }
 
-        // ------------------------------------------------------------------ stubs
+        // ------------------------------------------------------------------ still head-side
 
         private void BtnAwarenessTutorial_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs TutorialService, wired when it moves to Core.
+            // ponytail: needs TutorialService, which drives an overlay window. Head-side.
         }
 
         private void BtnGateUnlock_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs PatreonService (opens the pledge page), wired when it moves to Core.
-        }
-
-        private void ChkAwarenessOcr_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings + App.ScreenOcr, wired when they move to Core.
-        }
-
-        private void ChkAwarenessKeyboard_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings + KeywordTriggerService, wired when they move to Core.
-        }
-
-        private void ChkAwarenessIgnoreOwnUi_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings, wired when it moves to Core.
-        }
-
-        private void ChkAwarenessLoopProtection_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings, wired when it moves to Core.
-        }
-
-        private void ChkAwarenessHighlight_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings + App.KeywordHighlight, wired when they move to Core.
-        }
-
-        private void ChkAwarenessHighlightVisibleInCapture_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings + the Win32 WDA_EXCLUDEFROMCAPTURE affordance on the
-            // highlight overlay windows, wired when they move to Core.
-        }
-
-        private void ChkAwarenessIgnoreOwnFocus_Changed(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings, wired when it moves to Core.
-        }
-
-        private void TxtAwarenessAppList_LostFocus(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.Settings (KeywordTriggerApps), wired when it moves to Core.
-        }
-
-        private void TxtAwarenessAppList_KeyDown(object? sender, KeyEventArgs e)
-        {
-            // ponytail: needs App.Settings (KeywordTriggerApps), wired when it moves to Core.
+            // ponytail: the premium gate. Needs PatreonService to open the pledge page, and
+            // RefreshPremiumGate to raise or drop the AwarenessGate overlay in the first place.
         }
 
         private void LnkAwarenessAdvanced_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.KeywordPresets to pick the installed preset and open its editor,
-            // wired when it moves to Core.
+            // ponytail: needs App.KeywordPresets to pick the installed preset and open its editor
+            // dialog; falls back to the custom-trigger drawer when nothing is installed.
         }
     }
 }

--- a/CCP.Avalonia/Views/Tabs/LockdownTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/LockdownTabView.axaml.cs
@@ -3,20 +3,24 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
     /// <summary>
     /// PORTED from ConditioningControlPanel/Views/Tabs/LockdownTabView.xaml.cs.
     ///
-    /// The view-only half is carried over intact: the intensity pills still behave as radio
-    /// buttons, the master switch still greys the Possession block rather than hiding it, and the
-    /// Emergency Exit slab still sinks under the finger. Everything that reads or writes
-    /// AppSettings, forwards to MainWindow, or opens the exit games is a stub - those live behind
-    /// App.* in the WPF head and get wired when they move to Core.
+    /// <para>The settings half is restored against <see cref="CoreSettings"/>: the Possession
+    /// master switch, the three intensity pills, tripwires / warden / photosafe and the four
+    /// Safeties all read and write <c>AppSettings</c> for real, one for one with the WPF bodies,
+    /// and the master switch still greys the Possession block rather than hiding it.</para>
+    ///
+    /// <para><b>Nothing here enforces a lockdown.</b> Activate, the gate unlock, the secret exit
+    /// and the timer taps are forwarders into <c>MainWindow.Lab.cs</c> / <c>LockdownService</c>,
+    /// which are Win32 and head-side; the Emergency Exit slab needs
+    /// <c>EmergencyExitHostService</c>. Those stay stubs and each says so at its own body.</para>
     /// </summary>
     public partial class LockdownTabView : UserControl
     {
@@ -24,31 +28,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// True while LoadPossessionSettings is writing the controls, so the change handlers do not
         /// write the value they were just given straight back into settings (and, worse, re-enter
         /// through the master switch's grey-out pass).
+        ///
+        /// Starts true: the XAML wires <c>IsCheckedChanged</c> itself, so a handler can fire from
+        /// inside InitializeComponent, before any field is assigned and before the seed has run.
+        /// Cleared by the first LoadPossessionSettings.
         /// </summary>
-        private bool _loadingPossession;
-
-        /// <summary>Stands in for AppSettings.LockdownPossessionIntensity so a tab re-show does not
-        /// throw the user's pick away. Delete with the stub in LoadPossessionSettings.</summary>
-        private int _intensity = 1;
-
-        // The compiled-XAML x:Name fields are only populated by the generated
-        // InitializeComponent(); this head loads its views with AvaloniaXamlLoader.Load, so every
-        // control the code touches is resolved by name here, as in AdornedAvatar and EmiRingPicker.
-        private readonly StackPanel _possessionBlock;
-        private readonly CheckBox _chkPossessionEnabled;
-        private readonly ToggleButton _btnPossGentle;
-        private readonly ToggleButton _btnPossEerie;
-        private readonly ToggleButton _btnPossFullDoki;
+        private bool _loadingPossession = true;
 
         public LockdownTabView()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+            // x:Name fields this code-behind reads.
+            InitializeComponent();
 
-            _possessionBlock = this.FindControl<StackPanel>("PossessionBlock")!;
-            _chkPossessionEnabled = this.FindControl<CheckBox>("ChkPossessionEnabled")!;
-            _btnPossGentle = this.FindControl<ToggleButton>("BtnPossGentle")!;
-            _btnPossEerie = this.FindControl<ToggleButton>("BtnPossEerie")!;
-            _btnPossFullDoki = this.FindControl<ToggleButton>("BtnPossFullDoki")!;
+            LoadPossessionSettings();
 
             // Tabs are shown and hidden rather than rebuilt, so the first attach fires once.
             // Re-read on every show for the same reason BambiTakeoverTabView does: something else
@@ -62,16 +55,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                 if (e.Property == IsVisibleProperty && IsVisible) LoadPossessionSettings();
             };
 
-            // ponytail: placeholder for the render proof. On WPF the active panel is flipped by
-            // MainWindow.Lab.cs when a lockdown starts; nothing on this head does that yet, so the
-            // Emergency Exit slab would be unreachable and unproven. Delete this line and the
-            // sample readout below the moment the host moves to Core.
-            this.FindControl<StackPanel>("LockdownActivePanel")!.IsVisible = true;
-            this.FindControl<TextBlock>("TxtPossessionRung")!.Text =
+            // ponytail: placeholder for the render proof, NOT a settings-driven state. On WPF the
+            // Setup/Active swap is driven by a RUNNING lockdown (MainWindow.Lab.cs:760/835, off
+            // App.Lockdown), and the rung readout is hooked only for the duration of one
+            // (HookPossessionReadout). Neither has a Core seam, so without this line the Emergency
+            // Exit slab would be unreachable and unproven. Delete it when the host lands.
+            LockdownActivePanel.IsVisible = true;
+            TxtPossessionRung.Text =
                 Loc.GetF("lockdown_poss_readout_fmt", Loc.Get("lockdown_poss_rung_1"));
-            var pips = this.FindControl<StackPanel>("PossessionPips")!;
-            for (var i = 0; i < pips.Children.Count; i++)
-                if (pips.Children[i] is Border pip)
+            for (var i = 0; i < PossessionPips.Children.Count; i++)
+                if (PossessionPips.Children[i] is Border pip)
                     pip.Background = new SolidColorBrush(Color.Parse(i <= 1 ? "#FF8A5C" : "#33FF8A5C"));
         }
 
@@ -80,19 +73,39 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// <summary>Paints every control on the card from AppSettings. Never writes anything back.</summary>
         private void LoadPossessionSettings()
         {
-            // ponytail: needs AppSettings, wired when it moves to Core. The WPF body reads
-            // LockdownPossessionEnabled / TripwiresEnabled / WardenEnabled / Photosafe and the four
-            // safeties, then calls the two Apply* helpers below - which ARE ported, so once the
-            // settings object lands this is eight assignments and nothing else.
             try
             {
+                var s = CoreSettings.Current;
+
                 _loadingPossession = true;
-                ApplyIntensityPills(_intensity);
-                ApplyPossessionEnabledLook(_chkPossessionEnabled.IsChecked == true);
+
+                Set(ChkPossessionEnabled, s.LockdownPossessionEnabled);
+                Set(ChkPossTripwires, s.LockdownTripwiresEnabled);
+                Set(ChkPossWarden, s.LockdownWardenEnabled);
+                Set(ChkPossPhotosafe, s.LockdownPhotosafe);
+
+                Set(ChkLockdownStrict, s.LockdownForceStrictLock);
+                Set(ChkLockdownNoPanic, s.LockdownDisablePanicKey);
+                Set(ChkLockdownSysKeys, s.LockdownBlockSystemKeys);
+                Set(ChkLockdownDose, s.LockdownDoseKeeperEnabled);
+
+                ApplyIntensityPills(s.LockdownPossessionIntensity);
+                ApplyPossessionEnabledLook(s.LockdownPossessionEnabled);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Lockdown card: failed to load possession settings");
             }
             finally
             {
                 _loadingPossession = false;
+            }
+
+            // Assign only on a real difference: Avalonia raises IsCheckedChanged on a programmatic
+            // set too, and every handler below is a live editor.
+            static void Set(CheckBox box, bool value)
+            {
+                if ((box.IsChecked ?? false) != value) box.IsChecked = value;
             }
         }
 
@@ -100,63 +113,115 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// one cannot turn the setting off, because there is no "no intensity".</summary>
         private void ApplyIntensityPills(int intensity)
         {
-            _btnPossGentle.IsChecked = intensity == 0;
-            _btnPossEerie.IsChecked = intensity == 1;
-            _btnPossFullDoki.IsChecked = intensity == 2;
+            BtnPossGentle.IsChecked = intensity == 0;
+            BtnPossEerie.IsChecked = intensity == 1;
+            BtnPossFullDoki.IsChecked = intensity == 2;
         }
 
         /// <summary>Greys rather than hides: see the XAML comment on the Possession block.</summary>
         private void ApplyPossessionEnabledLook(bool on)
         {
-            if (_possessionBlock == null) return;
-            _possessionBlock.IsEnabled = on;
-            _possessionBlock.Opacity = on ? 1.0 : 0.4;
+            if (PossessionBlock == null) return;
+            PossessionBlock.IsEnabled = on;
+            PossessionBlock.Opacity = on ? 1.0 : 0.4;
         }
 
         private void ChkPossessionEnabled_Changed(object? sender, RoutedEventArgs e)
         {
             if (_loadingPossession) return;
-            // ponytail: needs AppSettings (LockdownPossessionEnabled + Save), wired when it moves
-            // to Core. The grey-out is view-only, so it works now.
-            ApplyPossessionEnabledLook(_chkPossessionEnabled.IsChecked == true);
+            try
+            {
+                var s = CoreSettings.Current;
+                s.LockdownPossessionEnabled = ChkPossessionEnabled.IsChecked == true;
+                ApplyPossessionEnabledLook(s.LockdownPossessionEnabled);
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Lockdown card: failed to write LockdownPossessionEnabled");
+            }
         }
 
         private void PossIntensity_Click(object? sender, RoutedEventArgs e)
         {
             if (_loadingPossession) return;
+            try
+            {
+                // Tag carries the value so all three pills share one handler and the mapping lives
+                // next to the label the user actually reads.
+                if (sender is not ToggleButton tb || tb.Tag is not string tag || !int.TryParse(tag, out var value))
+                    return;
 
-            // Tag carries the value so all three pills share one handler and the mapping lives
-            // next to the label the user actually reads.
-            if (sender is not ToggleButton tb || tb.Tag is not string tag || !int.TryParse(tag, out var value))
-                return;
+                var s = CoreSettings.Current;
+                s.LockdownPossessionIntensity = value;
 
-            // ponytail: needs AppSettings (LockdownPossessionIntensity + Save), wired when it moves
-            // to Core. The radio behaviour is view-only, so it works now.
-            _intensity = value;
-            _loadingPossession = true;
-            try { ApplyIntensityPills(_intensity); }
-            finally { _loadingPossession = false; }
+                _loadingPossession = true;
+                try { ApplyIntensityPills(s.LockdownPossessionIntensity); }
+                finally { _loadingPossession = false; }
+
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Lockdown card: failed to write LockdownPossessionIntensity");
+            }
         }
 
-        // ponytail: the four handlers below need AppSettings (LockdownTripwiresEnabled,
-        // LockdownWardenEnabled, LockdownPhotosafe, and the four safeties read together), wired
-        // when it moves to Core. Nothing about them is view-only, so the bodies are empty rather
-        // than half-right.
-        private void ChkPossTripwires_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkPossTripwires_Changed(object? sender, RoutedEventArgs e)
+            => WriteFlag(v => CoreSettings.Current.LockdownTripwiresEnabled = v,
+                         ChkPossTripwires, "LockdownTripwiresEnabled");
 
-        private void ChkPossWarden_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkPossWarden_Changed(object? sender, RoutedEventArgs e)
+            => WriteFlag(v => CoreSettings.Current.LockdownWardenEnabled = v,
+                         ChkPossWarden, "LockdownWardenEnabled");
 
-        private void ChkPossPhotosafe_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkPossPhotosafe_Changed(object? sender, RoutedEventArgs e)
+            => WriteFlag(v => CoreSettings.Current.LockdownPhotosafe = v,
+                         ChkPossPhotosafe, "LockdownPhotosafe");
+
+        /// <summary>One box, one flag, one save - the shape three of the toggles share.</summary>
+        private void WriteFlag(Action<bool> write, CheckBox box, string name)
+        {
+            if (_loadingPossession) return;
+            try
+            {
+                write(box.IsChecked == true);
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Lockdown card: failed to write {Setting}", name);
+            }
+        }
 
         /// <summary>
         /// All four safeties share one handler: they are read together on Activate and none of them
         /// does anything until then, so there is nothing per-toggle to react to.
         /// </summary>
-        private void ChkLockdownSafety_Changed(object? sender, RoutedEventArgs e) { }
+        private void ChkLockdownSafety_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_loadingPossession) return;
+            try
+            {
+                var s = CoreSettings.Current;
+                s.LockdownForceStrictLock = ChkLockdownStrict.IsChecked == true;
+                s.LockdownDisablePanicKey = ChkLockdownNoPanic.IsChecked == true;
+                s.LockdownBlockSystemKeys = ChkLockdownSysKeys.IsChecked == true;
+                s.LockdownDoseKeeperEnabled = ChkLockdownDose.IsChecked == true;
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Lockdown card: failed to write the lockdown safeties");
+            }
+        }
 
         // ==== forwarded to MainWindow ====================================================
-        // ponytail: all four need the MainWindow lockdown partials (MainWindow.Lab.cs), wired when
-        // they move to Core. On WPF each one is Window.GetWindow(this) is MainWindow mw -> mw.<same>.
+        // All four need LockdownService and the MainWindow lockdown partials (MainWindow.Lab.cs).
+        // Starting a lockdown is Win32 - strict lock, the panic-key and system-key hooks, the
+        // always-on-top cage - so it is head-side by construction and no Core seam is planned.
+        // On WPF each body is `Window.GetWindow(this) is MainWindow mw -> mw.<same handler>`.
+        // NOTHING on this head enforces a lockdown; these are inert on purpose.
 
         private void BtnActivateLockdown_Click(object? sender, RoutedEventArgs e) { }
 
@@ -172,13 +237,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         // so its animations live here, on the view, and answer only to the photosafe setting.
 
         /// <summary>
-        /// Starts the slow ember breath under the slab.
-        /// ponytail: needs AppSettings (LockdownPhotosafe) plus a named target for the glow, wired
-        /// when settings move to Core. Avalonia cannot name an Effect (AVLN2000), so the WPF
-        /// storyboard on EEGlow.Opacity/BlurRadius becomes either a keyframe Animation over a
-        /// pseudo-class on the plate Border or a swapped DropShadowEffect instance - decide that
-        /// when there is a setting to gate it with. POSSESSION.md: photosafe means no flicker, not
-        /// no colour, so the resting glow in the XAML is already the correct photosafe state.
+        /// Starts the slow ember breath under the slab. Called by the host when the active panel
+        /// is shown.
+        /// ponytail: the gate is readable now (<c>CoreSettings.Current.LockdownPhotosafe</c>), but
+        /// the target is not: Avalonia cannot name an Effect (AVLN2000), so the WPF storyboard on
+        /// EEGlow.Opacity/BlurRadius has to become a keyframe Animation over a pseudo-class on the
+        /// plate Border, or a swapped DropShadowEffect instance - an XAML change, and the XAML is
+        /// not this layer's. POSSESSION.md: photosafe means no flicker, not no colour, so the
+        /// resting glow already in the XAML is the correct photosafe state, which is why an
+        /// unstarted pulse is a safe stub rather than a missing one.
         /// </summary>
         internal void StartEmergencyExitPulse() { }
 
@@ -194,9 +261,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         /// <summary>
         /// Opens the Emergency Exit games.
-        /// ponytail: needs EmergencyExitHostService, wired when it moves to Core. The host owns
-        /// everything after that line - the tripwire, the game pick, the verdict and whether the
-        /// lockdown actually ends (Services/EmergencyExit/EMERGENCY_EXIT.md).
+        /// ponytail: needs EmergencyExitHostService, which owns windows and so stays head-side. The
+        /// host owns everything after that line - the tripwire, the game pick, the verdict and
+        /// whether the lockdown actually ends (Services/EmergencyExit/EMERGENCY_EXIT.md).
         /// </summary>
         private void BtnEmergencyExit_Click(object? sender, RoutedEventArgs e) { }
     }


### PR DESCRIPTION
Both tabs were rendering stubs with the settings logic commented out against
`App.Settings`. AppSettings and CoreSettings are in Core now, so the settings
half of both is restored one for one with the WPF bodies, and both views switch
from `AvaloniaXamlLoader.Load` + `FindControl` to the generated
`InitializeComponent()`.

Lockdown: the Possession master switch, the three intensity pills, tripwires,
warden, photosensitive-safe and the four Safeties all seed from AppSettings and
write back through CoreSettings.Save. The master still greys the Possession
block rather than hiding it, and the pills still behave as radio buttons.

Awareness: the seed is MainWindow.SyncAwarenessTabUI's settings half, plus
RefreshAwarenessAppScopeUi and SyncAwarenessHighlightSwatchUi. The two cooldown
sliders, the master switch and its keyboard sub-toggle, Screen OCR,
ignore-own-UI, loop protection, highlight on/off, capture visibility,
ignore-own-focus, the app-scope mode and the highlight colour all read and write
AppSettings. The status dot, the Live/Off label, the app-list panel's visibility
and the selected swatch outline follow from those values instead of being
hard-coded.

Both loading guards are field-initialised to true: the XAML wires
`IsCheckedChanged` itself, so a handler can fire from inside
InitializeComponent, before the seed has run and before the x:Name fields are
assigned. Two Awareness boxes ship `IsChecked="True"` and would otherwise have
saved the XAML default over the user's file on construction.

This is the settings and visual-state half ONLY. Nothing here enforces a
lockdown or arms an awareness engine on Linux: Activate, the gate unlock, the
secret exit and the timer taps stay inert, and the Setup/Active panel swap
remains a render-proof placeholder because WPF drives it from a running
LockdownService, not from a setting.

Still blocked:
- LockdownService / MainWindow.Lab.cs - activate, the gate, the secret exit, the
  timer taps, and the Setup/Active panel swap. Win32 by construction.
- EmergencyExitHostService - the exit games.
- The Emergency Exit ember pulse: LockdownPhotosafe is readable now, but
  Avalonia cannot name an Effect (AVLN2000), so the target needs an XAML change
  this layer does not own.
- KeywordTriggerService - HasAccess (the Patreon gate on the master and OCR
  switches), ParseAppList (so the app-list box seeds and reads but does not
  commit), GetRecentForegroundApps (the "recently focused" chips), Start/Stop.
- ScreenOcr, the keyboard hook, KeywordHighlight.RefreshCaptureVisibility.
- KeywordTriggersPanel.SyncKeywordRescuePanelUi - the OCR-interval and
  highlight-duration sub-rows the OCR and highlight toggles are the master for.
- TutorialService, RefreshPremiumGate, KeywordPresets (the advanced link).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU