### PR TITLE
feat(avalonia): every colour button opens the real picker, and the monitor sentinels come from Core

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/ColorEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ColorEditorDialog.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
@@ -9,12 +10,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml.cs. Deviations:
     ///  - DialogResult becomes Close(bool).
-    ///  - App.Settings (AppSettings lives in the WPF head) is stubbed: the dialog opens on the
-    ///    WPF defaults and Save writes nowhere. FontPickerHelper is likewise a head helper, so the
-    ///    preview keeps the markup's Arial.
-    ///  - System.Windows.Forms.ColorDialog has no Avalonia twin in the referenced packages, so
-    ///    ShowColorPicker is a stub that returns null (no change).
+    ///  - System.Windows.Forms.ColorDialog becomes <see cref="ColorPickerDialog"/>, which is async
+    ///    and needs an owner, so the three swatch handlers await where WPF blocked inline.
+    ///  - FontPickerHelper is a WPF-head helper (it resolves the bundled Fredoka face from a
+    ///    pack:// URI), so the preview keeps the markup's Arial rather than the chosen face.
     ///  - The text outline stays a DropShadowEffect - Avalonia.Media has the same type.
+    ///
+    /// Save mutates <c>CoreSettings.Current</c> WITHOUT calling Save(), exactly as the WPF original
+    /// does: it is the live instance, and the shutdown SaveImmediate flushes it.
     /// </summary>
     public partial class ColorEditorDialog : Window
     {
@@ -47,9 +50,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             LoadCurrentSettings();
             UpdatePreview();
 
-            _btnBgColor.Click += (_, _) => Pick(ref _bgColor);
-            _btnTextColor.Click += (_, _) => Pick(ref _textColor);
-            _btnBorderColor.Click += (_, _) => Pick(ref _borderColor);
+            _btnBgColor.Click += (_, _) => Pick(_bgColor, c => _bgColor = c);
+            _btnTextColor.Click += (_, _) => Pick(_textColor, c => _textColor = c);
+            _btnBorderColor.Click += (_, _) => Pick(_borderColor, c => _borderColor = c);
             _chkBgTransparent.IsCheckedChanged += (_, _) => UpdatePreview();
             this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
             this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
@@ -57,15 +60,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void LoadCurrentSettings()
         {
-            // ponytail: needs SettingsManager (App.Settings.Current.Sub*), wired when it moves to Core.
-            // Values below are the WPF fallbacks for an unset setting.
-            _bgColor = ParseColor("", Colors.Black);
-            _textColor = ParseColor("", Color.FromRgb(255, 0, 255));
-            _borderColor = ParseColor("", Colors.White);
+            var settings = CoreSettings.Current;
 
-            _chkBgTransparent.IsChecked = false;
-            _chkTextTransparent.IsChecked = false;
-            _chkStealsFocus.IsChecked = false;
+            _bgColor = ParseColor(settings.SubBackgroundColor, Colors.Black);
+            _textColor = ParseColor(settings.SubTextColor, Color.FromRgb(255, 0, 255));
+            _borderColor = ParseColor(settings.SubBorderColor, Colors.White);
+
+            _chkBgTransparent.IsChecked = settings.SubBackgroundTransparent;
+            _chkTextTransparent.IsChecked = settings.SubTextTransparent;
+            _chkStealsFocus.IsChecked = settings.SubliminalStealsFocus;
 
             UpdateColorButtons();
         }
@@ -104,27 +107,30 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             };
         }
 
-        private void Pick(ref Color target)
+        /// <summary>The three swatch handlers, WPF's body with the blocking ColorDialog swapped for
+        /// the awaited head picker. A cancelled pick answers null and changes nothing.</summary>
+        private async void Pick(Color current, Action<Color> assign)
         {
-            var color = ShowColorPicker(target);
+            var color = await ColorPickerDialog.PickAsync(this, current);
             if (color.HasValue)
             {
-                target = color.Value;
+                assign(color.Value);
                 UpdateColorButtons();
                 UpdatePreview();
             }
         }
 
-        private Color? ShowColorPicker(Color currentColor)
-        {
-            // ponytail: needs a colour picker (WPF used System.Windows.Forms.ColorDialog); Avalonia's
-            // ColorPicker lives in a package this head does not reference yet. Returns "no change".
-            return null;
-        }
-
         private void BtnSave_Click()
         {
-            // ponytail: needs SettingsManager to persist Sub* colours and the two toggles, wired when it moves to Core
+            var settings = CoreSettings.Current;
+
+            settings.SubBackgroundColor = ColorToHex(_bgColor);
+            settings.SubTextColor = ColorToHex(_textColor);
+            settings.SubBorderColor = ColorToHex(_borderColor);
+            settings.SubBackgroundTransparent = _chkBgTransparent.IsChecked ?? false;
+            settings.SubTextTransparent = _chkTextTransparent.IsChecked ?? false;
+            settings.SubliminalStealsFocus = _chkStealsFocus.IsChecked ?? false;
+
             Serilog.Log.Information("Subliminal settings updated");
             Close(true);
         }
@@ -135,5 +141,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             if (!hex.StartsWith("#")) hex = "#" + hex;
             return Color.TryParse(hex, out var color) ? color : fallback;
         }
+
+        private static string ColorToHex(Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/LockCardColorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LockCardColorDialog.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
@@ -9,10 +10,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/LockCardColorDialog.xaml.cs. Deviations:
     ///  - DialogResult becomes Close(bool).
-    ///  - App.Settings and App.Mods (both WPF-head services) are stubbed: the dialog opens on the
-    ///    WPF defaults with the stock #FF69B4 accent, and Save writes nowhere.
-    ///  - System.Windows.Forms.ColorDialog has no Avalonia twin in the referenced packages, so
-    ///    ShowColorPicker is a stub that returns null (no change).
+    ///  - App.Settings / App.Mods become CoreSettings / CoreMods. CoreMods.AccentColorHex never
+    ///    answers null, so WPF's <c>?? "#FF69B4"</c> survives only as the parse fallback.
+    ///  - System.Windows.Forms.ColorDialog becomes <see cref="ColorPickerDialog"/>, which is async
+    ///    and needs an owner, so the five swatch handlers await where WPF blocked inline.
+    ///
+    /// Save mutates <c>CoreSettings.Current</c> WITHOUT calling Save(), exactly as the WPF original
+    /// does: it is the live instance, and the shutdown SaveImmediate flushes it.
     /// </summary>
     public partial class LockCardColorDialog : Window
     {
@@ -41,25 +45,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             LoadCurrentSettings();
             UpdatePreview();
 
-            _btnBgColor.Click += (_, _) => Pick(ref _bgColor);
-            _btnTextColor.Click += (_, _) => Pick(ref _textColor);
-            _btnInputBgColor.Click += (_, _) => Pick(ref _inputBgColor);
-            _btnInputTextColor.Click += (_, _) => Pick(ref _inputTextColor);
-            _btnAccentColor.Click += (_, _) => Pick(ref _accentColor);
+            _btnBgColor.Click += (_, _) => Pick(_bgColor, c => _bgColor = c);
+            _btnTextColor.Click += (_, _) => Pick(_textColor, c => _textColor = c);
+            _btnInputBgColor.Click += (_, _) => Pick(_inputBgColor, c => _inputBgColor = c);
+            _btnInputTextColor.Click += (_, _) => Pick(_inputTextColor, c => _inputTextColor = c);
+            _btnAccentColor.Click += (_, _) => Pick(_accentColor, c => _accentColor = c);
             this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
             this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
         }
 
         private void LoadCurrentSettings()
         {
-            // ponytail: needs SettingsManager (App.Settings.Current.LockCard*) and Mods.GetAccentColorHex,
-            // wired when they move to Core. Values below are the WPF fallbacks for an unset setting.
-            var accent = Color.Parse("#FF69B4");
-            _bgColor = ParseColor("", Color.FromRgb(26, 26, 46));
-            _textColor = ParseColor("", accent);
-            _inputBgColor = ParseColor("", Color.FromRgb(37, 37, 66));
-            _inputTextColor = ParseColor("", Colors.White);
-            _accentColor = ParseColor("", accent);
+            var settings = CoreSettings.Current;
+
+            var accent = ParseColor(CoreMods.AccentColorHex, Color.FromRgb(255, 105, 180)); // #FF69B4
+            _bgColor = ParseColor(settings.LockCardBackgroundColor, Color.FromRgb(26, 26, 46));
+            _textColor = ParseColor(settings.LockCardTextColor, accent);
+            _inputBgColor = ParseColor(settings.LockCardInputBackgroundColor, Color.FromRgb(37, 37, 66));
+            _inputTextColor = ParseColor(settings.LockCardInputTextColor, Colors.White);
+            _accentColor = ParseColor(settings.LockCardAccentColor, accent);
 
             UpdateColorButtons();
         }
@@ -92,27 +96,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             this.FindControl<Border>("PreviewProgressBar")!.Background = new SolidColorBrush(_accentColor);
         }
 
-        private void Pick(ref Color target)
+        /// <summary>The five swatch handlers, WPF's body with the blocking ColorDialog swapped for
+        /// the awaited head picker. A cancelled pick answers null and changes nothing.</summary>
+        private async void Pick(Color current, Action<Color> assign)
         {
-            var color = ShowColorPicker(target);
+            var color = await ColorPickerDialog.PickAsync(this, current);
             if (color.HasValue)
             {
-                target = color.Value;
+                assign(color.Value);
                 UpdateColorButtons();
                 UpdatePreview();
             }
         }
 
-        private Color? ShowColorPicker(Color currentColor)
-        {
-            // ponytail: needs a colour picker (WPF used System.Windows.Forms.ColorDialog); Avalonia's
-            // ColorPicker lives in a package this head does not reference yet. Returns "no change".
-            return null;
-        }
-
         private void BtnSave_Click()
         {
-            // ponytail: needs SettingsManager to persist the five LockCard* colours, wired when it moves to Core
+            var settings = CoreSettings.Current;
+
+            settings.LockCardBackgroundColor = ColorToHex(_bgColor);
+            settings.LockCardTextColor = ColorToHex(_textColor);
+            settings.LockCardInputBackgroundColor = ColorToHex(_inputBgColor);
+            settings.LockCardInputTextColor = ColorToHex(_inputTextColor);
+            settings.LockCardAccentColor = ColorToHex(_accentColor);
+
             Serilog.Log.Information("Lock card colors updated");
             Close(true);
         }
@@ -123,5 +129,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             if (!hex.StartsWith("#")) hex = "#" + hex;
             return Color.TryParse(hex, out var color) ? color : fallback;
         }
+
+        private static string ColorToHex(Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
     }
 }

--- a/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
@@ -45,12 +45,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             SliderOpacity.ValueChanged += SliderOpacity_Changed;
             CmbColorMode.SelectionChanged += CmbColorMode_Changed;
             CmbFont.SelectionChanged += CmbFont_Changed;
-            BtnChooseColor.Click += (_, _) =>
-            {
-                // ponytail: needs a colour picker. WPF opens System.Windows.Forms.ColorDialog;
-                // Avalonia's equivalent is the Avalonia.Controls.ColorPicker package, which is
-                // NOT referenced by CCP.Avalonia.csproj (a csproj edit is the coordinator's call).
-            };
+            BtnChooseColor.Click += BtnChooseColor_Click;
             BtnResetColor.Click += BtnResetColor_Click;
             ChkFxBreathing.IsCheckedChanged += FxToggle_Changed;
             ChkFxWobble.IsCheckedChanged += FxToggle_Changed;
@@ -221,6 +216,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (string.IsNullOrWhiteSpace(name) || s.BouncingTextFont == name) return;
             s.BouncingTextFont = name!;
             CoreSettings.Save();
+            SafeRefresh();
+        }
+
+        /// <summary>
+        /// The Fixed-mode colour pick. WPF opened a blocking <c>System.Windows.Forms.ColorDialog</c>
+        /// seeded with the effective colour; this awaits <see cref="ColorPickerDialog"/> instead,
+        /// which needs a non-null owner Window. Cancel answers null and writes nothing, matching
+        /// WPF's early return on anything but DialogResult.OK. The stored form is the WPF one,
+        /// <c>#RRGGBB</c> - EffectiveColor parses exactly that back.
+        /// </summary>
+        private async void BtnChooseColor_Click(object? sender, RoutedEventArgs e)
+        {
+            var owner = TopLevel.GetTopLevel(this) as Window;
+            if (owner is null) return;   // detached, or a headless render: nothing to own the modal
+
+            var (er, eg, eb) = EffectiveColor();
+            var picked = await ColorPickerDialog.PickAsync(owner, Color.FromRgb(er, eg, eb));
+            if (picked is not { } c) return;
+
+            CoreSettings.Current.BouncingTextFixedColor = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+            CoreSettings.Save();
+            UpdateSwatch();
             SafeRefresh();
         }
 

--- a/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
@@ -9,7 +9,9 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.UI;
 using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
@@ -27,12 +29,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
     /// </summary>
     public partial class PinkFilterFeatureControl : UserControl
     {
-        // ponytail: local copy of App.MonitorTargetFollowGlobal / App.MonitorTargetAll
-        // (ConditioningControlPanel/App.ScreenResolver.cs), still in the WPF head. They are the
-        // sentinels persisted in AppSettings.PinkFilterTargetMonitor, so both heads must agree.
-        private const int MonitorTargetFollowGlobal = -1;
-        private const int MonitorTargetAll = -2;
-
         private bool _isLoading = true;
         private bool _monitorPopulating;
         private AppSettings? _hooked;
@@ -45,12 +41,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             SliderOpacity.ValueChanged += SliderOpacity_Changed;
             CmbMonitor.DropDownOpened += (_, _) => PopulateMonitors();
             CmbMonitor.SelectionChanged += CmbMonitor_Changed;
-            BtnChooseColor.Click += (_, _) =>
-            {
-                // ponytail: needs a colour picker. WPF opens System.Windows.Forms.ColorDialog;
-                // Avalonia's equivalent is the Avalonia.Controls.ColorPicker package, which is
-                // NOT referenced by CCP.Avalonia.csproj (a csproj edit is the coordinator's call).
-            };
+            BtnChooseColor.Click += BtnChooseColor_Click;
             BtnResetColor.Click += BtnResetColor_Click;
 
             LoadFromSettings();
@@ -151,8 +142,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             try
             {
                 CmbMonitor.Items.Clear();
-                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = MonitorTargetFollowGlobal });
-                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = MonitorTargetAll });
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = MonitorTarget.FollowGlobal });
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = MonitorTarget.All });
 
                 var screens = ScreenList.Enumerate(this);
                 string monitorLabel = Loc.Get("monitor_label");
@@ -187,6 +178,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             s.PinkFilterTargetMonitor = target;
             CoreSettings.Save();
             // ponytail: WPF then calls App.Overlay.RefreshOverlays() - see ChkEnable_Changed.
+        }
+
+        /// <summary>
+        /// The tint colour pick. WPF opened a blocking <c>System.Windows.Forms.ColorDialog</c>
+        /// seeded with the effective colour; this awaits <see cref="ColorPickerDialog"/> instead,
+        /// which needs a non-null owner Window. Cancel answers null and writes nothing, matching
+        /// WPF's early return on anything but DialogResult.OK. The stored form is the WPF one,
+        /// <c>#RRGGBB</c> - <c>CoreMods.TryParseHexColor</c> parses exactly that back.
+        /// </summary>
+        private async void BtnChooseColor_Click(object? sender, RoutedEventArgs e)
+        {
+            var owner = TopLevel.GetTopLevel(this) as Window;
+            if (owner is null) return;   // detached, or a headless render: nothing to own the modal
+
+            var (er, eg, eb) = EffectiveColor();
+            var picked = await ColorPickerDialog.PickAsync(owner, Color.FromRgb(er, eg, eb));
+            if (picked is not { } c) return;
+
+            CoreSettings.Current.PinkFilterColor = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+            CoreSettings.Save();
+            UpdateSwatch();
+            // ponytail: WPF then calls App.Overlay.RefreshFilterColor() + RefreshOverlays() to push
+            // the colour into a tint already on screen - see ChkEnable_Changed.
         }
 
         private void BtnResetColor_Click(object? sender, RoutedEventArgs e)

--- a/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
@@ -14,6 +14,7 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.UI;
 using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
@@ -32,12 +33,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
     /// </summary>
     public partial class SpiralFeatureControl : UserControl
     {
-        // ponytail: local copy of App.MonitorTargetFollowGlobal / App.MonitorTargetAll
-        // (ConditioningControlPanel/App.ScreenResolver.cs), still in the WPF head. They are the
-        // sentinels persisted in AppSettings.SpiralTargetMonitor, so both heads must agree.
-        private const int MonitorTargetFollowGlobal = -1;
-        private const int MonitorTargetAll = -2;
-
         private static readonly string[] SpiralImageExts =
             { ".gif", ".png", ".jpg", ".jpeg", ".webp", ".bmp" };
         private static readonly string[] SpiralVideoExts =
@@ -216,8 +211,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             try
             {
                 CmbMonitor.Items.Clear();
-                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = MonitorTargetFollowGlobal });
-                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = MonitorTargetAll });
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_default"), Tag = MonitorTarget.FollowGlobal });
+                CmbMonitor.Items.Add(new ComboBoxItem { Content = Loc.Get("monitor_target_all"), Tag = MonitorTarget.All });
 
                 var screens = ScreenList.Enumerate(this);
                 string monitorLabel = Loc.Get("monitor_label");


### PR DESCRIPTION
ColorEditorDialog: the three subliminal swatches open ColorPickerDialog awaited on this
window, and the dialog is live again against CoreSettings - it loads Sub{Background,Text,
Border}Color plus the transparency and steal-focus toggles, and Save writes them back in the
WPF order and logs the same line. As in the WPF original, Save mutates the live AppSettings
instance without calling Save(); the shutdown SaveImmediate flushes it. The preview font stays
the markup's Arial: FontPickerHelper resolves the bundled Fredoka face from a pack:// URI and
is WPF-only.

LockCardColorDialog: the same, for the five LockCard* colours. WPF's
App.Mods.GetAccentColorHex() ?? "#FF69B4" becomes CoreMods.AccentColorHex, which never answers
null, so the literal survives only as the parse fallback.

BouncingTextFeatureControl / PinkFilterFeatureControl: BtnChooseColor is a real handler. It
seeds the picker with EffectiveColor(), stores the pick as WPF's #RRGGBB (which the same
EffectiveColor / CoreMods.TryParseHexColor parses back), saves, and repaints the swatch. A
cancel answers null and writes nothing, matching WPF's early return on anything but
DialogResult.OK. Avalonia's ShowDialog needs a non-null owner, so both bail when detached.

PinkFilterFeatureControl / SpiralFeatureControl: the local const copies of
App.MonitorTargetFollowGlobal / App.MonitorTargetAll are deleted in favour of
Services.UI.MonitorTarget.FollowGlobal / .All in Core - these are persisted sentinels and the
copies were the drift hazard. The WPF head already reads them from the same place.

Still blocked:
- App.Overlay.RefreshOverlays() / RefreshFilterColor()
  (ConditioningControlPanel/Services/Notifications/OverlayService.cs) - the tint windows are
  Win32 layered windows, so the new colour is saved but not pushed to a tint already on screen.
- App.BouncingText (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs) -
  SafeRefresh/SafeRestart stay named no-ops.
- Helpers.FontPickerHelper.Resolve (ConditioningControlPanel/Helpers/FontPickerHelper.cs) -
  ColorEditorDialog's preview cannot show the chosen subliminal face.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU