### PR TITLE
feat(avalonia): the Companion prompt and attention-target editors load, save and confirm for real

### DIFF
--- a/CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml.cs
@@ -9,6 +9,8 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 {
@@ -25,13 +27,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// is false (the mockup's <c>animation:none</c> asleep state), and whenever the viewmodel is
     /// swapped out.</para>
     ///
-    /// <para>The WPF original also owns the portrait's optical centring (a pixel probe of the
-    /// bust's opaque bounds) and its mod repaint (<c>App.Mods.ModChanged</c>). Both are stubbed
-    /// here — see <see cref="ApplyAvatarArt"/> and <see cref="CentrePortrait"/>.</para>
+    /// <para>The mod repaint is wired: <see cref="CoreMods.ModChanged"/> is the authoritative
+    /// "the art answers differently now" signal, and the only one this tab gets, so the hook is
+    /// taken on Loaded and released on Unloaded exactly as the WPF original does with
+    /// <c>App.Mods.ModChanged</c>. What it can re-read is still thin — see
+    /// <see cref="ApplyAvatarArt"/> — and the portrait's optical centring is stubbed, see
+    /// <see cref="CentrePortrait"/>.</para>
     /// </summary>
     public partial class CompanionHeroCard : UserControl
     {
         private CompanionHeroCardViewModel? _observed;
+
+        /// <summary>Guards the ModChanged hook: Loaded fires again on every re-parent.</summary>
+        private bool _modHooked;
 
         public CompanionHeroCard()
         {
@@ -51,9 +59,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 
         private void OnLoaded(object? sender, RoutedEventArgs e)
         {
+            // WPF's "Known Issues #2: never animate before the element is loaded and templated"
+            // guard is deliberately NOT ported: RefreshAmbientState and StartAmbientLoop already
+            // re-check IsLoaded, and an early return here would also skip the mod hook.
             Observe(ViewModel);
 
-            // ponytail: needs App.Mods (ModChanged -> ApplyAvatarArt), wired when it moves to Core.
+            // Hook on Loaded, unhook on Unloaded, and never let a re-parent double-subscribe.
+            if (!_modHooked)
+            {
+                CoreMods.ModChanged += OnModChanged;
+                _modHooked = true;
+            }
 
             // DispatcherPriority.Normal, never Loaded — Loaded is starved in this app and the
             // breathe would silently never start.
@@ -65,7 +81,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         {
             Observe(null);
             StopAmbientLoop();
+
+            if (_modHooked) CoreMods.ModChanged -= OnModChanged;
+            _modHooked = false;
         }
+
+        /// <summary>ModChanged can be raised off the UI thread; marshal before touching the art.</summary>
+        private void OnModChanged(object? sender, ModPackage mod)
+            => Dispatcher.UIThread.Post(ApplyAvatarArt);
 
         private void OnDataContextChanged(object? sender, EventArgs e)
         {
@@ -127,14 +150,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         // =====================================================================================
 
         /// <summary>
-        /// Re-reads her bust and re-centres it in the ring. The WPF version calls
-        /// <c>CompanionHeroRuntimeVm.Sync()</c> first (which resolves the active mod's pose-1
-        /// through <c>ModResourceResolver</c>).
+        /// Re-reads her bust and re-centres it in the ring. Called on Loaded and on every
+        /// <see cref="CoreMods.ModChanged"/>. The WPF version calls
+        /// <c>CompanionHeroRuntimeVm.Sync()</c> first, which is what re-reads her name, mod chip
+        /// and flavour as well as the pose.
         /// </summary>
         internal void ApplyAvatarArt()
         {
-            // ponytail: needs CompanionHeroRuntimeVm / ModResourceResolver, wired when they move to Core.
-            CentrePortrait();
+            if (!Dispatcher.UIThread.CheckAccess()) { Dispatcher.UIThread.Post(ApplyAvatarArt); return; }
+
+            try
+            {
+                // ponytail: the Sync() half needs ConditioningControlPanel/Views/Controls/Companion/
+                // Runtime/CompanionHeroRuntimeVm.Sync, which reads App.Companion, App.AvatarWindow
+                // and CompanionRuntimeContext.Navigator - head navigation, not a mod lookup, so it
+                // cannot cross to Core as it stands. The hook below it is live, so the moment a
+                // portable hero viewmodel exists this method re-reads on every mod switch.
+                CentrePortrait();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("Companion hero: avatar art refresh failed: {E}", ex.Message);
+            }
         }
 
         /// <summary>
@@ -142,10 +179,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         /// </summary>
         private void CentrePortrait()
         {
-            // ponytail: the WPF ink probe (OpaqueBounds/InkViewbox, PortraitInkFill=0.86,
-            // alpha floor 8, 96px probe) reads BitmapSource pixels. On Avalonia it is
-            // Bitmap.CopyPixels into ImageBrush.SourceRect; port it with the first real bust —
-            // the placeholder viewmodel ships Portrait=null and the vector disc needs no centring.
+            // ponytail: blocked on CompanionHeroCard.axaml, which this layer does not own. WPF
+            // points a NAMED ImageBrush's Viewbox at the ink; the Avalonia XAML dropped every
+            // x:Name on non-controls (illegal there), so there is no brush to give a SourceRect to
+            // before the pixel probe (OpaqueBounds/InkViewbox, PortraitInkFill=0.86, alpha floor 8,
+            // 96px probe -> Bitmap.CopyPixels) is even relevant. The placeholder viewmodel ships
+            // Portrait=null and the vector disc needs no centring, so nothing is visibly wrong yet.
         }
     }
 

--- a/CCP.Avalonia/Views/Dialogs/AttentionTargetEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AttentionTargetEditorDialog.axaml.cs
@@ -10,10 +10,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// Dialog for customizing attention target appearance.
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/AttentionTargetEditorDialog.xaml.cs. Deviations:
-    ///  - Settings load/save, the colour picker (WinForms ColorDialog) and the test target
-    ///    (Services.FloatingText on a Win32 screen) are stubs - see the ponytail comments.
+    ///  - Settings load/save run for real against <see cref="CoreSettings"/>; the colour buttons
+    ///    open this head's <see cref="ColorPickerDialog"/> instead of WinForms' ColorDialog.
+    ///  - The test target (Services.FloatingText on a Win32 screen) is still a stub - see BtnTest.
     ///  - <c>PreviewTextShadow</c> is gone with the DropShadowEffect it coloured.
-    ///  - <c>DialogResult = x; Close()</c> becomes <c>Close(x)</c>.
+    ///  - <c>DialogResult = x; Close()</c> becomes <c>Close(x)</c>. WPF's picker was modal and
+    ///    inline; Avalonia's is awaited, so the four colour handlers are async void.
     /// </summary>
     public partial class AttentionTargetEditorDialog : Window
     {
@@ -46,24 +48,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _borderColorRow = this.FindControl<Grid>("BorderColorRow")!;
 
             // Load current settings
-            // ponytail: needs App.Settings.Current.Attention*, wired when settings move to Core.
-            // These are the "purple classic" preset values.
-            _color1 = "#9B59B6";
-            _color2 = "#8E44AD";
-            _textColor = "#FFFFFF";
-            _borderColor = "#FFFFFF";
-            _showBorder = false;
-            _floatingText = false;
-            _font = "Segoe UI";
+            var settings = CoreSettings.Current;
+            _color1 = settings.AttentionColor1;
+            _color2 = settings.AttentionColor2;
+            _textColor = settings.AttentionTextColor;
+            _borderColor = settings.AttentionBorderColor;
+            _showBorder = settings.AttentionShowBorder;
+            _floatingText = settings.AttentionFloatingText;
+            _font = settings.AttentionFont;
 
             this.FindControl<Button>("PresetPurple")!.Click += (_, _) => PresetPurple_Click();
             this.FindControl<Button>("PresetPink")!.Click += (_, _) => PresetPink_Click();
             this.FindControl<Button>("PresetGreen")!.Click += (_, _) => PresetGreen_Click();
             this.FindControl<Button>("PresetBlue")!.Click += (_, _) => PresetBlue_Click();
-            this.FindControl<Button>("BtnColor1")!.Click += (_, _) => PickInto(ref _color1);
-            this.FindControl<Button>("BtnColor2")!.Click += (_, _) => PickInto(ref _color2);
-            this.FindControl<Button>("BtnTextColor")!.Click += (_, _) => PickInto(ref _textColor);
-            this.FindControl<Button>("BtnBorderColor")!.Click += (_, _) => PickInto(ref _borderColor);
+            this.FindControl<Button>("BtnColor1")!.Click += (_, _) => Pick(_color1, v => _color1 = v);
+            this.FindControl<Button>("BtnColor2")!.Click += (_, _) => Pick(_color2, v => _color2 = v);
+            this.FindControl<Button>("BtnTextColor")!.Click += (_, _) => Pick(_textColor, v => _textColor = v);
+            this.FindControl<Button>("BtnBorderColor")!.Click += (_, _) => Pick(_borderColor, v => _borderColor = v);
             this.FindControl<Button>("BtnTest")!.Click += (_, _) => BtnTest_Click();
             this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close(false);
             this.FindControl<Button>("BtnSave")!.Click += (_, _) => BtnSave_Click();
@@ -164,17 +165,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             catch { }
         }
 
-        private void PickInto(ref string field)
+        /// <summary>
+        /// WPF's <c>PickColor</c>: seed the picker with the colour we already hold, and on OK take
+        /// the six-digit hex the settings model stores. A ref parameter cannot cross an await, so
+        /// the field is handed in as a setter instead. Cancel leaves everything alone, exactly as
+        /// <c>DialogResult.Cancel</c> did.
+        /// </summary>
+        private async void Pick(string current, Action<string> assign)
         {
-            // ponytail: needs a colour picker; WPF used WinForms ColorDialog. Avalonia's ColorPicker
-            // is a separate package and no dependency may be added here. Wired when one is chosen.
-            string? color = null;
-            if (color != null)
-            {
-                field = color;
-                UpdateColorButtons();
-                UpdatePreview();
-            }
+            Color initial;
+            try { initial = Color.Parse(current); }
+            catch { initial = Colors.Magenta; }   // WPF swallowed an unparseable hex the same way
+
+            var chosen = await ColorPickerDialog.PickAsync(this, initial);
+            if (chosen is not { } c) return;
+
+            assign($"#{c.R:X2}{c.G:X2}{c.B:X2}");   // never Color.ToString(): Avalonia writes #AARRGGBB
+            UpdateColorButtons();
+            UpdatePreview();
         }
 
         private void ChkFloatingText_Changed()
@@ -204,8 +212,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void PresetPurple_Click()
         {
-            // ponytail: App.Mods?.GetSecondaryColorHex() fallback kept; wired when Mods moves to Core.
-            _color1 = "#9B59B6";
+            _color1 = CoreMods.SecondaryColorHex;
             _color2 = "#8E44AD";
             _textColor = "#FFFFFF";
             _showBorder = false;
@@ -262,14 +269,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void BtnTest_Click()
         {
-            // ponytail: needs Services.FloatingText (a Win32 layered window, bucket E) and
-            // App.Settings; wired when the overlay has a per-platform implementation.
+            // ponytail: needs ConditioningControlPanel/Services/Video/VideoService.cs:8130
+            // (internal class FloatingText : IAttentionTarget - a Win32 layered
+            // click-through window, bucket E) and System.Windows.Forms.Screen.PrimaryScreen. The
+            // settings half is ready - WPF applies these seven fields, spawns the target on the
+            // primary screen and restores the old values in a finally - so this is one window
+            // reimplementation away, not a settings problem.
         }
 
         private void BtnSave_Click()
         {
-            // ponytail: needs App.Settings.Current.Attention* to persist; wired when settings move
-            // to Core. The chosen values live in the fields above until then.
+            // Save to settings. No CoreSettings.Save() here on purpose: WPF's BtnSave_Click writes
+            // the fields and closes, and neither caller (MainWindow.BtnAttentionStyle_Click,
+            // VideoFeatureControl.BtnAttentionStyle_Click) saves either - the values ride out with
+            // the next write of the settings file, and adding a flush would not be the same app.
+            var settings = CoreSettings.Current;
+            settings.AttentionColor1 = _color1;
+            settings.AttentionColor2 = _color2;
+            settings.AttentionTextColor = _textColor;
+            settings.AttentionBorderColor = _borderColor;
+            settings.AttentionShowBorder = _showBorder;
+            settings.AttentionFloatingText = _floatingText;
+            settings.AttentionFont = _font;
+
             Close(true);
         }
     }

--- a/CCP.Avalonia/Views/Dialogs/CompanionPromptEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CompanionPromptEditorDialog.axaml.cs
@@ -1,12 +1,15 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services.Moderation;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -17,11 +20,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// PORTED from ConditioningControlPanel/Dialogs/CompanionPromptEditorDialog.xaml.cs. Deviations:
     ///  - <c>NullOrEmptyToCollapsedConverter</c> is gone: the XAML uses Avalonia's built-in
     ///    <c>StringConverters.IsNotNullOrEmpty</c> on <c>IsVisible</c>.
-    ///  - Settings come from <c>CompanionPromptSettings.GetDefaults()</c> in Core; persisting them,
-    ///    the community-prompt lookup and the moderation log are stubs (ponytail comments below).
+    ///  - Settings load and save for real against <see cref="CoreSettings"/>, knowledge links
+    ///    included; the community-prompt lookup and the moderation log are still stubs.
     ///  - <c>PromptValidator</c> lives in Core and runs for real on Save.
-    ///  - The three MessageBox confirms have no Avalonia equivalent and no package may be added;
-    ///    they are stubbed and noted, so Cancel/Reset All/close act without asking.
+    ///  - <c>MessageBox.Show</c> becomes this head's <see cref="MessageDialog"/>, which is awaited,
+    ///    so Remove / Reset All / Cancel are async void. Its two-button shape covers the Yes/No
+    ///    confirms; the X button's three-way Save/Discard/Cancel prompt is not portable and is
+    ///    noted at the bottom of this file instead.
     ///  - <c>DialogResult = x; Close()</c> -> <c>Close(x)</c>.
     /// </summary>
     public partial class CompanionPromptEditorDialog : Window
@@ -83,25 +88,30 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private void ApplyPolicyBannerState()
         {
-            // ponytail: needs App.Settings.Current.CompanionPrompt.PromptEditorDisclaimerAcknowledged,
-            // wired when settings move to Core. The default is "not yet acknowledged".
-            var acked = _policyAcked;
+            var acked = CoreSettings.Current.CompanionPrompt.PromptEditorDisclaimerAcknowledged;
             this.FindControl<Border>("PolicyBannerFull")!.IsVisible = !acked;
             this.FindControl<Border>("PolicyBannerSlim")!.IsVisible = acked;
         }
 
-        private bool _policyAcked;
-
         private void BtnPolicyGotIt_Click()
         {
-            _policyAcked = true; // ponytail: persisted via App.Settings.Save() once settings move to Core
+            CoreSettings.Current.CompanionPrompt.PromptEditorDisclaimerAcknowledged = true;
+            CoreSettings.Save();
             ApplyPolicyBannerState();
         }
 
-        private void BtnPolicyRead_Click()
+        /// <summary>WPF used Process.Start with UseShellExecute; Avalonia's Launcher is the
+        /// cross-platform equivalent and needs no shell assumptions.</summary>
+        private async void BtnPolicyRead_Click()
         {
-            // ponytail: needs a launcher for https://app.cclabs.app/policies/prohibited-content;
-            // Process.Start(UseShellExecute) is per-platform and belongs behind a Core interface.
+            try
+            {
+                await Launcher.LaunchUriAsync(new Uri("https://app.cclabs.app/policies/prohibited-content"));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "CompanionPromptEditorDialog: failed to open policy URL");
+            }
         }
 
         /// <summary>
@@ -110,10 +120,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private void LoadKnowledgeLinks()
         {
             _knowledgeLinks.Clear();
-            // ponytail: needs App.Settings.Current.GlobalKnowledgeBaseLinks; wired when settings
-            // move to Core. One sample row so the template renders.
-            _knowledgeLinks.Add(new KnowledgeBaseLink { Title = "Sample link", Url = "https://example.com", Description = "Placeholder entry" });
+            foreach (var link in CoreSettings.Current.GlobalKnowledgeBaseLinks)
+            {
+                _knowledgeLinks.Add(link);
+            }
             _lstKnowledgeLinks.ItemsSource = _knowledgeLinks;
+        }
+
+        /// <summary>
+        /// Saves global knowledge base links from the list.
+        /// </summary>
+        private void SaveKnowledgeLinks()
+        {
+            var links = CoreSettings.Current.GlobalKnowledgeBaseLinks;
+            links.Clear();
+            foreach (var link in _knowledgeLinks)
+            {
+                links.Add(link);
+            }
         }
 
         /// <summary>
@@ -122,26 +146,47 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private void UpdateActivePromptDisplay()
         {
             var txt = this.FindControl<TextBlock>("TxtActivePromptName")!;
-            // ponytail: needs App.Settings.Current.ActiveCommunityPromptId + App.CommunityPrompts;
-            // wired when they move to Core. Until then only the "custom" and "default" branches exist.
-            if (_chkUseCustom.IsChecked == true)
+            var settings = CoreSettings.Current;
+
+            if (!string.IsNullOrEmpty(settings.ActiveCommunityPromptId))
+            {
+                // ponytail: a community prompt IS active, but its display name needs
+                // ConditioningControlPanel/Services/Companion/CommunityPromptService.GetInstalledPrompt,
+                // which is head-only. Painting "unknown prompt" here would be an invented answer -
+                // WPF says that only when the lookup MISSES - so the badge keeps its XAML default
+                // until the service crosses.
+                return;
+            }
+
+            if (settings.CompanionPrompt.UseCustomPrompt)
             {
                 // Custom prompt is active
-                txt.Text = Loc.Get("label_custom");
-                txt.Foreground = new SolidColorBrush(Color.Parse("#FF69B4")); // App.Mods accent fallback
+                BindLoc(txt, "label_custom");
+                txt.Foreground = new SolidColorBrush(Color.Parse(CoreMods.AccentColorHex));
             }
             else
             {
                 // Default prompt
-                txt.Text = Loc.Get("label_default");
+                BindLoc(txt, "label_default");
                 txt.Foreground = new SolidColorBrush(Color.FromRgb(112, 112, 112)); // Gray
             }
         }
 
+        /// <summary>
+        /// TxtActivePromptName carries <c>{loc:Str label_default}</c> from the XAML. An assignment
+        /// to .Text sits UNDER that binding and is undone on the next language change, so the
+        /// branch picks a key and rebinds - the same binding {loc:Str} would have produced.
+        /// </summary>
+        private static void BindLoc(TextBlock target, string key)
+            => target.Bind(TextBlock.TextProperty, new Binding($"[{key}]")
+            {
+                Source = LocalizationManager.Instance,
+                Mode = BindingMode.OneWay,
+            });
+
         private void LoadCurrentSettings()
         {
-            // ponytail: needs App.Settings.Current.CompanionPrompt; wired when settings move to Core.
-            var settings = new CompanionPromptSettings();
+            var settings = CoreSettings.Current.CompanionPrompt;
 
             _chkUseCustom.IsChecked = settings.UseCustomPrompt;
 
@@ -165,9 +210,33 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void SaveSettings()
         {
-            // ponytail: needs App.Settings (persist, CommunityPromptService.ClearCustomPromptOverride,
-            // Save) and App.Logger; wired when settings move to Core.
+            var settings = CoreSettings.Current.CompanionPrompt;
+            settings.UseCustomPrompt = _chkUseCustom.IsChecked == true;
+            // Provider/model/host/effect-permission settings are owned by the AI Brain
+            // panel; we only persist personality-related fields here.
+            // Coalesced: WPF's TextBox.Text is never null, Avalonia's is null when empty, and
+            // the settings model's fields are non-nullable strings.
+            settings.Personality = _txtPersonality.Text ?? string.Empty;
+            settings.ExplicitReaction = _txtExplicitReaction.Text ?? string.Empty;
+            settings.SlutModePersonality = _txtSlutMode.Text ?? string.Empty;
+            settings.KnowledgeBase = _txtKnowledgeBase.Text ?? string.Empty;
+            settings.ContextReactions = _txtContextReactions.Text ?? string.Empty;
+            settings.OutputRules = _txtOutputRules.Text ?? string.Empty;
+
+            // ponytail: un-ticking "use custom prompt" must also drop the community id, through
+            // ConditioningControlPanel/Services/Companion/CommunityPromptService.ClearCustomPromptOverride,
+            // or the Companion tab keeps reporting "Custom: <name>" off an override that is no
+            // longer on the wire. That service is head-only. Its body is NOT inlined here on
+            // purpose: one shared call is what keeps the two call sites from drifting apart.
+
+            // Save global knowledge base links
+            SaveKnowledgeLinks();
+
+            CoreSettings.Save();
             _hasUnsavedChanges = false;
+
+            Log.Information("Companion prompt settings saved. UseCustomPrompt={UseCustom}, GlobalLinks={LinkCount}",
+                settings.UseCustomPrompt, _knowledgeLinks.Count);
         }
 
         private void UpdateEnabledState()
@@ -195,20 +264,27 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             }
         }
 
-        private void RemoveKnowledgeLink_Click()
+        private async void RemoveKnowledgeLink_Click()
         {
             if (_lstKnowledgeLinks.SelectedItem is KnowledgeBaseLink link)
             {
                 _knowledgeLinks.Remove(link);
                 _hasUnsavedChanges = true;
             }
-            // ponytail: WPF showed MessageBox(msg_please_select_a_link_to_remove) otherwise; no
-            // MessageBox stand-in exists in this head yet.
+            else
+            {
+                await MessageDialog.ShowAsync(this, "No Selection", Loc.Get("msg_please_select_a_link_to_remove"));
+            }
         }
 
-        private void ResetAll_Click()
+        private async void ResetAll_Click()
         {
-            // ponytail: WPF confirmed with a Yes/No MessageBox first; stubbed, see class summary.
+            // These two strings are hardcoded English in the WPF original, not loc keys; ported as
+            // literals rather than inventing key names no catalogue carries.
+            var confirmed = await MessageDialog.ConfirmAsync(this, "Reset All Prompts",
+                "Reset all prompts to their default values?\n\nThis cannot be undone.");
+            if (!confirmed) return;
+
             _txtPersonality.Text = _defaults.Personality;
             _txtExplicitReaction.Text = _defaults.ExplicitReaction;
             _txtSlutMode.Text = _defaults.SlutModePersonality;
@@ -266,8 +342,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                     box.BorderThickness = new Thickness(2);
                     ToolTip.SetTip(box, Loc.GetF("prompt_validator_warning", result.MatchedPatterns.Count));
                     flaggedNames.Add(fieldName);
-                    // ponytail: App.ModerationLog?.RecordEdit(fieldName, count, "companion_prompt"),
-                    // wired when the moderation log moves to Core.
+                    // ponytail: App.ModerationLog?.RecordEdit(fieldName, count, "companion_prompt").
+                    // The CLASS is already in Core (CCP.Core/Services/Moderation/ModerationLog.cs);
+                    // what is missing is a seam for the app's ONE instance, which today lives on
+                    // ConditioningControlPanel/App.xaml.cs:610. Constructing a second one here
+                    // would give it a different per-launch ModerationSession hash and split the
+                    // CCBill record file in two, so it waits for a CoreModeration provider.
                 }
             }
 
@@ -280,20 +360,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             {
                 this.FindControl<TextBlock>("TxtValidatorBanner")!.Text = Loc.GetF("prompt_validator_banner", flaggedNames.Count);
                 banner.IsVisible = true;
+                Log.Information("PromptValidator flagged {Count} field(s) in CompanionPromptEditorDialog",
+                    flaggedNames.Count);
             }
         }
 
-        private void BtnCancel_Click()
+        private async void BtnCancel_Click()
         {
             if (_hasUnsavedChanges)
             {
-                // ponytail: WPF asked "discard unsaved changes?" here; stubbed, see class summary.
+                var discard = await MessageDialog.ConfirmAsync(this, "Unsaved Changes",
+                    "You have unsaved changes. Discard them?");
+                if (!discard) return;
             }
+
             Close(false);
         }
 
-        // ponytail: WPF's OnClosing prompted Save/Discard/Cancel on the X button with unsaved
-        // changes; without a MessageBox stand-in the X simply closes. _hasUnsavedChanges is kept so
-        // the prompt drops in unchanged.
+        // ponytail: WPF's OnClosing prompts Save / Discard / CANCEL-THE-CLOSE on the X button when
+        // there are unsaved changes. MessageDialog (CCP.Avalonia/Views/Dialogs/MessageDialog.axaml.cs)
+        // is two-button, so the three-way answer cannot be expressed and the X still just closes.
+        // Whoever adds a three-button dialog also needs two things Avalonia forces: Closing is
+        // SYNCHRONOUS, so the shape is `e.Cancel = true; await ...; Close()` behind a re-entry
+        // flag; and WPF's `!DialogResult.HasValue` guard has no twin, because Close(x) raises
+        // Closing too - it needs a "closed by a button" flag set in BtnSave_Click/BtnCancel_Click.
     }
 }


### PR DESCRIPTION
Three Companion editors get their logic back. Most of what their notes said was
missing had already landed: AppSettings' Attention* fields, CompanionPrompt,
GlobalKnowledgeBaseLinks and ActiveCommunityPromptId are all in Core, and this
head already ships a MessageDialog and a ColorPickerDialog, so the "no MessageBox
stand-in" and "no colour picker" notes were stale rather than blocked.

CompanionPromptEditorDialog: loads and saves the whole personality form and the
global knowledge-base links through CoreSettings, with WPF's save log line. The
content-policy banner reads and writes PromptEditorDisclaimerAcknowledged instead
of a per-instance bool, so "Got it" survives a reopen; "Read content policy" opens
the URL via Avalonia's Launcher. Reset All, Cancel-with-unsaved-changes and the
empty Remove selection all ask through MessageDialog, which is awaited, so those
three handlers are async void. The active-prompt badge follows WPF's three-way
shape and paints with CoreMods.AccentColorHex; because that TextBlock carries
{loc:Str}, the custom/default branches rebind the key rather than assigning .Text,
which a language change would have undone. PromptValidator's banner regains its
Information log line.

AttentionTargetEditorDialog: the seven Attention* fields load in the constructor
and are written back on Save (no explicit flush, matching WPF - neither caller
saves either). The four colour buttons open ColorPickerDialog and take a six-digit
hex; a ref parameter cannot cross an await, so PickInto became Pick(current,
assign). Purple Classic takes CoreMods.SecondaryColorHex.

CompanionHeroCard: subscribes to CoreMods.ModChanged on Loaded and releases it on
Unloaded, behind the re-parent guard the WPF original uses, and marshals the
callback onto the UI thread. This is the only signal the Companion room gets on a
mod switch, so the hook is what a portable hero viewmodel will hang off; its
handler is still thin until one exists.

Still blocked:
 - CommunityPromptService.GetInstalledPrompt and .ClearCustomPromptOverride
   (ConditioningControlPanel/Services/Companion/CommunityPromptService.cs) - head-only.
 - A seam for the app's single ModerationLog instance (App.xaml.cs:610); the class
   itself is already in Core but a second instance would split the CCBill record file.
 - A three-button Save/Discard/Cancel dialog for the X-button close path;
   MessageDialog is two-button.
 - FloatingText (ConditioningControlPanel/Services/Video/VideoService.cs:8130) and
   Screen.PrimaryScreen, for Test Target.
 - CompanionHeroRuntimeVm.Sync (App.Companion, App.AvatarWindow, ctx.Navigator).
 - CentrePortrait, which needs a named ImageBrush in CompanionHeroCard.axaml - a
   file this layer does not own.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU