### PR TITLE
feat(avalonia): quiz and mantra windows warn, persist and play against Core

### DIFF
--- a/CCP.Avalonia/Views/Windows/MantraWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MantraWindow.axaml.cs
@@ -14,13 +14,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// and the whole scene warms from cold purple to hot pink as the streak climbs.
     ///
     /// PORTED from ConditioningControlPanel/Windows/MantraWindow.xaml.cs. Deviations:
-    ///  - <c>App.Mantra</c> (MantraService), <c>App.Audio</c> and <c>App.Settings</c> live in the
-    ///    WPF head, so the session itself is stubbed: no completion counting, no streak events, no
-    ///    NAudio drone or tones, no session-complete overlay trigger. What is ported verbatim is
-    ///    everything that only touches the view — the per-character highlight system, the streak
-    ///    intensity ramp, the colour lerp and the float drift — driven here by
-    ///    <see cref="SampleMantra"/> and <see cref="SampleStreak"/> so the render shows the live
-    ///    state rather than a cold empty one.
+    ///  - <c>App.Mantra</c> (MantraService) is pinned to the WPF head by App.Progression /
+    ///    App.Quests, so the SESSION half is still stubbed: no completion counting, no streak
+    ///    events, no NAudio drone or tones, no session-complete trigger. The VIEW half is ported
+    ///    verbatim — the per-character highlight system, the streak intensity ramp, the colour
+    ///    lerp, the float drift and the #734 anti-cheat guard — and its text and rep target now
+    ///    come from <c>CoreSettings.Current</c> (MantraPool, MantraDefaultCount) rather than an
+    ///    invented English line; <see cref="SampleStreak"/> still drives the warm palette so the
+    ///    render shows a live scene rather than a cold empty one.
     ///  - Five WPF Storyboards (pulse, shake, letter-pulse, wrong-shake, glow) are dropped:
     ///    Avalonia has no Storyboard and every one of them is begun from a service event that is
     ///    stubbed above. ponytail: re-add as Avalonia Animations when MantraService reaches Core.
@@ -33,11 +34,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// </summary>
     public partial class MantraWindow : Window
     {
-        /// <summary>ponytail: needs MantraService.CurrentMantra / TargetCount, wired when the
-        /// service moves to Core. Placeholder so the letter highlighting has something to draw.</summary>
+        /// <summary>Last-resort line for the letter highlighting when the user's pool is empty.
+        /// ponytail: the live line needs MantraService.CurrentMantra from
+        /// ConditioningControlPanel/Services/MantraService.cs — it is pinned to the head by
+        /// App.Progression / App.Quests, so no Core seam exists for it yet.</summary>
         private const string SampleMantra = "good girls sink deeper every time";
         private const int SampleStreak = 7;
-        private const int SampleTarget = 10;
 
         private DispatcherTimer? _floatTimer;
         private DateTime _startTime;
@@ -100,13 +102,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             _startTime = DateTime.UtcNow;
 
-            // ponytail: needs MantraService (StreakChanged / StreakBroken / MantraCompleted /
-            // SessionComplete), the NAudio drone and the tone player; all wired when the service
-            // moves to Core.
+            // ponytail: subscribing StreakChanged / StreakBroken / MantraCompleted /
+            // SessionComplete needs ConditioningControlPanel/Services/MantraService.cs; the drone
+            // and the streak tones need NAudio's SignalGenerator + WaveOutEvent, which CoreAudio
+            // deliberately does not cover (PlayOneShot takes a file path, not a generator).
 
             // Build initial letter display
-            BuildMantraRuns(SampleMantra);
-            _txtTarget.Text = $"/{SampleTarget}";
+            var mantra = CurrentMantra ?? "";
+            BuildMantraRuns(mantra);
+            // ponytail: the live figure is MantraService.TargetCount, which the caller sets via
+            // StartSession(reps). MantraDefaultCount is the settings-backed default that caller
+            // reads, so it is the honest stand-in rather than an invented number.
+            _txtTarget.Text = $"/{CoreSettings.Current.MantraDefaultCount}";
             _txtCompletions.Text = "0";
             _txtStreak.Text = "0";
             _txtBestStreak.Text = "0";
@@ -118,7 +125,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // Placeholder session state, so the highlight ramp and the warm palette both draw.
             OnStreakChanged(SampleStreak);
-            UpdateHighlights(SampleMantra.Substring(0, 11));
+            UpdateHighlights(mantra[..Math.Min(11, mantra.Length)]);
 
             _txtInput.Focus();
         }
@@ -213,8 +220,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         #endregion
 
-        /// <summary>ponytail: needs MantraService.CurrentMantra, wired when it moves to Core.</summary>
-        private static string? CurrentMantra => SampleMantra;
+        /// <summary>
+        /// The line on screen. The user's own <c>MantraPool</c> is in Core, so the window shows a
+        /// real mantra rather than an invented English one; the pool's FIRST entry is deliberate —
+        /// picking at random here would be a second copy of <c>MantraService.NextMantra</c>'s
+        /// no-immediate-repeat rotation, which is the drift the service exists to prevent.
+        /// ponytail: needs MantraService.CurrentMantra for the rotating line.
+        /// </summary>
+        private static string? CurrentMantra
+        {
+            get
+            {
+                var pool = CoreSettings.Current.MantraPool;
+                return pool is { Count: > 0 } && !string.IsNullOrWhiteSpace(pool[0])
+                    ? pool[0]
+                    : SampleMantra;
+            }
+        }
 
         private void FloatTimer_Tick(object? sender, EventArgs e)
         {
@@ -222,7 +244,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             if (_mantraTranslate != null)
                 _mantraTranslate.Y = Math.Sin(elapsed * 0.5) * 6;
 
-            // ponytail: the drone gain ramp lived here; needs NAudio plus App.Settings.
+            // ponytail: the drone gain ramp lived here. Needs NAudio's SignalGenerator (the tone is
+            // synthesised, not a file), which CoreAudio.PlayOneShot cannot express; its volume knob
+            // CoreSettings.Current.MantraDroneVolume is already in Core and waits on the generator.
         }
 
         private void TxtInput_TextChanged()
@@ -236,18 +260,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             int matchCount = UpdateHighlights(input);
 
             // Check completion: all characters match and input length equals mantra length.
-            // ponytail: needs MantraService.TryCompleteMantra to count the rep and roll the next
-            // mantra; until then a finished line just stays lit.
+            // ponytail: needs MantraService.TryCompleteMantra from
+            // ConditioningControlPanel/Services/MantraService.cs to count the rep, clear the box
+            // and roll the next mantra; until then a finished line just stays lit. The
+            // _updatingInput re-entry guard belongs with it — it only exists to cover that clear.
             _ = matchCount;
         }
 
         private void TxtInput_PreviewKeyDown(object? sender, KeyEventArgs e)
         {
-            // WPF called LockCardWindow.IsBlockedInputGesture(e.Key, Keyboard.Modifiers) — shared
-            // deliberately so the two anti-cheat surfaces can't drift apart again (#734).
-            // ponytail: needs LockCardWindow, wired when that view is ported; inlining the gesture
-            // list here would recreate exactly the drift #734 removed.
-            _ = e;
+            // Same gesture set as the lock card (paste/copy/cut/select-all/undo/redo plus the
+            // legacy Shift+Insert / Ctrl+Insert / Shift+Delete clipboard gestures) — shared with
+            // LockCardWindow deliberately so the two anti-cheat surfaces can't drift apart
+            // again (#734). WPF read Keyboard.Modifiers; Avalonia carries them on the args.
+            if (LockCardWindow.IsBlockedInputGesture(e.Key, e.KeyModifiers))
+            {
+                e.Handled = true;
+            }
         }
 
         private void OnStreakChanged(int streak)
@@ -360,8 +389,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             _floatTimer?.Stop();
 
-            // ponytail: unsubscribing the four MantraService events and ending the session go here,
-            // wired when the service moves to Core.
+            // ponytail: unsubscribing the four MantraService events and MantraService.EndSession()
+            // go here, plus StopDrone(); all need ConditioningControlPanel/Services/MantraService.cs
+            // and NAudio respectively.
 
             Close();
         }

--- a/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -7,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Threading;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
@@ -59,8 +61,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             IsOpen = true;
 
-            // ponytail: needs App.AvatarWindow (SetMuteAvatar). WPF muted the avatar for the whole
-            // quiz so her z-order work could not cover this window, and restored it in OnClosed.
+            // ponytail: needs AvatarWindow.IsMuted / SetMuteAvatar from
+            // ConditioningControlPanel/Windows/AvatarWindow.xaml.cs (head-side). WPF muted the
+            // avatar for the whole quiz so her z-order work could not cover this window, and
+            // restored it in OnClosed.
 
             AvaloniaXamlLoader.Load(this);
             _question = question;
@@ -143,8 +147,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // Award XP
             if (!_isTest)
             {
-                // ponytail: needs App.Progression.AddXP(25, XPSource.Other), wired when the
-                // progression service moves to Core.
+                // ponytail: needs ProgressionService.AddXP(25, XPSource.Other) from
+                // ConditioningControlPanel/Services/ProgressionService.cs — still head-side, and
+                // there is no CoreProgression seam yet.
             }
 
             // Show affirmation
@@ -165,14 +170,39 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // the second call hits the mismatch branch and clears whatever interaction the
             // first Complete just dequeued (same #462 class as the lock-card fix).
             _answered = true;
-            // ponytail: needs App.InteractionQueue.Complete(InteractionType.PopQuiz).
+            // ponytail: needs InteractionQueueService.Complete(InteractionType.PopQuiz) from
+            // ConditioningControlPanel/Services/InteractionQueueService.cs — still head-side.
             Close();
         }
 
-        /// <summary>ponytail: needs App.Audio (PlayOneShot), App.Settings.MasterVolume and the
-        /// Resources/sounds chimes. The whole body of the WPF original was those three.</summary>
+        /// <summary>
+        /// The WPF body verbatim against the seams: <c>App.Settings.Current</c> is
+        /// <see cref="CoreSettings.Current"/>, <c>App.Audio</c> is <see cref="CoreAudio"/> and
+        /// <c>App.Logger</c> is Serilog's static <c>Log</c>. Silent on this head for the two
+        /// reasons that are both the WPF no-op branch: the chimes are Content in the WPF head and
+        /// are not laid down beside CCP.Avalonia, so the probe misses; and nothing seeds
+        /// <c>CoreAudio.PlayOneShotProvider</c> yet, so the seam fires its finished callback and
+        /// returns.
+        /// </summary>
         private static void PlayChime()
         {
+            try
+            {
+                var soundsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "sounds");
+                var files = new[] { "chime1.mp3", "chime2.mp3", "chime3.mp3" };
+                var file = files[_random.Next(files.Length)];
+                var path = Path.Combine(soundsPath, file);
+                if (!File.Exists(path)) return;
+
+                var master = CoreSettings.Current.MasterVolume / 100f;
+                var volume = (float)Math.Pow(master * 0.5f, 1.5);
+
+                CoreAudio.PlayOneShot(path, volume, "popquiz-chime");
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("PopQuiz chime failed: {Error}", ex.Message);
+            }
         }
 
         // Hover effects
@@ -236,9 +266,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             IsOpen = false;
 
-            // ponytail: restoring App.AvatarWindow's mute state, and the safety-net
-            // `if (!_answered) App.InteractionQueue.Complete(...)`, both go here, wired with the
-            // services above. _answered is deliberately NOT set here — that flag is what tells the
+            // ponytail: restoring the avatar mute state needs AvatarWindow.IsMuted /
+            // SetMuteAvatar from ConditioningControlPanel/Windows/AvatarWindow.xaml.cs, and the
+            // safety net `if (!_answered) InteractionQueue.Complete(...)` needs
+            // ConditioningControlPanel/Services/InteractionQueueService.cs. Both head-side. _answered is deliberately NOT set here — that flag is what tells the
             // safety net an unanswered quiz still owes a Complete.
 
             base.OnClosed(e);

--- a/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Services.Moderation;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
@@ -23,9 +26,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - <c>QuizService</c> is not in Core either, so the template dropdown, the AI preview, the
     ///    built-in name-collision check and Delete are stubs. Each carries a ponytail comment.
     ///  - <c>PromptValidator</c> IS in Core, so <see cref="RunPromptValidation"/> runs for real.
-    ///  - The four <c>MessageBox.Show</c> calls have no Avalonia equivalent and no package may be
-    ///    added; they become ponytail comments, so the empty-field guards still block the save but
-    ///    do so silently (CompanionPromptEditorDialog precedent).
+    ///  - The <c>MessageBox.Show</c> calls are this head's <see cref="MessageDialog"/>, which is
+    ///    async, so Save and Delete are <c>async void</c> handlers. Only the name-collision warning
+    ///    is missing, because the check behind it needs QuizService.
     ///  - <c>DialogResult = x; Close()</c> -> <c>Close(x)</c>.
     ///  - The public ctor loses its <c>= null</c> default: with a parameterless render ctor beside
     ///    it, <c>new QuizCategoryEditorWindow()</c> would be ambiguous (CS0121).
@@ -38,7 +41,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     {
         private readonly QuizCategoryDefinition? _existing;
         private string _selectedColor = "#FF69B4";
-        private bool _policyAcked;
 
         /// <summary>Row i holds { name, min, max, description } for archetype i.</summary>
         private readonly List<TextBox[]> _arch = new();
@@ -270,8 +272,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             var templateId = item.Tag?.ToString();
             if (string.IsNullOrEmpty(templateId)) return;
 
-            // ponytail: needs QuizService.GetBuiltInCategories()/FindCategory() for the real
-            // category name and its archetype table; wired when the quiz service moves to Core.
+            // ponytail: needs QuizService.GetBuiltInCategories() / FindCategory() from
+            // ConditioningControlPanel/Services/Quiz/QuizService.cs for the real category name and
+            // its archetype table - still head-side.
             // The skeleton below is the WPF original's, minus the RESULT ARCHETYPES block it filled
             // from the built-in definition.
             _txtPrompt.Text = GetBuiltInPromptText(templateId);
@@ -316,8 +319,9 @@ Do NOT include any other text before or after the question format. Just the ques
                 return;
             }
 
-            // ponytail: needs QuizService.StartQuizAsync to round-trip the prompt through the AI
-            // provider; wired when the quiz service moves to Core. Until then the panel opens with
+            // ponytail: needs QuizService.StartQuizAsync from
+            // ConditioningControlPanel/Services/Quiz/QuizService.cs to round-trip the prompt
+            // through the AI provider - still head-side. Until then the panel opens with
             // the same "couldn't generate" copy the WPF original shows on a null question, so the
             // busy/idle hint swap and ShowPreviewResult stay exercised.
             _txtPreviewHint.Text = Loc.Get("label_generating");
@@ -334,26 +338,43 @@ Do NOT include any other text before or after the question format. Just the ques
             this.FindControl<Border>("PreviewResultPanel")!.IsVisible = true;
         }
 
-        private void BtnSave_Click(Border _)
+        /// <summary>
+        /// WPF's four <c>MessageBox.Show</c> warnings are this head's <see cref="MessageDialog"/>,
+        /// which makes the handler async — hence <c>async void</c>, which is what an event handler
+        /// is allowed to be and what <see cref="WireActionBorder"/> binds to.
+        /// </summary>
+        private async void BtnSave_Click(Border _)
         {
             var name = (_txtName.Text ?? "").Trim();
-            // ponytail: WPF showed MessageBox(msg_please_enter_a_category_name) here; no Avalonia
-            // equivalent and no package may be added, so the guard blocks silently.
-            if (string.IsNullOrWhiteSpace(name)) return;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                await MessageDialog.ShowAsync(this, "Missing Name",
+                    Loc.Get("msg_please_enter_a_category_name"));
+                return;
+            }
 
             if (name.Length > 30) name = name[..30];
 
             var prompt = (_txtPrompt.Text ?? "").Trim();
-            // ponytail: WPF showed MessageBox(msg_please_enter_a_system_prompt_for_the_ai) here.
-            if (string.IsNullOrWhiteSpace(prompt)) return;
+            if (string.IsNullOrWhiteSpace(prompt))
+            {
+                await MessageDialog.ShowAsync(this, "Missing Prompt",
+                    Loc.Get("msg_please_enter_a_system_prompt_for_the_ai"));
+                return;
+            }
 
             var archetypes = CollectArchetypes();
-            // ponytail: WPF showed MessageBox(msg_please_define_at_least_2_archetypes) here.
-            if (archetypes.Count < 2) return;
+            if (archetypes.Count < 2)
+            {
+                await MessageDialog.ShowAsync(this, "Need Archetypes",
+                    Loc.Get("msg_please_define_at_least_2_archetypes"));
+                return;
+            }
 
-            // ponytail: needs QuizService.GetBuiltInCategories() to reject a name that collides with
-            // a built-in one (msg_this_name_conflicts_with_a_built_in_category); wired when the
-            // quiz service moves to Core.
+            // ponytail: the built-in name-collision guard (and its
+            // msg_this_name_conflicts_with_a_built_in_category warning) needs
+            // QuizService.GetBuiltInCategories() from
+            // ConditioningControlPanel/Services/Quiz/QuizService.cs — still head-side.
 
             // P1.3 PromptValidator: soft validation, warns but does not block save.
             RunPromptValidation(prompt);
@@ -398,17 +419,30 @@ Do NOT include any other text before or after the question format. Just the ques
             this.FindControl<TextBlock>("TxtValidatorBanner")!.Text = Loc.GetF("prompt_validator_banner", 1);
             banner.IsVisible = true;
 
-            // ponytail: App.ModerationLog?.RecordEdit("SystemPromptTemplate", count, "quiz_category")
-            // and the matching App.Logger line, wired when the moderation log moves to Core.
+            Log.Information(
+                "PromptValidator flagged QuizCategoryEditorWindow system prompt ({Count} matches)",
+                result.MatchedPatterns.Count);
+
+            // ponytail: needs the app-wide ModerationLog INSTANCE (App.ModerationLog) for
+            // RecordEdit("SystemPromptTemplate", count, "quiz_category"). The class itself is in
+            // Core (CCP.Core/Services/Moderation/ModerationLog.cs) but it is instance-scoped over a
+            // ModerationSession and an append-only file; constructing a second one here would give
+            // the process two writers of moderation.log. Needs a CoreModeration seam.
         }
 
-        private void BtnDelete_Click(Border _)
+        private async void BtnDelete_Click(Border _)
         {
             if (_existing == null) return;
 
-            // ponytail: WPF confirmed with a Yes/No MessageBox and then called
-            // QuizService.DeleteCustomCategory(_existing.Id); both are stubbed, so the dialog just
-            // closes with a null Result - which is already the "deleted" signal the caller reads.
+            // WPF's Yes/No MessageBox, verbatim - the copy is hardcoded English there too.
+            var confirmed = await MessageDialog.ConfirmAsync(this, "Delete Category",
+                $"Delete the \"{_existing.Name}\" category? This cannot be undone.");
+            if (!confirmed) return;
+
+            // ponytail: needs QuizService.DeleteCustomCategory(_existing.Id) from
+            // ConditioningControlPanel/Services/Quiz/QuizService.cs to remove it from the stored
+            // custom-category file - still head-side. The null Result below is already the
+            // "deleted" signal the caller reads, so the dialog contract itself is complete.
             Result = null;
             Close(true);
         }
@@ -418,22 +452,38 @@ Do NOT include any other text before or after the question format. Just the ques
         /// </summary>
         private void ApplyPolicyBannerState()
         {
-            // ponytail: needs App.Settings.Current.CompanionPrompt.PromptEditorDisclaimerAcknowledged,
-            // wired when settings move to Core. The default is "not yet acknowledged".
-            this.FindControl<Border>("PolicyBannerFull")!.IsVisible = !_policyAcked;
-            this.FindControl<Border>("PolicyBannerSlim")!.IsVisible = _policyAcked;
+            var acked = CoreSettings.Current.CompanionPrompt?.PromptEditorDisclaimerAcknowledged == true;
+            this.FindControl<Border>("PolicyBannerFull")!.IsVisible = !acked;
+            this.FindControl<Border>("PolicyBannerSlim")!.IsVisible = acked;
         }
 
         private void BtnPolicyGotIt_Click()
         {
-            _policyAcked = true; // ponytail: persisted via App.Settings.Save() once settings move to Core
+            var settings = CoreSettings.Current.CompanionPrompt;
+            if (settings != null)
+            {
+                settings.PromptEditorDisclaimerAcknowledged = true;
+                CoreSettings.Save();
+            }
             ApplyPolicyBannerState();
         }
 
+        /// <summary>
+        /// WPF's <c>Process.Start(UseShellExecute)</c> verbatim: on Linux that hands the URL to
+        /// xdg-open, which is the same "ask the platform" contract, so there is nothing to put
+        /// behind an interface (the SeasonRecapWindow precedent).
+        /// </summary>
         private void BtnPolicyRead_Click()
         {
-            // ponytail: needs a launcher for https://app.cclabs.app/policies/prohibited-content;
-            // Process.Start(UseShellExecute) is per-platform and belongs behind a Core interface.
+            try
+            {
+                Process.Start(new ProcessStartInfo(
+                    "https://app.cclabs.app/policies/prohibited-content") { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "QuizCategoryEditorWindow: failed to open policy URL");
+            }
         }
 
         private static QuizCategoryDefinition SampleCategory() => new()


### PR DESCRIPTION
This is the VIEW half of the three session-activity windows: settings reads and
writes, the answer chime, the anti-cheat guard, the policy banner and the four
warning dialogs. The running activities themselves - the pop quiz's XP and
interaction queue, the mantra session engine and its drone - are NOT wired, so
nothing here yet counts a rep or awards anything. See "Still blocked" below.

PopQuizWindow: PlayChime is the WPF body verbatim against the seams -
CoreSettings.Current.MasterVolume for the master level, the same
pow(master*0.5, 1.5) curve, CoreAudio.PlayOneShot with the "popquiz-chime" tag,
and Serilog's static Log for the debug line. It is silent on this head for the
two reasons that are the WPF no-op branch: no chime is laid down beside the
binary, and nothing seeds CoreAudio.PlayOneShotProvider - the seam fires
onFinished, so the answer -> affirmation -> auto-dismiss sequence still runs.

MantraWindow: the #734 anti-cheat guard is restored. LockCardWindow.
IsBlockedInputGesture already exists on this head, so the TextBox's tunnelled
KeyDown swallows the same paste/copy/cut/select-all/undo/redo and legacy
clipboard gestures as the lock card, shared rather than inlined so the two
surfaces cannot drift apart again. The window also stops inventing its content:
the line comes from CoreSettings.Current.MantraPool and the rep target from
MantraDefaultCount, which is the figure the WPF caller passes to StartSession.
The pool's FIRST entry is deliberate - picking at random here would be a second
copy of MantraService.NextMantra's no-immediate-repeat rotation.

QuizCategoryEditorWindow: the CCBill policy banner is live - it reads
CompanionPrompt.PromptEditorDisclaimerAcknowledged from Core and "Got it"
persists it through CoreSettings.Save(), so the slim banner survives a restart.
"Read content policy" opens the URL through Process.Start(UseShellExecute),
which is xdg-open on Linux. The four MessageBox.Show warnings were noted as
having no Avalonia equivalent; that note was stale - this head has
Views/Dialogs/MessageDialog, so the three empty-field guards warn instead of
blocking silently and Delete asks for confirmation again. Save and Delete are
async void handlers as a result. PromptValidator's Serilog line is restored;
only its ModerationLog write is still missing.

Still blocked:
  ProgressionService.AddXP / XPSource.Other      (ConditioningControlPanel/Services/ProgressionService.cs)
  InteractionQueueService.Complete               (ConditioningControlPanel/Services/InteractionQueueService.cs)
  AvatarWindow.IsMuted / SetMuteAvatar           (ConditioningControlPanel/Windows/AvatarWindow.xaml.cs)
  App.MainWindowRef                              (the self-close watchdog)
  MantraService (CurrentMantra, TargetCount, TryCompleteMantra, BreakStreak,
    EndSession and the four events)              (ConditioningControlPanel/Services/MantraService.cs)
    - pinned to the head by App.Progression / App.Quests, no Core seam exists
  NAudio SignalGenerator + WaveOutEvent          (the mantra drone and the streak/completion tones;
    CoreAudio.PlayOneShot takes a file path, not a generator, so it cannot express them)
  QuizService.GetBuiltInCategories / FindCategory / StartQuizAsync /
    DeleteCustomCategory                         (ConditioningControlPanel/Services/Quiz/QuizService.cs)
  App.ModerationLog (the app-wide instance)      (the class is already in CCP.Core/Services/Moderation/
    ModerationLog.cs, but it is instance-scoped over an append-only file - a second
    instance here would give the process two writers. Needs a CoreModeration seam.)

Verified: core-guards, CCP.Core and CCP.Avalonia both build with 0 errors,
--smoke passes, and all three views render headless with real strings.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU