### PR TITLE
feat(avalonia): audio layers, tube fit and the mercy card persist for real

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -6,14 +7,16 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
     /// <summary>
     /// "Tube Fit" editor — a WYSIWYG preview of how the ACTIVE mod's avatar PNG sits inside the
     /// avatar tube, with an Attached/Detached switch and scale/offset sliders. The result is saved
-    /// as a per-mod user override (never into the mod itself) and the live tube window is
-    /// hot-refreshed.
+    /// as a per-mod user override in <see cref="AppSettings.TubeLayoutOverridesByMod"/> (never into
+    /// the mod itself) and the live tube window is hot-refreshed.
     ///
     /// The preview replicates the real tube's geometry: the tube window is a 780x1020 rect holding a
     /// Uniform Viewbox over a 780x1080 design canvas, so content renders at 1020/1080 and anything
@@ -21,12 +24,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// and the margin formulas below are copied from AvatarTubeWindow.ApplyTubeLayoutOffsets.
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/TubeFitDialog.xaml.cs. Deviations:
-    ///  - <c>App.Settings</c> / <c>App.Mods</c> / <c>App.AvatarWindow</c> / <c>App.Logger</c>,
-    ///    <c>Services.ModResourceResolver</c>, <c>Services.AvatarPortraitLoader</c> and the
-    ///    <c>ModTubeLayout</c> model all live in the WPF head, so the load / save / reset paths are
-    ///    stubs and the five working values start at their defaults. Everything between them - the
-    ///    sliders, the mode switch, the margin maths, the transforms and the readouts - is the real
-    ///    ported logic and runs.
+    ///  - <b>The whole value path is real.</b> <c>ModTubeLayout</c>,
+    ///    <c>AppSettings.TubeLayoutOverridesByMod</c>, <c>ModManifest.TubeLayout</c>,
+    ///    <c>SelectedAvatarSet</c>, <c>AvatarTubeDetached</c> and <c>BuiltInMods.LockedId</c> are
+    ///    all in Core, so load / save / reset persist for real against <see cref="CoreSettings"/>
+    ///    and <see cref="CoreMods"/>. The mod's shipped manifest layout is read through
+    ///    <c>CoreMods.InstalledMods[ActiveModId].Manifest.TubeLayout</c>, which is what
+    ///    <c>ModService.ActiveMod</c> hands back.
+    ///  - Still head-side, each with a note: <c>AvatarPortraitLoader.HasManifestForActiveMod()</c>,
+    ///    <c>ModResourceResolver.ResolveImage / .HasModOverride</c> and the tube window's
+    ///    <c>RefreshTubeLayout()</c>.
     ///  - The two <c>Image</c> elements are placeholder Borders (the head ships no Resources/ PNGs);
     ///    the avatar box is sized from <see cref="PlaceholderPixelWidth"/>/<see cref="PlaceholderPixelHeight"/>
     ///    by the same uniform-fit formula the real readout uses.
@@ -68,6 +75,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private bool _detachedMode;
         private bool _suppressSliderEvents;
 
+        private readonly string _modId;
         private readonly int _avatarSet;
         private readonly bool _portraitMode;
         private readonly string[] _poses = { "🧍", "🙋", "💃", "🧎" };
@@ -93,10 +101,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         {
             AvaloniaXamlLoader.Load(this);
 
-            // ponytail: needs App.Mods / App.Settings / Services.AvatarPortraitLoader, wired when
-            // they move to Core. Defaults are the first-run state: built-in mod, avatar set 1, no
-            // portrait manifest, attached tube.
-            _avatarSet = 1;
+            _modId = CoreMods.ActiveModId;
+            _avatarSet = Math.Max(1, CoreSettings.Current.SelectedAvatarSet);
+            // ponytail: needs AvatarPortraitLoader.HasManifestForActiveMod()
+            // (ConditioningControlPanel/Services/AvatarPortraitLoader.cs). It reads a per-mod
+            // portrait manifest off disk; no Core equivalent, so this head is always legacy-pose.
             _portraitMode = false;
 
             _rbAttached = this.FindControl<RadioButton>("RbAttached")!;
@@ -129,9 +138,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             this.FindControl<Button>("BtnReset")!.Click += (_, _) => BtnReset_Click();
             this.FindControl<Button>("BtnCancel")!.Click += (_, _) => Close();
 
-            LoadWorkingValues();
+            LoadWorkingValues(EffectiveLayout());
 
             // Start on whatever state the real tube is in, so the preview matches what the user sees.
+            _detachedMode = CoreSettings.Current.AvatarTubeDetached;
             _suppressSliderEvents = true;
             if (_detachedMode) _rbDetached.IsChecked = true; else _rbAttached.IsChecked = true;
             _suppressSliderEvents = false;
@@ -145,17 +155,30 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         // ============================================================
 
         /// <summary>
-        /// ponytail: needs AppSettings.TubeLayoutOverridesByMod and ModManifest.TubeLayout (both
-        /// WPF-head models), wired when they move to Core. The clamps are the original's, so the
-        /// call site does not change when the real layout is handed in.
+        /// The layout currently in force for this mod: the user's saved override wins, else the mod
+        /// manifest's tubeLayout, else null (all defaults). Mirrors ModService.EffectiveTubeLayout.
         /// </summary>
-        private void LoadWorkingValues()
+        private ModTubeLayout? EffectiveLayout()
         {
-            _offsetX = Math.Clamp(0, -1000, 1000);
-            _detachedOffsetX = Math.Clamp(0, -1000, 1000);
-            _scale = Math.Clamp(1.0, 0.1, 3.0);
-            _offsetY = Math.Clamp(0, -500, 500);
-            _detachedOffsetY = Math.Clamp(0, -500, 500);
+            if (CoreSettings.Current.TubeLayoutOverridesByMod?.TryGetValue(_modId, out var userLayout) == true
+                && userLayout != null)
+                return userLayout;
+
+            return ManifestLayout();
+        }
+
+        /// <summary>The active mod's shipped layout. <c>CoreMods.InstalledMods</c> unseeded is the
+        /// built-in CCP default, which is what ModService answers with no mod layer up.</summary>
+        private ModTubeLayout? ManifestLayout() =>
+            CoreMods.InstalledMods.TryGetValue(_modId, out var pkg) ? pkg?.Manifest?.TubeLayout : null;
+
+        private void LoadWorkingValues(ModTubeLayout? layout)
+        {
+            _offsetX = Math.Clamp(layout?.AvatarOffsetX ?? 0, -1000, 1000);
+            _detachedOffsetX = Math.Clamp(layout?.AvatarDetachedOffsetX ?? 0, -1000, 1000);
+            _scale = Math.Clamp(layout?.AvatarScale ?? 1.0, 0.1, 3.0);
+            _offsetY = Math.Clamp(layout?.AvatarOffsetY ?? 0, -500, 500);
+            _detachedOffsetY = Math.Clamp(layout?.AvatarDetachedOffsetY ?? 0, -500, 500);
         }
 
         /// <summary>
@@ -181,9 +204,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         // AVATAR POSES
         // ============================================================
 
-        // ponytail: LoadPoses() needs Services.ModResourceResolver.ResolveImage plus the embedded
-        // Resources/avatar*_pose*.png; wired when the resolver moves to Core. Until then the four
-        // slots are placeholder glyphs, so the stepper and the "Pose n/4" readout still work.
+        // ponytail: LoadPoses() needs ModResourceResolver.ResolveImage
+        // (ConditioningControlPanel/Services/ModResourceResolver.cs) plus the embedded
+        // Resources/avatar*_pose*.png. Until then the four slots are placeholder glyphs, so the
+        // stepper and the "Pose n/4" readout still work.
         private void StepPose(int delta)
         {
             _poseIndex = (_poseIndex + _poses.Length + delta) % _poses.Length;
@@ -198,12 +222,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// True when the active mod overrides tube.png but not tube2.png — in that case the detached
         /// state uses the mod's tube.png AND the attached margins, exactly like the real tube
         /// (AvatarTubeWindow.ModOverridesAttachedTubeOnly, bug report #172).
-        /// ponytail: needs Services.ModResourceResolver.HasModOverride, wired when it moves to Core.
+        /// ponytail: needs ModResourceResolver.HasModOverride("tube.png"/"tube2.png")
+        /// (ConditioningControlPanel/Services/ModResourceResolver.cs).
         /// </summary>
         private static bool ModOverridesAttachedTubeOnly() => false;
 
         private void UpdatePreview()
         {
+          try
+          {
             bool useAttachedLayout = !_detachedMode || ModOverridesAttachedTubeOnly();
 
             // Tube frame
@@ -246,6 +273,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _previewAvatarBorder.RenderTransform = BuildBorderTransform();
 
             UpdateReadouts(maxW, maxH);
+          }
+          catch (Exception ex)
+          {
+            Log.Warning(ex, "[TubeFit] Failed to update preview");
+          }
         }
 
         private ITransform? BuildBorderTransform()
@@ -262,8 +294,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             }
 
             // Locked's set 1 ("The Lure") art reads smaller than the other stages.
-            // ponytail: needs App.Mods.ActiveModId == BuiltInMods.LockedId, wired when ModService
-            // moves to Core.
+            if (_modId == BuiltInMods.LockedId)
+                return new ScaleTransform(1.06, 1.06);
+
             return null;
         }
 
@@ -334,19 +367,41 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void BtnSave_Click()
         {
-            // ponytail: needs AppSettings.TubeLayoutOverridesByMod + App.Settings.Save() +
-            // App.AvatarWindow.RefreshTubeLayout(), all WPF-head; wired when they move to Core.
-            // The five working values below are what gets written.
+            var settings = CoreSettings.Current;
+
+            settings.TubeLayoutOverridesByMod ??= new Dictionary<string, ModTubeLayout>();
+            settings.TubeLayoutOverridesByMod[_modId] = new ModTubeLayout
+            {
+                AvatarOffsetX = _offsetX,
+                AvatarDetachedOffsetX = _detachedOffsetX,
+                AvatarScale = _scale,
+                AvatarOffsetY = _offsetY,
+                AvatarDetachedOffsetY = _detachedOffsetY
+            };
+            // The dictionary was mutated in place, so no INPC auto-save fired - persist explicitly.
+            CoreSettings.Save();
+
+            Log.Information("[TubeFit] Saved tube layout override for mod {ModId} " +
+                "(scale {Scale:0.00}, attached {OffX}/{OffY}, detached {DetX}/{DetY})",
+                _modId, _scale, _offsetX, _offsetY, _detachedOffsetX, _detachedOffsetY);
+
+            // ponytail: needs the tube window's RefreshTubeLayout() to re-read the override live.
+            // CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs has no such method yet, so
+            // the saved layout is picked up on the tube's next construction rather than at once.
             Close();
         }
 
         private void BtnReset_Click()
         {
-            // ponytail: needs App.Settings (drop the override, save) and
-            // App.AvatarWindow.RefreshTubeLayout(); wired when they move to Core. The view-local
-            // half - reload the working values from the mod's shipped manifest and follow with the
-            // preview - is real and runs.
-            LoadWorkingValues();
+            if (CoreSettings.Current.TubeLayoutOverridesByMod?.Remove(_modId) == true)
+                CoreSettings.Save();
+
+            Log.Information("[TubeFit] Reset tube layout to mod default for mod {ModId}", _modId);
+
+            // ponytail: needs RefreshTubeLayout() - see BtnSave_Click.
+
+            // Reload the working values from the mod's shipped manifest so the preview follows.
+            LoadWorkingValues(ManifestLayout());
             PushSlidersFromWorkingValues();
             UpdatePreview();
         }

--- a/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml.cs
@@ -29,11 +29,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - <b>Width=400/Height=300 in the ctor are dropped.</b> They were dead in WPF too - the XAML
     ///    already carries <c>WindowState="Maximized"</c> and Loaded re-asserts it, so the 400x300
     ///    box was never on screen.
-    ///  - <b>Services are stubbed</b> (see the ponytail comments): App.Settings.DualMonitorEnabled,
-    ///    App.GetAllScreensCached, App.Progression.AddXP, App.Achievements.TrackBubbleCountResult,
-    ///    App.Mods.GetPhrases, App.Logger, BubbleCountService.ScaleXpByDuration and LockCardWindow.
-    ///    Everything that only touches the view - the 3-attempt loop, the too-high/too-low hints,
-    ///    the cross-window input mirroring, the inactivity watchdog - is ported verbatim.
+    ///  - <b>The monitor set and the mercy card are real.</b> <c>DualMonitorEnabled</c> is in Core
+    ///    and the screens come from <c>ScreenList.Enumerate</c> (the same helper the pink-filter
+    ///    control uses); the mercy phrase comes from <c>CoreMods.GetPhrases("BubbleCountMercy")</c>
+    ///    and drives <c>LockCardWindow.ShowOnAllMonitors</c> plus the 500 ms
+    ///    <c>IsAnyOpen()</c> poll, exactly as WPF. Those two LockCardWindow statics are no-ops on
+    ///    this head - that note lives in LockCardWindow, not here.
+    ///  - <b>Still stubbed</b>: the XP and achievement writes (see the ponytail comment in
+    ///    CheckAnswer). Everything that only touches the view - the 3-attempt loop, the
+    ///    too-high/too-low hints, the cross-window input mirroring, the inactivity watchdog - is
+    ///    ported verbatim.
     ///  - <c>PreviewTextInput</c> -> a tunnelling <c>TextInputEvent</c> handler; <c>Visibility</c>
     ///    -> <c>IsVisible</c>; <c>SourceInitialized</c>/<c>Loaded</c> -> <c>Opened</c>/<c>Loaded</c>.
     ///  - The feedback and attempt strings stay the hardcoded English of the WPF original: there is
@@ -145,9 +150,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// <summary>
         /// Show result window on all monitors.
         ///
-        /// ponytail: needs App.Settings.Current.DualMonitorEnabled and App.GetAllScreensCached() to
-        /// pick the screen set, wired when those move to Core. Until then this shows one window on
-        /// the primary screen, which is the single-monitor path the setting defaults to.
+        /// <para>Avalonia has no screen list without a TopLevel, so the primary window is built
+        /// first and its <c>Screens</c> is what the set is drawn from - the reverse of WPF's
+        /// secondaries-first order, which nothing depends on. An empty enumeration (headless, or a
+        /// window with no platform impl yet) is the single-screen path rather than WPF's
+        /// <c>onComplete(false)</c>: on this head empty means "no topology reported", not "no
+        /// display".</para>
         /// </summary>
         public static void ShowOnAllMonitors(int correctAnswer, bool strictMode, Action<bool> onComplete)
         {
@@ -155,6 +163,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _sharedInput = "";
 
             var primaryWindow = new BubbleCountResultWindow(correctAnswer, strictMode, onComplete, null, true);
+
+            if (CoreSettings.Current.DualMonitorEnabled)
+            {
+                var all = Features.ScreenList.Enumerate(primaryWindow);
+                var primary = all.FirstOrDefault(s => s.IsPrimary) ?? all.FirstOrDefault();
+                foreach (var screen in all.Where(s => s != primary))
+                {
+                    var window = new BubbleCountResultWindow(correctAnswer, strictMode, onComplete, screen, false);
+                    window.Show();
+                }
+            }
+
             primaryWindow.Show();
             primaryWindow.Activate();   // WPF SetForegroundWindow equivalent
         }
@@ -216,8 +236,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             if (answer == _correctAnswer)
             {
                 // Correct! XP scaled by video duration.
-                // ponytail: needs BubbleCountService.ScaleXpByDuration(250), App.Progression.AddXP
-                // and App.Achievements.TrackBubbleCountResult(true); wired when they move to Core.
+                // ponytail: needs BubbleCountService.ScaleXpByDuration(250)
+                // (ConditioningControlPanel/Services/BubbleCountService.cs), then
+                // ProgressionService.AddXP(xp, XPSource.BubbleCount) - the enum lives in
+                // ConditioningControlPanel/Services/Companion/CompanionService.cs - and
+                // AchievementService.TrackBubbleCountResult(true). None of the three has a Core
+                // seam; CCP.Core/Services has no Progression or Achievements at all.
                 var xp = 250;
                 ShowFeedbackOnAll($"🎉 CORRECT! +{xp} XP 🎉", Color.FromRgb(50, 205, 50));
                 DisableInputOnAll();
@@ -238,8 +262,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 _attemptsRemaining--;
                 UpdateAttemptsOnAll();
 
-                // ponytail: needs App.Achievements.TrackBubbleCountResult(false) - a wrong answer
-                // breaks the streak; wired when the service moves to Core.
+                // ponytail: needs AchievementService.TrackBubbleCountResult(false) - a wrong answer
+                // breaks the streak. Same missing service as above.
 
                 if (_attemptsRemaining <= 0)
                 {
@@ -328,12 +352,40 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 window.Hide();
             }
 
-            // ponytail: needs App.Mods.GetPhrases("BubbleCountMercy") and LockCardWindow
-            // (not ported yet). The WPF original picks a mod-aware mercy phrase - never one that
-            // contains the answer - and makes the user type it twice on a lock card, then polls
-            // LockCardWindow.IsAnyOpen() before completing. Without the card there is nothing to
-            // wait for, so this completes straight away, as the poll would have.
-            CompleteAll(false);
+            // Mod-aware mercy phrases (no answer included!)
+            var mercyPhrases = CoreMods.GetPhrases("BubbleCountMercy") ?? new[] { "GOOD GIRLS PAY ATTENTION" };
+
+            var phrase = mercyPhrases[Random.Shared.Next(mercyPhrases.Length)];
+
+            // Show mercy lock card (no answer in phrase!)
+            LockCardWindow.ShowOnAllMonitors(
+                phrase,
+                2, // Type twice
+                _strictMode);
+
+            // After lock card closes, complete
+            // Note: LockCardWindow handles its own close, we just complete after a delay
+            var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+            timer.Tick += (_, _) =>
+            {
+                timer.Stop();
+                // Panic/engine stop force-closed everything while we were polling: bail without
+                // firing the completion callback — in strict mode OnGameComplete(false) retries
+                // the game, resurrecting a fullscreen bubble count seconds after "stop everything".
+                // (Normal mercy flow keeps the hidden result windows in _allWindows until
+                // CompleteAll, so an empty list can only mean ForceCloseAll ran.)
+                if (_allWindows.Count == 0) return;
+                // Check if lock card is still open
+                if (LockCardWindow.IsAnyOpen())
+                {
+                    timer.Start(); // Keep checking
+                }
+                else
+                {
+                    CompleteAll(false);
+                }
+            };
+            timer.Start();
         }
 
         /// <summary>

--- a/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml.cs
@@ -31,8 +31,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    reference it, so <see cref="Offer"/>, <see cref="Choices"/> and <see cref="Copy"/> below
     ///    are local stand-ins carrying the fields and strings this window actually reads. The copy
     ///    is placeholder — the real sentences come back when DescentCeremonyCopy moves to Core.
-    ///  - <c>App.Settings</c>, <c>App.DescentMigration.ApplyChoice</c> and
-    ///    <c>App.AvatarWindow.GigglePriority</c> are stubs for the same reason.
+    ///  - <c>App.Settings</c> is NOT a stub any more: the player level comes from
+    ///    <c>CoreSettings.Current.PlayerLevel</c>, so the standing line and the closing act carry
+    ///    the real number. <c>DescentMigrationService.ApplyChoice</c> and the companion's
+    ///    <c>GigglePriority</c> are still head-side, and each keeps a note.
     ///  - The GlowLayer breath is a declarative Animation in the XAML, so the <c>Closed</c> teardown
     ///    of it disappears; <c>OnLoaded</c> shrinks to the companion's opening line, which it also
     ///    spoke in the original.
@@ -97,8 +99,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // Both doors are priced BEFORE the user sees either, from the same pure function the
             // submit will use — so the number on the card is the number they get, not an estimate.
-            // ponytail: needs DescentMigration.Resolve (WPF head, Services/Descent), wired when it
-            // moves to Core. The sample offer carries the level the resolve would have produced.
+            // ponytail: needs DescentMigration.Resolve(string, DescentMigrationOffer).Level in
+            // ConditioningControlPanel/Services/Descent/DescentMigration.cs, which also holds
+            // DescentMigrationOffer and DescentMigrationChoices. Core carries only the persisted
+            // flags (AppSettings.DescentMigrationCompleted / .DescentMigrationChoice), not the
+            // relevel maths. The sample offer carries the level the resolve would have produced.
             _restoreLevel = _offer.ResolvedRestoreLevel;
 
             PopulateCopy();
@@ -128,8 +133,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void PopulateCopy()
         {
-            // ponytail: needs App.Settings.Current.PlayerLevel, wired when settings move to Core.
-            var currentLevel = _offer.PlayerLevel;
+            var currentLevel = CoreSettings.Current.PlayerLevel;
 
             this.FindControl<TextBlock>("IntroHeadline")!.Text = Copy.IntroHeadline;
             this.FindControl<TextBlock>("IntroStanding")!.Text = Copy.IntroStanding(
@@ -259,7 +263,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             _committed = true;
 
-            var level = _offer.PlayerLevel;
+            var level = CoreSettings.Current.PlayerLevel;
             _doneBody.Text = Copy.DoneBody(choice!, level);
             ShowAct(_actDone);
 
@@ -272,8 +276,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// </summary>
         private bool ApplyChoice(string choice)
         {
-            // ponytail: needs App.DescentMigration.ApplyChoice(choice, offer), wired when
-            // Services/Descent moves to Core. Never make this return true before it is real —
+            // ponytail: needs DescentMigrationService.ApplyChoice(string, DescentMigrationOffer)
+            // in ConditioningControlPanel/Services/Descent/DescentMigrationService.cs, which is
+            // where the local relevel, the epoch flip and the keepsakes live. Never return true
+            // before it is real —
             // a faked commit on an irreversible choice is the one bug this surface cannot survive.
             Log.Warning("[Descent] ApplyChoice({Choice}) is not wired on this head — nothing was committed.", choice);
             return false;
@@ -293,7 +299,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// </summary>
         private static void Say(string line)
         {
-            // ponytail: needs App.AvatarWindow.GigglePriority, wired when the companion moves to Core.
+            // ponytail: needs GigglePriority(line, playSound, aiGenerated) — the WPF head's
+            // AvatarTubeWindow has it; CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs does
+            // not, and there is no companion seam in Core.
             Log.Debug("[Descent] Companion line (not yet spoken on this head): {Line}", line);
         }
 
@@ -303,14 +311,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         /// <summary>
         /// The fields of <c>DescentMigrationOffer</c> this window reads, plus the resolved restore
-        /// level and the player level it took off App.Settings.
-        /// ponytail: replaced by the real DescentMigrationOffer when Services/Descent moves to Core.
+        /// level. The player's own level is no longer here — it comes from
+        /// <c>CoreSettings.Current.PlayerLevel</c>, as it did from App.Settings on WPF.
+        /// ponytail: replaced by the real DescentMigrationOffer (Services/Descent/DescentMigration.cs)
+        /// when it moves to Core.
         /// </summary>
         public sealed class Offer
         {
             public double TotalXpEarned { get; init; }
             public int DevotionDays { get; init; }
-            public int PlayerLevel { get; init; }
             public int ResolvedRestoreLevel { get; init; }
 
             /// <summary>Internal, so no production caller can ship the render sample.</summary>
@@ -318,12 +327,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             {
                 TotalXpEarned = 184_500,
                 DevotionDays = 213,
-                PlayerLevel = 47,
                 ResolvedRestoreLevel = 38,
             };
         }
 
-        /// <summary>ponytail: mirrors DescentMigrationChoices; the two literals are the wire values.</summary>
+        /// <summary>ponytail: mirrors DescentMigrationChoices
+        /// (ConditioningControlPanel/Services/Descent/DescentMigration.cs); the two literals are
+        /// the wire values.</summary>
         private static class Choices
         {
             public const string Restore = "restore";
@@ -335,12 +345,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// PLACEHOLDER COPY. The real sentences live in DescentCeremonyCopy in the WPF head; the
         /// short constants are verbatim, the multi-paragraph bodies are stood in for so the acts
         /// render with real text rather than blank panels.
-        /// ponytail: needs DescentCeremonyCopy, wired when it moves to Core — this class deletes
-        /// itself entirely at that point.
+        /// ponytail: needs DescentCeremonyCopy
+        /// (ConditioningControlPanel/Services/Descent/DescentCeremonyCopy.cs) — this class deletes
+        /// itself entirely when that moves to Core.
         /// </summary>
         private static class Copy
         {
-            /// <summary>ponytail: mirrors DescentMigration.CycleXpBonus (1.10).</summary>
+            /// <summary>ponytail: mirrors DescentMigration.CycleXpBonus (1.10), in
+            /// ConditioningControlPanel/Services/Descent/DescentMigration.cs.</summary>
             private const double CycleXpBonus = 1.10;
 
             public const string IntroHeadline = "The last season has ended.";

--- a/CCP.Avalonia/Views/Windows/LayeredAudioWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/LayeredAudioWindow.axaml.cs
@@ -21,13 +21,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// master volume.
     ///
     /// PORTED from ConditioningControlPanel/Windows/LayeredAudioWindow.xaml.cs. Deviations:
-    ///  - App.Settings and App.LayeredAudio are both still in the WPF head, so the track list is
-    ///    an in-memory placeholder seeded with two sample tracks, and every Save/Start/Stop/
-    ///    Restart/SetVolumeLive call is a marked stub. The card building, the toggles, the
-    ///    dim-when-off body, the empty state and its master-on warning are ported for real -
-    ///    they are the whole point of this window and none of them touches a service.
+    ///  - The settings half is REAL: the track list, the master enable, the master volume and the
+    ///    audio-only switch all read and write <see cref="CoreSettings"/>, which carries
+    ///    AudioLayers / AudioLayersEnabled / AudioLayersMasterVolume / AudioOnlySession.
+    ///  - What is still missing is the MIXER, and only the mixer. <c>CoreAudio</c> is a one-shot
+    ///    seam (PlayOneShot / Duck / Unduck / DuckGeneration) with no multi-track surface, so
+    ///    <c>LayeredAudioService.Start/Stop/Restart/SetMasterVolumeLive/SetTrackVolumeLive</c>
+    ///    (ConditioningControlPanel/Services/Audio/LayeredAudioService.cs) have no Core equivalent.
+    ///    Each of those five call sites keeps a note; everything around them runs.
     ///  - The file picker uses Avalonia's StorageProvider (async) instead of
-    ///    Microsoft.Win32.OpenFileDialog, and adds to the placeholder list.
+    ///    Microsoft.Win32.OpenFileDialog.
     ///  - The static Open(DependencyObject) helper is DROPPED. Its three jobs - best-effort
     ///    Owner, single-instance re-surface, and EnsureOnScreen against SystemParameters'
     ///    virtual-desktop metrics - are WPF window-manager repairs with no caller in this head.
@@ -47,15 +50,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         // handlers must stay inert until LoadMasterControls owns the flag.
         private bool _loading = true;
 
-        // ponytail: needs App.Settings.Current.AudioLayers, wired when settings move to Core.
-        // Two sample tracks so --render-view draws the row cards rather than the empty state;
-        // the empty state and its master-on warning are still reachable by removing both.
-        private readonly List<AudioLayerTrack> _tracks = new()
-        {
-            new AudioLayerTrack { Path = "/music/rain-loop.mp3", Volume = 70, Enabled = true },
-            new AudioLayerTrack { Path = "/music/deep-hum.ogg", Volume = 45, Enabled = false },
-        };
-
         private readonly CheckBox _chkMasterEnable, _chkAudioOnly;
         private readonly Slider _sliderMaster;
         private readonly TextBlock _txtMaster;
@@ -72,7 +66,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _slotsPanel = this.FindControl<StackPanel>("SlotsPanel")!;
 
             _saveDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
-            _saveDebounce.Tick += (_, _) => { _saveDebounce.Stop(); SaveSettings(); };
+            _saveDebounce.Tick += (_, _) => { _saveDebounce.Stop(); CoreSettings.Save(); };
 
             _chkMasterEnable.IsCheckedChanged += (_, _) => ChkMasterEnable_Changed();
             _chkAudioOnly.IsCheckedChanged += (_, _) => ChkAudioOnly_Changed();
@@ -84,17 +78,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             BuildRows();
         }
 
-        private List<AudioLayerTrack> Tracks() => _tracks;
+        /// <summary>The persisted track list, materialised on first use exactly as WPF did.</summary>
+        private static List<AudioLayerTrack> Tracks()
+        {
+            var s = CoreSettings.Current;
+            var list = s.AudioLayers ?? new List<AudioLayerTrack>();
+            if (s.AudioLayers == null) s.AudioLayers = list;
+            return list;
+        }
 
         private void LoadMasterControls()
         {
             _loading = true;
-            // ponytail: needs App.Settings.Current (AudioLayersEnabled / AudioLayersMasterVolume /
-            // AudioOnlySession). The XAML defaults stand in until settings move to Core.
-            _chkMasterEnable.IsChecked = true;
-            _sliderMaster.Value = 70;
+            var s = CoreSettings.Current;
+            _chkMasterEnable.IsChecked = s.AudioLayersEnabled;
+            _sliderMaster.Value = s.AudioLayersMasterVolume;
             _txtMaster.Text = $"{(int)_sliderMaster.Value}%";
-            _chkAudioOnly.IsChecked = false;
+            _chkAudioOnly.IsChecked = s.AudioOnlySession;
             _loading = false;
         }
 
@@ -236,8 +236,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             {
                 track.Volume = (int)e.NewValue;
                 volValue.Text = $"{track.Volume}%";
-                // ponytail: needs App.LayeredAudio.SetTrackVolumeLive - live per-track gain, no
-                // graph rebuild, so drags stay smooth.
+                // ponytail: needs LayeredAudioService.SetTrackVolumeLive(AudioLayerTrack, int)
+                // (ConditioningControlPanel/Services/Audio/LayeredAudioService.cs) - live per-track
+                // gain with no graph rebuild. CoreAudio has no multi-track surface.
                 SaveDebounced();
             }));
             Grid.SetColumn(volSlider, 1);
@@ -260,7 +261,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             remove.Click += (_, _) =>
             {
-                Tracks().Remove(track);
+                var list = Tracks();
+                list.Remove(track);
+                CoreSettings.Current.AudioLayers = list;
                 BuildRows();
                 ApplyStructural();
             };
@@ -286,9 +289,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             });
             if (files.Count == 0) return;
 
+            var list = Tracks();
             foreach (var file in files)
-                Tracks().Add(new AudioLayerTrack { Path = file.TryGetLocalPath() ?? file.Name, Volume = 70, Enabled = true });
+                list.Add(new AudioLayerTrack { Path = file.TryGetLocalPath() ?? file.Name, Volume = 70, Enabled = true });
 
+            CoreSettings.Current.AudioLayers = list;
             BuildRows();
             ApplyStructural();
         }
@@ -296,8 +301,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private void ChkMasterEnable_Changed()
         {
             if (_loading) return;
-            // ponytail: needs App.Settings (AudioLayersEnabled) and App.LayeredAudio.Start/Stop.
-            SaveSettings();
+            var s = CoreSettings.Current;
+            s.AudioLayersEnabled = _chkMasterEnable.IsChecked ?? false;
+            CoreSettings.Save();
+
+            // ponytail: needs LayeredAudioService.Start() / .Stop()
+            // (ConditioningControlPanel/Services/Audio/LayeredAudioService.cs). The setting is
+            // persisted either way, so the mixer picks it up when this head gets one.
 
             // The empty-state warning above depends on this toggle.
             if (Tracks().Count == 0) BuildRows();
@@ -306,28 +316,27 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private void ChkAudioOnly_Changed()
         {
             if (_loading) return;
-            // ponytail: needs App.Settings (AudioOnlySession).
-            SaveSettings();
+            CoreSettings.Current.AudioOnlySession = _chkAudioOnly.IsChecked ?? false;
+            CoreSettings.Save();
         }
 
         private void SliderMaster_Changed(object? sender, RangeBaseValueChangedEventArgs e)
         {
             if (_loading) return;
-            // ponytail: needs App.Settings (AudioLayersMasterVolume) and
-            // App.LayeredAudio.SetMasterVolumeLive.
+            CoreSettings.Current.AudioLayersMasterVolume = (int)e.NewValue;
             _txtMaster.Text = $"{(int)e.NewValue}%";
+            // ponytail: needs LayeredAudioService.SetMasterVolumeLive()
+            // (ConditioningControlPanel/Services/Audio/LayeredAudioService.cs).
             SaveDebounced();
         }
 
         /// <summary>A structural change (add/remove/enable): rebuild the mixer if it's on.</summary>
         private void ApplyStructural()
         {
-            SaveSettings();
-            // ponytail: needs App.LayeredAudio.Restart when AudioLayersEnabled is true.
+            CoreSettings.Save();
+            // ponytail: needs LayeredAudioService.Restart() when AudioLayersEnabled is true
+            // (ConditioningControlPanel/Services/Audio/LayeredAudioService.cs).
         }
-
-        /// <summary>ponytail: needs App.Settings.Save, wired when settings move to Core.</summary>
-        private void SaveSettings() { }
 
         private void SaveDebounced()
         {


### PR DESCRIPTION
Four windows whose "wired when settings move to Core" notes were stale. Everything
Core already carries is now read and written; only genuinely head-side services keep
a note, each naming the exact missing member and its path.

LayeredAudioWindow: the two sample tracks are gone. The list is AppSettings.AudioLayers,
materialised on first use exactly as WPF did, and add/remove reassign it before saving.
The master enable, master volume and audio-only switch seed from and write to
CoreSettings, and the debounce tick saves for real. CoreAudio is a one-shot seam
(PlayOneShot/Duck/Unduck/DuckGeneration) with no multi-track surface, so the five mixer
calls are the only stubs left. With no tracks and the master defaulting off, the window
now renders its empty state rather than two fake rows.

DescentCeremonyWindow: the standing line and the closing act read
CoreSettings.Current.PlayerLevel, so Offer no longer carries a player level of its own.
The relevel maths, the offer type, the copy and the companion line stay head-side.

BubbleCountResultWindow: ShowOnAllMonitors honours DualMonitorEnabled and enumerates
screens through the existing ScreenList helper - the primary window is built first
because Avalonia has no screen list without a TopLevel, and an empty enumeration is
treated as the single-screen path rather than a failure. The mercy card is the WPF body
again: CoreMods.GetPhrases("BubbleCountMercy") with its fallback, a random pick, the
lock card, and the 500 ms IsAnyOpen poll including the ForceCloseAll bail. LockCardWindow's
statics are no-ops on this head; that note belongs to LockCardWindow, not here.

TubeFitDialog: the whole value path is real. EffectiveLayout prefers the user's
TubeLayoutOverridesByMod entry over the mod manifest's TubeLayout, the mode seeds from
AvatarTubeDetached, the avatar set from SelectedAvatarSet, the Locked scale branch is
back, Save writes the override and persists explicitly (the dictionary is mutated in
place, so no INPC auto-save fires) and Reset drops it. UpdatePreview regained its
try/catch and the original log line.

Still blocked:
  LayeredAudioService.Start / .Stop / .Restart / .SetMasterVolumeLive /
    .SetTrackVolumeLive(AudioLayerTrack,int)  - Services/Audio/LayeredAudioService.cs
  DescentMigration.Resolve, DescentMigrationOffer, DescentMigrationChoices,
    DescentMigration.CycleXpBonus                - Services/Descent/DescentMigration.cs
  DescentMigrationService.ApplyChoice            - Services/Descent/DescentMigrationService.cs
  DescentCeremonyCopy                            - Services/Descent/DescentCeremonyCopy.cs
  GigglePriority(line, playSound, aiGenerated)   - absent from
    CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs; no companion seam in Core
  BubbleCountService.ScaleXpByDuration(int)      - Services/BubbleCountService.cs
  ProgressionService.AddXP(int, XPSource) and AchievementService.TrackBubbleCountResult(bool)
    - no Core seam; XPSource itself lives in Services/Companion/CompanionService.cs
  AvatarPortraitLoader.HasManifestForActiveMod() - Services/AvatarPortraitLoader.cs
  ModResourceResolver.ResolveImage / .HasModOverride - Services/ModResourceResolver.cs
  RefreshTubeLayout()                            - absent from
    CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU