### PR TITLE
feat(core): a progression seam - the pop quiz and bubble count award XP again

### DIFF
--- a/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/BubbleCountResultWindow.axaml.cs
@@ -35,8 +35,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    and drives <c>LockCardWindow.ShowOnAllMonitors</c> plus the 500 ms
     ///    <c>IsAnyOpen()</c> poll, exactly as WPF. Those two LockCardWindow statics are no-ops on
     ///    this head - that note lives in LockCardWindow, not here.
-    ///  - <b>Still stubbed</b>: the XP and achievement writes (see the ponytail comment in
-    ///    CheckAnswer). Everything that only touches the view - the 3-attempt loop, the
+    ///  - <b>The XP and achievement writes are real</b>, through <see cref="CoreProgression"/>;
+    ///    they are silent no-ops on a head with no progression service, which is this one today.
+    ///    Only the duration scaling is still stubbed (see the ponytail comment in CheckAnswer):
+    ///    the award is the flat WPF base of 250. Everything that only touches the view - the 3-attempt loop, the
     ///    too-high/too-low hints, the cross-window input mirroring, the inactivity watchdog - is
     ///    ported verbatim.
     ///  - <c>PreviewTextInput</c> -> a tunnelling <c>TextInputEvent</c> handler; <c>Visibility</c>
@@ -236,16 +238,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             if (answer == _correctAnswer)
             {
                 // Correct! XP scaled by video duration.
-                // ponytail: needs BubbleCountService.ScaleXpByDuration(250)
-                // (ConditioningControlPanel/Services/BubbleCountService.cs), then
-                // ProgressionService.AddXP(xp, XPSource.BubbleCount) - the enum lives in
-                // ConditioningControlPanel/Services/Companion/CompanionService.cs - and
-                // AchievementService.TrackBubbleCountResult(true). None of the three has a Core
-                // seam; CCP.Core/Services has no Progression or Achievements at all.
+                // ponytail: the scaling still needs BubbleCountService.ScaleXpByDuration(250)
+                // (ConditioningControlPanel/Services/BubbleCountService.cs), which is head-side and
+                // has no Core seam, so the flat WPF base of 250 is awarded until it moves.
                 var xp = 250;
+                CoreProgression.AddXP(xp, "BubbleCount");
                 ShowFeedbackOnAll($"🎉 CORRECT! +{xp} XP 🎉", Color.FromRgb(50, 205, 50));
                 DisableInputOnAll();
                 StopWatchdog(); // terminal success: no more input expected
+
+                // Track achievement - correct answer
+                CoreProgression.TrackBubbleCountResult(true);
 
                 // Delay then complete
                 var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
@@ -262,8 +265,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 _attemptsRemaining--;
                 UpdateAttemptsOnAll();
 
-                // ponytail: needs AchievementService.TrackBubbleCountResult(false) - a wrong answer
-                // breaks the streak. Same missing service as above.
+                // Track achievement - wrong answer (breaks streak)
+                CoreProgression.TrackBubbleCountResult(false);
 
                 if (_attemptsRemaining <= 0)
                 {

--- a/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
@@ -147,9 +147,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // Award XP
             if (!_isTest)
             {
-                // ponytail: needs ProgressionService.AddXP(25, XPSource.Other) from
-                // ConditioningControlPanel/Services/ProgressionService.cs — still head-side, and
-                // there is no CoreProgression seam yet.
+                CoreProgression.AddXP(25, "Other");
             }
 
             // Show affirmation

--- a/CCP.Core/CoreProgression.cs
+++ b/CCP.Core/CoreProgression.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The progression seam: the two things ported views ask of the XP and achievement services.
+    /// <c>ProgressionService</c> and <c>AchievementService</c> stay in the WPF head - they own the
+    /// companion bonuses, the level-up popups and the achievement toast windows, none of which is
+    /// engine work.
+    ///
+    /// <para>Unseeded means "this head has no progression", which is a real state (the Avalonia
+    /// head today), not an error: XP is silently not awarded, the streak is silently not recorded,
+    /// nothing throws, and a view that awards XP still finishes its own flow. That is the whole
+    /// contract - both calls are fire-and-forget on the WPF side too, where the services are
+    /// reached through a null-conditional <c>App.Progression?.</c>.</para>
+    ///
+    /// <para><b>Why <c>source</c> is a string.</b> <c>XPSource</c> is a plain enum with no head
+    /// dependencies, but it is declared inside
+    /// <c>ConditioningControlPanel/Services/Companion/CompanionService.cs</c>, a file that uses
+    /// <c>System.Windows.Threading</c> and <c>App.</c> and so cannot move. Declaring a second copy
+    /// here is exactly the drift this repo forbids, so the seam names the member and the head
+    /// parses it. The enum's own comment - members are APPENDED, never reordered - is what makes a
+    /// name-based parse stable.
+    /// ponytail: string until XPSource is extracted out of CompanionService.cs into Core; then
+    /// this parameter becomes the enum and the head's Enum.TryParse goes away.</para>
+    ///
+    /// <para>Volatile for the same reason as <see cref="CoreMods"/>: a head seeds these on the
+    /// startup thread while a view may award XP from a timer or background thread that never
+    /// triggers the head's type initializer.</para>
+    /// </summary>
+    public static class CoreProgression
+    {
+        /// <summary>Amount and <c>XPSource</c> member name. Null when the head has no XP service.</summary>
+        public static volatile Action<double, string>? AddXPProvider;
+
+        /// <summary>True on a correct bubble-count answer, false on a wrong one (breaks the streak).</summary>
+        public static volatile Action<bool>? TrackBubbleCountResultProvider;
+
+        /// <summary>
+        /// Awards XP. <paramref name="source"/> is an <c>XPSource</c> member name; an unknown name
+        /// is charged to <c>Other</c> by the head rather than dropped. Swallows provider faults - a
+        /// throwing progression service must never take the awarding view down with it.
+        /// </summary>
+        public static void AddXP(double amount, string source = "Other")
+        {
+            try { AddXPProvider?.Invoke(amount, source); } catch { }
+        }
+
+        /// <summary>
+        /// Records a bubble-count answer against the achievement streak. Faults are swallowed -
+        /// see <see cref="AddXP"/>.
+        /// </summary>
+        public static void TrackBubbleCountResult(bool correct)
+        {
+            try { TrackBubbleCountResultProvider?.Invoke(correct); } catch { }
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -103,6 +103,24 @@ namespace ConditioningControlPanel.LinuxSmoke
                 CoreAudio.Duck(95); CoreAudio.Unduck();
                 Check("CoreAudio ducking is a no-op with no audio", CoreAudio.DuckGeneration == 0);
                 Check("CoreAi.IsAvailable is false with no head", !CoreAi.IsAvailable);
+                // The progression seam (wire/35). A head with no XP service is a real state, so
+                // the only thing to assert unseeded is that awarding is silent and does not throw
+                // - a minigame must still finish its flow on a head that keeps no score.
+                CoreProgression.AddXP(25, "Other");
+                CoreProgression.TrackBubbleCountResult(true);
+                Check("CoreProgression awards and tracks silently with no progression service", true);
+                double seenAmount = 0; string? seenSource = null; bool? seenCorrect = null;
+                CoreProgression.AddXPProvider = (a, s) => { seenAmount = a; seenSource = s; };
+                CoreProgression.TrackBubbleCountResultProvider = c => seenCorrect = c;
+                CoreProgression.AddXP(250, "BubbleCount");
+                CoreProgression.TrackBubbleCountResult(false);
+                Check("CoreProgression forwards amount and source once seeded", seenAmount == 250 && seenSource == "BubbleCount");
+                Check("CoreProgression forwards the bubble-count result once seeded", seenCorrect == false);
+                CoreProgression.AddXPProvider = (_, _) => throw new InvalidOperationException("boom");
+                CoreProgression.AddXP(1);
+                Check("CoreProgression swallows a throwing provider", true);
+                CoreProgression.AddXPProvider = null;
+                CoreProgression.TrackBubbleCountResultProvider = null;
                 // The speech seam (wire/21). Unseeded must be honest, never optimistic: a view
                 // that believed "available" here would offer voice input nothing can deliver.
                 Check("CoreSpeech.IsAvailable is false with no speech service", !CoreSpeech.IsAvailable);

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -308,6 +308,12 @@ namespace ConditioningControlPanel
             CoreAudio.UnduckProvider = generation => Audio?.Unduck(generation);
             CoreAudio.DuckGenerationProvider = () => Audio?.DuckGeneration ?? 0;
             CoreAi.IsAvailableProvider = () => Ai?.IsAvailable == true;
+            // Progression, for the ported minigame windows that award XP or record a streak. The
+            // source arrives as an XPSource member name - see CoreProgression for why - and an
+            // unknown name is charged to Other rather than dropped.
+            CoreProgression.AddXPProvider = (amount, source) =>
+                Progression?.AddXP(amount, Enum.TryParse<Services.XPSource>(source, out var s) ? s : Services.XPSource.Other);
+            CoreProgression.TrackBubbleCountResultProvider = correct => Achievements?.TrackBubbleCountResult(correct);
             // Speech capability, for the views that ask whether voice input is worth offering.
             // SpeechService itself stays here - it owns a capture device. Reading ModelStatus
             // lazily probes the model exactly as the WPF views already did.


### PR DESCRIPTION
CoreProgression is the two things ported views ask of the XP and achievement
services: award an amount against a source, and record a bubble-count answer
against the streak. ProgressionService and AchievementService stay in the WPF
head - they own companion bonuses, level-up popups and achievement toasts, none
of which is engine work. Unseeded is a supported state, not a bug: XP is
silently not awarded, the streak is silently not recorded, nothing throws, and
an awarding view still finishes its own flow. That is the WPF contract too,
where both services are reached through a null-conditional App.Progression?.

The XP source crosses the seam as an XPSource member name rather than the enum.
The enum itself is head-free, but it is declared inside
ConditioningControlPanel/Services/Companion/CompanionService.cs - a file that
uses System.Windows.Threading and App. and so cannot move - and that file is not
this layer's to edit. A second copy in Core is the drift this repo forbids, so
the head parses the name back with Enum.TryParse and charges an unknown one to
Other. Members of XPSource are appended and never reordered, which is what makes
a name-based parse stable. Extracting the enum is a one-line follow-up.

PopQuizWindow awards its 25 XP on an answer again, and BubbleCountResultWindow
awards on a correct count and records both outcomes against the achievement
streak, in the WPF order. The Windows head seeds both providers beside the audio
seam; the Avalonia head seeds neither, which is exactly the unseeded state the
smoke asserts - silent unseeded, forwarding once seeded, and a throwing provider
swallowed.

Still blocked:
 - Services.XPSource (ConditioningControlPanel/Services/Companion/CompanionService.cs)
   cannot be moved to Core without editing that file, which this layer does not own.
 - BubbleCountService.ScaleXpByDuration (ConditioningControlPanel/Services/BubbleCountService.cs)
   - the bubble award is the flat WPF base of 250 until it has a seam.
 - InteractionQueueService.Complete(InteractionType.PopQuiz)
   (ConditioningControlPanel/Services/InteractionQueueService.cs)
 - AvatarWindow.IsMuted / SetMuteAvatar, and App.MainWindowRef, both still head-side.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU