### PR TITLE
feat(core): the engine-running flag and the app's moderation log cross to Core

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -58,6 +58,16 @@ namespace ConditioningControlPanel.Avalonia
                 var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
                 CoreReleaseContent.AppVersionProvider = () =>
                     version is null ? null : $"{version.Major}.{version.Minor}.{version.Build}";
+                // CoreSession stays unseeded: this head has no session engine yet, so "not
+                // running" is the truth, and the feature cards fall to their save-only branch.
+                //
+                // CoreModerationLog stays unseeded too, and NOT because a log is unavailable here
+                // - ModerationLog is in Core and would construct fine. It hardcodes
+                // SpecialFolder.ApplicationData (~/.config on Linux) while this head's user data
+                // lives under CorePaths.UserData (~/.local/share), so seeding it would scatter the
+                // CCBill record file into a second tree. That is a fix to the class, in a later
+                // layer, not a seeding decision here.
+
                 // CoreSpeech is deliberately left unseeded: there is no speech engine on this head
                 // yet, and the seam's unseeded answers (no mic, empty device list, NotProbed) are
                 // exactly what that is. Seeding it with anything else would be a lie.

--- a/CCP.Avalonia/Views/Dialogs/CompanionPromptEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CompanionPromptEditorDialog.axaml.cs
@@ -342,12 +342,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                     box.BorderThickness = new Thickness(2);
                     ToolTip.SetTip(box, Loc.GetF("prompt_validator_warning", result.MatchedPatterns.Count));
                     flaggedNames.Add(fieldName);
-                    // ponytail: App.ModerationLog?.RecordEdit(fieldName, count, "companion_prompt").
-                    // The CLASS is already in Core (CCP.Core/Services/Moderation/ModerationLog.cs);
-                    // what is missing is a seam for the app's ONE instance, which today lives on
-                    // ConditioningControlPanel/App.xaml.cs:610. Constructing a second one here
-                    // would give it a different per-launch ModerationSession hash and split the
-                    // CCBill record file in two, so it waits for a CoreModeration provider.
+                    // Through the seam, so the app's ONE log (and its one per-launch session hash)
+                    // takes the entry. Unseeded on this head, so nothing is written here yet.
+                    CoreModerationLog.RecordEdit(fieldName, result.MatchedPatterns.Count, "companion_prompt");
                 }
             }
 

--- a/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuizCategoryEditorWindow.axaml.cs
@@ -25,7 +25,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    TextEditorDialog/QuizReportWindow precedent).
     ///  - <c>QuizService</c> is not in Core either, so the template dropdown, the AI preview, the
     ///    built-in name-collision check and Delete are stubs. Each carries a ponytail comment.
-    ///  - <c>PromptValidator</c> IS in Core, so <see cref="RunPromptValidation"/> runs for real.
+    ///  - <c>PromptValidator</c> IS in Core, so <see cref="RunPromptValidation"/> runs for real, and
+    ///    its flags go to the app's moderation log through <see cref="CoreModerationLog"/>.
     ///  - The <c>MessageBox.Show</c> calls are this head's <see cref="MessageDialog"/>, which is
     ///    async, so Save and Delete are <c>async void</c> handlers. Only the name-collision warning
     ///    is missing, because the check behind it needs QuizService.
@@ -423,11 +424,9 @@ Do NOT include any other text before or after the question format. Just the ques
                 "PromptValidator flagged QuizCategoryEditorWindow system prompt ({Count} matches)",
                 result.MatchedPatterns.Count);
 
-            // ponytail: needs the app-wide ModerationLog INSTANCE (App.ModerationLog) for
-            // RecordEdit("SystemPromptTemplate", count, "quiz_category"). The class itself is in
-            // Core (CCP.Core/Services/Moderation/ModerationLog.cs) but it is instance-scoped over a
-            // ModerationSession and an append-only file; constructing a second one here would give
-            // the process two writers of moderation.log. Needs a CoreModeration seam.
+            // Through the seam, so the app's ONE moderation.log writer takes the entry rather than
+            // a second instance with its own session hash. Unseeded here, so nothing is written yet.
+            CoreModerationLog.RecordEdit("SystemPromptTemplate", result.MatchedPatterns.Count, "quiz_category");
         }
 
         private async void BtnDelete_Click(Border _)

--- a/CCP.Core/CoreModerationLog.cs
+++ b/CCP.Core/CoreModerationLog.cs
@@ -1,0 +1,37 @@
+using System;
+using ConditioningControlPanel.Services.Moderation;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The seam for the app's ONE <see cref="ModerationLog"/>. The class itself already lives in
+    /// Core; what could not cross is the single instance, which hangs off the head's App and is
+    /// built over a per-launch <see cref="ModerationSession"/>. A second instance would hash a
+    /// second session id and split the CCBill record file in two, so callers reach the app's
+    /// through here rather than constructing their own.
+    ///
+    /// <para>The provider is re-read on every call, not cached: on Windows <c>App.ModerationLog</c>
+    /// is null until well into startup, so a prompt editor opened - or a moderation hit fired -
+    /// before that point must find null and shrug, not crash.</para>
+    ///
+    /// <para>Unseeded is a silent no-op: nothing is written, nothing throws. A head with no
+    /// moderation log keeps no record, which is the honest outcome; refusing the user's save
+    /// because the record file is absent would be the wrong trade.</para>
+    /// </summary>
+    public static class CoreModerationLog
+    {
+        public static volatile Func<ModerationLog?>? InstanceProvider;
+
+        /// <summary>Records a moderation hit. <paramref name="source"/> is input/output/memory.</summary>
+        public static void Record(ProhibitedCategory category, string source, string modelHint)
+        {
+            try { InstanceProvider?.Invoke()?.Record(category, source, modelHint); } catch { }
+        }
+
+        /// <summary>Records a PromptValidator flag from a prompt-editor surface. Counts only, never text.</summary>
+        public static void RecordEdit(string fieldName, int patternCount, string surface)
+        {
+            try { InstanceProvider?.Invoke()?.RecordEdit(fieldName, patternCount, surface); } catch { }
+        }
+    }
+}

--- a/CCP.Core/CoreSession.cs
+++ b/CCP.Core/CoreSession.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The session seam: whether the main engine is currently running.
+    ///
+    /// <para>A dozen ported feature cards gate their live-apply on this - "the user moved a
+    /// slider; do I push it into the running service, or only save it?". On Windows the answer is
+    /// <c>App.IsEngineRunning</c>, a plain flag <c>MainWindow.StartEngine</c>/<c>StopEngine</c>
+    /// writes. The engine itself stays in the head; only the flag crosses.</para>
+    ///
+    /// <para>No change event, deliberately: the WPF original raises none and nothing subscribes to
+    /// one. Every call site reads the flag at the moment it needs it.</para>
+    ///
+    /// <para>Unseeded answers <c>false</c>, which is the truth and not merely the safe answer: a
+    /// head with no session engine is not running one. Callers land on their save-only branch and
+    /// attempt no live-apply against a service that does not exist.</para>
+    /// </summary>
+    public static class CoreSession
+    {
+        public static volatile Func<bool>? IsEngineRunningProvider;
+
+        /// <summary>True while the main engine is running - plain runs and AI sessions alike.</summary>
+        public static bool IsEngineRunning
+        {
+            get { try { return IsEngineRunningProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -127,6 +127,12 @@ namespace ConditioningControlPanel.LinuxSmoke
                 Check("CoreSpeech.HasCaptureDevice is false with no speech service", !CoreSpeech.HasCaptureDevice);
                 Check("CoreSpeech.ModelStatus is NotProbed with no speech service", CoreSpeech.ModelStatus == CoreSpeechModelStatus.NotProbed);
                 Check("CoreSpeech.EnumerateInputDevices is empty with no speech service", CoreSpeech.EnumerateInputDevices().Count == 0);
+                // The session and moderation-log seams (wire/36). Unseeded, "no engine is running"
+                // is the truth on a head that has none, and the log sink swallows the write.
+                Check("CoreSession.IsEngineRunning is false with no engine", !CoreSession.IsEngineRunning);
+                CoreModerationLog.RecordEdit("smoke", 1, "linux_smoke");
+                CoreModerationLog.Record(ProhibitedCategory.Minor, "input", "smoke");
+                Check("CoreModerationLog records are silent no-ops with no log attached", true);
                 Check("CoreReleaseContent answers null with no pack service", CoreReleaseContent.GetPackInfo("mod-bambi") == null && CoreReleaseContent.GetStampFor("mod-bambi") == null);
                 Check("AwarenessIntensity.Current reads the ship default unseeded", Services.Awareness.AwarenessIntensityProfile.Current == Services.Awareness.AwarenessIntensity.Chatty);
                 // The subreddit rule moved from the online coordinator into Core with no test of its own.

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -314,6 +314,12 @@ namespace ConditioningControlPanel
             CoreProgression.AddXPProvider = (amount, source) =>
                 Progression?.AddXP(amount, Enum.TryParse<Services.XPSource>(source, out var s) ? s : Services.XPSource.Other);
             CoreProgression.TrackBubbleCountResultProvider = correct => Achievements?.TrackBubbleCountResult(correct);
+            // The engine-running flag, for the feature cards that only live-apply while a session
+            // is up. The engine stays here; the flag is the whole seam.
+            CoreSession.IsEngineRunningProvider = () => IsEngineRunning;
+            // The app's one moderation log. Read lazily on every call because ModerationLog is
+            // constructed in OnStartup, long after this ctor - and it is declared null! until then.
+            CoreModerationLog.InstanceProvider = () => ModerationLog;
             // Speech capability, for the views that ask whether voice input is worth offering.
             // SpeechService itself stays here - it owns a capture device. Reading ModelStatus
             // lazily probes the model exactly as the WPF views already did.


### PR DESCRIPTION
CoreSession carries one thing: whether the main engine is running. The ported
feature cards ask it before deciding whether a slider change is a live-apply or a
save-only, and on Windows the answer has always been App.IsEngineRunning, a plain
flag MainWindow.StartEngine/StopEngine writes. The engine stays in the head. No
change event, because the WPF original raises none and nothing subscribes to one.
Unseeded answers false, which is the truth on a head with no session engine and
not merely the safe answer: callers land on their save-only branch instead of
pushing at a service that is not there.

CoreModerationLog is the sink for the app's ONE ModerationLog. The class was
already in Core; the instance was not, because it is built over a per-launch
ModerationSession and appends to one file, so a view that constructed its own
would hash a second session id and split the CCBill record in two. The provider is
re-read on every call rather than cached, since App.ModerationLog is null until
well into OnStartup and a prompt editor opened before that must shrug, not crash.
Unseeded is a silent no-op. CompanionPromptEditorDialog and
QuizCategoryEditorWindow now record their PromptValidator flags through it, with
the field names, counts and surface tags taken verbatim from the WPF call sites.

The Windows head seeds both; the Avalonia head deliberately seeds neither. It has
no session engine, and ModerationLog hardcodes SpecialFolder.ApplicationData
(~/.config) while this head's user data is under CorePaths.UserData
(~/.local/share) - seeding it would scatter the record file into a second tree.
That is a fix to the class in a later layer, not a seeding decision here. Both
unseeded answers are asserted in CCP.LinuxSmoke.

Still blocked:
- CoreSession has no consumers yet. The ported cards still carrying an
  IsEngineRunning note are CCP.Avalonia/Views/Features/{BouncingText,BubblePop,
  BubbleCount,LockCard,Flash,Video,Subliminal}FeatureControl.axaml.cs,
  CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs and
  CCP.Avalonia/Views/Windows/MainShellWindow.axaml.cs. Their live-apply also needs
  the feature services themselves (App.Bubbles, App.BrainDrain, App.Subliminal),
  all still head-side, so the flag alone does not unblock them.
- CCP.Avalonia/Views/Dialogs/AwarenessPresetDetailDialog.axaml.cs:1240 wants the
  same RecordEdit and can now have it, but that file is not this layer's.
- CoreModerationLog.Record has no Core caller until AiService, QuizService and
  MemoryStore move. The ported views ask only for RecordEdit; Record is four extra
  lines on the same pattern, added because every one of those pending call sites is
  already written against App.ModerationLog?.Record.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU