### PR TITLE
feat(avalonia): the Studio rack reads live settings; the tube gets its layout and chat shortcut back

### DIFF
--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
@@ -65,6 +67,16 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
     /// <see cref="RunOnAvatar"/> marshals to <c>Dispatcher.UIThread</c> and the setting has no
     /// meaning here. The guards are kept so callers from a worker thread still behave.</para>
     ///
+    /// <para><b>Three members from the partials DID cross</b>, because three other ported files
+    /// ask for them by name and each is self-contained: the chat-shortcut trio
+    /// (<see cref="FormatChatShortcut"/>, <see cref="SerializeModifiers"/>,
+    /// <see cref="ApplyChatShortcutTo"/>, from ChatInput.cs - the setting they read is in Core and
+    /// Avalonia's <c>KeyBindings</c> replaces WPF's <c>InputBindings</c>) and
+    /// <see cref="RefreshTubeLayout"/> with its margin maths (from Avatar.cs + Speech.cs, which
+    /// TubeFitDialog hot-refreshes the live tube with). <c>GigglePriority</c> did NOT: its
+    /// signature promises voice, and the queue, the interrupt rules and the TTS behind it are the
+    /// 2,873-line Speech.cs pipeline.</para>
+    ///
     /// <para><b>ponytail: the eight partials did not come.</b> This layer ports the .xaml.cs only.
     /// Avatar loading and the 60fps float loop (Avatar.cs), speech and barks (Speech.cs), chat and
     /// the AI pipeline (ChatInput.cs), Circe emotes (CirceEmotes.cs), reactions (Reactions.cs), the
@@ -129,6 +141,10 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             _txtUserInput.Text = "type something…";
             this.FindControl<Grid>("FuseCandleHost")!.IsVisible = true;
             this.FindControl<Border>("TakeoverCountdownBar")!.IsVisible = true;
+            // Runs the layout maths in the render (OnOpened never fires headless), so the frame
+            // proves ApplyTubeLayoutOffsets + ApplySpeechBubblePlacement execute and land on the
+            // XAML defaults rather than only that they compile.
+            RefreshTubeLayout();
             // Note: the AI and POLICY badges are single-message-mode only (ShowChatHistory hides the
             // AI one, exactly as the WPF original does), so they are not in this frame. Both were
             // rendered separately during the port to confirm they draw with real strings.
@@ -198,6 +214,10 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             // calls into a partial this layer does not have, and --render-all constructs ~180 windows
             // in one process, where a stray timer firing at a closed window is a flaky failure.
 
+            // WPF did this from Loaded on this window; same here. See ApplyChatShortcutTo for why
+            // the binding on THIS window is the lesser half.
+            Loaded += (_, _) => ApplyChatShortcutTo(this);
+
             Log.Information("AvatarTubeWindow initialized with avatar set {Set}", _currentAvatarSet);
         }
 
@@ -216,12 +236,30 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             if (_parentWindow is not null)
                 X11Overlay.RestackAbove(this, _parentWindow);
 
+            // The live tube owns the static chat command for as long as it is open. WPF routed the
+            // RoutedUICommand up the tree to whichever window handled it; there is no routed-command
+            // tree here, so the command holds one sink and the open tube is it.
+            OpenChatSink = OpenChatInput;
+
+            // WPF's OnLoaded ran this as part of the layout pass; it is idempotent and it is what
+            // puts the avatar, title, input panel, Takeover bar and speech bubble on the mod's
+            // chamber rather than on the stock one.
+            RefreshTubeLayout();
+
             // ponytail: needs AvatarTubeWindow.Windowing.cs. WPF's OnLoaded also ran
-            // CalculateScaleFactor / UpdatePosition / StartFloatingAnimation /
-            // ApplySpeechBubblePlacement / RestoreSavedPlacement / StartFullscreenDetection and
-            // InitTakeoverCountdownBar. Screens.ScreenFromPoint + screen.WorkingArea/Scaling are the
-            // replacements for GetDpiForMonitor / MonitorFromPoint / SystemParameters.WorkArea when
-            // that partial ports; nothing here needs them yet.
+            // CalculateScaleFactor / UpdatePosition / StartFloatingAnimation / RestoreSavedPlacement
+            // / StartFullscreenDetection and InitTakeoverCountdownBar. Screens.ScreenFromPoint +
+            // screen.WorkingArea/Scaling are the replacements for GetDpiForMonitor /
+            // MonitorFromPoint / SystemParameters.WorkArea when that partial ports.
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            // Never leave the static command pointing at a closed window. Delegate == compares
+            // target and method, which is what makes "is the sink still MINE?" answerable at all;
+            // ReferenceEquals would be false every time because the conversion allocates.
+            if (OpenChatSink == (Action)OpenChatInput) OpenChatSink = null;
+            base.OnClosed(e);
         }
 
         // =========================================================================================
@@ -582,6 +620,295 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             }
             catch (Exception ex) { Log.Debug("AvatarTube HidePossessionNote failed: {Error}", ex.Message); }
         });
+
+        // =========================================================================================
+        //  Tube layout. PORTED from AvatarTubeWindow.Avatar.cs (RefreshTubeLayout /
+        //  ApplyTubeLayoutOffsets), Speech.cs (ApplySpeechBubblePlacement) and the constants in
+        //  Windowing.cs. TubeFitDialog calls RefreshTubeLayout to hot-refresh the live tube.
+        // =========================================================================================
+
+        /// <summary>Design reference width the XAML is drawn at.</summary>
+        private const double DesignWidth = 780;
+
+        /// <summary>Transparent right margin of the tube frame, MEASURED off tube.png's alpha
+        /// bounds - see the derivation in AvatarTubeWindow.Windowing.cs. Everything right of it is
+        /// alpha-0, i.e. click-through, which is why the tube's RECT may overlap main's rail.</summary>
+        private const double TubeArtRightPadding = 353;
+
+        /// <summary>Canvas px of OPAQUE art allowed over main's left edge. 0 = flush against the
+        /// door rail; 60 is the ceiling. The seam is a HIT-TEST budget, not just a look.</summary>
+        private const double SeamOverlapOverMain = 0;
+
+        /// <summary>12px of daylight so a short bubble does not read as glued to main's frame.</summary>
+        private const double AttachedBubbleSeamGap = 12;
+
+        private const double AttachedBubbleRightMargin =
+            TubeArtRightPadding - SeamOverlapOverMain + AttachedBubbleSeamGap;
+
+        /// <summary>Attached = riding beside main. The attach/detach gesture itself lives in
+        /// Windowing.cs, which did not port, so the tube stays in the state it starts in.</summary>
+        private bool _isAttached = true;
+
+        /// <summary>
+        /// Re-applies the tube layout after the user edits it (Mod Manager -> Tube Fit). Public so
+        /// the dialog can hot-refresh the live tube without a mod reload. Self-marshalling: the
+        /// dialog's OK handler may not be on the UI thread.
+        /// </summary>
+        public void RefreshTubeLayout() => RunOnAvatar(() =>
+        {
+            try { ApplyTubeLayoutOffsets(); }
+            catch (Exception ex) { Log.Warning("RefreshTubeLayout failed: {Error}", ex.Message); }
+        });
+
+        /// <summary>
+        /// Applies the active mod's tube layout offsets to the avatar, title, input panel, Takeover
+        /// bar and speech bubble. A mod's tube art may put the glass cylinder somewhere else, so the
+        /// offset shifts every element horizontally to line up with the chamber the author drew.
+        /// <para>The margins are the WPF ones verbatim, and with the offsets at 0 they are exactly
+        /// the XAML defaults - so an unseeded head lays out identically to today.</para>
+        /// </summary>
+        private void ApplyTubeLayoutOffsets()
+        {
+            // Deviation: WPF used LayoutTransform, which Avalonia has no per-control equivalent for
+            // (its twin is a LayoutTransformControl wrapper). RenderTransform about the feet is the
+            // same visual for a bottom-aligned avatar; only the parent's measured size differs, and
+            // AvatarBorder's size is margin-driven anyway.
+            var scale = EffAvatarScale();
+            var transform = Math.Abs(scale - 1.0) > 0.001 ? new ScaleTransform(scale, scale) : null;
+            foreach (var name in new[] { "ImgAvatar", "ImgAvatarAnimated", "ImgAvatarAnimatedB" })
+            {
+                var img = this.FindControl<Image>(name);
+                if (img == null) continue;
+                img.RenderTransformOrigin = new RelativePoint(0.5, 1.0, RelativeUnit.Relative);
+                img.RenderTransform = transform;
+            }
+
+            // When the mod only overrides the ATTACHED tube image, force the attached layout in the
+            // detached state too - otherwise the avatar lands outside the chamber the mod author
+            // drew (bug report #172).
+            var useAttachedLayout = _isAttached || ModOverridesAttachedTubeOnly();
+
+            var avatarBorder = this.FindControl<Border>("AvatarBorder");
+            var titleBox = this.FindControl<Border>("TitleBox");
+            var takeoverBar = this.FindControl<Border>("TakeoverCountdownBar");
+
+            if (useAttachedLayout)
+            {
+                var dx = EffAvatarOffsetX();
+                var dy = EffAvatarOffsetY();
+                if (avatarBorder != null) avatarBorder.Margin = new Thickness(5, 100, 126 - dx, 210 + dy);
+                if (titleBox != null) titleBox.Margin = new Thickness(0, 0, 121 - dx, 180);
+                _inputPanel.Margin = new Thickness(0, 0, 126 - dx, 520);
+                if (takeoverBar != null) takeoverBar.Margin = new Thickness(0, 0, 116 - dx, 246);
+            }
+            else
+            {
+                var dx = EffAvatarDetachedOffsetX();
+                var dy = EffAvatarDetachedOffsetY();
+                // Detached nudge: 20px higher and net 5px left (the element is centred, so the
+                // offset is (L-R)/2).
+                if (avatarBorder != null) avatarBorder.Margin = new Thickness(5, 100, 436 - dx, 228 + dy);
+                if (titleBox != null) titleBox.Margin = new Thickness(0, 0, 416 - dx, 193);
+                _inputPanel.Margin = new Thickness(0, 0, 426 - dx, 520);
+                // Keep the Takeover bar glued to the pod; it is not in the XAML's attached-only
+                // default, so without this it floats at the attached spot whenever the tube
+                // detaches (#464).
+                if (takeoverBar != null) takeoverBar.Margin = new Thickness(0, 0, 416 - dx, 264);
+            }
+
+            ApplySpeechBubblePlacement();
+        }
+
+        /// <summary>
+        /// Places the speech bubble. Attached it is anchored by its RIGHT edge on the seam and grows
+        /// leftward, because an OPAQUE pixel right of the tube art is NOT click-through: it swallows
+        /// the click and main's door rail goes dead for as long as she is talking (v6.8.6). A bubble
+        /// too wide to fit left of the seam gives the seam up rather than hang off the canvas and get
+        /// clipped - an unreadable bubble is the worse bug. Detached there is nothing underneath to
+        /// protect, so that mode keeps the centred placement it has always had.
+        /// </summary>
+        private void ApplySpeechBubblePlacement()
+        {
+            var useAttached = _isAttached || ModOverridesAttachedTubeOnly();
+            var dx = useAttached ? EffAvatarOffsetX() : EffAvatarDetachedOffsetX();
+
+            double right;
+            if (useAttached)
+            {
+                // A mod's avatar offset may pull the bubble LEFT with the art it belongs to, never
+                // right - the seam is main's, not the mod's.
+                right = Math.Max(AttachedBubbleRightMargin, AttachedBubbleRightMargin - dx);
+
+                var maxWidth = _speechBubble.MaxWidth;
+                if (double.IsFinite(maxWidth) && maxWidth > 0)
+                    right = Math.Min(right, Math.Max(0, DesignWidth - maxWidth));
+            }
+            else
+            {
+                right = 425 - dx;
+            }
+
+            _speechBubble.HorizontalAlignment = useAttached ? HorizontalAlignment.Right
+                                                            : HorizontalAlignment.Center;
+            _speechBubble.Margin = new Thickness(0, 0, right, 550);
+        }
+
+        // ponytail: the five mod-layout reads are not in Core. WPF has them as
+        // App.Mods.GetAvatarScale / GetAvatarOffsetX / GetAvatarOffsetY /
+        // GetAvatarDetachedOffsetX / GetAvatarDetachedOffsetY, each combined with the Circe
+        // emote-set override in AvatarTubeWindow.CirceEmotes.cs (EffAvatar*). The neutral answers
+        // below are the ones WPF gives with no mod override and no emote running, which is why the
+        // margins above then equal the XAML defaults exactly.
+        private static double EffAvatarScale() => 1.0;
+        private static int EffAvatarOffsetX() => 0;
+        private static int EffAvatarOffsetY() => 0;
+        private static int EffAvatarDetachedOffsetX() => 0;
+        private static int EffAvatarDetachedOffsetY() => 0;
+
+        /// <summary>
+        /// ponytail: needs <c>Services.ModResourceResolver.HasModOverride</c>, which is a WPF-head
+        /// service. False is the honest unseeded answer - no mod, so no partial tube override - and
+        /// it is the safe one: it keeps the detached layout detached instead of forcing a mod
+        /// chamber nobody installed.
+        /// </summary>
+        private static bool ModOverridesAttachedTubeOnly() => false;
+
+        // =========================================================================================
+        //  Chat shortcut. PORTED from AvatarTubeWindow.ChatInput.cs. DevicesSettingsSection and the
+        //  companion hero card read the label; the capture dialog writes the setting back through
+        //  SerializeModifiers.
+        // =========================================================================================
+
+        /// <summary>
+        /// Where <see cref="OpenChatCommand"/> lands. WPF used a <c>RoutedUICommand</c> and let the
+        /// routed-command tree find whichever window handled it; Avalonia has no routed commands, so
+        /// the open tube claims this in <c>OnOpened</c> and releases it in <c>OnClosed</c>. Volatile
+        /// and null-tolerant for the same reason every seam here is: with no tube open the shortcut
+        /// must do nothing, not throw into a keypress handler.
+        /// </summary>
+        private static volatile Action? OpenChatSink;
+
+        /// <summary>The command the chat-shortcut KeyBinding is bound to on every window that
+        /// carries it. Always executable - the sink decides whether there is anything to open.</summary>
+        public static readonly ICommand OpenChatCommand = new OpenChatCommandImpl();
+
+        private sealed class OpenChatCommandImpl : ICommand
+        {
+            // Never raised: enablement does not change, so Avalonia's one-shot CanExecute read is
+            // the whole story here (see the porting note about CanExecuteChanged).
+            public event EventHandler? CanExecuteChanged { add { } remove { } }
+            public bool CanExecute(object? parameter) => true;
+            public void Execute(object? parameter)
+            {
+                try { OpenChatSink?.Invoke(); } catch { /* a hotkey must never take the app down */ }
+            }
+        }
+
+        /// <summary>Opens the chat input panel and puts the caret in it.</summary>
+        public void OpenChatInput() => RunOnAvatar(() =>
+        {
+            _inputPanel.IsVisible = true;
+            // Input priority, not inline: the panel has just become visible and is not laid out yet,
+            // so focusing it in the same beat silently does nothing.
+            Dispatcher.UIThread.Post(() => _txtUserInput.Focus(), DispatcherPriority.Input);
+        });
+
+        /// <summary>
+        /// Rebuilds the chat-shortcut KeyBinding on a window from the user's setting. Removes any
+        /// prior binding for <see cref="OpenChatCommand"/> first, so repeated calls do not stack
+        /// duplicates. Falls back to Ctrl+T on an empty or unparseable setting.
+        /// <para>The binding on the TUBE is the lesser half: the tube is
+        /// <c>ShowActivated="False"</c> and rarely holds focus, so the binding that actually fires
+        /// is the one the shell puts on itself - WPF calls this for MainWindow too.</para>
+        /// <para>Deviation: WPF caught <c>NotSupportedException</c> from <c>KeyGesture</c>, which
+        /// rejects a bare letter. Avalonia's <c>KeyGesture</c> accepts any pair, so there is nothing
+        /// to catch; the capture dialog already refuses a modifier-less letter at the source.</para>
+        /// </summary>
+        public static void ApplyChatShortcutTo(Window? window)
+        {
+            if (window == null) return;
+
+            var (key, mods) = CurrentChatShortcut();
+
+            for (int i = window.KeyBindings.Count - 1; i >= 0; i--)
+                if (ReferenceEquals(window.KeyBindings[i].Command, OpenChatCommand))
+                    window.KeyBindings.RemoveAt(i);
+
+            window.KeyBindings.Add(new KeyBinding
+            {
+                Gesture = new KeyGesture(key, mods),
+                Command = OpenChatCommand,
+            });
+        }
+
+        /// <summary>"Ctrl+T" / "Alt+Shift+B" — for the hero card button and the Devices row.</summary>
+        public static string FormatChatShortcut()
+        {
+            var (key, mods) = CurrentChatShortcut();
+
+            var parts = new List<string>();
+            if ((mods & KeyModifiers.Control) != 0) parts.Add("Ctrl");
+            if ((mods & KeyModifiers.Alt) != 0) parts.Add("Alt");
+            if ((mods & KeyModifiers.Shift) != 0) parts.Add("Shift");
+            if ((mods & KeyModifiers.Meta) != 0) parts.Add("Win");
+            parts.Add(key.ToString());
+            return string.Join("+", parts);
+        }
+
+        /// <summary>
+        /// The stored shortcut, defaulted. One reader for both the label and the binding so they can
+        /// never disagree about what an unparseable setting means.
+        /// </summary>
+        private static (Key Key, KeyModifiers Mods) CurrentChatShortcut()
+        {
+            var s = CoreSettings.Current.CompanionPrompt;
+            var keyName = string.IsNullOrWhiteSpace(s?.ChatShortcutKey) ? "T" : s!.ChatShortcutKey;
+            var modsName = s?.ChatShortcutModifiers ?? "Control";
+
+            if (!Enum.TryParse<Key>(keyName, ignoreCase: true, out var key)) key = Key.T;
+            if (!TryParseModifiers(modsName, out var mods)) mods = KeyModifiers.Control;
+            return (key, mods);
+        }
+
+        /// <summary>
+        /// Parses the stored "Control,Shift" form. Hand-mapped rather than
+        /// <c>Enum.TryParse&lt;KeyModifiers&gt;</c>: Avalonia calls the Windows key <c>Meta</c>, so a
+        /// settings file written on the WPF head - which stores "Windows" - would fail to parse and
+        /// silently drop the whole combo back to Ctrl+T.
+        /// </summary>
+        private static bool TryParseModifiers(string s, out KeyModifiers result)
+        {
+            result = KeyModifiers.None;
+            if (string.IsNullOrWhiteSpace(s)) return true;
+            foreach (var part in s.Split(new[] { ',', '+', ' ' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                switch (part.Trim().ToLowerInvariant())
+                {
+                    case "control": case "ctrl": result |= KeyModifiers.Control; break;
+                    case "alt": result |= KeyModifiers.Alt; break;
+                    case "shift": result |= KeyModifiers.Shift; break;
+                    case "windows": case "win": case "meta": result |= KeyModifiers.Meta; break;
+                    case "none": break;
+                    default: return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// The stored form, written back by the capture dialog. Still serializes <c>"Windows"</c>
+        /// rather than Avalonia's <c>"Meta"</c>, so one settings file keeps working on both heads.
+        /// </summary>
+        public static string SerializeModifiers(KeyModifiers m)
+        {
+            if (m == KeyModifiers.None) return "";
+            var parts = new List<string>();
+            if ((m & KeyModifiers.Control) != 0) parts.Add("Control");
+            if ((m & KeyModifiers.Alt) != 0) parts.Add("Alt");
+            if ((m & KeyModifiers.Shift) != 0) parts.Add("Shift");
+            if ((m & KeyModifiers.Meta) != 0) parts.Add("Windows");
+            return string.Join(",", parts);
+        }
 
         // =========================================================================================
         //  Stubs. Each one is a handler the WPF XAML wired inline whose body lives in a partial

--- a/CCP.Avalonia/Views/Tabs/StudioTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/StudioTabView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -13,6 +14,7 @@ using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
@@ -33,14 +35,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// the selection contract (<see cref="FocusRackEntry"/> / <see cref="PreselectRackEntry"/> /
     /// <see cref="OnTabShown"/>) and the detail header's OwnHeader collapse.</para>
     ///
+    /// <para><b>Wired against Core.</b> The thirteen state dots read their own
+    /// <c>CoreSettings.Current.&lt;Feature&gt;Enabled</c> flag (Haptics the nested
+    /// <c>Haptics.Enabled</c>) and repaint from a filtered <c>PropertyChanged</c> listener plus a
+    /// <c>CurrentReplaced</c> rebind, so a cloud restore cannot leave the rack reading - and
+    /// writing back to - a discarded settings instance. Row captions go through
+    /// <see cref="CoreMods.MakeModAware"/>, the accent through
+    /// <see cref="CoreMods.GetFilterColorRgb"/>, and <see cref="CoreMods.ModChanged"/> drives
+    /// <see cref="RepaintModAwareChrome"/>. The Scheduler and Ramp quick-toggles flip their
+    /// panel's own master checkbox, which is what WPF does and what keeps the write and the Save
+    /// in one place.</para>
+    ///
     /// <para><b>What is stubbed, and why.</b> Everything the WPF code-behind reaches into the app
-    /// head for: <c>App.Settings</c> (the dots and their live PropertyChanged listener, the
-    /// CurrentReplaced rebind), <c>App.Bark.NotifyFeatureOpened</c>, <c>App.Logger</c>,
-    /// <c>MainWindow.ModAwareLabel</c> and <c>MainWindow.ToggleWallFeature</c>,
-    /// <c>ModResourceResolver</c> (the rack's feature art and the door medallion),
-    /// <c>FxTheme.GlowColor</c> (the mod accent), <c>MotionFx</c> and
-    /// <c>PerimeterCometAdorner</c> (the detail crossfade, the dot ping and the active tile's
-    /// comet), and <c>HapticsTabView</c>. Each is marked <c>ponytail:</c> at its site.</para>
+    /// head for: <c>MainWindow.ToggleWallFeature</c> (the eleven wall modules' quick-toggle, which
+    /// owns the session-lock refusal and the per-feature service start/stop),
+    /// <c>BarkService.NotifyFeatureOpened</c>, <c>ModResourceResolver</c> (the rack's feature art
+    /// and the door medallion), <c>MotionFx</c> and <c>PerimeterCometAdorner</c> (the detail
+    /// crossfade, the dot ping and the active tile's comet), and <c>HapticsTabView</c> with its
+    /// <c>ChkHapticsEnabled</c> master box. Each is marked <c>ponytail:</c> at its site.</para>
     ///
     /// <para><b>Quiet surface (PLAN §2.7).</b> No ambient loop is registered for this view and
     /// none may be. On WPF the one exception is the checked tile's perimeter comet, gated twice on
@@ -159,12 +171,22 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private readonly List<Action<Color>> _accentTints = new();
 
         /// <summary>
-        /// The accent this page paints with.
-        /// <para>ponytail: needs <c>Services.FxTheme.GlowColor</c>, wired when it moves to Core.
-        /// #FF69B4 is FxTheme's OWN fallback for a missing theme key, so a mod-less head paints
-        /// exactly what the WPF head paints today; only a mod's accent is missing.</para>
+        /// The accent this page paints with: the active mod's colour, re-read on every
+        /// <see cref="RetintChrome"/>.
+        /// <para>Deviation from WPF, which reads <c>FxTheme.GlowColor</c>. That resolves
+        /// glowColor -&gt; filterColor -&gt; accentColor; Core carries the last two links as
+        /// <see cref="CoreMods.GetFilterColorRgb"/>, so a mod that sets a DISTINCT
+        /// <c>fxPalette.glowColor</c> paints its filter colour on this rack instead. Unseeded that
+        /// is the built-in manifest's #FF69B4 - what the WPF head paints today.</para>
         /// </summary>
-        private static Color Accent => Color.FromRgb(0xFF, 0x69, 0xB4);
+        private static Color Accent
+        {
+            get
+            {
+                var (r, g, b) = CoreMods.GetFilterColorRgb();
+                return Color.FromRgb(r, g, b);
+            }
+        }
 
         public StudioTabView()
         {
@@ -408,44 +430,72 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void BuildRack()
         {
             _layout.Add("st4_studio_group_effects");
-            Add("flash", "⚡", "flash.png", "Flash Images", "section_flash_images", HostFlash, PanelFlash, "Flash");
-            Add("video", "🎬", "mandatory_videos.png", "Mandatory Video", "section_mandatory_video", HostVideo, PanelVideo, "Video");
-            Add("subliminal", "💭", "subliminal.png", "Subliminals", "section_subliminals_2", HostSubliminal, PanelSubliminal, "Subliminal");
-            Add("spiral", "🌀", "spiral_overlay.png", "Spiral Overlay", "label_spiral_overlay", HostSpiral, PanelSpiral, "Spiral");
-            Add("pinkfilter", "💗", "Pink_filter.png", "Pink Filter", "label_pink_filter", HostPinkFilter, PanelPinkFilter, "PinkFilter");
+            Add("flash", "⚡", "flash.png", "Flash Images", "section_flash_images", HostFlash, PanelFlash, "Flash",
+                () => CoreSettings.Current.FlashEnabled);
+            Add("video", "🎬", "mandatory_videos.png", "Mandatory Video", "section_mandatory_video", HostVideo, PanelVideo, "Video",
+                () => CoreSettings.Current.MandatoryVideosEnabled);
+            Add("subliminal", "💭", "subliminal.png", "Subliminals", "section_subliminals_2", HostSubliminal, PanelSubliminal, "Subliminal",
+                () => CoreSettings.Current.SubliminalEnabled);
+            Add("spiral", "🌀", "spiral_overlay.png", "Spiral Overlay", "label_spiral_overlay", HostSpiral, PanelSpiral, "Spiral",
+                () => CoreSettings.Current.SpiralEnabled);
+            Add("pinkfilter", "💗", "Pink_filter.png", "Pink Filter", "label_pink_filter", HostPinkFilter, PanelPinkFilter, "PinkFilter",
+                () => CoreSettings.Current.PinkFilterEnabled);
             // Visuals has no single master toggle - the dashboard card is deliberately neutral too.
             // A dot that cannot be wired honestly is omitted, and with it the right-click gesture.
-            Add("visuals", "👁", null, "Visuals", "section_visuals", HostVisuals, PanelVisuals, "Visuals", dot: false);
+            Add("visuals", "👁", null, "Visuals", "section_visuals", HostVisuals, PanelVisuals, "Visuals", null);
 
             _layout.Add("st4_studio_group_games");
-            Add("bubbles", "🫧", "Bubble_pop.png", "Bubble Pop", "label_bubble_pop", HostBubblePop, PanelBubblePop, "BubblePop");
-            Add("bubblecount", "🔢", "Bubble_count.png", "Bubble Count", "label_bubble_count", HostBubbleCount, PanelBubbleCount, "BubbleCount");
-            Add("lockcard", "📐", "Phrase_Lock.png", "Lock Card", "label_lock_card", HostLockCard, PanelLockCard, "LockCard");
-            Add("bouncingtext", "📺", "bouncing_text.png", "Bouncing Text", "label_bouncing_text", HostBouncingText, PanelBouncingText, "BouncingText");
+            Add("bubbles", "🫧", "Bubble_pop.png", "Bubble Pop", "label_bubble_pop", HostBubblePop, PanelBubblePop, "BubblePop",
+                () => CoreSettings.Current.BubblesEnabled);
+            Add("bubblecount", "🔢", "Bubble_count.png", "Bubble Count", "label_bubble_count", HostBubbleCount, PanelBubbleCount, "BubbleCount",
+                () => CoreSettings.Current.BubbleCountEnabled);
+            Add("lockcard", "📐", "Phrase_Lock.png", "Lock Card", "label_lock_card", HostLockCard, PanelLockCard, "LockCard",
+                () => CoreSettings.Current.LockCardEnabled);
+            Add("bouncingtext", "📺", "bouncing_text.png", "Bouncing Text", "label_bouncing_text", HostBouncingText, PanelBouncingText, "BouncingText",
+                () => CoreSettings.Current.BouncingTextEnabled);
 
             _layout.Add("st4_studio_group_immersion");
-            Add("mindwipe", "🧠", "Mind_Wipers.png", "Mind Wipe", "label_mind_wipe", HostMindWipe, PanelMindWipe, "MindWipe");
+            Add("mindwipe", "🧠", "Mind_Wipers.png", "Mind Wipe", "label_mind_wipe", HostMindWipe, PanelMindWipe, "MindWipe",
+                () => CoreSettings.Current.MindWipeEnabled);
             // "BrainDrain" is a NEW feature_eq value; all three built-in mods carry a matching
             // feat_braindrain FeatureOpened rule.
-            Add("braindrain", "💧", "brain_drain.png", "Brain Drain", "section_brain_drain", HostBrainDrain, PanelBrainDrain, "BrainDrain");
+            Add("braindrain", "💧", "brain_drain.png", "Brain Drain", "section_brain_drain", HostBrainDrain, PanelBrainDrain, "BrainDrain",
+                () => CoreSettings.Current.BrainDrainEnabled);
             // Haptics: no FeatureOpened key. ShowTab("haptics") still fires
             // NotifyTabNavigated("haptics"), which is what its 3 rules per mod match on. Panel is
             // null because the placard is not a UserControl the session-lock sweep can paint, and
             // on WPF the real page is excluded from that sweep for its own reasons anyway.
+            // The dot reads a nested settings object with no INPC of its own, so it repaints on
+            // every Studio show and every selection rather than live - exactly as on WPF.
             // Tier 1: the rack's one paid module, same bar as the premium rail's chip.
-            Add("haptics", "📳", "vibe.png", "Haptics", "tab_haptics", PanelHaptics, null, null, tier: 1);
+            Add("haptics", "📳", "vibe.png", "Haptics", "tab_haptics", PanelHaptics, null, null,
+                () => CoreSettings.Current.Haptics?.Enabled,
+                // ponytail: WPF flips PanelHaptics.ChkHapticsEnabled here, so the page's own
+                // handler AND its premium gate run with the write. HapticsTabView is not on this
+                // head, so the row keeps its honest dot and loses only the gesture; writing the
+                // nested flag from here would skip the gate, which is the unsafe direction.
+                toggle: null,
+                tier: 1);
 
             _layout.Add("st4_studio_group_timing");
             // Both fire the popup's single "SchedulerRamp" key so the existing rules keep firing.
-            Add("scheduler", "📅", null, "Scheduler", "section_scheduler", HostScheduler, PanelScheduler, "SchedulerRamp");
-            Add("ramp", "📈", null, "Intensity Ramp", "section_intensity_ramp", HostRamp, PanelRamp, "SchedulerRamp");
+            // Neither is a wall tile and neither drives a service directly (the scheduler tick and
+            // the session ramp read the flags), so the honest quick-toggle is the panel's own
+            // enable box - it writes the flag and Saves in one place.
+            Add("scheduler", "📅", null, "Scheduler", "section_scheduler", HostScheduler, PanelScheduler, "SchedulerRamp",
+                () => CoreSettings.Current.SchedulerEnabled,
+                toggle: () => FlipMasterCheckBox(PanelScheduler?.Inner.FindControl<CheckBox>("ChkEnabled")));
+            Add("ramp", "📈", null, "Intensity Ramp", "section_intensity_ramp", HostRamp, PanelRamp, "SchedulerRamp",
+                () => CoreSettings.Current.IntensityRampEnabled,
+                toggle: () => FlipMasterCheckBox(PanelRamp?.Inner.FindControl<CheckBox>("ChkEnabled")));
 
             RenderRackRows();
             RefreshRackLabels();
             RefreshDots();
 
             void Add(string key, string glyph, string? art, string english, string locKey, Control? host,
-                     UserControl? panel, string? bark, bool ownHeader = true, int tier = 0, bool dot = true)
+                     UserControl? panel, string? bark, Func<bool?>? dot, bool ownHeader = true,
+                     Action? toggle = null, int tier = 0)
             {
                 var entry = new StudioRackEntry
                 {
@@ -457,11 +507,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                     Host = host,
                     Panel = panel,
                     BarkFeature = bark,
-                    Dot = dot ? () => PlaceholderDotOn.Contains(key) : null,
+                    Dot = dot,
                     OwnHeader = ownHeader,
                     Tier = tier,
-                    // A module with no single on/off gets no gesture rather than a guessed one.
-                    Toggle = dot ? () => QuickToggle(key) : null,
+                    // Default: route the rack key into the dashboard's own quick-toggle. Derived
+                    // rather than hand-listed per row so adding a wall tile for a module (or a
+                    // module for a wall tile) cannot leave the rack behind.
+                    Toggle = toggle ?? (WallToggleKeys.Contains(key) ? () => QuickToggle(key) : null),
                 };
                 _entries.Add(entry);
                 _layout.Add(entry);
@@ -469,18 +521,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         }
 
         /// <summary>
-        /// Placeholder dot states.
-        /// <para>ponytail: needs <c>App.Settings.Current</c> — on WPF each row reads its own
-        /// <c>AppSettings.&lt;Feature&gt;Enabled</c> flag (and Haptics the nested
-        /// <c>Haptics.Enabled</c>), repainting from a filtered PropertyChanged listener plus a
-        /// <c>CurrentReplaced</c> rebind for cloud restore. Wired when settings move to Core. This
-        /// mixed set exists so the render proves BOTH dot states, the lit one's accent halo and
-        /// the tooltip that goes with each.</para>
+        /// Flips a panel's own master checkbox. Going through the box rather than the settings flag
+        /// is what makes the panel's real handler - and any premium or session gate on it - run
+        /// with the write instead of behind its back. A disabled box has refused already.
         /// </summary>
-        private static readonly HashSet<string> PlaceholderDotOn = new(StringComparer.OrdinalIgnoreCase)
+        private static void FlipMasterCheckBox(CheckBox? cb)
         {
-            "flash", "subliminal", "pinkfilter", "bouncingtext", "braindrain",
-        };
+            if (cb == null || !cb.IsEnabled) return;
+            cb.IsChecked = !(cb.IsChecked ?? false);
+        }
 
         private void RenderRackRows()
         {
@@ -569,7 +618,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                 e.Row.Click += RackEntry_Click;
                 // Right-click = quick-toggle, the same second gesture the dashboard tiles carry.
                 // On the ROW, not on the dot: the dot is 7px, and the gesture belongs to the whole
-                // entry. Rows with no Toggle fall through unhandled (Visuals).
+                // entry. Rows with no Toggle fall through unhandled (Visuals, and Haptics until
+                // its page lands with the master box the gesture has to go through).
                 e.Row.PointerReleased += RackEntry_RightClick;
                 // Instant, animation-free state swap. Wired to the checked change rather than
                 // driven from SelectEntry so the swap can never drift out of step with IsChecked -
@@ -1052,13 +1102,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         }
 
         /// <summary>
-        /// ponytail: needs <c>MainWindow.ModAwareLabel(english, locKey)</c>, which lets a
-        /// <c>.ccpmod</c> rename a feature. Without it this is the localized string, which is what
-        /// ModAwareLabel itself returns when no mod overrides the name — and the English column is
-        /// kept as the fallback ModAwareLabel takes for a missing key.
+        /// WPF's <c>MainWindow.ModAwareLabel(english, locKey)</c>, inlined: a <c>.ccpmod</c> that
+        /// renames a feature renames the rack row too, and with no override the localized string
+        /// wins. <see cref="CoreMods.MakeModAware"/> returns its argument unchanged when no mod
+        /// layer is up, which is what makes the first branch fall through.
         /// </summary>
         private static string LabelFor(StudioRackEntry e)
         {
+            var modText = CoreMods.MakeModAware(e.English);
+            if (!string.IsNullOrEmpty(modText) && !string.Equals(modText, e.English, StringComparison.Ordinal))
+                return StripLeadingGlyph(modText);
+
             var text = Loc.Get(e.LocKey);
             // LocalizationManager returns the key itself when it has no string for it; showing a
             // raw snake_case key on the rack is a failed render, so fall back to the English column.
@@ -1139,15 +1193,103 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         private void OnLoaded(object? sender, RoutedEventArgs e)
         {
-            // ponytail: WPF also hooks App.Settings.PropertyChanged (filtered to the thirteen
-            // *Enabled flags that move a dot), App.Settings.CurrentReplaced (a cloud restore or a
-            // factory Reset SWAPS the settings instance out from under a rack that lives for the
-            // whole session) and the haptics page's own master checkbox, whose enable lives on a
-            // nested object with no INPC of its own. All three are settings-service work; wired
-            // when App.Settings moves to Core.
             RefreshRackLabels();
             ApplyDoorIcon();
             RefreshDots();
         }
+
+        // =====================================================================================
+        //  live state — the settings listener and the mod hook
+        // =====================================================================================
+
+        /// <summary>The AppSettings properties whose changes move a rack dot. Filtered rather than
+        /// repainting on every PropertyChanged, because the session engine rewrites the ramped
+        /// dials about once a second.</summary>
+        private static readonly HashSet<string> DotProperties = new(StringComparer.Ordinal)
+        {
+            nameof(AppSettings.FlashEnabled),
+            nameof(AppSettings.MandatoryVideosEnabled),
+            nameof(AppSettings.SubliminalEnabled),
+            nameof(AppSettings.SpiralEnabled),
+            nameof(AppSettings.PinkFilterEnabled),
+            nameof(AppSettings.BubblesEnabled),
+            nameof(AppSettings.BubbleCountEnabled),
+            nameof(AppSettings.LockCardEnabled),
+            nameof(AppSettings.BouncingTextEnabled),
+            nameof(AppSettings.MindWipeEnabled),
+            nameof(AppSettings.BrainDrainEnabled),
+            nameof(AppSettings.SchedulerEnabled),
+            nameof(AppSettings.IntensityRampEnabled),
+        };
+
+        /// <summary>The instance the dot listener is currently on. Tracked rather than re-read
+        /// from <see cref="CoreSettings.Current"/>, which after a restore is already a DIFFERENT
+        /// object - detaching from that one leaves the old subscription live and the new one
+        /// absent.</summary>
+        private AppSettings? _hookedSettings;
+        private bool _modHooked;
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+
+            // A cloud restore or a factory Reset SWAPS the settings instance out from under a rack
+            // that lives for the whole session; without this the rack shows - and writes back to -
+            // the discarded one for the rest of it.
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnSettingsCurrentReplaced;
+            BindDotListener();
+
+            if (!_modHooked)
+            {
+                CoreMods.ModChanged += OnModChanged;
+                _modHooked = true;
+            }
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnSettingsCurrentReplaced;
+            UnbindDotListener();
+
+            if (_modHooked) CoreMods.ModChanged -= OnModChanged;
+            _modHooked = false;
+
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void BindDotListener()
+        {
+            UnbindDotListener();
+            _hookedSettings = CoreSettings.Current;
+            _hookedSettings.PropertyChanged += OnSettingsPropertyChanged;
+        }
+
+        private void UnbindDotListener()
+        {
+            if (_hookedSettings != null) _hookedSettings.PropertyChanged -= OnSettingsPropertyChanged;
+            _hookedSettings = null;
+        }
+
+        /// <summary>Re-point the listener at the live instance and repaint. Posted rather than run
+        /// inline: CurrentReplaced can be raised off the UI thread by the restore that swapped
+        /// it.</summary>
+        private void OnSettingsCurrentReplaced() => Dispatcher.UIThread.Post(() =>
+        {
+            try { BindDotListener(); RefreshDots(); }
+            catch { /* a rebind must never take the rack down */ }
+        });
+
+        private void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == null || !DotProperties.Contains(e.PropertyName)) return;
+            // Marshalled because the writer may be the session engine's timer thread.
+            Dispatcher.UIThread.Post(RefreshDots, DispatcherPriority.Normal);
+        }
+
+        /// <summary>ModChanged can be raised off the UI thread; marshal before touching brushes.
+        /// This is the authoritative "the mod answers differently now" signal and the only one the
+        /// rack gets on this head, so the accent and the captions ride on it.</summary>
+        private void OnModChanged(object? sender, ModPackage mod) =>
+            Dispatcher.UIThread.Post(RepaintModAwareChrome);
     }
 }


### PR DESCRIPTION
The Studio rack's thirteen state dots stop being a hard-coded placeholder set and read their
own CoreSettings.Current.<Feature>Enabled flag (Haptics the nested Haptics.Enabled). They
repaint from a PropertyChanged listener filtered to those thirteen names - unfiltered would
repaint on every ramp tick the session engine writes - and the listener is re-pointed on
SettingsService.CurrentReplaced, so a cloud restore or a factory Reset cannot leave a rack that
lives for the whole session reading, and writing back to, the instance that was discarded. Row
captions go through CoreMods.MakeModAware, which is what lets a .ccpmod rename "Flash Images" on
the rack the way it already renames it everywhere else, and the page accent now comes from
CoreMods.GetFilterColorRgb instead of a frozen #FF69B4, with CoreMods.ModChanged driving
RepaintModAwareChrome so a mid-session mod switch actually repaints. WPF reads FxTheme.GlowColor,
whose chain is glowColor -> filterColor -> accentColor; Core carries the last two links only, so
a mod that sets a DISTINCT fxPalette.glowColor paints its filter colour on this rack. The
Scheduler and Ramp right-click quick-toggles are real again: they flip the panel's own ChkEnabled,
which is what makes the panel's handler and its Save run instead of a write behind its back. The
eleven wall keys deliberately stay a no-op - MainWindow.ToggleWallFeature owns the session-lock
refusal and the per-feature service start/stop, and a bare flag flip here would be LESS safe than
the unwired state.

The avatar tube gets the three members other ported files already ask for by name.
RefreshTubeLayout / ApplyTubeLayoutOffsets / ApplySpeechBubblePlacement come across with the
margin maths verbatim, including the hit-test seam that keeps an opaque speech bubble off main's
door rail; TubeFitDialog can call it. The chat-shortcut trio - FormatChatShortcut,
SerializeModifiers, ApplyChatShortcutTo - reads CompanionPrompt.ChatShortcutKey/Modifiers from
Core and binds through Avalonia's KeyBindings. Modifiers are hand-parsed rather than
Enum.TryParse<KeyModifiers>: Avalonia calls the Windows key Meta, so a settings file written by
the WPF head (which stores "Windows") would have parsed as garbage and silently dropped the whole
combo back to Ctrl+T. It still SERIALIZES "Windows", so one file keeps working on both heads.
WPF's static RoutedUICommand becomes a plain ICommand over a volatile sink the open tube claims
in OnOpened and releases in OnClosed.

Still blocked:
- MainWindow.ToggleWallFeature / SetWallFeature / RefuseIfSessionFeatureLocked
  (ConditioningControlPanel/MainWindow/MainWindow.Presets.cs) - the eleven wall-module
  quick-toggles.
- BarkService.NotifyFeatureOpened (ConditioningControlPanel/Services/Companion/BarkService.cs) - Core has
  the bark MODELS only, so StudioTabView.Announce still fires nothing. The keys are correct.
- Services.ModResourceResolver.ResolveImageDecoded / HasModOverride
  (ConditioningControlPanel/Services/ModResourceResolver.cs) plus Resources/features/*.png and
  Resources/nav/door_studio.png as AvaloniaResources - RefreshRackArt and ApplyDoorIcon.
- MotionFx.AllowTransitions and PerimeterCometAdorner - the detail crossfade, the dot ping and
  the active tile's comet. Quiet surface; the port carries no clock.
- Views/Tabs/HapticsTabView and its ChkHapticsEnabled - the Haptics row keeps its dot and loses
  only the right-click gesture, because writing the nested flag from here would skip the page's
  premium gate.
- App.Mods.GetAvatarScale / GetAvatarOffsetX / GetAvatarOffsetY / GetAvatarDetachedOffsetX /
  GetAvatarDetachedOffsetY (ConditioningControlPanel/Services/ModService.cs) and the Circe
  emote-set overrides in ConditioningControlPanel/AvatarTube/AvatarTubeWindow.CirceEmotes.cs -
  the tube layout runs on neutral 1.0/0 answers, which is exactly the XAML default.
- AvatarTubeWindow.GigglePriority (ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs,
  2,873 lines) for DescentCeremonyWindow. NOT stubbed: the signature promises playSound, and a
  body that shows a bubble and drops the voice would lie to every caller.
- GlobalHotkeyService (ConditioningControlPanel/Services/Input/GlobalHotkeyService.cs) - the shortcut
  binds per-window here; the "activate from any app" half is Win32.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU