### PR TITLE
feat(avalonia): five Lab cards ask CoreSession whether the engine is running

### DIFF
--- a/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BouncingTextFeatureControl.axaml.cs
@@ -158,9 +158,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (s.BouncingTextEnabled == want) return;   // an echo of the seed must not save
             s.BouncingTextEnabled = want;
             CoreSettings.Save();
-            // ponytail: WPF then live-applies through App.BouncingText.Start()/Stop() while
-            // App.IsEngineRunning (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs),
-            // still in the WPF head - it draws Win32 layered windows.
+
+            // Live-apply: start/stop the bouncing-text service if the engine is running.
+            if (CoreSession.IsEngineRunning)
+            {
+                // ponytail: App.BouncingText.Start()/Stop() - BouncingTextService
+                // (ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs), still in
+                // the WPF head - it draws Win32 layered windows.
+            }
         }
 
         private void SliderSpeed_Changed(object? sender, RangeBaseValueChangedEventArgs e)

--- a/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BubblePopFeatureControl.axaml.cs
@@ -48,10 +48,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             LoadFromSettings();
 
             // ponytail: WPF also repaints the hero and side art plates here (ApplyFeatureArt).
-            // Needs Services.ModResourceResolver.ResolveImageDecoded
-            // (ConditioningControlPanel/Services/, still in the WPF head) AND a named ImageBrush
-            // in the .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port
-            // draws a static wash instead, so there is nothing here to repaint.
+            // The mod-override half of ResolveImageDecoded is portable now
+            // (CoreModArt.OverridePath), but the plate still needs a named ImageBrush in the
+            // .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port draws a
+            // static wash instead, so there is nothing here to repaint.
         }
 
         /// <summary>The seven effect boxes, each carrying its variant id in <c>Tag</c>.</summary>
@@ -185,9 +185,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (_isLoading) return;
             CoreSettings.Current.BubblesEnabled = ChkEnable.IsChecked ?? false;
             CoreSettings.Save();
-            // ponytail: WPF also live-applies here - App.Bubbles.Start()/Stop() when
-            // App.IsEngineRunning. Needs BubbleService (ConditioningControlPanel/Services/) and the
-            // engine-running flag off App, both still in the WPF head.
+
+            // Live-apply: start/stop the bubble service if the engine is running.
+            if (CoreSession.IsEngineRunning)
+            {
+                // ponytail: App.Bubbles.Start()/Stop() - BubbleService
+                // (ConditioningControlPanel/Services/BubbleService.cs), still in the WPF head.
+            }
         }
 
         private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)
@@ -236,9 +240,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (_isLoading) return;
             CoreSettings.Current.BubbleSharedHost = ChkSolidMode.IsChecked ?? false;
             CoreSettings.Save();
-            // ponytail: the render path is latched per Start->Stop session, so WPF bounces a live
-            // bubble service here to pick up the new mode. Needs BubbleService
-            // (ConditioningControlPanel/Services/) and App.IsEngineRunning, still in the WPF head.
+
+            // The render path is latched per Start->Stop session, so a live bubble service has to
+            // be bounced to pick up the new mode. Two of WPF's three conjuncts are real here; the
+            // third ("is it actually running") is the service's own.
+            if (CoreSession.IsEngineRunning && CoreSettings.Current.BubblesEnabled)
+            {
+                // ponytail: App.Bubbles.IsRunning, then Stop() + Start() - BubbleService
+                // (ConditioningControlPanel/Services/BubbleService.cs), still in the WPF head.
+            }
         }
 
         private void ChkTriggers_Changed(object? sender, RoutedEventArgs e)

--- a/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/FlashFeatureControl.axaml.cs
@@ -50,10 +50,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             LoadFromSettings();
 
             // ponytail: WPF also repaints the hero and side art plates here (ApplyFeatureArt +
-            // App.Mods.ModChanged). Needs Services.ModResourceResolver.ResolveImageDecoded
-            // (ConditioningControlPanel/Services/, still in the WPF head) AND a named ImageBrush
-            // in the .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port
-            // draws a static wash instead, so there is nothing here to repaint.
+            // App.Mods.ModChanged). The mod-override half of ResolveImageDecoded is portable now
+            // (CoreModArt.OverridePath), but the plate still needs a named ImageBrush in the
+            // .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port draws a
+            // static wash instead, so there is nothing here to repaint.
         }
 
         // ---- settings instance tracking (WPF: SettingsHook + ISettingsRebindable) --------------
@@ -198,9 +198,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (_isLoading) return;
             CoreSettings.Current.FlashEnabled = ChkEnable.IsChecked ?? false;
             CoreSettings.Save();
-            // ponytail: WPF also live-applies here - App.Flash.Start()/Stop() when
-            // App.IsEngineRunning. Needs FlashService (ConditioningControlPanel/Services/) and the
-            // engine-running flag off App, both still in the WPF head.
+
+            // Live-apply: start/stop the flash service if the engine is running. The GATE is real
+            // now (CoreSession); what it gates is not.
+            if (CoreSession.IsEngineRunning)
+            {
+                // ponytail: App.Flash.Start()/Stop() - FlashService
+                // (ConditioningControlPanel/Services/Flash/FlashService.cs), still in the WPF head:
+                // it spawns Win32 layered flash windows.
+            }
         }
 
         private void SliderFrequency_Changed(object? sender, RangeBaseValueChangedEventArgs e)

--- a/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
@@ -266,11 +266,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
         {
             SpiralLibraryPanel.Children.Clear();
 
-            // Built-in spiral (active when SpiralPath is empty / missing).
-            // ponytail: WPF thumbnails it with Services.ModResourceResolver.ResolveSpiralUri()
-            // (ConditioningControlPanel/Services/ModResourceResolver.cs), still in the WPF head, so
-            // the Default card falls through to the glyph here.
-            SpiralLibraryPanel.Children.Add(BuildSpiralCard("", "Default", null));
+            // Built-in spiral (active when SpiralPath is empty / missing). The MOD half of WPF's
+            // ResolveSpiralUri() is portable and lives in CoreModArt; a null falls through to the
+            // glyph, which is exactly the "no mod override" answer.
+            // ponytail: the OTHER half - the head's own shipped spiral - has no thumbnail here:
+            // Assets/spiral.gif is not <AvaloniaResource Include= Link=>-linked in
+            // CCP.Avalonia/CCP.Avalonia.csproj, so there is no avares:// URI to decode yet.
+            SpiralLibraryPanel.Children.Add(BuildSpiralCard("", "Default", CoreModArt.SpiralOverridePath()));
 
             int fileCount = 0;
             try

--- a/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs
@@ -187,9 +187,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             var on = ChkEnable.IsChecked ?? false;
             if (s.SubliminalEnabled == on) return;
             s.SubliminalEnabled = on;
-            // ponytail: SubliminalService.SetEnabled also does the live Start()/Stop() gated on
-            // App.IsEngineRunning - ConditioningControlPanel/Services/Subliminal/SubliminalService.cs,
-            // still in the WPF head. Route this whole handler back through it when it moves.
+
+            // SetEnabled's gate, in its original position: between the write and the save.
+            if (CoreSession.IsEngineRunning)
+            {
+                // ponytail: the idempotent Start()/Stop() SetEnabled does here - SubliminalService
+                // (ConditioningControlPanel/Services/Subliminal/SubliminalService.cs), still in the
+                // WPF head. Route this whole handler back through it when it moves.
+            }
+
             CoreSettings.Save();
             Log.Information("Subliminals toggled: {Enabled}", on);
         }

--- a/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/VideoFeatureControl.axaml.cs
@@ -56,10 +56,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             LoadFromSettings();
 
             // ponytail: WPF also repaints the hero and side art plates here (ApplyFeatureArt +
-            // App.Mods.ModChanged). Needs Services.ModResourceResolver.ResolveImageDecoded
-            // (ConditioningControlPanel/Services/, still in the WPF head) AND a named ImageBrush
-            // in the .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port
-            // draws a static wash instead, so there is nothing here to repaint.
+            // App.Mods.ModChanged). The mod-override half of ResolveImageDecoded is portable now
+            // (CoreModArt.OverridePath), but the plate still needs a named ImageBrush in the
+            // .axaml, which Avalonia rejects (x:Name on a brush is AVLN2000); the port draws a
+            // static wash instead, so there is nothing here to repaint.
         }
 
         // ---- settings instance tracking (WPF: SettingsHook + ISettingsRebindable) --------------
@@ -196,9 +196,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (_isLoading) return;
             CoreSettings.Current.MandatoryVideosEnabled = ChkEnable.IsChecked ?? false;
             CoreSettings.Save();
-            // ponytail: WPF also live-applies here - App.Video.Start()/Stop() when
-            // App.IsEngineRunning. Needs VideoService (ConditioningControlPanel/Services/) and the
-            // engine-running flag off App, both still in the WPF head.
+
+            // Live-apply: start/stop the video service if the engine is running.
+            if (CoreSession.IsEngineRunning)
+            {
+                // ponytail: App.Video.Start()/Stop() - VideoService
+                // (ConditioningControlPanel/Services/Video/VideoService.cs), still in the WPF head.
+            }
         }
 
         private void SliderPerHour_Changed(object? sender, RangeBaseValueChangedEventArgs e)


### PR DESCRIPTION
Flash, Bubble Pop, Mandatory Video, Bouncing Text and Subliminals each guarded
their live-apply on App.IsEngineRunning in WPF. That flag is CoreSession.IsEngineRunning
now, so all five Enable toggles carry the real gate instead of a note about one.
Bubble Pop's Solid-mode bounce gets the compound gate: WPF's three conjuncts are
IsEngineRunning && BubblesEnabled && Bubbles.IsRunning, and the first two are real
here - only the service's own "am I running" is left in the note.

Be clear about what this is NOT. The gate is real; the thing it gates is still a
note. FlashService, BubbleService, VideoService, BouncingTextService and
SubliminalService all draw Win32 layered windows and stay in the WPF head, so
flipping Enable still only writes and saves the setting. This is half the WPF
behaviour, and it is the half that decides whether anything happens at all.
On this head CoreSession is deliberately unseeded (CCP.Avalonia/App.axaml.cs:61 -
no session engine yet), so the gate answers false and every card takes its
save-only branch, which is the truthful answer rather than merely the safe one.

Spiral is the odd one out and carried no such note for a reason: the WPF original
never reads App.IsEngineRunning at all. Nothing to wire, nothing missed. What it
did have was a stale note about ModResourceResolver.ResolveSpiralUri, whose mod
half is portable now - the Default library card asks CoreModArt.SpiralOverridePath()
and thumbnails a mod's spiral when one overrides it, falling through to the glyph
when nothing does. The hero-art notes on Flash, Bubble Pop and Video were stale the
same way and now name the real blocker (no named ImageBrush in the .axaml) instead
of a resolver half of which has moved.

Still blocked:
- App.Flash.Start()/Stop(), RefreshSchedule - ConditioningControlPanel/Services/Flash/FlashService.cs
- App.Bubbles.Start()/Stop(), RefreshFrequency, IsRunning - ConditioningControlPanel/Services/BubbleService.cs
- BubbleService.AmbientBubbleDailyXpCap / AmbientBubbleXpPaidToday - same file
- App.Video.Start()/Stop() - ConditioningControlPanel/Services/Video/VideoService.cs
- VideoService.IsPlaying / ForceCleanup / TriggerVideo, InteractionQueue, AutonomyService.ForceEndWebVideoTakeover - ConditioningControlPanel/Services/
- App.BouncingText.Start()/Stop()/Refresh/Restart - ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
- SubliminalService.SetEnabled's Start()/Stop() - ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
- App.Overlay.RefreshOverlays - ConditioningControlPanel/Services/Notifications/OverlayService.cs
- SessionEngine.Active.RefreshCornerGifPolicy - ConditioningControlPanel/Services/Session/SessionEngine.cs
- Services.Chaos.LoomHostService.Launch, DtrhLoomStore.Changed - ConditioningControlPanel/Services/Chaos/
- the built-in spiral thumbnail: Assets/spiral.gif is not AvaloniaResource-linked in CCP.Avalonia/CCP.Avalonia.csproj (not owned by this layer)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU