### PR TITLE
feat(avalonia): the Bubble Count live-apply is gated on the real session flag

### DIFF
--- a/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs
@@ -43,9 +43,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             Loaded += (_, _) => RebindToCurrentSettings();
             Unloaded += (_, _) => Unhook();
 
-            // ponytail: WPF also repaints the hero and side plates on ModChanged through
-            // Services/ModResourceResolver.cs (WPF head) from Resources/features/Bubble_count.png.
-            // The Avalonia .axaml drops both plates deliberately, so nothing here to repaint yet.
+            // ponytail: the mod-aware hero and side plates are still missing, but no longer for
+            // the reason the old note gave. CoreModArt.OverridePath("features/Bubble_count.png")
+            // answers the portable half now, and the built-in art DOES ship on this head
+            // (CCP.Avalonia.csproj links ..\Assets\features\*.png to
+            // avares://CCP.Avalonia/Resources/features/). What is missing is somewhere to paint:
+            // BubbleCountFeatureControl.axaml gives neither plate an x:Name, so this file has no
+            // control to reach. Name them and ApplyFeatureArt + a CoreMods.ModChanged
+            // subscription land here; TubeFitDialog.TryLoadImage is the decode pattern.
 
             RebindToCurrentSettings();
         }
@@ -109,9 +114,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             s.BubbleCountEnabled = on;
             CoreSettings.Save();
 
-            // ponytail: WPF live-applies here - App.BubbleCount.Start()/Stop(), gated on
-            // App.IsEngineRunning. BubbleCountService (ConditioningControlPanel/Services/) and
-            // App.IsEngineRunning (ConditioningControlPanel/App.xaml.cs) are both still head-side.
+            // The gate is real; what it gates is not. CoreSession.IsEngineRunning is the seam the
+            // WPF head fills from App.IsEngineRunning, so the "only live-apply while a session is
+            // actually running" rule is now enforced here rather than described in a comment. On
+            // this head it answers false (App.axaml.cs seeds no session engine), so the body never
+            // runs - and it would have nothing to run anyway.
+            if (CoreSession.IsEngineRunning)
+            {
+                // ponytail: WPF calls App.BubbleCount.Start() / Stop() here. BubbleCountService
+                // (ConditioningControlPanel/Services/BubbleCountService.cs) is still head-side -
+                // it owns the challenge window - so there is no portable call to make yet.
+            }
         }
 
         private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)

--- a/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml.cs
@@ -45,9 +45,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             Loaded += (_, _) => RebindToCurrentSettings();
             Unloaded += (_, _) => Unhook();
 
-            // ponytail: WPF also repaints the hero and side plates on ModChanged through
-            // Services/ModResourceResolver.cs (WPF head) from Resources/features/Mind_Wipers.png.
-            // The Avalonia .axaml drops both plates deliberately, so nothing here to repaint yet.
+            // ponytail: hero and side plates, same state as BubbleCount's - see the longer note
+            // there. CoreModArt.OverridePath("features/Mind_Wipers.png") answers the override half
+            // and the built-in ships at avares://CCP.Avalonia/Resources/features/Mind_Wipers.png;
+            // MindWipeFeatureControl.axaml just gives neither plate an x:Name to paint into.
 
             RebindToCurrentSettings();
         }

--- a/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
@@ -44,6 +44,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             BtnChooseColor.Click += BtnChooseColor_Click;
             BtnResetColor.Click += BtnResetColor_Click;
 
+            // ponytail: WPF also repaints a mod-aware hero and side plate here and on ModChanged
+            // (ApplyFeatureArt, Resources/features/Pink_filter.png). The port dropped both
+            // silently. CoreModArt.OverridePath("features/Pink_filter.png") answers the override
+            // half now and the built-in ships at
+            // avares://CCP.Avalonia/Resources/features/Pink_filter.png, so the only thing still
+            // missing is an x:Name on the two plate Borders in PinkFilterFeatureControl.axaml -
+            // without one this file has no control to paint. See BubbleCountFeatureControl for
+            // the full note and TubeFitDialog.TryLoadImage for the decode.
+
             LoadFromSettings();
         }
 


### PR DESCRIPTION
ChkEnable_Changed now asks CoreSession.IsEngineRunning instead of describing
App.IsEngineRunning in a comment. Read it as exactly what it is: the GATE is
real, the thing behind the gate is not. CoreSession is unseeded on this head
(CCP.Avalonia/App.axaml.cs seeds no session engine), so it answers false and the
body never runs - and the body is empty anyway, because BubbleCountService still
lives in the WPF head. Nothing about Bubble Count works that did not work
before; what changed is that the rule is now enforced by code that the WPF head
will make true the moment it seeds the seam, rather than by a note someone has
to remember to act on.

The three mod-art notes were stale in a way that hid real work. They said the
hero and side plates were dropped because ModResourceResolver is head-side. That
is no longer the blocker: CoreModArt.OverridePath answers the portable half, and
the built-in art DOES ship on this head - CCP.Avalonia.csproj links
..\Assets\features\*.png to avares://CCP.Avalonia/Resources/features/. The real
blocker is smaller and duller: neither plate Border in the three .axaml files
carries an x:Name, so the code-behind has no control to paint into, and those
files are not in this layer's grant. Each note now names the CoreModArt call,
the avares:// URI, the missing x:Name and TubeFitDialog.TryLoadImage as the
decode pattern, so the follow-up layer that owns the markup can do the whole job
in one pass. PinkFilter had no art note at all - the WPF ApplyFeatureArt was
dropped silently - so it gets one.

Verified: core-guards, both builds, --smoke, and --render-view on all three
touched views. The renders prove the cards still draw with real strings; nothing
visual changed in this layer, and the empty right-hand card in each PNG is the
missing plate.

Still blocked:
- CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml - x:Name on the
  hero plate (line 32, Width="240") and the side plate (line 121), each with an
  ImageBrush default of
  avares://CCP.Avalonia/Resources/features/Bubble_count.png. Header note
  "Resources/features/*.png does not ship in CCP.Avalonia" is stale.
- CCP.Avalonia/Views/Features/MindWipeFeatureControl.axaml - same, lines 31 and
  163, features/Mind_Wipers.png. Same stale header note.
- CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml - same, lines 29
  and 121, features/Pink_filter.png. Same stale header note.
- App.BubbleCount.Start/Stop/RefreshSchedule/TriggerGame - BubbleCountService,
  ConditioningControlPanel/Services/BubbleCountService.cs.
- App.MindWipe.UpdateSettings/StartLoop/StopLoop/TriggerOnce/ReloadAudioFiles -
  ConditioningControlPanel/Services/MindWipeService.cs.
- App.Overlay.RefreshOverlays / RefreshFilterColor -
  ConditioningControlPanel/Services/Notifications/OverlayService.cs (Win32
  layered windows, bucket E).
- StartupManager.IsRegistered - ConditioningControlPanel/Services/StartupManager.cs,
  a Windows Startup-folder shortcut, head-side by nature.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU