### PR TITLE
feat(avalonia): the shell paints the Trainer Card, the rail's premium tags and closes stale tooltips

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionTab.cs
@@ -1,24 +1,57 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CompanionTab.cs (472 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.CompanionTab.cs (471 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Sorted member by member: GENUINELY 100% head-side, and blocked TWICE over - once on the service
+// and once on the controls, which is worth stating because the second half is not obvious.
 //
-// Members dropped (8):
-//   private void SyncCompanionTabUI(…)
-//   private void UpdateCompanionCardsUI(…)
-//   private string GetActivePromptDisplayName(…)
-//   private void UpdateCommunityPromptsUI(…)
-//   private FrameworkElement CreatePromptRow(…)
-//   internal void CompanionCard_Click(…)
-//   internal void BtnCompanionPersonality_Click(…)
-//   private void UpdateCompanionPromptLabels(…)
+// THE CONTROLS. Every member here writes CompanionTab.<Name> - forty-odd of the ~110 names the WPF
+// CompanionTabView re-publishes so MainWindow's seven companion partials can keep the accessor path
+// they always had. The ported Views/Tabs/CompanionTabView publishes NONE of them (its own header
+// says why: they are passthroughs into a CompanionRoomRuntimeVm and eight zone viewmodels that have
+// not moved, and writing 110 properties returning null would be a seam in name only). The controls
+// themselves DO exist on this head, but inside the room's cells - SliderTriggerIntervalCompanion
+// lives in Views/Controls/Companion/Runtime/WorkshopTriggersCell, for instance - so a future wiring
+// reaches them through the cell that owns them, not through the tab.
+//
+// THE SERVICE. What each member needs, exactly:
+//   SyncCompanionTabUI      - the settings half IS reachable (CoreSettings.Current carries
+//                             TriggerModeEnabled, TriggerIntervalSeconds, IdleGiggleIntervalSeconds,
+//                             BubbleDurationSeconds), but the rest of the method is
+//                             _avatarTubeWindow.IsDetached (ConditioningControlPanel/AvatarTube/),
+//                             SyncAiBrainUI (MainWindow.AiBrain.cs) and CompanionRoom.Sync - and it
+//                             writes all of it through the tab accessors above. Note also the
+//                             _isLoading guard it wraps everything in: on Avalonia that guard is
+//                             MORE necessary, not less, because CheckBox and ToggleSwitch raise
+//                             IsCheckedChanged on a programmatic set.
+//   UpdateCompanionCardsUI  - App.Companion.ActiveCompanion / GetProgress / IsCompanionUnlocked
+//   CompanionCard_Click       (ConditioningControlPanel/Services/Companion/CompanionService.cs) and
+//                             App.Mods.IsCompanionSupported. Models.CompanionDefinition and
+//                             CompanionProgress ARE in Core (CCP.Core/Models/), and CoreMods answers
+//                             GetAccentColorHex and MakeModAware - so the five cards' names and
+//                             colours are the one part that would resolve. Their level, lock state
+//                             and active ring do not, and a card wearing four right answers and one
+//                             wrong one is worse than a card that waits.
+//   UpdateCommunityPromptsUI- App.CommunityPrompts.GetInstalledPrompts / ActivatePrompt /
+//   CreatePromptRow           GetInstalledPrompt (…/Services/Companion/CommunityPromptService.cs)
+//                             and Models.CommunityPrompt. The row BUILDER itself is portable
+//                             (Grid/StackPanel/TextBlock/Button + Loc.GetF("label_by_author", …)),
+//                             and its explicit-content gate is too - Services.ExplicitContentGate is
+//                             in Core (CCP.Core/Services/ExplicitContentGate.cs) and this head ships
+//                             Views/Dialogs/ExplicitContentAcknowledgementDialog. Only the roster is
+//                             missing, so this is the member to restore FIRST once
+//                             CommunityPromptService crosses.
+//   GetActivePromptDisplayName - App.Settings.Current.CompanionPrompt is reachable; the display name
+//                             it resolves comes from CommunityPromptService.
+//   BtnCompanionPersonality_Click - a Microsoft.Win32.OpenFileDialog seeded from
+//                             App.EffectiveAssetsPath (CorePaths answers that half) plus
+//                             CompanionService.GetAssignedPromptName. The picker maps to Avalonia's
+//                             StorageProvider; the assignment it performs does not.
+//   UpdateCompanionPromptLabels - the same assigned-name lookup, once per card.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ModCatalogue.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ModCatalogue.cs
@@ -1,24 +1,43 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ModCatalogue.cs (192 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.ModCatalogue.cs (191 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Sorted member by member: GENUINELY 100% head-side. The file is two round trips - upload a mod to
+// the web catalogue, install one dropped on the window - and every step of both is a service this
+// head does not have. Nothing here is layout or settings, so there is no half to restore.
 //
-// Members dropped (8):
-//   private const string CatalogueSchemaMod
-//   private const int ModPreviewMaxPixels
-//   private const int ModPreviewMaxBytes
-//   internal async Task ShareModToCatalogueAsync(…)
-//   private async Task HandleModDropAsync(…)
-//   private static JObject BuildModCatalogueAsset(…)
-//   private static long SafeDirectorySize(…)
-//   private static string? TryBuildPreviewThumb(…)
+// What each member needs, exactly:
+//   ShareModToCatalogueAsync - App.Catalogue.SubmitCatalogueAssetAsync
+//                              (ConditioningControlPanel/Services/CatalogueService.cs), the auth
+//                              token from AppSettings.AuthToken (reachable) plus App.UserDisplayName
+//                              (not), App.Notifications.Show
+//                              (…/Services/Notifications/NotificationService.cs) for all four
+//                              outcome toasts, and RecordCatalogueSubmission /
+//                              ShowCatalogueSubmissionResultToast, which are in
+//                              MainShellWindow.CatalogueSubmissions.cs - still a stub, and not a
+//                              file this layer owns. The AssetSubmitDialog it opens IS ported
+//                              (Views/Dialogs/AssetSubmitDialog).
+//   HandleModDropAsync       - App.Mods.ReadManifest / InstallModAsync
+//                              (ConditioningControlPanel/Services/ModService.cs). CoreMods carries
+//                              the READ side of the mod seam (Affirmation, InstalledMods, the
+//                              colours); installing an archive is not on it. The MessageBox confirm
+//                              maps to Views/Dialogs/MessageDialog.ConfirmAsync, which this head
+//                              ships.
+//   BuildModCatalogueAsset   - Models.ModPackage / ModManifest
+//   SafeDirectorySize          (ConditioningControlPanel/Models/, not in Core). SafeDirectorySize is
+//                              pure BCL and would compile here, but a helper with no asset to size
+//                              is not a restoration.
+//   TryBuildPreviewThumb     - BitmapImage + JpegBitmapEncoder. The Avalonia equivalent is
+//                              Avalonia.Media.Imaging.Bitmap.CreateScaledBitmap + Save(stream), so
+//                              this one is a real port rather than a seam - it just has no caller
+//                              until BuildModCatalogueAsset above has its models.
+//   CatalogueSchemaMod       - "ccp-mod/v1", and the two preview caps. Constants with no reader.
+//   ModPreviewMaxPixels
+//   ModPreviewMaxBytes
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.NavPremiumTags.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.NavPremiumTags.cs
@@ -1,26 +1,98 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.NavPremiumTags.cs (191 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.NavPremiumTags.cs (191 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// The little gold ★ that rides after a rail entry's label while that entry's door is shut to this
+// account, and disappears the moment it opens.
 //
-// Members dropped (10):
-//   private IEnumerable<(…)
-//   internal IEnumerable<FrameworkElement> NavPremiumTagElements
-//   private bool _navTagPatreonHooked
-//   private bool _navTagSubStarHooked
-//   private bool _navTagDailyFreeHooked
-//   private bool _navTagIntakePassHooked
-//   private void HookNavPremiumTags(…)
-//   private void QueueNavPremiumTagRefresh(…)
-//   internal void RefreshNavPremiumTags(…)
-//   private static bool IsNavEntryLocked(…)
+// WHAT CROSSES: the JOIN. "Which rail row is which sold feature" is a fact about
+// MainShellWindow.axaml and lives nowhere else, so it is the one thing this file has always
+// owned - eight tag Borders keyed by their ShowTab key, which is also the feature's roster key.
+// The pills are reached with Named<Border>() because this window's generated x:Name fields are
+// never assigned (see MainShellWindow.TabNavigation.cs).
+//
+// WHAT DOES NOT: the ANSWER. IsNavEntryLocked asks Models.ExclusiveFeature.All /
+// ExclusiveFeature.GateState (ConditioningControlPanel/Models/ExclusiveFeature.cs) and
+// DailyFreeService.IsFreeToday through App.DailyFree; the roster type is still WPF-side and this
+// head seeds no DailyFreeService instance, so there is no entitlement to read. That is NOT a
+// reason to invent one: the WPF original already fails to NO TAG on anything it cannot answer,
+// deliberately, because "an un-starred row that turns out to be locked costs a TierGate toast the
+// user was going to see anyway, while a starred row that is actually open is the rail lying about
+// what somebody already paid for". A head with no entitlement service is exactly that case, so
+// the honest answer here is the original's own fallback and the pills stay as authored
+// (IsVisible=False on the NavEntryPremiumTag theme).
+//
+// Also head-side: HookNavPremiumTags and QueueNavPremiumTagRefresh, whose four subscriptions are
+// App.Patreon.TierChanged, App.SubscribeStar.TierChanged, App.DailyFree.TodayChanged and
+// App.IntakePass.PassStateChanged - four services, none of them on this head. The marshal they
+// wrap is CoreDispatch/Dispatcher.UIThread.Post here, one line, once there is something to
+// subscribe to.
+//
+// Callers this layer does not own: InitializeNavRail and RefreshNavPremiumTags' repaint callers
+// live in MainShellWindow.NavRail.cs / MainShellWindow.PremiumRail.cs, and the collapse fade that
+// reads NavPremiumTagElements is SetNavRailExpanded in MainShellWindow.NavRail.cs.
+
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>
+        /// The join: one premium tag Border per rail entry, keyed by the entry's ShowTab key -
+        /// which is also its ExclusiveFeature key. Adding a rail row for a sold feature means
+        /// adding its pill in MainShellWindow.axaml and one row here; nothing else.
+        ///
+        /// <para>Two roster entries deliberately have no row: "fyp" and "justdrop" are window
+        /// launchers, not rail entries, so there is nothing to tag.</para>
+        /// </summary>
+        private IEnumerable<(Border? Tag, string Key)> NavPremiumTagMap
+        {
+            get
+            {
+                yield return (Named<Border>("TagPremiumHaptics"), "haptics");
+                yield return (Named<Border>("TagPremiumTakeover"), "bambitakeover");
+                yield return (Named<Border>("TagPremiumSheListening"), "shelistening");
+                yield return (Named<Border>("TagPremiumAwareness"), "awareness");
+                yield return (Named<Border>("TagPremiumGradedIntake"), "gradedintake");
+                yield return (Named<Border>("TagPremiumLockdown"), "lockdown");
+                yield return (Named<Border>("TagPremiumBlinkTrainer"), "blinktrainer");
+                yield return (Named<Border>("TagPremiumRemoteControl"), "remotecontrol");
+            }
+        }
+
+        /// <summary>The pills, for the rail's collapse fade. Non-null only; a tag whose control
+        /// failed to resolve simply is not faded, because it is not on screen either.</summary>
+        internal IEnumerable<Control> NavPremiumTagElements =>
+            NavPremiumTagMap.Select(t => t.Tag).Where(t => t is not null)!;
+
+        /// <summary>
+        /// Paints every rail premium tag from the roster. Cheap enough to be unconditional: eight
+        /// namescope lookups, no allocation that matters, no clock started. Never throws - the
+        /// rail's chrome must not be able to break a tab switch.
+        /// </summary>
+        internal void RefreshNavPremiumTags()
+        {
+            foreach (var (tag, key) in NavPremiumTagMap)
+            {
+                if (tag is null) continue;
+                tag.IsVisible = IsNavEntryLocked(key);
+            }
+        }
+
+        /// <summary>
+        /// "Is this door shut to this account right now?" - see the header for why this head can
+        /// only answer no. Kept as its own member rather than folded into the loop above so the
+        /// roster lookup lands in one place when ExclusiveFeature crosses.
+        /// </summary>
+        private static bool IsNavEntryLocked(string exclusiveKey)
+        {
+            // ponytail: needs Models.ExclusiveFeature.All + GateState
+            // (ConditioningControlPanel/Models/ExclusiveFeature.cs) and DailyFreeService.IsFreeToday
+            // for the feature's DailyFreeKey. WPF's own fallback for an unanswerable key is "not
+            // locked", which is what an entitlement-less head is.
+            _ = exclusiveKey;
+            return false;
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
@@ -1,22 +1,50 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.PlayTab.cs (332 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.PlayTab.cs (331 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Sorted member by member against the fifteen Core seams and the ported views: this file is
+// GENUINELY 100% head-side, and it is head-side for one reason rather than fifteen. It is the Play
+// wall's ENTITLEMENT painter - every line of it decides "is this card locked, free today, or paid
+// for", and not one of those answers exists on this head. There is nothing here that is layout,
+// navigation or settings, so there is no half to restore; a token method would be a lie about a
+// wall that would then draw every card unlocked.
 //
-// Members dropped (6):
-//   private const double GoonPerkLockedOpacity
-//   internal void RefreshPlayCards(…)
-//   private static void RefreshPlayFreeStamps(…)
-//   private static void SetFreeStamp(…)
-//   private void RefreshPlayIntakeCard(…)
-//   internal void StartMantraSession(…)
+// What each member needs, exactly:
+//   RefreshPlayCards        - Services.TierGate.RequiresLab / RequiresPremium
+//                             (ConditioningControlPanel/Services/TierGate.cs) for eight verdicts;
+//                             MainWindow.PremiumRail.cs's SetLockband / SetLockbandVisible to paint
+//                             one; App.Patreon.HasPremiumAccess / HasLabAccess
+//                             (ConditioningControlPanel/Services/Account/PatreonService.cs) for the
+//                             two Goon perk lines; and the two static door flags
+//                             Services.Arcademy.ArcademyHostService.DoorAvailable and
+//                             Services.JustDrop.JustDropService.DoorAvailable, which decide whether
+//                             those two cards are on the wall at all.
+//   RefreshPlayFreeStamps   - App.DailyFree.IsFreeToday. DailyFreeService itself IS in Core
+//   SetFreeStamp              (CCP.Core/Services/DailyFreeService.cs), but no head seeds an
+//                             instance and there is no CoreDailyFree seam, so nothing can be asked
+//                             which door the wheel opened today. The TierBadge.FreeToday property
+//                             it writes is already ported (Views/Controls/TierBadge).
+//   RefreshPlayIntakeCard   - App.IntakePass.State + IntakePassService.DaysUntilNextPass
+//                             (ConditioningControlPanel/Services/Progression/IntakePassService.cs)
+//                             for the card's four pass states.
+//   StartMantraSession      - App.Mantra.StartSession
+//                             (ConditioningControlPanel/Services/MantraService.cs) and the
+//                             MantraWindow it opens (ConditioningControlPanel/Windows/
+//                             MantraWindow.xaml.cs), neither of which is ported. Note the WPF file's
+//                             own header: this helper has had NO CALLER since the 2026-08-12
+//                             relayout took the Mantras card off the page, and it is kept there
+//                             only because it is the one place that knows the window needs
+//                             StartSession(n) to have run before it loads.
+//   GoonPerkLockedOpacity   - the 0.42 dim for an unbought Goon perk. A constant with no reader
+//                             until RefreshPlayCards has its two entitlement answers.
+//
+// One more trap for whoever wires this: Views/Tabs/PlayTabView loads with AvaloniaXamlLoader.Load,
+// so ITS x:Name fields (PlayLockDtrh, SlotArcademy, TxtPlayGoonPerkSend, …) are null too - the same
+// hazard this window has. Every one of them must be reached with tab.FindControl<T>(name).
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PresetIO.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PresetIO.cs
@@ -1,30 +1,50 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.PresetIO.cs (368 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.PresetIO.cs (367 lines) - and for
+// its two phrase members, NOT NEEDED: they already ship on this head somewhere better.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// THE STALE NOTE THIS FILE USED TO CARRY. BtnExportPhrases_Click and BtnImportPhrases_Click are
+// live in Views/Controls/AppSettings/DataSettingsSection.axaml.cs, over the same
+// Services.PhraseBackupService (now in Core, CCP.Core/Services/PhraseBackupService.cs), with WPF's
+// Microsoft.Win32 Save/OpenFileDialog replaced by TopLevel.StorageProvider and the destructive
+// import still confirm-gated. Their axaml Click= handlers name that section, not this window, so
+// re-adding them here would be a second copy competing for the same buttons. Deleted deliberately.
 //
-// Members dropped (14):
-//   private const string CatalogueSchemaPreset
-//   private const string CatalogueSchemaSession
-//   private Services.PresetFileService? _presetFileService
-//   internal void BtnExportPreset_Click(…)
-//   private Services.PhraseBackupService? _phraseBackupService
-//   internal void BtnExportPhrases_Click(…)
-//   internal void BtnImportPhrases_Click(…)
-//   private void HandlePresetDrop(…)
-//   internal async void BtnSharePreset_Click(…)
-//   private async Task SharePresetToCatalogueAsync(…)
-//   private async Task ShareSessionToCatalogueAsync(…)
-//   internal static Border? CreateCatalogueStatusBadge(…)
-//   private void UpdatePresetShareStatusBadge(…)
-//   private void RefreshCatalogueShareBadges(…)
+// The rest of the file is the catalogue share path, and it is head-side. What each member needs:
+//   BtnExportPreset_Click     - Services.PresetFileService
+//                               (ConditioningControlPanel/Services/PresetFileService.cs) is still in
+//                               the head, and the _selectedPreset it exports lives in
+//                               MainShellWindow.Presets.cs, another stub this layer does not own.
+//                               The save picker itself maps to StorageProvider.SaveFilePickerAsync,
+//                               exactly as the phrase export above already does, and the two result
+//                               dialogs map to Views/Dialogs/MessageDialog - so once
+//                               PresetFileService crosses, this member is a ten-minute port.
+//   HandlePresetDrop          - the same service's import half, plus the window drag-and-drop
+//                               handlers in MainShellWindow.axaml.cs, which are stubs.
+//   BtnSharePreset_Click      - App.Catalogue.SubmitCatalogueAssetAsync
+//   SharePresetToCatalogueAsync (ConditioningControlPanel/Services/CatalogueService.cs) plus
+//   ShareSessionToCatalogueAsync App.UserDisplayName, and RecordCatalogueSubmission /
+//                               ShowCatalogueSubmissionResultToast from
+//                               MainShellWindow.CatalogueSubmissions.cs (a stub, not owned here).
+//                               The AssetSubmitDialog both open IS ported
+//                               (Views/Dialogs/AssetSubmitDialog).
+//   CreateCatalogueStatusBadge- builds a coloured pill from a Models.DeeperSubmissionRecord, which
+//                               IS in Core (CCP.Core/Models/DeeperSubmissionRecord.cs), so the
+//                               builder itself would compile here as a Border + TextBlock. It is not
+//                               restored because its status test (IsCatalogueAcceptedStatus) lives
+//                               in MainShellWindow.CatalogueSubmissions.cs and its two callers -
+//                               UpdatePresetShareStatusBadge and ModManagerDialog - have neither a
+//                               record to read nor a host to draw into yet. A pill nothing can hand
+//                               a record to is scaffolding, not a port.
+//   UpdatePresetShareStatusBadge - GetCatalogueRecord, same unowned partial, and PresetsTabView's
+//   RefreshCatalogueShareBadges    PresetShareStatusHost / the session rack repaint
+//                                  (MainShellWindow.SessionIO.cs).
+//   CatalogueSchemaPreset     - "ccp-preset/v1" and "ccp-session/v1". Constants with no reader.
+//   CatalogueSchemaSession
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCard.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCard.cs
@@ -1,33 +1,237 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileCard.cs (417 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProfileCard.cs (417 lines) - the
+// part of it that is presentation over ported controls, which is most of the file.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// The Trainer Card itself is Views/Tabs/DiscordTabView; this partial is the shell-side painter
+// for the surfaces that card cannot fill on its own: whose card is on screen, the Showcase's
+// unlock meter, the community rail's sharing footer, and the Privacy & Sharing dialog.
 //
-// Members dropped (17):
-//   public string Id
-//   public string Name
-//   public System.Windows.Media.ImageSource? Image
-//   private bool _profileMeFirstDone
-//   private bool _profileViewingSelf
-//   private Visibility PinPlaceholderVisibility(…)
-//   internal void EnsureProfileMeFirst(…)
-//   internal void SetProfileViewingSelf(…)
-//   private bool _profileStatBadgesModHooked
-//   internal void RefreshProfileStatBadges(…)
-//   internal void UpdateProfileXpMeter(…)
-//   private DescentReceiptKind OwnDescentReceiptKind(…)
-//   internal void RefreshProfileDescentReceipt(…)
-//   internal void UpdateProfileShowcase(…)
-//   private static string? FindNextAchievementName(…)
-//   internal void UpdateProfileSharingSummary(…)
-//   internal void OpenProfilePrivacyDialog(…)
+// TWO NAMESCOPE HAZARDS, both live here:
+//   1. This window loads with AvaloniaXamlLoader.Load, so its generated x:Name fields are never
+//      assigned - the tab is reached with Named<T>() (MainShellWindow.TabNavigation.cs).
+//   2. DiscordTabView loads the SAME way, so ITS x:Name fields are null too. Every control below
+//      is therefore reached with page.FindControl<T>(name), never `page.TxtProfileNextUp`. That
+//      compiles either way; only one of them draws.
+//
+// ProfileAchievementTile is NOT redeclared here: this head already carries it, as a public class
+// beside DiscordTabView, because the axaml's two DataTemplates name it (x:DataType).
+//
+// Still head-side, each with the exact symbol and where it lives today:
+//   EnsureProfileMeFirst        - calls DiscordTabView.BtnViewMyProfile_Click, which forwards to
+//                                 MainWindow's leaderboard-then-local profile fetch
+//                                 (ConditioningControlPanel/MainWindow/MainWindow.Browser.cs).
+//   RefreshProfileStatBadges    - Services.ModResourceResolver.ResolveImage
+//                                 (ConditioningControlPanel/Services/ModResourceResolver.cs)
+//                                 decodes to System.Windows.Media.ImageSource and falls back to a
+//                                 pack:// URI. CoreModArt.OverridePath answers the override half,
+//                                 but this head ships no Resources/achievements/*.png to fall back
+//                                 to, so there is nothing to paint yet.
+//   UpdateProfileXpMeter        - ProgressionService.GetXPForLevel
+//                                 (ConditioningControlPanel/Services/Progression/ProgressionService.cs).
+//                                 CoreProgression carries AddXP only, not the level curve.
+//   RefreshProfileDescentReceipt- DescentReceipt / DescentMigration.ActiveCycleXpBonus
+//                                 (ConditioningControlPanel/Services/Descent/). SetProfileViewingSelf
+//                                 below still enforces the half that is portable: a searched card
+//                                 wears no receipt.
+//   OwnDescentReceiptKind       - the same two types.
+//   FindNextAchievementName     - Models.Achievement.All
+//                                 (ConditioningControlPanel/Models/Achievement.cs).
+//   RefreshProfileSpiralPlate   - MainShellWindow.ProfileSpiral.cs, still a stub.
+//
+// No caller yet for any member below: the buttons that invoke them are DiscordTabView's inert
+// handlers (BtnProfilePrivacy_Click, BtnProfileSearch_Click) and MainShellWindow.Browser.cs's
+// profile render, none of which this layer owns.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>The Profile tab. Resolved on every read - see hazard 1 in the header.</summary>
+        internal Tabs.DiscordTabView? ProfilePage => Named<Tabs.DiscordTabView>("DiscordTab");
+
+        /// <summary>
+        /// Whose card is on screen. Read by the empty-pin placeholder rule below: the four ☆
+        /// plates carry second-person copy and must never appear over somebody else's profile.
+        /// Defaults to true because the tab opens on your own card.
+        /// </summary>
+        private bool _profileViewingSelf = true;
+
+        /// <summary>Shown only on YOUR card, and only while nothing is pinned. Both callers go
+        /// through here so the rule cannot drift.</summary>
+        private bool PinPlaceholdersVisible(bool hasPins) => !hasPins && _profileViewingSelf;
+
+        /// <summary>
+        /// Shows or hides the header's "back to me" chip, and with it every self-only surface on
+        /// the card. Someone else's card is on screen ⇒ the chip is the way home, and Customize
+        /// and Privacy step aside because they always edit YOUR loadout whoever's card is up
+        /// (bug #1113).
+        /// </summary>
+        internal void SetProfileViewingSelf(bool isSelf)
+        {
+            try
+            {
+                _profileViewingSelf = isSelf;
+
+                var page = ProfilePage;
+                if (page is null) return;
+
+                var customize = page.FindControl<Button>("BtnProfileCustomize");
+                if (customize is not null) customize.IsVisible = isSelf;
+                var privacy = page.FindControl<Button>("BtnProfilePrivacy");
+                if (privacy is not null) privacy.IsVisible = isSelf;
+
+                // The migration receipt rides the same switch: a searched card must never wear
+                // your descent. WPF re-resolves the pill through RefreshProfileDescentReceipt;
+                // only its "what does a self card show" half is blocked (see the header), and
+                // hiding it on a stranger's card is the half that must not wait for that.
+                if (!isSelf)
+                {
+                    var receipt = page.FindControl<Border>("ProfileDescentReceipt");
+                    if (receipt is not null) receipt.IsVisible = false;
+                }
+
+                var back = page.FindControl<Button>("BtnProfileBackToMe");
+                if (back is not null) back.IsVisible = !isSelf;
+            }
+            catch (Exception ex) { Log.Debug("SetProfileViewingSelf: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Updates the Showcase's expander header, unlock bar, summary and "next up" line.
+        ///
+        /// <para><paramref name="unlockedIds"/> is only available for the viewer's own card (the
+        /// leaderboard hands out a count, not a list). It is carried unused for now because the
+        /// only thing that reads it is FindNextAchievementName, which needs Models.Achievement.All
+        /// - so the "next up" line is HIDDEN rather than guessed at, exactly as WPF hides it when
+        /// the list is null.</para>
+        /// </summary>
+        internal void UpdateProfileShowcase(int unlocked, int total, HashSet<string>? unlockedIds)
+        {
+            try
+            {
+                var page = ProfilePage;
+                if (page is null) return;
+
+                // The two counts can arrive from different universes: your own card passes
+                // free-only unlocked / free-only total, a searched card passes the leaderboard's
+                // raw AchievementsCount (patron exclusives and hidden entries included) against
+                // the same free-only total, so a heavy patron arrives with unlocked > total.
+                // Clamp once, here, so the header, the bar and the summary cannot disagree
+                // ("54 of 46 · 100%").
+                if (unlocked < 0) unlocked = 0;
+                if (total > 0 && unlocked > total) unlocked = total;
+
+                var header = page.FindControl<TextBlock>("TxtProfileAllAchievementsHeader");
+                if (header is not null) header.Text = Loc.GetF("profile_showcase_all_count", unlocked);
+
+                var fraction = total > 0 ? (double)unlocked / total : 0;
+                fraction = Math.Clamp(fraction, 0, 1);
+                SetProfileMeter(page, "ProfileUnlockBar", fraction);
+
+                var summary = page.FindControl<TextBlock>("TxtProfileUnlockSummary");
+                if (summary is not null)
+                {
+                    summary.Text = total > 0
+                        ? Loc.GetF("profile_showcase_progress", unlocked, total, (int)Math.Round(fraction * 100))
+                        : string.Empty;
+                }
+
+                var nextUp = page.FindControl<TextBlock>("TxtProfileNextUp");
+                if (nextUp is not null)
+                {
+                    // ponytail: FindNextAchievementName needs Models.Achievement.All
+                    // (ConditioningControlPanel/Models/Achievement.cs). Until it is reachable the
+                    // answer is "unknown", and WPF's own rule for unknown is to say nothing.
+                    _ = unlockedIds;
+                    nextUp.Text = string.Empty;
+                    nextUp.IsVisible = false;
+                }
+
+                // The four empty pin plates step aside as soon as something is pinned - and never
+                // appear at all on someone else's card, because their copy is addressed to you.
+                var placeholders = page.FindControl<StackPanel>("ProfilePinnedPlaceholders");
+                if (placeholders is not null)
+                {
+                    var hasPins = page.FindControl<ItemsControl>("ProfilePinnedShowcase")?.ItemsSource
+                                      is IEnumerable src && src.Cast<object>().Any();
+                    placeholders.IsVisible = PinPlaceholdersVisible(hasPins);
+                }
+            }
+            catch (Exception ex) { Log.Debug("UpdateProfileShowcase: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The community rail's footer line: how many of the ten sharing toggles are on. Read
+        /// straight from settings rather than from the checkboxes, so it is correct before the
+        /// Privacy dialog has ever been opened and the panel's controls have been touched.
+        /// </summary>
+        internal void UpdateProfileSharingSummary()
+        {
+            try
+            {
+                var text = ProfilePage?.FindControl<TextBlock>("TxtProfileSharingSummary");
+                if (text is null) return;
+
+                var s = CoreSettings.Current;
+                var flags = new[]
+                {
+                    s.DiscordRichPresenceEnabled,
+                    s.DiscordShowLevelInPresence,
+                    s.ShowOnlineStatus,
+                    s.DiscordShareAchievements,
+                    s.DiscordShareLevelUps,
+                    s.AllowDiscordDm,
+                    s.ShareProfilePicture,
+                    s.GoonShareAvatar,
+                    s.GoonShareDiscordDm,
+                    s.GoonRichPresence,
+                };
+                var on = flags.Count(f => f);
+                text.Text = Loc.GetF("profile_sharing_summary", on, flags.Length - on);
+            }
+            catch (Exception ex) { Log.Debug("UpdateProfileSharingSummary: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Opens the relocated sharing controls. The dialog BORROWS DiscordTabView's single
+        /// long-lived <c>PrivacyPanel</c> instance, so the toggles inside it are the very controls
+        /// the shell keeps writing to - opening and closing changes nothing but where they render.
+        ///
+        /// <para>async void, and ShowDialog needs an owner: Avalonia's is awaitable where WPF's
+        /// blocks. The summary is repainted in the finally either way, as WPF does.</para>
+        /// </summary>
+        internal async void OpenProfilePrivacyDialog()
+        {
+            try
+            {
+                var page = ProfilePage;
+                if (page is null) return;
+                await new ProfilePrivacyDialog(page.PrivacyPanel).ShowDialog(this);
+            }
+            catch (Exception ex) { Log.Error(ex, "OpenProfilePrivacyDialog failed"); }
+            finally { UpdateProfileSharingSummary(); }
+        }
+
+        /// <summary>
+        /// One two-column star meter's fill. WPF names the two ColumnDefinitions
+        /// (ProfileXpFillCol / ProfileXpRestCol); an Avalonia ColumnDefinition is not a
+        /// StyledElement and cannot carry an x:Name (AVLN2000), so the axaml names the GRID and
+        /// the columns are written by index - the same two GridLengths.
+        /// </summary>
+        private static void SetProfileMeter(Control page, string gridName, double fraction)
+        {
+            var grid = page.FindControl<Grid>(gridName);
+            if (grid is null || grid.ColumnDefinitions.Count < 2) return;
+            grid.ColumnDefinitions[0].Width = new GridLength(fraction, GridUnitType.Star);
+            grid.ColumnDefinitions[1].Width = new GridLength(1 - fraction, GridUnitType.Star);
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.QuestsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.QuestsTab.cs
@@ -1,33 +1,50 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs (991 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs (990 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Sorted member by member: this file is GENUINELY 100% head-side. Its seventeen members are one
+// service's presentation layer - every path starts at App.Quests and none of the seams answer for
+// it. The card control it feeds IS ported (Views/Controls/DailyQuestCard + DailyQuestCardModel,
+// already carrying IImage in place of ImageSource), so what is missing is strictly the data, not
+// the drawing.
 //
-// Members dropped (17):
-//   internal void RerollDailySlot(…)
-//   internal void BtnRerollWeekly_Click(…)
-//   private readonly string?[] _dailyCardQuestIds
-//   private readonly Dictionary<string, BitmapImage> _questArtCache
-//   internal BitmapImage? GetQuestArt(…)
-//   internal void ClearQuestArtCache(…)
-//   private Views.Controls.DailyQuestCardModel BuildDailyCardModel(…)
-//   private void RefreshQuestUI(…)
-//   private void RefreshPunchCard(…)
-//   private static FrameworkElement BuildPunchHole(…)
-//   private void RefreshStreakCalendar(…)
-//   internal void StreakCalendarCanvas_SizeChanged(…)
-//   internal void BtnFixStreak_Click(…)
-//   private void ExitStreakFixMode(…)
-//   private async void StreakFixDay_Click(…)
-//   private void OnSettingsPropertyChangedForQuests(…)
-//   private void RecalculateDailyQuestStreak(…)
+// What each member needs, exactly:
+//   RerollDailySlot         - App.Quests.RerollDaily / RerollWeekly and the reroll budget
+//   BtnRerollWeekly_Click     (ConditioningControlPanel/Services/Progression/QuestService.cs).
+//   RefreshQuestUI          - the same service for the three daily seats, the weekly card, the
+//   BuildDailyCardModel       stats tiles and the streak, plus Models.QuestDefinition /
+//   _dailyCardQuestIds        Models.ActiveQuest (ConditioningControlPanel/Models/Quest.cs) and
+//                             QuestDefinitionService for the roster. Neither model is in Core.
+//   ComputeQuestXpDisplay   - ProgressionService.QuestLevelScale
+//                             (ConditioningControlPanel/Services/Progression/ProgressionService.cs)
+//                             and App.SkillTree.GetRerollBonusMultiplier
+//                             (…/Progression/SkillTreeService.cs). CoreProgression carries AddXP
+//                             only, so the ONE formula that must match what CompleteQuest actually
+//                             pays cannot be reproduced here - and a second, drifting copy of it is
+//                             exactly the bug the WPF comment says this method was written to end.
+//   GetQuestArt             - GetModeAwareQuestImagePath + LoadQuestImage, both in
+//   ClearQuestArtCache        MainWindow.xaml.cs, which resolve mod-aware art to a BitmapImage over
+//                             pack:// URIs. CoreModArt.OverridePath answers the mod-override half,
+//                             but this head ships no Resources/quests art to fall back to.
+//   RefreshPunchCard        - App.Quests' punch-card state; BuildPunchHole draws with
+//   BuildPunchHole            System.Windows.Shapes + a DropShadowEffect.
+//   RefreshStreakCalendar   - App.Quests' completion history + AppSettings.StreakFixCharges for the
+//   BtnFixStreak_Click        button caption. The settings half IS reachable (CoreSettings.Current),
+//   ExitStreakFixMode         but a calendar with no history to paint is not a calendar.
+//   StreakFixDay_Click      - App.Quests.SpendStreakFix, which is a server round trip.
+//   RecalculateDailyQuestStreak - App.Quests.RecalculateStreak. One line, and the line is the service.
+//   OnSettingsPropertyChangedForQuests - the only member whose TRIGGER is portable
+//                             (AppSettings implements INPC and CoreSettings.Current hands it over,
+//                             and DispatcherHelper.RunOnUI maps to Dispatcher.UIThread.Post). It is
+//                             not restored because all it does is call RefreshQuestUI, so on this
+//                             head it would be a subscription that repaints nothing.
+//
+// Trap for whoever wires this: Views/Tabs/QuestsTabView loads with AvaloniaXamlLoader.Load, so ITS
+// x:Name fields are null - reach every control with tab.FindControl<T>(name).
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ToolTipHygiene.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ToolTipHygiene.cs
@@ -1,28 +1,85 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ToolTipHygiene.cs (247 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.ToolTipHygiene.cs (247 lines), and
+// the port is one tenth the size because the hazard is the same and the framework is not.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// THE PROBLEM, unchanged: a tooltip is dismissed when the pointer leaves its owner, and nothing
+// else. This app is navigated by clicks, by code (~25 ShowTab call sites) and, in the automated
+// play-test harness, by accessibility automation - none of which move the cursor. So a tooltip
+// opened by a stationary pointer outlives the tab it belongs to and hangs over the NEXT tab until
+// the user physically twitches the mouse. It looks like a rendering bug and it shows up in every
+// screenshot sweep.
 //
-// Members dropped (12):
-//   private const int ToolTipSweepMaxDepth
-//   private const int ToolTipSweepMaxVisuals
-//   private bool _toolTipHygieneHooked
-//   private WeakReference<DependencyObject>? _openToolTipOwner
-//   internal void EnsureToolTipHygiene(…)
-//   private void OnAnyToolTipOpening(…)
-//   private void OnAnyToolTipClosing(…)
-//   private void CloseStaleToolTip(…)
-//   private static void CloseToolTipOn(…)
-//   private static void SweepOpenToolTips(…)
-//   private static IEnumerable<ToolTip> FindToolTips(…)
-//   private static void SyntheticMouseLeave(…)
+// WHY THE WPF FILE IS 247 LINES AND THIS IS NOT. WPF's ToolTip is a Popup in its own HWND with its
+// own PresentationSource, and ToolTipService.GetToolTip hands back either a ToolTip or raw content
+// WPF wrapped in one - so the original had to sweep every PresentationSource on the thread to find
+// the live popup whatever shape it was declared in, then synthesize a MouseLeave and a
+// Mouse.Synchronize so PopupControlService dropped its own reference. None of that exists here:
+//   ToolTipService.ToolTipOpening/Closing + a WeakReference owner
+//        -> dropped. Avalonia records the open state ON THE OWNER, as the ToolTip.IsOpen attached
+//           property, so the owner needs no tracking - it can be read back off the tree.
+//   SweepOpenToolTips / FindToolTips over PresentationSource.CurrentSources
+//        -> the pointer-over descent below. Avalonia opens at most one tooltip at a time and only
+//           over a control the pointer is on, so the owner is always ON the hover chain: descend
+//           from the window through children whose IsPointerOver is set and the first one with
+//           ToolTip.IsOpen is it. That is a walk of the tree's DEPTH, not its size, so it is cheap
+//           enough to run on every tab switch - which is what the WPF version's two bounded-sweep
+//           constants (ToolTipSweepMaxDepth / ToolTipSweepMaxVisuals) were buying with a cap.
+//   CloseToolTipOn / SyntheticMouseLeave / Mouse.Synchronize
+//        -> ToolTip.SetIsOpen(owner, false). Avalonia's tooltip service reads the same property,
+//           so there is no second bookkeeping copy to talk out of its belief.
+//
+// NOT WIRED BY THIS LAYER: the caller. WPF closes the stale tooltip from inside ShowTab, which is
+// MainShellWindow.TabNavigation.cs - one line (`CloseStaleToolTip();` beside SwitchTabFx), in a
+// file this layer does not own.
+
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>How far down the hover chain to look before giving up. The shell nests deeply
+        /// (rail -> door -> flyout -> row -> glyph), so this is generous where WPF's popup-root cap
+        /// was 6 - but it is still a cap, so a cycle or a pathological tree cannot spin here.</summary>
+        private const int ToolTipHoverMaxDepth = 64;
+
+        /// <summary>
+        /// Closes whatever tooltip is up. Never throws: this is meant to run inside ShowTab, and a
+        /// cosmetic tidy-up must not be able to break navigation.
+        /// </summary>
+        internal void CloseStaleToolTip()
+        {
+            try
+            {
+                var owner = FindOpenToolTipOwner(this);
+                if (owner is not null) ToolTip.SetIsOpen(owner, false);
+            }
+            catch (Exception ex) { Log.Debug("CloseStaleToolTip: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The control whose tooltip is open, found by following the pointer-over chain down from
+        /// <paramref name="root"/>. Null when nothing is up, which is the common case.
+        ///
+        /// <para>The chain is what makes this correct rather than merely cheap: a tooltip only ever
+        /// opens over a control the pointer is on, and a code-driven tab switch moves no pointer, so
+        /// the stale tooltip's owner is still flagged IsPointerOver when we come looking.</para>
+        /// </summary>
+        private static Control? FindOpenToolTipOwner(Visual root)
+        {
+            Visual? node = root;
+            for (var depth = 0; node is not null && depth < ToolTipHoverMaxDepth; depth++)
+            {
+                if (node is Control control && ToolTip.GetIsOpen(control)) return control;
+                node = node.GetVisualChildren()
+                           .FirstOrDefault(v => v is InputElement { IsPointerOver: true });
+            }
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Eight MainShellWindow partials, sorted member by member against the fifteen Core seams and the
ported views rather than against their own stale "wholesale stub" header. Three of them had real
work left in them; five are genuinely 100% head-side and now say exactly which symbol at which
head path is missing instead of repeating a blanket claim that stopped being true several layers
ago.

ProfileCard is the substantial one. SetProfileViewingSelf, UpdateProfileShowcase,
UpdateProfileSharingSummary and OpenProfilePrivacyDialog are real bodies now: the "back to me"
chip and the two self-only buttons follow whose card is on screen, the Showcase's unlock meter,
header and summary are clamped and painted (a heavy patron arrives with unlocked > total, so the
three cannot disagree), the community rail's sharing footer counts the ten toggles straight out of
CoreSettings.Current, and the Privacy dialog borrows DiscordTabView's long-lived panel and
repaints the footer on close. Two namescope hazards live in this file and are documented at the
top of it: DiscordTabView loads with AvaloniaXamlLoader.Load exactly as this window does, so ITS
x:Name fields are null too and every control is reached with page.FindControl - the shell hazard
is not confined to the shell. ProfileAchievementTile is deliberately not redeclared; this head
already carries it beside DiscordTabView because the axaml's DataTemplates name it.

NavPremiumTags gets back the one thing it has always owned - the JOIN from each rail pill to its
ShowTab key, which is a fact about MainShellWindow.axaml and lives nowhere else - resolved through
Named<Border> because this window's generated fields are never assigned. The ANSWER stays
head-side, and IsNavEntryLocked returns false on purpose: that is the WPF original's own documented
fallback for a key it cannot resolve, because a starred row over a door somebody already paid for
is the worse failure.

ToolTipHygiene is a real port at a tenth the size. WPF needed 247 lines to find a tooltip popup in
its own HWND and then talk PopupControlService out of its belief; Avalonia records the open state
on the OWNER as ToolTip.IsOpen, and only ever over a control the pointer is on, so the whole file
collapses to descending the pointer-over chain and clearing the flag. That is a walk of the tree's
depth, not its size, which is why it needs no visual-count cap.

PresetIO carried the layer's one stale-note correction worth calling out: its two phrase members
are not missing, they SHIP - BtnExportPhrases_Click and BtnImportPhrases_Click are live in
Views/Controls/AppSettings/DataSettingsSection.axaml.cs over the same PhraseBackupService with
StorageProvider in place of Microsoft.Win32. Re-adding them here would have been a second copy
competing for the same buttons.

Still blocked:
- MainShellWindow.TabNavigation.cs (not owned by this layer): ShowTab needs one line,
  CloseStaleToolTip(), beside SwitchTabFx. Until then the tooltip sweep has no caller.
- MainShellWindow.NavRail.cs / .PremiumRail.cs (not owned): InitializeNavRail must call
  RefreshNavPremiumTags, and SetNavRailExpanded must fade NavPremiumTagElements.
- Views/Tabs/DiscordTabView.axaml.cs (not owned): BtnProfilePrivacy_Click, BtnProfileSearch_Click
  and BtnViewMyProfile_Click are inert, so nothing yet calls the four ProfileCard members.
- Models.ExclusiveFeature.All / GateState (ConditioningControlPanel/Models/ExclusiveFeature.cs) and
  a DailyFreeService instance seam: IsNavEntryLocked cannot answer without them.
- ProgressionService.GetXPForLevel (…/Services/Progression/ProgressionService.cs):
  UpdateProfileXpMeter.
- DescentReceipt / DescentMigration.ActiveCycleXpBonus (…/Services/Descent/):
  RefreshProfileDescentReceipt, OwnDescentReceiptKind.
- Models.Achievement.All (ConditioningControlPanel/Models/Achievement.cs): FindNextAchievementName,
  so the Showcase's "next up" line stays hidden.
- Services.ModResourceResolver.ResolveImage (…/Services/ModResourceResolver.cs):
  RefreshProfileStatBadges. CoreModArt answers the override half, but this head ships no
  Resources/achievements art to fall back to.
- Services.TierGate (…/Services/TierGate.cs), App.Patreon (…/Services/Account/PatreonService.cs),
  App.IntakePass (…/Services/Progression/IntakePassService.cs), App.Quests + App.SkillTree
  (…/Services/Progression/), App.Companion + App.CommunityPrompts (…/Services/Companion/),
  App.Catalogue (…/Services/CatalogueService.cs), App.Notifications
  (…/Services/Notifications/NotificationService.cs), Services.PresetFileService: the whole of
  PlayTab, QuestsTab, CompanionTab, ModCatalogue and PresetIO.
- CompanionTab is blocked twice: the ported CompanionTabView republishes none of the ~110 control
  names its members write, so a future wiring goes through the room cell that owns each control.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU