### PR TITLE
feat(avalonia): the shell banner rotates, login state gates its tabs, the session lock derives and paints

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CloudBackup.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CloudBackup.cs
@@ -1,22 +1,46 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CloudBackup.cs (286 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.CloudBackup.cs (285 lines).
+// Not "waiting for a service to move to Core" - two structural blockers:
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// 1. THE BUTTONS LEFT THIS WINDOW. WPF carried the Settings door inline in MainWindow.xaml, so
+//    these handlers hung off the shell. The port moved all four WITH their markup to
+//    CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml(.cs), where
+//    BtnBackupSettingsNow_Click / BtnRestoreSettings_Click / BtnExportData_Click /
+//    BtnPrivacyPolicy_Click already exist as that control's own stubs. Restoring them here would
+//    be a second copy nothing routes to. Cloud backup gets wired in THAT file.
 //
-// Members dropped (6):
-//   internal void ReloadSettingsUiAfterRestore(…)
-//   internal async void BtnBackupSettingsNow_Click(…)
-//   internal async void BtnRestoreSettings_Click(…)
+// 2. NO CLOUD IDENTITY IS REACHABLE HERE. Every body needs
+//    ConditioningControlPanel/Services/ProfileSyncService.cs (BackupSettingsAsync,
+//    RestoreSettingsAsync, ExportDataAsync, GetSettingsBackupInfoAsync) plus App.HasCloudIdentity -
+//    an authenticated client keyed by the account token. The token seam is CoreSecrets, whose rule
+//    is absolute: unseeded means NO STORE, never plaintext. This head seeds none, so it holds no
+//    token and has nothing to authenticate with. That is the end state until a keyring-backed
+//    CoreSecrets provider exists, not a gap to route around.
+//
+// Members, so nothing disappears silently:
+//   internal void ReloadSettingsUiAfterRestore()
+//       Re-seeds the Settings door from the swapped AppSettings. Needs LoadSettings() and its
+//       _isLoading guard, which here are spread across Views/Controls/AppSettings/*Section.axaml.cs.
+//       No caller either - only the manual restore and App.CheckCloudSettingsRestoreAsync.
+//   internal async void BtnBackupSettingsNow_Click(…) / BtnRestoreSettings_Click(…)
+//       ProfileSyncService, per (2). The restore path's LOCAL-WINS field list (progression,
+//       entitlement windows, OpenRouterApiKey) is settings-model logic that would port unchanged -
+//       there is just no restore to run it after.
 //   internal async void BtnExportData_Click(…)
+//       ExportDataAsync, then Microsoft.Win32.SaveFileDialog. Avalonia's twin is
+//       StorageProvider.SaveFilePickerAsync on this window; the export it would save is what's missing.
 //   internal void BtnPrivacyPolicy_Click(…)
-//   private async Task UpdateBackupStatus(…)
+//       Process.Start(UseShellExecute) on the privacy-policy URL. No browser launcher on this head
+//       (WPF's is ConditioningControlPanel/Helpers/BrowserLauncher.cs, whose no-default-browser
+//       prompt is its whole point). Cheap once one exists - in AccountSettingsSection, per (1).
+//   private async Task UpdateBackupStatus()
+//       Writes TxtCloudBackupStatus from GetSettingsBackupInfoAsync. Same blocker; that TextBlock
+//       is in AccountSettingsSection.axaml too.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Nothing here on purpose - every member of the WPF twin belongs to
+        // CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml.cs on this head.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.KeywordTriggers.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.KeywordTriggers.cs
@@ -1,38 +1,62 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.KeywordTriggers.cs (622 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.KeywordTriggers.cs (621 lines).
+// The old header here claimed every member reaches App.*, a service or Win32. That was wrong
+// about half of them and hid where the work now goes.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHERE THESE MEMBERS LIVE ON THIS HEAD. WPF's MainWindow owned them because the Awareness markup
+// was inline in MainWindow.xaml. The port moved that markup twice over:
+//   - the two cooldown sliders are on CCP.Avalonia/Views/Tabs/AwarenessTabView.axaml, and that
+//     view ALREADY owns their handlers (AwarenessTabView.axaml.cs:66-79 writes
+//     KeywordGlobalCooldownSeconds / KeywordPerKeywordCooldownSeconds through CoreSettings, :132-133
+//     loads them back). Those two are done, in the right place.
+//   - the rest is on CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml, hosted in
+//     the Awareness tab; its code-behind already tracks the four value labels with the WPF format
+//     strings.
+// A member restored HERE would be a second copy no click can reach.
 //
-// Members dropped (22):
-//   internal void SliderKeywordBufferTimeout_ValueChanged(…)
-//   internal void SliderAwarenessGlobalCooldown_ValueChanged(…)
-//   internal void SliderAwarenessSameWordCooldown_ValueChanged(…)
-//   internal void SliderKeywordSessionMultiplier_ValueChanged(…)
-//   internal void SliderScreenOcrInterval_ValueChanged(…)
-//   internal void SliderKeywordHighlightDuration_ValueChanged(…)
-//   internal void CmbOcrHighlightMode_SelectionChanged(…)
-//   internal void CmbOcrConfirmation_SelectionChanged(…)
-//   internal void BtnAddKeywordTrigger_Click(…)
-//   internal void BtnImportFromCustomTriggers_Click(…)
-//   private void BtnDeleteKeywordTrigger_Click(…)
-//   private void ChkKeywordTriggerEnabled_Changed(…)
-//   private void TxtKeywordTriggerKeyword_LostFocus(…)
-//   private void BtnKeywordTriggerBrowseAudio_Click(…)
-//   private void CmbKeywordVisualEffect_SelectionChanged(…)
-//   private void SliderKeywordTriggerCooldown_ValueChanged(…)
-//   private void SliderKeywordTriggerVolume_ValueChanged(…)
-//   private void ChkKeywordTriggerHaptic_Changed(…)
-//   private void ChkKeywordTriggerDuckAudio_Changed(…)
-//   private void RefreshKeywordTriggerList(…)
-//   internal void SyncKeywordRescuePanelUi(…)
-//   private Border CreateKeywordTriggerRow(…)
+// WHAT IS GENUINELY MISSING, and where:
+//
+//   The PERSISTENCE half of six editors, in KeywordTriggersPanel.axaml.cs. Each is "read the
+//   control, write one CoreSettings field, Save" - every field is already in CoreSettings:
+//     SliderKeywordBufferTimeout_ValueChanged      -> KeywordBufferTimeoutMs
+//     SliderKeywordSessionMultiplier_ValueChanged  -> KeywordSessionMultiplier
+//     SliderScreenOcrInterval_ValueChanged         -> ScreenOcrIntervalMs (seconds x 1000)
+//     SliderKeywordHighlightDuration_ValueChanged  -> KeywordHighlightDurationMs
+//     CmbOcrHighlightMode_SelectionChanged         -> OcrHighlightAll (SelectedIndex == 0)
+//     CmbOcrConfirmation_SelectionChanged          -> OcrConfirmationScans (SelectedIndex + 1)
+//   The panel currently updates the label and drops the value. Two of the six also push into a
+//   live service and cannot be fully restored: SliderScreenOcrInterval calls
+//   App.ScreenOcr.UpdateInterval, and the highlight pair feeds App.KeywordHighlight. Whoever does
+//   it needs WPF's `if (_isLoading) return;` guard - a Slider/ComboBox raises its change event on
+//   a PROGRAMMATIC set too, so without it every load writes settings straight back.
+//
+//   internal void SyncKeywordRescuePanelUi()
+//     The load pass for all of the above plus the two detail gates (ScreenOcrIntervalPanel /
+//     TxtScreenOcrOffHint follow ScreenOcrEnabled; HighlightDurationPanel / TxtHighlightOffHint
+//     follow KeywordHighlightEnabled). Every value it reads is in CoreSettings; two things are
+//     not: KeywordTriggerService.HasAccess() (the premium gate, ANDed into the OCR section's "on")
+//     and RefreshKeywordTriggerList. KeywordTriggersPanel.SetScreenOcrDetail / SetHighlightDetail
+//     are the setters it would drive - they exist and are called with a hard-coded `true` today.
+//
+//   The trigger LIST - service-bound throughout:
+//     BtnAddKeywordTrigger_Click          KeywordTriggerService.RebuildActionsFromFlatFields
+//     BtnImportFromCustomTriggers_Click   App.KeywordTriggers.ImportFromCustomTriggers
+//     RefreshKeywordTriggerList / CreateKeywordTriggerRow   build a row per trigger
+//   and the seven per-row editors, which only exist once a row does: BtnDeleteKeywordTrigger_Click,
+//   ChkKeywordTriggerEnabled_Changed, TxtKeywordTriggerKeyword_LostFocus,
+//   BtnKeywordTriggerBrowseAudio_Click (a file picker - Avalonia's StorageProvider covers it),
+//   CmbKeywordVisualEffect_SelectionChanged, SliderKeywordTriggerCooldown_ValueChanged,
+//   SliderKeywordTriggerVolume_ValueChanged, ChkKeywordTriggerHaptic_Changed,
+//   ChkKeywordTriggerDuckAudio_Changed.
+//   AppSettings.KeywordTriggers and the KeywordTrigger model ARE in Core; what is not is
+//   ConditioningControlPanel/Services/KeywordTriggerService.cs (HasAccess, the flat-fields rebuild,
+//   the import).
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Nothing here on purpose. The controls, and the remaining work, moved to
+        // CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs and
+        // CCP.Avalonia/Views/Tabs/AwarenessTabView.axaml.cs.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Login.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Login.cs
@@ -1,22 +1,103 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Login.cs (400 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.Login.cs (399 lines) - the one
+// member of it that is about PAINTING login state rather than performing a login.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE: UpdateQuickLoginUI. Signed-in-ness on this head is
+// CoreSettings.Current.UnifiedId, which the settings model already carries, so the login button,
+// the signed-in strip, the OG star and the two gated tabs' login overlays all paint correctly
+// from Core alone. It runs on OnLoaded (MainShellWindow.Marquee.cs, which owns that override)
+// and again on every language change, so the gates are right from the first frame.
 //
-// Members dropped (6):
-//   internal void BtnUnifiedLogin_Click(…)
-//   private void OpenUnifiedLoginDialog(…)
-//   private void ClearProgressionData(…)
-//   private void ClearAccountData(…)
+// TxtLoggedInName carries {loc:Str label_username} in the XAML and this writes over it, which
+// the porting rules warn about - a language change reasserts the placeholder. There is no key to
+// bind instead (it is a person's name), so the LanguageChanged re-run is the fix, not a comment.
+//
+// WHAT IS NOT, and precisely why. Nothing here is "wired when a service moves to Core":
+//
+//   internal void BtnUnifiedLogin_Click(…) / private void OpenUnifiedLoginDialog()
+//       CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs DOES exist on this head, so the dialog is
+//       not the blocker. What OpenUnifiedLoginDialog does AFTER it closes is: App.UnifiedUserId,
+//       App.StartupUnifiedId and _lastKnownUnifiedId (account-switch detection),
+//       ProfileSyncService (StartHeartbeat, LoadProfileAsync, SyncProfileAsync,
+//       ResetLoadedProfileState), App.Achievements.SuppressPopups and App.Quests. None of those
+//       has a seam. The click handler itself now belongs to
+//       CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs:329 (BtnUnifiedLogin_Click), where the
+//       button lives - restoring it here would be a second, unreachable copy.
+//
 //   internal async void BtnQuickLogout_Click(…)
-//   private void UpdateQuickLoginUI(…)
+//       Same file, SettingsTabView.axaml.cs:330. Needs ProfileSyncService (a final SyncProfileAsync
+//       then StopHeartbeat) and App.Patreon / App.Discord Logout().
+//
+//   private void ClearAccountData(bool wipeQuestProgress = false)
+//       The identity half is pure settings (UnifiedId, AuthToken, UserDisplayName,
+//       HasLinkedDiscord, HasLinkedPatreon) and would port verbatim onto CoreSettings. The rest
+//       does not: App.SubscribeStar.Logout, App.Quests.StampOwner (the BUG-BN8X9B9SZ5 same-account
+//       re-login stamp), ProfileSyncService.ResetLoadedProfileState, App.Descent.Reset. It has no
+//       caller here either - only BtnQuickLogout_Click and account deletion reach it - so
+//       restoring the settings half alone would be dead code that also silently skips four
+//       teardown steps. Wire it WITH the logout path, not before it.
+//
+//       One line of it is worth naming on its own: AuthToken is nulled on logout because the
+//       server rotates it on every auth event (#455). On this head that field is not persisted at
+//       all - CoreSecrets is unseeded, which means NO STORE, never plaintext - so there is no
+//       stale token to clear in the first place.
+//
+//   private void ClearProgressionData(bool generateQuests, bool preserveQuestProgress)
+//       ~30 CoreSettings field writes (XP, level, skill points, both streak families, streak
+//       shields, usage stats, rerolls, season/OG) that would port unchanged, plus four things
+//       that would not: Services.ProfileSyncService.ClearXpWatermark (#865 - the ONLY surface
+//       allowed to void the server-confirmed XP watermark, and it must go with the rest or the
+//       next sync refuses the new account's numbers as a regression), App.Quests.ResetProgress,
+//       App.Achievements.ResetProgress and DrawSkillTree. Same dead-code argument as above: its
+//       only callers are the login/logout/delete paths.
+
+using System;
+using Avalonia.Controls;
+using ConditioningControlPanel.Localization;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>
+        /// Paints every surface that changes with signed-in-ness: the login button and the
+        /// signed-in strip on the Settings door, and the login overlays that gate the Quests and
+        /// Enhancements tabs.
+        ///
+        /// <para>Controls are found by name through the hosting view rather than through a
+        /// generated field, so a view this head does not carry is skipped instead of throwing -
+        /// and so it does not matter which XAML loader each tab view happened to use.</para>
+        ///
+        /// <para>ponytail: WPF also falls back to App.Patreon / App.Discord / App.SubscribeStar
+        /// DisplayName, and ORs App.IsLoggedIn into the test. No provider exists on this head, so
+        /// a session is "signed in" exactly when the settings model carries a UnifiedId.</para>
+        /// </summary>
+        internal void UpdateQuickLoginUI()
+        {
+            try
+            {
+                var s = CoreSettings.Current;
+                var isLoggedIn = !string.IsNullOrEmpty(s.UnifiedId);
+                var displayName = string.IsNullOrEmpty(s.UserDisplayName) ? "User" : s.UserDisplayName!;
+
+                var settings = SettingsPage;
+                SetVisible(settings?.FindControl<Button>("BtnUnifiedLogin"), !isLoggedIn);
+                SetVisible(settings?.FindControl<Border>("LoggedInStatusPanel"), isLoggedIn);
+
+                SetVisible(Named<Tabs.QuestsTabView>("QuestsTab")?.FindControl<Border>("QuestsLoginOverlay"), !isLoggedIn);
+                SetVisible(Named<Tabs.EnhancementsTabView>("EnhancementsTab")?.FindControl<Border>("EnhancementsLoginOverlay"), !isLoggedIn);
+
+                if (isLoggedIn && settings?.FindControl<TextBlock>("TxtLoggedInName") is { } name)
+                    name.Text = s.IsSeason0Og ? $"⭐ {displayName}" : displayName;
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Warning(ex, "UpdateQuickLoginUI failed");
+            }
+        }
+
+        private static void SetVisible(Control? control, bool visible)
+        {
+            if (control is not null) control.IsVisible = visible;
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Marquee.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Marquee.cs
@@ -1,44 +1,281 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs (1171 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.Marquee.cs (1,170 lines) - the
+// header banner's rotation, which is the part of that file this head can actually run.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE: the two-or-three beat rotation over the three TextBlocks
+// MainShellWindow.axaml already carries (TxtBannerPrimary, TxtBannerSecondary, TxtBannerWeb).
+// The beat array is built from CoreSettings (the One Account beat rides SeenFeatureIntros and
+// drops out once spent), the welcome-back line is written from CoreSettings' offline name /
+// display name, the 4s DispatcherTimer crossfades between beats, SetBannerAnnouncement replaces
+// the welcome line, and RetireWebBannerBeat spends the key and hands the beat's slot back with
+// the same 500ms fade rather than blinking empty.
 //
-// Members dropped (28):
-//   internal const string WebBannerSeenKey
-//   private TextBlock[] _bannerBeats
-//   private void InitializeBannerRotation(…)
-//   private TextBlock[] BuildBannerBeats(…)
-//   private void UpdateBannerWelcomeMessage(…)
-//   private void ShowOgWelcomePopup(…)
-//   public static bool IsStartupDialogShowing
-//   private bool _seasonRecapShown
-//   public void TryPresentSeasonRecap(…)
-//   private void ShowWhatsNewIfNeeded(…)
-//   private void BannerRotationTimer_Tick(…)
-//   public void SetBannerAnnouncement(…)
-//   private void BannerWebLink_Click(…)
-//   internal void RetireWebBannerBeat(…)
-//   private void InitializeMarqueeBanner(…)
-//   private async void RefreshMarqueeFromSettings(…)
-//   private class MarqueeResponse
-//   private class UpdateBannerResponse
-//   private string? _serverUpdateUrl
-//   private async void CheckServerUpdateBanner(…)
-//   private class AnnouncementResponse
-//   private async void CheckServerAnnouncement(…)
-//   private bool _serverAnnouncementShownThisLaunch
-//   private void CheckIntakePassNudge(…)
-//   private void StartIntakeFromNudge(…)
-//   private static string LocOr(…)
-//   private void StartMarqueeAnimation(…)
-//   public void UpdateMarqueeMessage(…)
+// The crossfade is an Avalonia Transitions entry on Opacity, not a WPF DoubleAnimation:
+// BeginAnimation/Storyboard have no twin here, and a DoubleTransition attached once and driven
+// by plain Opacity writes is the same 500ms quadratic curve with none of the clock bookkeeping
+// (no FillBehavior, no BeginAnimation(prop, null) afterwards to release the animated value).
+//
+// This partial owns OnLoaded on MainShellWindow. It has to: the window's constructor is in
+// MainShellWindow.axaml.cs, which this layer does not own, so there is no other hook to start
+// the rotation from. OnOpened is already taken by MainShellWindow.WorkAreaFit.cs.
+//
+// Beat text and {loc:Str}: TxtBannerSecondary carries {loc:Str} in the XAML, and writing .Text
+// over a binding is undone on the next language change (the porting rule). The welcome line is
+// a FORMATTED string (Loc.GetF with a name), so there is no key to bind instead - so
+// UpdateBannerWelcomeMessage re-runs on LocalizationManager.LanguageChanged, which is what
+// actually keeps it honest.
+//
+// STILL BLOCKED, each naming what it needs rather than guessing at "when X moves to Core":
+//   ShowOgWelcomePopup / TryPresentSeasonRecap / ShowWhatsNewIfNeeded - App.Achievements,
+//     App.Seasons and the startup dialog queue in ConditioningControlPanel/App.xaml.cs. The
+//     dialogs themselves DO exist here (CCP.Avalonia/Views/Dialogs/WhatsNewDialog.axaml.cs,
+//     Views/Controls/SeasonRecapCard); what is missing is the "has this launch already shown a
+//     modal" arbitration those read from App.
+//   RefreshMarqueeFromSettings / CheckServerUpdateBanner / CheckServerAnnouncement and their
+//     three response DTOs (MarqueeResponse, UpdateBannerResponse, AnnouncementResponse), plus
+//     _serverUpdateUrl and _serverAnnouncementShownThisLaunch - all three are HttpClient calls
+//     to the CC Labs API. Networking is not a Core seam and this head has no API client.
+//   CheckIntakePassNudge / StartIntakeFromNudge - App.Programs (the weekly intake pass); the
+//     accepted nudge then wants ShowTab("gradedintake"), which does exist here.
+//   BannerWebLink_Click - Helpers.BrowserLauncher (ConditioningControlPanel/Helpers/
+//     BrowserLauncher.cs), a ShellExecute with a no-default-browser prompt. There is no browser
+//     launcher on this head, so the URL renders as text (see the <Run> notes in
+//     MainShellWindow.axaml) and only the Web App door and the one-account card can retire the
+//     beat.
+//   LocOr - a Loc.Get with an English literal fallback. Used only by the marquee and takeaway
+//     formatters, neither of which runs here; Loc.Get already returns the key when a string is
+//     missing, so there is nothing to restore in isolation.
+//   StartMarqueeAnimation / UpdateMarqueeMessage - the scrolling marquee strip, a WPF Storyboard
+//     over a TranslateTransform on a control MainShellWindow.axaml does not carry. Nothing to
+//     drive: a still banner that says the right thing beats a faked scroll.
+//   SweepBannerSheen - MainShellWindow.ChromeFx.cs, still a stub. The BannerSheen border is in
+//     the XAML and parked at Opacity 0, so its absence costs nothing visible.
+
+using System;
+using System.Linq;
+using Avalonia.Animation;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>
+        /// Seen-list key for the One Account banner beat (and the surfaces that retire it). It
+        /// rides <see cref="Models.AppSettings.SeenFeatureIntros"/> rather than a new bool - the
+        /// same registry the intro cards spend - but it is NOT a card key: FeatureIntros.All has
+        /// no entry for it, so nothing can ever open a modal for it.
+        /// </summary>
+        internal const string WebBannerSeenKey = "banner-web";
+
+        /// <summary>
+        /// True while a startup modal owns the screen. FeatureIntroPopup reads this to refuse to
+        /// stack a card on a modal. Nothing on this head SETS it yet - the startup dialog queue
+        /// lives in App.xaml.cs - so it is a gate that is always open here; it exists so the
+        /// readers compile against the real member rather than against nothing.
+        /// </summary>
+        public static bool IsStartupDialogShowing { get; set; }
+
+        private const int BannerFadeMs = 500;
+        private static readonly TimeSpan BannerRotationInterval = TimeSpan.FromSeconds(4);
+
+        private DispatcherTimer? _bannerRotationTimer;
+        private int _bannerCurrentIndex;          // 0 = Primary (support), 1 = Secondary (welcome)
+        private TextBlock[] _bannerBeats = Array.Empty<TextBlock>();
+
+        // Resolved through Named<T> on every read, never through a generated x:Name field: this
+        // window loads with AvaloniaXamlLoader.Load, so its generated fields are permanently null.
+        private TextBlock? BannerPrimary => Named<TextBlock>("TxtBannerPrimary");
+        private TextBlock? BannerSecondary => Named<TextBlock>("TxtBannerSecondary");
+        private TextBlock? BannerWeb => Named<TextBlock>("TxtBannerWeb");
+
+        /// <summary>
+        /// The only hook this layer has into the window's lifetime - see the header. Guarded as a
+        /// whole: a banner that cannot build must never stop the shell from opening.
+        /// </summary>
+        protected override void OnLoaded(global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            try
+            {
+                InitializeBannerRotation();
+                UpdateQuickLoginUI();
+                RefreshSessionFeatureLock();
+
+                // Both of these write .Text over a control that carries {loc:Str}, which a
+                // language change would otherwise undo - see the header and
+                // MainShellWindow.Login.cs.
+                LocalizationManager.Instance.LanguageChanged += (_, _) =>
+                {
+                    UpdateBannerWelcomeMessage();
+                    UpdateQuickLoginUI();
+                };
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Shell OnLoaded (banner rotation / login state / session lock) failed");
+            }
+        }
+
+        private void InitializeBannerRotation()
+        {
+            _bannerBeats = BuildBannerBeats();
+            foreach (var beat in _bannerBeats) EnsureFadeTransition(beat);
+
+            UpdateBannerWelcomeMessage();
+
+            _bannerRotationTimer = new DispatcherTimer { Interval = BannerRotationInterval };
+            _bannerRotationTimer.Tick += BannerRotationTimer_Tick;
+            _bannerRotationTimer.Start();
+        }
+
+        /// <summary>
+        /// Support + welcome-back always; the One Account beat only while unspent. The array is
+        /// what the tick indexes, so a beat that is not in it simply never fades in - its
+        /// TextBlock stays exactly as MainShellWindow.axaml authored it (Opacity 0, hit-test off).
+        /// A beat the XAML does not carry is dropped rather than crashing the rotation.
+        /// </summary>
+        private TextBlock[] BuildBannerBeats()
+        {
+            var spent = CoreSettings.Current.SeenFeatureIntros.Contains(WebBannerSeenKey);
+            var beats = spent
+                ? new[] { BannerPrimary, BannerSecondary }
+                : new[] { BannerPrimary, BannerSecondary, BannerWeb };
+            return beats.Where(b => b is not null).Select(b => b!).ToArray();
+        }
+
+        /// <summary>
+        /// One DoubleTransition on Opacity, attached once. Every later fade is then a plain
+        /// Opacity write - which is why <see cref="RetireWebBannerBeat"/> needs no animation code
+        /// of its own.
+        /// </summary>
+        private static void EnsureFadeTransition(TextBlock beat)
+        {
+            var transitions = beat.Transitions ??= new Transitions();
+            foreach (var t in transitions)
+                if (t is DoubleTransition dt && dt.Property == OpacityProperty) return;
+
+            transitions.Add(new DoubleTransition
+            {
+                Property = OpacityProperty,
+                Duration = TimeSpan.FromMilliseconds(BannerFadeMs),
+                Easing = new global::Avalonia.Animation.Easings.QuadraticEaseInOut(),
+            });
+        }
+
+        private void UpdateBannerWelcomeMessage()
+        {
+            var secondary = BannerSecondary;
+            if (secondary is null) return;
+
+            var s = CoreSettings.Current;
+
+            if (s.OfflineMode && !string.IsNullOrWhiteSpace(s.OfflineUsername))
+            {
+                secondary.Text = Loc.GetF("label_welcome_back_0_offline_mode", s.OfflineUsername);
+                return;
+            }
+
+            // ponytail: WPF falls back to App.Patreon/App.Discord DisplayName when the unified
+            // name is blank. Neither provider exists on this head, so a user who linked an
+            // account but has no UserDisplayName written back gets the generic line.
+            var displayName = s.UserDisplayName;
+            secondary.Text = string.IsNullOrEmpty(displayName)
+                ? Loc.Get("label_welcome_consider_logging_in_with_patreon_for")
+                : Loc.GetF("label_welcome_back_0", displayName!);
+        }
+
+        private void BannerRotationTimer_Tick(object? sender, EventArgs e)
+        {
+            var banners = _bannerBeats;
+            if (banners.Length < 2) return;
+            if (_bannerCurrentIndex >= banners.Length) _bannerCurrentIndex = 0;
+
+            var nextIndex = (_bannerCurrentIndex + 1) % banners.Length;
+            Crossfade(banners[_bannerCurrentIndex], banners[nextIndex]);
+            _bannerCurrentIndex = nextIndex;
+
+            // ponytail: WPF also calls SweepBannerSheen() here. MainShellWindow.ChromeFx.cs is
+            // still a stub, so the sheen pass is skipped rather than faked.
+        }
+
+        /// <summary>
+        /// Hands the banner from one beat to the next. Hit-testing follows the fade rather than
+        /// the opacity, for the reason WPF spells out: a link parked at Opacity 0 still eats
+        /// clicks.
+        /// </summary>
+        private static void Crossfade(TextBlock outgoing, TextBlock incoming)
+        {
+            EnsureFadeTransition(outgoing);
+            EnsureFadeTransition(incoming);
+
+            outgoing.Opacity = 0;
+            incoming.Opacity = 1;
+            outgoing.IsHitTestVisible = false;
+            incoming.IsHitTestVisible = true;
+        }
+
+        /// <summary>
+        /// Set a temporary announcement message to display in the banner rotation. It takes the
+        /// welcome beat's slot, exactly as in WPF, so the rotation length does not change.
+        /// </summary>
+        public void SetBannerAnnouncement(string message)
+        {
+            if (string.IsNullOrEmpty(message)) return;
+
+            var secondary = BannerSecondary;
+            if (secondary is not null) secondary.Text = message;
+
+            if (_bannerRotationTimer is { IsEnabled: false }) _bannerRotationTimer.Start();
+        }
+
+        /// <summary>
+        /// Spends the One Account banner beat and takes it out of the live rotation. Called from
+        /// every surface that counts as "the nudge worked". Idempotent - once the key is spent
+        /// the rebuild is a two-beat array either way.
+        ///
+        /// <para>If the beat is on screen at the moment it is retired, it hands its slot to the
+        /// support beat with the same fade the rotation uses, so the banner never blinks empty.
+        /// Any other beat on screen keeps its turn: the index is re-found in the rebuilt array
+        /// rather than reset.</para>
+        /// </summary>
+        internal void RetireWebBannerBeat()
+        {
+            try
+            {
+                var settings = CoreSettings.Current;
+                if (!settings.SeenFeatureIntros.Contains(WebBannerSeenKey))
+                {
+                    settings.SeenFeatureIntros.Add(WebBannerSeenKey);
+                    CoreSettings.Save();
+                }
+
+                var web = BannerWeb;
+                if (web is null || Array.IndexOf(_bannerBeats, web) < 0) return;
+
+                var current = _bannerCurrentIndex < _bannerBeats.Length
+                    ? _bannerBeats[_bannerCurrentIndex]
+                    : BannerPrimary;
+                _bannerBeats = BuildBannerBeats();
+
+                if (ReferenceEquals(current, web))
+                {
+                    _bannerCurrentIndex = 0;
+                    var primary = BannerPrimary;
+                    if (primary is not null) Crossfade(web, primary);
+                }
+                else if (current is not null)
+                {
+                    var idx = Array.IndexOf(_bannerBeats, current);
+                    _bannerCurrentIndex = idx >= 0 ? idx : 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "RetireWebBannerBeat failed; the beat rotates on until next launch");
+            }
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramBanner.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramBanner.cs
@@ -1,41 +1,51 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProgramBanner.cs (496 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProgramBanner.cs (495 lines) -
+// the dashboard Today card's decoration: banner art, accent-derived fog and sheen, sparkles, an
+// ambient loop and a hover parallax. Two blockers, only one of them a missing service.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// 1. THE ENTRY POINT NAMES TYPES THIS HEAD DOES NOT HAVE.
+//    ApplyProgramBannerArt(ProgramDefinition?, Brush?) is the only door in, and ProgramDefinition
+//    is ConditioningControlPanel/Models/Program/ProgramDefinition.cs - it did NOT move to Core. So
+//    did its art resolver: ResolveProgramBannerArt is one line, `ProgramArt.Banner(program)`, and
+//    ProgramArt (ConditioningControlPanel/Services/Program/ProgramArt.cs) returns a WPF ImageSource
+//    from a pack:// URI. There is no caller here either - the card is refreshed by
+//    MainWindow.ProgramsTab / .DashboardFx, also stubs. ProgramBannerAccentColor's fallback,
+//    FxTheme.GlowColor (ConditioningControlPanel/Services/FxTheme.cs), has an equivalent here in
+//    the FxGlowColor resource of CCP.Avalonia/Theme/Colors.xaml.
 //
-// Members dropped (25):
-//   private const string ProgramBannerFolder
-//   private const double ProgramBannerArtOpacity
-//   private const double ProgramBannerParallax
-//   private bool _programBannerHooked
-//   private bool _programBannerFxRunning
-//   private bool _programBannerSparklesBuilt
-//   internal void ApplyProgramBannerArt(…)
-//   private void EnsureProgramBannerHooks(…)
-//   private void ProgramBannerCard_IsVisibleChanged(…)
-//   private void ProgramBannerDecor_SizeChanged(…)
-//   private void LayoutProgramBannerDecor(…)
-//   private static ImageSource? ResolveProgramBannerArt(…)
-//   private static Color ProgramBannerAccentColor(…)
-//   private static Color WithAlpha(…)
-//   private static Color TowardWhite(…)
-//   private static Brush ProgramBannerFogBrush(…)
-//   private static Brush ProgramBannerSheenBrush(…)
-//   private void StartProgramBannerFx(…)
-//   private void StopProgramBannerFx(…)
-//   private void BuildProgramBannerSparkles(…)
-//   private void PositionProgramBannerSparkles(…)
-//   private void StartProgramBannerSparkles(…)
-//   private void ProgramBannerCard_MouseEnter(…)
-//   private void ProgramBannerCard_MouseLeave(…)
-//   private void NudgeProgramBannerArt(…)
+// 2. THE REST IS WPF STORYBOARD MOTION WITH NO EQUIVALENT WRITTEN HERE. A still card that reads
+//    as finished beats a moving one that is wrong, so these are named rather than faked:
+//      StartProgramBannerFx / StopProgramBannerFx - two looping DoubleAnimations (fog drift) and a
+//        repeating sheen sweep, started and stopped by hand. Avalonia's twin is a keyframe
+//        Animation with IterationCount.Infinite: a real port, not a mapping.
+//      BuildProgramBannerSparkles / PositionProgramBannerSparkles / StartProgramBannerSparkles -
+//        ellipses added to the ProgramTodaySparkles Canvas at fractions of the card width, each on
+//        its own staggered twinkle clock.
+//      ProgramBannerCard_MouseEnter / _MouseLeave / NudgeProgramBannerArt - the hover parallax. The
+//        art overhangs the card by 14px each side (that negative margin is
+//        CCP.Avalonia/Views/Tabs/SettingsTabView.axaml:533) and slides within it. Avalonia's events
+//        are PointerEntered/PointerExited; the slide is the storyboard part.
+//      const ProgramBannerParallax / ProgramBannerArtOpacity, _programBannerFxRunning,
+//      _programBannerSparklesBuilt.
+//
+// NOT A BLOCKER, so nobody re-derives it: the MARKUP is all here and correct. SettingsTabView.axaml
+// carries ProgramTodayDecor, ProgramTodayArt, ProgramTodayFog, ProgramTodaySheen and the
+// ProgramTodaySparkles Canvas, each collapsed until this file paints it - which is why the card
+// renders today as a finished, undecorated card rather than a hole. The brush builders
+// (ProgramBannerFogBrush, ProgramBannerSheenBrush) and the colour helpers (WithAlpha, TowardWhite)
+// are pure gradient/colour arithmetic and would port as-is; they are just not worth restoring with
+// nothing to hand them to.
+//
+// Remaining members: const ProgramBannerFolder (Resources/programs/<id>/banner.png, resolved by
+// ProgramArt so it goes with it), _programBannerHooked, EnsureProgramBannerHooks (one-shot hookup
+// of the card's four events), ProgramBannerCard_IsVisibleChanged (starts/stops the loop with the
+// card), ProgramBannerDecor_SizeChanged / LayoutProgramBannerDecor (sizes fog and sheen to the card).
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Nothing here on purpose. The decoration markup is in
+        // CCP.Avalonia/Views/Tabs/SettingsTabView.axaml and stays collapsed until a
+        // ProgramDefinition-shaped seam and an Avalonia animation port exist.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs
@@ -1,28 +1,44 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs (501 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs (500 lines). Two
+// unrelated reasons, neither of them "wired when the models move to Core" - the models are ALREADY
+// there (CCP.Core/Models/RoadmapDefinition.cs carries RoadmapTrack and
+// RoadmapTrackDefinition.GetByTrack; CCP.Core/Models/RoadmapProgress.cs carries IsTrackUnlocked).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// 1. THE VIEW ALREADY DOES THE VIEW HALF. WPF's three chrome handlers hung off the shell because
+//    the Quests markup was inline in MainWindow.xaml. CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
+//    now owns them: ShowDailyWeekly() / ShowRoadmap() swap DailyWeeklyPanel and RoadmapPanel and
+//    restyle the two sub-tab buttons (lines 64-95), and the three track buttons restyle themselves.
+//    Restoring BtnQuestSubDaily_Click / BtnQuestSubRoadmap_Click / BtnTrack_Click here would be a
+//    second copy nothing routes to; _currentRoadmapTrack belongs with them, in that view.
 //
-// Members dropped (12):
-//   private Models.RoadmapTrack _currentRoadmapTrack
-//   internal void BtnQuestSubDaily_Click(…)
-//   internal void BtnQuestSubRoadmap_Click(…)
-//   internal void BtnTrack_Click(…)
-//   private void RefreshRoadmapUI(…)
-//   private void GenerateRoadmapNodes(…)
-//   private Border CreateRoadmapNode(…)
-//   private void RoadmapNode_Click(…)
-//   private void ShowPhotoConfirmation(…)
-//   private void RefreshRoadmapStats(…)
-//   private void OnRoadmapStepCompleted(…)
-//   private void OnRoadmapTrackUnlocked(…)
+// 2. EVERYTHING ELSE NEEDS THE SERVICE, NOT THE MODEL. App.Roadmap is
+//    ConditioningControlPanel/Services/RoadmapService.cs and has no seam: it owns the loaded
+//    RoadmapProgress instance, GetTrackProgress, IsTrackUnlocked against live progress, the
+//    photo-submission flow and the StepCompleted / TrackUnlocked events. Core has the SHAPES; it has
+//    no instance and no persistence for them, and RoadmapProgress is not a field of AppSettings. A
+//    CoreRoadmap seam over those four reads plus the two events would be the right fix - and it is
+//    a Core layer, not this one.
+//
+// Member by member:
+//   _currentRoadmapTrack, BtnQuestSubDaily_Click, BtnQuestSubRoadmap_Click, BtnTrack_Click
+//       -> QuestsTabView, per (1).
+//   RefreshRoadmapUI()
+//       Paints TxtRoadmapTrackName / TxtRoadmapTrackSubtitle from RoadmapTrackDefinition (Core,
+//       available) but needs App.Roadmap for GetTrackProgress, IsTrackUnlocked and
+//       Progress.HasCertifiedBlowdollBadge - the numbers, the locked overlay and the badge. The
+//       controls all exist in QuestsTabView.axaml (TrackLockedOverlay, RoadmapScrollContainer,
+//       TxtLockReason, BadgeIndicator).
+//   GenerateRoadmapNodes() / CreateRoadmapNode(…)   node-per-step, driven by per-step completion.
+//   RoadmapNode_Click(…) / ShowPhotoConfirmation(…) the photo-submission flow: a file picker plus
+//                                                   App.Roadmap's submit/confirm calls.
+//   RefreshRoadmapStats()                           aggregates across all three tracks.
+//   OnRoadmapStepCompleted(…) / OnRoadmapTrackUnlocked(…)  handlers for RoadmapService's two
+//                                                   events. Nothing to subscribe to.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Nothing here on purpose. Chrome: CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs.
+        // Data: needs a RoadmapService seam in Core.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SessionFeatureLock.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SessionFeatureLock.cs
@@ -1,35 +1,372 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SessionFeatureLock.cs (532 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.SessionFeatureLock.cs (531 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// "Session feature lock" - while a session is running, the prescribed dose belongs to the
+// session, not to the user. Read the WPF file's class remarks for the four rules; they are the
+// design, and none of them changed in the port. The two that shape THIS file:
 //
-// Members dropped (19):
-//   private const string SessionLockBannerTag
-//   private UserControl? _activeFeaturePopupContent
-//   internal bool IsSessionFeatureLockActive
-//   private bool IsProgramSessionActive
-//   internal string SessionFeatureLockReason
-//   private bool? _sessionLockPainted
-//   internal void RefreshSessionFeatureLock(…)
-//   private static bool PaintSection(…)
-//   private void ApplySessionLockRibbon(…)
-//   private void ApplySessionLockToTabs(…)
-//   private void ApplySessionLockToFeaturePopup(…)
-//   private void ApplySessionLockToStudioRack(…)
-//   private static Border? FindSessionLockBanner(…)
-//   private static void UpdateSessionLockBanner(…)
-//   private static Border BuildSessionLockBanner(…)
-//   private static void SetToggleLock(…)
-//   internal bool RefuseIfSessionFeatureLocked(…)
-//   internal bool RefuseActionIfSessionLocked(…)
-//   private void PulseSessionLockRibbon(…)
+//   DERIVE, NEVER LATCH. IsSessionFeatureLockActive is computed from live engine state on every
+//   read, and every accessor fails OPEN on any exception. Nothing here remembers "we locked", so
+//   a crash or an out-of-order stop cannot strand the user with a permanently dead UI.
+//
+//   NEVER A SAFETY CONTROL. Stop / panic / No-Panic / Strict Lock / Withdraw / exit / volume are
+//   untouched, and must stay that way.
+//
+// WHAT IS REAL HERE. The lock's whole derivation and both refusal gates, plus the paint on the
+// two surfaces this head carries:
+//   - IsSessionFeatureLockActive reads CoreSession.IsEngineRunning. That seam is the exact
+//     mapping: WPF asks _sessionEngine.IsRunning && CurrentSession != null, and the seam's
+//     unseeded answer (false = not running) is the truth for a head with no engine, so the lock
+//     is simply never active here rather than being fake-active.
+//   - The ribbon (SettingsTabView.ProgramFeatureLockRibbon / TxtProgramFeatureLock, both in the
+//     ported XAML) shows and hides with the derived state and carries the reason.
+//   - The Studio rack's feature panels (StudioTabView.HostedFeaturePanels) get the master
+//     ChkEnable greyed, the reason as a tooltip, and the lock banner inserted above them - the
+//     same painter WPF uses for the dashboard popups, in both directions, idempotent, banner
+//     found by Tag before insert so repaints cannot stack it.
+//
+// WHAT IS NOT, and why - not one of these is "wired when a service moves to Core":
+//   - The per-dial marker sweep. WPF marks each dosage dial in XAML with
+//     features:SessionLock.Owned and finds them with Features.SessionLock.FindOwnedControls.
+//     That attached property was DROPPED in the port (every ported Features/*FeatureControl.axaml
+//     says so in its header, e.g. CCP.Avalonia/Views/Features/FlashFeatureControl.axaml:11), so
+//     there is nothing to sweep. CONSEQUENCE, stated plainly: on this head a running session
+//     greys the master enable and shows the banner, but the individual dose sliders under it stay
+//     draggable. Restoring the full lock needs the attached property ported first - it belongs in
+//     CCP.Avalonia/Features/SessionLock.cs, which does not exist.
+//   - ApplySessionLockToTabs, for the same reason plus a second one: it sweeps GradedIntakeTab,
+//     AwarenessTab and HapticsTab by marker only. Those three views exist here
+//     (CCP.Avalonia/Views/Tabs/{GradedIntake,Awareness,Haptics}TabView.axaml) and are reachable
+//     through Named<T>, so this method is one line away the moment the marker lands.
+//   - ApplySessionLockToFeaturePopup's OTHER caller: _activeFeaturePopupContent, the dashboard
+//     tile popup. The popup host is MainShellWindow.TakeoverUi.cs / FeatureSettingsPopup, still a
+//     stub, so nothing sets that field and the painter is called for the rack only.
+//   - IsProgramSessionActive and the program half of SessionFeatureLockReason ("First Week is
+//     running this - Day 3") need App.Programs (ConditioningControlPanel/Services/
+//     ProgramService.cs) for ActiveProgram.Title and Today.DayIndex. The session-generic reason
+//     is what every caller gets here, which is the same string WPF falls back to.
+//   - PulseSessionLockRibbon is a WPF DoubleAnimationUsingKeyFrames flashing the ribbon after a
+//     refused click. Avalonia has no BeginAnimation and a five-keyframe opacity strobe is not
+//     worth a hand-rolled Transitions dance - the refusal is still logged and, for the action
+//     form, still explained in a dialog. Cosmetic only; named so it is not lost silently.
+//   - SetToggleLock's ToolTipService.ShowOnDisabled has no Avalonia twin to need: Avalonia shows
+//     a ToolTip on a disabled control already, which is the whole reason WPF needed the flag.
+//
+// RefuseActionIfSessionLocked's MessageBox becomes Views/Dialogs/MessageDialog, which is async
+// and needs an owner. The refusal itself is synchronous and returns immediately - the dialog is
+// posted and awaited on its own, exactly as WPF's modal is "after the refusal" in effect.
+
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>Marks the banner we inject into a feature panel so we can find it again.</summary>
+        private const string SessionLockBannerTag = "__sessionFeatureLockBanner";
+
+        private static readonly Color LockPink = Color.FromRgb(0xFF, 0x69, 0xB4);
+
+        /// <summary>The Dashboard, resolved the only way a partial of this window may - see the
+        /// header of MainShellWindow.TabNavigation.cs.</summary>
+        internal Tabs.SettingsTabView? SettingsPage => Named<Tabs.SettingsTabView>("SettingsTab");
+
+        /// <summary>
+        /// True while ANY session is live - program, preset or remote. Fully derived from
+        /// <see cref="CoreSession.IsEngineRunning"/>; nothing here latches, and a fault answers
+        /// "not locked" because a stuck lock is worse than a missing one.
+        /// </summary>
+        internal bool IsSessionFeatureLockActive
+        {
+            get
+            {
+                try { return CoreSession.IsEngineRunning; }
+                catch { return false; }
+            }
+        }
+
+        /// <summary>
+        /// Why the dials are grey. Never blank while the lock is active: a greyed-out control
+        /// with no explanation reads as a bug.
+        /// <para>ponytail: the program-specific line ("First Week is running this - Day 3") needs
+        /// App.Programs; this head always gives the session-generic reason, which is WPF's own
+        /// fallback string.</para>
+        /// </summary>
+        internal string SessionFeatureLockReason
+        {
+            get
+            {
+                try { return Loc.Get("session_lock_reason"); }
+                catch { return "session_lock_reason"; }
+            }
+        }
+
+        /// <summary>
+        /// Last state actually painted, so a heartbeat can skip redundant repaints. A render
+        /// cache, NOT a latch - and deliberately left null after a partial paint so the next tick
+        /// retries. Play-testing on WPF found why: one throw in one section, plus a cache already
+        /// updated, left real dials unlocked for a whole session.
+        /// </summary>
+        private bool? _sessionLockPainted;
+
+        /// <summary>
+        /// Re-derives the locked state and repaints every affected surface. Idempotent and
+        /// in-memory only, so it is safe to call as often as you like.
+        /// </summary>
+        /// <param name="force">true (default) repaints even when the state matches the last
+        /// paint. A per-second heartbeat passes false purely to save work.</param>
+        internal void RefreshSessionFeatureLock(bool force = true)
+        {
+            bool locked;
+            string? reason;
+            try
+            {
+                locked = IsSessionFeatureLockActive;
+                if (!force && _sessionLockPainted == locked) return;
+                reason = locked ? SessionFeatureLockReason : null;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[SessionLock] Could not derive lock state");
+                return;
+            }
+
+            var allOk = true;
+            allOk &= PaintSection("ribbon", () => ApplySessionLockRibbon(locked, reason));
+            allOk &= PaintSection("studio", ApplySessionLockToStudioRack);
+
+            // Only remember this paint if it fully succeeded, so a partial one is retried.
+            _sessionLockPainted = allOk ? locked : null;
+        }
+
+        private static bool PaintSection(string name, Action paint)
+        {
+            try { paint(); return true; }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[SessionLock] Paint section '{Section}' failed", name);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The "why". A pink pill across the top of the dashboard naming the reason. It is an
+        /// overlay in the XAML (RowSpan/ColumnSpan, Top-aligned, IsHitTestVisible=False), so it
+        /// adds no height and swallows no clicks: being locked out of CHANGING the dose is not a
+        /// reason to be locked out of reading it.
+        /// </summary>
+        private void ApplySessionLockRibbon(bool locked, string? reason)
+        {
+            var dash = SettingsPage;
+            var ribbon = dash?.ProgramFeatureLockRibbon;
+            if (ribbon is null) return;
+
+            if (!locked) { ribbon.IsVisible = false; return; }
+
+            if (dash!.TxtProgramFeatureLock is { } label)
+                label.Text = reason ?? SessionFeatureLockReason;
+            ribbon.IsVisible = true;
+        }
+
+        /// <summary>
+        /// The Studio rack hosts the same Features/*FeatureControl panels the dashboard popups
+        /// host, so it is a second door onto the prescribed dose and gets the identical painter.
+        /// The rack's panels are long-lived (built once, toggled by IsVisible), which is exactly
+        /// why this runs on session start/stop rather than on reveal.
+        /// </summary>
+        private void ApplySessionLockToStudioRack()
+        {
+            var rack = StudioRack;
+            if (rack is null) return;
+
+            foreach (var panel in rack.HostedFeaturePanels)
+                ApplySessionLockToFeaturePopup(panel);
+        }
+
+        /// <summary>
+        /// A locked feature panel: the master enable greys out and a banner names the reason
+        /// above it. Both directions are applied, so a session that ends while the panel is on
+        /// screen re-enables it in place. No latch.
+        /// </summary>
+        private void ApplySessionLockToFeaturePopup(UserControl? content)
+        {
+            if (content is null) return;
+
+            try
+            {
+                var locked = IsSessionFeatureLockActive;
+                var reason = locked ? SessionFeatureLockReason : null;
+
+                // Uniform convention across every Features/*FeatureControl.axaml: the master
+                // on/off is named ChkEnable. FindControl searches the control's own namescope
+                // only, so this cannot reach a same-named control elsewhere in the app.
+                SetToggleLock(content.FindControl<CheckBox>("ChkEnable"), locked, reason);
+
+                if (content.Content is Panel root)
+                {
+                    var existing = FindSessionLockBanner(root);
+                    if (locked && existing is null)
+                        root.Children.Insert(0, BuildSessionLockBanner(reason));
+                    else if (locked && existing is not null)
+                        UpdateSessionLockBanner(existing, reason);
+                    else if (!locked && existing is not null)
+                        root.Children.Remove(existing);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[SessionLock] Failed to apply lock to feature panel");
+            }
+        }
+
+        private static Border? FindSessionLockBanner(Panel root)
+        {
+            foreach (var child in root.Children)
+                if (child is Border b && (b.Tag as string) == SessionLockBannerTag) return b;
+            return null;
+        }
+
+        private static void UpdateSessionLockBanner(Border banner, string? reason)
+        {
+            if (banner.Child is StackPanel sp)
+                foreach (var child in sp.Children)
+                    if (child is TextBlock tb && (tb.Tag as string) == SessionLockBannerTag)
+                    {
+                        tb.Text = reason ?? Loc.Get("session_lock_reason");
+                        return;
+                    }
+        }
+
+        /// <summary>
+        /// Built in code rather than XAML because the panels live in Views/Features/ and are
+        /// shared; injecting one banner here beats editing fourteen files. The strings resolve at
+        /// BUILD time, so a language change while it is on screen leaves it stale until the next
+        /// repaint - which every session start/stop performs.
+        /// <para>The lock glyph is a plain TextBlock: Avalonia draws colour emoji natively, so
+        /// WPF's EmojiTextBlock/EmojiToImageSource detour is not needed here.</para>
+        /// </summary>
+        private static Border BuildSessionLockBanner(string? reason)
+        {
+            var stack = new StackPanel { Orientation = Orientation.Horizontal };
+
+            stack.Children.Add(new TextBlock
+            {
+                Text = "🔒",
+                FontSize = 13,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new global::Avalonia.Thickness(0, 0, 8, 0),
+            });
+
+            stack.Children.Add(new TextBlock
+            {
+                Tag = SessionLockBannerTag,
+                Text = reason ?? Loc.Get("session_lock_reason"),
+                FontSize = 11,
+                FontWeight = FontWeight.SemiBold,
+                TextWrapping = TextWrapping.Wrap,
+                VerticalAlignment = VerticalAlignment.Center,
+                Foreground = new SolidColorBrush(LockPink),
+            });
+
+            return new Border
+            {
+                Tag = SessionLockBannerTag,
+                Background = new SolidColorBrush(Color.FromArgb(0x33, LockPink.R, LockPink.G, LockPink.B)),
+                BorderBrush = new SolidColorBrush(LockPink),
+                BorderThickness = new global::Avalonia.Thickness(1),
+                CornerRadius = new global::Avalonia.CornerRadius(9),
+                Padding = new global::Avalonia.Thickness(12, 8, 12, 8),
+                Margin = new global::Avalonia.Thickness(0, 0, 0, 10),
+                Child = stack,
+            };
+        }
+
+        /// <summary>
+        /// Greys a control and gives it the reason as its tooltip.
+        /// <para>ClearValue on unlock rather than "= true": the control may be disabled for some
+        /// OTHER reason (entitlement gating disables whole containers), and hard-writing true
+        /// would silently promote the user past that gate.</para>
+        /// </summary>
+        private static void SetToggleLock(Control? control, bool locked, string? reason)
+        {
+            if (control is null) return;
+
+            if (locked)
+            {
+                control.IsEnabled = false;
+                ToolTip.SetTip(control, reason ?? Loc.Get("session_lock_reason"));
+            }
+            else
+            {
+                control.ClearValue(global::Avalonia.Input.InputElement.IsEnabledProperty);
+                // ponytail: WPF's SessionLock.ApplyLockToolTip restores whatever tooltip the
+                // control carried before the lock. Without the attached property there is no
+                // saved original to restore, so unlocking clears the tip outright. A ported
+                // Features/SessionLock.cs would take this over.
+                ToolTip.SetTip(control, null);
+            }
+        }
+
+        /// <summary>
+        /// Call from any handler that is about to change the prescribed dose. Returns true when
+        /// the change must be refused.
+        /// <para>ponytail: WPF also flashes the ribbon (PulseSessionLockRibbon) so the refusal is
+        /// visible rather than a dead click. See the header - no Avalonia twin yet.</para>
+        /// </summary>
+        internal bool RefuseIfSessionFeatureLocked(string what)
+        {
+            if (!IsSessionFeatureLockActive) return false;
+
+            Log.Information("[SessionLock] Refused feature change '{What}' - {Reason}",
+                what, SessionFeatureLockReason);
+            return true;
+        }
+
+        /// <summary>
+        /// Refuses a whole ACTION (as opposed to a single dial) that would overwrite the
+        /// prescribed dose wholesale, and explains why in a dialog.
+        ///
+        /// <para>Greying is the right answer for a dial the user is staring at. It is the wrong
+        /// answer for "Remember", "Jump right in", "Load preset" and "Restore from cloud": each
+        /// rewrites ~40 prescribed fields in one click, from headers and tabs where the ribbon is
+        /// not even on screen. A silently dead button there reads as a broken app.</para>
+        ///
+        /// <para>Not a safety control: none of these is a way out of a session.</para>
+        /// </summary>
+        /// <param name="what">Short identifier for the log line, e.g. "remember-recall".</param>
+        internal bool RefuseActionIfSessionLocked(string what)
+        {
+            if (!IsSessionFeatureLockActive) return false;
+
+            var reason = SessionFeatureLockReason;
+            Log.Information("[SessionLock] Refused action '{What}' - {Reason}", what, reason);
+
+            // Fire and forget: the refusal is synchronous and must return NOW. Awaiting a modal
+            // here would invert WPF's order, where MessageBox.Show blocks after the decision is
+            // already made.
+            _ = ExplainRefusalAsync(reason);
+            return true;
+        }
+
+        private async Task ExplainRefusalAsync(string reason)
+        {
+            try
+            {
+                await Dialogs.MessageDialog.ShowAsync(
+                    this,
+                    Loc.Get("session_lock_action_title"),
+                    Loc.GetF("session_lock_action_body", reason));
+            }
+            catch (Exception ex)
+            {
+                // Never let the explanation itself break the refusal.
+                Log.Debug(ex, "[SessionLock] Could not show the refusal dialog");
+            }
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Takeaway.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Takeaway.cs
@@ -1,41 +1,48 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Takeaway.cs (671 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.Takeaway.cs (670 lines) - the
+// Presets-tab receipt strip for Just Drop orders.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// ONE BLOCKER, hard rather than pending: every member takes or returns a
+// JustDropOrdersService.Order. That type is
+// ConditioningControlPanel/Services/JustDrop/JustDropOrdersService.cs, an internal static class
+// that reads the server's order drawer live over the device-token door and keeps nothing locally.
+// It is not in Core and CANNOT be seeded here the way CoreSession or CoreModArt can: the drawer
+// needs the device token, the token seam is CoreSecrets, and unseeded CoreSecrets means NO STORE,
+// never a token in the clear. No token, no drawer, no orders to format or paint.
 //
-// Members dropped (25):
-//   private const int TakeawayShelfCap
-//   private bool _takeawayLoading
-//   private bool _takeawayTrayOpen
-//   private TextBlock? _takeawayMoreLabel
-//   private int _takeawayMoreCount
-//   internal void RefreshTakeawayShelf(…)
-//   private async System.Threading.Tasks.Task LoadTakeawayShelfAsync(…)
-//   private void PaintTakeawayShelf(…)
-//   private void SetTakeawayTrayOpen(…)
-//   private static string TakeawayMoreText(…)
-//   private Border? BuildTakeawayDropChip(…)
-//   private Border? BuildTakeawayMoreChip(…)
-//   private Border? BuildTakeawayTrayRow(…)
-//   private TextBlock MakeTakeawayRowMeta(…)
-//   private Border? BuildTakeawayCopyChip(…)
-//   private Border? BuildTakeawayDoorChip(…)
-//   private static string FormatTakeawayMeta(…)
-//   private static string FormatTakeawayDate(…)
-//   private static string FormatTakeawayMinutes(…)
-//   private static string FormatTakeawayAge(…)
-//   private static string SafeOrderName(…)
-//   private void TakeawayCard_Click(…)
-//   private void TakeawayCopyLink_Click(…)
-//   private void TakeawayMore_Click(…)
-//   private void TakeawayDoor_Click(…)
+// That reaches even the pure-looking helpers: FormatTakeawayMeta / Date / Minutes / Age and
+// SafeOrderName are all `static string F(JustDropOrdersService.Order)`. Their bodies are portable
+// string work, but a formatter for a type this head cannot name is not restorable in isolation -
+// it would need rewriting against a Core order shape that does not exist.
+//
+// The strip is not missing: CCP.Avalonia/Views/Tabs/PresetsTabView.axaml.cs already paints a
+// placeholder shelf into TakeawayShelf/TakeawayTray with the real chrome, so the tab renders
+// finished rather than gapped. What it has no way to get is rows.
+//
+// Members, grouped by what each needs:
+//   Load + repaint (JustDropOrdersService list read):
+//     RefreshTakeawayShelf, LoadTakeawayShelfAsync, PaintTakeawayShelf,
+//     const TakeawayShelfCap (3 pinned before the "+n more" toggle), _takeawayLoading.
+//   Chip/row construction, all taking an Order:
+//     BuildTakeawayDropChip, BuildTakeawayMoreChip, BuildTakeawayTrayRow, MakeTakeawayRowMeta,
+//     BuildTakeawayCopyChip, BuildTakeawayDoorChip.
+//   Formatters - portable bodies, unportable parameter (above):
+//     FormatTakeawayMeta, FormatTakeawayDate, FormatTakeawayMinutes, FormatTakeawayAge,
+//     SafeOrderName.
+//   Overflow tray - no service dependency at all, and dead without rows to expand:
+//     _takeawayTrayOpen, _takeawayMoreLabel, _takeawayMoreCount, SetTakeawayTrayOpen,
+//     TakeawayMoreText, TakeawayMore_Click.
+//   Actions, each a different missing head capability:
+//     TakeawayCard_Click     JustDropHostService.LaunchReplay - the WebView2 shop host (bucket D).
+//     TakeawayDoor_Click     JustDropService.DoorAvailable + LaunchShop, same host.
+//     TakeawayCopyLink_Click System.Windows.Clipboard (Avalonia's TopLevel.Clipboard covers it)
+//                            plus JustDropService.TasteUrl for the link and App.Notifications for
+//                            the toast. The clipboard is the available third.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Nothing here on purpose. Shelf chrome: CCP.Avalonia/Views/Tabs/PresetsTabView.axaml.cs.
+        // Rows need an order-drawer seam, which needs a seeded CoreSecrets first.
     }
 }


### PR DESCRIPTION
The header banner is live. Two beats always (support + welcome-back) plus the v6.8.0 One Account
beat while SeenFeatureIntros has not spent "banner-web", crossfading every 4s. The fade is an
Avalonia DoubleTransition on Opacity attached once, not a WPF DoubleAnimation, so a beat handover
is a plain Opacity write with no clock to release afterwards; hit-testing follows the fade so a
link at Opacity 0 cannot eat a click. RetireWebBannerBeat spends the key through CoreSettings and,
when the retired beat is the one on screen, hands its slot to the support beat with the same fade
rather than blinking empty. The welcome line comes from CoreSettings (offline username, else
UserDisplayName, else the generic invitation) and re-runs on LocalizationManager.LanguageChanged,
because it writes .Text over a control that carries {loc:Str} and a formatted name has no key to
bind instead.

This partial takes OnLoaded on MainShellWindow. It has to: the window's constructor lives in
MainShellWindow.axaml.cs, which this layer does not own, and OnOpened is already WorkAreaFit's.
Every control is reached through Named<T>, never a generated x:Name field, per the shell hazard.

UpdateQuickLoginUI is restored and runs from that same hook, so signed-in-ness paints from the
first frame: the Settings door shows either the login button or the signed-in strip with its OG
star, and the Quests and Enhancements tabs show their login overlays. On this head "signed in" is
exactly CoreSettings.Current.UnifiedId - there is no Patreon/Discord/SubscribeStar provider to
fall back to.

The session feature lock derives and paints. IsSessionFeatureLockActive is CoreSession
.IsEngineRunning, which is the exact mapping and whose unseeded "false" is the truth here rather
than merely safe; nothing latches and every accessor fails open. RefreshSessionFeatureLock paints
the dashboard ribbon and every Studio rack feature panel (master ChkEnable greyed with the reason
as its tooltip, the lock banner inserted above it, found by Tag so repaints cannot stack it), in
both directions, with per-section isolation so a partial paint retries next tick instead of
latching. RefuseIfSessionFeatureLocked and RefuseActionIfSessionLocked both work; the second
explains itself through MessageDialog. No safety control is touched.

The other five files keep no code and stop lying. Each names the exact symbols and the exact head
path that would take them, and drops the blanket "wired when the services move to Core" header,
which was wrong about most of them: the work has usually MOVED to a tab view on this head rather
than being blocked at all.

Still blocked:
- Marquee: ShowOgWelcomePopup / TryPresentSeasonRecap / ShowWhatsNewIfNeeded (App.Achievements,
  App.Seasons, the startup dialog queue in ConditioningControlPanel/App.xaml.cs - the dialogs
  themselves exist here); RefreshMarqueeFromSettings / CheckServerUpdateBanner /
  CheckServerAnnouncement + their DTOs (HttpClient to the CC Labs API); CheckIntakePassNudge /
  StartIntakeFromNudge (App.Programs); BannerWebLink_Click (ConditioningControlPanel/Helpers/
  BrowserLauncher.cs); StartMarqueeAnimation / UpdateMarqueeMessage (a WPF Storyboard over a
  control MainShellWindow.axaml does not carry); SweepBannerSheen (MainShellWindow.ChromeFx.cs).
- SessionFeatureLock: the per-dial marker sweep. features:SessionLock.Owned was dropped in the
  port (see CCP.Avalonia/Views/Features/FlashFeatureControl.axaml:11), so a running session greys
  the master enable but leaves the dose sliders draggable. It needs CCP.Avalonia/Features/
  SessionLock.cs, which does not exist. With it, ApplySessionLockToTabs is one line - GradedIntake,
  Awareness and Haptics tab views are all here. Also blocked: IsProgramSessionActive and the
  program-named reason (App.Programs), PulseSessionLockRibbon (a WPF keyframe strobe), and
  _activeFeaturePopupContent (MainShellWindow.TakeoverUi.cs / FeatureSettingsPopup).
- CloudBackup: all six members belong to CCP.Avalonia/Views/Controls/AppSettings/
  AccountSettingsSection.axaml.cs now, and need ConditioningControlPanel/Services/
  ProfileSyncService.cs. There is no cloud identity to authenticate with either: CoreSecrets is
  unseeded here, and unseeded means no store, never plaintext.
- Login: BtnUnifiedLogin_Click / BtnQuickLogout_Click are CCP.Avalonia/Views/Tabs/
  SettingsTabView.axaml.cs:329-330 and need App.UnifiedUserId + ProfileSyncService.
  ClearAccountData / ClearProgressionData would port their CoreSettings halves verbatim but not
  ProfileSyncService.ClearXpWatermark (#865), App.Quests.StampOwner, App.Achievements or
  App.Descent - and nothing calls them here, so restoring half would be dead code that also skips
  four teardown steps.
- Roadmap: the sub-tab and track chrome is already QuestsTabView.axaml.cs:64-95; the rest needs a
  CoreRoadmap seam over ConditioningControlPanel/Services/RoadmapService.cs (GetTrackProgress,
  IsTrackUnlocked, the photo flow, StepCompleted/TrackUnlocked). The models are already in Core.
- Takeaway: every member takes JustDropOrdersService.Order, which needs the device token, which
  needs a seeded CoreSecrets. The formatters are portable bodies with an unportable parameter.
  Replay and the shop door additionally need the WebView2 host.
- KeywordTriggers: the two cooldown sliders are already done in AwarenessTabView.axaml.cs:66-79.
  The persistence half of six more editors is pure CoreSettings work waiting in
  CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs (needs an _isLoading guard -
  a programmatic set raises the change event); the trigger list needs
  ConditioningControlPanel/Services/KeywordTriggerService.cs.
- ProgramBanner: ApplyProgramBannerArt names ProgramDefinition and ProgramArt, neither in Core;
  the fog/sheen/sparkle/parallax members are WPF storyboards with no Avalonia port written. The
  markup in CCP.Avalonia/Views/Tabs/SettingsTabView.axaml is complete and stays collapsed, so the
  card renders finished rather than holed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU