### PR TITLE
feat(avalonia): the Chaos HUD remembers its edge; the gaze minigame plays its reward and asks before quitting

### DIFF
--- a/CCP.Avalonia/Views/Chaos/ChaosHudWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosHudWindow.axaml.cs
@@ -50,6 +50,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     ///    tier colour, the tier font size, the glow, the final opacity, the parked slide offset.
     ///    The state-driven visuals are therefore all present; only the motion between them is not.
     ///    The one animation that was already a timer - the hot-streak jitter - is ported as-is.
+    ///  - <b>Settings.</b> The persisted edge (<c>ChaosHudOnRight</c>) and the panic-key hint
+    ///    read and write <c>CoreSettings.Current</c>, one for one with the <c>App.Settings</c>
+    ///    pair WPF used, so the side switch survives a restart again.
     ///  - <c>Mouse.GetPosition</c> has no Avalonia twin (there is no global cursor query), so the
     ///    collapse grace tests the LAST SEEN pointer position instead; see CursorInHudGrace.
     ///  - <c>SystemParameters.WorkArea</c> -> <c>Screens</c>; <c>Left</c>/<c>Top</c> ->
@@ -229,8 +232,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             // screen (shrinks from the bottom up). Left/right edge is chosen by ApplySide.
             Height = WorkAreaDip().Height * 0.6;
             if (double.IsNaN(Height) || Height < 200) Height = 780;   // headless, or no screen yet
-            // ponytail: needs App.Settings (ChaosHudOnRight), wired when settings move to Core.
-            ApplySide(false);
+            ApplySide(CoreSettings.Current.ChaosHudOnRight);
             LoadPortrait();
             AttachHudTips();
         }
@@ -346,8 +348,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
         /// <summary>
         /// Sidebar portrait slot. WPF resolved art by convention through <c>ChaosArt.Resolve</c>
         /// and collapsed the host when no file was present.
-        /// ponytail: needs ChaosArt, wired when it moves to Core. Until then this is the no-art
-        /// path - which is what a fresh install renders anyway.
+        /// <para>ponytail: needs <c>Services/Chaos/ChaosArt.cs</c>, still in the WPF head because
+        /// it returns <c>System.Windows.Media.ImageSource</c>. Only the RESOLUTION half is
+        /// portable (<c>ChaosArt.PathFor</c> / <c>FilePath</c>, returning an absolute path each
+        /// head decodes itself) - that is the half to move, as <c>CoreModArt</c> did for mod art.
+        /// Whoever moves it: <c>Roots()</c> yields <c>App.UserAssetsPath</c> (= UserData/assets)
+        /// and the callers then append <c>assets/Chaos/...</c>, so the user root probes a doubled
+        /// <c>assets</c> segment; decide whether that is the intended layout before copying it.
+        /// Until then this is the no-art path - what a fresh install renders anyway.</para>
         /// </summary>
         private void LoadPortrait()
         {
@@ -620,10 +628,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             PersistSide(true);
         }
 
-        /// <summary>ponytail: needs App.Settings (ChaosHudOnRight), wired when settings move to
-        /// Core. The side switch works for the session; it just does not survive a restart.</summary>
+        /// <summary>Remember the chosen edge across restarts. Compare-before-write, as WPF did:
+        /// the switch handlers already early-out on a no-op, but a debounced save is not free.</summary>
         private void PersistSide(bool onRight)
         {
+            try
+            {
+                if (CoreSettings.Current.ChaosHudOnRight == onRight) return;
+                CoreSettings.Current.ChaosHudOnRight = onRight;
+                CoreSettings.Save();
+            }
+            catch (Exception ex) { Log.Debug("ChaosHud side persist: {E}", ex.Message); }
         }
 
         /// <summary>Pin the panel open for the pre-run loadout glance (FALL IN → countdown), then
@@ -745,9 +760,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             {
                 _btnHero.IsVisible = !paused;
                 _pauseChoiceRow.IsVisible = paused;
-                // ponytail: needs App.Settings (PanicKeyEnabled / PanicKey), wired when settings
-                // move to Core. Until then the hint reads as it does with the panic key off.
-                _txtPauseHint.Text = "⏸ HELD · the hole waits";
+                var settings = CoreSettings.Current;
+                _txtPauseHint.Text = settings.PanicKeyEnabled
+                    ? $"⏸ HELD · {settings.PanicKey} again wakes you up"
+                    : "⏸ HELD · the hole waits";
                 _txtPauseHint.IsVisible = paused;
                 _pinnedOpen = paused;
                 if (paused)

--- a/CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs
@@ -39,13 +39,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
     ///    because the chips, sliders and warning ARE view logic. Load/Save/Discover are stubs.
     ///  - The library is seeded with <see cref="SampleLibrary"/> so the render exercises the
     ///    card builder, both drop zones, the library strip and an enabled Start button.
+    ///  - The reward CLIP plays through <c>CoreAudio.PlayOneShot</c> (WPF's master^1.5 curve
+    ///    carried over); its folder is not linked into this head's csproj, so it currently logs
+    ///    a miss. The other four reward effects have no seam yet.
     ///  - <c>App.Webcam</c> / <c>App.Flash</c> / <c>App.Haptics</c> / <c>App.Bubbles</c> /
     ///    <c>App.MindWipe</c> / <c>App.Overlay</c> / <c>WebcamCalibrationWindow</c>, LibVLC
     ///    (<c>VideoView</c> + the whole stop/detach/dispose dance and its message pump), NAudio
     ///    and XamlAnimatedGif are all head-side; each is a stub. Gaze never changes side, so a
     ///    round resolves on its display cap.
-    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so the
-    ///    "quit the session?" confirmation is not raised (ChaosSlotPickerWindow precedent).
+    ///  - <c>MessageBox.Show</c> -> this head's <c>Views/Dialogs/MessageDialog.ConfirmAsync</c>,
+    ///    so the mid-run "quit the session?" confirmation is raised again (awaited, hence the
+    ///    re-test of <c>_gameRunning</c> after it).
     ///  - <c>FolderBrowserDialog</c> -> <c>StorageProvider.OpenFolderPickerAsync</c>.
     ///  - Mouse* -> Pointer*; Avalonia 12's <c>DoDragDropAsync</c> only takes a
     ///    <see cref="PointerPressedEventArgs"/>, so the drag starts on press and the WPF
@@ -92,7 +96,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         /// Field-for-field twin of the head's <c>GazeMinigameSettings</c>, minus the JSON
         /// attributes. The presets, the clamps and the bundled-audio list are copied verbatim:
         /// they drive the difficulty chips and the sliders, which are view logic.
-        /// ponytail: needs Lab/GazeMinigame/GazeMinigameSettings.cs, wired when it moves to Core.
+        /// <para>ponytail: this whole class and the three enums above are a SECOND COPY of
+        /// <c>ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs</c>, which CLAUDE.md
+        /// forbids - they exist only because that file is still in the WPF head. It is portable
+        /// today: Newtonsoft plus <c>CorePaths</c>, and the only head-ism is two
+        /// <c>App.Logger</c> calls that become Serilog's static <c>Log</c>. <b>Move it to
+        /// CCP.Core/Lab/GazeMinigame/ and DELETE this twin</b>, which also restores Load/Save (and
+        /// with them the persisted difficulty, chips, sliders and pack roles).</para>
         /// </summary>
         private sealed class GazeMinigameSettings
         {
@@ -351,9 +361,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         private void DiscoverLibrary()
         {
             _library.Clear();
-            // ponytail: needs Lab/GazeMinigame/GazePackLibrary.Discover, wired when it moves to
-            // Core. Until then the strip shows the sample library so the gallery, both zones and
-            // the Start gating all draw.
+            // ponytail: needs ConditioningControlPanel/Lab/GazeMinigame/GazePackLibrary.cs, still
+            // in the WPF head. It is portable today - it already calls CorePaths.EffectiveAssets
+            // and Core's AssetPack, and its only head-ism is one App.Logger call. Move it to
+            // CCP.Core/Lab/GazeMinigame/ and this becomes GazePackLibrary.Discover(_customPaths).
+            // Until then the strip shows the sample library so the gallery, both zones and the
+            // Start gating all draw.
             _library.AddRange(SampleLibrary());
 
             foreach (var pack in _library)
@@ -1230,11 +1243,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
 
         /// <summary>
         /// WPF fanned this out to App.Flash.TriggerFlashOnce / App.Bubbles.SpawnOnce ×5 /
-        /// PlayRewardAudio / App.MindWipe.TriggerOnce / App.Overlay.PulseOverlays.
-        /// ponytail: needs those services, wired when they move to Core.
+        /// PlayRewardAudio / App.MindWipe.TriggerOnce / App.Overlay.PulseOverlays. Only the audio
+        /// arm has a seam - <c>CoreAudio</c> - so only the audio arm fires here.
+        /// ponytail: the other four need <c>App.Flash</c> (FlashService.TriggerFlashOnce),
+        /// <c>App.Bubbles</c> (BubbleService.SpawnOnce), <c>App.MindWipe</c>
+        /// (MindWipeService.TriggerOnce) and <c>App.Overlay</c> (OverlayService.PulseOverlays),
+        /// all still in the WPF head; each wants a seam of its own.
         /// </summary>
-        private static void FireRewardEffect(GazeRewardEffect effect)
-            => Log.Debug("GazeMinigame: reward effect {Effect} suppressed (services not on this head)", effect);
+        private void FireRewardEffect(GazeRewardEffect effect)
+        {
+            if (effect == GazeRewardEffect.Audio) { PlayRewardAudio(_settings.RewardAudioFile); return; }
+            if (effect == GazeRewardEffect.None) return;
+            Log.Debug("GazeMinigame: reward effect {Effect} suppressed (service not on this head)", effect);
+        }
 
         /// <summary>
         /// WPF posted HapticEventKind.GazeReward so the Haptics tab's "Gaze reward" routing row
@@ -1243,10 +1264,33 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         private static void FireVibration(string tag)
             => Log.Debug("GazeMinigame: vibration {Tag} suppressed (haptics not on this head)", tag);
 
-        /// <summary>ponytail: needs NAudio + App.Settings.MasterVolume, wired when audio
-        /// playback moves to Core.</summary>
+        /// <summary>The short reward clip, through the audio seam. WPF spun up its own
+        /// self-disposing NAudio pair here; <c>CoreAudio.PlayOneShot</c> is that pattern already,
+        /// so only the volume curve is carried across - master/100 raised to 1.5, exactly as
+        /// <c>PlayTriggerAudio</c> and the other ported one-shots do.
+        /// <para>ponytail: <c>Resources/AwarenessPresets/audio/</c> is not linked into
+        /// <c>CCP.Avalonia.csproj</c> (which ships a ~33 MB subset of the Resources tree), so on
+        /// this head the file is missing and playback logs and returns. Link the folder to hear
+        /// it; the call itself is wired.</para></summary>
         private static void PlayRewardAudio(string fileName)
-            => Log.Debug("GazeMinigame: reward audio {File} suppressed (no audio on this head)", fileName);
+        {
+            try
+            {
+                var path = System.IO.Path.Combine(
+                    AppContext.BaseDirectory, "Resources", "AwarenessPresets", "audio", fileName);
+                if (!System.IO.File.Exists(path))
+                {
+                    Log.Warning("GazeMinigame: reward audio missing '{Path}'", path);
+                    return;
+                }
+                var master = CoreSettings.Current.MasterVolume / 100f;
+                CoreAudio.PlayOneShot(path, (float)Math.Pow(master, 1.5), "gaze-reward");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "GazeMinigame: PlayRewardAudio failed");
+            }
+        }
 
         // chime.wav is bundled at Resources/AwarenessPresets/audio/chime.wav and plays on every
         // correct round, independent of the configured RewardEffect.
@@ -1526,12 +1570,32 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
             }
 
             if (e.Key != Key.Escape) return;
+            e.Handled = true;
 
-            // WPF raised a MessageBox here ("Quit the current session?") when a game was
-            // running. Avalonia has no MessageBox and no package may be added, so the
-            // confirmation is not raised — same call ChaosSlotPickerWindow made.
+            if (_gameRunning)
+            {
+                // Mid-run ESC asks before throwing the run away. MessageDialog is this head's
+                // MessageBox; it is awaited, so re-test _gameRunning after it - the round ticker
+                // can have ended the game while the dialog was up.
+                _ = ConfirmQuitAsync();
+                return;
+            }
+
+            // Outside of gameplay, ESC closes (after exiting fullscreen if needed).
             ExitFullscreen();
             Close();
+        }
+
+        private async Task ConfirmQuitAsync()
+        {
+            try
+            {
+                bool quit = await Views.Dialogs.MessageDialog.ConfirmAsync(
+                    this, "Gaze minigame",
+                    "Quit the current session? Your progress for this run will be lost.");
+                if (quit && _gameRunning) Close();
+            }
+            catch (Exception ex) { Log.Warning(ex, "GazeMinigame: quit confirmation failed"); }
         }
 
         private void Window_Closing(object? sender, WindowClosingEventArgs e)
@@ -1541,8 +1605,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
             DisposeCurrentRoundPlayers(synchronous: true);
             UnsubscribeWebcam();
             // WPF also resumed the main-session FlashService here, but only when the engine was
-            // still running (bug #221). ponytail: needs App.Flash + App.IsEngineRunning, wired
-            // when they move to Core.
+            // still running (bug #221). ponytail: needs App.Flash (FlashService.Start/Stop), still
+            // in the WPF head - BtnStartGame_Click has the matching suspend stub. The #221 gate
+            // itself no longer blocks: CoreSession.IsEngineRunning answers it.
         }
     }
 }


### PR DESCRIPTION
Chaos HUD. The sidebar edge is persisted again: the window opens on
CoreSettings.Current.ChaosHudOnRight and the strip's under-clock switch writes it
back through CoreSettings.Save (compare-before-write, as WPF did), so the side
survives a restart instead of only the session. The paused hint reads the real
panic key again - "HELD, <key> again wakes you up" when PanicKeyEnabled, the
plain "the hole waits" otherwise. Nothing else in that window was restorable:
every remaining stub is a Chaos service that is still WPF-only.

Gaze minigame. The reward CLIP plays through CoreAudio.PlayOneShot, carrying
WPF's volume curve verbatim (MasterVolume/100 raised to 1.5) rather than its
hand-rolled NAudio pair; PlayJingle rides the same path. FireRewardEffect is no
longer a blanket stub - its Audio arm fires, the other four still log. ESC
mid-run raises the "quit the current session?" confirmation again via this head's
MessageDialog.ConfirmAsync; it is awaited, so _gameRunning is re-tested before
Close. The class note claiming Avalonia has no MessageBox was stale and is gone.

The split, stated plainly: restorable was everything reading or writing
AppSettings, plus the one-shot audio seam and the dialog. Head-side and NOT
restored: the webcam gaze tracker (so the minigame draws but tracks nothing - a
round still resolves on its display cap), the Chaos host services (so the HUD
renders but no run drives it), video playback, haptics, and the flash/bubble/
mind-wipe/overlay reward effects.

Still blocked:
- ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs and
  GazePackLibrary.cs -> CCP.Core/Lab/GazeMinigame/. Both are portable today
  (Newtonsoft + CorePaths + Core's AssetPack); the only head-ism is App.Logger ->
  Serilog Log. Until they move, GazeMinigameWindow carries a private twin of the
  settings record and of GazePackRole/GazeVibrationMode/GazeRewardEffect - the
  second copy of logic CLAUDE.md forbids. Moving them restores Load/Save (hence
  the persisted difficulty, sliders and pack roles), Discover, and lets the twin
  and the SampleLibrary/SampleRole placeholders be deleted.
- WebcamTrackingService (ConditioningControlPanel/Services/Webcam/): the Start
  gate, App.Webcam.Calibration for the nudge banner, and the gaze stream.
  WebcamCalibrationWindow.ShowDialogWithRecalibrate has no twin on this head -
  CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs exists but has no
  such static and no tracker behind it.
- ChaosModeService, ChaosRunState, ChaosArt, ChaosTips, ChaosWindowZ
  (ConditioningControlPanel/Services/Chaos/ + ConditioningControlPanel/Chaos/).
  Only ChaosArt's resolution half (PathFor/FilePath) is portable; its Roots()
  probes a doubled "assets" segment under the user root - decide that before
  copying it.
- App.Flash (FlashService.Start/Stop/TriggerFlashOnce, incl. the bug #221 resume;
  CoreSession.IsEngineRunning now answers that gate), App.Haptics
  (HapticEventKind.GazeReward, IsConnected), App.Bubbles.SpawnOnce,
  App.MindWipe.TriggerOnce, App.Overlay.PulseOverlays, LibVLCSharp VideoView.
- CCP.Avalonia.csproj does not link Resources/AwarenessPresets/audio/, so the
  reward clip logs a miss on this head. The call is wired; the asset is not.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU