### PR TITLE
feat(avalonia): the gear opens Emi's real options, and her width persists

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml.cs
@@ -61,8 +61,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         public const double BodyAspect = 869.0 / 859.0;
 
         /// <summary>
-        /// Her width when nothing has been persisted. WPF read <c>App.Settings.EmiDeskWidth</c>;
-        /// ponytail: needs App.Settings, wired when the settings service moves to Core.
+        /// Her width when nothing has been persisted - the fallback behind
+        /// <c>CoreSettings.Current.EmiDeskWidth</c>, which is where her width actually lives.
         /// </summary>
         public const double DefaultBodyWidth = 220.0;
 
@@ -337,9 +337,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             _btnGear.IsHitTestVisible = false;
             _btnHelp.IsHitTestVisible = false;
 
-            // ponytail: needs App.Settings.Current.EmiDeskWidth, wired when the settings service
-            // moves to Core. Until then she is born at her default width.
-            _bodyWidth = ClampWidth(DefaultBodyWidth);
+            // Her width has ONE home and it is the setting (BRIEF 5: the rect, the pins and the
+            // usage counters live in EmiState, the width does not).
+            try { _bodyWidth = ClampWidth(CoreSettings.Current.EmiDeskWidth); }
+            catch { _bodyWidth = DefaultBodyWidth; }
 
             // One controlled re-clamp when the monitor scale settles. This is the useful half of
             // WPF's WM_DPICHANGED hook; the deadlock the other half guarded against was a WPF
@@ -630,13 +631,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// into that monitor's work area. A monitor that is gone, or no saved rect at all, parks her
         /// bottom right on the main window's monitor.
         /// </summary>
-        // ponytail: needs EmiState (Services/EmiDesk/EmiState.cs) for the saved rect and monitor
-        // name, and App.Settings for the width re-read; neither is in Core. Until they are she is
-        // parked by default on every summon, which is what a first run does anyway.
+        // ponytail: needs EmiState (Services/EmiDesk/EmiState.cs) for the saved rect and the
+        // monitor name, which is not in Core. Until it is she is parked by default on every summon,
+        // which is what a first run does anyway. The WIDTH half of the WPF body is ported: it lives
+        // in the setting, not in EmiState, and re-reading it here is what puts a change made while
+        // she was away - the shrink offer, the settings slider - on her the next time she comes out.
         public void RestorePlacement()
         {
-            try { ParkBottomRightOfMain(); }
-            catch (Exception ex) { Log.Warning(ex, "[EmiDesk] RestorePlacement failed"); }
+            try
+            {
+                double wantW = CoreSettings.Current.EmiDeskWidth;
+                if (Math.Abs(wantW - _bodyWidth) > 0.5) ApplyBodyWidth(wantW);
+                ParkBottomRightOfMain();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] RestorePlacement failed, parking her by default");
+                try { ParkBottomRightOfMain(); } catch { /* out of options */ }
+            }
         }
 
         private void SetBodyPhysical(double bodyLeftPx, double bodyTopPx)
@@ -1273,21 +1285,60 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
 
         // ---- her options panel ----------------------------------------------------
 
-        /// <summary>True while her options panel is beside her. Read by the glass before it flips.</summary>
-        // ponytail: needs EmiOptionsWindow, which has no Avalonia twin yet (its own layer).
-        public bool OptionsOpen => false;
+        private EmiOptionsWindow? _options;
 
-        /// <summary>Show her options beside her.</summary>
-        // ponytail: needs EmiOptionsWindow. It is built lazily and KEPT in WPF, because it carries a
-        // 25-tile pin picker and rebuilding that per gear click is a wall of decoded thumbnails.
-        // While it is up the chrome stays lit (EmiChromeHold.Menu), which is why that latch exists.
+        /// <summary>True while her options panel is beside her. Read by the glass before it flips.</summary>
+        public bool OptionsOpen
+        {
+            get
+            {
+                try { return _options?.IsOpen == true; }
+                catch { return false; }
+            }
+        }
+
+        /// <summary>
+        /// Show her options beside her. Built lazily and KEPT, the way the ring window is: it
+        /// carries a 25-tile pin picker, and rebuilding that on every gear click is a wall of
+        /// decoded thumbnails per open.
+        /// </summary>
         private void OpenOptionsPanel()
         {
+            try
+            {
+                if (_options == null)
+                {
+                    _options = new EmiOptionsWindow(this);
+                    // While the panel is up the chrome stays lit, so the gear that opened it is
+                    // still there to close it again after the round trip across the desktop.
+                    _options.PanelClosed += (_, _) => ChromeHold(EmiChromeHold.Menu, false);
+                    _options.CardsRequested += (_, _) => ToggleRingFromGesture();
+                }
+
+                ChromeHold(EmiChromeHold.Menu, true);
+                _options.OpenPanel();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] options panel failed to open");
+                ChromeHold(EmiChromeHold.Menu, false);
+            }
         }
 
         /// <summary>Fold her options. Idempotent, and safe where the panel was never built.</summary>
         public void CloseOptionsPanel()
         {
+            try { _options?.ClosePanel(); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] options panel close failed"); }
+        }
+
+        /// <summary>Drop the options panel for good. It is a sibling window holding a subscription
+        /// to this one's Moved/Resized, so it has to go before she does.</summary>
+        private void KillOptionsPanel()
+        {
+            try { _options?.Kill(); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] options kill failed"); }
+            _options = null;
         }
 
         /// <summary>Let the panel keep the chrome lit while the pointer is inside it.</summary>
@@ -1451,9 +1502,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 e.Handled = true;
                 ClampIntoWorkArea();
                 SavePlacement();
-                // ponytail: needs App.Settings.EmiDeskWidth + Save() - her width's one home is the
-                // setting, not EmiState - and App.EmiDesk.Fire("resized"). Both move with the app
-                // shell to Core.
+                // Her width's one home is the setting, not EmiState. Half a pixel of slack, as WPF
+                // had: a save rewrites the whole file and a grip drag ends on a fractional DIP.
+                if (Math.Abs(CoreSettings.Current.EmiDeskWidth - _bodyWidth) > 0.5)
+                {
+                    CoreSettings.Current.EmiDeskWidth = _bodyWidth;
+                    CoreSettings.Save();
+                }
+                // ponytail: needs App.EmiDesk.Fire("resized") - her own event bus, which moves with
+                // the app shell.
                 FireDeskEvent("resized");
             }
             catch (Exception ex)
@@ -1535,7 +1592,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 _closingForGood = true;
                 try { OnTearDownCore(); }
                 catch (Exception ex) { Log.Debug(ex, "[EmiDesk] teardown seam threw"); }
-                CloseOptionsPanel();
+                KillOptionsPanel();
                 StopIdleBeats();
                 StopAlive();
                 DisarmPet();
@@ -1557,7 +1614,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             try
             {
                 _closingForGood = true;
-                CloseOptionsPanel();
+                KillOptionsPanel();
                 StopIdleBeats();
                 StopAlive();
                 DisarmPet();

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml.cs
@@ -49,10 +49,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
     ///         click on this panel can still focus it on X11.</item>
     ///   <item><b>The two global hooks have no equivalent on this head</b> and are stubbed. See
     ///         <see cref="InstallHooks"/> for exactly which two behaviours that costs.</item>
-    ///   <item><b>The owner is not ported yet.</b> <c>EmiDeskWindow</c> is the widget this panel
-    ///         hangs off, and it does not exist on this head, so the constructor takes no owner and
-    ///         every <c>_owner.*</c> call is a stub. That also makes this its own render
-    ///         constructor - there is no argument left to supply sample data for.</item>
+    ///   <item><b>The owner is optional.</b> <c>EmiDeskWindow</c> is the widget this panel hangs
+    ///         off and it is ported, so the constructor takes it and every <c>_owner.*</c> call is
+    ///         real. It stays NULLABLE for one reason: <c>--render-view</c> needs a parameterless
+    ///         constructor, and a headless render has no widget to hang off. Every owner call is
+    ///         therefore <c>?.</c> with the same fallback the unowned panel used.</item>
     ///   <item><b>Localize() is gone.</b> Its sixteen <c>Loc.Get</c> assignments are
     ///         <c>{loc:Str}</c> in the markup, so a language change re-renders them (CLAUDE.md).
     ///         The one string it set that is NOT static - the summon chord, which is either the
@@ -77,11 +78,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>How long a width drag rests before the number is written to settings.</summary>
         private const int WidthPersistMs = 400;
 
-        // ponytail: needs EmiDeskWindow.MinBodyWidth / MaxBodyWidth, wired when the widget is
-        // ported. The two literals below are the ones the WPF markup already declared on the
-        // slider; WireControls() then overwrote them with the same pair from the owner.
-        private const double MinBodyWidth = 152.0;
-        private const double MaxBodyWidth = 420.0;
+        private readonly EmiDeskWindow? _owner;
 
         private readonly Button _btnPanelClose;
         private readonly Button _btnOpenCards;
@@ -106,15 +103,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
 
         // ---------------------------------------------------------------- ctor
 
+        /// <summary>The render constructor: a panel with no widget behind it. See the header.</summary>
+        public EmiOptionsWindow() : this(null) { }
+
         /// <summary>
-        /// Builds the panel. Created folded; <see cref="OpenPanel"/> shows it.
-        ///
-        /// <para>Parameterless where WPF took an <c>EmiDeskWindow</c>: that widget is not on this
-        /// head yet, so there is nothing to hold and nothing to null-check. It doubles as the
-        /// render constructor for that reason.</para>
+        /// Builds the panel for one widget. Created folded; <see cref="OpenPanel"/> shows it.
         /// </summary>
-        public EmiOptionsWindow()
+        public EmiOptionsWindow(EmiDeskWindow? owner)
         {
+            _owner = owner;
             AvaloniaXamlLoader.Load(this);
 
             _btnPanelClose = this.FindControl<Button>("BtnPanelClose")!;
@@ -141,8 +138,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             PointerEntered += (_, _) => Hold(true);
             PointerExited += (_, _) => Hold(false);
 
-            // WPF also subscribed _owner.Moved / _owner.Resized here. See NotifyOwnerMoved and
-            // NotifyOwnerResized: with no owner type on this head the widget calls in instead.
+            // She moves, she resizes: the panel is anchored to her edge and has to come along.
+            if (_owner is not null)
+            {
+                _owner.Moved += OnOwnerMoved;
+                _owner.Resized += OnOwnerResized;
+            }
         }
 
         /// <summary>The panel folded. The desk window drops its chrome hold on this.</summary>
@@ -194,8 +195,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 }
             };
 
-            _sldWidth.Minimum = MinBodyWidth;
-            _sldWidth.Maximum = MaxBodyWidth;
+            _sldWidth.Minimum = EmiDeskWindow.MinBodyWidth;
+            _sldWidth.Maximum = EmiDeskWindow.MaxBodyWidth;
             _sldWidth.ValueChanged += OnWidthChanged;
             // A track click is not a drag, so the debounce is what actually persists both. Kept
             // anyway: it is what makes the write land the instant the thumb is let go.
@@ -212,8 +213,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             _spiceAnything.IsCheckedChanged += (_, _) => { if (_spiceAnything.IsChecked == true) OnSpicePicked(2); };
         }
 
-        // ponytail: needs EmiDeskWindow.HoldChromeForPanel, wired when the widget is ported.
-        private void Hold(bool on) { _ = on; }
+        private void Hold(bool on)
+        {
+            try { _owner?.HoldChromeForPanel(on); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] options chrome hold failed"); }
+        }
 
         // ---------------------------------------------------------------- open / close
 
@@ -279,6 +283,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             {
                 _closingForGood = true;
                 ClosePanel();
+                if (_owner is not null)
+                {
+                    _owner.Moved -= OnOwnerMoved;
+                    _owner.Resized -= OnOwnerResized;
+                }
                 Close();
             }
             catch (Exception ex)
@@ -289,41 +298,35 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
 
         // ---------------------------------------------------------------- values
 
-        /// <summary>
-        /// Fill the controls in.
-        ///
-        /// <para>ponytail: needs App.Settings and EmiDeskWindow.BodyWidth, wired when they move to
-        /// Core. The placeholders below are chosen to prove the templates rather than to look
-        /// tidy: one switch off and two on, and a checked middle segment, so a render shows both
-        /// states of the pill and both states of the segment.</para>
-        /// </summary>
+        /// <summary>Fill the controls in from the live settings and from her current width.</summary>
         private void LoadValues()
         {
             try
             {
                 _loading = true;
 
-                _chkMute.IsChecked = false;
-                _chkOffers.IsChecked = true;
-                _chkGlass.IsChecked = true;
+                var s = CoreSettings.Current;
+                _chkMute.IsChecked = s.EmiDeskMuteAvatar;
+                _chkOffers.IsChecked = s.EmiDeskOffers;
+                _chkGlass.IsChecked = s.EmiDeskGlass;
 
                 // The three segments ARE the 0..2 scale the lines file carries. No translation.
-                int spice = Math.Max(0, Math.Min(2, 1));
+                int spice = Math.Max(0, Math.Min(2, s.EmiDeskSpice));
                 _spiceInnocent.IsChecked = spice == 0;
                 _spiceSuggestive.IsChecked = spice == 1;
                 _spiceAnything.IsChecked = spice == 2;
 
-                var chord = "Ctrl+Alt+E";
+                var chord = s.EmiDeskHotkey;
                 // Chosen in code, not markup: which of the two strings applies depends on whether
-                // a chord is bound. Bind the key rather than assign .Text once App.Settings is
-                // here - an assignment is undone by the next language change (CLAUDE.md).
+                // a chord is bound. Safe as an assignment - TxtHotkey carries no {loc:Str}, so
+                // there is no binding for a language change to put back (CLAUDE.md).
                 _txtHotkey.Text = string.IsNullOrWhiteSpace(chord)
                     ? Loc.Get("emi_desk_hotkey_unbound")
                     : chord;
 
                 // Her CURRENT width, not the stored one: the grip writes settings on mouse-up, so
                 // mid-drag the window is the truth and the file is one drag behind.
-                double w = 220.0;
+                double w = _owner?.BodyWidth ?? EmiDeskWindow.DefaultBodyWidth;
                 _sldWidth.Value = Math.Max(_sldWidth.Minimum, Math.Min(_sldWidth.Maximum, w));
                 _txtWidth.Text = ((int)Math.Round(_sldWidth.Value)).ToString();
             }
@@ -337,20 +340,34 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             }
         }
 
-        // ponytail: needs App.Settings, wired when it moves to Core. WPF read Current, ran the
-        // write and called Save(); with no settings service on this head there is nothing to write.
-        private static void Persist(Action write) { _ = write; }
+        /// <summary>Run one settings write and persist it. CoreSettings.Current is never null.</summary>
+        private static void Persist(Action write)
+        {
+            try
+            {
+                write();
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] options settings write failed");
+            }
+        }
 
         private void OnMuteChanged(object? sender, RoutedEventArgs e)
         {
             if (_loading) return;
             bool on = _chkMute.IsChecked == true;
+            // Compare before writing. Avalonia raises IsCheckedChanged on a PROGRAMMATIC set too,
+            // and this handler has a SIDE EFFECT - a spurious raise would silently wipe the user's
+            // "don't ask again" without the switch ever having moved.
+            if (CoreSettings.Current.EmiDeskMuteAvatar == on) return;
             Persist(() =>
             {
-                // ponytail: needs App.Settings.EmiDeskMuteAvatar = on, and the same rule as the
-                // settings tab - flipping the switch clears EmiDeskMuteDontAsk, because the user
-                // has just changed their mind about the whole arrangement.
-                _ = on;
+                CoreSettings.Current.EmiDeskMuteAvatar = on;
+                // Same rule as the settings tab: flipping the switch clears "don't ask again",
+                // because the user has just changed their mind about the whole arrangement.
+                CoreSettings.Current.EmiDeskMuteDontAsk = false;
             });
         }
 
@@ -358,24 +375,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         {
             if (_loading) return;
             bool on = _chkOffers.IsChecked == true;
-            // ponytail: needs App.Settings.EmiDeskOffers = on
-            Persist(() => { _ = on; });
+            if (CoreSettings.Current.EmiDeskOffers == on) return;
+            Persist(() => CoreSettings.Current.EmiDeskOffers = on);
         }
 
         private void OnGlassChanged(object? sender, RoutedEventArgs e)
         {
             if (_loading) return;
             bool on = _chkGlass.IsChecked == true;
-            // ponytail: needs App.Settings.EmiDeskGlass = on
-            Persist(() => { _ = on; });
+            if (CoreSettings.Current.EmiDeskGlass == on) return;
+            Persist(() => CoreSettings.Current.EmiDeskGlass = on);
         }
 
         private void OnSpicePicked(int spice)
         {
             if (_loading) return;
             int v = Math.Max(0, Math.Min(2, spice));
-            // ponytail: needs App.Settings.EmiDeskSpice = v
-            Persist(() => { _ = v; });
+            if (CoreSettings.Current.EmiDeskSpice == v) return;
+            Persist(() => CoreSettings.Current.EmiDeskSpice = v);
         }
 
         /// <summary>
@@ -389,8 +406,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             try
             {
                 _txtWidth.Text = ((int)Math.Round(e.NewValue)).ToString();
-                // ponytail: needs EmiDeskWindow.ApplyBodyWidth + ClampIntoWorkArea, wired when the
-                // widget is ported. Without them the number moves and she does not.
+                _owner?.ApplyBodyWidth(e.NewValue);
+                _owner?.ClampIntoWorkArea();
                 ArmWidthPersist();
             }
             catch (Exception ex)
@@ -429,9 +446,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         private void PersistWidth()
         {
             StopWidthPersist();
-            // ponytail: needs App.Settings.EmiDeskWidth and EmiDeskWindow.BodyWidth /
-            // SavePlacement, wired when both move to Core. WPF wrote the width only when it had
-            // moved by more than half a pixel, then saved her placement alongside it.
+            if (_owner is null) return;
+            try
+            {
+                double w = _owner.BodyWidth;
+                // Half a pixel, as WPF did: the slider reports every intermediate value of a drag
+                // and a save rewrites the whole settings file.
+                if (Math.Abs(CoreSettings.Current.EmiDeskWidth - w) > 0.5)
+                {
+                    CoreSettings.Current.EmiDeskWidth = w;
+                    CoreSettings.Save();
+                }
+                _owner.SavePlacement();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] options width persist failed");
+            }
         }
 
         // ---------------------------------------------------------------- placement
@@ -450,10 +481,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 if (screens == null || screens.ScreenCount == 0)
                     return new PixelRect(0, 0, 1920, 1080);
 
-                // ponytail: needs EmiDeskWindow.BodyScreenRect for the centre of her body, wired
-                // when the widget is ported. Until then the panel's own screen is the best guess,
-                // and it is the right one whenever she and the panel share a monitor.
-                var screen = screens.ScreenFromWindow(this) ?? screens.Primary;
+                // The monitor SHE is standing on, not the one this panel happens to be over: the
+                // panel is placed relative to her, so a straddle has to clamp into her screen's
+                // work area. With no owner, this window's own screen is the best guess left.
+                var body = _owner?.BodyScreenRect;
+                var screen = body is null
+                    ? screens.ScreenFromWindow(this) ?? screens.Primary
+                    : screens.ScreenFromPoint(new PixelPoint(
+                          (int)Math.Round(body.Value.X + body.Value.Width / 2),
+                          (int)Math.Round(body.Value.Y + body.Value.Height / 2))) ?? screens.Primary;
                 return screen?.WorkingArea ?? new PixelRect(0, 0, 1920, 1080);
             }
             catch (Exception ex)
@@ -492,10 +528,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 // Measure with the cap applied: the height is content-driven and not known until now.
                 UpdateLayout();
 
-                // ponytail: needs EmiDeskWindow.BodyScreenRect, wired when the widget is ported.
-                // With no body to hang off, the panel sits at the work area's top-left corner - the
-                // same fallback the clamp below would produce for a body pinned there.
-                var bodyPx = new PixelRect(work.X, work.Y, 1, 1);
+                // With no owner (the headless render) the panel sits at the work area's top-left
+                // corner - the same fallback the clamp below would produce for a body pinned there.
+                var b = _owner?.BodyScreenRect;
+                var bodyPx = b is null
+                    ? new PixelRect(work.X, work.Y, 1, 1)
+                    : new PixelRect((int)Math.Round(b.Value.X), (int)Math.Round(b.Value.Y),
+                                    (int)Math.Round(b.Value.Width), (int)Math.Round(b.Value.Height));
 
                 double w = (Bounds.Width > 1 ? Bounds.Width : Width) * s;
                 double h = (Bounds.Height > 1 ? Bounds.Height : MinHeight) * s;
@@ -522,9 +561,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         }
 
         /// <summary>She moved. The panel is anchored to her edge and has to come along.</summary>
-        /// <remarks>WPF subscribed <c>EmiDeskWindow.Moved</c> in the constructor. With no owner type
-        /// on this head the widget calls in here instead; the body is unchanged.</remarks>
-        public void NotifyOwnerMoved()
+        private void OnOwnerMoved(object? sender, EventArgs e)
         {
             if (!_open) return;
             try
@@ -539,10 +576,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         }
 
         /// <summary>She was resized, by the grip or by this panel's own slider.</summary>
-        /// <remarks>The WPF twin of <c>EmiDeskWindow.Resized</c>. The grip can drive this too, so
-        /// the slider follows her rather than the other way round; <c>_loading</c> keeps that from
-        /// bouncing straight back into <c>ApplyBodyWidth</c>.</remarks>
-        public void NotifyOwnerResized(double width)
+        /// <remarks>The grip can drive this too, so the slider follows her rather than the other
+        /// way round; <c>_loading</c> keeps that from bouncing straight back into
+        /// <c>ApplyBodyWidth</c>.</remarks>
+        private void OnOwnerResized(object? sender, double width)
         {
             if (!_open) return;
             try


### PR DESCRIPTION
Her options panel is no longer an orphan. EmiOptionsWindow takes the widget it
hangs off, so the gear builds it once and keeps it, the chrome stays lit while
the pointer is inside it, and it follows her Moved/Resized as she is dragged or
resized. Every switch in it is live against CoreSettings: quiet-the-avatar (and
the "don't ask again" it clears), let-her-ask, her little screen, the three
daring segments and the summon chord all read and write the real settings, and
the size slider resizes her under the pointer and re-clamps her into the work
area. The owner stays nullable for one reason only - --render-view needs a
parameterless constructor - so every owner call is `?.` with the fallback the
unowned panel already used.

Her width now has one home and it is the setting. She is born at
CoreSettings.Current.EmiDeskWidth, RestorePlacement re-reads it on every summon
so a change made while she was away lands on her, and both the grip and the
panel's slider write it back on a half-pixel threshold. The EmiState half of
RestorePlacement (the saved rect and the monitor name) stays a note.

Portability of the services these two blockers name, so the next layer does not
have to re-derive it:

  Services/EmiDesk/EmiSuggester.cs   PURE. The only mention of App is in a doc
                                     comment on line 29. A one-commit git mv.
  Services/EmiDesk/EmiRingLayout.cs  Pure math, but its Plan record and every
                                     signature use System.Windows.Point and Core
                                     has no Point type. Portable after swapping
                                     that for a Core struct - a content edit, not
                                     a pure mv.
  Services/EmiDesk/EmiAlive.cs       Same shape: pure predicates over
                                     System.Windows.Point/Rect in the signatures.
  Services/EmiDesk/EmiSfx.cs         Two seam swaps and it moves:
                                     App.Settings.Current.MasterVolume ->
                                     CoreSettings, App.Audio.PlayOneShot ->
                                     CoreAudio.PlayOneShot, whose signature
                                     already matches (path, volume, tag).
  Services/EmiDesk/EmiState.cs       System.Windows.Point/Rect plus
                                     App.UserDataPath -> CorePaths.
  Services/EmiDesk/EmiFace.cs        HEAD-SIDE. PixelFont is a WPF FontFamily and
                                     the renderer is System.Windows.Media
                                     throughout; only the glyph table could be
                                     separated out.
  Services/ModResourceResolver.cs    HEAD-SIDE and staying there: BitmapImage and
                                     pack:// URIs.

Still blocked:

  EmiDeskWindow.DrawFace          EmiFace.PixelFont / the glyph renderer
                                  (ConditioningControlPanel/Services/EmiDesk/EmiFace.cs).
                                  The face is mono text in the same pink for now.
  EmiDeskWindow.SetPose,
  PaintOutfitOver                 EmiChains.FrameKey / BodyPath / OverPath
                                  (Services/EmiDesk/EmiChains.cs), and the art
                                  itself: no emi/ asset is linked into
                                  CCP.Avalonia.csproj, so the body placeholder
                                  stays up either way.
  EmiDeskWindow.PlayChain, Say,
  RunBodyMove, RestartIdleBeats   EmiChains + EmiChains.Player, EmiAlive.BlinkDelayMs.
  EmiDeskWindow.SavePlacement,
  RestorePlacement (the rect)     EmiState (Services/EmiDesk/EmiState.cs).
  EmiDeskWindow.PlayPatSfx        EmiSfx.Pat (Services/EmiDesk/EmiSfx.cs). Not
                                  inlined here - that would be a second copy of
                                  its volume rule.
  EmiDeskWindow.OpenBook          EmiBook.Open (Services/EmiDesk/EmiBook.cs).
  EmiDeskWindow.Dismiss,
  ResetOnboarding, FireDeskEvent  App.EmiDesk (EmiDeskService), which moves with
                                  the app shell.
  EmiOptionsWindow.InstallHooks,
  UpdateHotRects                  No desktop-wide input hook on X11. Click-away
                                  and global Escape stay lost until a
                                  compositor-side dismissal lands.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU