### PR TITLE
feat(avalonia): She's Listening and the Companion room stop being wholesale stubs

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Companion.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Companion.cs
@@ -1,27 +1,203 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Companion.cs (312 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.Companion.cs (312 lines) - the
+// avatar tube's window management plus the XP-drain flash, sorted member by member.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE. The tube itself is on this head
+// (CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow), so the four members that only ever open,
+// close, pose and wake it are real ports; so is FlashOverlay, whose WPF DoubleAnimation with
+// AutoReverse becomes one Avalonia keyframe Animation of the same total 500ms.
 //
-// Members dropped (11):
-//   private void OnCompanionXPAwarded(…)
-//   private void OnCompanionLevelUp(…)
-//   private void OnCompanionXPDrained(…)
-//   private void FlashXpBarOnDrain(…)
-//   private static void FlashOverlay(…)
-//   private void OnCompanionSwitched(…)
-//   private void InitializeAvatarTube(…)
-//   public void ShowAvatarTube(…)
-//   public void HideAvatarTube(…)
-//   public void WakeBambiUp(…)
-//   public void SetAvatarPose(…)
+// THE OWN-THREAD BRANCH IS GONE, not stubbed. WPF ran the tube on its own STA thread behind
+// AppSettings.AvatarOwnThread and pumped a second Dispatcher; Avalonia has ONE UI thread per
+// process, and the ported tube says so in its own header - RunOnAvatar marshals to
+// Dispatcher.UIThread and the setting has no meaning on this head. There is nothing to port,
+// so InitializeAvatarTube is the else-branch alone.
+//
+// STILL HEAD-SIDE, each with the exact symbol and where it lives today:
+//   OnCompanionXPAwarded   - App.Companion's XPAwarded / LevelUp / XPDrained / CompanionSwitched
+//   OnCompanionLevelUp       events (ConditioningControlPanel/Services/Companion/CompanionService.cs)
+//   OnCompanionXPDrained     and UpdateCompanionCardsUI, which is itself blocked twice over -
+//   OnCompanionSwitched      see MainShellWindow.CompanionTab.cs. The level-up half also needs
+//                            _trayIcon.ShowNotification (System.Windows.Forms.ToolTipIcon, WPF
+//                            head only), PlayLevelUpSound (MainShellWindow.HomeAudio.cs) and
+//                            UpdateLevelDisplay (MainShellWindow.Progression.cs), both stubs.
+//   FlashXpBarOnDrain      - restored for the HEADER bar only. Its second overlay,
+//                            CompanionTab.PrgCompanion0FlashOverlay, lives inside
+//                            CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml and
+//                            CompanionTabView re-publishes none of the room's cell controls
+//                            (MainShellWindow.CompanionTab.cs says why), so there is no accessor
+//                            path to it. A future wiring reaches it through the hero card.
+//   the mute + detach half - AvatarTubeWindow.SetMuteAvatar, ShowTube, HideTube, IsDetached,
+//                            Detach and Giggle are all in the EIGHT WPF partials that did not
+//                            cross (ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
+//                            and .Windowing.cs). Their absence is why HideAvatarTube below has no
+//                            detach guard: nothing on this head can detach the tube, so the guard
+//                            would be dead code rather than a missing safeguard.
+//
+// _avatarTubeWindow IS DECLARED HERE. WPF declares it in MainWindow.xaml.cs:179, whose twin
+// (MainShellWindow.axaml.cs) already lists it in its dropped ledger and is not this layer's to
+// own. A partial-class field can be declared exactly once, so whoever restores that file must
+// take the field from here rather than re-declare it.
+//
+// NO CALLER YET for any of it: the tray menu's "Wake Bambi Up!", the companion room's avatar
+// toggle (MainShellWindow.CompanionRoom.cs, this layer) and the shell's minimise/restore path
+// (MainShellWindow.axaml.cs) are the three call sites, and only the second is on this head.
+
+using System;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Styling;
+using ConditioningControlPanel.Avalonia.Views.AvatarTube;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>The companion's tube, or null before it has ever been opened. See the header:
+        /// this is the one declaration of the field for the whole partial class.</summary>
+        private AvatarTubeWindow? _avatarTubeWindow;
+
+        // ============================== the XP-drain flash ==============================
+
+        /// <summary>
+        /// Pulses the pink overlay on the header XP bar each time Brain Parasite drains. Fired
+        /// whatever tab is visible - animating an off-screen Border is harmless.
+        /// </summary>
+        internal void FlashXpBarOnDrain()
+        {
+            Log.Information("XP drain flash fired");
+            FlashOverlay(Named<Border>("XPBarFlashOverlay"));
+        }
+
+        /// <summary>
+        /// One 0 -> 1 -> 0 opacity pulse. WPF ran a 250ms DoubleAnimation with AutoReverse; the
+        /// Avalonia twin is one 500ms keyframe animation with the peak at the halfway cue, which
+        /// is the same curve and leaves the overlay back at its XAML opacity afterwards (FillMode
+        /// None) rather than pinned by a local value.
+        /// </summary>
+        private static void FlashOverlay(Border? overlay)
+        {
+            if (overlay == null) return;
+            var anim = new Animation
+            {
+                Duration = TimeSpan.FromMilliseconds(500),
+                Easing = new QuadraticEaseOut(),
+                FillMode = FillMode.None,
+                Children =
+                {
+                    new KeyFrame { Cue = new Cue(0d),   Setters = { new Setter(Visual.OpacityProperty, 0d) } },
+                    new KeyFrame { Cue = new Cue(0.5d), Setters = { new Setter(Visual.OpacityProperty, 1d) } },
+                    new KeyFrame { Cue = new Cue(1d),   Setters = { new Setter(Visual.OpacityProperty, 0d) } },
+                },
+            };
+            _ = anim.RunAsync(overlay);
+        }
+
+        // ============================== the avatar tube ==============================
+
+        /// <summary>
+        /// Builds the tube once. Never auto-shows a companion the user has dismissed (#888):
+        /// callers that mean to show it anyway flip AvatarEnabled back on first, which is exactly
+        /// what <see cref="WakeBambiUp"/> and the room's toggle do.
+        /// </summary>
+        private void InitializeAvatarTube()
+        {
+            if (_avatarTubeWindow != null)
+            {
+                Log.Warning("InitializeAvatarTube called but window already exists");
+                return;
+            }
+
+            try
+            {
+                bool showNow = IsVisible
+                               && WindowState != WindowState.Minimized
+                               && CoreSettings.Current.AvatarEnabled;
+
+                _avatarTubeWindow = new AvatarTubeWindow(this);
+
+                // ponytail: AvatarMuted has nowhere to land - AvatarTubeWindow.SetMuteAvatar is in
+                // the Speech.cs partial that did not cross. The setting is still read and saved by
+                // the room's mute toggle, so it is honoured the moment that partial lands.
+
+                if (showNow)
+                {
+                    _avatarTubeWindow.Show();
+                    _avatarTubeWindow.StartPoseAnimation();
+                }
+
+                Log.Information("Avatar Tube Window initialized");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Failed to initialize Avatar Tube Window: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>Show her, unless she has been dismissed. Recreates the tube if it was closed.</summary>
+        public void ShowAvatarTube()
+        {
+            if (!CoreSettings.Current.AvatarEnabled) return;
+
+            if (_avatarTubeWindow == null)
+            {
+                InitializeAvatarTube();
+                return;
+            }
+
+            // ShowSafe is the ported twin of WPF's ShowTube: it marshals to the UI thread and
+            // shows. Z-order pairing is the tube's own business (see its OnOpened).
+            _avatarTubeWindow.ShowSafe();
+            _avatarTubeWindow.StartPoseAnimation();
+        }
+
+        /// <summary>
+        /// Park her. WPF skipped this for a DETACHED tube so a floating companion survived the
+        /// shell minimising; nothing on this head can detach one (AvatarTubeWindow.Windowing.cs
+        /// did not cross), so that branch would be dead code and is left out rather than faked.
+        /// </summary>
+        public void HideAvatarTube()
+        {
+            if (_avatarTubeWindow == null) return;
+            _avatarTubeWindow.StopPoseAnimation();
+            _avatarTubeWindow.RunOnAvatar(() => _avatarTubeWindow?.Hide());
+        }
+
+        /// <summary>
+        /// The tray's "Wake Bambi Up!". Waking her is the opposite decision to Dismiss and has to
+        /// survive a restart the same way (#888), so AvatarEnabled is written BEFORE the tube is
+        /// built - creation and the speech gate both read it.
+        /// </summary>
+        public void WakeBambiUp()
+        {
+            try
+            {
+                if (!CoreSettings.Current.AvatarEnabled)
+                {
+                    CoreSettings.Current.AvatarEnabled = true;
+                    CoreSettings.Save();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("Failed to persist avatar wake: {Error}", ex.Message);
+            }
+
+            if (_avatarTubeWindow == null) InitializeAvatarTube();
+            if (_avatarTubeWindow == null) return;
+
+            _avatarTubeWindow.ShowSafe();
+            _avatarTubeWindow.StartPoseAnimation();
+
+            // ponytail: the WPF version then Detach()es the tube so it floats independently and
+            // has her Giggle("Good morning~!"). Both live in AvatarTubeWindow.Windowing.cs /
+            // .Speech.cs, neither of which crossed - so she wakes attached and silent here.
+        }
+
+        /// <summary>Force a pose. Poses themselves load in the tube's Avatar.cs partial, which has
+        /// not crossed, so on this head this cycles the placeholder set.</summary>
+        public void SetAvatarPose(int poseNumber) => _avatarTubeWindow?.SetPose(poseNumber);
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionRoom.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionRoom.cs
@@ -1,31 +1,226 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CompanionRoom.cs (410 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.CompanionRoom.cs (410 lines) - the
+// Companion tab's write surface after the "Her Room" redesign, sorted member by member.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Every method takes a VALUE rather than reading a control, exactly as on WPF: the redesign moved
+// where a thing is ASKED FOR, never what it does.
 //
-// Members dropped (15):
-//   private CompanionRoomRuntimeVm? CompanionRoom
-//   internal void SyncCompanionRoom(…)
-//   private bool _awarenessV2ConsentAsked
-//   internal void EnsureAwarenessV2Consent(…)
-//   internal void SetAvatarEnabled(…)
-//   internal void SetAvatarMuted(…)
-//   internal bool SetSlutMode(…)
-//   internal bool ActivatePersonalityPreset(…)
-//   internal bool SetAwarenessEnabled(…)
-//   internal void SetAwarenessIntensity(…)
-//   internal void SetAiProviderMode(…)
-//   internal void SetCustomApiKey(…)
-//   internal void PromptForDailyRequestLimit(…)
-//   internal void TestCloudConnection(…)
-//   internal void ClearCompanionConversation(…)
+// WHAT IS REAL HERE: the operations whose whole body is settings, the ported avatar tube or the
+// ported consent dialog - the avatar's show/hide and mute, awareness on/off with its one-time
+// plain-language consent (Views/Dialogs/AwarenessConsentDialog.EnsureConsentAsync), the v2
+// upgrader prompt, the Workshop's intensity dial and the daily request limit
+// (Views/Dialogs/InputDialog). Three are async where WPF blocked - Avalonia's ShowDialog is awaited.
+//
+// _roomLoading, not _isLoading: the class-wide field is listed in MainShellWindow.axaml.cs's
+// dropped ledger and belongs to that file. A partial-class field is declared exactly once.
+//
+// EVERY `CompanionRoom?.Sync…()` LINE IS DROPPED, and that is the one thing to restore first:
+// CompanionRoomRuntimeVm is at ConditioningControlPanel/Views/Controls/Companion/Runtime/
+// CompanionRoomRuntimeVm.cs and its eight zone viewmodels are still WPF-side, so the room's
+// dials do not re-read after a write yet. Nothing below depends on that to be CORRECT - the
+// settings are written either way - only to be reflected.
+//
+// STILL HEAD-SIDE, each with the exact symbol and where it lives today:
+//   CompanionRoom / SyncCompanionRoom - CompanionRoomRuntimeVm (path above). CompanionTabView on
+//                            this head publishes no Vm, deliberately.
+//   SetSlutMode            - App.Personality.GetActivePreset
+//                            (ConditioningControlPanel/Services/Companion/PersonalityService.cs).
+//                            ExplicitContentGate IS in Core and the acknowledgement dialog IS on
+//                            this head, but RequiresAcknowledgement(null, true) returns FALSE - so
+//                            shipping it without the preset lookup would be a SKIPPED gate, not a
+//                            degraded one. Blocked whole, deliberately.
+//   ActivatePersonalityPreset - the same PersonalityService, plus GetPersonalityDisplayName.
+//   SetAiProviderMode      - EngineRoomRuntimeVm.SettingsFor / ClearsLiveActions
+//                            (…/Views/Controls/Companion/Runtime/EngineRoomRuntimeVm.cs) and
+//                            App.AiLiveActions.
+//   SetCustomApiKey        - Services.Auth.SecureStringHelper.Protect
+//                            (ConditioningControlPanel/Services/Auth/SecureStringHelper.cs).
+//                            CompanionPromptSettings.OpenAiCompatibleApiKey holds a DPAPI blob,
+//                            so writing the typed key there on this head would put a BYO API key
+//                            in settings.json IN THE CLEAR. CoreSecrets is the seam that fixes
+//                            this (CoreSecrets.ApiKey), but nothing READS the key from it yet, so
+//                            half the pair is worse than neither. Blocked on purpose.
+//   TestCloudConnection    - EngineRoomRuntimeVm.SetStatus. CoreAi.IsAvailable already answers
+//                            the fact it reports; only the status line to write it to is missing.
+//   ClearCompanionConversation - App.Brain.ForgetThread
+//                            (ConditioningControlPanel/Services/Companion/Brain/) and
+//                            AiServiceStrategy.ClearLocalHistory. The confirm dialog is portable;
+//                            a confirmed button that then forgets nothing is not.
+//   the awareness observer - App.WindowAwareness.Start/Stop
+//                            (ConditioningControlPanel/Services/Awareness/). Dropped from
+//                            SetAwarenessEnabled and EnsureAwarenessV2Consent below: there is no
+//                            observer on this head to start, so the setting write and the consent
+//                            record are the whole of what can be honoured.
+//   the premium bar        - Services.TierGate.DemandPremium
+//                            (ConditioningControlPanel/Services/TierGate.cs), the ON-edge gate in
+//                            SetAwarenessEnabled.
+//   AwarenessSettingsPanel - the legacy cooldown sliders' host, inside
+//                            CCP.Avalonia/Views/Controls/Companion/; CompanionTabView publishes
+//                            none of the room's cells (MainShellWindow.CompanionTab.cs).
+//
+// NO CALLER YET: the room's dials are in Views/Controls/Companion/Runtime/*Cell, whose Avalonia
+// twins carry inert handlers, and the tray/dashboard paths are in MainShellWindow.axaml.cs.
+
+using System;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services.Awareness;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>Seeding guard for the room's writes. See the header for why it is not
+        /// _isLoading.</summary>
+        private bool _roomLoading;
+
+        /// <summary>Asked at most once per process - a declined dialog must not become a nag.</summary>
+        private bool _awarenessV2ConsentAsked;
+
+        // =====================================================================================
+        //  quick actions (Z1)
+        // =====================================================================================
+
+        /// <summary>
+        /// Show/hide the avatar tube. The old ChkAvatarEnabled_Changed body, with the checkbox
+        /// read replaced by the caller's value.
+        /// </summary>
+        internal void SetAvatarEnabled(bool enabled)
+        {
+            if (_roomLoading) return;
+
+            CoreSettings.Current.AvatarEnabled = enabled;
+            if (enabled) ShowAvatarTube();
+            else HideAvatarTube();
+            CoreSettings.Save();
+        }
+
+        /// <summary>
+        /// Mute/unmute her voice - the old ChkMuteAvatar_Changed body.
+        ///
+        /// <para>The setting is written and persisted; the live
+        /// <c>AvatarTubeWindow.SetMuteAvatar</c> call is dropped because that method is in the
+        /// tube's Speech.cs partial, which did not cross. Nothing on this head speaks yet, so the
+        /// stored value is the whole of the behaviour there is to have - and it is the value the
+        /// speech pipeline will read the moment it lands.</para>
+        /// </summary>
+        internal void SetAvatarMuted(bool muted)
+        {
+            if (_roomLoading) return;
+            CoreSettings.Current.AvatarMuted = muted;
+            CoreSettings.Save();
+        }
+
+        // =====================================================================================
+        //  awareness (Z5)
+        // =====================================================================================
+
+        /// <summary>
+        /// The awareness capability, driven by Z5's dial.
+        ///
+        /// <para><b>Consent is not silent.</b> Turning it on raises the one-time plain-language
+        /// dialog; declining leaves awareness OFF and returns false, and the caller re-reads so
+        /// the dial snaps back. This is the only place AwarenessModeEnabled and
+        /// AwarenessConsentGiven are written outside settings load, which is what keeps "every
+        /// entry point is gated" a fact.</para>
+        ///
+        /// <para>Returns whether awareness is enabled after the call. async, because the consent
+        /// dialog is.</para>
+        /// </summary>
+        internal async System.Threading.Tasks.Task<bool> SetAwarenessEnabled(bool enabled)
+        {
+            var s = CoreSettings.Current;
+            if (_roomLoading) return s.AwarenessModeEnabled;
+
+            // Turning it OFF is deliberately never gated: whatever her account is doing, the
+            // switch that closes her eyes is on screen and it works.
+            if (enabled && !await AwarenessConsentDialog.EnsureConsentAsync(this, s))
+            {
+                // Declined (or the dialog could not open). Nothing is written and nothing starts.
+                return false;
+            }
+
+            s.AwarenessModeEnabled = enabled;
+            s.AwarenessConsentGiven = enabled;
+            CoreSettings.Save();
+
+            // Opening her eyes lifts any running "pause for an hour": the user just said yes on
+            // purpose.
+            if (enabled) AwarenessPause.Resume();
+
+            Log.Information("Awareness Mode {State} via the awareness dial", enabled ? "enabled" : "disabled");
+            return enabled;
+        }
+
+        /// <summary>
+        /// Raises the v2 consent dialog for an UPGRADER: someone whose awareness was already on
+        /// before this version, so the dial they would otherwise have to touch is already in the
+        /// "on" position and <see cref="AwarenessConsentDialog.EnsureConsentAsync"/> would never
+        /// run.
+        ///
+        /// <para>Declining leaves them on the legacy pipeline they already consented to, and is
+        /// not asked again this session. Turning the dial off remains the way to say no
+        /// permanently.</para>
+        /// </summary>
+        internal async void EnsureAwarenessV2Consent()
+        {
+            if (_awarenessV2ConsentAsked || _roomLoading) return;
+
+            var s = CoreSettings.Current;
+            if (!s.UseAwarenessV2) return;                 // kill switch down: v2 has nothing to ask
+            if (s.AwarenessConsentShownV2) return;         // already accepted
+            if (!s.AwarenessModeEnabled || !s.AwarenessConsentGiven) return;  // off: the dial asks
+
+            _awarenessV2ConsentAsked = true;
+
+            if (!await AwarenessConsentDialog.EnsureConsentAsync(this, s))
+                Log.Information("Awareness: v2 consent declined by an upgrader — staying on the legacy pipeline");
+        }
+
+        /// <summary>
+        /// The Workshop's intensity dial: how talkative she is, not whether she watches. Writing it
+        /// never opens her eyes - that stays Z5's single gated decision - so this needs no consent
+        /// gate of its own.
+        /// </summary>
+        internal void SetAwarenessIntensity(AwarenessIntensity intensity)
+        {
+            if (_roomLoading) return;
+            var s = CoreSettings.Current;
+            if (s.AwarenessIntensity == intensity) return;
+
+            s.AwarenessIntensity = intensity;
+            // The migration flag is what stops a later start-up from overwriting this choice.
+            s.AwarenessIntensityMigrated = true;
+            CoreSettings.Save();
+
+            Log.Information("Awareness intensity set to {Intensity}", intensity);
+        }
+
+        // =====================================================================================
+        //  the engine room (Z7)
+        // =====================================================================================
+
+        /// <summary>
+        /// The daily request limit, which used to be a bare TextBox on the AI Brain card. Same
+        /// parse rules: blank or unparseable means "no limit" (0), negatives are clamped by the
+        /// same test. async because Avalonia's ShowDialog is.
+        /// </summary>
+        internal async void PromptForDailyRequestLimit()
+        {
+            var s = CoreSettings.Current.CompanionPrompt;
+            if (s == null) return;
+
+            var current = s.DailyRequestLimit > 0 ? s.DailyRequestLimit.ToString() : string.Empty;
+            var dialog = new InputDialog(
+                Loc.Get("label_daily_request_limit"),
+                Loc.Get("label_daily_request_limit_hint"),
+                current);
+
+            if (await dialog.ShowDialog<bool>(this) != true) return;
+
+            var text = (dialog.ResultText ?? string.Empty).Trim();
+            s.DailyRequestLimit = int.TryParse(text, out var value) && value > 0 ? value : 0;
+            CoreSettings.Save();
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SheListening.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SheListening.cs
@@ -1,33 +1,265 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SheListening.cs (481 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.SheListening.cs (481 lines) - the
+// "She's Listening" surface, sorted member by member rather than stubbed wholesale.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE. Everything this page needs that is settings, arithmetic or CoreSpeech:
+// the loudness-gate mapping (SensToThreshold/ThresholdToSens, pure maths), MicIsArmed, the
+// sensitivity slider's write, the spoken-mantras toggle with its mic-consent gate
+// (Views/Dialogs/MicConsentDialog is on this head), the device chips, the status hero and the
+// tab's own re-seed. CoreSpeech answers IsAvailable / HasCaptureDevice / ModelStatus, which is
+// the whole of what RefreshSheListeningStatus asks a service for.
 //
-// Members dropped (17):
-//   private static bool DemandSheListeningPremium(…)
-//   internal void SL_Mantras_Changed(…)
-//   private bool _calibratingWake
-//   internal async void SL_Calibrate_Click(…)
-//   private void RefreshWakeEngineStatus(…)
-//   internal bool MicIsArmed(…)
-//   internal void ToggleVoiceMic(…)
-//   internal void DisarmVoiceMic(…)
-//   internal void SL_RevokeMicConsent_Click(…)
-//   internal void RefreshSheListeningTab(…)
-//   internal void RefreshSheListeningDeviceChips(…)
-//   private const double LoudThrAtMinSens
-//   private const double LoudThrAtMaxSens
-//   private static double SensToThreshold(…)
-//   private static double ThresholdToSens(…)
-//   internal void SL_MicSensitivity_Changed(…)
-//   private void RefreshSheListeningStatus(…)
+// SheListeningTabView loads with the GENERATED InitializeComponent, so ITS x:Name fields are
+// real and are used directly. This WINDOW does not - the tab itself is reached only through
+// Named<T>() (see MainShellWindow.TabNavigation.cs).
+//
+// _slLoading, not _isLoading. The class-wide _isLoading is listed in MainShellWindow.axaml.cs's
+// dropped ledger and belongs to that file; a partial-class field can be declared exactly once,
+// so this concern carries its own. It is MORE load-bearing here than on WPF: Avalonia's CheckBox
+// and Slider raise IsCheckedChanged / ValueChanged on a PROGRAMMATIC set, so seeding a control
+// would otherwise write settings straight back.
+//
+// NO CALLER YET, and both call sites are named so this is not mistaken for a live page:
+//   - the seven handlers in CCP.Avalonia/Views/Tabs/SheListeningTabView.axaml.cs are still
+//     `(_, _) => { }`; they are one forward each to the members below once that file is a
+//     layer's to own.
+//   - the on-show refresh belongs in OnTabShown (MainShellWindow.TabNavigation.cs), beside the
+//     StudioTab cases already there.
+//
+// STILL HEAD-SIDE, each with the exact symbol and where it lives today:
+//   DemandSheListeningPremium  - Services.TierGate.DemandPremium
+//                                (ConditioningControlPanel/Services/TierGate.cs). With it,
+//                                ToggleVoiceMic's arming half and the SheListeningGate veil.
+//   ToggleVoiceMic             - App.Autonomy.RefreshVoiceInputModes / StopVoiceInput
+//   DisarmVoiceMic               (ConditioningControlPanel/Services/AutonomyService.cs),
+//                                App.Speech.StopListening
+//                                (ConditioningControlPanel/Services/Speech/SpeechService.cs) and
+//                                LockCardWindow.DisableVoiceForAll
+//                                (ConditioningControlPanel/Windows/LockCardWindow.xaml.cs).
+//                                The settings half of both is trivial; shipping it WITHOUT the
+//                                stop calls would leave a mic open behind a switch that says off,
+//                                which is the one failure this file must not have. Blocked whole.
+//   SL_RevokeMicConsent_Click  - the same three, through DisarmVoiceMic. Clearing the four
+//                                consent settings is pointless while the capture cannot be cut.
+//   SL_Calibrate_Click         - Services.Speech.SherpaWakeService.CalibrateAsync
+//   RefreshWakeEngineStatus      (ConditioningControlPanel/Services/Speech/SherpaWakeService.cs).
+//                                CoreSpeech carries no wake engine, only the recognizer's status.
+//   UpdateMicPill              - MainShellWindow.PrivacyPill.cs, still a stub.
+//   SetSheListeningStatusPulse - MainShellWindow.SheListeningFx.cs, still a stub.
+//   RefreshPremiumRail         - MainShellWindow.PremiumRail.cs / RefreshPremiumGate, both
+//   RefreshPremiumGate           TierGate again.
+// Every one of those calls is DROPPED from the restored bodies below, never faked.
+
+using System;
+using Avalonia.Controls;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>The She's Listening tab. Resolved on every read - this window's generated
+        /// x:Name fields are never assigned (MainShellWindow.TabNavigation.cs).</summary>
+        internal Tabs.SheListeningTabView? SheListeningPage =>
+            Named<Tabs.SheListeningTabView>("SheListeningTab");
+
+        /// <summary>Seeding guard for this page. See the header for why it is not _isLoading.</summary>
+        private bool _slLoading;
+
+        // ---- the loudness gate -----------------------------------------------------------
+        // Slider 0..100 maps INVERSELY to the RMS threshold: 100% = most sensitive (lowest
+        // threshold, softest speech OK), 0% = strictest. Verbatim from the WPF file - pure
+        // arithmetic, no dependency at all, and the numbers are the gate's useful range.
+
+        private const double LoudThrAtMinSens = 0.045; // slider 0%
+        private const double LoudThrAtMaxSens = 0.004; // slider 100%
+
+        private static double SensToThreshold(double sens)
+            => LoudThrAtMinSens - (LoudThrAtMinSens - LoudThrAtMaxSens) * (Math.Clamp(sens, 0, 100) / 100.0);
+
+        private static double ThresholdToSens(double thr)
+            => Math.Clamp((LoudThrAtMinSens - thr) / (LoudThrAtMinSens - LoudThrAtMaxSens) * 100.0, 0, 100);
+
+        /// <summary>
+        /// True when the offline mic is actually armed: consent given AND at least one input mode
+        /// (wake word or push-to-talk) is on. The "She's Listening" master on/off state, fully
+        /// independent of Takeover.
+        /// </summary>
+        internal bool MicIsArmed()
+        {
+            var s = CoreSettings.Current;
+            return s.MicConsentGiven && (s.SpeechWakeWordEnabled || s.SpeechPushToTalkEnabled);
+        }
+
+        /// <summary>
+        /// Mic-sensitivity slider: tunes the loudness gate that decides whether a recognized
+        /// command or mantra was "said out loud". Applies live. Does NOT touch the wake word -
+        /// that is calibration. Avalonia hands the new value rather than WPF's
+        /// RoutedPropertyChangedEventArgs, so the signature takes it directly.
+        /// </summary>
+        internal void SL_MicSensitivity_Changed(double newValue)
+        {
+            if (_slLoading) return;
+            var tab = SheListeningPage;
+            if (tab == null) return;
+
+            CoreSettings.Current.SpeechLoudnessThreshold = SensToThreshold(newValue);
+            CoreSettings.Save();
+            tab.TxtSL_MicSensitivity.Text = $"{(int)Math.Round(newValue)}%";
+        }
+
+        /// <summary>
+        /// On-demand spoken mantras (AppSettings.SpokenMantrasEnabled). Separate from the Takeover
+        /// "surprise" auto-trigger. First enable asks for mic consent, since a mantra opens the mic
+        /// to hear you repeat the phrase - and a declined dialog un-ticks the box, which is why the
+        /// revert is wrapped in the seeding guard.
+        ///
+        /// <para>async, unlike WPF: Avalonia's ShowDialog is awaited, never blocking.</para>
+        /// </summary>
+        internal async void SL_Mantras_Changed()
+        {
+            var tab = SheListeningPage;
+            if (_slLoading || tab == null) return;
+            var s = CoreSettings.Current;
+
+            var turningOn = tab.ChkSL_Mantras.IsChecked == true;
+            if (turningOn && !s.MicConsentGiven)
+            {
+                var dlg = new Dialogs.MicConsentDialog();
+                await dlg.ShowDialog(this);
+                if (!dlg.ConsentGiven)
+                {
+                    var wasLoading = _slLoading;
+                    _slLoading = true;
+                    tab.ChkSL_Mantras.IsChecked = false;
+                    _slLoading = wasLoading;
+                    return;
+                }
+            }
+
+            s.SpokenMantrasEnabled = turningOn;
+            CoreSettings.Save();
+            RefreshSheListeningStatus();
+        }
+
+        /// <summary>Load the She's-Listening controls from settings and repaint the status hero.
+        /// Called on tab show.</summary>
+        internal void RefreshSheListeningTab()
+        {
+            var tab = SheListeningPage;
+            if (tab == null) return;
+            var s = CoreSettings.Current;
+
+            var wasLoading = _slLoading;
+            _slLoading = true;
+            try
+            {
+                tab.ChkSL_Mantras.IsChecked = s.SpokenMantrasEnabled && s.MicConsentGiven;
+                double sens = ThresholdToSens(s.SpeechLoudnessThreshold);
+                tab.SldSL_MicSensitivity.Value = sens;
+                tab.TxtSL_MicSensitivity.Text = $"{(int)Math.Round(sens)}%";
+            }
+            catch (Exception ex) { Log.Debug("RefreshSheListeningTab: {E}", ex.Message); }
+            finally { _slLoading = wasLoading; }
+
+            // "Revoke consent" only means something once consent exists.
+            tab.SL_PrivacyCard.IsVisible = s.MicConsentGiven;
+
+            RefreshSheListeningDeviceChips();
+            RefreshSheListeningStatus();
+        }
+
+        /// <summary>
+        /// Repaint the read-only microphone chips on She's Listening AND re-seed the voice-mode
+        /// rows in Settings &gt; Devices from the settings file.
+        ///
+        /// <para>Both halves matter. The chips are display: device, wake word, push-to-talk and
+        /// headphone rows were live editors until Phase 2 and are now a summary of what
+        /// Settings &gt; Devices owns. The re-seed is the other direction - the master Start/Stop
+        /// button writes those settings without touching a checkbox, so the Settings page has to
+        /// be told.</para>
+        ///
+        /// <para>The re-seed is ONE call here rather than WPF's four control writes:
+        /// DevicesSettingsSection.SyncFromSettings does exactly that job and owns its own
+        /// _loading guard, so poking its checkboxes from outside would only be a second, worse
+        /// copy of it.</para>
+        /// </summary>
+        internal void RefreshSheListeningDeviceChips()
+        {
+            var s = CoreSettings.Current;
+
+            AppSettingsPage?.FindControl<Controls.AppSettings.DevicesSettingsSection>("SectionDevices")
+                           ?.SyncFromSettings();
+
+            var tab = SheListeningPage;
+            if (tab == null) return;
+
+            var device = string.IsNullOrWhiteSpace(s.SpeechInputDeviceName)
+                ? Loc.Get("set2_mic_system_default")
+                : s.SpeechInputDeviceName;
+            var off = Loc.Get("set2_chip_off");
+
+            tab.TxtSL_MicDeviceChip.Text = device;
+            tab.TxtSL_WakeWordChip.Text =
+                s.SpeechWakeWordEnabled && s.MicConsentGiven
+                    ? (string.IsNullOrWhiteSpace(s.SpeechWakeWords) ? "hey bambi" : s.SpeechWakeWords)
+                    : off;
+            tab.TxtSL_PttChip.Text =
+                s.SpeechPushToTalkEnabled && s.MicConsentGiven
+                    ? (string.IsNullOrWhiteSpace(s.SpeechPushToTalkKey) ? "F8" : s.SpeechPushToTalkKey)
+                    : off;
+            tab.TxtSL_HeadphonesChip.Text = s.SpeechHeadphonesMode ? Loc.Get("set2_chip_on") : off;
+        }
+
+        /// <summary>
+        /// The hero: mic readiness / armed state plus the master Start/Stop button.
+        ///
+        /// <para>Every string is hard-coded English here BECAUSE IT IS ON WPF TOO - this page's
+        /// status copy never got loc keys, and inventing one would produce a plausible key that
+        /// resolves to nothing. The button's Content is a TextBlock (Avalonia parses `_` in a bare
+        /// string Content as an access key), so the label is written through it.</para>
+        /// </summary>
+        internal void RefreshSheListeningStatus()
+        {
+            var tab = SheListeningPage;
+            if (tab == null) return;
+
+            var available = CoreSpeech.IsAvailable;
+            var armed = available && MicIsArmed();
+
+            tab.BtnSL_MicMaster.IsEnabled = available;
+            if (tab.BtnSL_MicMaster.Content is TextBlock label)
+                label.Text = armed ? "■  Stop listening" : "▶  Start listening";
+            tab.BtnSL_MicMaster.Foreground = armed
+                ? new SolidColorBrush(Color.FromRgb(0xFF, 0xB0, 0xB0))
+                : new SolidColorBrush(Color.FromRgb(0x90, 0xEE, 0x90));
+
+            if (!available)
+            {
+                tab.SL_StatusDot.Fill = new SolidColorBrush(Color.FromRgb(0x5A, 0x4A, 0x6A));
+                tab.SL_StatusTitle.Text = "Microphone not ready";
+                tab.SL_StatusSub.Text =
+                    !CoreSpeech.HasCaptureDevice
+                        ? "No microphone detected — connect one to use voice."
+                        : CoreSpeech.ModelStatus == CoreSpeechModelStatus.LoadFailed
+                            ? "Speech model found but it would not load — remove any extra model you added under Resources\\Models\\vosk, then restart."
+                            : "Offline speech model not installed yet — voice stays off until it is.";
+                return;
+            }
+
+            if (armed)
+            {
+                tab.SL_StatusDot.Fill = new SolidColorBrush(Color.FromRgb(0x90, 0xEE, 0x90));
+                tab.SL_StatusTitle.Text = "She's listening";
+                tab.SL_StatusSub.Text = "The mic is open. Call her, then say a command.";
+            }
+            else
+            {
+                tab.SL_StatusDot.Fill = new SolidColorBrush(Color.FromRgb(0xFF, 0xC1, 0x07));
+                tab.SL_StatusTitle.Text = "Mic off";
+                tab.SL_StatusSub.Text = "Tap Start listening so she can hear you. Works with or without Takeover.";
+            }
+        }
     }
 }


### PR DESCRIPTION
Split from a single shell-partial layer to keep each layer reviewable; the profile group follows in
the next layer. Both of these were headed "every member below reaches App.*, a service, a device",
which was written before the seams existed and is wrong for most of what is here. Each member was
sorted against the fifteen Core seams and the ported views instead, and the blanket header is gone.

She's Listening: the loudness gate maths, MicIsArmed, the sensitivity write, the spoken-mantras
toggle behind the ported MicConsentDialog, the device chips, and the status hero painted from
CoreSpeech.IsAvailable / HasCaptureDevice / ModelStatus rather than the WPF literals it used to
carry. The Settings > Devices half is one call to DevicesSettingsSection.SyncFromSettings, not a
second copy of that section's four control writes - two copies of the same paint drift apart.

The Companion room: avatar show/hide and mute, awareness on and off behind the ported
AwarenessConsentDialog.EnsureConsentAsync, the v2 upgrader prompt, the intensity dial and the daily
request limit. The avatar tube opens, closes, poses and wakes against the ported AvatarTubeWindow.

Three members were deliberately NOT restored, each with its reason written into the file, because a
half-port of any of them is worse than the stub:

- ToggleVoiceMic / DisarmVoiceMic. Without App.Speech.StopListening, a switch reading "off" would
  leave the microphone open. A control that lies about a capture device is not a degraded port.
- SetSlutMode. RequiresAcknowledgement(null, true) returns false here, so shipping it without
  App.Personality would SKIP the gate rather than degrade it.
- SetCustomApiKey. That field holds a DPAPI blob. This head seeds no secret store, so a plaintext
  write would put a bring-your-own API key into settings.json in the clear. CoreSecrets' rule is
  absolute: unseeded means no store, never store in the clear.

No caller yet for any restored member - every WPF call site is in a shell partial still stubbed here,
and each file names where its caller belongs. CompanionTab was re-verified against Core and needed
no change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU