### PR TITLE
feat(avalonia): the profile vat, cosmetics and wardrobe stop being wholesale stubs

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCosmetics.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCosmetics.cs
@@ -1,36 +1,80 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileCosmetics.cs (532 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProfileCosmetics.cs (532 lines) -
+// the Trainer Card's cosmetics painter, sorted member by member. TWO of its twenty members cross,
+// and both are rules rather than paint.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// ONE SERVICE BLOCKS SEVENTEEN OF THE OTHERS: Services.CosmeticsCatalog
+// (ConditioningControlPanel/Services/Profile/CosmeticsCatalog.cs). It owns SanitizeOwn,
+// SanitizeViewed, GetAvatarImage, GetBannerImage and TryGetAccentColor - both what a loadout is
+// ALLOWED to contain and what it looks like. The sanitize half is portable logic; the four
+// image/colour members decode to System.Windows.Media types, so the class cannot move as it
+// stands - it splits, or it grows a seam. Until then ApplyOwnProfileCosmetics,
+// ApplyViewedProfileCosmetics, ApplyProfileCosmetics, ApplyProfileAvatarPreset,
+// ApplyProfileBanner, ApplyProfileAccent, ApplyProfilePins, RefreshShowcasePinArt,
+// OpenProfileCustomizeDialog, PersistOwnCosmetics and ToggleOwnAchievementPin are all blocked at
+// the door. Models.ProfileCosmetics itself IS in Core, so the model is not what is missing.
 //
-// Members dropped (20):
-//   private static readonly Color DefaultHeroBorderColor
-//   internal void ApplyOwnProfileCosmetics(…)
-//   internal void ApplyViewedProfileCosmetics(…)
-//   private void ApplyProfileCosmetics(…)
-//   private ImageSource? _appliedPresetAvatar
-//   private ProfilePictureLoad _profilePictureLoad
-//   internal void SetProfilePictureLoad(…)
-//   private void ApplyProfileAvatarPreset(…)
-//   private void ApplyProfileBanner(…)
-//   private void ApplyProfileAccent(…)
-//   private void ApplyProfileTitle(…)
-//   internal static string? ResolveAchievementTitle(…)
-//   private void ApplyProfilePins(…)
-//   internal void RefreshShowcasePinArt(…)
-//   internal void OpenProfileCustomizeDialog(…)
-//   private void PersistOwnCosmetics(…)
-//   internal void ToggleOwnAchievementPin(…)
-//   private DispatcherTimer? _pinCapNoticeTimer
-//   private void FlashPinCapNotice(…)
-//   internal static bool PresetMayClaim(…)
+// THE REST, each with the exact symbol and where it lives today:
+//   ApplyProfileTitle          - Models.Achievement.All / .LocalizedName
+//   ResolveAchievementTitle      (ConditioningControlPanel/Models/Achievement.cs). CoreMods
+//                                .MakeModAware answers the mod-aware half; the roster does not
+//                                exist here, so every id would resolve to null.
+//   OpenProfileCustomizeDialog - Dialogs/ProfileCustomizeDialog (WPF head) plus
+//                                App.Achievements.Progress.UnlockedAchievements.
+//   PersistOwnCosmetics        - the settings write IS reachable, but its point is the push that
+//                                follows: App.ProfileSync.PendingCosmeticsClear / SyncProfileAsync
+//                                (…/Services/Profile/ProfileSyncService.cs). Saving a loadout the
+//                                server is never told about is the half that looks like it worked.
+//   ToggleOwnAchievementPin    - App.Achievements again, plus CosmeticsCatalog's pin cap.
+//   FlashPinCapNotice          - portable, but only ever fires from ToggleOwnAchievementPin.
+//   SetProfilePictureLoad      - clears _appliedPresetAvatar, an ImageSource only
+//                                ApplyProfileAvatarPreset reads. A setter without its only reader
+//                                is a token method.
+//   DefaultHeroBorderColor     - belongs with ApplyProfileAccent.
+//
+// WHAT IS REAL HERE: ProfilePictureLoad and ProfileAvatarSlot.PresetMayClaim - the avatar slot's
+// CLAIM RULE (bug #847), kept as a pure function so it can be reasoned about without standing a
+// Window up, and carrying no WPF type at all. They belong in CCP.Core, which this layer does not
+// own; restored here verbatim so the layer that ports ApplyProfileAvatarPreset finds the rule
+// rather than re-deriving it from the bug report. NO CALLER YET - that method is blocked above.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
+    /// <summary>
+    /// Where the real profile picture stands for the card on screen. The preset avatar and the
+    /// picture share one slot, so "no picture" and "no picture YET" have to be distinguishable -
+    /// an empty bubble on its own means neither (#847).
+    /// </summary>
+    internal enum ProfilePictureLoad
+    {
+        /// <summary>A load is in flight; the empty slot belongs to it and nothing else may take it.</summary>
+        Pending,
+        /// <summary>A real picture is in the slot.</summary>
+        Loaded,
+        /// <summary>The load finished with nothing: no avatar, sharing off, or a lookup that failed.</summary>
+        None
+    }
+
+    /// <summary>
+    /// The avatar slot's claim rule, kept as a pure function so it can be reasoned about (and
+    /// tested) without standing a Window up. See MainWindow.ApplyProfileAvatarPreset.
+    /// </summary>
+    internal static class ProfileAvatarSlot
+    {
+        /// <summary>Whether the preset avatar may write the shared avatar slot right now.</summary>
+        internal static bool PresetMayClaim(bool slotHoldsOurPreset, bool slotHasPicture, ProfilePictureLoad load)
+        {
+            // Already ours: swapping one preset for another, or clearing back to the blank circle.
+            if (slotHoldsOurPreset) return true;
+            // Someone's real picture is in there. It always wins.
+            if (slotHasPicture) return false;
+            // Empty - but only a load that has DEFINITIVELY come back with nothing hands it over.
+            return load == ProfilePictureLoad.None;
+        }
+    }
+
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileFx.cs
@@ -1,30 +1,57 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileFx.cs (239 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProfileFx.cs (239 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Sorted member by member against the fifteen Core seams: GENUINELY 100% head-side. Every one of
+// its fourteen members is either a WPF animation clock or a gate on two static services that have
+// not moved, and the file has no third concern hiding in it. Recorded as a finding rather than
+// padded with token methods.
 //
-// Members dropped (14):
-//   private const int ProfileSearchGlowMs
-//   private const byte ProfileSearchGlowAlpha
-//   private bool _profileFxInitialized
-//   private bool _ogBorderLoopRunning
-//   private SolidColorBrush? _profileSearchBrush
-//   internal void OnProfileTabVisibilityChanged(…)
-//   private void InitializeProfileFx(…)
-//   private void OnProfileFxWindowStateish(…)
-//   internal void ApplyOgBorderLoop(…)
-//   private void StaggerProfileCards(…)
-//   private void EnsureProfileSearchBrush(…)
-//   private void ProfileSearch_GotFocus(…)
-//   private void ProfileSearch_LostFocus(…)
-//   private void ApplyProfileSearchGlow(…)
+// THE TWO SERVICES, and they are what block eleven of the fourteen:
+//   Services.MotionFx  (ConditioningControlPanel/Services/MotionFx.cs) - AllowAmbientLoops,
+//        AllowTransitions and StaggerIn, i.e. the reduced-motion and performance-tier gate plus
+//        the entrance choreography itself. This head has a partial stand-in, the private `Env`
+//        class inside CCP.Avalonia/Controls/AmbientFxCanvas.cs, which carries its own ponytail
+//        note saying it IS the missing MotionFx with the reduced-motion half absent. Reaching
+//        into it from here would spread a documented placeholder to a second consumer.
+//   Services.FxTheme   (ConditioningControlPanel/Services/FxTheme.cs) - GlowColor, the mod's
+//        accent that the search-box focus glow animates to. CoreMods.AccentColorHex answers a
+//        neighbouring question, not this one: FxTheme resolves a GLOW slot with its own fallback.
+//
+// THE ANIMATION CLOCKS, which have no direct Avalonia twin:
+//   ApplyOgBorderLoop      - gates Begin/Stop on a Storyboard read out of
+//                            OgBorderContainer.Resources by key ("OgBorderAnimation"). That
+//                            resource does not exist here and cannot: the WPF storyboard spins a
+//                            GradientBrush's RelativeTransform, which Avalonia's GradientBrush has
+//                            no equivalent of. DiscordTabView.axaml:145 carries the matching note
+//                            and draws the static gold frame; a restore is a DispatcherTimer
+//                            rotating the stops - a decision, not a copy.
+//   ApplyProfileSearchGlow - BeginAnimation(SolidColorBrush.ColorProperty) on a brush the window
+//   EnsureProfileSearchBrush owns. Avalonia has no per-object BeginAnimation; the twin is a
+//   ProfileSearch_GotFocus   BrushTransition. Cheap to write - but the colour it animates TO is
+//   ProfileSearch_LostFocus  FxTheme.GlowColor, so it would be motion toward an invented tint.
+//   StaggerProfileCards    - MotionFx.StaggerIn plus EnsureCardTransforms
+//                            (MainShellWindow.Animations.cs, still a stub). The three tuning
+//                            constants and three state fields exist only to serve these.
+//
+// THE LIFECYCLE MEMBERS, blocked on their own callees rather than on FX:
+//   OnProfileTabVisibilityChanged - UpdateProfileSharingSummary and RefreshProfileShareButton
+//                            (MainShellWindow.ProfileBubble.cs, a stub), EnsureProfileMeFirst
+//                            (named as head-side in MainShellWindow.ProfileCard.cs's own header),
+//                            IsIncomingTab (MainShellWindow.Animations.cs) and
+//                            OnProfileVatVisibilityChanged (MainShellWindow.ProfileVat.cs, whose
+//                            body needs App.Descent). Five callees, none of them here.
+//   InitializeProfileFx / OnProfileFxWindowStateish - Activated/Deactivated/StateChanged hooks
+//                            whose only purpose is to re-run ApplyOgBorderLoop and EvaluateVatPoll.
+//                            Both callees are blocked, so the hooks would fire into nothing.
+//
+// The controls this file drives ARE all on this head - ProfileColumnStack, OgBorderContainer,
+// ProfileSearchBox and TxtProfileSearch are in CCP.Avalonia/Views/Tabs/DiscordTabView.axaml - so
+// what is missing is the motion policy and the two clocks, never a surface to animate.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileVat.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileVat.cs
@@ -1,34 +1,207 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileVat.cs (420 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProfileVat.cs (420 lines) - THE VAT
+// on the Trainer Card, sorted member by member.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE: the geometry swap that turns the 104px hero avatar into a portrait floating
+// inside the glass jar, its exact undo, and the readout under it. Every number is derived from
+// the locked ratios on CCP.Avalonia/Controls/VatGlassCanvas (a full port, ratios and all), so the
+// portrait cannot drift out of the glass if the jar height is ever retuned.
 //
-// Members dropped (18):
-//   private const double VatJarHeight
-//   private const double VatDarkAvatarSize
-//   private readonly VatFillCoordinator _vatCoordinator
-//   private DispatcherTimer? _vatPollTimer
-//   private bool _vatWired
-//   private bool _vatArmed
-//   private bool _vatOnScreen
-//   private int _vatCap
-//   private void OnProfileVatVisibilityChanged(…)
-//   private void EvaluateVatPoll(…)
-//   private DispatcherTimer CreateVatPollTimer(…)
-//   private void WireProfileVat(…)
-//   private void OnDescentBlockChanged(…)
-//   private void OnVatFillPercentChanged(…)
-//   private void UpdateVatReadout(…)
-//   private void ApplyDescentToVat(…)
-//   private void ArmVat(…)
-//   private void DisarmVat(…)
+// THE TRI-STATE LAW IS INTACT, and it is the feature's safety property: no `descent` block and the
+// vat DOES NOT EXIST - the jar stays hidden, the avatar stays 104px at its original 6px margin,
+// and the card measures exactly as it did before this file was written. Nothing here derives a
+// fill from local XP; DisarmVat is what a missing block produces, and it is the state the XAML
+// ships in.
+//
+// Controls are reached with ProfilePage?.FindControl<T>(name) (ProfilePage is in
+// MainShellWindow.ProfileCard.cs). DiscordTabView loads with AvaloniaXamlLoader.Load, so its
+// generated x:Name fields are permanently null - `page.ProfileVatGlass` would compile and be a
+// silent no-op forever.
+//
+// STILL HEAD-SIDE, each with the exact symbol and where it lives today:
+//   ApplyDescentToVat      - App.Descent (ConditioningControlPanel/Services/Descent/
+//   OnDescentBlockChanged    DescentService.cs), the wire half of the feature. Services.Descent's
+//   WireProfileVat           VatFillCoordinator and DescentReader ARE in Core
+//   EvaluateVatPoll          (CCP.Core/Services/Descent/), so the fold and the read parsing are
+//   CreateVatPollTimer       already portable - only the thing that ASKS the server is not, and a
+//                            vat filled from anything else is a number nobody agreed to.
+//   the faucet               - _faucetHold, ArmFaucet, DisarmFaucet, OnFaucetVatOffScreen,
+//                            UpdateFaucetPresentation and PositionVatTickGlyphs are all in
+//                            MainShellWindow.ProfileFaucet.cs, still a wholesale stub (1,146 WPF
+//                            lines). ArmVat and DisarmVat below therefore arm and disarm the JAR
+//                            only; the tap that holds earned XP comes with that file.
+//   MaybeShowFeatureIntro  - CCP.Avalonia/Views/Windows/FeatureIntroPopup exists, but the spend
+//                            ledger it reads is on the shell's stub side; and the explainer may
+//                            only fire from ApplyDescentToVat, which is blocked above.
+//   OnProfileVatVisibilityChanged - its caller (OnProfileTabVisibilityChanged,
+//                            MainShellWindow.ProfileFx.cs) is 100% head-side, and its own body is
+//                            the poll plus the faucet snap. Blocked at both ends.
+//
+// NO CALLER YET: on WPF every entry into this file is OnProfileVatVisibilityChanged or
+// OnDescentBlockChanged, both named above. The four restored members are called by whoever
+// restores MainShellWindow.ProfileFaucet.cs / the Descent seam.
+
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using ConditioningControlPanel.Avalonia.Controls;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // ---- geometry ----------------------------------------------------------------
+        // The jar's height is the only free number; everything else is the locked mockup's
+        // ratios. 218 is chosen so the armed bay - jar + readout + the hero grid's 16px margins -
+        // still fits inside ProfileHeroCard's MinHeight and never grows the card.
+
+        private const double VatJarHeight = 218;
+
+        /// <summary>The avatar size the hero uses when the vat is dark. Do not change.</summary>
+        private const double VatDarkAvatarSize = 104;
+
+        private bool _vatArmed;
+
+        /// <summary>
+        /// The server's daily cap for the last accepted reading - the divisor the readout needs to
+        /// turn the DRAWN fill fraction back into an XP amount. 0 means "no cap known", and the
+        /// readout falls back to the bare percent rather than inventing a total.
+        /// </summary>
+        private int _vatCap;
+
+        /// <summary>The glass, or null before the Profile tab has been realized.</summary>
+        private VatGlassCanvas? VatGlass => ProfilePage?.FindControl<VatGlassCanvas>("ProfileVatGlass");
+
+        /// <summary>Repaint the readout when the drawn percent changes. Wired by WireProfileVat on
+        /// WPF; that method needs App.Descent and is not restored here.</summary>
+        private void OnVatFillPercentChanged(object? sender, int pct)
+        {
+            try { UpdateVatReadout(); }
+            catch (Exception ex) { Log.Debug("OnVatFillPercentChanged: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// THE READOUT under the jar: banked XP, the level-scaled total that fills it, and the
+        /// percent, on one line - the cap is level-scaled, so the percent alone never says how big
+        /// today's jar is.
+        ///
+        /// <para>IT READS THE DRAWN LEVEL, NOT THE SERVER'S. <c>VatGlassCanvas.Fill</c> is the
+        /// fraction actually on screen, which is the whole point: the desktop faucet HOLDS earned
+        /// XP until the user pours it, and a readout sourced from the block would print XP the
+        /// liquid has not risen to yet.</para>
+        ///
+        /// <para>ProfileVatReadout carries no {loc:Str}, so writing .Text is safe here; the
+        /// formatted strings come from Loc.GetF with the WPF keys and argument order.</para>
+        /// </summary>
+        private void UpdateVatReadout()
+        {
+            var readout = ProfilePage?.FindControl<TextBlock>("ProfileVatReadout");
+            if (readout == null) return;
+
+            double fill = VatGlass?.Fill ?? 0;
+            // Same rounding as VatGlassCanvas.NotifyPercent, so the two can never disagree about
+            // which whole percent is on screen.
+            int pct = (int)Math.Round(fill * 100);
+
+            if (_vatCap <= 0)
+            {
+                readout.Text = pct.ToString(CultureInfo.CurrentCulture) + "%";
+                ToolTip.SetTip(readout, null);
+                return;
+            }
+
+            int shown = (int)Math.Round(fill * _vatCap);
+            int toFill = Math.Max(0, _vatCap - shown);
+
+            readout.Text = Loc.GetF("profile_vat_readout",
+                shown.ToString("N0", CultureInfo.CurrentCulture),
+                _vatCap.ToString("N0", CultureInfo.CurrentCulture),
+                pct);
+
+            ToolTip.SetTip(readout, toFill > 0
+                ? Loc.GetF("profile_vat_readout_tip",
+                    shown.ToString("N0", CultureInfo.CurrentCulture),
+                    _vatCap.ToString("N0", CultureInfo.CurrentCulture),
+                    toFill.ToString("N0", CultureInfo.CurrentCulture))
+                : Loc.GetF("profile_vat_readout_tip_full",
+                    shown.ToString("N0", CultureInfo.CurrentCulture),
+                    _vatCap.ToString("N0", CultureInfo.CurrentCulture)));
+        }
+
+        /// <summary>
+        /// Turn the hero avatar into the jar's portrait. Idempotent, and the ONLY place the avatar
+        /// is resized. <paramref name="cap"/> is the accepted server cap for this reading, which
+        /// the readout needs before anything can raise FillPercentChanged.
+        /// </summary>
+        private void ArmVat(VatGlassCanvas glass, int cap)
+        {
+            _vatCap = cap;
+            if (_vatArmed) { UpdateVatReadout(); return; }
+            _vatArmed = true;
+
+            double jarH = VatJarHeight;
+            double jarW = jarH / VatGlassCanvas.JarAspect;
+            double portrait = Math.Round(jarW * VatGlassCanvas.PortraitDiameterRatio);
+            double left = Math.Round((jarW - portrait) / 2);
+            double top = Math.Round(jarH * VatGlassCanvas.PortraitCenterYRatio - 2 - portrait / 2);
+
+            glass.Width = jarW;
+            glass.Height = jarH;
+            glass.IsVisible = true;
+
+            var avatar = ProfilePage?.FindControl<Controls.AdornedAvatar>("ProfileHeroAvatar");
+            if (avatar != null)
+            {
+                // AdornedAvatar scales its decoration off AvatarSize, so the wardrobe follows the
+                // portrait down without a second number to keep in step.
+                avatar.AvatarSize = portrait;
+                avatar.Margin = new Thickness(left, top, 0, 0);
+            }
+
+            var readout = ProfilePage?.FindControl<TextBlock>("ProfileVatReadout");
+            if (readout != null)
+            {
+                readout.Width = jarW;
+                readout.IsVisible = true;
+            }
+            UpdateVatReadout();
+
+            // ponytail: ArmFaucet(glass, jarW, jarH) belongs here - see the header.
+            Log.Information("[Descent] vat armed on the Trainer Card");
+        }
+
+        /// <summary>
+        /// Put the hero back exactly as it ships without the Descent: 104px avatar at its original
+        /// 6px margin, no jar, no readout, and a bay that measures to the avatar alone.
+        /// </summary>
+        private void DisarmVat()
+        {
+            var glass = VatGlass;
+            if (!_vatArmed)
+            {
+                // Still make sure the hidden state holds on first pass - the XAML ships it hidden,
+                // so this is a no-op in the normal case.
+                if (glass != null) glass.IsVisible = false;
+                return;
+            }
+            _vatArmed = false;
+            _vatCap = 0;
+
+            if (glass != null) glass.IsVisible = false;
+
+            var avatar = ProfilePage?.FindControl<Controls.AdornedAvatar>("ProfileHeroAvatar");
+            if (avatar != null)
+            {
+                avatar.AvatarSize = VatDarkAvatarSize;
+                avatar.Margin = new Thickness(6, 6, 0, 0);
+            }
+
+            var readout = ProfilePage?.FindControl<TextBlock>("ProfileVatReadout");
+            if (readout != null) readout.IsVisible = false;
+
+            // ponytail: DisarmFaucet() belongs here - see the header.
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileWardrobe.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProfileWardrobe.cs
@@ -1,23 +1,64 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProfileWardrobe.cs (168 lines).
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProfileWardrobe.cs (168 lines) -
+// Phase 3 of the Profile redesign, sorted member by member. ONE of its four members crosses.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE: ApplyProfileAvatarDecoration. It is two property writes onto the ported
+// CCP.Avalonia/Views/Controls/AdornedAvatar, whose DecorationId / DecorationTransform are real
+// StyledProperties and whose CosmeticTransform is the Core model (CCP.Core/Models/
+// ProfileCosmetics.cs). It paints NOTHING today - AdornedAvatar's own GetImage returns null until
+// the wardrobe art crosses - and that is exactly the WPF contract for a missing PNG: the plain
+// avatar renders. Restoring it now means the hat appears the moment the art does, with no second
+// call site to remember.
 //
-// Members dropped (7):
-//   private List<string>? _appliedCharmIds
-//   private Dictionary<string, CosmeticTransform>? _appliedCharmTransforms
-//   private bool _charmResizeHooked
-//   private void ApplyProfileWardrobe(…)
-//   private void ApplyProfileAvatarDecoration(…)
-//   private void ApplyProfileCharms(…)
-//   private void LayoutProfileCharms(…)
+// STILL HEAD-SIDE, each with the exact symbol and where it lives today:
+//   ApplyProfileCharms     - Services.WardrobeCatalog.GetImage / .Find
+//   (and its two fields)     (ConditioningControlPanel/Services/Profile/WardrobeCatalog.cs). It
+//                            reads Resources/cosmetics/registry.json and decodes to
+//                            System.Windows.Media.ImageSource, so the class cannot move as it
+//                            stands - the registry parse is portable, the BitmapImage is not.
+//   LayoutProfileCharms    - Services.WardrobeStageGeometry.CharmRect / DefaultCharmAnchors
+//                            (ConditioningControlPanel/Services/Profile/WardrobeStageGeometry.cs).
+//                            USEFUL FINDING: that file is pure arithmetic with no WPF type in it
+//                            at all, it is already unit-tested (Tests/WardrobeGeometryTests), and
+//                            it is the one place wardrobe fractions turn into pixels for BOTH the
+//                            card and the editor's stage. It is a clean `git mv` into
+//                            CCP.Core/Services/Profile/ - blocked only on this layer not owning
+//                            CCP.Core/. Move it and LayoutProfileCharms is a straight port
+//                            (Canvas.SetLeft/SetTop and a TransformGroup exist on Avalonia).
+//   ApplyProfileWardrobe   - the two-line entry point. Restoring it while ApplyProfileCharms is
+//                            missing would be a method that silently does half its name.
+//
+// The controls themselves ARE on this head - ProfileCharmLayer, ProfileCharmSlot1/2 and
+// ProfileHeroCard are all in CCP.Avalonia/Views/Tabs/DiscordTabView.axaml - so the charm half is
+// blocked on the catalogue and the geometry, not on anything to draw into.
+//
+// NO CALLER YET: on WPF the entry is ApplyProfileCosmetics (MainShellWindow.ProfileCosmetics.cs),
+// which is blocked on Services.CosmeticsCatalog.
+
+using System;
+using Avalonia.Controls;
+using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>
+        /// The decoration worn over the hero avatar. Placement lives in the art plus the wearer's
+        /// optional transform; AdornedAvatar turns both into pixels. Writing both properties on
+        /// every apply is what makes taking a decoration off really take it off, rather than
+        /// leaving the last card's hat on a stranger's face after a search.
+        /// </summary>
+        internal void ApplyProfileAvatarDecoration(string? decorationId, CosmeticTransform? transform)
+        {
+            try
+            {
+                var avatar = ProfilePage?.FindControl<Controls.AdornedAvatar>("ProfileHeroAvatar");
+                if (avatar == null) return;
+                avatar.DecorationId = decorationId;
+                avatar.DecorationTransform = transform;
+            }
+            catch (Exception ex) { Log.Debug("ApplyProfileAvatarDecoration: {E}", ex.Message); }
+        }
     }
 }


### PR DESCRIPTION
The second half of the shell-partial layer; same procedure as the layer below it - every member
sorted against the fifteen Core seams and the ported views rather than trusting the blanket
"wholesale stub" header, which is now gone from all of them.

The Vat: ArmVat, DisarmVat, UpdateVatReadout and OnVatFillPercentChanged with the WPF loc keys, plus
the XP-drain flash, which is an Avalonia keyframe animation on XPBarFlashOverlay rather than the WPF
storyboard it replaces.

Cosmetics and wardrobe: ApplyProfileAvatarDecoration and the #847 avatar-slot claim rule.

One deliberate signature divergence, so that a later porter cannot reintroduce a bug quietly:
ArmVat(glass) became ArmVat(glass, int cap) and writes _vatCap itself, where WPF sets it in
ApplyDescentToVat after the call. Someone copying that method verbatim from the WPF file now gets a
loud CS7036 instead of a silent drift.

ProfileFx is genuinely 100% head-side and now says so per member rather than as a blanket claim: it
is MotionFx, FxTheme and two WPF storyboard clocks, none of which have an Avalonia twin here.

No caller yet for any restored member - each file names where its caller belongs.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU