### PR TITLE
feat(avalonia): three tab effects come on - skill-tree dust, roster fog parking, Deeper glyph drift

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AmbientFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AmbientFx.cs
@@ -4,16 +4,22 @@
 // with the same Pause()/Resume() contract, so the tab-level park/resume hook the WPF window uses
 // works on this head unchanged. SwitchTabFx is called from ShowTab.
 //
+// THE HOOK NOW HAS CALLERS. WPF initialises each tab's FX from that tab's own IsVisibleChanged
+// handler; the tab views on this head do not raise one into the shell (several load with
+// AvaloniaXamlLoader and would need a second wiring pass each), so the lazy-init dispatch lives
+// HERE, at the top of SwitchTabFx - the one place every tab arrival already funnels through.
+// Same semantics as WPF: a tab a user never opens costs nothing, and each tab's FX is composed
+// exactly once, by the partial that owns it.
+//
 // What is NOT here: AmbientFrameRate. It is a storyboard frame-rate cap
 // (System.Windows.Media.Animation.Timeline.DesiredFrameRate) and this head has no storyboards -
 // AmbientFxCanvas drives its own clock and gates it on reduced motion, the Performance tier and
 // window activation itself (see its Evaluate()). A constant nothing reads would be a lie about a
 // knob that does not exist here.
 //
-// No caller yet: every RegisterTabFx call site on WPF is inside an FX partial
-// (MainWindow.EnhancementsFx / DashboardFx / ProgramsFx / SubjectsFx.cs) or a tab view
-// (Views/Tabs/PlayTabView.xaml.cs:86), all of which are still stubs on this head. The hook lands
-// first so each of those is one line when it arrives rather than a second registry.
+// Registered by this batch: "enhancements" (MainShellWindow.EnhancementsFx.cs) and
+// "availablesubjects" (MainShellWindow.SubjectsFx.cs). "settings" (MosaicFx), "programs", "play"
+// and "exclusives" belong to files this layer does not own and are still unregistered.
 
 using System;
 using System.Collections.Generic;
@@ -43,10 +49,36 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             catch (Exception ex) { Log.Debug("RegisterTabFx: {E}", ex.Message); }
         }
 
+        /// <summary>
+        /// Composes the incoming tab's FX the first time that tab is shown. Each case is one call
+        /// into the tab's own FX partial, which owns its guard flag - a dispatch table, not a
+        /// second registry. Wrapped as a whole: an entrance effect must never cost the navigation
+        /// that asked for it.
+        /// </summary>
+        private void EnsureTabFx(string tab)
+        {
+            try
+            {
+                switch (tab)
+                {
+                    case "enhancements": EnsureEnhancementsFx(); break;
+                    case "availablesubjects": EnsureSubjectsFx(); break;
+                    case "deeper": EnsureDeeperFx(); break;
+                }
+            }
+            catch (Exception ex) { Log.Debug("EnsureTabFx({T}): {E}", tab, ex.Message); }
+        }
+
         /// <summary>Pauses every registered canvas that does not belong to the incoming tab, and
         /// resumes the ones that do. Must never throw - it runs inside ShowTab.</summary>
         private void SwitchTabFx(string tab)
         {
+            // Both of these run BEFORE the early return below: the first visit to a tab is the
+            // visit that registers its canvas, and it has to be resumed on that same pass. The
+            // Deeper drift is not a canvas at all and is not in the registry.
+            EnsureTabFx(tab);
+            ApplyDeeperGlyphDrift(tab);
+
             if (_tabFxCanvases.Count == 0) return;
             try
             {

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AssetsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AssetsFx.cs
@@ -1,9 +1,26 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.AssetsFx.cs (226 lines).
+// PORTED-AS-A-NOTE from ConditioningControlPanel/MainWindow/MainWindow.AssetsFx.cs (226 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Nothing is wired here, and unlike the two tabs this batch DID turn on, the reason is not a
+// missing service - the Assets tab has no AmbientFxCanvas at all, in WPF or here. All three of
+// its effects are interaction motion on controls, and each is blocked on something concrete:
+//
+//   * the pack-card sheen (CardSheenAdorner over the hovered card). WPF hangs it off an
+//     AdornerLayer with a FrameworkElement host. There is no CardSheenAdorner on this head - it
+//     was never ported, and it is a control, so it belongs to a controls layer, not to a
+//     MainShellWindow partial. Avalonia does have an AdornerLayer, so this is a port and not a
+//     reimplementation, but it is somebody else's file.
+//   * the asset-tree row nudge (AssetTreeRowNudgePx over AssetTreeRowNudgeMs on hover). The
+//     target exists - AssetsTabView.axaml:518, TreeView x:Name="AssetTreeView" - but the hover
+//     handler belongs to the row template inside AssetsTabView, which this layer does not own.
+//   * the media-log pulse (MediaLogPulseBeats beats down to MediaLogPulseFloor when the log has
+//     unseen entries). The button exists (AssetsTabView.axaml:138, x:Name="BtnMediaLog") and the
+//     motion is a plain opacity Animation - but "unseen" is _mediaLogSeenCount against the media
+//     log service, which is still in the WPF head, and pulsing on a count this head cannot read
+//     would be decoration lying about state.
+//
+// None of the three is a storyboard-only effect: all three have real Avalonia equivalents
+// (Animation over OpacityProperty / a TranslateTransform, and AdornerLayer for the sheen). They
+// are blocked on ownership and on the media-log service, not on the framework.
 //
 // Members dropped (18):
 //   private const double AssetTreeRowNudgePx

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionFx.cs
@@ -1,9 +1,31 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CompanionFx.cs (95 lines).
+// PORTED-AS-A-NOTE from ConditioningControlPanel/MainWindow/MainWindow.CompanionFx.cs (95 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Nothing is wired here, and re-checked rather than assumed: the WPF file has NO ambient effect
+// left to register. Both of its loops moved out in the "Her Room" redesign - the hero disc's
+// breathe belongs to CompanionHeroCard.StartAmbientLoop (parked by CompanionRoomView off the
+// tab's own visibility, including her asleep state, which a MainWindow clock could not see), and
+// the connect sheen was deleted with the AI-brain card it swept. So there is no RegisterTabFx
+// call to make on this tab and no canvas in CompanionTabView.axaml to make it with.
+//
+// What is left in the WPF file is a REPAINT hook, not an effect: a mod switch changes her name,
+// her portrait, her flavour line, the mod chip and the five-card picker (a mod can hide a whole
+// avatar set), and this is the one place that repaints them.
+//
+// Half of that hook is now available and half is not:
+//   * AVAILABLE - CoreMods.ModChanged (CCP.Core/CoreMods.cs:206) is the seam the head forwards
+//     its service's event into. Subscribing is one line, and CoreDispatch covers the
+//     Dispatcher.CheckAccess marshalling WPF does by hand.
+//   * MISSING - every repaint target. CompanionRoomView on this head has no ViewModel and no
+//     Sync(): CompanionTabView's own note records that it needs CompanionRoomRuntimeVm plus the
+//     eight zone viewmodels, all still in the WPF head. UpdateCompanionCardsUI and
+//     UpdateCompanionPromptLabels do not exist here either. A subscription with nothing to call
+//     would be a live event handler that does nothing, which is worse than the note.
+//
+// Wire this when CompanionRoomRuntimeVm lands: subscribe to CoreMods.ModChanged from an
+// EnsureCompanionFx case in EnsureTabFx (MainShellWindow.AmbientFx.cs) and call Room.Sync().
+//
+// Also dropped with its service: PersistCompanionDrawerStates (a settings write on tab exit) and
+// EnsureAwarenessV2Consent (the upgrade consent dialog raised on this page).
 //
 // Members dropped (4):
 //   private bool _companionFxInitialized

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperFx.cs
@@ -1,34 +1,147 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperFx.cs (207 lines).
+// PORTED-IN-PART from ConditioningControlPanel/MainWindow/MainWindow.DeeperFx.cs (207 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// The hero loop is live: the Deeper header's wave glyph drifts. WPF ran two DoubleAnimations with
+// AutoReverse + RepeatBehavior.Forever on one TranslateTransform; Avalonia's twin is two
+// Animations with PlaybackDirection.Alternate + IterationCount.Infinite over the same transform,
+// which is the same motion rather than an approximation of it. The amplitudes and the deliberately
+// mismatched half-periods are verbatim (3.0dip over 11.5s, 2.0dip over 15.5s), so the path still
+// never repeats on a beat the eye can find and the glyph reads as floating, not as a pendulum.
 //
-// Members dropped (18):
-//   private const double DeeperGlyphDriftY
-//   private const double DeeperGlyphDriftX
-//   private const double DeeperGlyphDriftYSeconds
-//   private const double DeeperGlyphDriftXSeconds
-//   private const int DeeperGlyphFrameRate
-//   private const double DeeperRowLiftPx
-//   private const int DeeperRowLiftMs
-//   private bool _deeperFxInitialized
-//   private TranslateTransform? _deeperGlyphDrift
-//   private AnimationClock? _deeperGlyphClockY
-//   private AnimationClock? _deeperGlyphClockX
-//   private bool DeeperFxOnScreen
-//   internal void OnDeeperTabVisibilityChanged(…)
-//   private void InitializeDeeperFx(…)
+// Start and stop are driven by SwitchTabFx: arriving at "deeper" runs it, leaving cancels it and
+// puts the glyph back at 0,0. That replaces WPF's OnDeeperTabVisibilityChanged.
+//
+// Two of WPF's gates have no equivalent here and are NOT faked:
+//   * MotionFx.AllowAmbientLoops (reduced motion + the performance tier). The only copy of that
+//     gate on this head is AmbientFxCanvas's private nested Env, which a non-canvas loop cannot
+//     reach. So this drift currently runs whenever the tab is showing. Restore the gate when
+//     MotionFx moves to Core - it is one `if` at the top of ApplyDeeperGlyphDrift.
+//   * DeeperGlyphFrameRate = 10. That is Timeline.SetDesiredFrameRate, a per-storyboard frame cap.
+//     Avalonia has no per-animation clock rate, so it drops for the same reason AmbientFrameRate
+//     did (see MainShellWindow.AmbientFx.cs). A 3px sine over 11.5s is sub-pixel per frame either
+//     way; what is lost is the CPU saving, not the look.
+// Window activation/minimise parking (WPF's Activated/Deactivated/StateChanged funnel) is also
+// gone: the drift is two interpolators on one transform, and a tab the user is not looking at
+// already cancels it.
+//
+// Still a note: OnDeeperRowHover, the 2px library-row hover lift. It needs MotionFx.AllowTransitions
+// AND a hover handler on the row template inside DeeperTabView, which this layer does not own.
+// The rows keep the border-brush reveal their template already carries, so hover is not dead -
+// only the lift is missing.
+//
+// Members of the WPF file still dropped (6):
+//   private const double DeeperRowLiftPx / private const int DeeperRowLiftMs
+//   private const int DeeperGlyphFrameRate                 - no Avalonia equivalent, see above
+//   private bool DeeperFxOnScreen                          - the tab key SwitchTabFx passes IS this
 //   private void OnDeeperFxWindowStateish(…)
-//   private void ApplyDeeperGlyphDrift(…)
-//   private void StopDeeperGlyphDrift(…)
 //   internal void OnDeeperRowHover(…)
+
+using System;
+using System.Threading;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>Drift amplitudes in DIPs, verbatim from WPF. Small on purpose: the glyph sits
+        /// next to a title, and anything the eye can measure against that baseline reads as a
+        /// wobble.</summary>
+        private const double DeeperGlyphDriftY = 3.0;
+        private const double DeeperGlyphDriftX = 2.0;
+
+        /// <summary>Half-periods; 23s and 31s round trips, mismatched so the path does not repeat
+        /// on an obvious beat.</summary>
+        private const double DeeperGlyphDriftYSeconds = 11.5;
+        private const double DeeperGlyphDriftXSeconds = 15.5;
+
+        private bool _deeperFxInitialized;
+        private TranslateTransform? _deeperGlyphDrift;
+        private CancellationTokenSource? _deeperGlyphClock;
+
+        /// <summary>
+        /// Resolves the glyph and gives it the transform the drift animates. Once, on the first
+        /// arrival at the tab - called from EnsureTabFx.
+        /// </summary>
+        private void EnsureDeeperFx()
+        {
+            if (_deeperFxInitialized) return;
+            _deeperFxInitialized = true;
+            try
+            {
+                // FindControl, not the generated field: DeeperTabView loads with
+                // AvaloniaXamlLoader.Load, so DeeperWaveGlyph is null on it despite compiling.
+                var glyph = Named<Tabs.DeeperTabView>("DeeperTab")
+                    ?.FindControl<TextBlock>("DeeperWaveGlyph");
+                if (glyph == null) return;
+
+                if (glyph.RenderTransform is TranslateTransform existing) _deeperGlyphDrift = existing;
+                else if (glyph.RenderTransform == null)
+                {
+                    _deeperGlyphDrift = new TranslateTransform();
+                    glyph.RenderTransform = _deeperGlyphDrift;
+                }
+                // else: an authored transform. Never clobbered - the glyph simply does not drift.
+            }
+            catch (Exception ex) { Log.Warning(ex, "EnsureDeeperFx failed"); }
+        }
+
+        /// <summary>
+        /// Runs the drift while the Deeper tab is the one showing, and parks it flat otherwise.
+        /// Called from SwitchTabFx with the incoming tab key, so leaving the tab stops it.
+        /// </summary>
+        private void ApplyDeeperGlyphDrift(string tab)
+        {
+            try
+            {
+                bool wanted = string.Equals(tab, "deeper", StringComparison.OrdinalIgnoreCase)
+                              && _deeperGlyphDrift != null;
+                if (!wanted) { StopDeeperGlyphDrift(); return; }
+                if (_deeperGlyphClock != null) return;    // already drifting
+
+                _deeperGlyphClock = new CancellationTokenSource();
+                Drift(TranslateTransform.YProperty, DeeperGlyphDriftY, DeeperGlyphDriftYSeconds);
+                Drift(TranslateTransform.XProperty, DeeperGlyphDriftX, DeeperGlyphDriftXSeconds);
+            }
+            catch (Exception ex) { Log.Debug("ApplyDeeperGlyphDrift: {E}", ex.Message); }
+
+            void Drift(AvaloniaProperty property, double amplitude, double seconds)
+            {
+                var anim = new Animation
+                {
+                    Duration = TimeSpan.FromSeconds(seconds),
+                    IterationCount = IterationCount.Infinite,
+                    PlaybackDirection = PlaybackDirection.Alternate,
+                    Easing = new SineEaseInOut(),
+                    Children =
+                    {
+                        new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(property, -amplitude) } },
+                        new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(property, amplitude) } },
+                    },
+                };
+                _ = anim.RunAsync(_deeperGlyphDrift!, _deeperGlyphClock!.Token);
+            }
+        }
+
+        private void StopDeeperGlyphDrift()
+        {
+            var clock = _deeperGlyphClock;
+            if (clock == null) return;
+            _deeperGlyphClock = null;
+            try
+            {
+                clock.Cancel();
+                clock.Dispose();
+                // A cancelled Avalonia animation leaves the property wherever it stopped, so the
+                // glyph is put back on its baseline explicitly.
+                if (_deeperGlyphDrift != null) { _deeperGlyphDrift.X = 0; _deeperGlyphDrift.Y = 0; }
+            }
+            catch (Exception ex) { Log.Debug("StopDeeperGlyphDrift: {E}", ex.Message); }
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.EnhancementsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.EnhancementsFx.cs
@@ -1,37 +1,82 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.EnhancementsFx.cs (256 lines).
+// PORTED-IN-PART from ConditioningControlPanel/MainWindow/MainWindow.EnhancementsFx.cs (256 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// ONE of this file's three effects is live here: the hero ambient. EnhancementsTabView.axaml
+// already carries the <fx:AmbientFxCanvas x:Name="SkillTreeFx"/> the WPF tab has, and nothing was
+// starting it - the tree drew on bare background paint. EnsureEnhancementsFx composes it with the
+// WPF tuning (DustField at 0.55) and registers it with RegisterTabFx, so it parks on the way out
+// of the tab and resumes on the way back in. Called from EnsureTabFx (MainShellWindow.AmbientFx.cs)
+// on the first ShowTab("enhancements"), which is the same laziness as WPF calling it from
+// RefreshEnhancementsUI: a user who never opens the tab never pays for it.
 //
-// Members dropped (21):
-//   private const double SkillTreeFxIntensity
-//   private const double OwnedNodeGlowMinOpacity
-//   private const double OwnedNodeGlowMaxOpacity
-//   private const double OwnedNodeGlowSeconds
-//   private const double SkillNodeHoverScale
-//   private const int SkillNodeHoverInMs
-//   private const int SkillNodeHoverOutMs
-//   private bool _enhancementsFxInitialized
+// The canvas gates itself on the performance tier, window activation and its own visibility, so
+// none of WPF's Activated/Deactivated/StateChanged subscriptions are needed for it - that whole
+// funnel existed for the owned-node AnimationClock, which is not here. See below.
+//
+// The two micro effects stay notes, because both attach to nodes that do not exist on this head:
+//
+//   * the owned-node breath (a single AnimationClock shared by every owned node's
+//     DropShadowEffect, 0.38<->0.72 over 3.8s). Its enrolment point is RegisterOwnedNodeGlow,
+//     called from MainWindow.Enhancements.cs's DrawSkillTree - and the tree on this head is a
+//     SAMPLE drawn by EnhancementsTabView itself (it needs Services/SkillTreeService.cs and
+//     Models/SkillTree.cs, both still in the WPF head). There is no owned node to enrol. When the
+//     tree becomes real, the Avalonia twin is one Animation with IterationCount.Infinite and
+//     PlaybackDirection.Alternate over DropShadowEffect.OpacityProperty, plus the window
+//     Activated/Deactivated/PropertyChanged(WindowState) hooks WPF used to park it.
+//   * the node hover pop (1.25 over 250ms in, 200ms out). Lives on the node visual and belongs to
+//     whoever draws it, i.e. EnhancementsTabView, which this layer does not own.
+//
+// Also not here: EnhancementsAmbientAllowed / EnhancementsFxOnScreen. Both are re-expressed
+// inside AmbientFxCanvas.Evaluate() for the one loop that survived; a second copy of the gate
+// with no second consumer would be a lie about what it gates.
+//
+// Members of the WPF file still dropped (12):
+//   private const double OwnedNodeGlowMinOpacity / MaxOpacity / GlowSeconds
+//   private const double SkillNodeHoverScale, private const int SkillNodeHoverInMs / OutMs
 //   private readonly List<DropShadowEffect> _ownedNodeGlows
 //   private AnimationClock? _ownedNodeGlowClock
-//   private static bool EnhancementsAmbientAllowed
-//   private bool EnhancementsFxOnScreen
-//   private void EnsureEnhancementsFx(…)
-//   private void OnEnhancementsFxWindowStateish(…)
-//   private void OnEnhancementsTabVisibilityChanged(…)
-//   private void ApplyEnhancementsFxLoops(…)
-//   private void ResetOwnedNodeGlows(…)
-//   private void RegisterOwnedNodeGlow(…)
-//   private void ApplyOwnedNodeBreath(…)
-//   private void StopOwnedNodeGlowClock(…)
-//   private void ApplySkillNodeHover(…)
+//   private void ApplyEnhancementsFxLoops / ResetOwnedNodeGlows / RegisterOwnedNodeGlow /
+//   ApplyOwnedNodeBreath / StopOwnedNodeGlowClock / ApplySkillNodeHover
+
+using System;
+using Avalonia.Controls;
+using ConditioningControlPanel.Avalonia.Controls;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>Dust alpha multiplier, verbatim from WPF. Low: the tree art is the subject,
+        /// this is the air.</summary>
+        private const double SkillTreeFxIntensity = 0.55;
+
+        private bool _enhancementsFxInitialized;
+
+        /// <summary>
+        /// Composes the skill tree's ambient dust, once, on the first arrival at the tab.
+        /// </summary>
+        private void EnsureEnhancementsFx()
+        {
+            if (_enhancementsFxInitialized) return;
+            _enhancementsFxInitialized = true;
+            try
+            {
+                // FindControl, never the generated field: this window loads with
+                // AvaloniaXamlLoader.Load, so EnhancementsTab is permanently null (see the header
+                // of MainShellWindow.TabNavigation.cs).
+                var canvas = Named<Tabs.EnhancementsTabView>("EnhancementsTab")
+                    ?.FindControl<AmbientFxCanvas>("SkillTreeFx");
+                if (canvas == null) return;
+
+                canvas.StartLayers(new AmbientFxConfig
+                {
+                    Layers = AmbientFxLayers.DustField,
+                    Intensity = SkillTreeFxIntensity,
+                });
+                // ShowTab parks it on the way out and resumes it on the way in, for free.
+                RegisterTabFx("enhancements", canvas);
+            }
+            catch (Exception ex) { Log.Warning(ex, "EnsureEnhancementsFx failed"); }
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.EventFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.EventFx.cs
@@ -1,9 +1,28 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs (460 lines).
+// PORTED-AS-A-NOTE from ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs (460 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// This one is NOT blocked on the framework, and that is worth stating plainly so a later layer
+// does not re-derive it: AmbientFxCanvas.Burst (Controls/AmbientFxCanvas.cs:333) is a full port,
+// so the particle burst every Celebrate* method fires can be drawn on this head today. What is
+// missing is every CALLER - the progression moments themselves:
+//
+//   CelebrateLevelUp                <- the XP/level path (MainWindow.ProfileBubble.cs)
+//   CelebrateAchievementUnlock      <- MainWindow.AchievementsTab.cs:782
+//   CelebrateQuestComplete          <- MainWindow.Quests.cs:77 (a quest-completed event)
+//   CelebrateProgramDayComplete     <- MainWindow.ProgramsTab.cs:1020
+//   CelebrateEnhancementPurchase    <- MainWindow.Enhancements.cs:2059
+//   CelebratePrestige               <- the prestige rank roll
+//
+// Not one of those six sites exists on this head. Restoring the six methods now would add ~200
+// lines of overlay plumbing that nothing can call and nothing can prove: the whole file is
+// "when X happens, burst here", and X does not happen yet. It comes back with the progression
+// wiring that fires it, not before - and when it does, EnsureEventBurstLayer is a Panel insert
+// into the shell's root grid plus one Burst call, because the canvas is already here.
+//
+// The one piece that WOULD need thought at that point, named so it is not a surprise: the
+// achievement tile reveal (AchievementRevealMs / RevealAchievementTile) composes a blur radius
+// with a scale as the tile lands. Avalonia has BlurEffect and can animate it, but a blur
+// animation per unlocked tile is a real cost at the Performance tier, and the tier gate
+// (EventFxAllowed) is MotionFx + PerformanceProfile, still in the WPF head.
 //
 // Members dropped (28):
 //   private const double BurstBoxPx

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.LeaderboardFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.LeaderboardFx.cs
@@ -1,9 +1,27 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.LeaderboardFx.cs (405 lines).
+// PORTED-AS-A-NOTE from ConditioningControlPanel/MainWindow/MainWindow.LeaderboardFx.cs (405 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Nothing is wired here. The Leaderboard tab carries no AmbientFxCanvas - both of its effects are
+// data-driven decoration, and the data is the blocker in each case:
+//
+//   * the podium glow breath (PodiumGlowMinOpacity..MaxOpacity over PodiumGlowSeconds on the #1
+//     card). The host exists - LeaderboardTabView.axaml:531, ItemsControl x:Name="PodiumHost" -
+//     but ApplyPodiumFx picks the glow card out of the generated containers, and the containers
+//     on this head are placeholder rows. A breath on a sample card is decoration attached to
+//     nothing, and it would need re-attaching on every real refresh anyway.
+//   * the rank flash (CollectMovedRows -> FlashMovedRows, a staggered rise+fade on up to
+//     RankFlashMaxRows rows that CHANGED position since the last pull). This one is not merely
+//     unattached, it is undefined: "moved" is a diff between two service pulls, and
+//     Services.LeaderboardEntry plus the leaderboard client are still in the WPF head. With no
+//     previous pull to diff against, every row is either always flashing or never - and the
+//     first is the failure mode a reviewer would never catch from a screenshot.
+//
+// Neither is storyboard-only: Avalonia can express both (an Animation over OpacityProperty for
+// the breath, per-row Animations with a start delay for the stagger). They are blocked on the
+// leaderboard service, and they should land in the same layer that brings it.
+//
+// LeaderboardAmbientAllowed and the Activated/Deactivated/StateChanged parking funnel go with
+// them: both loops are plain animations rather than canvases, so unlike the two tabs this batch
+// turned on they cannot lean on AmbientFxCanvas.Evaluate() for their gate.
 //
 // Members dropped (30):
 //   private const double PodiumGlowMinOpacity

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SubjectsFx.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SubjectsFx.cs
@@ -1,23 +1,65 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SubjectsFx.cs (143 lines).
+// PORTED-IN-PART from ConditioningControlPanel/MainWindow/MainWindow.SubjectsFx.cs (143 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// The hero fog is live, and half of it was already here: AvailableSubjectsTabView starts its own
+// SubjectsAmbientFx on Loaded (two puffs at 0.40, the WPF tuning), because when that view was
+// ported there was no tab host to start it. What was missing is the OTHER half - the tab-level
+// park. Without the registration below, the roster's fog kept ticking while the user sat on a
+// completely different tab, which is exactly the idle burn RegisterTabFx exists to stop.
 //
-// Members dropped (7):
-//   private const int SubjectsFogPuffs
-//   private const double SubjectsFogIntensity
-//   private bool _subjectsFxInitialized
-//   internal void OnAvailableSubjectsTabVisibilityChanged(…)
-//   private void InitializeSubjectsFx(…)
+// So this file registers, and deliberately does not start: the view owns the tuning constants and
+// a second StartLayers from here would reseed a composition the view already made.
+//
+// ponytail: AvailableSubjectsTabView.OnTabLoaded calls StartLayers, and StartLayers clears the
+// paused flag. Loaded fires once per attach, so in practice the park holds - but if that view is
+// ever re-attached while another tab is showing, it un-parks itself. The canvas still self-gates
+// on IsVisible, so the worst case is a composed-but-invisible surface, not a running clock.
+//
+// Still notes, both of them motion this head cannot express yet:
+//   * StaggerSubjectCards - the roster's entrance stagger. Needs MotionFx.StaggerIn (still in the
+//     WPF head) and the item containers: WPF walks list.ItemContainerGenerator after a forced
+//     UpdateLayout, and the Avalonia twin is ItemsControl.ContainerFromIndex after a
+//     realization pass. Both halves are missing, and a stagger with no gate would animate under
+//     reduced motion. The WPF file's allowRetry dance (ShowTab makes the tab visible BEFORE the
+//     roster binds) has the same shape here - EnsureTabFx runs inside ShowTab too.
+//   * OnSubjectConnectPress - the press squish on a roster card's Connect button. MotionFx
+//     .PressSquish, and the handler belongs to AvailableSubjectsTabView, which this layer does
+//     not own.
+//
+// Members of the WPF file still dropped (5):
+//   private const int SubjectsFogPuffs / private const double SubjectsFogIntensity
+//        (both live on AvailableSubjectsTabView now, at the same values)
+//   internal void OnAvailableSubjectsTabVisibilityChanged(…)   - replaced by EnsureTabFx
 //   private void StaggerSubjectCards(…)
 //   internal void OnSubjectConnectPress(…)
+
+using System;
+using Avalonia.Controls;
+using ConditioningControlPanel.Avalonia.Controls;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        private bool _subjectsFxInitialized;
+
+        /// <summary>
+        /// Enrols the roster's fog in the tab-level park/resume, once, on first arrival.
+        /// </summary>
+        private void EnsureSubjectsFx()
+        {
+            if (_subjectsFxInitialized) return;
+            _subjectsFxInitialized = true;
+            try
+            {
+                // FindControl on both hops. AvailableSubjectsTabView loads with
+                // AvaloniaXamlLoader.Load, so its generated SubjectsAmbientFx field is null too -
+                // the x:Name hazard is not confined to this window.
+                var canvas = Named<Tabs.AvailableSubjectsTabView>("AvailableSubjectsTab")
+                    ?.FindControl<AmbientFxCanvas>("SubjectsAmbientFx");
+                RegisterTabFx("availablesubjects", canvas);
+            }
+            catch (Exception ex) { Log.Warning(ex, "EnsureSubjectsFx failed"); }
+        }
     }
 }


### PR DESCRIPTION
RegisterTabFx had no caller: every WPF call site lives in an FX partial, and this batch owns
three of them. The dispatch lands at the top of SwitchTabFx (MainShellWindow.AmbientFx.cs) rather
than on each tab view's IsVisibleChanged, because several tab views load with
AvaloniaXamlLoader and would each need a second wiring pass to raise one. Same laziness as WPF:
a tab nobody opens costs nothing, and each tab composes its FX exactly once.

Enhancements: EnhancementsTabView.axaml already carried the SkillTreeFx canvas and nothing was
starting it - the tree drew on bare background paint. It is now composed with the WPF tuning
(DustField at 0.55) and registered, so it parks leaving the tab and resumes on return.

Available Subjects: the view starts its own fog (it had no tab host when it was ported), so what
was missing was the park. Registering it stops the roster's fog ticking while the user sits on a
different tab. The view keeps the tuning; this file only registers.

Deeper: the header wave glyph drifts again. WPF's two AutoReverse/Forever DoubleAnimations become
two Avalonia Animations with PlaybackDirection.Alternate and IterationCount.Infinite over one
TranslateTransform - the same motion, not an approximation, with the amplitudes and mismatched
half-periods verbatim (3.0dip/11.5s, 2.0dip/15.5s). Leaving the tab cancels it and puts the glyph
back on its baseline.

Every control is reached through Named<T>() and then FindControl on the tab view - DeeperTabView
and AvailableSubjectsTabView both load with AvaloniaXamlLoader too, so their generated
DeeperWaveGlyph / SubjectsAmbientFx fields are null despite compiling.

Companion, Assets, Event and Leaderboard stay notes, each rewritten to be true today rather than
repeating "wired when the services move to Core":
  - Companion has no ambient loop left to register at all (both moved into CompanionHeroCard in
    the Her Room redesign). Its remaining hook is a mod-switch repaint: CoreMods.ModChanged is
    available, every repaint target (CompanionRoomView.Sync, UpdateCompanionCardsUI) is not.
  - Event is blocked on callers, not on the framework: AmbientFxCanvas.Burst is fully ported, and
    all six Celebrate* call sites (achievements, quests, programs, enhancements, level, prestige)
    are absent from this head. The note names each one.
  - Assets needs CardSheenAdorner ported, hover handlers inside AssetsTabView, and the media-log
    service for "unseen"; Leaderboard needs the leaderboard client, because "moved rows" is a
    diff between two pulls and with one pull every row either always flashes or never does.

Not faked, and named: MotionFx.AllowAmbientLoops has no reachable copy on this head (the only one
is AmbientFxCanvas's private nested Env), so the Deeper drift runs whenever its tab shows;
DeeperGlyphFrameRate drops with AmbientFrameRate, since Avalonia has no per-animation clock rate.

Still blocked:
  Services/MotionFx.cs, Services/PerformanceProfile.cs      (ConditioningControlPanel/Services/)
  Services/SkillTreeService.cs, Models/SkillTree.cs         - owned-node breath, node hover pop
  Controls/CardSheenAdorner.cs                              - the pack-card sheen
  Services/LeaderboardEntry + the leaderboard client        - podium glow, rank flash
  CompanionRoomRuntimeVm + the eight zone viewmodels        - CompanionRoomView.Sync()
  MainWindow.AchievementsTab/Quests/ProgramsTab/Enhancements - the six Celebrate* call sites

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU