### PR TITLE
feat(avalonia): awareness presets install/uninstall/clone/delete for real, and the phrase editor's remembered-and-removed bookkeeping

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/AwarenessPresetDetailDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessPresetDetailDialog.axaml.cs
@@ -11,7 +11,11 @@ using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
+using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Moderation;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -32,15 +36,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/AwarenessPresetDetailDialog.xaml.cs.
     /// Deviations, all forced:
-    ///  - Every <c>App.*</c> reach is a stub behind <see cref="IsInstalled"/> / <see cref="Persist"/>
-    ///    (see the ponytail notes on both). The preset object itself is a Core model, so all list
-    ///    and action editing below is the real logic operating on the real type; only persistence,
-    ///    install/uninstall, clone and the live-clone mirror in <c>settings.KeywordTriggers</c> are
-    ///    missing, which is also why the installed branch of Add/Delete trigger collapses to the
-    ///    source list.
-    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so
-    ///    <see cref="Confirm"/> is a minimal stand-in (same shape as TextEditorDialog.Ask). The two
-    ///    destructive confirmations are kept: they are the guard against silent data loss.
+    ///  - <c>App.Settings</c> is <see cref="CoreSettings"/> and <c>App.KeywordPresets</c> is a
+    ///    local <see cref="KeywordTriggerPresetService"/>, both in Core, so install / uninstall /
+    ///    clone / delete, the live-clone list in <c>settings.KeywordTriggers</c> and every
+    ///    per-action save run for real.
+    ///  - <c>MessageBox.Show</c> becomes <see cref="MessageDialog"/>, this head's replacement. The
+    ///    two destructive confirmations are kept: they guard against silent data loss.
     ///  - <c>Microsoft.Win32.OpenFileDialog</c> -> <c>StorageProvider.OpenFilePickerAsync</c>, the
     ///    native Avalonia picker. Not a stub: it needs no service and no Win32.
     ///  - <c>Checked</c>/<c>Unchecked</c> -> one <c>IsCheckedChanged</c> handler.
@@ -122,7 +123,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             this.FindControl<Button>("BtnPolicyReadSlim")!.Click += (_, _) => BtnPolicyRead_Click();
             this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
             _btnInstall.Click += (_, _) => BtnInstall_Click();
-            _btnClone.Click += (_, _) => BtnClone_Click();
+            _btnClone.Click += async (_, _) => await BtnClone_Click();
             _btnDeletePreset.Click += async (_, _) => await BtnDeletePreset_Click();
 
             _preset = preset;
@@ -188,44 +189,53 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         }
 
         // ============================================================
-        // Service stubs — the whole App.* surface this dialog used
+        // Services — App.KeywordPresets and App.Settings, both now in Core
         // ============================================================
 
-        // ponytail: needs App.KeywordPresets (KeywordTriggerPresetService), wired when it moves to
-        // Core. Until then the dialog toggles its own flag so the Activate/Deactivate button and
-        // the editable/read-only split still behave.
-        private bool _installed;
+        /// <summary>
+        /// WPF's <c>App.KeywordPresets</c>. The service is stateless — every read and write goes
+        /// through <see cref="CoreSettings.Current"/> — so a local instance installs, uninstalls
+        /// and clones exactly as the head-owned one does.
+        ///
+        /// ponytail: its <c>PresetsChanged</c> event therefore fires only on this instance. Nothing
+        /// on this head subscribes yet (the Awareness tab refreshes off <see cref="Changed"/>);
+        /// give the head one shared instance if a listener ever needs it.
+        /// </summary>
+        private static readonly KeywordTriggerPresetService Presets = new();
 
-        private bool IsInstalled() => _installed;
+        private string LiveClonePrefix => "preset:" + _preset.Id + ":";
 
-        // ponytail: needs App.Settings.Save(); wired when settings move to Core. Every edit below
-        // already mutates the Core model in place, so this is the only missing half.
-        private void Persist() { }
+        private bool IsInstalled() => Presets.IsInstalled(_preset.Id);
+
+        private void Persist() => CoreSettings.Save();
 
         /// <summary>
         /// CCBill AI Addendum: show full content-policy banner until acked, then slim version.
         /// </summary>
         private void ApplyPolicyBannerState()
         {
-            // ponytail: needs App.Settings.Current.CompanionPrompt.PromptEditorDisclaimerAcknowledged,
-            // wired when settings move to Core. The default is "not yet acknowledged".
-            var acked = _policyAcked;
+            var acked = CoreSettings.Current.CompanionPrompt?.PromptEditorDisclaimerAcknowledged == true;
             this.FindControl<Border>("PolicyBannerFull")!.IsVisible = !acked;
             this.FindControl<Border>("PolicyBannerSlim")!.IsVisible = acked;
         }
 
-        private bool _policyAcked;
-
         private void BtnPolicyGotIt_Click()
         {
-            _policyAcked = true; // ponytail: persisted via App.Settings.Save() once settings move to Core
+            var prompt = CoreSettings.Current.CompanionPrompt;
+            if (prompt != null)
+            {
+                prompt.PromptEditorDisclaimerAcknowledged = true;
+                CoreSettings.Save();
+            }
             ApplyPolicyBannerState();
         }
 
-        private void BtnPolicyRead_Click()
+        private async void BtnPolicyRead_Click()
         {
-            // ponytail: needs a launcher for https://app.cclabs.app/policies/prohibited-content;
-            // Process.Start(UseShellExecute) is per-platform and belongs behind a Core interface.
+            // WPF used Process.Start(UseShellExecute); TopLevel.Launcher is Avalonia's own, so no
+            // seam is needed. Same precedent as CompanionPromptEditorDialog.
+            try { await Launcher.LaunchUriAsync(new Uri("https://app.cclabs.app/policies/prohibited-content")); }
+            catch (Exception ex) { Log.Warning(ex, "AwarenessPresetDetailDialog: failed to open policy URL"); }
         }
 
         /// <summary>
@@ -236,11 +246,38 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         {
             if (_isCustomPresetUnsaved)
             {
-                // ponytail: needs App.Settings.Current.KeywordTriggerPresets to add _preset to.
+                var list = CoreSettings.Current.KeywordTriggerPresets;
+                if (list != null && !list.Any(p => p.Id == _preset.Id))
+                    list.Add(_preset);
                 _isCustomPresetUnsaved = false;
                 Changed = true;
             }
             Persist();
+        }
+
+        /// <summary>
+        /// For user-created presets that are currently installed, mirror the live cloned triggers
+        /// in <c>settings.KeywordTriggers</c> back into <c>preset.Triggers</c>. Keeps the preset
+        /// source-of-truth in sync so a later Uninstall -> Install cycle preserves user edits.
+        /// No-op for built-ins (their source is owned by the bundled preset JSON).
+        /// </summary>
+        private void MirrorLiveClonesToCustomSource()
+        {
+            if (_preset.IsBuiltIn) return;
+            if (!IsInstalled()) return;
+
+            var prefix = LiveClonePrefix;
+            var synced = new List<KeywordTrigger>();
+            foreach (var clone in CoreSettings.Current.KeywordTriggers
+                         .Where(t => t?.Id?.StartsWith(prefix, StringComparison.Ordinal) == true)
+                         .ToList())
+            {
+                var copy = clone.Clone();
+                copy.Id = clone.Id!.Substring(prefix.Length);
+                copy.LastTriggeredAt = DateTime.MinValue;
+                synced.Add(copy);
+            }
+            _preset.Triggers = synced;
         }
 
         /// <summary>
@@ -266,10 +303,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
             var editable = IsEditable();
 
-            // ponytail: when installed, WPF edits the LIVE CLONES out of
-            // settings.KeywordTriggers (id prefix "preset:<id>:") so every mutation flows back via
-            // App.Settings.Save(). No settings service here, so both states edit preset.Triggers.
-            var triggers = _preset.Triggers?.Where(t => t != null).ToList() ?? new List<KeywordTrigger>();
+            // Installed: edit the LIVE CLONES out of settings.KeywordTriggers (id prefix
+            // "preset:<id>:") so every mutation flows back through CoreSettings.Save(). Uninstalled:
+            // edit preset.Triggers directly (custom presets) or preview them read-only (built-ins).
+            var prefix = LiveClonePrefix;
+            var triggers = IsInstalled()
+                ? CoreSettings.Current.KeywordTriggers
+                    .Where(t => t?.Id?.StartsWith(prefix, StringComparison.Ordinal) == true)
+                    .ToList()
+                : _preset.Triggers?.Where(t => t != null).ToList() ?? new List<KeywordTrigger>();
 
             foreach (var trigger in triggers)
                 _triggerStack.Children.Add(BuildTriggerBorder(trigger, editable));
@@ -358,10 +400,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             // exactly what they want via the per-trigger "+ Add action" menu.
             newTrigger.Actions = new List<KeywordAction>();
 
-            // ponytail: when installed, WPF also adds a live clone to settings.KeywordTriggers under
-            // the "preset:<presetId>:<sourceId>" id convention so the trigger fires immediately.
-            _preset.Triggers ??= new List<KeywordTrigger>();
-            _preset.Triggers.Add(newTrigger);
+            if (IsInstalled())
+            {
+                // Live clone list uses the "preset:<presetId>:<sourceId>" id convention, so the
+                // trigger fires immediately.
+                var sourceId = Guid.NewGuid().ToString("N")[..8];
+                newTrigger.Id = LiveClonePrefix + sourceId;
+                CoreSettings.Current.KeywordTriggers.Add(newTrigger);
+
+                // For custom presets, also add a matching source entry so
+                // uninstall -> reinstall preserves this addition.
+                if (!_preset.IsBuiltIn)
+                {
+                    var sourceCopy = newTrigger.Clone();
+                    sourceCopy.Id = sourceId;
+                    _preset.Triggers ??= new List<KeywordTrigger>();
+                    _preset.Triggers.Add(sourceCopy);
+                }
+            }
+            else
+            {
+                _preset.Triggers ??= new List<KeywordTrigger>();
+                _preset.Triggers.Add(newTrigger);
+            }
 
             PersistAndMaybeCreate();
             Changed = true;
@@ -373,9 +434,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private void DeleteTrigger(KeywordTrigger trigger)
         {
-            // ponytail: when installed, WPF also strips the live clone from
-            // settings.KeywordTriggers so the keyword stops firing at once.
-            _preset.Triggers?.RemoveAll(t => t.Id == trigger.Id);
+            if (IsInstalled())
+            {
+                // Strip the live clone so the keyword stops firing at once.
+                CoreSettings.Current.KeywordTriggers.RemoveAll(t => t.Id == trigger.Id);
+
+                if (!_preset.IsBuiltIn)
+                {
+                    // Source id == live clone id with the prefix stripped.
+                    var prefix = LiveClonePrefix;
+                    if (trigger.Id?.StartsWith(prefix, StringComparison.Ordinal) == true)
+                        _preset.Triggers?.RemoveAll(t => t.Id == trigger.Id.Substring(prefix.Length));
+                }
+            }
+            else
+            {
+                _preset.Triggers?.RemoveAll(t => t.Id == trigger.Id);
+            }
 
             PersistAndMaybeCreate();
             Changed = true;
@@ -486,7 +561,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                 deleteTriggerBtn.Click += async (_, _) =>
                 {
                     var label = string.IsNullOrWhiteSpace(trigger.Keyword) ? "(unnamed trigger)" : $"\"{trigger.Keyword}\"";
-                    var confirm = await Confirm(
+                    var confirm = await MessageDialog.ConfirmAsync(this,
                         "Delete trigger",
                         $"Delete trigger {label}?\n\nThis removes the keyword and all its actions.");
                     if (confirm)
@@ -692,11 +767,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             body.Children.Add(browseBtn);
 
             var testBtn = MakeChipButton("▶ Test", editable);
-            testBtn.Click += (_, _) =>
-            {
-                // ponytail: needs App.KeywordTriggers.PreviewAudioClip(path, volume), wired when the
-                // keyword-trigger service moves to Core.
-            };
+            testBtn.Click += (_, _) => PreviewAudioClip(pa.FilePath, pa.Volume);
             Grid.SetColumn(testBtn, 2);
             body.Children.Add(testBtn);
 
@@ -1008,10 +1079,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private static IEnumerable<string> GetAvailableFallbackCategories()
         {
-            // ponytail: needs Services.CompanionPhraseService.GetCategoryNames() +
-            // App.Settings.Current.CustomCompanionPhrases; wired when both move to Core. Placeholder
-            // pools so the dropdown renders with realistic content.
-            var result = new List<string> { "BimboGiggle", "ChastityShame", "PuppyPraise", "TranceMurmur" };
+            // ponytail: the built-in half is CompanionPhraseEditorDialog's copy of
+            // CompanionPhraseService.GetCategoryNames(); both collapse into that call when the
+            // service moves to Core.
+            var result = new List<string>(CompanionPhraseEditorDialog.CategoryNames);
+            foreach (var c in CoreSettings.Current.CustomCompanionPhrases
+                         .Select(c => c.Category)
+                         .Where(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                if (!result.Contains(c, StringComparer.OrdinalIgnoreCase)) result.Add(c);
+            }
             result.Sort(StringComparer.OrdinalIgnoreCase);
             return result;
         }
@@ -1178,22 +1255,43 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             if (_isCustomPresetUnsaved)
                 PersistAndMaybeCreate();
 
-            // ponytail: needs App.KeywordPresets.InstallPreset / UninstallPreset, and for a custom
-            // preset the MirrorLiveClonesToCustomSource() pass that copies live clone edits back
-            // into preset.Triggers before uninstall wipes them. Wired when the service moves to
-            // Core; the flag below keeps the button and the editable/read-only split honest.
-            _installed = !_installed;
+            if (IsInstalled())
+            {
+                // For custom presets: capture any in-place edits to the live clones back into the
+                // source list before uninstall wipes the clones, so a later re-install keeps the
+                // user's tuning.
+                if (!_preset.IsBuiltIn)
+                    MirrorLiveClonesToCustomSource();
+                Presets.UninstallPreset(_preset.Id);
+            }
+            else
+            {
+                Presets.InstallPreset(_preset.Id);
+            }
 
             Changed = true;
             RebuildRows();
             UpdateInstallButton();
         }
 
-        private void BtnClone_Click()
+        private async Task BtnClone_Click()
         {
-            // ponytail: needs App.KeywordPresets.CloneToCustom(_preset.Id), which returns the copy
-            // this dialog then reopens itself on. Wired when the service moves to Core.
+            var copy = Presets.CloneToCustom(_preset.Id);
             Changed = true;
+            if (copy == null)
+            {
+                await MessageDialog.ShowAsync(this, "Copy failed", "Couldn't copy this preset.");
+                return;
+            }
+
+            // Close this preview and open the fresh editable copy so the user lands straight in the
+            // new preset (which is also now a card in the grid). Owner is captured BEFORE Close():
+            // Avalonia clears it on close, and ShowDialog needs a live owner.
+            var owner = Owner as Window;
+            Close();
+            var dlg = new AwarenessPresetDetailDialog(copy);
+            if (owner != null) await dlg.ShowDialog(owner);
+            else dlg.Show();
         }
 
         /// <summary>
@@ -1212,13 +1310,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             }
 
             var label = string.IsNullOrWhiteSpace(_preset.Name) ? "this preset" : $"\"{_preset.Name}\"";
-            var confirm = await Confirm(
+            var confirm = await MessageDialog.ConfirmAsync(this,
                 "Delete preset",
                 $"Delete {label}?\n\nThis removes the preset and all its triggers permanently.");
             if (!confirm) return;
 
-            // ponytail: needs App.KeywordPresets.UninstallPreset (to clean up cloned triggers and
-            // injected phrases) and App.Settings.Current.KeywordTriggerPresets.RemoveAll.
+            // Uninstall first so cloned triggers / canned phrases are cleaned up.
+            if (IsInstalled())
+                Presets.UninstallPreset(_preset.Id);
+
+            CoreSettings.Current.KeywordTriggerPresets?.RemoveAll(p => p.Id == _preset.Id);
             Persist();
 
             Changed = true;
@@ -1237,9 +1338,54 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private void RunAwarenessPromptValidation(TextBox promptBox)
         {
-            // ponytail: needs App.PromptValidator (+ App.ModerationLog.RecordEdit and the
-            // "prompt_validator_warning" string with the match count), wired when the validator
-            // moves to Core. The paint-and-warn half is three lines once it is there.
+            if (promptBox == null) return;
+
+            var result = new PromptValidator().Validate(promptBox.Text ?? string.Empty);
+            if (result.Clean)
+            {
+                promptBox.BorderBrush = new SolidColorBrush(Color.FromRgb(0x3A, 0x3A, 0x5A));
+                promptBox.BorderThickness = new Thickness(1);
+                promptBox.ClearValue(ToolTip.TipProperty);
+                return;
+            }
+
+            promptBox.BorderBrush = new SolidColorBrush(Color.FromRgb(0xE5, 0xC7, 0x6B));
+            promptBox.BorderThickness = new Thickness(2);
+            ToolTip.SetTip(promptBox, Loc.GetF("prompt_validator_warning", result.MatchedPatterns.Count));
+
+            // Through the seam, so the app's ONE moderation log takes the entry. Unseeded on this
+            // head, so nothing is written here yet.
+            CoreModerationLog.RecordEdit("avatarPromptTemplate", result.MatchedPatterns.Count, "awareness_preset");
+            Log.Information(
+                "PromptValidator flagged AwarenessPresetDetailDialog avatar prompt ({Count} matches)",
+                result.MatchedPatterns.Count);
+        }
+
+        /// <summary>
+        /// WPF's <c>App.KeywordTriggers.PreviewAudioClip</c>: audition a clip a user is about to
+        /// assign to a trigger, resolving relative preset paths the way dispatch does.
+        ///
+        /// ponytail: the resolve is KeywordTriggerService.ResolveAudioPath verbatim; both collapse
+        /// into that call when the keyword-trigger service moves to Core. WPF's NAudio path also
+        /// applied a pow(1.5) master-volume curve, which lives inside the audio service the seam
+        /// calls, so playback here is the seam's own curve, not that one.
+        /// </summary>
+        private static void PreviewAudioClip(string? path, int volumePercent)
+        {
+            if (string.IsNullOrEmpty(path)) return;
+
+            var resolved = path;
+            if (!Path.IsPathRooted(path))
+            {
+                // Preset-bundled audio under Resources/ first (install dir, then content pack),
+                // then the legacy sub_audio folder.
+                var res = ContentLocator.Resolve(Path.Combine("Resources", path));
+                var sub = ContentLocator.Resolve(Path.Combine("Resources", "sub_audio", path));
+                resolved = File.Exists(res) ? res : File.Exists(sub) ? sub : path;
+            }
+
+            if (!File.Exists(resolved)) return;
+            CoreAudio.PlayOneShot(resolved, volumePercent / 100f, "keyword-preview");
         }
 
         private static Button MakeChipButton(string label, bool editable)
@@ -1308,63 +1454,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                 }
             }
             return sb.ToString().TrimEnd();
-        }
-
-        /// <summary>
-        /// Minimal stand-in for WPF's MessageBox Yes/No confirm, which Avalonia has no equivalent
-        /// of and no package may be added for. Same shape as TextEditorDialog.Ask; dismissing the
-        /// window counts as No. Buttons hold a TextBlock, not Content, for the access-key reason
-        /// in CLAUDE.md.
-        /// </summary>
-        private async Task<bool> Confirm(string title, string message)
-        {
-            var row = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 16, 0, 0),
-            };
-
-            var dialog = new Window
-            {
-                Title = title,
-                SizeToContent = SizeToContent.WidthAndHeight,
-                CanResize = false,
-                ShowInTaskbar = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                Background = Background,
-                Content = new StackPanel
-                {
-                    Margin = new Thickness(20),
-                    Children =
-                    {
-                        new TextBlock
-                        {
-                            Text = message,
-                            Foreground = Brushes.White,
-                            FontSize = 13,
-                            TextWrapping = TextWrapping.Wrap,
-                            MaxWidth = 360,
-                        },
-                        row,
-                    },
-                },
-            };
-
-            foreach (var (label, value) in new[] { ("Yes", true), ("No", false) })
-            {
-                var button = new Button
-                {
-                    Content = new TextBlock { Text = label },
-                    Padding = new Thickness(14, 6),
-                    Cursor = new Cursor(StandardCursorType.Hand),
-                };
-                button.Click += (_, _) => dialog.Close(value);
-                row.Children.Add(button);
-            }
-
-            return await dialog.ShowDialog<bool>(this);
         }
 
         /// <summary>

--- a/CCP.Avalonia/Views/Dialogs/CompanionPhraseEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CompanionPhraseEditorDialog.axaml.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -11,7 +12,9 @@ using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Styling;
+using Avalonia.Platform.Storage;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -26,20 +29,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - <c>CollectionViewSource</c> has no Avalonia equivalent. Grouping and filtering move into
     ///    <see cref="Regroup"/>, which rebuilds a list of <see cref="PhraseGroup"/> and rebinds. The
     ///    WPF filter predicate is <see cref="Matches"/>, unchanged in behaviour.
-    ///  - <c>App.CompanionPhrases</c>, <c>App.Settings</c> and
-    ///    <c>Services.CompanionPhraseService</c> are all in the WPF head, not Core, so everything
-    ///    that loads or persists is a stub. Each carries a ponytail comment; the view-only halves
-    ///    (selection, filtering, the enable toggle, the count line) run for real.
-    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so the
-    ///    "no phrases selected" and confirm prompts become ponytail comments and the action
-    ///    proceeds (QuizCategoryEditorWindow precedent).
-    ///  - <c>OpenFileDialog</c> plus <c>CopyAudioToFolder</c> is one stub: the picker would be
-    ///    <c>StorageProvider.OpenFilePickerAsync</c>, but the copy target is the service's.
+    ///  - <c>App.Settings</c> is <see cref="CoreSettings"/>, so every write runs for real: the
+    ///    disabled/removed id sets, the custom-phrase list and the audio overrides all persist,
+    ///    which is the bookkeeping issue #892 depends on. <c>CompanionPhraseService.GetAllPhrases</c>
+    ///    is still head-side, so <see cref="LoadPhrases"/> rebuilds its mod + custom halves from
+    ///    <see cref="CoreMods.GetPhrases"/>; voice-line files and bark lines stay missing.
+    ///  - <c>MessageBox.Show</c> becomes <see cref="MessageDialog"/>, this head's replacement, so
+    ///    the "no phrases selected" notice and both destructive confirms are kept.
+    ///  - <c>OpenFileDialog</c> -> <c>StorageProvider.OpenFilePickerAsync</c>;
+    ///    <c>CopyAudioToFolder</c> is a file copy into the install tree, so it is inlined here.
     ///  - <c>HitsInteractive</c> is dropped. Avalonia's Button (so also the row CheckBoxes) and
     ///    TextBox mark PointerPressed handled, so a click on them never reaches the row handler -
     ///    which is exactly what that WPF visual-tree walk existed to emulate.
-    ///  - <c>TxtCustomPhrase_LostFocus</c> only persisted, so it is gone with the persistence; the
-    ///    TextBox still writes back to the bound row.
+    ///  - <c>TxtCustomPhrase_LostFocus</c> is one list-level LostFocus handler rather than a
+    ///    per-row one: template content has no name scope to FindControl through.
     /// </summary>
     public partial class CompanionPhraseEditorDialog : Window
     {
@@ -93,19 +96,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             { BarkCategory, "🐰 Bark Lines" },
         };
 
-        // ponytail: needs Services.CompanionPhraseService.GetCategoryNames(), wired when it moves to
-        // Core. Verbatim copy of that service's _categoryNames plus its VoiceLineCategory, which is
-        // what GetCategoryNames() returns.
-        private static readonly string[] _categoryNames =
+        /// <summary>Categories carrying a mod-supplied phrase pool - CompanionPhraseService's
+        /// own <c>_categoryNames</c>, which is what <see cref="LoadPhrases"/> iterates.</summary>
+        private static readonly string[] _modCategoryNames =
         {
             "Greeting", "StartupGreeting", "Idle", "RandomFloating", "Generic",
             "Gaming", "Browsing", "Shopping", "Social", "Discord",
             "TrainingSite", "HypnoContent", "Working", "Media", "Learning",
             "WindowAwarenessIdle", "EngineStop", "FlashPre", "SubliminalAck",
             "RandomBubble", "BubbleCountMercy", "BubblePop", "GameFailed",
-            "BubbleMissed", "FlashClicked", "LevelUp", "MindWipe", "BrainDrain",
-            "VoiceLine"
+            "BubbleMissed", "FlashClicked", "LevelUp", "MindWipe", "BrainDrain"
         };
+
+        // ponytail: what Services.CompanionPhraseService.GetCategoryNames() returns - the mod pool
+        // categories plus its VoiceLineCategory. Collapses into that call when the service moves to
+        // Core. Shared with AwarenessPresetDetailDialog's fallback-pool dropdown.
+        internal static readonly string[] CategoryNames =
+            _modCategoryNames.Append(VoiceLineCategory).ToArray();
+
+        private const string VoiceLineCategory = "VoiceLine";
 
         private static string GetDisplayName(string category) =>
             _categoryDisplayNames.TryGetValue(category, out var dn) ? dn : category;
@@ -132,7 +141,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             this.FindControl<Button>("BtnEnableSelected")!.Click += (_, _) => SetSelectedEnabled(true);
             this.FindControl<Button>("BtnDisableSelected")!.Click += (_, _) => SetSelectedEnabled(false);
             this.FindControl<Button>("BtnAddPhrase")!.Click += (_, _) => BtnAddPhrase_Click();
-            this.FindControl<Button>("BtnRemoveSelected")!.Click += (_, _) => BtnRemoveSelected_Click();
+            this.FindControl<Button>("BtnRemoveSelected")!.Click += async (_, _) => await BtnRemoveSelected_Click();
             this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
 
             // Two handlers on the list instead of per-row handlers inside the DataTemplate: template
@@ -140,6 +149,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             // buttons carry x:Names so one handler can tell them apart.
             _phraseList.AddHandler(Button.ClickEvent, PhraseList_RowButtonClick);
             _phraseList.AddHandler(InputElement.PointerPressedEvent, PhraseList_PointerPressed);
+            _phraseList.AddHandler(InputElement.LostFocusEvent, PhraseList_LostFocus);
         }
 
         private void PopulateCategoryFilter()
@@ -148,7 +158,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             {
                 new() { Content = "All Categories", Tag = "All Categories" }
             };
-            foreach (var cat in _categoryNames)
+            foreach (var cat in CategoryNames)
                 items.Add(new ComboBoxItem { Content = GetDisplayName(cat), Tag = cat });
             items.Add(new ComboBoxItem { Content = GetDisplayName("Custom"), Tag = "Custom" });
             // One entry for the ~1,200 bark lines; the list still groups them per rule via GroupLabel.
@@ -168,9 +178,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             // Preserve selection across the rebuild (rows are fresh CompanionPhrase instances).
             var selected = new HashSet<string>(_phrases.Where(p => p.IsSelected).Select(p => p.Id));
 
-            // ponytail: needs App.CompanionPhrases (CompanionPhraseService), wired when it moves to
-            // Core. Sample rows until then - see SamplePhrases.
-            var all = SamplePhrases();
+            // With no head attached (headless render, tests) CoreSettings hands out one shared
+            // default instance and CoreMods answers nothing, so the pool would be empty; the sample
+            // set draws the template instead. See SamplePhrases.
+            var all = CoreSettings.HasProvider ? LoadPhrases() : SamplePhrases();
             var fresh = new ObservableCollection<CompanionPhrase>();
             foreach (var p in all)
             {
@@ -187,6 +198,60 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _phrases = fresh;
             Regroup();
             UpdateTotalCount();
+        }
+
+        /// <summary>
+        /// The mod-pool and custom halves of <c>CompanionPhraseService.GetAllPhrases()</c>, resolved
+        /// against the user's bookkeeping: <c>RemovedPhraseIds</c> hides a row for good,
+        /// <c>DisabledPhraseIds</c> mutes it, <c>PhraseAudioOverrides</c> re-points its audio. That
+        /// order is what keeps a mod top-up from resurrecting a phrase the user deleted (#892).
+        ///
+        /// ponytail: voice-line files (CompanionPhraseService.ResolveVoiceLineFolder) and bark lines
+        /// (BarkService.GetAllBarkLines) are still head-side, so those two row kinds are missing
+        /// here. Collapses into one GetAllPhrases() call when the service moves to Core.
+        /// </summary>
+        private static List<CompanionPhrase> LoadPhrases()
+        {
+            var settings = CoreSettings.Current;
+            var disabled = settings.DisabledPhraseIds;
+            var removed = settings.RemovedPhraseIds;
+            var overrides = settings.PhraseAudioOverrides;
+            var result = new List<CompanionPhrase>();
+
+            foreach (var category in _modCategoryNames)
+            {
+                var phrases = CoreMods.GetPhrases(category) ?? Array.Empty<string>();
+                for (int i = 0; i < phrases.Length; i++)
+                {
+                    var id = $"{category}:{i}";
+                    if (removed.Contains(id)) continue;
+
+                    result.Add(new CompanionPhrase
+                    {
+                        Id = id,
+                        Text = phrases[i],
+                        Category = category,
+                        IsBuiltIn = true,
+                        IsEnabled = !disabled.Contains(id),
+                        AudioFileName = overrides.TryGetValue(id, out var audio) ? audio : null,
+                    });
+                }
+            }
+
+            foreach (var custom in settings.CustomCompanionPhrases)
+            {
+                result.Add(new CompanionPhrase
+                {
+                    Id = custom.Id,
+                    Text = custom.Text,
+                    Category = custom.Category,
+                    IsBuiltIn = false,
+                    IsEnabled = custom.Enabled,
+                    AudioFileName = custom.AudioFileName,
+                });
+            }
+
+            return result;
         }
 
         // ============================================================
@@ -261,8 +326,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             switch (b.Name)
             {
                 case "RemoveBtn": BtnRemovePhrase_Click(p); break;
-                case "BrowseBtn": BrowseAndSetAudio(p); break;
+                case "BrowseBtn": _ = BrowseAndSetAudio(p); break;
                 case "ClearAudioBtn": BtnClearAudio_Click(p); break;
+            }
+        }
+
+        /// <summary>
+        /// WPF's TxtCustomPhrase_LostFocus. The row TextBox writes straight back to the bound
+        /// CompanionPhrase; this is what copies that edit onto the stored CustomCompanionPhrase so
+        /// it survives a reload.
+        /// </summary>
+        private void PhraseList_LostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (e.Source is not TextBox txt || PhraseOf(txt) is not CompanionPhrase p) return;
+
+            var custom = CoreSettings.Current.CustomCompanionPhrases.FirstOrDefault(c => c.Id == p.Id);
+            if (custom != null && custom.Text != txt.Text)
+            {
+                custom.Text = txt.Text;
+                CoreSettings.Save();
             }
         }
 
@@ -281,10 +363,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private void PersistEnabled(CompanionPhrase p)
         {
-            // ponytail: needs App.Settings (SettingsService), wired when it moves to Core. The WPF
-            // body moved p.Id in or out of DisabledPhraseIds, or set custom.Enabled, then saved.
+            var settings = CoreSettings.Current;
+
+            if (p.IsBuiltIn)
+            {
+                if (p.IsEnabled) settings.DisabledPhraseIds.Remove(p.Id);
+                else settings.DisabledPhraseIds.Add(p.Id);
+            }
+            else
+            {
+                var custom = settings.CustomCompanionPhrases.FirstOrDefault(c => c.Id == p.Id);
+                if (custom != null) custom.Enabled = p.IsEnabled;
+            }
+
             if (!_bulkUpdating)
+            {
+                CoreSettings.Save();
                 UpdateTotalCount();
+            }
         }
 
         private void UpdateTotalCount()
@@ -296,27 +392,113 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         private void BtnRemovePhrase_Click(CompanionPhrase phrase)
         {
-            // ponytail: needs App.Settings, wired when it moves to Core. Built-in and bark rows went
-            // into RemovedPhraseIds; custom rows were deleted from CustomCompanionPhrases. Dropping
-            // the row locally keeps the view honest until then.
-            _phrases.Remove(phrase);
-            Regroup();
-            UpdateTotalCount();
+            var settings = CoreSettings.Current;
+            if (phrase.IsBuiltIn)
+                settings.RemovedPhraseIds.Add(phrase.Id);   // bark + built-in: hide (also silences barks)
+            else
+                settings.CustomCompanionPhrases.RemoveAll(c => c.Id == phrase.Id);
+
+            CoreSettings.Save();
+            RefreshPhraseList();
         }
 
         private void BtnClearAudio_Click(CompanionPhrase phrase)
         {
-            // ponytail: needs App.Settings, wired when it moves to Core (PhraseAudioOverrides for
-            // built-ins, custom.AudioFileName otherwise).
-            phrase.AudioFileName = null;
-            Regroup();
+            var settings = CoreSettings.Current;
+            if (phrase.IsBuiltIn)
+                settings.PhraseAudioOverrides.Remove(phrase.Id);
+            else
+            {
+                var custom = settings.CustomCompanionPhrases.FirstOrDefault(c => c.Id == phrase.Id);
+                if (custom != null) custom.AudioFileName = null;
+            }
+
+            CoreSettings.Save();
+            RefreshPhraseList();
         }
 
-        private void BrowseAndSetAudio(CompanionPhrase phrase)
+        private async Task BrowseAndSetAudio(CompanionPhrase phrase)
         {
-            // ponytail: needs App.Settings and App.CompanionPhrases.CopyAudioToFolder, wired when
-            // they move to Core. The picker itself would be StorageProvider.OpenFilePickerAsync with
-            // an mp3/wav/ogg/flac filter, but there is nowhere to copy the file to yet.
+            var picked = await PickAudioFile();
+            if (picked == null) return;
+
+            var fileName = CopyAudioToFolder(picked, phrase.Text);
+            if (fileName == null) return;
+
+            var settings = CoreSettings.Current;
+            if (phrase.IsBuiltIn)
+                settings.PhraseAudioOverrides[phrase.Id] = fileName;
+            else
+            {
+                var custom = settings.CustomCompanionPhrases.FirstOrDefault(c => c.Id == phrase.Id);
+                if (custom != null) custom.AudioFileName = fileName;
+            }
+
+            CoreSettings.Save();
+            RefreshPhraseList();
+        }
+
+        /// <summary>WPF's <c>Microsoft.Win32.OpenFileDialog</c>; the Avalonia picker is native.</summary>
+        private async Task<string?> PickAudioFile()
+        {
+            var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Select audio file for phrase",
+                AllowMultiple = false,
+                FileTypeFilter = new[]
+                {
+                    new FilePickerFileType("Audio Files") { Patterns = new[] { "*.mp3", "*.wav", "*.ogg", "*.flac" } },
+                    new FilePickerFileType("All Files") { Patterns = new[] { "*" } },
+                },
+            });
+            var picked = files.FirstOrDefault();
+            return picked?.TryGetLocalPath();
+        }
+
+        /// <summary>
+        /// CompanionPhraseService.CopyAudioToFolder: copy a user-picked clip into the folder the
+        /// rows read audio back from (<see cref="CompanionPhrase.DefaultAudioFolder"/>, which is
+        /// that service's CompanionAudioFolder) and hand back the bare filename that gets stored in
+        /// settings. A name collision gets a _1, _2 suffix rather than overwriting someone else's
+        /// clip.
+        /// </summary>
+        private static string? CopyAudioToFolder(string sourcePath, string phraseText)
+        {
+            try
+            {
+                var folder = CompanionPhrase.DefaultAudioFolder;
+                Directory.CreateDirectory(folder);
+                var ext = Path.GetExtension(sourcePath);
+                var sanitized = SanitizeFileName(phraseText);
+                var fileName = $"{sanitized}{ext}";
+                var destPath = Path.Combine(folder, fileName);
+
+                int counter = 1;
+                while (File.Exists(destPath))
+                {
+                    fileName = $"{sanitized}_{counter}{ext}";
+                    destPath = Path.Combine(folder, fileName);
+                    counter++;
+                }
+
+                File.Copy(sourcePath, destPath);
+                return fileName;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("Failed to copy audio file: {Error}", ex.Message);
+                return null;
+            }
+        }
+
+        private static string SanitizeFileName(string text)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            var sanitized = new string(text.Where(c => !invalid.Contains(c)).ToArray());
+            sanitized = sanitized.Replace(' ', '_');
+            if (sanitized.Length > 50) sanitized = sanitized[..50];
+            if (string.IsNullOrWhiteSpace(sanitized)) sanitized = "phrase";
+            return sanitized;
         }
 
         // ============================================================
@@ -343,23 +525,34 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             foreach (var p in selected) p.IsEnabled = enabled; // PropertyChanged → PersistEnabled (Save deferred)
             _bulkUpdating = false;
 
-            // ponytail: needs App.Settings.Save(), wired when it moves to Core.
+            CoreSettings.Save();
             UpdateTotalCount();
         }
 
-        private void BtnRemoveSelected_Click()
+        private async Task BtnRemoveSelected_Click()
         {
             var selected = _phrases.Where(p => p.IsSelected).ToList();
-            // ponytail: WPF showed a MessageBox here ("No phrases selected." / the remove-N confirm).
-            // Avalonia has no MessageBox and no package may be added, so both are silent: nothing
-            // selected is a no-op, and a selection is removed without the confirm.
-            if (selected.Count == 0) return;
+            if (selected.Count == 0)
+            {
+                await MessageDialog.ShowAsync(this, "Remove Selected", "No phrases selected.");
+                return;
+            }
 
+            var confirm = await MessageDialog.ConfirmAsync(this, "Remove Selected",
+                $"Remove {selected.Count} selected phrase(s)?\n\nBuilt-in phrases and bark lines will be hidden (can be restored by clearing settings).\nCustom phrases will be permanently deleted.");
+            if (!confirm) return;
+
+            var settings = CoreSettings.Current;
             foreach (var phrase in selected)
-                _phrases.Remove(phrase);
+            {
+                if (phrase.IsBuiltIn)
+                    settings.RemovedPhraseIds.Add(phrase.Id);
+                else
+                    settings.CustomCompanionPhrases.RemoveAll(c => c.Id == phrase.Id);
+            }
 
-            Regroup();
-            UpdateTotalCount();
+            CoreSettings.Save();
+            RefreshPhraseList();
         }
 
         private IEnumerable<CompanionPhrase> VisiblePhrases() => _phrases.Where(Matches);
@@ -416,7 +609,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             if (this.TryFindResource("DarkComboBoxStyle", out var darkStyle) && darkStyle is ControlTheme ct)
                 categoryCombo.Theme = ct;
 
-            var categoryItems = _categoryNames
+            var categoryItems = CategoryNames
                 .Select(cat => new ComboBoxItem { Content = GetDisplayName(cat), Tag = cat })
                 .ToList();
             categoryCombo.ItemsSource = categoryItems;
@@ -482,24 +675,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
             var selectedCategory = (categoryCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "Custom";
 
-            // ponytail: needs App.Settings (to add a CustomCompanionPhrase and save) and the
-            // MessageBox + OpenFileDialog audio prompt that followed it; wired when they move to
-            // Core. Until then the new row is added to the in-memory list only.
-            var added = new CompanionPhrase
+            var newPhrase = new CustomCompanionPhrase
             {
                 Id = Guid.NewGuid().ToString("N")[..8],
                 Text = text,
                 Category = selectedCategory,
-                GroupLabel = GetDisplayName(selectedCategory),
-                IsBuiltIn = false,
-                IsEnabled = true
+                Enabled = true
             };
-            // WPF got this from the RefreshPhraseList() that followed its save; the stub cannot
-            // reload, so the new row subscribes here or its On/Off toggle never updates the count.
-            added.PropertyChanged += Phrase_PropertyChanged;
-            _phrases.Add(added);
-            Regroup();
-            UpdateTotalCount();
+
+            if (await MessageDialog.ConfirmAsync(this, "Audio File",
+                    "Would you like to connect an audio file to this phrase?"))
+            {
+                var picked = await PickAudioFile();
+                if (picked != null)
+                {
+                    var fileName = CopyAudioToFolder(picked, text);
+                    if (fileName != null) newPhrase.AudioFileName = fileName;
+                }
+            }
+
+            CoreSettings.Current.CustomCompanionPhrases.Add(newPhrase);
+            CoreSettings.Save();
+            RefreshPhraseList();
         }
 
         // ============================================================


### PR DESCRIPTION
AwarenessPresetDetailDialog. Every ponytail note here was stale: the
keyword-preset service and AppSettings both moved to Core layers ago. The
dialog now holds a KeywordTriggerPresetService (stateless over
CoreSettings.Current, so a local instance behaves as App.KeywordPresets did)
and Activate/Deactivate, Copy-to-custom and Delete preset run through it.
That brings back the live-clone half the port had collapsed: an installed
preset's rows are read from and written to settings.KeywordTriggers under the
"preset:<id>:<sourceId>" convention, adding a trigger writes a clone plus a
matching source entry for custom presets, deleting one strips both, and
MirrorLiveClonesToCustomSource - absent from the port entirely - copies live
edits back before an uninstall wipes them, so uninstall -> reinstall keeps the
user's tuning. The content-policy ack persists, the policy link opens through
TopLevel.Launcher, the avatar-prompt validator runs (PromptValidator is in
Core) and logs through CoreModerationLog, the fallback-pool dropdown lists the
real custom-phrase categories, and the audio Test button previews through
CoreAudio. The dialog's hand-rolled Confirm window is deleted in favour of
this head's MessageDialog.

CompanionPhraseEditorDialog. The pool bookkeeping issue #892 depends on is
ported whole rather than sampled: RemovedPhraseIds hides a row permanently,
DisabledPhraseIds mutes it, custom rows live in CustomCompanionPhrases, and
LoadPhrases applies all three when rebuilding, so a mod top-up cannot
resurrect a phrase the user deleted. Every mutation ends in CoreSettings.Save()
plus a reload, as WPF's did - that round trip is what makes a removal stick.
The built-in half of the pool comes from CoreMods.GetPhrases, the same call
CompanionPhraseService.GetCategoryPhrases makes. TxtCustomPhrase_LostFocus is
back as one list-level handler. Browse-for-audio works: the native Avalonia
picker plus CopyAudioToFolder, and the audio overrides persist. The MessageBox
prompts - "no phrases selected", the remove-N confirm and the add-audio
question - are restored through MessageDialog. With no head attached the
sample rows still draw, so --render-view proves the template.

Still blocked, all in ConditioningControlPanel/Services/:
  - Companion/CompanionPhraseService.GetVoiceLineFiles / ResolveVoiceLineFolder
    - voice-line rows are missing from the phrase pool.
  - Companion/BarkService.GetAllBarkLines - bark rows likewise; the "Bark Lines"
    filter entry has nothing to match until it moves.
  - KeywordTriggerService.PreviewAudioClip - its ResolveAudioPath is inlined
    here, and CoreAudio is unseeded on this head, so Test resolves but is
    silent.
  - KeywordTriggerPresetService.PresetsChanged reaches only this dialog's own
    instance; the head needs one shared instance before a listener can exist.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU