### PR TITLE
feat(avalonia): restore the catalogue submission read side; correct three stale port notes

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CatalogueSubmissions.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CatalogueSubmissions.cs
@@ -1,30 +1,96 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.CatalogueSubmissions.cs (223 lines).
+// PARTIALLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.CatalogueSubmissions.cs
+// (223 lines). Sorted member by member against the fifteen Core seams; the file splits cleanly in
+// two along the read/write line, and the READ half is restored below.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// THE READ HALF IS HERE AND IS REAL. Every one of its inputs is in Core: the record shape is
+// CCP.Core/Models/DeeperSubmissionRecord.cs and the three per-kind dictionaries are fields of
+// AppSettings (CataloguePresetSubmissions / CatalogueSessionSubmissions / CatalogueModSubmissions,
+// AppSettings.cs:2347-2375), which CoreSettings.Current hands over. Nothing here touches a control,
+// so the x:Name hazard does not apply to this partial at all.
 //
-// Members dropped (14):
-//   public const string CatalogueKindPresets
-//   public const string CatalogueKindSessions
-//   public const string CatalogueKindMods
-//   private static readonly TimeSpan CatalogueCheckThrottle
-//   private readonly Dictionary<string, DateTime> _lastCatalogueCheckUtc
-//   private readonly HashSet<string> _catalogueChecksInFlight
-//   private static bool IsCatalogueAcceptedStatus(…)
-//   private static string CanonicalCataloguePathKey(…)
-//   private static Dictionary<string, DeeperSubmissionRecord>? GetCatalogueDict(…)
-//   internal static DeeperSubmissionRecord? GetCatalogueRecord(…)
-//   private void RecordCatalogueSubmission(…)
-//   public async Task CheckCatalogueSubmissionStatusesAsync(…)
-//   private void NotifyCatalogueSubmissionAccepted(…)
-//   private string ResolveCatalogueDisplayName(…)
+// Nothing on this head CALLS these yet, and that is the point of restoring them now: three ported
+// files name this file as what blocks their share-status badge -
+//   MainShellWindow.PresetIO.cs        CreateCatalogueStatusBadge (wants IsCatalogueAcceptedStatus),
+//                                      UpdatePresetShareStatusBadge (wants GetCatalogueRecord)
+//   MainShellWindow.SessionIO.cs       the session rack pill (CanonicalCataloguePathKey + record)
+//   Views/Dialogs/ModManagerDialog.axaml.cs:258  the per-row pill (kind "mods" + mod.Id)
+// - and none of those files is owned by this layer. They can now be wired without a Core change.
+//
+// THE WRITE HALF IS STILL OUT, for two different reasons:
+//   RecordCatalogueSubmission(kind, key, SubmissionResult)
+//       Its persistence body is portable line for line, but its parameter type is not:
+//       SubmissionResult is ConditioningControlPanel/Services/CatalogueService.cs:518, a head-only
+//       record hierarchy. Re-typing it to (id, status) here would be a second, divergent signature
+//       for the one call the WPF share paths make; it comes back with the catalogue client.
+//       It also ends by calling RefreshCatalogueShareBadges (MainShellWindow.PresetIO.cs, a stub).
+//   CheckCatalogueSubmissionStatusesAsync(kind, force)
+//       App.Catalogue.FetchMySubmissionsAsync / FetchMyCatalogueAssetsAsync - a network round trip
+//       with no seam. Its three throttle members (CatalogueCheckThrottle, _lastCatalogueCheckUtc,
+//       _catalogueChecksInFlight) exist only to pace that call and are left out with it.
+//   NotifyCatalogueSubmissionAccepted / ResolveCatalogueDisplayName
+//       App.Notifications.ShowSticky (ConditioningControlPanel/Services/Notifications/
+//       NotificationService.cs), which this head does not ship. ResolveCatalogueDisplayName itself
+//       would compile - UserPresets is in Core and CoreMods.InstalledMods answers the mod name -
+//       but its only caller is the toast above it, so it waits for the toast.
+//
+// Checked and NOT the blocker: CoreReleaseContent. It answers pack ids, install stamps and pack
+// info; the catalogue submission flow reads none of those.
+
+using System;
+using System.Collections.Generic;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        /// <summary>Route segment / dictionary selector for user-shared presets.</summary>
+        public const string CatalogueKindPresets = "presets";
+
+        /// <summary>Route segment / dictionary selector for user-shared sessions.</summary>
+        public const string CatalogueKindSessions = "sessions";
+
+        /// <summary>Route segment / dictionary selector for user-shared mods.</summary>
+        public const string CatalogueKindMods = "mods";
+
+        /// <summary>The two server statuses that mean "it is in the catalogue". Anything else -
+        /// pending, rejected, null - is still open.</summary>
+        internal static bool IsCatalogueAcceptedStatus(string? status) =>
+            string.Equals(status, "approved", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(status, "published", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>Sessions are file-backed, so their submission key is the canonical full path.
+        /// Presets and mods key by Id and do not go through here.</summary>
+        internal static string CanonicalCataloguePathKey(string filePath)
+        {
+            try { return System.IO.Path.GetFullPath(filePath); }
+            catch { return filePath; }
+        }
+
+        private static Dictionary<string, DeeperSubmissionRecord>? GetCatalogueDict(string kind)
+        {
+            // CoreSettings.Current is never null - with no head attached it is the shared default
+            // instance, whose three dictionaries are empty. That is the honest "nothing shared yet"
+            // answer, so the WPF null branch has nothing left to guard.
+            var s = CoreSettings.Current;
+            return kind switch
+            {
+                CatalogueKindPresets => s.CataloguePresetSubmissions,
+                CatalogueKindSessions => s.CatalogueSessionSubmissions,
+                CatalogueKindMods => s.CatalogueModSubmissions,
+                _ => null,
+            };
+        }
+
+        /// <summary>Current moderation status for one shared asset, or null if it was never
+        /// submitted. Static so a dialog can render its badge without a shell reference - that is
+        /// how ModManagerDialog uses it on WPF.</summary>
+        internal static DeeperSubmissionRecord? GetCatalogueRecord(string kind, string key)
+        {
+            var dict = GetCatalogueDict(kind);
+            if (dict == null || string.IsNullOrEmpty(key)) return null;
+            dict.TryGetValue(key, out var rec);
+            return rec;
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperSubmissions.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperSubmissions.cs
@@ -1,24 +1,37 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperSubmissions.cs (183 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.DeeperSubmissions.cs (183 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// The Deeper-specific twin of MainShellWindow.CatalogueSubmissions.cs, whose read half IS restored.
+// This one is not, and the reason is not "the models are missing" - AppSettings.DeeperSubmissions
+// (AppSettings.cs:2337) and DeeperSubmissionRecord are both in Core. It is that this file has no
+// read half worth extracting:
 //
-// Members dropped (8):
-//   private DateTime _lastSubmissionCheckUtc
-//   private static readonly TimeSpan SubmissionCheckThrottle
-//   private bool _submissionCheckInFlight
-//   private static bool IsAcceptedStatus(…)
-//   private static string CanonicalSubmissionKey(…)
-//   private void RecordDeeperSubmission(…)
-//   public async Task CheckDeeperSubmissionStatusesAsync(…)
-//   private void NotifyDeeperSubmissionAccepted(…)
+//   IsAcceptedStatus, CanonicalSubmissionKey
+//       Byte-identical bodies to IsCatalogueAcceptedStatus / CanonicalCataloguePathKey, which are
+//       now live one file over. Nothing outside this file calls the Deeper copies on WPF either
+//       (grepped), so restoring them would add a second spelling of a test this head already has.
+//       Whoever wires the Deeper library badge should call the catalogue pair.
+//   RecordDeeperSubmission(filePath, SubmissionResult)
+//       Blocked on its PARAMETER TYPE, not its body: SubmissionResult is
+//       ConditioningControlPanel/Services/CatalogueService.cs:518, head-only. It also ends by
+//       calling ApplyDeeperFilterAndSort, which is a stub in MainShellWindow.DeeperHub.cs.
+//   CheckDeeperSubmissionStatusesAsync(force)
+//       App.Catalogue.FetchMySubmissionsAsync - a network round trip with no seam. Its three
+//       pacing members (_lastSubmissionCheckUtc, SubmissionCheckThrottle, _submissionCheckInFlight)
+//       exist only to throttle that call and go with it.
+//   NotifyDeeperSubmissionAccepted(catalogueId, canonicalPath)
+//       App.Notifications.ShowSticky, which this head does not ship, plus _deeperAllEntries and
+//       SwitchToDeeperLibraryTab (both stubs, MainShellWindow.DeeperHub.cs / DeeperTab.cs). Its
+//       loc keys are real and portable: deeper_submission_accepted_toast_fmt via Loc.GetF, and
+//       deeper_submission_accepted_action_view for the View action.
+//
+// Checked and NOT the blocker: CoreReleaseContent. Pack ids, install stamps and pack info are not
+// read anywhere in this flow.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ModCatalogue.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ModCatalogue.cs
@@ -12,23 +12,30 @@
 //                              (…/Services/Notifications/NotificationService.cs) for all four
 //                              outcome toasts, and RecordCatalogueSubmission /
 //                              ShowCatalogueSubmissionResultToast, which are in
-//                              MainShellWindow.CatalogueSubmissions.cs - still a stub, and not a
-//                              file this layer owns. The AssetSubmitDialog it opens IS ported
-//                              (Views/Dialogs/AssetSubmitDialog).
+//                              MainShellWindow.CatalogueSubmissions.cs. That file's READ half is
+//                              live now (CatalogueKindMods, GetCatalogueRecord,
+//                              IsCatalogueAcceptedStatus), but the record-WRITE half is still out
+//                              because its parameter type SubmissionResult is head-only. The
+//                              AssetSubmitDialog it opens IS ported (Views/Dialogs/AssetSubmitDialog).
 //   HandleModDropAsync       - App.Mods.ReadManifest / InstallModAsync
 //                              (ConditioningControlPanel/Services/ModService.cs). CoreMods carries
 //                              the READ side of the mod seam (Affirmation, InstalledMods, the
 //                              colours); installing an archive is not on it. The MessageBox confirm
 //                              maps to Views/Dialogs/MessageDialog.ConfirmAsync, which this head
 //                              ships.
-//   BuildModCatalogueAsset   - Models.ModPackage / ModManifest
-//   SafeDirectorySize          (ConditioningControlPanel/Models/, not in Core). SafeDirectorySize is
-//                              pure BCL and would compile here, but a helper with no asset to size
-//                              is not a restoration.
-//   TryBuildPreviewThumb     - BitmapImage + JpegBitmapEncoder. The Avalonia equivalent is
-//                              Avalonia.Media.Imaging.Bitmap.CreateScaledBitmap + Save(stream), so
-//                              this one is a real port rather than a seam - it just has no caller
-//                              until BuildModCatalogueAsset above has its models.
+//   BuildModCatalogueAsset   - CORRECTION: an earlier revision of this header said ModPackage and
+//   SafeDirectorySize          ModManifest are "not in Core". They ARE - CCP.Core/Models/
+//                              ModPackage.cs and ModManifest.cs - and CCP.Avalonia gets
+//                              Newtonsoft.Json transitively through CCP.Core, so the JObject
+//                              envelope compiles here too. What actually blocks these two is
+//                              simply that their only caller is ShareModToCatalogueAsync above.
+//                              SafeDirectorySize is pure BCL; a helper with no asset to size is
+//                              not a restoration.
+//   TryBuildPreviewThumb     - BitmapImage + JpegBitmapEncoder, and this one is NOT a straight
+//                              rewrite: Avalonia's Bitmap.Save writes PNG only, so the 64 KB JPEG
+//                              cap below needs SkiaSharp's encoder reached directly. Avalonia.Skia
+//                              is referenced but SkiaSharp is not a direct package reference, and
+//                              a .csproj edit is out of this layer's scope.
 //   CatalogueSchemaMod       - "ccp-mod/v1", and the two preview caps. Constants with no reader.
 //   ModPreviewMaxPixels
 //   ModPreviewMaxBytes

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
@@ -36,9 +36,11 @@
 //   GoonPerkLockedOpacity   - the 0.42 dim for an unbought Goon perk. A constant with no reader
 //                             until RefreshPlayCards has its two entitlement answers.
 //
-// One more trap for whoever wires this: Views/Tabs/PlayTabView loads with AvaloniaXamlLoader.Load,
-// so ITS x:Name fields (PlayLockDtrh, SlotArcademy, TxtPlayGoonPerkSend, …) are null too - the same
-// hazard this window has. Every one of them must be reached with tab.FindControl<T>(name).
+// One correction for whoever wires this: an earlier revision of this header warned that
+// Views/Tabs/PlayTabView loads with AvaloniaXamlLoader.Load and so has null x:Name fields. That was
+// fixed at the source - PlayTabView's constructor calls InitializeComponent(), so PlayLockDtrh,
+// SlotArcademy, TxtPlayGoonPerkSend and the rest are populated and can be used directly. The hazard
+// is still real for THIS window, whose partials must reach controls through Named<T>(name).
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Quests.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Quests.cs
@@ -1,21 +1,38 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Quests.cs (124 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.Quests.cs (124 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// Five members, and both real ones are EVENT HANDLERS for App.Quests
+// (ConditioningControlPanel/Services/Progression/QuestService.cs). CoreProgression carries AddXP
+// and nothing else, so there is no QuestCompleted / QuestProgressChanged to subscribe to on this
+// head - a restored handler would be a method with no publisher. What they draw is not the
+// problem: QuestCompleteBanner and TxtQuestComplete are both in QuestsTabView.axaml:437-441 and
+// Views/Windows/QuestCompletePopup is ported.
 //
-// Members dropped (5):
-//   private QuestCompletePopup? _questCompletePopup
-//   private SolidColorBrush? _dailySegmentGold
-//   private SolidColorBrush? _dailySegmentGrey
-//   private void OnQuestCompleted(…)
-//   private void OnQuestProgressChanged(…)
+//   OnQuestCompleted(sender, QuestCompletedEventArgs)
+//       Needs Services.QuestCompletedEventArgs (head-only) for the quest name and XP it prints.
+//       Its body then reaches five more head services: App.PerkNotificationsSuppressed for the
+//       announce opt-out, App.Flash.PlayRandomSound for the celebration, RefreshQuestUI and
+//       RefreshQuestStamps (both stubs - see MainShellWindow.QuestsTab.cs), CelebrateQuestComplete
+//       (MainShellWindow.EventFx.cs), and App.ProfileSync.SyncProfileAsync. The banner's own
+//       shape ports cleanly when there is an event: IsVisible instead of Visibility, and the
+//       5-second auto-hide is Dispatcher.UIThread.Post off a Task.Delay.
+//   OnQuestProgressChanged(sender, QuestProgressEventArgs)
+//       Same missing event source, and its whole body is a call to RefreshQuestUI.
+//   _questCompletePopup
+//       Held only so the previous popup can be closed before the next opens. It belongs with
+//       OnQuestCompleted and comes back with it.
+//   _dailySegmentGold, _dailySegmentGrey
+//       Not used in this file at all - they are the lazily-built #FFD700 / #3D3D60 brushes for the
+//       daily progress segments, read in MainWindow.QuestsTab.cs:223-224. They land with the
+//       segment painter, in MainShellWindow.QuestsTab.cs, not here.
+//
+// What would unblock it: a quest seam carrying the two events plus the definition/active-quest
+// models. That is a Core layer, not this one.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.QuestsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.QuestsTab.cs
@@ -37,8 +37,12 @@
 //                             not restored because all it does is call RefreshQuestUI, so on this
 //                             head it would be a subscription that repaints nothing.
 //
-// Trap for whoever wires this: Views/Tabs/QuestsTabView loads with AvaloniaXamlLoader.Load, so ITS
-// x:Name fields are null - reach every control with tab.FindControl<T>(name).
+// One correction for whoever wires this: an earlier revision of this header warned that
+// Views/Tabs/QuestsTabView loads with AvaloniaXamlLoader.Load and so has null x:Name fields. That
+// was fixed at the source - QuestsTabView's constructor calls InitializeComponent() and already
+// uses DailyCard0..2, BtnRerollWeekly and StreakCalendarCanvas directly, so its fields can be used
+// as written. The hazard is still real for THIS window, whose partials must reach controls through
+// Named<T>(name).
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SubscribeStar.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SubscribeStar.cs
@@ -1,20 +1,46 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SubscribeStar.cs (121 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.SubscribeStar.cs (121 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// All four members are one account provider's presentation layer, and there is no provider on this
+// head: App.SubscribeStar is ConditioningControlPanel/Services/Account/SubscribeStarService.cs and
+// none of the fifteen seams covers an account, an entitlement or a tier. So this is a REFUSAL on
+// the safety line, not a "waiting for a model to move" note.
 //
-// Members dropped (4):
-//   private void InitializeSubscribeStarTab(…)
-//   private void OnSubscribeStarTierChanged(…)
-//   private void UpdateSubscribeStarUI(…)
-//   internal void BtnSubscribeStarLogin_Click(…)
+//   InitializeSubscribeStarTab   Subscribes to App.SubscribeStar.TierChanged. No event source.
+//   OnSubscribeStarTierChanged   The handler for it. Its WPF body then calls UpdatePatreonUI,
+//                                UpdateUnlockablesVisibility, RefreshProgramsUI and
+//                                MaybeShowPremiumCelebration - four more shell members that are
+//                                themselves stubs on this head. (Its Dispatcher.BeginInvoke maps
+//                                to Dispatcher.UIThread.Post, which is the only portable line in
+//                                the file.)
+//   UpdateSubscribeStarUI        THE ONE THAT MUST NOT BE HALF-PORTED. Its inputs are
+//                                svc.IsAuthenticated / CurrentTier / IsWhitelisted /
+//                                IsActiveSubscriber; with no service every one of them reads
+//                                false-or-None, so restoring it would paint the disconnected
+//                                branch unconditionally and forever - a card asserting "not
+//                                connected" about an account nobody asked. The card already says
+//                                that HONESTLY and statically: AccountSettingsSection.axaml:105-115
+//                                binds label_not_connected and
+//                                label_login_to_unlock_exclusive_features with {loc:Str}. Writing
+//                                .Text over those bindings would also drop them on the next
+//                                language change (the standing Avalonia trap), trading a correct
+//                                localized card for a stale one.
+//   BtnSubscribeStarLogin_Click  A login button. Needs App.SubscribeStar.Logout, App.Patreon /
+//                                App.Discord for the "last provider out tears the account down"
+//                                test, ClearAccountData, and OpenUnifiedLoginDialog - the unified
+//                                login dialog, which is not ported. The handler exists as an empty
+//                                stub where the card lives
+//                                (Views/Controls/AppSettings/AccountSettingsSection.axaml.cs:27),
+//                                so the button is inert rather than wrong.
+//
+// What would unblock it: an account seam over IsAuthenticated / CurrentTier / IsWhitelisted /
+// IsActiveSubscriber / DisplayName plus the TierChanged event, seeded per head. That is a Core
+// layer, not this one.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml.
     }
 }


### PR DESCRIPTION
MainShellWindow.CatalogueSubmissions.cs is no longer a wholesale stub. Its read half is back
for real - the three kind constants, IsCatalogueAcceptedStatus, CanonicalCataloguePathKey,
GetCatalogueDict and GetCatalogueRecord - because every input is already in Core:
DeeperSubmissionRecord is CCP.Core/Models/DeeperSubmissionRecord.cs and the three per-kind
dictionaries are AppSettings fields that CoreSettings.Current hands over. GetCatalogueDict drops
its WPF null branch: CoreSettings.Current is never null, and the default instance's empty
dictionaries are the honest "nothing shared yet" answer. NOTHING ON THIS HEAD CALLS THESE YET -
that is the point. Three ported files name this partial as what blocks their share-status badge
(MainShellWindow.PresetIO.cs, MainShellWindow.SessionIO.cs and
Views/Dialogs/ModManagerDialog.axaml.cs:258), none of them owned by this layer, and they can now
be wired without a Core change. No member touches a control, so the x:Name hazard does not apply
to this partial.

The write half stays out. RecordCatalogueSubmission is blocked on its PARAMETER TYPE, not its
body - SubmissionResult is head-only - and re-typing it to (id, status) would be a second,
divergent signature for the one call every share path makes.

DeeperSubmissions, SubscribeStar and Quests lose the blanket "wired when the services move to
Core" header for a per-member sort. SubscribeStar is a deliberate REFUSAL rather than a wait:
UpdateSubscribeStarUI with no account service would paint the disconnected branch
unconditionally and forever, and AccountSettingsSection.axaml:105-115 already says exactly that
honestly with {loc:Str} bindings that a .Text write would break on the next language change.
DeeperSubmissions' two pure statics are byte-identical duplicates of the catalogue pair now
live one file over, and nothing outside that file calls them even on WPF.

Three stale notes corrected. PlayTab and QuestsTab warned that PlayTabView and QuestsTabView
suffer the x:Name hazard; both constructors call InitializeComponent() and their fields are
populated, so that advice was wrong and is replaced by the fix. ModCatalogue claimed ModPackage
and ModManifest are "not in Core"; both are, and Newtonsoft.Json arrives transitively through
CCP.Core, so BuildModCatalogueAsset is blocked only by having no caller - while
TryBuildPreviewThumb is harder than that note said, because Avalonia's Bitmap.Save writes PNG
and the 64 KB JPEG cap needs SkiaSharp directly. Roadmap was already accurate and is untouched.

Checked and NOT the blocker anywhere here: CoreReleaseContent. It answers pack ids, install
stamps and pack info; no catalogue or submission path reads any of them.

Still blocked:
  SubmissionResult - ConditioningControlPanel/Services/CatalogueService.cs:518
  App.Catalogue.FetchMySubmissionsAsync / FetchMyCatalogueAssetsAsync / SubmitCatalogueAssetAsync
      - ConditioningControlPanel/Services/CatalogueService.cs
  App.Notifications.Show / ShowSticky
      - ConditioningControlPanel/Services/Notifications/NotificationService.cs
  App.SubscribeStar (IsAuthenticated, CurrentTier, IsWhitelisted, TierChanged, Logout)
      - ConditioningControlPanel/Services/Account/SubscribeStarService.cs
  OpenUnifiedLoginDialog, ClearAccountData, UpdatePatreonUI - unported shell members
  App.Quests (QuestCompleted, QuestProgressChanged, RerollDaily, SpendStreakFix)
      - ConditioningControlPanel/Services/Progression/QuestService.cs
  App.Roadmap (GetTrackProgress, IsTrackUnlocked, StepCompleted, TrackUnlocked)
      - ConditioningControlPanel/Services/RoadmapService.cs
  Services.TierGate.RequiresLab / RequiresPremium, App.Patreon.HasPremiumAccess / HasLabAccess,
      App.DailyFree.IsFreeToday, App.IntakePass.State - the Play wall's entitlement answers
  App.Mods.InstallModAsync / ModService.PeekManifestAsync
      - ConditioningControlPanel/Services/ModService.cs
  RefreshCatalogueShareBadges, ApplyDeeperFilterAndSort - stubs in
      MainShellWindow.PresetIO.cs / MainShellWindow.DeeperHub.cs, not owned by this layer

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU