### PR TITLE
feat(avalonia): the You door's three entries, the Catalogue link and the wall toggles work

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.AchievementsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.AchievementsTab.cs
@@ -1,14 +1,33 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.AchievementsTab.cs (875 lines).
+// PARTLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.AchievementsTab.cs (875 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// THE THREE NAV HANDLERS WERE NEVER BLOCKED. BtnAchievements_Click, BtnCompanion_Click and
+// BtnLeaderboard_Click are one ShowTab call each in WPF (MainWindow.AchievementsTab.cs:94-107) -
+// they live in this file only because the buttons sit next to the achievement grid in
+// MainWindow.xaml, not because they touch a service. All three are restored below, so the You
+// door's three top-level entries lead somewhere.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// The rest of the file IS blocked, but the reason is not "services move to Core" - it is that
+// the grid it builds does not exist on this head in this shape. WPF builds ~48 achievement cards
+// in code (BuildAchievementCard, BuildRewardBand, the filter chips, the tooltip pass) straight
+// into MainWindow.xaml's panel. The port gave the tab its own view,
+// CCP.Avalonia/Views/Tabs/AchievementsTabView, which draws the same page from XAML with an
+// AchievementsTabViewModel supplying the formatted counters. A card builder restored here would
+// have nothing to build into.
 //
-// Members dropped (48):
+// So the honest blocker list for the achievements page is short and specific, and all of it is
+// AchievementsTabView's rather than this file's:
+//   - the counts are placeholders in AchievementsTabViewModel (Unlocked/Total, RewardsEarned/
+//     RewardsTotal, PatronUnlocked/PatronTotal). Real values need AchievementService, which is
+//     head-side; CoreProgression deliberately does NOT carry it - the seam is AddXP and
+//     TrackBubbleCountResult, the two calls ported views actually make, not the whole service.
+//     "Is achievement X unlocked" is not on it, so IsAchievementUnlocked / RefreshAchievementTile
+//     / OnAchievementUnlockedInMainWindow have no source of truth here yet.
+//   - the reward map needs Services.WardrobeItem (head-side), and LoadAchievementImage needs the
+//     achievement art under the same asset root.
+//   - BtnViewSeasonRecap_Click needs Services.SeasonRecapService.HasAnySnapshot(), which is not in
+//     Core (only Models/SeasonRecap.cs is) - see BtnLeaderboard_Click below.
+//
+// Members dropped (48 - the three now restored are marked RESTORED):
 //   private const double AchvBadgePx
 //   private const double AchvRewardIconPx
 //   private static readonly SolidColorBrush AchvMutedBrush
@@ -28,9 +47,9 @@
 //   private const string AchvFilterUnlocked
 //   private const string AchvFilterLocked
 //   private const string AchvFilterRewards
-//   private void BtnAchievements_Click(…)
-//   private void BtnCompanion_Click(…)
-//   private void BtnLeaderboard_Click(…)
+//   private void BtnAchievements_Click(…)              RESTORED
+//   private void BtnCompanion_Click(…)                 RESTORED
+//   private void BtnLeaderboard_Click(…)               RESTORED
 //   internal void BtnViewSeasonRecap_Click(…)
 //   private void UpdateAchievementCount(…)
 //   private void UpdateRewardCount(…)
@@ -62,14 +81,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.AchievementsTab.cs; wired when they move to Core.
-        private void BtnAchievements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        private void BtnAchievements_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+            => ShowTab("achievements");
 
-        // ponytail: needs the services in MainWindow.AchievementsTab.cs; wired when they move to Core.
-        private void BtnCompanion_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        private void BtnCompanion_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+            => ShowTab("companion");
 
-        // ponytail: needs the services in MainWindow.AchievementsTab.cs; wired when they move to Core.
-        private void BtnLeaderboard_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>
+        /// Opens the Leaderboard.
+        ///
+        /// <para>ponytail: WPF also reveals LeaderboardTab.BtnViewSeasonRecap here, when
+        /// <c>Services.SeasonRecapService.HasAnySnapshot()</c> says a persisted snapshot exists.
+        /// That service is not in Core (only <c>CCP.Core/Models/SeasonRecap.cs</c> is), and the
+        /// button is authored hidden in LeaderboardTabView.axaml, so the correct state here is
+        /// "left hidden" - showing a re-view button with no snapshot to re-view would be the
+        /// worse half of the port. One line once the snapshot reader crosses.</para>
+        /// </summary>
+        private void BtnLeaderboard_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+            => ShowTab("leaderboard");
 
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Lab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Lab.cs
@@ -1,14 +1,42 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Lab.cs (1354 lines).
+// PARTLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.Lab.cs (1354 lines) - the
+// lockdown partial, and the launcher for every Lab activity.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// LockdownTabView names this file as its blocker. That is still true of the LOCKDOWN half and this
+// layer does not change it, but it is worth being exact about which half, because the two do not
+// have the same shape:
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+//   THE ONE MEMBER THAT WAS NEVER BLOCKED is LockdownBadge_Click, restored below. The badge is a
+//   signpost, not a control: it navigates to the Lockdown page and cannot end anything. ShowTab is
+//   real here, so the badge in the title bar now leads somewhere instead of swallowing the click.
 //
-// Members dropped (47):
+//   THE LOCKDOWN LIFECYCLE IS HARD-BLOCKED, and not on a service move. InitializeLockdown,
+//   BtnActivateLockdown_Click, OnLockdownActivated/Deactivated/Tick, the exit-phrase path and
+//   PreviewShowLockdownActivePanel need ConditioningControlPanel/Services/LockdownService plus the
+//   low-level keyboard hook (_keyboardHook.SuppressSystemKeys) - a Win32 WH_KEYBOARD_LL hook whose
+//   whole job is suppressing Win/Alt-Tab. There is no cross-platform twin of that, so it is a
+//   per-platform reimplementation (CLAUDE.md bucket E), not a port.
+//   SetLockdownBadge and FormatLockdownClock would compile here today - they are Named<Border> +
+//   TimeSpan.ToString - but they exist only to be driven by OnLockdownTick, so restoring them
+//   would add a clock nothing winds. Left named rather than half-built.
+//   ApplyLockdownTheme / RestoreLockdownTheme / PlayLockdownActivationAnimation repaint the whole
+//   window's brushes from code; on this head those are theme resources, and repainting them for a
+//   lockdown that cannot start would be motion with no cause.
+//
+//   THE POP-QUIZ AND GRADED-INTAKE EDITORS ARE NOT THIS FILE'S ANY MORE. WPF's MainWindow owned
+//   ChkPopQuizEnabled_Changed / SliderPopQuizFrequency_ValueChanged / BtnTestPopQuiz_Click because
+//   the intake markup was inline in MainWindow.xaml. The port moved that markup to
+//   CCP.Avalonia/Views/Tabs/GradedIntakeTabView.axaml, whose Click=/Changed= handlers name THAT
+//   view (GradedIntakeTabView.axaml.cs:36-38, still stubs). The first two are one CoreSettings
+//   write each - PopQuizEnabled and PopQuizFrequency are both in Core, and the slider needs the
+//   `_isLoading` guard because Avalonia raises ValueChanged on a programmatic set too. Restoring
+//   them HERE would be a second copy no click can reach; they belong in that view's layer.
+//   RefreshGradedIntakeGate / SetGradedIntakeGateCopy / EnsureIntakePassHooked stay blocked
+//   wherever they land: IntakePassService and App.Patreon.HasPremiumAccess are the gate.
+//
+//   THE ACTIVITY LAUNCHERS are all "new SomeWindow(...).Show()" over a service: quiz, intake,
+//   bureau, goon, chaos, arcademy, the FYP feed. Windows and services both, so both blocked.
+//
+// Members dropped (47 - the one now restored is marked RESTORED):
 //   private void InitializeLockdown(…)
 //   internal void BtnActivateLockdown_Click(…)
 //   internal void BtnStartQuiz_Click(…)
@@ -33,7 +61,7 @@
 //   private void OnLockdownTick(…)
 //   private static string FormatLockdownClock(…)
 //   private void SetLockdownBadge(…)
-//   private void LockdownBadge_Click(…)
+//   private void LockdownBadge_Click(…)                RESTORED
 //   internal void TxtLockdownTimer_Click(…)
 //   internal void TxtLockdownExit_KeyDown(…)
 //   private Action<PossessionRung>? _possessionRungHandler
@@ -57,12 +85,38 @@
 //   private void RestoreLockdownTheme(…)
 //   private void PlayLockdownActivationAnimation(…)
 
+using System;
+using Serilog;
+
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.Lab.cs; wired when they move to Core.
-        private void LockdownBadge_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
-
+        /// <summary>
+        /// The crimson pill in the title bar's status row. It is a signpost, not a button that
+        /// ends anything: it navigates to the Lockdown page, where the Emergency Exit and the
+        /// secret phrase both live. Nothing here can end a lockdown, which is what lets it sit one
+        /// pixel from the window's close button.
+        ///
+        /// <para><c>e.Handled = true</c> is kept for the same reason WPF sets it: the badge sits
+        /// inside the draggable title bar, and an unhandled press would start a window drag under
+        /// the finger that just navigated.</para>
+        ///
+        /// <para>ponytail: the badge's own visibility and clock still need
+        /// <c>SetLockdownBadge</c>/<c>OnLockdownTick</c>, i.e. LockdownService - see the header.
+        /// The XAML leaves it hidden, so today this handler is reachable only from a preview.</para>
+        /// </summary>
+        private void LockdownBadge_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e)
+        {
+            try
+            {
+                e.Handled = true;
+                ShowTab("lockdown");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Lockdown: badge navigation failed");
+            }
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.LabTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.LabTab.cs
@@ -1,14 +1,36 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs (1413 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.LabTab.cs (1413 lines) - the
+// webcam and microphone partial. Sorted member by member, and unlike its neighbours the blanket
+// claim holds here: this file is the camera and the mic. What it does NOT hold for:
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+//   OpenDeviceSettings and RefreshDeviceSettingsLists are listed below as dropped, and one of them
+//   is stale. OpenDeviceSettings ALREADY SHIPS on this head - MainShellWindow.Settings.cs:82,
+//   ShowTab("appsettings") + AppSettingsPage.FocusSection("devices"), asserted by --nav-check and
+//   called from SystemFeatureControl. Do not re-add it here; a second definition is a compile
+//   error, and a second copy would be the wrong kind of fix if it were not.
+//   RefreshDeviceSettingsLists genuinely is missing, and needs the camera/monitor enumeration
+//   below before it means anything.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// THE TWO STATUS PILLS ARE DELIBERATELY LEFT AS STUBS, and this is the file's one real judgement
+// call rather than a missing dependency:
 //
-// Members dropped (79):
+//   MicActivePill_Click is WPF's DisarmVoiceMic - it clears wake-word and push-to-talk, cuts live
+//   capture, tears down the audio loop and the keyboard hook, and downgrades any open Voice Lock
+//   Card to a typed solve so the lock still holds. It is a PRIVACY STOP.
+//   WebcamActivePill_Click is the same affordance for the camera: GazeFocus.Stop, BlinkTrainer.Stop,
+//   Webcam.Stop, released together.
+//   Half-porting either one is worse than the stub. The restorable half is the part that hides the
+//   pill; the unrestorable half is the part that closes the device. A pill that vanishes on click
+//   while the capture device stays open is a control that LIES about the most safety-relevant state
+//   this app has. Neither pill can be shown at all on this head today (both are driven by
+//   App.Webcam/App.Speech state changes that never arrive), so the stub costs nothing and the
+//   half-port would cost the user's trust.
+//
+// The rest is genuinely the device: WebcamTrackingService and its debug counters, the calibration
+// and quick-recal flows, the loading splash, GazeSide/FocusGaze, the blink trainer's countdown,
+// the camera and monitor enumerations, and the two consent buttons (WebcamConsent itself IS in
+// Core, but "revoke" has to stop a running capture, which is App.Webcam again).
+//
+// Members dropped (79 - OpenDeviceSettings is already live elsewhere, see above):
 //   private bool _webcamDebugSubscribed
 //   private int _webcamDebugBlinkCount
 //   private int _webcamDebugMouthOpenCount
@@ -44,7 +66,7 @@
 //   private void UpdateLabTrackerUi(…)
 //   private void UpdateWebcamStatusChips(…)
 //   private static string WebcamStateText(…)
-//   internal void OpenDeviceSettings(…)
+//   internal void OpenDeviceSettings(…)               ALREADY LIVE (MainShellWindow.Settings.cs:82)
 //   internal void RefreshDeviceSettingsLists(…)
 //   private string? _quickRecalTooltipBase
 //   private void RefreshQuickRecalHotkeyHint(…)
@@ -93,10 +115,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.LabTab.cs; wired when they move to Core.
+        // REFUSED, not pending - see the header. This is the mic's privacy stop (DisarmVoiceMic).
+        // The half that would port is the half that hides the pill; the half that cannot is the
+        // half that closes the capture device. Do not "wire" this one until App.Speech's disarm
+        // path exists on this head.
         private void MicActivePill_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
 
-        // ponytail: needs the services in MainWindow.LabTab.cs; wired when they move to Core.
+        // REFUSED for the same reason: the camera's panic stop (GazeFocus/BlinkTrainer/Webcam all
+        // released together). A pill that clears while the camera stays open is worse than one
+        // that does nothing.
         private void WebcamActivePill_Click(object? sender, global::Avalonia.Input.PointerPressedEventArgs e) { }
 
     }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Leaderboard.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Leaderboard.cs
@@ -1,11 +1,34 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs (1452 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.Leaderboard.cs (1452 lines) - and
+// for most of it, NOT HERE either. The old header said "the bodies come back when the services
+// move to Core", which is wrong twice: it names the wrong destination for a third of the file, and
+// the wrong blocker for the pure half.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHERE THIS WORK NOW GOES. WPF's MainWindow owned the board because the leaderboard markup was
+// inline in MainWindow.xaml. The port gave it a view, CCP.Avalonia/Views/Tabs/LeaderboardTabView,
+// which already owns the parts that need no service: the season countdown and its timer
+// start/stop discipline, SetLeaderboardMode + the Level-column relabel for the All-Time board, the
+// tier band construction (its Band(index) is BuildTierBand with the same four bound tables), and a
+// placeholder board so the page renders finished rather than gapped. Anything restored HERE that
+// paints a row would be a second copy no click can reach - the tab's own axaml names the tab's
+// handlers, not this window's, and NO member of this partial is referenced from
+// MainShellWindow.axaml at all. That is why the class body below is deliberately empty.
 //
-// Members dropped (54):
+// WHAT IS ACTUALLY BLOCKED, and by what:
+//   The rows. RefreshLeaderboardAsync / RankLeaderboardEntries / RebuildLeaderboardView /
+//   UpdateYouBar / UpdateYourRankDisplay / UpdateTrophyCaseColumns all start from
+//   Services.LeaderboardEntry over the account API (and the trophy-case columns additionally need
+//   SkillService). Neither is in Core. Sorting, searching and filtering are pure list work over
+//   those rows and are blocked only by having no rows - they are a half-hour once the fetch exists,
+//   and they belong in the VIEW when it happens.
+//   BtnLeaderboardDiscord_Click needs the Discord DM path; ReleaseLinks in Core carries links, not
+//   the DM.
+//   BtnJumpToMe_Click and the whole _lbFx* group are WPF-specific: an attached DependencyProperty
+//   (LbScrollOffsetProperty) animated to drive ScrollViewer offset, plus FindVisualDescendant,
+//   ScrollViewer clip fiddling and an overscroll bounce. Avalonia has no attached-DP animation
+//   twin; the port is Offset transitions on the ListBox's ScrollViewer, and it is view work, not
+//   window work. Explicitly a rewrite, not a move.
+//
+// Members dropped (54 - all of them; see above for which are simply in the wrong file now):
 //   private List<Services.LeaderboardEntry> _leaderboardRanked
 //   private string _leaderboardSortKey
 //   private string _leaderboardFilter
@@ -65,6 +88,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
+        // Deliberately empty - see the header. No member of this partial is referenced from
+        // MainShellWindow.axaml, and the parts that are not service-bound already live on
+        // CCP.Avalonia/Views/Tabs/LeaderboardTabView.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Presets.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Presets.cs
@@ -1,14 +1,32 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Presets.cs (2316 lines).
+// PARTLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.Presets.cs (2316 lines).
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// The old blanket header claimed every member reaches App.*, a service, a device, WebView2 or
+// Win32. Sorted member by member that is wrong three ways, and the three matter:
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+//   1. THE PRESET DROPDOWN IS DEAD ON BOTH HEADS. CmbPresets carries Visibility="Collapsed" in
+//      MainWindow.xaml:1830 and IsVisible="False" here, and NOTHING in either head ever shows it -
+//      grep for CmbPresets.Visibility returns no writes at all. So InitializePresets,
+//      RefreshPresetsDropdown and the load-confirm inside CmbPresets_SelectionChanged would
+//      populate a control no user can open. Every dependency of those three is available
+//      (Models.Preset with GetDefaultPresets/ApplyTo and AppSettings.UserPresets are in Core,
+//      CoreMods.MakeModAware and AccentColorHex answer) - they are skipped because there is
+//      nothing to show, not because anything is missing. The LIVE preset surface is the chip rail
+//      on PresetsTabView (RefreshPresetsList / CreatePresetCard / SelectPreset), which paints into
+//      PresetsTab.PresetCardsPanel and PresetsTab's detail pane; that is a view this layer does
+//      not own, and restoring the rail here would be a second copy no click can reach.
 //
-// Members dropped (87):
+//   2. The eleven Dashboard wall toggles resolve completely and are restored below.
+//
+//   3. BtnCatalogue_Click is a browser launch, not a service call, and is restored below.
+//
+// The rest of the list is genuinely blocked, for the reasons the old header gave: the session
+// engine (start/stop/pause and every OnSession* callback), the overlay services the feature cards
+// drive, FeaturePopupWindow, the corner-GIF picker, and the styled/media-drop dialogs.
+//
+// The handlers named by MainShellWindow.axaml are real methods, because a missing one is a XAML
+// compile error, not a runtime gap.
+//
+// Members dropped (87 - the four now restored are marked RESTORED):
 //   private void SetupHelpButtons(…)
 //   private void SetHelpContent(…)
 //   private void HelpVideoButton_Click(…)
@@ -52,9 +70,9 @@
 //   private static string? MysteryFeatureName(…)
 //   private static int MysteryFeatureTier(…)
 //   private static string MysteryFeatureArtPath(…)
-//   internal void ToggleWallFeature(…)
-//   internal static bool IsWallFeatureOn(…)
-//   internal void SetWallFeature(…)
+//   internal void ToggleWallFeature(…)                 RESTORED
+//   internal static bool IsWallFeatureOn(…)            RESTORED
+//   internal void SetWallFeature(…)                    RESTORED
 //   private void OnSettingsPropertyChangedForWall(…)
 //   internal void RefreshWallActiveStates(…)
 //   private static void SetTierBadge(…)
@@ -62,7 +80,7 @@
 //   internal void VelvetBtnWebcam_Click(…)
 //   internal void VelvetBtnAppInfo_Click(…)
 //   internal void VelvetBtnSchedulerRamp_Click(…)
-//   internal void BtnCatalogue_Click(…)
+//   internal void BtnCatalogue_Click(…)                RESTORED
 //   internal void BtnSessionHistory_Click(…)
 //   internal void BtnStartSession_Click(…)
 //   private async void StartSession(…)
@@ -97,7 +115,7 @@
 //   internal void BtnSaveOverPreset_Click(…)
 //   internal void BtnDeletePreset_Click(…)
 
-// ONE member of that list is NOT blocked and is restored below: OpenStudioModule. It is
+// OpenStudioModule was the first member restored here, and is not blocked either: it is
 // ShowTab("studio") + StudioTab.FocusRackEntry(key), and both halves are on this head - ShowTab is
 // real (MainShellWindow.TabNavigation.cs) and StudioTabView.FocusRackEntry is a full port. It is
 // the single editor entry every mosaic tile and the Play door's Loom card route through, so
@@ -137,13 +155,120 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             ShowTab("studio");
         }
 
-        // ponytail: needs the services in MainWindow.Presets.cs; wired when they move to Core.
-        private void BtnCatalogue_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>
+        /// The Catalogue entry on the Library door. WPF opens the web catalogue with
+        /// <c>Process.Start(UseShellExecute)</c>; Avalonia's <c>TopLevel.Launcher</c> is this
+        /// head's equivalent and works on Linux, so this is a port rather than a seam - the same
+        /// swap Views/Dialogs/UpdateFailedDialog and LoginDialog already make.
+        /// </summary>
+        private async void BtnCatalogue_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            try { await Launcher.LaunchUriAsync(new Uri("https://app.cclabs.app/catalogue")); }
+            catch (Exception ex) { Log.Warning(ex, "Failed to open CCP Catalogue URL"); }
+        }
 
-        // ponytail: needs the services in MainWindow.Presets.cs; wired when they move to Core.
+        // =====================================================================================
+        //  the Dashboard wall toggles
+        // =====================================================================================
+        // The eleven mosaic card toggles. Restored because every dependency answers: the flags are
+        // AppSettings fields (Core), the save is CoreSettings.Save, the refusal is
+        // MainShellWindow.SessionFeatureLock.cs, and the "also start or stop the live service"
+        // half is gated on App.IsEngineRunning - which is CoreSession.IsEngineRunning here, and
+        // FALSE on this head. So that branch is not dropped or faked: it is taken correctly, and
+        // with no engine running the persisted flag IS the whole truth of the feature's state.
+        // Nothing here can lie about a service that is running, because none can be.
+        // Two of the eleven are not gated that way: WPF's spiral and pinkfilter cases call
+        // App.Overlay.RefreshOverlays() UNCONDITIONALLY (MainWindow.Presets.cs:1329-1330), because
+        // the overlays repaint from settings rather than being started and stopped. There is no
+        // overlay service on this head either, so the outcome is the same - write the flag, save -
+        // but the reason differs, and it is the line to re-read when the overlays land.
+        //
+        // ponytail: SettingsTabView's thirteen Card*_Toggle / Combo*_Toggle stubs are what call
+        // these on WPF, and they are still stubs (Views/Tabs/SettingsTabView.axaml.cs:270-295,
+        // each already carrying in a comment the mw.ToggleWallFeature("<key>") it wants). That
+        // view is not this layer's, so these three have no caller yet - one line per stub.
+        //
+        // Still missing from this group, and all for the same reason: RefreshWallActiveStates,
+        // RefreshMosaicTierBadges, RefreshMysteryTile, SetTierBadge and
+        // OnSettingsPropertyChangedForWall PAINT the tiles, so they need SettingsTabView's card
+        // controls (and the tier badges additionally need App.Patreon). The state is correct
+        // here; showing it stays with the view that owns the cards.
+
+        /// <summary>The persisted flag behind a wall key. Unknown key = false.</summary>
+        internal static bool IsWallFeatureOn(string key)
+        {
+            var s = CoreSettings.Current;
+            return key switch
+            {
+                "flash" => s.FlashEnabled,
+                "video" => s.MandatoryVideosEnabled,
+                "subliminal" => s.SubliminalEnabled,
+                "spiral" => s.SpiralEnabled,
+                "pinkfilter" => s.PinkFilterEnabled,
+                "bubbles" => s.BubblesEnabled,
+                "lockcard" => s.LockCardEnabled,
+                "bubblecount" => s.BubbleCountEnabled,
+                "bouncingtext" => s.BouncingTextEnabled,
+                "mindwipe" => s.MindWipeEnabled,
+                "braindrain" => s.BrainDrainEnabled,
+                _ => false,
+            };
+        }
+
+        /// <summary>
+        /// Sets a wall feature to an explicit state and persists it. The one seam every
+        /// programmatic flip goes through - the wall card via <see cref="ToggleWallFeature"/>, and
+        /// on WPF the lockdown Dose keeper too. Deliberately does NOT consult the session feature
+        /// lock: the caller decides, exactly as in WPF.
+        /// </summary>
+        internal void SetWallFeature(string key, bool on)
+        {
+            var s = CoreSettings.Current;
+            try
+            {
+                switch (key)
+                {
+                    case "flash": s.FlashEnabled = on; break;
+                    case "video": s.MandatoryVideosEnabled = on; break;
+                    case "subliminal": s.SubliminalEnabled = on; break;
+                    case "spiral": s.SpiralEnabled = on; break;
+                    case "pinkfilter": s.PinkFilterEnabled = on; break;
+                    case "bubbles": s.BubblesEnabled = on; break;
+                    case "lockcard": s.LockCardEnabled = on; break;
+                    case "bubblecount": s.BubbleCountEnabled = on; break;
+                    case "bouncingtext": s.BouncingTextEnabled = on; break;
+                    case "mindwipe": s.MindWipeEnabled = on; break;
+                    case "braindrain": s.BrainDrainEnabled = on; break;
+                    default: return;   // unknown key: no write, no save
+                }
+                CoreSettings.Save();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "SetWallFeature({Key},{On}) failed", key, on);
+            }
+        }
+
+        /// <summary>Flips one wall card, refusing while a session holds the feature lock.</summary>
+        internal void ToggleWallFeature(string key)
+        {
+            if (RefuseIfSessionFeatureLocked($"card:{key}")) return;
+            SetWallFeature(key, !IsWallFeatureOn(key));
+        }
+
+        // ---- still blocked -------------------------------------------------------------------
+
+        // Pause needs the session engine itself (_sessionEngine.Pause/ResumeSession and its
+        // PauseCount for the tooltip) plus App.Lockdown.IsActive for the refusal, neither on this
+        // head. The middle third of it - the "costs XP" confirm over AppSettings.SkipPauseXpWarning
+        // and Views/Dialogs/MessageDialog - would port today, but a confirm in front of a pause
+        // that never happens is worse than a button that does nothing.
         private void BtnPauseSession_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
 
-        // ponytail: needs the services in MainWindow.Presets.cs; wired when they move to Core.
+        // Empty, and not because anything is missing: CmbPresets is collapsed on both heads (see
+        // item 1 in the header), so this handler cannot fire. Loading a preset for real would also
+        // need WPF's LoadSettings() re-seed of every open editor, which on this head is spread
+        // across the tab views rather than owned by the window.
         private void CmbPresets_SelectionChanged(object? sender, global::Avalonia.Controls.SelectionChangedEventArgs e) { }
 
     }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.QuestStamps.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.QuestStamps.cs
@@ -1,14 +1,33 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs (1034 lines).
+// PARTLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs (1034 lines) -
+// the wax-stamp cluster in the title bar, one stamp per daily/weekly quest.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS RESTORED. QuestStamps_Click, the whole cluster's navigation: "the plates do not handle
+// the click, so it bubbles here from a stamp and from the gaps between them alike" (WPF's own
+// comment), and the destination is ShowTab("quests"), which is real on this head. It is one third
+// of the file's user-visible behaviour and it never needed a service.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// WHAT THE OTHER TWO HANDLERS NEED, and why they are notes rather than bodies:
+//   QuestStamps_MouseEnter/Leave are MotionFx.HoverLift on QuestStampHost, plus - on leave - the
+//   per-stamp unzoom and the popup teardown. MotionFx is head-side (the reduced-motion gate reads
+//   App.Settings through it), and the lift itself is a RenderTransform tween Avalonia would write
+//   as a transition. The leave half additionally unwinds _hoveredStampKey/_stampInfos/_stampPopup,
+//   none of which exist without the build pass below. Faking the lift alone would be motion with
+//   no state behind it, so both stay named. See Views/Features/FeatureCard.axaml.cs:116/299 for
+//   the shape a hover lift takes on this head when it IS wanted.
 //
-// Members dropped (73):
+// WHAT IS GENUINELY BLOCKED. Everything that BUILDS a stamp: RefreshQuestStamps / AddStamp /
+// BuildQuestStamp read App.Quests for the day's quest list, its progress and its XP, and
+// InitializeQuestStamps subscribes to that service's five events (completed, progress, refreshed,
+// dismissed, mod changed). CoreProgression is not that seam - it carries AddXP and
+// TrackBubbleCountResult, deliberately narrow, and knows nothing about quests. The hover popup
+// (EnsureStampPopup / PaintStampPopup / Show / Hide) needs the same quest rows to paint, and the
+// twenty-odd frozen Brushes and the stamp geometry are constants that only that builder reads.
+// Net: this file draws nothing until a quest seam exists. QuestStampHost is authored empty AND
+// IsVisible="False" (MainShellWindow.axaml:2261) rather than filled with placeholder wax, so the
+// restored click below is correct-but-unreachable today: it becomes live the moment the builder
+// does, with no second edit here.
+//
+// Members dropped (73 - the one now restored is marked RESTORED):
 //   private const double QuestStampDailySize
 //   private const double QuestStampWeeklySize
 //   private static readonly double[] QuestStampOffsets
@@ -79,21 +98,40 @@
 //   private void Stamp_MouseEnter(…)
 //   private void Stamp_MouseLeave(…)
 //   private void RestoreStampHover(…)
-//   private void QuestStamps_Click(…)
+//   private void QuestStamps_Click(…)                  RESTORED
 //   private void QuestStamps_MouseEnter(…)
 //   private void QuestStamps_MouseLeave(…)
+
+using System;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.QuestStamps.cs; wired when they move to Core.
-        private void QuestStamps_Click(object? sender, global::Avalonia.Input.PointerReleasedEventArgs e) { }
+        /// <summary>
+        /// The whole cluster is one target: a click goes to the Quests tab through the same funnel
+        /// the nav button uses, so door expansion and the per-tab FX behave identically. WPF hides
+        /// the hover popup first; there is no popup on this head yet, so that line has nothing to
+        /// undo rather than being skipped.
+        /// </summary>
+        private void QuestStamps_Click(object? sender, global::Avalonia.Input.PointerReleasedEventArgs e)
+        {
+            try
+            {
+                e.Handled = true;
+                ShowTab("quests");
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[QuestStamps] navigation failed: {E}", ex.Message);
+            }
+        }
 
-        // ponytail: needs the services in MainWindow.QuestStamps.cs; wired when they move to Core.
+        // Both hover handlers are MotionFx.HoverLift plus, on leave, the popup teardown - see the
+        // header for why a lift with no stamps under it is not worth faking.
         private void QuestStamps_MouseEnter(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
 
-        // ponytail: needs the services in MainWindow.QuestStamps.cs; wired when they move to Core.
         private void QuestStamps_MouseLeave(object? sender, global::Avalonia.Input.PointerEventArgs e) { }
 
     }


### PR DESCRIPTION
Six MainShellWindow partials from the presets/keywords/status group, sorted member by member
against CCP.Core rather than against their own notes. Three of the eight named in the brief do
not exist on this head (MainShellWindow.KeywordHighlight.cs, .Achievements.cs, .Progression.cs);
their nearest equivalents that still carried the wholesale-stub header were taken instead -
.LabTab.cs, .AchievementsTab.cs and .QuestStamps.cs. The other two named files were already
finished and are untouched: .WorkAreaFit.cs is a full port, .Takeaway.cs already carries a precise
per-member blocker list.

Navigation. BtnAchievements_Click, BtnCompanion_Click and BtnLeaderboard_Click are one ShowTab
call each in WPF and were never blocked - the You door's three top-level entries now lead
somewhere instead of swallowing the click. LockdownBadge_Click (the title-bar badge is a signpost,
not a control that can end a lockdown) and QuestStamps_Click go the same way; both of those
controls are still authored hidden, so they are correct-but-unreachable until their state owners
exist, and each says so at its body.

The Catalogue entry on the Library door opens app.cclabs.app/catalogue for real, through
TopLevel.Launcher rather than WPF's Process.Start.

The eleven Dashboard wall toggles - IsWallFeatureOn / SetWallFeature / ToggleWallFeature - are
restored whole. Every flag is an AppSettings field in Core, the save is CoreSettings.Save, the
refusal is the session feature lock, and the "also start or stop the live service" branch is gated
on CoreSession.IsEngineRunning, which is false here - so that branch is taken correctly rather
than faked or dropped, and with no engine the persisted flag is the whole truth of the state.
NOTHING CALLS THESE THREE YET: their thirteen callers are SettingsTabView's Card*_Toggle stubs,
a view this layer does not own. One line per stub when that view's layer lands.

Refused on purpose, with the reason written into the file: MicActivePill_Click and
WebcamActivePill_Click. Both are privacy stops (disarm the mic; stop webcam + gaze + blink
trainer together). The half that ports is the half that hides the pill; the half that cannot is
the half that closes the capture device, so a half-port is a control that lies about the most
safety-relevant state in the app.

Four stale claims corrected while sorting: the preset dropdown is dead on BOTH heads (CmbPresets
is Visibility="Collapsed" in MainWindow.xaml:1830 and nothing anywhere ever shows it), so
InitializePresets / RefreshPresetsDropdown are skipped for having nothing to show rather than
anything missing; the pop-quiz editors moved to GradedIntakeTabView and would be a second copy
here; OpenDeviceSettings already ships at MainShellWindow.Settings.cs:82; and the leaderboard's
non-service half already lives on LeaderboardTabView.

Still blocked:
  LockdownService + the WH_KEYBOARD_LL hook (_keyboardHook.SuppressSystemKeys) - the whole
    lockdown lifecycle in MainShellWindow.Lab.cs, and therefore LockdownTabView's Activate,
    gate unlock, secret exit and timer taps. Bucket E, a per-platform reimplementation.
  App.Speech disarm path + App.Webcam/App.GazeFocus/App.BlinkTrainer Stop - the two pills in
    MainShellWindow.LabTab.cs.
  App.Quests (quest rows, progress, XP, five events) - every builder in
    MainShellWindow.QuestStamps.cs.
  Services/AchievementService + Services.WardrobeItem - the real counters behind
    AchievementsTabViewModel; CoreProgression is deliberately AddXP + TrackBubbleCountResult only.
  Services/SeasonRecapService.HasAnySnapshot - LeaderboardTabView's BtnViewSeasonRecap.
  Services.LeaderboardEntry fetch + SkillService - every row on the leaderboard.
  The session engine + App.Lockdown.IsActive - BtnPauseSession_Click.
  Views/Tabs/SettingsTabView.axaml.cs:270-295 - the thirteen toggle stubs that would call the
    restored wall members. Not this layer's file.

Verified: core-guards, CCP.Core and CCP.Avalonia build clean, --smoke, --nav-check and
--render-view MainShellWindow all pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU