### PR TITLE
feat(avalonia): the three FX surfaces obey the performance tier, reduced motion and mod switches

### DIFF
--- a/CCP.Avalonia/Controls/AmbientFxCanvas.cs
+++ b/CCP.Avalonia/Controls/AmbientFxCanvas.cs
@@ -6,6 +6,9 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using ConditioningControlPanel.Services;
 using Serilog;
+using ModPackage = ConditioningControlPanel.Models.ModPackage;
+using MotionLevel = ConditioningControlPanel.Models.MotionLevel;
+using PerformanceTier = ConditioningControlPanel.Models.PerformanceTier;
 
 namespace ConditioningControlPanel.Avalonia.Controls
 {
@@ -223,6 +226,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
         /// </summary>
         private readonly List<IDisposable> _windowHooks = new();
         private Window? _window;
+        private bool _modHooked;
 
         public AmbientFxCanvas()
         {
@@ -310,10 +314,9 @@ namespace ConditioningControlPanel.Avalonia.Controls
         }
 
         /// <summary>
-        /// Re-read the mod palette and repaint. The WPF original subscribed to
-        /// <c>App.Mods.ModChanged</c> for this; the Avalonia head has no mod service yet, so the
-        /// shell calls it instead.
-        /// ponytail: needs ModService.ModChanged, wired when it moves to Core.
+        /// Re-read the mod palette and repaint. Wired to <see cref="CoreMods.ModChanged"/> while
+        /// attached, exactly as the WPF twin subscribes to <c>App.Mods.ModChanged</c>; still public
+        /// because a host that repaints for its own reasons (a live event tint) pushes it too.
         /// </summary>
         public void RefreshPalette()
         {
@@ -592,8 +595,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
             try
             {
                 HookWindow(TopLevel.GetTopLevel(this) as Window);
-                // ponytail: needs ModService.ModChanged to re-read the palette on a mod switch,
-                // wired when it moves to Core; RefreshPalette() is the seam it will call.
+                if (!_modHooked) { CoreMods.ModChanged += OnModChanged; _modHooked = true; }
                 Evaluate();
             }
             catch (Exception ex) { Log.Debug("AmbientFxCanvas.OnAttachedToVisualTree: {E}", ex.Message); }
@@ -605,9 +607,21 @@ namespace ConditioningControlPanel.Avalonia.Controls
             {
                 StopClock();
                 UnhookWindow();
+                if (_modHooked) { CoreMods.ModChanged -= OnModChanged; _modHooked = false; }
             }
             catch (Exception ex) { Log.Debug("AmbientFxCanvas.OnDetachedFromVisualTree: {E}", ex.Message); }
             base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>
+        /// A mod switch re-reads the palette and repaints; it never reseeds, so the fog keeps its
+        /// drift and only its colour moves. The head raises this from whatever thread its mod
+        /// service switched on, so it is marshalled before touching the brushes.
+        /// </summary>
+        private void OnModChanged(object? sender, ModPackage mod)
+        {
+            if (Dispatcher.UIThread.CheckAccess()) RefreshPalette();
+            else Dispatcher.UIThread.Post(RefreshPalette);
         }
 
         /// <summary>The WPF twin's IsVisibleChanged handler; Avalonia routes it through the property system.</summary>
@@ -1087,39 +1101,29 @@ namespace ConditioningControlPanel.Avalonia.Controls
         }
 
         /// <summary>
-        /// Local copy of ConditioningControlPanel/Models/AppSettings.cs:PerformanceTier. The WPF
-        /// enum lives beside <c>AppSettings</c>, which is pinned to the head by <c>App.</c>; this
-        /// canvas only needs the three names to keep its tier switches a line-for-line diff against
-        /// the original. Nested and private on purpose: every FX control in this port hits the same
-        /// missing enum, and a second top-level copy in this namespace would be a CS0101 the moment
-        /// the stack is chained.
-        /// ponytail: local copy of Models/AppSettings.cs:PerformanceTier, delete when AppSettings
-        /// moves to Core.
-        /// </summary>
-        private enum PerformanceTier
-        {
-            Quality,
-            Balanced,
-            Performance,
-        }
-
-        /// <summary>
-        /// Everything this canvas asks the app about. In the WPF head these are
-        /// <c>PerformanceProfile</c>, <c>MotionFx</c> and <c>FxTheme</c>, all three of which read
-        /// <c>App.Settings</c>, <c>App.Mods</c> and <c>Application.Current.Resources</c> and so
-        /// cannot come along yet.
+        /// Everything the FX controls in this head ask the app about, in one place. In the WPF head
+        /// these are three services - <c>PerformanceProfile</c>, <c>MotionFx</c> and <c>FxTheme</c>.
+        /// The first two read <c>App.Settings</c>, which is <see cref="CoreSettings"/> now, so the
+        /// tier and the motion gate below are the real decision rather than a placeholder.
         ///
-        /// <para>ponytail: needs PerformanceProfile, MotionFx and FxTheme, wired when they move to
-        /// Core. The values below are the WPF Quality tier and FxTheme's own #FF69B4 fallback -
-        /// placeholder data, chosen so the canvas draws its full composition rather than silently
-        /// rendering nothing while the services are missing.</para>
+        /// <para>ponytail: internal and nested rather than a file of its own, because
+        /// <see cref="TakeoverOrb"/> and <see cref="VatGlassCanvas"/> read it and the per-tier
+        /// tables must exist exactly once. Those tables are pure and belong in Core beside
+        /// <c>PerformanceTier</c>; when PerformanceProfile moves, this becomes a forwarder.</para>
         /// </summary>
-        private static class Env
+        internal static class Env
         {
-            /// <summary>FxTheme.Fallback, the colour every slot resolves to with no mod loaded.</summary>
+            /// <summary>FxTheme.Fallback, the colour every slot resolves to with no palette set.</summary>
             private static readonly Color Fallback = Color.FromRgb(0xFF, 0x69, 0xB4);
 
-            public static PerformanceTier CurrentTier => PerformanceTier.Quality;
+            /// <summary>
+            /// PerformanceProfile.CurrentTier. Its automatic escalation counts live flash windows
+            /// and ambient bubbles; this head has neither, so HeavyElementCount is 0,
+            /// AutoPerformanceMode can never escalate, and the explicit toggle IS the whole
+            /// decision. Do not "fix" the missing Balanced branch - it is unreachable here.
+            /// </summary>
+            public static PerformanceTier CurrentTier =>
+                CoreSettings.Current.PerformanceMode ? PerformanceTier.Performance : PerformanceTier.Quality;
 
             /// <summary>PerformanceProfile.MaxAmbientParticles, verbatim.</summary>
             public static int MaxAmbientParticles(PerformanceTier tier) => tier switch
@@ -1140,17 +1144,49 @@ namespace ConditioningControlPanel.Avalonia.Controls
             /// <summary>PerformanceProfile.AllowAmbientMotion, verbatim.</summary>
             public static bool AllowAmbientMotion(PerformanceTier tier) => tier != PerformanceTier.Performance;
 
-            /// <summary>MotionFx.AllowAmbientLoops - the reduced-motion half is the missing piece.</summary>
-            public static bool AllowAmbientLoops => AllowAmbientMotion(CurrentTier);
+            /// <summary>
+            /// MotionFx.Level. WPF caps the user's setting to Reduced when Windows' animation-
+            /// effects flag is off; Avalonia exposes no cross-platform twin, and that cap can only
+            /// ever REMOVE motion, so its absence shows the user exactly what they picked rather
+            /// than more than they asked for.
+            /// ponytail: read the desktop's reduced-motion preference here when Avalonia has one.
+            /// </summary>
+            public static MotionLevel Level => CoreSettings.Current.MotionLevel;
+
+            /// <summary>MotionFx.AllowAmbientLoops, now the real gate.</summary>
+            public static bool AllowAmbientLoops =>
+                Level == MotionLevel.Full && AllowAmbientMotion(CurrentTier);
 
             /// <summary>MotionFx.AllowParticles.</summary>
             public static bool AllowParticles => AllowAmbientLoops && MaxAmbientParticles(CurrentTier) > 0;
 
-            public static Color MistColor => Fallback;
-            public static Color ParticleColor => Fallback;
-            public static Color GlowColor => Fallback;
-            public static Color FlashTintColor => Fallback;
+            // FxTheme's colours are read, not computed: it writes four Color keys into the app
+            // resources from the mod palette and every consumer reads them back. Theme/Colors.xaml
+            // already carries the keys, so this is that same read path - and nothing on this head
+            // writes them yet, which means the CCP default accent until an FxTheme twin lands.
+            public static Color MistColor => ThemeColor("FxMistColor");
+            public static Color ParticleColor => ThemeColor("FxParticleColor");
+            public static Color GlowColor => ThemeColor("FxGlowColor");
+            public static Color FlashTintColor => ThemeColor("FxFlashTintColor");
+
+            /// <summary>
+            /// FxTheme.MistOpacity. ponytail: needs <c>App.Mods.GetMistOpacity()</c>, which
+            /// CoreMods does not expose; 1.0 is what that call answers with no mod loaded.
+            /// </summary>
             public static double MistOpacity => 1.0;
+
+            /// <summary>FxTheme.Read's Avalonia twin: the same key out of the app resources.</summary>
+            private static Color ThemeColor(string key)
+            {
+                try
+                {
+                    var app = Application.Current;
+                    if (app != null && app.TryGetResource(key, app.ActualThemeVariant, out var v) && v is Color c)
+                        return c;
+                }
+                catch { /* decoration; the fallback is FxTheme's own */ }
+                return Fallback;
+            }
         }
     }
 }

--- a/CCP.Avalonia/Controls/TakeoverOrb.cs
+++ b/CCP.Avalonia/Controls/TakeoverOrb.cs
@@ -7,6 +7,7 @@ using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using Avalonia.Threading;
 using SkiaSharp;
+using ModPackage = ConditioningControlPanel.Models.ModPackage;
 
 namespace ConditioningControlPanel.Avalonia.Controls
 {
@@ -22,7 +23,8 @@ namespace ConditioningControlPanel.Avalonia.Controls
     /// second one:
     ///   • a self-stopping <see cref="DispatcherTimer"/> that only runs while the control is loaded,
     ///     visible, and its window is active and not minimized;
-    ///   • colours and the performance budget read ONCE at (re)start, never per tick;
+    ///   • colours and the performance budget read ONCE at (re)start and on a mod switch, never
+    ///     per tick;
     ///   • nothing allocated per frame - three persistent <see cref="SKImage"/> sprites baked once
     ///     for the whole app, two <see cref="SKPaint"/>s, and colour filters rebuilt only when the
     ///     palette moves;
@@ -84,6 +86,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
 
         private bool _active;
         private bool _paused;
+        private bool _modHooked;
         private int _faults;
         private Window? _window;
         private readonly Random _rng = new();
@@ -196,15 +199,16 @@ namespace ConditioningControlPanel.Avalonia.Controls
         {
             try
             {
-                // ponytail: needs PerformanceProfile + MotionFx, wired when they move to Core. The
-                // WPF original reads CurrentTier -> FxTargetFps / MaxAmbientParticles; these are the
-                // Quality-tier values it returns, so the orb behaves as it does on a default install.
-                _targetFps = 30;
+                // CurrentTier -> FxTargetFps / MaxAmbientParticles, exactly as the WPF original.
+                // At the Performance tier FxTargetFps is 0, which ShouldRun reads as "never start
+                // the clock" - the orb still PAINTS, it just stops moving.
+                var tier = AmbientFxCanvas.Env.CurrentTier;
+                _targetFps = AmbientFxCanvas.Env.FxTargetFps(tier);
                 if (_targetFps > 0)
                     _timer.Interval = TimeSpan.FromMilliseconds(1000.0 / _targetFps);
 
                 // A third of the shared ambient budget: this is one small element, not a field.
-                _wispBudget = Math.Clamp(60 / 4, 0, MaxWisps);
+                _wispBudget = Math.Clamp(AmbientFxCanvas.Env.MaxAmbientParticles(tier) / 4, 0, MaxWisps);
 
                 // The palette half of FxTheme is not a service - it reads the app resource
                 // dictionary, and Theme/Colors.xaml is already ported - so this is the real thing.
@@ -262,8 +266,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
             try
             {
                 HookWindow(TopLevel.GetTopLevel(this) as Window);
-                // ponytail: needs App.Mods.ModChanged, wired when the mod service moves to Core.
-                // Until then the palette is read once here and on Restart(), not on every mod swap.
+                if (!_modHooked) { CoreMods.ModChanged += OnModChanged; _modHooked = true; }
                 Evaluate();
             }
             catch (Exception ex) { Log("TakeoverOrb.OnLoaded: " + ex.Message); }
@@ -275,8 +278,26 @@ namespace ConditioningControlPanel.Avalonia.Controls
             {
                 StopClock();
                 UnhookWindow();
+                if (_modHooked) { CoreMods.ModChanged -= OnModChanged; _modHooked = false; }
             }
             catch (Exception ex) { Log("TakeoverOrb.OnUnloaded: " + ex.Message); }
+        }
+
+        /// <summary>
+        /// A mod switch re-reads the palette and the budget and repaints - it never reseeds, so the
+        /// ring keeps its orbits and only its colour moves, which is what the WPF twin does. The
+        /// head may raise this off the UI thread, so it is marshalled before the colour filters are
+        /// rebuilt.
+        /// </summary>
+        private void OnModChanged(object? sender, ModPackage mod)
+        {
+            void Apply()
+            {
+                try { ReadEnvironment(); Repaint(); }
+                catch (Exception ex) { Log("TakeoverOrb.OnModChanged: " + ex.Message); }
+            }
+            if (Dispatcher.UIThread.CheckAccess()) Apply();
+            else Dispatcher.UIThread.Post(Apply);
         }
 
         /// <summary>
@@ -339,8 +360,9 @@ namespace ConditioningControlPanel.Avalonia.Controls
             if (_paused || _faults >= FaultLimit) return false;
             if (!IsLoaded || !IsEffectivelyVisible) return false;
             if (_targetFps <= 0) return false;
-            // ponytail: needs MotionFx.AllowAmbientLoops, wired when it moves to Core. That flag is
-            // the reduced-motion / Performance-tier kill switch; assumed true here.
+            // The reduced-motion / Performance-tier kill switch. It stops the CLOCK only: Render
+            // still paints, so "off" is a still orb rather than a hole in the hero row.
+            if (!AmbientFxCanvas.Env.AllowAmbientLoops) return false;
             var w = _window;
             if (w != null)
             {
@@ -619,8 +641,8 @@ namespace ConditioningControlPanel.Avalonia.Controls
             return fallback;
         }
 
-        /// <summary>ponytail: needs App.Logger, wired when logging moves to Core.</summary>
-        private static void Log(string message) => System.Diagnostics.Debug.WriteLine(message);
+        /// <summary>App.Logger's twin: Serilog's static Log, fully qualified past this method.</summary>
+        private static void Log(string message) => Serilog.Log.Debug("{Message}", message);
 
         /// <summary>Soft white radial dot - the glow and wisp sprite.</summary>
         private static SKImage? Dot

--- a/CCP.Avalonia/Controls/VatGlassCanvas.cs
+++ b/CCP.Avalonia/Controls/VatGlassCanvas.cs
@@ -6,8 +6,12 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
+using Avalonia.Platform;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using Serilog;
+using ModPackage = ConditioningControlPanel.Models.ModPackage;
+using MotionLevel = ConditioningControlPanel.Models.MotionLevel;
 
 namespace ConditioningControlPanel.Avalonia.Controls
 {
@@ -80,6 +84,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
         private double _lastTickMs;
         private int _faults;
         private Window? _window;
+        private bool _modHooked;
 
         // ----------------------------------------------------------- engine state
 
@@ -179,19 +184,16 @@ namespace ConditioningControlPanel.Avalonia.Controls
         /// <summary>True while the faucet is in and pouring.</summary>
         public bool IsPouring => _pourT > 0;
 
-        // ponytail: needs MotionFx (perf tier + prefers-reduced-motion), wired when it moves to
-        // Core. Until then the vat draws its Full-motion self — waves, bubbles, foam and the 2.1s
-        // pour all run — which is the WPF behaviour on an unloaded machine.
         /// <summary>
         /// Reduced motion is the desktop's prefers-reduced-motion: waves, bubbles,
         /// the faucet, splash and spill all drop out and the level snaps instead of
         /// easing. The vat itself never disappears — a user who turned animation off
         /// did not ask to stop seeing today's XP.
         /// </summary>
-        private static bool Animated => true;
+        private static bool Animated => AmbientFxCanvas.Env.AllowAmbientLoops;
 
         /// <summary>MotionFx.Level == MotionLevel.Full. See <see cref="Animated"/>.</summary>
-        private static bool FullMotion => true;
+        private static bool FullMotion => AmbientFxCanvas.Env.Level == MotionLevel.Full;
 
         // ============================== public API ==============================
 
@@ -398,8 +400,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
             try
             {
                 HookWindow(TopLevel.GetTopLevel(this) as Window);
-                // ponytail: needs ModService.ModChanged to re-read the accent on a mod switch,
-                // wired when it moves to Core. RefreshPalette() is public so a host can push it.
+                if (!_modHooked) { CoreMods.ModChanged += OnModChanged; _modHooked = true; }
                 ReadPalette();
                 Evaluate();
             }
@@ -412,8 +413,26 @@ namespace ConditioningControlPanel.Avalonia.Controls
             {
                 StopClock();
                 UnhookWindow();
+                if (_modHooked) { CoreMods.ModChanged -= OnModChanged; _modHooked = false; }
             }
             catch (Exception ex) { Log.Debug("VatGlassCanvas.OnUnloaded: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// A mod switch re-reads the accent and repaints; the level, the pour and the wave phase
+        /// are untouched, so only the liquid's colour moves. Marshalled because the head may raise
+        /// the switch off the UI thread.
+        /// </summary>
+        private void OnModChanged(object? sender, ModPackage mod)
+        {
+            if (Dispatcher.UIThread.CheckAccess()) Apply();
+            else Dispatcher.UIThread.Post(Apply);
+
+            void Apply()
+            {
+                try { RefreshPalette(); }
+                catch (Exception ex) { Log.Debug("VatGlassCanvas.OnModChanged: {E}", ex.Message); }
+            }
         }
 
         /// <summary>WPF's IsVisibleChanged. Avalonia routes it through the property system.</summary>
@@ -952,19 +971,54 @@ namespace ConditioningControlPanel.Avalonia.Controls
             _liquidEdge = light;
         }
 
-        // ponytail: needs ModService (App.Mods.GetAccentColorHex / GetAccentLightColorHex), wired
-        // when it moves to Core. Null keeps the mockup's own hot-pink literals, which is exactly
-        // what the WPF file falls back to for a mod that ships no theme.
-        private static string? AccentHex => null;
-        private static string? AccentLightHex => null;
+        /// <summary>ModService.GetAccentColorHex's non-event branch, through the mod seam.</summary>
+        private static string? AccentHex => CoreMods.AccentColorHex;
+
+        /// <summary>
+        /// GetAccentLightColorHex's non-event branch, read off the active manifest the way
+        /// TubeFitDialog reads its tube layout - CoreMods exposes no accent-light provider.
+        /// ponytail: needs CoreMods.AccentLightColorHexProvider for the live-event tint, which
+        /// ModService shades from the event accent rather than taking from the manifest.
+        /// </summary>
+        private static string? AccentLightHex =>
+            CoreMods.InstalledMods.TryGetValue(CoreMods.ActiveModId, out var pkg)
+                ? pkg?.Manifest?.Theme?.AccentLightColor
+                : null;
 
         private static Color ParseHex(string? hex, Color fallback)
             => !string.IsNullOrWhiteSpace(hex) && Color.TryParse(hex, out var c) ? c : fallback;
 
-        // ponytail: needs the faucet art (Resources/descent/faucet.png, a WPF pack:// resource not
-        // yet in the Avalonia head's assets), wired when the descent art moves across. Null is the
-        // WPF file's own degradation path — the stream falls from 55% of the box with no plumbing
-        // drawn, because the level is the information and the faucet is only the theater.
-        private static IImage? LoadFaucet() => null;
+        /// <summary>
+        /// The faucet art, decoded once for the whole app. /Assets/descent is linked into this head
+        /// as Resources/descent, so the WPF pack:// URI becomes the avares:// one and nothing else
+        /// about the draw changes. Null stays the WPF file's own degradation path — the stream
+        /// falls from 55% of the box with no plumbing drawn — and _faucetTried keeps a miss from
+        /// re-decoding every frame.
+        /// </summary>
+        private static IImage? LoadFaucet()
+        {
+            if (_faucet != null || _faucetTried) return _faucet;
+            lock (FaucetLock)
+            {
+                if (_faucet != null || _faucetTried) return _faucet;
+                _faucetTried = true;
+                try
+                {
+                    var uri = new Uri("avares://CCP.Avalonia/Resources/descent/faucet.png");
+                    if (!AssetLoader.Exists(uri)) return null;
+                    using var stream = AssetLoader.Open(uri);
+                    _faucet = new Bitmap(stream);
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug("VatGlassCanvas: faucet art unavailable: {E}", ex.Message);
+                }
+                return _faucet;
+            }
+        }
+
+        private static IImage? _faucet;
+        private static bool _faucetTried;
+        private static readonly object FaucetLock = new();
     }
 }


### PR DESCRIPTION
The performance tier and the motion level. AmbientFxCanvas.Env was placeholder data -
a hardcoded Quality tier and a hardcoded #FF69B4 - because PerformanceProfile, MotionFx
and FxTheme all read App.Settings. AppSettings is in Core now, so Env reads
CoreSettings.Current: CurrentTier is PerformanceMode ? Performance : Quality (the auto
tier escalates on live flash windows and bubbles, neither of which exists on this head,
so HeavyElementCount is 0 and the explicit toggle IS the whole decision - said so in the
file), and AllowAmbientLoops is the real MotionLevel.Full && AllowAmbientMotion gate.
The private PerformanceTier copy is gone, replaced by the Core enum through a using
alias. Env is now internal and nested, and the orb and the vat read it, so the per-tier
tables exist exactly once in this head rather than three times; ugly name, right shape,
and the tables belong in Core beside PerformanceTier when PerformanceProfile moves.

That gate is what makes TakeoverOrb read FxTargetFps and MaxAmbientParticles/4 like the
WPF original instead of assuming 30fps and a 15-wisp ring, and what makes
VatGlassCanvas.Animated / FullMotion real - waves, bubbles, foam, the faucet and the
2.1s pour all drop out under reduced motion and the pour collapses to 120ms, exactly as
MotionFx.AllowAmbientLoops and MotionFx.Level drive them in the head. Neither surface
disappears when the clock stops: the orb keeps painting a still orb and the vat keeps
showing today's level, which is the promise both file headers already made and which
nothing on this head had exercised until now.

Mod switches. All three subscribed to nothing; CoreMods.ModChanged has been in Core for
several layers, so each hooks it while attached and re-reads its palette on the UI
thread (the head may raise the switch off it). Each does what its WPF twin does and no
more - re-read and repaint, never reseed - so a switch re-tints the fog, the ring and
the liquid without restarting their drift. No animation was added or changed anywhere:
these are DispatcherTimer sims, not storyboards, and the per-frame paths still allocate
nothing (the faucet bitmap is decoded once behind a double-checked flag, the radial
brushes still rebuild only when the palette moves). On THIS head the handlers are wired
and idle: only the WPF App forwards its ModService through CoreMods.RaiseModChanged, and
this head seeds no mod provider, so nothing raises the event here yet.

The vat's accent is CoreMods.AccentColorHex now, and its accent-light is read off the
active manifest the way TubeFitDialog reads its tube layout. Its faucet art was a stale
note: /Assets/descent is already linked into this head as Resources/descent, so the WPF
pack:// URI is an avares:// one and the plumbing draws. TakeoverOrb's logger note was
stale too - Serilog's static Log, fully qualified past the local Log helper.

Still blocked:
  - PerformanceProfile.MaxAmbientParticles / FxTargetFps / AllowAmbientMotion and
    MotionFx.ResolveLevel are pure and belong in CCP.Core beside PerformanceTier;
    AmbientFxCanvas.Env carries the copy until then
    (ConditioningControlPanel/Services/PerformanceProfile.cs, Services/MotionFx.cs).
  - No reduced-motion cap from the desktop. WPF caps MotionLevel to Reduced on
    SystemParameters.ClientAreaAnimation; Avalonia exposes no cross-platform twin, so
    this head shows the user exactly what they picked. The cap can only ever remove
    motion, so its absence never adds any.
  - FxTheme's WRITE half. Env reads the four Fx*Color keys out of the app resources,
    which is FxTheme's own read path, but nothing on this head writes them from the mod
    palette - so they stay Theme/Colors.xaml's CCP default. Needs an Avalonia
    FxTheme.ApplyForActiveMod (ConditioningControlPanel/Services/FxTheme.cs), plus
    CoreMods providers for GetMistColorRgb / GetParticleColorRgb / GetGlowColorRgb /
    GetFlashTintRgb / GetMistOpacity.
  - CoreMods.AccentLightColorHexProvider, for the live-event tint: ModService shades
    the event accent by 1.18 rather than taking accentLight off the manifest, and the
    manifest read here cannot see an event.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU