### PR TITLE
feat(avalonia): four shell buttons navigate for real, and the Deeper welcome card obeys its flag

### DIFF
--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Assets.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Assets.cs
@@ -1,127 +1,76 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.Assets.cs (2911 lines).
+// PARTIALLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.Assets.cs (2911 lines).
+// Sorted member by member against the fifteen Core seams. Only the tab's own entry point is real;
+// everything else is held back, and the two reasons below are different in kind.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// A REFUSAL, NOT A WAIT - the remote-media picker (InitializeRemoteMediaPicker,
+// BuildRemoteSourceChips, BuildRemoteNicheChips, RefreshRemoteMediaPicker, RemoteSourceChip_Changed,
+// RemoteNicheChip_Changed, AskRemoteMediaConsent, SliderRemoteRatio_Changed, AddRemoteCustomSub,
+// RemoveRemoteCustomSub, ToggleRemoteSubSelection, PersistRemoteChannelChange,
+// RebuildRemoteCustomSubChips, RebuildRemoteNicheSubs, BuildRemoteChip, MutedRemoteNote,
+// EndRemoteSubProbe, ShowRemoteSubError, TxtRemoteCustomSub_KeyDown, BtnRemoteAddSub_Click and the
+// MediaSrc* / RemoteCustomSubCap constants). Two things make a partial port worse than the stub:
+//   1. AskRemoteMediaConsent is a SYNCHRONOUS gate. RemoteSourceChip_Changed writes
+//      settings.MediaSource only if MessageBox.Show came back Yes (MainWindow.Assets.cs:2353-2360).
+//      This head's MessageDialog.ShowDialog<T> is async, so a straight transcription flips the chip
+//      and returns before the answer lands - a consent gate that is SKIPPED rather than degraded,
+//      on the one switch that starts fetching third-party adult content.
+//   2. Even with the ask solved, the switch calls FypOnlineCoordinator.ResetAllChannels()
+//      (ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs) and
+//      InvalidateAssetPoolsAfterSelectionChange(). Without both, the media services keep serving
+//      pools built for the OLD source while the picker says the new one is live.
+// The picker comes back with the coordinator and an async consent gate, together, or not at all.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// A WAIT - the asset tree, and worth being exact because one dependency has already moved.
+// AssetTreeItem IS in Core (CCP.Core/Models/AssetTreeItem.cs), CorePaths.EffectiveAssets is the
+// asset root, and DisabledAssetPaths is a field of CoreSettings.Current. BuildFolderTree therefore
+// transcribes line for line, and is still left out because its only caller cannot be honest:
+// RefreshAssetTree's third branch is the Content Packs node, built from
+// App.ContentPacks.GetActivePackIds (ConditioningControlPanel/Services/Content/ContentPackService.cs), and
+// a tree that quietly omits every installed pack's media reads to the user as "those files are
+// gone" rather than "packs are not ported". It comes back with the pack service, in one piece.
+// The same holds for RefreshAssetTree, BuildPackTree, UpdateAssetCounts, CountAssetsRecursive,
+// RecalculateFolderCheckState, RecalculateAllFolderCheckStates, SetFolderAndChildrenChecked,
+// UpdateFolderFilesCheckState, UpdateFileCheckState, UpdateParentFolderCheckState,
+// FolderCheckBox_Changed, ThumbnailCheckBox_Changed, AssetTreeView_SelectedItemChanged,
+// BtnSelectAllAssets_Click, BtnDeselectAllAssets_Click, BtnSaveAssetSelection_Click and
+// InvalidateAssetPoolsAfterSelectionChange.
 //
-// Members dropped (106):
-//   private ObservableCollection<AssetTreeItem> _assetTree
-//   private ObservableCollection<AssetFileItem> _currentFolderFiles
-//   private AssetTreeItem? _selectedFolder
-//   private void BtnAssets_Click(…)
-//   internal void BtnOpenAssetsFolder_Click(…)
-//   internal void BtnDeleteDownloadedPacks_Click(…)
-//   private async Task RefreshPacksAsync(…)
-//   private void StartPackPreviewRotation(…)
-//   private void StopPackPreviewRotation(…)
-//   private async Task<List<BitmapImage>> LoadPreviewImagesFromUrlsAsync(…)
-//   private static string GetPackPreviewFileStem(…)
-//   private void OnPackDownloadProgress(…)
-//   private void OnPackDownloadCompleted(…)
-//   private void OnPackAuthenticationRequired(…)
-//   private void OnPackRateLimitExceeded(…)
-//   internal void BtnCreatorDiscord_Click(…)
-//   internal void BtnGetPacks_Click(…)
-//   internal void PacksScrollViewer_PreviewMouseWheel(…)
-//   internal void HorizontalScrollViewer_PreviewMouseWheel(…)
-//   internal void InnerScrollViewer_PreviewMouseWheel(…)
-//   internal void BtnRefreshPacks_Click(…)
-//   private void RefreshAssetTree(…)
-//   private AssetTreeItem? BuildPackTree(…)
-//   private AssetTreeItem BuildFolderTree(…)
-//   internal void AssetTreeView_SelectedItemChanged(…)
-//   private void RecalculateFolderCheckState(…)
-//   private void RecalculateAllFolderCheckStates(…)
-//   private void LoadPackFolderThumbnails(…)
-//   private const int MaxThumbnailCacheEntries
-//   private const long MaxThumbnailCacheBytes
-//   private static readonly Dictionary<string, ImageSource> _packThumbnailCache
-//   private static readonly Dictionary<string, long> _packThumbnailLastAccess
-//   private static readonly Dictionary<string, long> _packThumbnailSizes
-//   private static long _packThumbnailCacheBytes
-//   private static long _packThumbnailAccessCounter
-//   private static readonly SemaphoreSlim _thumbnailSemaphore
-//   private async Task LoadPackThumbnailAsync(…)
-//   private void LoadFolderThumbnails(…)
-//   private async Task LoadThumbnailAsync(…)
-//   private bool _isUpdatingFolderCheckState
-//   internal void FolderCheckBox_Changed(…)
-//   private void SetFolderAndChildrenChecked(…)
-//   private void RefreshThumbnailCheckboxes(…)
-//   private void UpdateFolderFilesCheckState(…)
-//   internal void ThumbnailCheckBox_Changed(…)
-//   internal void ThumbnailItem_Click(…)
-//   internal void ThumbnailItem_Preview_Click(…)
-//   internal void ThumbnailItem_OpenInExplorer_Click(…)
-//   private void OpenAssetPreview(…)
-//   private void UpdateFileCheckState(…)
-//   private void UpdateParentFolderCheckState(…)
-//   private void InvalidateAssetPoolsAfterSelectionChange(…)
-//   internal void BtnSelectAllAssets_Click(…)
-//   internal void BtnDeselectAllAssets_Click(…)
-//   private void BtnSaveAssetSelection_Click(…)
-//   private bool _isLoadingPreset
-//   private void InitializeAssetPresets(…)
-//   private void UpdatePresetCountsFromCurrentState(…)
-//   private void CountEnabledFilesRecursive(…)
-//   private void RefreshAssetPresetsComboBox(…)
-//   internal void CmbAssetPresets_SelectionChanged(…)
-//   internal void BtnSaveAssetPreset_Click(…)
-//   internal void BtnUpdateAssetPreset_Click(…)
-//   internal void BtnDeleteAssetPreset_Click(…)
-//   private bool _isLoadingPhrasePreset
-//   private void InitializePhrasePresets(…)
-//   private void RefreshPhrasePresetsComboBox(…)
-//   internal void CmbPhrasePresets_SelectionChanged(…)
-//   internal void BtnSavePhrasePreset_Click(…)
-//   internal void BtnDeletePhrasePreset_Click(…)
-//   private void UpdateAssetCounts(…)
-//   private void CountAssetsRecursive(…)
-//   internal async void BtnPackDownload_Click(…)
-//   internal void BtnPackActivate_Click(…)
-//   private void BtnPackUpgrade_Click(…)
-//   private void BtnPackPatreon_Click(…)
-//   private const string MediaSrcLocal
-//   private const string MediaSrcOnline
-//   private const string MediaSrcMixed
-//   private bool _remotePickerWired
-//   private bool _remotePickerSyncing
-//   private readonly List<ToggleButton> _remoteSourceChipButtons
-//   private readonly List<ToggleButton> _remoteNicheChipButtons
-//   private readonly HashSet<string> _remoteNicheExpanded
-//   private string? _remoteSubPending
-//   private const int RemoteCustomSubCap
-//   private void InitializeRemoteMediaPicker(…)
-//   private void BuildRemoteSourceChips(…)
-//   private void BuildRemoteNicheChips(…)
-//   private void RefreshRemoteMediaPicker(…)
-//   private void RemoteSourceChip_Changed(…)
-//   private bool AskRemoteMediaConsent(…)
-//   private void RemoteNicheChip_Changed(…)
-//   private void SliderRemoteRatio_Changed(…)
-//   private void BtnRemoteAddSub_Click(…)
-//   private void TxtRemoteCustomSub_KeyDown(…)
-//   private async void AddRemoteCustomSub(…)
-//   private void EndRemoteSubProbe(…)
-//   private void ShowRemoteSubError(…)
-//   private void RemoveRemoteCustomSub(…)
-//   private void ToggleRemoteSubSelection(…)
-//   private void PersistRemoteChannelChange(…)
-//   private void RebuildRemoteCustomSubChips(…)
-//   private Border BuildRemoteChip(…)
-//   private void RebuildRemoteNicheSubs(…)
-//   private static TextBlock MutedRemoteNote(…)
+// Checked and NOT the blocker anywhere in this file: CoreModArt. It answers a mod's art override
+// as a path, and this partial reads no mod art at all - its thumbnails come from the user's own
+// library and from downloaded packs. CorePaths.EffectiveAssets IS the right root for the tree, and
+// is named above rather than wired, because nothing here is wired yet.
+//
+// The rest, by blocker:
+//   App.ContentPacks - RefreshPacksAsync, BtnRefreshPacks_Click, BtnPackDownload_Click,
+//     BtnPackActivate_Click, BtnPackUpgrade_Click, BtnDeleteDownloadedPacks_Click, and the four
+//     OnPack* progress/auth/rate-limit callbacks.
+//   Thumbnail decode + cache - LoadPackFolderThumbnails, LoadPackThumbnailAsync,
+//     LoadFolderThumbnails, LoadThumbnailAsync, RefreshThumbnailCheckboxes and the six static cache
+//     fields. WPF decodes to BitmapImage with DecodePixelWidth; the Avalonia twin is
+//     new Avalonia.Media.Imaging.Bitmap(path), so this is a rewrite rather than a move, and it
+//     belongs with the tree that would display it.
+//   The OS - BtnOpenAssetsFolder_Click (Process.Start("explorer.exe")), ThumbnailItem_OpenInExplorer_Click,
+//     BtnCreatorDiscord_Click, BtnGetPacks_Click, BtnPackPatreon_Click. The shell already ships the
+//     folder PICKER (MainShellWindow.Settings.cs, RequestPickAssetsFolder); what is missing is the
+//     "show it to me" half, which is a file-manager launch and belongs in a head helper, not here.
+//   Preview windows - OpenAssetPreview, ThumbnailItem_Click, ThumbnailItem_Preview_Click,
+//     StartPackPreviewRotation, StopPackPreviewRotation, LoadPreviewImagesFromUrlsAsync,
+//     GetPackPreviewFileStem (pure, and held with the rotation that is its only caller).
+//   Preset dropdowns - InitializeAssetPresets, RefreshAssetPresetsComboBox,
+//     CmbAssetPresets_SelectionChanged, BtnSaveAssetPreset_Click, BtnUpdateAssetPreset_Click,
+//     BtnDeleteAssetPreset_Click, UpdatePresetCountsFromCurrentState, CountEnabledFilesRecursive,
+//     and the phrase-preset five. Blocked on the asset tree above, which is what they count.
+//   WPF input - PacksScrollViewer_PreviewMouseWheel, HorizontalScrollViewer_PreviewMouseWheel,
+//     InnerScrollViewer_PreviewMouseWheel. Avalonia has no PreviewMouseWheel; these are the
+//     nested-scroller workaround and need re-deriving, not porting.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.Assets.cs; wired when they move to Core.
-        private void BtnAssets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
+        /// <summary>The rail's Library door. One ShowTab call, exactly as in WPF
+        /// (MainWindow.Assets.cs:39). The tab it opens is still an empty shell.</summary>
+        private void BtnAssets_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+            => ShowTab("assets");
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperTab.cs
@@ -1,74 +1,127 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.DeeperTab.cs (1241 lines).
+// PARTIALLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.DeeperTab.cs (1241 lines).
+// Sorted member by member against the fifteen Core seams; the blanket "wired when the services
+// move to Core" claim was wrong for the tab's own entry path, which is restored below.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL HERE: opening the Deeper tab. BtnDeeper_Click navigates, retires the rail pulse
+// flag (HasSeenDeeperTab, CCP.Core/Models/AppSettings.cs:7929) through CoreSettings, and shows or
+// hides the welcome card from HasSeenDeeperWelcome (:7935). DismissDeeperWelcomeCard writes the
+// other flag and folds the card. NOTHING CALLS DismissDeeperWelcomeCard YET - its three WPF
+// callers (BtnDeeperWelcomeTour / Demo / Dismiss) relay from DeeperTabView.axaml.cs, which this
+// layer does not own; it is internal so that relay needs no Core change when it lands.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// THE x:NAME HAZARD APPLIES TWICE HERE, and both hops go through FindControl for that reason.
+// This window loads with AvaloniaXamlLoader.Load(this), so "DeeperTab" is reached with Named<T>.
+// DeeperTabView loads the same way (DeeperTabView.axaml.cs:24), so its DeeperWelcomeCard field is
+// permanently null even though the .axaml marks it x:FieldModifier="internal" - that modifier
+// invites exactly the write that would silently do nothing. FindControl on the view reads its own
+// name scope and is the only form that works.
 //
-// Members dropped (53):
-//   internal void BtnDeeper_Click(…)
-//   private void UpdateDeeperWelcomeCardVisibility(…)
-//   private void DismissDeeperWelcomeCard(…)
-//   internal void BtnDeeperWelcomeTour_Click(…)
-//   internal void BtnDeeperWelcomeDemo_Click(…)
-//   internal void BtnDeeperWelcomeDismiss_Click(…)
-//   internal void BtnDeeperTutorial_Click(…)
-//   private void OpenDeeperBundledDemo(…)
-//   private void StartDeeperTabTutorial(…)
-//   internal void ChkEnableDeeper_Changed(…)
-//   private bool _deeperPulseRunning
-//   private void StartDeeperTabPulse(…)
-//   private void StopDeeperTabPulse(…)
-//   internal void BtnDeeperNewEnhancement_Click(…)
-//   internal void BtnDeeperOpenPlayer_Click(…)
-//   private void OnDeeperBrowserBound(…)
-//   private void OnDeeperBrowserUnbound(…)
-//   private bool _browserWebcamStateSubscribed
-//   private Action<WebcamTrackingState>? _onBrowserWebcamStateChanged
-//   private string? _browserWebcamPromptShownForUrl
-//   private void EnsureBrowserWebcamStateSubscribed(…)
-//   private void RefreshBrowserWebcamButton(…)
-//   internal async void BtnWebcamTracking_Click(…)
-//   private static bool BrowserEnhancementNeedsWebcam(…)
-//   private void MaybePromptBrowserWebcamForEnhancement(…)
-//   private bool _mandatoryVideoEnhanceNudgeShown
-//   private async void MaybePromptMandatoryVideoEnhancement(…)
-//   internal void ToggleEnhanceIfPossible_Changed(…)
-//   internal void ChkForceShowBambiCloud_Changed(…)
-//   private void OnBrowserEnhanceMatchChanged(…)
-//   private void OpenDeeperEditor(…)
-//   public void OpenInDeeperPlayer(…)
-//   public void OpenDeeperEditorFromPlayer(…)
-//   public void OpenDeeperEnhancementInPlayer(…)
-//   public void OpenInDeeperEditorForMedia(…)
-//   public void HandlePendingFileOpen(…)
-//   private void OnDeeperLibraryChanged(…)
-//   private void RefreshDeeperLibraryUI(…)
-//   private void OpenDeeperFile(…)
-//   internal void BtnDeeperOpenLibraryFolder_Click(…)
-//   internal void BtnDeeperImport_Click(…)
-//   private static bool IsImportableEnhancementPath(…)
-//   private void ImportEnhancementFiles(…)
-//   private void DeleteDeeperLibraryEntry(…)
-//   private void TriggerCatalogueLookupForNavigation(…)
-//   private async System.Threading.Tasks.Task RunCatalogueLookupAsync(…)
-//   private void ShowCatalogueLookupToast(…)
-//   private void OpenCataloguePickerDialog(…)
-//   private async System.Threading.Tasks.Task DownloadAndOpenCatalogueEntryAsync(…)
-//   private void SwitchToDeeperLibraryTab(…)
-//   private static bool IsCatalogueEligible(…)
-//   private async Task SubmitDeeperLibraryEntryAsync(…)
-//   private void ShowCatalogueSubmissionResultToast(…)
+// NOT BLOCKED, MOVED: ChkEnableDeeper_Changed. The Deeper master switch is now owned by
+// Views/Controls/AppSettings/GeneralSettingsSection.axaml.cs:142, which persists EnableDeeper and
+// guards its own programmatic sets. It is not this partial's job any more; a second copy here
+// would be a second writer for one setting.
+//
+// STILL OUT, and why:
+//   The library, the player and the editor - OpenDeeperFile, OpenInDeeperPlayer,
+//   OpenDeeperEditorFromPlayer, OpenInDeeperEditorForMedia, RefreshDeeperLibraryUI,
+//   OnDeeperLibraryChanged, BtnDeeperImport_Click, ImportEnhancementFiles, DeleteDeeperLibraryEntry,
+//   OpenDeeperBundledDemo, HandlePendingFileOpen. All of them go through App.EnhancementLibrary
+//   (ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs). The Deeper windows on this
+//   head reach a library of their own; the SHELL has no reference to one and there is no seam.
+//   InitializeDeeperHub / ReloadDeeperLibraryFromDisk are stubs in MainShellWindow.DeeperHub.cs,
+//   which this layer does not own, so BtnDeeper_Click leaves that pair out rather than half-scan.
+//   The browser half - OnDeeperBrowserBound/Unbound, RefreshBrowserWebcamButton,
+//   BtnWebcamTracking_Click, MaybePromptBrowserWebcamForEnhancement, OnBrowserEnhanceMatchChanged,
+//   ChkForceShowBambiCloud_Changed, ToggleEnhanceIfPossible_Changed. WebView2 plus WebcamTrackingState.
+//   BtnWebcamTracking_Click is also a REFUSAL and not just a wait: its portable half flips a caption,
+//   its unportable half opens or closes the camera, and the same judgement recorded for the two
+//   status pills in MainShellWindow.LabTab.cs holds - a control that reports tracking with no
+//   camera behind it is worse than one that does nothing.
+//   The tutorial - StartDeeperTabTutorial, BtnDeeperTutorial_Click, BtnDeeperWelcomeTour_Click.
+//   StartTutorial(TutorialType.Deeper) is not on this head.
+//   The rail pulse - StartDeeperTabPulse / StopDeeperTabPulse, a WPF storyboard on BtnDeeper.
+//   The catalogue - TriggerCatalogueLookupForNavigation, RunCatalogueLookupAsync,
+//   OpenCataloguePickerDialog, DownloadAndOpenCatalogueEntryAsync, SubmitDeeperLibraryEntryAsync,
+//   ShowCatalogueLookupToast, ShowCatalogueSubmissionResultToast, IsCatalogueEligible. App.Catalogue
+//   plus App.Notifications, the same pair MainShellWindow.CatalogueSubmissions.cs left out.
+//   IsImportableEnhancementPath is pure and would compile, and is held back with
+//   ImportEnhancementFiles, its only caller.
+//   SwitchToDeeperLibraryTab, MaybePromptMandatoryVideoEnhancement, BtnDeeperOpenPlayer_Click,
+//   BtnDeeperNewEnhancement_Click, BtnDeeperOpenLibraryFolder_Click - all relays into the above.
+
+using System;
+using Avalonia.Controls;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.DeeperTab.cs; wired when they move to Core.
-        private void BtnDeeper_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>
+        /// The rail's Deeper entry. Navigates, then retires the "you have not opened this yet"
+        /// pulse flag exactly where WPF does - on the first open, not on install - so the rail
+        /// stops nagging even though the pulse animation itself is not on this head.
+        /// </summary>
+        private void BtnDeeper_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            ShowTab("deeper");
 
+            var s = CoreSettings.Current;          // never null; the seam hands over a real instance
+            if (!s.HasSeenDeeperTab)
+            {
+                s.HasSeenDeeperTab = true;
+                CoreSettings.Save();
+            }
+
+            UpdateDeeperWelcomeCardVisibility();
+            // ponytail: WPF also calls InitializeDeeperHub() + ReloadDeeperLibraryFromDisk() here.
+            // Both are stubs in MainShellWindow.DeeperHub.cs (App.EnhancementLibrary), not owned
+            // by this layer - a half-scan that filled the list from nothing would read as an empty
+            // library rather than an unported one.
+        }
+
+        /// <summary>
+        /// Shows the first-run welcome card until it has been dismissed once. Reached through
+        /// FindControl on the view, NOT through its x:FieldModifier="internal" field: DeeperTabView
+        /// loads with AvaloniaXamlLoader.Load(this), so that field is permanently null and a write
+        /// to it would compile, review clean and do nothing forever.
+        ///
+        /// The card's IsVisible ALSO carries {Binding ShowWelcomeCard} (DeeperTabView.axaml:444).
+        /// That binding is one-shot today - ShowWelcomeCard is a get-only `=> true` on a placeholder
+        /// view model with no change notification (DeeperTabView.axaml.cs:172), so it evaluates once
+        /// at load and never pushes again, and this local set wins and stays won. When that view
+        /// model becomes real and starts raising PropertyChanged, this write must move INTO it:
+        /// Avalonia keeps a binding alive under a local value, so the next push would silently undo
+        /// the line below (CLAUDE.md, "Porting a WPF view to Avalonia").
+        /// </summary>
+        private void UpdateDeeperWelcomeCardVisibility()
+        {
+            try
+            {
+                var card = Named<Tabs.DeeperTabView>("DeeperTab")?.FindControl<Border>("DeeperWelcomeCard");
+                if (card is null) return;
+                card.IsVisible = !CoreSettings.Current.HasSeenDeeperWelcome;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("UpdateDeeperWelcomeCardVisibility failed: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Folds the welcome card and remembers it. Internal because its three callers are the
+        /// tour / demo / dismiss buttons on DeeperTabView, which relay into the shell on WPF and
+        /// are stubs on this head - nothing calls this yet.
+        /// </summary>
+        internal void DismissDeeperWelcomeCard()
+        {
+            var s = CoreSettings.Current;
+            if (!s.HasSeenDeeperWelcome)
+            {
+                s.HasSeenDeeperWelcome = true;
+                CoreSettings.Save();
+            }
+            UpdateDeeperWelcomeCardVisibility();
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsTab.cs
@@ -1,79 +1,61 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.ProgramsTab.cs (2312 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.ProgramsTab.cs (2312 lines).
+// Sorted member by member against the fifteen Core seams; unlike its neighbours the blanket claim
+// survives here, but for a reason the old header did not give and that is worth writing down so
+// nobody re-checks it: THE PROGRAM MODEL ITSELF IS STILL IN THE HEAD.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+//   ProgramDefinition, ProgramDay, ProgramEnrollment   ConditioningControlPanel/Models/Program/
+//   ProgramService, ProgramSessionBuilder, ProgramArt  ConditioningControlPanel/Services/Program/
 //
-// Members dropped (63):
-//   private bool _programsSubscribed
-//   private bool _programsAppHooked
-//   private bool _programsPulseRunning
-//   private void StartProgramsTabPulse(…)
-//   private void StopProgramsTabPulse(…)
-//   private void EnsureProgramsSubscribed(…)
-//   private void EnsureProgramsAppHooks(…)
-//   private void OnProgramTodayChanged(…)
-//   private void OnProgramLapsed(…)
-//   private void OnProgramGraduated(…)
-//   private void MarshalProgramRefresh(…)
-//   internal void ProgramTodayCard_Loaded(…)
-//   private static Brush ProgramThemeBrush(…)
-//   private static Brush ProgramAccentBrush(…)
-//   private static bool ProgramHasPremium
-//   private static Brush ProgramContrastForeground(…)
-//   private static double SrgbToLinear(…)
-//   private static string ProgramRunKey(…)
-//   private static Brush ProgramRailFillBrush(…)
-//   private static Brush ProgramRadialGlowBrush(…)
-//   private static void ApplyProgramArtMask(…)
-//   private static string? ProgramTaskIconPath(…)
-//   private static string? ProgramTaskHowTo(…)
-//   private static readonly(…)
-//   private static Models.SessionSettings? ProgramDaySettings(…)
-//   internal void RefreshProgramsUI(…)
-//   private void RebuildProgramsTab(…)
-//   private void BuildProgramBrowseList(…)
-//   private void BuildProgramRunPanel(…)
-//   private void BuildProgramDayStrip(…)
-//   private void BuildProgramTodayPanel(…)
-//   private void BuildProgramTodayLayers(…)
-//   private void BuildProgramUpNext(…)
-//   private static string FormatProgramClock(…)
-//   internal void UpdateProgramSessionRow(…)
-//   private bool _programsFxHooked
-//   private bool _programSheenActive
-//   private string? _programDayCompletePopped
-//   private readonly HashSet<string> _programTasksSeenIncomplete
-//   private string? _programRunKeySeen
-//   private bool _programsRefreshPending
-//   private void ResetProgramRunPopsIfRunChanged(…)
-//   private void EnsureProgramsFxHooked(…)
-//   private void OnProgramsTabVisibleChanged(…)
-//   private void StartProgramRunEntrance(…)
-//   private static void AnimateProgramPanelIn(…)
-//   private void EnsureProgramSessionSheen(…)
-//   private void StopProgramSessionSheen(…)
-//   private static void PopProgramScale(…)
-//   internal void AnnounceProgramSessionStarted(…)
-//   internal void AnnounceProgramSessionEnded(…)
-//   private void BuildProgramLapsedPanel(…)
-//   private void BuildProgramGraduatedPanel(…)
-//   internal void BtnProgramEnroll_Click(…)
-//   internal void BtnProgramPauseResume_Click(…)
-//   internal void BtnProgramWithdraw_Click(…)
-//   internal void BtnProgramRestart_Click(…)
-//   internal void BtnProgramDismissGraduated_Click(…)
-//   internal void BtnProgramSubmitRitual_Click(…)
-//   internal void BtnStartTodaySession_Click(…)
-//   internal async void StartProgramSession(…)
-//   internal void ProgramTodayCard_Click(…)
-//   internal void RefreshProgramTodayCard(…)
+// Nothing in CCP.Core names any of them. That is a stronger blocker than a missing seam: not one
+// member of this file can be written at all, because there is no type here to write it against.
+// Check with `grep -rl "ProgramEnrollment\|ProgramDefinition" CCP.Core` before assuming otherwise -
+// when that grep starts hitting, most of this file becomes a straight transcription.
+//
+// What that leaves, grouped so the eventual port can be taken in bites:
+//
+//   THE BUILDERS - RebuildProgramsTab, BuildProgramBrowseList, BuildProgramRunPanel,
+//   BuildProgramDayStrip, BuildProgramTodayPanel, BuildProgramTodayLayers, BuildProgramUpNext,
+//   BuildProgramLapsedPanel, BuildProgramGraduatedPanel, RefreshProgramsUI, RefreshProgramTodayCard,
+//   UpdateProgramSessionRow, ProgramTodayCard_Loaded, ProgramTodayCard_Click. Code-built panels over
+//   ProgramService state; they also want the tab's own ControlThemes, which is a second job.
+//
+//   THE COMMANDS - BtnProgramEnroll_Click, BtnProgramPauseResume_Click, BtnProgramWithdraw_Click,
+//   BtnProgramRestart_Click, BtnProgramDismissGraduated_Click, BtnProgramSubmitRitual_Click,
+//   BtnStartTodaySession_Click, StartProgramSession, AnnounceProgramSessionStarted /
+//   AnnounceProgramSessionEnded. ProgramService plus SessionEngine. None of these is a lie-risk -
+//   they simply have no service to command.
+//
+//   THE SUBSCRIPTIONS - EnsureProgramsSubscribed, EnsureProgramsAppHooks, OnProgramTodayChanged,
+//   OnProgramLapsed, OnProgramGraduated, MarshalProgramRefresh, _programsSubscribed,
+//   _programsAppHooked. Events on ProgramService; MarshalProgramRefresh's WPF Dispatcher.Invoke is
+//   Dispatcher.UIThread.Post here.
+//
+//   THE PAINT HELPERS - ProgramThemeBrush, ProgramAccentBrush, ProgramContrastForeground,
+//   SrgbToLinear, ProgramRailFillBrush, ProgramRadialGlowBrush, ApplyProgramArtMask,
+//   ProgramTaskIconPath, ProgramTaskHowTo, ProgramRunKey, FormatProgramClock, ProgramDaySettings,
+//   ProgramHasPremium. Two of these - SrgbToLinear (the sRGB->linear curve behind the WCAG
+//   luminance pick) and FormatProgramClock - are pure and portable TODAY. They are left out because
+//   they are orphans: every caller is a builder above, and a lone contrast helper with nothing to
+//   contrast is padding, not a port. ProgramRailFillBrush and ProgramRadialGlowBrush additionally
+//   call Freeze(), which Avalonia has no equivalent for; ProgramHasPremium is App.Patreon;
+//   ProgramDaySettings is ProgramSessionBuilder.
+//
+//   THE FX - EnsureProgramsFxHooked, OnProgramsTabVisibleChanged, StartProgramRunEntrance,
+//   AnimateProgramPanelIn, EnsureProgramSessionSheen, StopProgramSessionSheen, PopProgramScale,
+//   StartProgramsTabPulse, StopProgramsTabPulse, ResetProgramRunPopsIfRunChanged and their seven
+//   state flags. WPF storyboards; the keyframe-Animation recipe in CLAUDE.md covers the shapes, but
+//   there is nothing on screen to animate until the builders land.
+//
+// Checked and NOT the blocker here: CoreProgression and CoreSession. Programs are their own
+// enrollment ledger - CoreProgression answers XP and level, CoreSession answers the running
+// session, and no member of this file reads either. Do not wire them expecting the tab to fill.
+//
+// No member of this partial is referenced from MainShellWindow.axaml. The rail's Programs button is
+// BtnPrograms_Click, which already ships in MainShellWindow.TabNavigation.cs:205.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.RemoteControl.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.RemoteControl.cs
@@ -1,110 +1,87 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs (1575 lines).
+// PARTIALLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs (1575 lines).
+// Sorted member by member against the fifteen Core seams. The blanket header claimed all 77 were
+// blocked; one is not, and the rest have ONE blocker between them worth naming precisely.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// THE BLOCKER IS A NETWORK CLIENT, NOT A SEAM: App.RemoteControl, which is
+// ConditioningControlPanel/Services/RemoteControlService.cs - the pairing socket, the code and PIN,
+// the controller identity, the command stream and the tier handshake. It is not a Core seam and
+// there is no substitute for it; every emote send, every status line, every QR code and every
+// session-from-remote command goes through it. Nothing here invents a client, and nothing here
+// paints a status from a client that is not there: an "idle" or "connected" line derived from local
+// state alone would be a control lying about who is driving this machine, which is the most
+// consequential state in the app.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// WHAT IS REAL: BtnAvailableSubjects_Click. One ShowTab("availablesubjects"), the same one line as
+// WPF (MainWindow.RemoteControl.cs:491). "availablesubjects" IS a mapped tab on this head
+// (MainShellWindow.TabNavigation.cs:88 -> AvailableSubjectsTab), so the door opens and the panel
+// swaps; that panel's roster is still filled by App.AvailableSubjects, so the click navigates to an
+// empty page rather than to nothing.
 //
-// Members dropped (77):
-//   internal async void ChkRemoteControlEnabled_Changed(…)
-//   private string GetSelectedRemoteTier(…)
-//   private bool ShowRemoteControlWaiver(…)
-//   internal async void CmbRemoteTier_SelectionChanged(…)
-//   internal void BtnCopyRemoteCode_Click(…)
-//   internal void BtnCopyRemoteLink_Click(…)
-//   internal async void BtnStopRemote_Click(…)
-//   internal void ChkStopEffectsOnRemoteDisconnect_Changed(…)
-//   internal async void ChkRemoteShareAvatar_Changed(…)
-//   private Models.EmotePreset? _editingPreset
-//   internal async void BtnEmotePreset_Click(…)
-//   internal async void BtnEmoteCustomSend_Click(…)
-//   internal async void TxtEmoteCustom_KeyDown(…)
-//   private async void BtnEmotePresetBig_Click(…)
-//   private async void BtnEmoteCustomSendBig_Click(…)
-//   private async void TxtEmoteCustomBig_KeyDown(…)
-//   private async Task SendCustomEmoteAsync(…)
-//   internal async Task<bool> SendEmoteAndReportAsync(…)
-//   internal void BtnEmoteEdit_Click(…)
-//   internal void TxtEditEmoteText_TextChanged(…)
-//   internal void BtnEditEmoteSave_Click(…)
-//   internal void BtnEditEmoteCancel_Click(…)
-//   private bool _availableSubjectsBound
-//   internal void BtnAvailableSubjects_Click(…)
-//   internal void BtnBecomeASubject_Click(…)
-//   private void RefreshBecomeASubjectCta(…)
-//   private void EnsureAvailableSubjectsBound(…)
-//   private void OnAvailableSubjectsServicePropertyChanged(…)
-//   internal void AvailableSubjectsScroller_PreviewMouseWheel(…)
-//   private void UpdateAvailableSubjectsEmptyAndError(…)
-//   internal async void BtnConnectSubject_Click(…)
-//   private const int OptInMaxTags
-//   private System.Windows.Controls.CheckBox[] OptInTagCheckBoxes(…)
-//   internal void ChkOptIntoDirectory_Changed(…)
-//   private void PopulateOptInFormFromSavedSettings(…)
-//   internal void TxtOptInStatus_TextChanged(…)
-//   private void UpdateOptInStatusCharCount(…)
-//   internal void ChkOptInTag_Click(…)
-//   private List<string> GetSelectedDirectoryTags(…)
-//   private System.Windows.Threading.DispatcherTimer? _optInFeedbackTimer
-//   private void ShowOptInFeedback(…)
-//   private async Task RunOptInChainAsync(…)
-//   private bool _directoryOptedIn
-//   private void UpdateDirectoryListingStatus(…)
-//   private async Task StopRemoteControl(…)
-//   private void OnRemoteControllerChanged(…)
-//   private void OnRemoteControllerIdleChanged(…)
-//   private void OnRemoteSessionEnded(…)
-//   private void UpdateRemoteStatus(…)
-//   private void ShowRemoteControlOverlay(…)
-//   private void HideRemoteControlOverlay(…)
-//   private void WireRemoteSessionCallbacks(…)
-//   private void StartRemoteSessionInfoTimer(…)
-//   private void UpdateRemoteSessionInfo(…)
-//   private void OnRemoteCommandReceived(…)
-//   private void AppendRemoteCommandLog(…)
-//   private void UpdateRemoteControlUI(…)
-//   private string BuildRemotePairingUrl(…)
-//   private void RefreshRemoteQrCode(…)
-//   private void RefreshTierCardHighlight(…)
-//   internal void TierCard_Click(…)
-//   private void ShowCommandNotification(…)
-//   private void HideCommandNotification(…)
-//   private async void BtnEndRemoteSession_Click(…)
-//   private Models.Session? _remoteStartedSession
-//   internal bool IsSessionRemoteStarted
-//   internal async void StartSessionFromRemote(…)
-//   internal void PauseSessionFromRemote(…)
-//   internal void ResumeSessionFromRemote(…)
-//   internal void StopSessionFromRemote(…)
-//   internal void StopEngineAndSession(…)
-//   internal void TriggerPanicFromRemote(…)
-//   internal void MinimizeToTrayForRemote(…)
-//   public void MinimizeToTrayForChaos(…)
-//   private void NotifyRemoteControllerJoined(…)
-//   internal void RestoreFromTrayForRemote(…)
-//   public void ShowFromTray(…)
+// THE FOUR OTHER HANDLERS MainShellWindow.axaml NAMES STAY EMPTY, deliberately:
+//   BtnEmotePresetBig_Click / BtnEmoteCustomSendBig_Click / TxtEmoteCustomBig_KeyDown all end in
+//     SendEmoteAndReportAsync -> App.RemoteControl.SendEmote. There is nowhere to send to.
+//   BtnEndRemoteSession_Click ends a session on the SUBJECT'S machine. With no session to end it
+//     would be a button that reports having stopped something it never touched.
+//
+// PORTABLE BUT HELD, and each for a stated reason rather than a wait:
+//   BuildRemotePairingUrl - two string interpolations, and one of them is App.RemoteControl.ConnectPin.
+//     A pairing URL built without the PIN is a link that fails to pair; there is no honest half.
+//   GetSelectedRemoteTier / ShowRemoteControlWaiver / RefreshTierCardHighlight / TierCard_Click -
+//     the tier picker reads and writes RemoteControlTabView, which loads with
+//     AvaloniaXamlLoader.Load(this) and is not owned by this layer. Reaching into another view's
+//     name scope to set a tier that no session will use is churn.
+//   UpdateOptInStatusCharCount / GetSelectedDirectoryTags / OptInTagCheckBoxes /
+//     PopulateOptInFormFromSavedSettings / TxtOptInStatus_TextChanged / ChkOptInTag_Click /
+//     ChkOptIntoDirectory_Changed / ShowOptInFeedback / UpdateDirectoryListingStatus / OptInMaxTags.
+//     The directory opt-in form is genuinely settings-shaped and would persist through CoreSettings,
+//     but it PUBLISHES the user to a public subject directory - RunOptInChainAsync is the server
+//     call that makes it real. A form that saves the fields locally and shows "listed" without ever
+//     calling the chain is a consent surface that lies about being public, so the whole form waits
+//     for the chain. OptInTagCheckBoxes is additionally typed System.Windows.Controls.CheckBox[].
+//
+// THE REST, by group, all on App.RemoteControl unless noted:
+//   Enable / disable and tier - ChkRemoteControlEnabled_Changed, CmbRemoteTier_SelectionChanged,
+//     BtnStopRemote_Click, StopRemoteControl, ChkStopEffectsOnRemoteDisconnect_Changed,
+//     ChkRemoteShareAvatar_Changed.
+//   Pairing display - BtnCopyRemoteCode_Click, BtnCopyRemoteLink_Click, RefreshRemoteQrCode
+//     (a QR encoder as well as the code), UpdateRemoteControlUI.
+//   Live session - OnRemoteControllerChanged, OnRemoteControllerIdleChanged, OnRemoteSessionEnded,
+//     UpdateRemoteStatus, WireRemoteSessionCallbacks, StartRemoteSessionInfoTimer,
+//     UpdateRemoteSessionInfo, OnRemoteCommandReceived, AppendRemoteCommandLog,
+//     ShowRemoteControlOverlay, HideRemoteControlOverlay, ShowCommandNotification,
+//     HideCommandNotification, NotifyRemoteControllerJoined.
+//   Emotes - BtnEmotePreset_Click, BtnEmoteCustomSend_Click, TxtEmoteCustom_KeyDown,
+//     SendCustomEmoteAsync, SendEmoteAndReportAsync, BtnEmoteEdit_Click, TxtEditEmoteText_TextChanged,
+//     BtnEditEmoteSave_Click, BtnEditEmoteCancel_Click, _editingPreset. EmotePreset is a Core model;
+//     the sending is not.
+//   Subjects roster - BtnBecomeASubject_Click, RefreshBecomeASubjectCta, EnsureAvailableSubjectsBound,
+//     OnAvailableSubjectsServicePropertyChanged, UpdateAvailableSubjectsEmptyAndError,
+//     BtnConnectSubject_Click, AvailableSubjectsScroller_PreviewMouseWheel (no PreviewMouseWheel in
+//     Avalonia either way).
+//   Remote-driven session control - StartSessionFromRemote, PauseSessionFromRemote,
+//     ResumeSessionFromRemote, StopSessionFromRemote, StopEngineAndSession, TriggerPanicFromRemote,
+//     IsSessionRemoteStarted, _remoteStartedSession. These drive SessionEngine
+//     (ConditioningControlPanel/Services/Session/SessionEngine.cs) as well as the remote client.
+//   Tray - MinimizeToTrayForRemote, MinimizeToTrayForChaos, RestoreFromTrayForRemote, ShowFromTray.
+//     A Win32 notify-icon on WPF; a per-platform reimplementation here, not a port.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
-        private void BtnAvailableSubjects_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
+        /// <summary>The Play door's Available Subjects entry. One ShowTab, as in WPF. The roster
+        /// on that page is still filled by App.AvailableSubjects, so this opens an empty tab.</summary>
+        private void BtnAvailableSubjects_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+            => ShowTab("availablesubjects");
 
-        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
+        // The four below reach App.RemoteControl and stay empty on purpose - see the header. They
+        // exist because MainShellWindow.axaml names them and a missing handler is a XAML error.
         private void BtnEmoteCustomSendBig_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
 
-        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
         private void BtnEmotePresetBig_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
 
-        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
         private void BtnEndRemoteSession_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
 
-        // ponytail: needs the services in MainWindow.RemoteControl.cs; wired when they move to Core.
         private void TxtEmoteCustomBig_KeyDown(object? sender, global::Avalonia.Input.KeyEventArgs e) { }
-
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SessionIO.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SessionIO.cs
@@ -1,109 +1,76 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.SessionIO.cs (2212 lines).
+// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.SessionIO.cs (2212 lines).
+// Sorted member by member against the fifteen Core seams. Nothing here is restored, and the two
+// notes below exist so the next pass does not repeat the checks.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// FIRST, A LEAD THAT DOES NOT APPLY TO THIS HEAD. MainShellWindow.CatalogueSubmissions.cs restored
+// its read half (CatalogueKindSessions, CanonicalCataloguePathKey, GetCatalogueRecord,
+// IsCatalogueAcceptedStatus) and named "the session rack pill" here as one of three surfaces it
+// unblocked. On WPF that pill is four lines inside BuildSessionRackRow
+// (MainWindow.SessionIO.cs:517-522). There is no pill to wire HERE, because there is no row: the
+// whole rack builder is unported, and the badge factory those four lines call,
+// CreateCatalogueStatusBadge, lives in MainShellWindow.PresetIO.cs, which this layer does not own.
+// The lead is correct about the DEPENDENCY and wrong about the work being small. It becomes true
+// the moment BuildSessionRackRow exists.
 //
-// Members dropped (93):
-//   private Services.SessionManager? _sessionManager
-//   private Services.SessionFileService? _sessionFileService
-//   private Services.AssetImportService? _assetImportService
-//   private void InitializeSessionManager(…)
-//   private void OnSessionsReloaded(…)
-//   public bool RegisterExternallySavedSession(…)
-//   private void OnSessionAdded(…)
-//   private void OnSessionRemoved(…)
-//   private const string RackSourceAll
-//   private const string RackSourceBuiltIn
-//   private const string RackSourceYours
-//   private const string RackSourceCatalogue
-//   private string _rackSourceFilter
-//   private string _rackSort
-//   private string _rackSearch
-//   private readonly HashSet<Models.SessionDifficulty> _rackDifficulties
-//   private readonly List<ToggleButton> _rackSourceChips
-//   private readonly List<ToggleButton> _rackDifficultyChips
-//   private bool _rackToolbarBuilt
-//   private bool _rackToolbarSyncing
-//   internal void RepaintSessionRack(…)
-//   private List<Models.Session> EnumerateRackSessions(…)
-//   private bool RackAccepts(…)
-//   private List<Models.Session> SortRackSessions(…)
-//   private static DateTime? RackFileStamp(…)
-//   private Border BuildSessionRackRow(…)
-//   private TextBlock MakeRackMeta(…)
-//   private static(…)
-//   private static void AttachRoundedClip(…)
-//   private void EnsureSessionRackToolbar(…)
-//   private static string RackSourceLabel(…)
-//   private static string RackSourceChipLabel(…)
-//   private static string RackDifficultyLabel(…)
-//   private void UpdateRackToolbarCounts(…)
-//   private void RackSourceChip_Changed(…)
-//   private void RackDifficultyChip_Changed(…)
-//   internal void CmbRackSort_SelectionChanged(…)
-//   internal void TxtRackSearch_TextChanged(…)
-//   private void ClearSessionRackFilters(…)
-//   private void RefreshSessionRackSelection(…)
-//   private bool HasSessionRackRow(…)
-//   private Border MakeRackPill(…)
-//   private Button CreateSessionActionButton(…)
-//   private Button CreateSessionDeleteButton(…)
-//   private Button CreateSessionRowButton(…)
-//   private void SelectSession(…)
-//   private string GenerateSessionTimelineDescription(…)
-//   internal void SessionDropZone_DragEnter(…)
-//   internal void SessionDropZone_DragOver(…)
-//   internal void SessionDropZone_DragLeave(…)
-//   private void Window_DragEnter(…)
-//   private void OpenAvatarChat_Executed(…)
-//   internal void BtnChatShortcut_Click(…)
-//   private void ApplyGlobalChatHotkey(…)
-//   private void BringToForegroundAndOpenChat(…)
-//   public void RefreshChatShortcutLabel(…)
-//   public static readonly RoutedUICommand ToggleCameraCommand
-//   private bool _cameraCommandBound
-//   private void ApplyCameraShortcutTo(…)
-//   private void ApplyGlobalCameraHotkey(…)
-//   private static ModifierKeys ParseModifiers(…)
-//   private static string FormatCameraShortcut(…)
-//   public void RefreshCameraShortcutLabel(…)
-//   internal void BtnCameraShortcut_Click(…)
-//   private void Window_DragOver(…)
-//   private void Window_DragLeave(…)
-//   private async void Window_Drop(…)
-//   private enum DropType
-//   private static readonly HashSet<string> AssetVideoExtensions
-//   private static readonly HashSet<string> AssetImageExtensions
-//   private static readonly HashSet<string> DeeperVideoExtensions
-//   private static readonly HashSet<string> DeeperAudioExtensions
-//   private enum MediaDropChoice
-//   private static bool IsDeeperPlayableMedia(…)
-//   private static DropType DetectDropType(…)
-//   private void UpdateDropOverlay(…)
-//   private void HandleSessionDrop(…)
-//   private async Task HandleAssetDropAsync(…)
-//   private void RefreshImagesList(…)
-//   private void RefreshVideosList(…)
-//   internal void SessionBtn_Edit(…)
-//   internal void SessionBtn_Export(…)
-//   private async void SessionBtn_Share(…)
-//   private void SyncCustomSessionsFromDisk(…)
-//   private void SessionBtn_Delete(…)
-//   private Models.Session? GetSessionById(…)
-//   internal bool RevealSessionInLibrary(…)
-//   internal void SessionDropZone_Drop(…)
-//   private void ShowDropZoneStatus(…)
-//   internal void BtnExportSession_Click(…)
-//   internal void BtnCreateSession_Click(…)
-//   private void SessionContextMenu_Export(…)
-//   private void ExportSessionToFile(…)
+// SECOND, THE REAL BLOCKER: Services.SessionManager
+// (ConditioningControlPanel/Services/Session/SessionManager.cs) and its two companions,
+// SessionFileService (same folder) and AssetImportService. SessionManager owns AllSessions, the
+// reload and add/remove events, DeleteSession's refusal to touch a built-in, and the disk sync;
+// every member below either reads it or repaints something it changed. Models.Session IS in Core,
+// which is why the FILTER half looks portable - see the next paragraph for why it is still out.
+//
+//   The rack - RepaintSessionRack, EnumerateRackSessions, BuildSessionRackRow, MakeRackMeta,
+//   MakeRackPill, AttachRoundedClip, CreateSessionActionButton, CreateSessionDeleteButton,
+//   CreateSessionRowButton, SelectSession, RefreshSessionRackSelection, HasSessionRackRow,
+//   GenerateSessionTimelineDescription, RevealSessionInLibrary. The host panel for these rows
+//   already exists on this head (Views/Tabs/PresetsTabView.axaml:653 - "ONE panel.
+//   RepaintSessionRack clears and refills it"), so this is a real, bounded next layer.
+//
+//   The rack toolbar - EnsureSessionRackToolbar, RackSourceChip_Changed, RackDifficultyChip_Changed,
+//   CmbRackSort_SelectionChanged, TxtRackSearch_TextChanged, ClearSessionRackFilters,
+//   UpdateRackToolbarCounts, RackSourceLabel, RackSourceChipLabel, RackDifficultyLabel, the four
+//   RackSource* constants and the six filter fields.
+//
+//   RackAccepts, SortRackSessions and RackFileStamp are the exception worth calling out: all three
+//   are pure over Models.Session and System.IO and would compile here today. They are held back
+//   because they are the filter engine for rows that do not exist - restoring a sorter with nothing
+//   to sort is padding, and splitting the rack across two layers is how the filters and the rows
+//   drift apart. They come back in the same layer as RepaintSessionRack, which is their only caller.
+//
+//   Session lifecycle - InitializeSessionManager, OnSessionsReloaded, OnSessionAdded,
+//   OnSessionRemoved, RegisterExternallySavedSession, SyncCustomSessionsFromDisk, GetSessionById,
+//   SessionBtn_Edit, SessionBtn_Export, SessionBtn_Delete, SessionBtn_Share,
+//   SessionContextMenu_Export, ExportSessionToFile, BtnExportSession_Click, BtnCreateSession_Click.
+//   SessionBtn_Share also needs the catalogue client (App.Catalogue) and the WRITE half of
+//   MainShellWindow.CatalogueSubmissions.cs, which is out for its head-only SubmissionResult type.
+//
+//   Drag and drop - Window_DragEnter, Window_DragOver, Window_DragLeave, Window_Drop,
+//   SessionDropZone_DragEnter / DragOver / DragLeave / Drop, DetectDropType, UpdateDropOverlay,
+//   HandleSessionDrop, HandleAssetDropAsync, ShowDropZoneStatus, IsDeeperPlayableMedia, DropType,
+//   MediaDropChoice and the four extension sets. The extension sets and DetectDropType are pure;
+//   the drop itself needs AssetImportService, and Avalonia's DragDrop is a different API from WPF's
+//   (DataFormats.FileNames -> DataFormats.Files, IDataObject -> IStorageItem), so this is a rewrite.
+//
+//   The two global hotkeys - ApplyGlobalChatHotkey, ApplyGlobalCameraHotkey, ApplyCameraShortcutTo,
+//   ParseModifiers, FormatCameraShortcut, RefreshChatShortcutLabel, RefreshCameraShortcutLabel,
+//   BtnChatShortcut_Click, BtnCameraShortcut_Click, ToggleCameraCommand, OpenAvatarChat_Executed,
+//   BringToForegroundAndOpenChat, _cameraCommandBound. RoutedUICommand and ModifierKeys are WPF
+//   types, and a DESKTOP-WIDE hotkey is a Win32 RegisterHotKey - the bucket-E problem CLAUDE.md
+//   describes, not a port. ToggleCameraCommand is additionally a camera control: see the refusal
+//   already recorded for the two device pills in MainShellWindow.LabTab.cs.
+//
+//   RefreshImagesList / RefreshVideosList - the assets tab's lists, blocked with the asset tree in
+//   MainShellWindow.Assets.cs.
+//
+// Checked and NOT the blocker: CoreSession. It answers the RUNNING session (start, stop, current
+// state); this file is the session LIBRARY - files on disk, the rack that lists them, import and
+// export. They share the word and nothing else.
+//
+// No member of this partial is referenced from MainShellWindow.axaml.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // No member of this partial is referenced from MainShellWindow.axaml.
     }
 }

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.UiUpdates.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.UiUpdates.cs
@@ -1,120 +1,79 @@
-// PORTED-AS-A-STUB from ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs (2904 lines).
+// PARTIALLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs (2904 lines).
+// Sorted member by member against the fifteen Core seams. One member is real; the blanket claim
+// was wrong for it and is right for most of the rest, with three exceptions worth naming.
 //
-// ponytail: wholesale stub. Every member below reaches App.*, a service, a device, a
-// WebView2 or Win32 - none of which this head may touch (see the layer rules: "Do not
-// move services"). The file exists and each member is NAMED so nothing disappears
-// silently; the bodies come back when the services move to Core.
+// WHAT IS REAL: BtnAccountChip_Click. WPF's body is ShowTab("appsettings") +
+// AppSettingsTab.FocusSection("account"), and BOTH halves already ship here as
+// OpenAppSettingsSection (MainShellWindow.Settings.cs:65) - "account" is one of the nine keys in
+// AppSettingsTabView.SectionKeys. It routes through that helper rather than repeating the pair,
+// which also means it gets the helper's Named<T> lookup: the generated AppSettingsTab field on
+// this window is permanently null (AvaloniaXamlLoader.Load), so AppSettingsTab?.FocusSection(...)
+// transcribed from WPF would have compiled, rendered, reviewed clean and done nothing.
 //
-// The handlers named by MainShellWindow.axaml are real (empty) methods, because a
-// missing one is a XAML compile error, not a runtime gap.
+// NOT BLOCKED, MOVED - the settings toggles. SliderMaster_Changed, SliderVideoVolume_Changed,
+// SliderDuck_Changed, ChkAudioDuck_Changed, ChkExcludeBambiCloudDucking_Changed,
+// CmbAudioOutputDevice_SelectionChanged, BtnAudioOutputRefresh_Click, BtnTestAudio_Click,
+// PopulateAudioOutputDevices, ChkPerformanceMode_Changed, ChkAutoPerformance_Changed,
+// CmbMotionLevel_SelectionChanged, ChkVideoHwDecode_Changed, ChkUnifiedOverlay_Changed,
+// ChkPanicOverridesAll_Changed, ChkNoPanic_Changed, ChkWinStart_Click, ChkStartHidden_Click,
+// BtnPauseKey_Click, BtnPanicKey_Click, BtnSelectStartupVideo_Click, BtnClearStartupVideo_Click and
+// ChkOfflineMode_Changed were all "MainWindow owns the handler, the section relays to it" on WPF.
+// On this head each section owns its own handler and its own _isLoading guard:
+// Views/Controls/AppSettings/{Audio,Performance,General,Devices,Data}SettingsSection.axaml.cs.
+// Adding any of them back here would be a SECOND writer for one setting, not a restoration.
 //
-// Members dropped (99):
-//   private void UpdateUI(…)
-//   private void UpdateLevelDisplay(…)
-//   private void ApplyModFeatureNames(…)
-//   private bool _modSweepQueued
-//   private bool _modSweepWatchersHooked
-//   private bool _presetsModDirty
-//   private void QueueModAwareSurfaceSweep(…)
-//   private void RefreshModAwareSurfaces(…)
-//   private static void SweepStep(…)
-//   private void EnsureModSweepWatchers(…)
-//   internal static string ModAwareLabel(…)
-//   private static string StripLeadingGlyph(…)
-//   private void ApplyBimboJournalModVisibility(…)
-//   private void UpdateXPBarLoginState(…)
-//   private static SolidColorBrush AccountChipBrush(…)
-//   private static readonly SolidColorBrush AccountChipTier1Brush
-//   private static readonly SolidColorBrush AccountChipTier2Brush
-//   private static readonly SolidColorBrush AccountChipNeutralBrush
-//   private void RefreshAccountChip(…)
-//   private void BtnAccountChip_Click(…)
-//   private void UpdateStatPills(…)
-//   private void RefreshXPBarBonuses(…)
-//   private static string? GetBonusChipTooltip(…)
-//   private void StartStatPillUpdateTimer(…)
-//   private void StartConditioningTimeTracker(…)
-//   private void StopConditioningTimeTracker(…)
-//   private async Task SyncConditioningTimeToServerAsync(…)
-//   private void UpdateUnlockablesVisibility(…)
-//   private void SetFeatureImageBlur(…)
-//   internal void SliderMaster_Changed(…)
-//   internal void SliderVideoVolume_Changed(…)
-//   internal void SliderDuck_Changed(…)
-//   internal void ChkAudioDuck_Changed(…)
-//   internal void ChkExcludeBambiCloudDucking_Changed(…)
-//   private bool _testingAudio
-//   internal async void BtnTestAudio_Click(…)
-//   private bool _populatingAudioOutputs
-//   private void PopulateAudioOutputDevices(…)
-//   internal void CmbAudioOutputDevice_SelectionChanged(…)
-//   internal void BtnAudioOutputRefresh_Click(…)
-//   internal void ImgLogo_MouseLeftButtonDown(…)
-//   private const int IntakePassFaceHoldMs
-//   private static readonly int[] IntakePassHalfTurnMs
-//   private const double IntakePassSkewDeg
-//   private int _intakePassSpinGen
-//   private bool _intakePassLoopRunning
-//   private bool _intakePassShowingCard
-//   private bool _intakePassLoadedHooked
-//   private bool _intakePassStateHooked
-//   private bool _intakePassVisibilityHooked
-//   private bool _intakePassModHooked
-//   private bool _intakePassHelpAttached
-//   private static readonly TimeSpan IntakePassCtaBreath
-//   private bool _intakePassCtaShouldPulse
-//   private bool _intakePassCtaPulsing
-//   internal void RefreshIntakePassTile(…)
-//   private void SetIntakePassFace(…)
-//   private void ApplyIntakePassFaceState(…)
-//   private void StartIntakePassCtaPulse(…)
-//   private void StopIntakePassCtaPulse(…)
-//   private void EnsureIntakePassHelpPopover(…)
-//   private static HelpContent BuildIntakePassHelpContent(…)
-//   private void CancelIntakePassSpin(…)
-//   private void StartIntakePassFlipLoop(…)
-//   private void HoldIntakePassFace(…)
-//   private void RunIntakePassSpinPhase(…)
-//   private void FinishIntakePassSpin(…)
-//   internal void IntakePassFace_MouseLeftButtonDown(…)
-//   private async void ShowEasterEgg(…)
-//   private void TriggerStartupVideo(…)
-//   internal void BtnSelectStartupVideo_Click(…)
-//   internal void BtnClearStartupVideo_Click(…)
-//   internal void BtnManageAttention_Click(…)
-//   internal void BtnAttentionStyle_Click(…)
-//   internal void BtnSubliminalSettings_Click(…)
-//   internal void BtnManageMessages_Click(…)
-//   private void BtnPrevImage_Click(…)
-//   private void BtnNextImage_Click(…)
-//   internal void BtnPickAssetsFolder_Click(…)
-//   private static void CopyDirectoryRecursive(…)
-//   private static string FormatFileSize(…)
-//   internal void BtnRefreshAssets_Click(…)
-//   private void BtnViewLog_Click(…)
-//   internal void ChkPanicOverridesAll_Changed(…)
-//   internal void BtnPauseKey_Click(…)
-//   internal void BtnPanicKey_Click(…)
-//   internal void ChkNoPanic_Changed(…)
-//   internal void ChkPerformanceMode_Changed(…)
-//   internal void ChkAutoPerformance_Changed(…)
-//   internal void CmbMotionLevel_SelectionChanged(…)
-//   internal void ChkVideoHwDecode_Changed(…)
-//   internal void ChkUnifiedOverlay_Changed(…)
-//   internal void ChkOfflineMode_Changed(…)
-//   private static void SetOfflineDisabled(…)
-//   private void UpdateOfflineModeUI(…)
-//   private void DisconnectNetworkServices(…)
-//   internal void ChkWinStart_Click(…)
-//   internal void ChkStartHidden_Click(…)
-//   private void XPBarTrack_ToolTipOpening(…)
+// PURE AND PORTABLE, LEFT OUT ANYWAY because they are orphans on this head:
+//   ModAwareLabel(english, locKey) - CoreMods.MakeModAware answers it, so it compiles today. Its
+//     consumer, StudioTabView, already carries its own inlined twin
+//     (Views/Tabs/StudioTabView.axaml.cs:1105-1131) precisely because a UserControl cannot reach a
+//     private on the shell. A second public copy with no caller is duplication, not progress.
+//   StripLeadingGlyph - same story, same file, already inlined there.
+//   FormatFileSize - its only callers are the assets-folder rows, which are not ported.
+//
+// STILL OUT, by blocker:
+//   App.Progression / the XP bar - UpdateLevelDisplay, UpdateXPBarLoginState, UpdateStatPills,
+//     RefreshXPBarBonuses, GetBonusChipTooltip, StartStatPillUpdateTimer, XPBarTrack_ToolTipOpening,
+//     RefreshAccountChip and the three AccountChip* brushes. CoreProgression is a seam, but the
+//     chip and the pills read App.Account / App.Patreon tier state on top of it, and a chip that
+//     paints the logged-out tier unconditionally is the same failure recorded for
+//     UpdateSubscribeStarUI in MainShellWindow.SubscribeStar.cs.
+//   The conditioning-time tracker - StartConditioningTimeTracker, StopConditioningTimeTracker,
+//     SyncConditioningTimeToServerAsync. A server round trip with no seam.
+//   UpdateUI / QueueModAwareSurfaceSweep / RefreshModAwareSurfaces / SweepStep /
+//     EnsureModSweepWatchers / ApplyModFeatureNames / ApplyBimboJournalModVisibility - the sweep
+//     walks named controls across every tab, most of which are unported; it is a pass over the
+//     finished UI, so it lands last, not first.
+//   UpdateUnlockablesVisibility / SetFeatureImageBlur - App.Unlockables plus a WPF BlurEffect.
+//   The Intake Pass tile - RefreshIntakePassTile, SetIntakePassFace, ApplyIntakePassFaceState,
+//     StartIntakePassCtaPulse, StopIntakePassCtaPulse, EnsureIntakePassHelpPopover,
+//     BuildIntakePassHelpContent, CancelIntakePassSpin, StartIntakePassFlipLoop, HoldIntakePassFace,
+//     RunIntakePassSpinPhase, FinishIntakePassSpin, IntakePassFace_MouseLeftButtonDown and their
+//     eleven state flags. App.IntakePass, plus a WPF 3D card flip.
+//   ImgLogo_MouseLeftButtonDown / ShowEasterEgg / TriggerStartupVideo - a media window each.
+//   BtnManageAttention_Click, BtnAttentionStyle_Click, BtnSubliminalSettings_Click,
+//     BtnManageMessages_Click, BtnViewLog_Click, BtnPrevImage_Click, BtnNextImage_Click,
+//     BtnRefreshAssets_Click - each opens an unported window or drives the unported asset tree.
+//   SetOfflineDisabled / UpdateOfflineModeUI / DisconnectNetworkServices - the toggle itself moved
+//     (DataSettingsSection.axaml.cs:67, which persists OfflineMode and asks for the offline name),
+//     but the TEARDOWN did not: App.Account, App.RemoteControl and the update checker are the
+//     things a disconnect disconnects, and none of them exists here to disconnect. The greying
+//     pass, SetOfflineDisabled, walks named controls on unported tabs.
+//   BtnPickAssetsFolder_Click / CopyDirectoryRecursive - the picker itself already ships as
+//     MainShellWindow.Settings.cs RequestPickAssetsFolder, called from SystemFeatureControl. What
+//     is missing here is only the WPF handler shell around it and the copy-the-old-library
+//     migration, which needs the assets tree to say what it copied.
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // ponytail: needs the services in MainWindow.UiUpdates.cs; wired when they move to Core.
-        private void BtnAccountChip_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) { }
-
+        /// <summary>
+        /// The header's account chip. Opens the Settings door and scrolls it to Account - no popup
+        /// and no reparenting, same as WPF (MainWindow.UiUpdates.cs). The scroll deliberately
+        /// happens after the tab is shown, because a section can only be measured once visible;
+        /// OpenAppSettingsSection keeps that order and swallows a failed scroll.
+        /// </summary>
+        private void BtnAccountChip_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+            => OpenAppSettingsSection("account");
     }
 }


### PR DESCRIPTION
Assets, Deeper, Available Subjects and the header's account chip stop being empty handlers.
BtnAssets_Click and BtnAvailableSubjects_Click are the same single ShowTab call they are on WPF;
both keys are already mapped (MainShellWindow.TabNavigation.cs:84-88), so the door opens and the
panel swaps - to a tab whose contents are still unported, which is the honest state and is said in
each file. BtnAccountChip_Click routes through OpenAppSettingsSection("account")
(MainShellWindow.Settings.cs:65) rather than repeating WPF's ShowTab + FocusSection pair; that also
avoids the x:Name hazard, because the generated AppSettingsTab field on this window is permanently
null and the literal WPF transcription would have been a silent no-op.

BtnDeeper_Click carries its settings half too: it retires HasSeenDeeperTab through CoreSettings on
the first open, then shows or hides the first-run welcome card from HasSeenDeeperWelcome.
UpdateDeeperWelcomeCardVisibility reaches that card with
Named<DeeperTabView>("DeeperTab")?.FindControl<Border>("DeeperWelcomeCard") and says why in the
file: DeeperTabView also loads with AvaloniaXamlLoader.Load(this), so its x:FieldModifier="internal"
field is null and writing to it would compile, render and review clean while doing nothing forever.
DismissDeeperWelcomeCard is restored as internal but NOTHING CALLS IT YET - its three callers are
buttons on DeeperTabView, which this layer does not own. That card's IsVisible also carries
{Binding ShowWelcomeCard}; the binding is one-shot (a get-only `=> true` on a placeholder view model
with no change notification), so the local set wins and stays won today, and the file says in full
that this write must move into the view model the moment that view model starts raising
PropertyChanged - Avalonia keeps a binding alive under a local value.

Verified by instrumenting the path rather than by reading the frame. A temporary probe in NavCheck
(reverted before this commit, not part of the diff) clicked each button on a shown headless shell:
BtnOpenAssetsTop -> AssetsTab visible; BtnDeeper -> tab=deeper, HasSeenDeeperTab written, card
visible with the flag clear and hidden once set; BtnAccountChip -> appsettings with SectionPillAccount
checked; BtnAvailableSubjects -> AvailableSubjectsTab visible.

The other five partials lose the blanket "wired when the services move to Core" header for a sorted
one. Two corrections and two refusals are the substance of that:

  MainShellWindow.SessionIO.cs - the lead that MainShellWindow.CatalogueSubmissions.cs unblocked
  "the session rack pill" here is right about the dependency and wrong about the size. On WPF that
  pill is four lines inside BuildSessionRackRow (MainWindow.SessionIO.cs:517-522); on this head
  there is no row at all, and the badge factory those lines call, CreateCatalogueStatusBadge, is in
  MainShellWindow.PresetIO.cs, which this layer does not own. Recorded so nobody re-checks it.
  RackAccepts / SortRackSessions / RackFileStamp are pure over Models.Session and would compile
  today; they are held with RepaintSessionRack, their only caller, rather than shipped as a sorter
  with nothing to sort.

  MainShellWindow.UiUpdates.cs - twenty-three of its "dropped" members are not blocked, they MOVED.
  Every audio slider, performance toggle, panic key, startup-video button and the offline switch is
  now owned by a section under Views/Controls/AppSettings with its own _isLoading guard; adding any
  of them back here would be a second writer for one setting. ModAwareLabel and StripLeadingGlyph
  compile today (CoreMods.MakeModAware answers them) and stay out because StudioTabView already
  carries its own inlined twin at StudioTabView.axaml.cs:1105-1131.

  MainShellWindow.Assets.cs - the remote-media picker is a REFUSAL, not a wait. RemoteSourceChip_Changed
  writes settings.MediaSource only after a SYNCHRONOUS consent ask (MainWindow.Assets.cs:2353-2360);
  this head's MessageDialog.ShowDialog<T> is async, so a straight transcription flips the chip before
  the answer lands - a skipped consent gate on the switch that starts fetching third-party adult
  content. Separately, the switch without FypOnlineCoordinator.ResetAllChannels() leaves the media
  services serving pools built for the old source. BuildFolderTree, by contrast, transcribes line for
  line (AssetTreeItem is Core, CorePaths.EffectiveAssets is the root, DisabledAssetPaths is on
  CoreSettings.Current) and is still out because RefreshAssetTree's Content Packs branch needs
  App.ContentPacks, and a tree that silently omits every installed pack reads as "those files are gone".

  MainShellWindow.RemoteControl.cs - one blocker for seventy-six members, and it is a network client,
  not a seam. The four handlers MainShellWindow.axaml names stay empty on purpose: an emote with
  nowhere to send it, and an End Session button that would report stopping something it never touched.
  The directory opt-in form is settings-shaped and still refused - saving the fields without
  RunOptInChainAsync is a consent surface that says "listed" while nothing was published.

  MainShellWindow.ProgramsTab.cs stays wholesale, for a blocker stronger than a missing seam: the
  program MODEL is still in the head (Models/Program/, Services/Program/), so not one member can be
  written against a type that exists here. Checked and NOT the blocker: CoreProgression, CoreSession.

Also checked and not the blocker anywhere: CoreModArt (Assets.cs reads no mod art - its thumbnails
are the user's library and downloaded packs); CoreSession in SessionIO.cs (that file is the session
LIBRARY, not the running session).

Still blocked:
  Services.SessionManager / SessionFileService / AssetImportService
      - ConditioningControlPanel/Services/Session/SessionManager.cs, SessionFileService.cs
  App.ContentPacks - ConditioningControlPanel/Services/Content/ContentPackService.cs
  Services.Fyp.Online.FypOnlineCoordinator
      - ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
  App.RemoteControl - ConditioningControlPanel/Services/RemoteControlService.cs
  App.AvailableSubjects - ConditioningControlPanel/Services/AvailableSubjectsService.cs
  App.EnhancementLibrary - ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs
  ProgramService / ProgramSessionBuilder / ProgramArt - ConditioningControlPanel/Services/Program/
  ProgramDefinition / ProgramDay / ProgramEnrollment - ConditioningControlPanel/Models/Program/
  App.Catalogue, App.Notifications - as recorded in MainShellWindow.CatalogueSubmissions.cs
  App.IntakePass, App.Unlockables, App.Patreon, App.Account - the XP bar, the stat pills and the
      Intake Pass tile in MainShellWindow.UiUpdates.cs
  StartTutorial(TutorialType.Deeper) - the Deeper tour, unported shell member
  InitializeDeeperHub / ReloadDeeperLibraryFromDisk - stubs in MainShellWindow.DeeperHub.cs,
      CreateCatalogueStatusBadge - stub in MainShellWindow.PresetIO.cs; neither owned by this layer
  Win32 RegisterHotKey - the global chat and camera hotkeys in SessionIO (bucket E, not a port)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU