### PR TITLE
feat(avalonia): the ? on her glass opens her book, anchored to her, and its unfurl actually runs

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
@@ -16,7 +16,9 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Styling;
 using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Controls;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services.EmiDesk;
 using Serilog;
 
@@ -68,17 +70,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
     ///     <c>Extent.Height - Viewport.Height - Offset.Y</c>. <c>ScrollToTop</c> -&gt;
     ///     <c>ScrollToHome</c>.</item>
     ///   <item><c>DoubleAnimation</c>/<c>BeginAnimation</c> -&gt; <c>Animation.RunAsync</c> on the
-    ///     <c>ScaleTransform</c> itself (a <c>Transform</c> is an <c>Animatable</c>);
-    ///     <c>BeginTime</c> -&gt; <c>Delay</c>. The fold closes on the awaited sweep, which is the
-    ///     same "close on the LAST animation, never on a timer" rule the original states.</item>
+    ///     HOST VISUAL that owns the <c>ScaleTransform</c> - NOT on the transform, which compiles
+    ///     and throws; <c>BeginTime</c> -&gt; <c>Delay</c>. See <see cref="Scale"/>. The fold closes
+    ///     on the awaited sweep, which is the same "close on the LAST animation, never on a timer"
+    ///     rule the original states.</item>
     ///   <item><c>Tag = "on"</c> -&gt; the <c>on</c> style class, because Avalonia has no property
     ///     trigger. <c>MouseEnter/Leave</c> -&gt; <c>PointerEntered/Exited</c>;
     ///     <c>MouseLeftButtonUp</c> -&gt; <c>PointerReleased</c>.</item>
-    ///   <item>The constructor is parameterless. The WPF one takes the desk window that owns the
-    ///     book and that type does not exist on this head yet, so the owner hooks are stubs - and
-    ///     the same constructor is what <c>--render-all</c> discovers. It selects the first card,
-    ///     which the WPF constructor left to <see cref="OpenBook"/>: a window that draws nothing
-    ///     until a service calls it renders as an empty panel.</item>
+    ///   <item><b>The owner is real.</b> <see cref="EmiDeskWindow"/> is ported on this head, so the
+    ///     constructor takes it and the chrome hold, her body box and the follow-her-around
+    ///     subscriptions are the WPF behaviour rather than stubs. It stays NULLABLE for one reason:
+    ///     <c>--render-view</c> needs a parameterless constructor and a headless render has no
+    ///     widget to hang off, so every owner call is <c>?.</c> with the fallback the unowned book
+    ///     already used. The parameterless ctor also selects the first card, which the WPF one left
+    ///     to <see cref="OpenBook"/>: a window that draws nothing until a service calls it renders
+    ///     as an empty panel.</item>
     /// </list>
     /// </summary>
     public partial class EmiBookWindow : Window
@@ -101,11 +107,31 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>How many bullets a card may show, whatever the deck hands over.</summary>
         private const int MaxNudges = 4;
 
-        // ponytail: needs MotionFx (WPF head, Services/MotionFx.cs), wired when it moves to Core.
-        // Both gates read "allowed" here, which is the shipped default; a reduced-motion desk gets
-        // the animation it asked not to have until the gate lands.
-        private const bool AllowTransitions = true;
-        private const bool AllowAmbientLoops = true;
+        /// <summary>
+        /// <c>MotionFx.AllowTransitions</c>, spelled out. MotionFx itself is still head-side, but
+        /// what it reads is not: <see cref="AmbientFxCanvas.Env"/> in this assembly already carries
+        /// the ported gate off <c>CoreSettings.Current.MotionLevel</c> and the tier, so the unfurl
+        /// now obeys the reader's setting instead of assuming the shipped default.
+        /// <c>Level != Off</c> is MotionFx's own definition, verbatim.
+        /// </summary>
+        private static bool AllowTransitions
+        {
+            get
+            {
+                try { return AmbientFxCanvas.Env.Level != MotionLevel.Off; }
+                catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book motion gate failed"); return true; }
+            }
+        }
+
+        /// <summary><c>MotionFx.AllowAmbientLoops</c>, through the same gate.</summary>
+        private static bool AllowAmbientLoops
+        {
+            get
+            {
+                try { return AmbientFxCanvas.Env.AllowAmbientLoops; }
+                catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book loop gate failed"); return true; }
+            }
+        }
 
         private readonly List<Border> _dots = new();
 
@@ -158,14 +184,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
 
         // ---------------------------------------------------------------- ctor
 
+        /// <summary>The widget this book hangs off. Null only under <c>--render-view</c>.</summary>
+        private readonly EmiDeskWindow? _owner;
+
+        /// <summary>The render constructor: a book with no widget behind it. See the header.</summary>
+        public EmiBookWindow() : this(null) { }
+
         /// <summary>
-        /// Builds the book. The WPF constructor takes the desk widget that owns it; that window is
-        /// not on this head yet, so the owner is a stub and this doubles as the render constructor.
+        /// Builds the book for one widget. Created hidden; <see cref="OpenBook"/> shows it.
         /// </summary>
-        // ponytail: needs EmiDeskWindow (owner: Moved, Resized, HoldChromeForPanel, SpeakLine,
-        // BodyScreenRect), wired when the desk moves to Core.
-        public EmiBookWindow()
+        public EmiBookWindow(EmiDeskWindow? owner)
         {
+            _owner = owner;
             AvaloniaXamlLoader.Load(this);
 
             _tab0 = this.FindControl<Button>("Tab0")!;
@@ -202,6 +232,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             PointerEntered += (_, _) => Hold(true);
             PointerExited += (_, _) => Hold(false);
 
+            // She moves, she resizes: the book is anchored to her body and has to come along.
+            if (_owner is not null)
+            {
+                _owner.Moved += OnOwnerMoved;
+                _owner.Resized += OnOwnerResized;
+            }
+
             // NOT in the WPF original, where OpenBook is always what fills the panel. Here the
             // render harness constructs the window and screenshots it, so an unpopulated book is an
             // empty pink box that passes.
@@ -209,29 +246,86 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             PaintStill();
         }
 
+        private void OnOwnerMoved(object? sender, EventArgs e)
+        {
+            if (_closingForGood || !IsVisible) return;
+            try { PlaceWindow(); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book follow-move failed"); }
+        }
+
+        private void OnOwnerResized(object? sender, double width)
+        {
+            if (_closingForGood || !IsVisible) return;
+            try { PlaceWindow(); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book follow-resize failed"); }
+        }
+
+        /// <summary>
+        /// The WPF original's <c>OnClosed</c>, verbatim in effect: the book is a sibling window
+        /// holding a subscription to hers, so the handlers come off however it went away - the
+        /// fold, her dismissal, or the app shutting down.
+        /// </summary>
+        protected override void OnClosed(EventArgs e)
+        {
+            try
+            {
+                StopClock();
+                if (_owner is not null)
+                {
+                    _owner.Moved -= OnOwnerMoved;
+                    _owner.Resized -= OnOwnerResized;
+                }
+                Hold(false);
+            }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book teardown failed"); }
+            base.OnClosed(e);
+        }
+
         // ---------------------------------------------------------------- wiring
 
         /// <summary>
-        /// ponytail: needs EmiFace (WPF head, Services/EmiDesk/EmiFace.cs) for Press Start 2P and
-        /// the body face, wired when the shipped fonts land as AvaloniaResource on this head. The
-        /// SIZES are ported verbatim because they are the layout - 16 for the title, 8 for the
-        /// chrome, one whole number of pixels per 8x8 cell - but at those sizes the default UI face
-        /// reads much smaller than the pixel font does, so the chrome is small until the face lands.
+        /// Press Start 2P for the chrome and the title, the mono body face for the copy - as
+        /// NAME CHAINS, which is the road EmiRingWindow and EmiDeskWindow.axaml already take on this
+        /// head. WPF loads both through a pack:// base URI out of <c>Resources/emi/fonts</c> and its
+        /// header warns that naming a font in markup finds installed fonts only; on Avalonia there
+        /// is nothing to name yet either way.
+        ///
+        /// <para>ponytail: the blocker is NOT EmiFace, and it is not a move to Core. Both faces are
+        /// already in the repo at <c>Assets/emi/fonts/PressStart2P-latin.ttf</c> and
+        /// <c>NotoSansMono-latin.ttf</c>; what is missing is an <c>AvaloniaResource</c> link for
+        /// <c>Assets/emi/fonts/</c> in CCP.Avalonia.csproj, which this layer does not own. Until
+        /// that one line lands the chain falls through to the system mono face - so the pixel
+        /// look is missing, nothing is blank, and the panel lights up the moment the link is
+        /// added or a reader has the font installed.</para>
+        ///
+        /// <para>The SIZES are ported verbatim because they are the layout - 16 for the title, 8 for
+        /// the chrome, one whole number of pixels per 8x8 cell. At those sizes a proportional
+        /// fallback reads much smaller than Press Start 2P does, which is why the chrome looks
+        /// small on a machine without it.</para>
         /// </summary>
         private void ApplyFonts()
         {
             try
             {
-                foreach (var b in new[] { _tab0, _tab1, _tab2 }) b.FontSize = 8;
+                foreach (var b in new[] { _tab0, _tab1, _tab2 }) { b.FontFamily = PixelFont; b.FontSize = 8; }
 
+                _btnClose.FontFamily = PixelFont;
                 _btnClose.FontSize = 8;
+                _btnPrev.FontFamily = PixelFont;
                 _btnPrev.FontSize = 10;
+                _btnNext.FontFamily = PixelFont;
                 _btnNext.FontSize = 10;
+                _btnGo.FontFamily = PixelFont;
                 _btnGo.FontSize = 8;
 
+                _stageLabel.FontFamily = PixelFont;
                 _stageLabel.FontSize = 6;
+                _cardTitle.FontFamily = PixelFont;
                 _cardTitle.FontSize = 16;
+
+                _cardGist.FontFamily = FaceFont;
                 _cardGist.FontSize = 13;
+                _cardCatch.FontFamily = FaceFont;
                 _cardCatch.FontSize = 11.5;
             }
             catch (Exception ex)
@@ -239,6 +333,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 Log.Warning(ex, "[EmiDesk] book fonts failed");
             }
         }
+
+        /// <summary><c>EmiFace.PixelFont</c>'s chain, the same string EmiRingWindow uses.</summary>
+        private static readonly FontFamily PixelFont = new("Press Start 2P, Consolas, monospace");
+
+        /// <summary><c>EmiFace.FaceFont</c>'s chain, the same one EmiDeskWindow.axaml carries.</summary>
+        private static readonly FontFamily FaceFont =
+            new("Noto Sans Mono, DejaVu Sans Mono, Consolas, monospace");
 
         private void WireControls()
         {
@@ -257,13 +358,33 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             _nudgeScroll.ScrollChanged += (_, _) => UpdateMoreCue();
         }
 
-        // ponytail: needs EmiDeskWindow.HoldChromeForPanel, wired when the desk moves to Core.
-        private void Hold(bool on) { _ = on; }
+        /// <summary>Keep the chrome on her body lit while the pointer is in the book.</summary>
+        private void Hold(bool on)
+        {
+            try { _owner?.HoldChromeForPanel(on); }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book chrome hold failed"); }
+        }
 
-        // ponytail: needs the EmiBook service (WPF head, Services/EmiDesk/EmiBook.cs) for Close,
-        // NoteCard and NoteSideChanged, wired when it moves to Core. Closing the window itself is
-        // the honest local half of it.
-        private void CloseBook() => Kill();
+        /// <summary>
+        /// The close button. Routed through the widget so SHE drops her reference to the book: a
+        /// bare <see cref="Kill"/> here would fold the window and leave the desk holding a closed
+        /// one, and the next <c>?</c> click would then re-open a dead panel.
+        ///
+        /// <para>ponytail: the WPF button calls <c>EmiBook.Close()</c>, whose two remaining halves
+        /// are still blocked - <c>EmiState.BookCard</c> (the bookmark) and <c>EmiBook.SideChanged</c>
+        /// (her bubble dodging away from the panel). Both live in
+        /// ConditioningControlPanel/Services/EmiDesk/EmiState.cs and EmiBook.cs.</para>
+        /// </summary>
+        private void CloseBook()
+        {
+            if (_owner is null) { Kill(); return; }
+            try { _owner.CloseBook(); }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] book close through the widget failed");
+                Kill();
+            }
+        }
 
         // ---------------------------------------------------------------- open / close
 
@@ -320,6 +441,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 _closingForGood = true;
                 StopClock();
                 Hold(false);
+                if (_owner is not null)
+                {
+                    _owner.Moved -= OnOwnerMoved;
+                    _owner.Resized -= OnOwnerResized;
+                }
 
                 if (!IsVisible)
                 {
@@ -365,8 +491,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 _openScale.ScaleY = 0.04;
                 _flash.Opacity = 0;
 
-                _ = Scale(ScaleTransform.ScaleXProperty, 0, 1, 170, 0, new CubicEaseOut()).RunAsync(_sweepScale);
-                _ = Scale(ScaleTransform.ScaleYProperty, 0.04, 1, 200, 160, new CubicEaseOut()).RunAsync(_openScale);
+                // THE VISUAL, NOT THE TRANSFORM. See the note on Scale: this window shipped
+                // animating the ScaleTransform objects, which throws before the flash is even
+                // reached, so the book snapped open with no unfurl and said nothing about it.
+                _ = Scale(ScaleTransform.ScaleXProperty, 0, 1, 170, 0, new CubicEaseOut()).RunAsync(_sweepHost);
+                _ = Scale(ScaleTransform.ScaleYProperty, 0.04, 1, 200, 160, new CubicEaseOut()).RunAsync(_openHost);
 
                 var flash = new Animation
                 {
@@ -389,7 +518,26 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             }
         }
 
-        /// <summary>One scale ramp, which is the only shape of animation this window has.</summary>
+        /// <summary>
+        /// One scale ramp, which is the only shape of animation this window has.
+        ///
+        /// <para><b>IT IS RUN ON THE VISUAL, NEVER ON THE TRANSFORM.</b> Avalonia resolves a
+        /// <c>Setter(ScaleTransform.ScaleXProperty, …)</c> to <c>TransformAnimator</c>, which casts
+        /// its target to <c>Visual</c>: <c>RunAsync(aScaleTransform)</c> throws
+        /// <c>InvalidCastException</c> SYNCHRONOUSLY, into whatever <c>catch</c> is nearest. That is
+        /// how this window shipped, so the unfurl snapped straight to the fallback in the catch, the
+        /// seam flash never ran at all (the throw is on the line above it), and the fold closed
+        /// instantly - three animations, silent, and a PNG cannot see any of it. Handed the VISUAL
+        /// that owns the transform it writes through to that same <c>ScaleTransform</c> instance:
+        /// measured on Avalonia 12.1.1 headless, 0.880 at 200 ms of a 400 ms CubicEaseOut ramp, same
+        /// object by reference at the end, and a later direct write still lands under the fill -
+        /// which is what <see cref="Unfurl"/>'s reset and its catch depend on.</para>
+        ///
+        /// <para>This is the cheap half of the same bug wire/61 found in EmiDeskWindow and
+        /// EmiRingWindow. It could not take this road there because those transforms are not the
+        /// visual's whole <c>RenderTransform</c>; here each host owns exactly one, so the fix is the
+        /// argument.</para>
+        /// </summary>
         private static Animation Scale(
             AvaloniaProperty prop, double from, double to, double ms, double delayMs, Easing easing)
         {
@@ -420,12 +568,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                     return;
                 }
 
-                _ = Scale(ScaleTransform.ScaleYProperty, 1, 0.04, 130, 0, new CubicEaseIn()).RunAsync(_openScale);
+                _ = Scale(ScaleTransform.ScaleYProperty, 1, 0.04, 130, 0, new CubicEaseIn()).RunAsync(_openHost);
 
                 // Awaited rather than fired on a timer, which is the same rule the original states:
                 // the close hangs off the LAST animation, so a slow frame cannot leave the window on
-                // screen at zero width with nothing coming to close it.
-                await Scale(ScaleTransform.ScaleXProperty, 1, 0, 140, 120, new CubicEaseIn()).RunAsync(_sweepScale);
+                // screen at zero width with nothing coming to close it. The await is only an await
+                // now that the target is the visual - run on the transform this threw before it
+                // suspended, and the fold was an instant Close() out of the catch.
+                await Scale(ScaleTransform.ScaleXProperty, 1, 0, 140, 120, new CubicEaseIn()).RunAsync(_sweepHost);
                 Close();
             }
             catch (Exception ex)
@@ -680,7 +830,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 FontSize = 12.5,
                 Foreground = NudgePlain,
             };
-            // ponytail: needs EmiFace.FaceFont, as in ApplyFonts.
+            tb.FontFamily = FaceFont;
             Emphasize(tb, text, NudgePlain, NudgeHot);
             row.Children.Add(tb);
 
@@ -840,9 +990,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>
         /// Her line in the margin: a comment ON the card, not a reading of it.
         ///
-        /// <para>ponytail: needs EmiDeskWindow.SpeakLine and the LineDraw record (WPF head), wired
-        /// when the desk moves to Core. Priority 2, keyed "book.margin.&lt;id&gt;", face from the
-        /// card - all of that is data this stub already carries, so only the delivery is missing.</para>
+        /// <para>ponytail: the OWNER is here now, so this is one member away. What is missing is
+        /// <c>EmiDeskWindow.SpeakLine</c> and the <c>LineDraw</c> record, and those are blocked on
+        /// <c>EmiLineEngine</c> + <c>EmiChains.Player</c>
+        /// (ConditioningControlPanel/Services/EmiDesk/): the widget's <c>Say</c> and
+        /// <c>PlayChain</c> are still no-ops on this head, so a line handed over would be swallowed
+        /// rather than spoken. Priority 2, keyed "book.margin.&lt;id&gt;", face from the card - all
+        /// of that is data this stub already carries, so only the delivery is missing.</para>
         /// </summary>
         private void SpeakMargin()
         {
@@ -863,13 +1017,30 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         // ---------------------------------------------------------------- placement
 
         /// <summary>
-        /// Her body box on the desk, in PHYSICAL pixels.
+        /// Her body box on the desk, in PHYSICAL pixels - read off the widget itself.
         ///
-        /// <para>ponytail: needs EmiDeskWindow.BodyScreenRect, wired when the desk moves to Core. A
-        /// fixed box on the right of a 1920 desk until then, which is where she usually stands and
-        /// therefore exercises the same branch the real one does.</para>
+        /// <para>With no owner (the headless render) it is a fixed box on the right of a 1920 desk,
+        /// which is where she usually stands and therefore exercises the same branch the real one
+        /// does. <c>EmiDeskWindow.BodyScreenRect</c> is a DIP-typed <see cref="Rect"/> already
+        /// holding physical pixels, so the only work here is the rounding into
+        /// <see cref="PixelRect"/>.</para>
         /// </summary>
-        private PixelRect BodyScreenRect => new(1480, 360, 220, 420);
+        private PixelRect BodyScreenRect
+        {
+            get
+            {
+                try
+                {
+                    var b = _owner?.BodyScreenRect;
+                    if (b is { Width: > 0, Height: > 0 })
+                        return new PixelRect(
+                            (int)Math.Round(b.Value.X), (int)Math.Round(b.Value.Y),
+                            (int)Math.Round(b.Value.Width), (int)Math.Round(b.Value.Height));
+                }
+                catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book body-rect read failed"); }
+                return new PixelRect(1480, 360, 220, 420);
+            }
+        }
 
         private PixelRect WorkArea()
         {
@@ -953,7 +1124,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 _sweepHost.RenderTransformOrigin = new RelativePoint(_onHerLeft ? 1 : 0, 0.5, RelativeUnit.Relative);
 
                 // ponytail: needs EmiBook.NoteSideChanged (her bubble dodges to the side the panel
-                // is NOT on), wired when it moves to Core.
+                // is NOT on). The event itself is trivial, but its one subscriber is the bubble's
+                // LayoutBubble dodge in EmiDeskWindow.Bubble.cs, which is not ported on this head -
+                // so an event raised here today would have nobody listening.
                 if (wasOnHerLeft != _onHerLeft)
                     Log.Debug("[EmiDesk] book changed side, now {Side}", SideOfHer);
             }

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml.cs
@@ -1354,6 +1354,73 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>Let the panel keep the chrome lit while the pointer is inside it.</summary>
         internal void HoldChromeForPanel(bool on) => ChromeHold(EmiChromeHold.Menu, on);
 
+        // ---- her book -------------------------------------------------------------
+
+        private EmiBookWindow? _book;
+
+        /// <summary>
+        /// HER MANUAL. Open the book beside her, at <paramref name="cardId"/> or at the first card.
+        ///
+        /// <para>The WPF path is <c>EmiBook.Open</c>, a static router that keeps the single instance
+        /// and resolves the owner off <c>App.EmiDesk</c>. There is no app shell on this head, so the
+        /// widget keeps the instance itself - the same shape it already uses for her options panel,
+        /// and the widget IS the owner the router was going looking for.</para>
+        ///
+        /// <para>Single instance, the router's own rule: a second open on a live book NAVIGATES it
+        /// rather than building a second panel.</para>
+        ///
+        /// <para>ponytail: three of the router's jobs are still blocked and none of them is view
+        /// work. <c>EmiBook.Bookmark</c> / <c>NoteCard</c> (the card she last had open) and
+        /// <c>EmiState.NoteCodexOpened()</c> need
+        /// ConditioningControlPanel/Services/EmiDesk/EmiState.cs; <c>NoteSideChanged</c> needs the
+        /// bubble dodge in EmiDeskWindow.Bubble.cs. So the book opens at the first card every time
+        /// until EmiState lands.</para>
+        /// </summary>
+        private void OpenBook(string? cardId = null)
+        {
+            try
+            {
+                if (_book != null)
+                {
+                    _book.GoTo(cardId);
+                    return;
+                }
+
+                var win = new EmiBookWindow(this);
+                // The window can go away without anybody calling CloseBook - the fold finishing, or
+                // the app shutting down - so the reference is dropped from the window's own Closed.
+                // Without this the next ? click would GoTo a dead panel.
+                win.Closed += OnBookClosed;
+                _book = win;
+                win.OpenBook(cardId);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[EmiDesk] the book failed to open");
+                try { CloseBook(); } catch { /* nothing else to try */ }
+            }
+        }
+
+        /// <summary>Fold the book. Safe when it is not up, and the road her close button takes.</summary>
+        internal void CloseBook()
+        {
+            var win = _book;
+            _book = null;
+            if (win == null) return;
+            try
+            {
+                win.Closed -= OnBookClosed;
+                win.Kill();
+            }
+            catch (Exception ex) { Log.Debug(ex, "[EmiDesk] book close failed"); }
+        }
+
+        private void OnBookClosed(object? sender, EventArgs e)
+        {
+            if (!ReferenceEquals(sender, _book)) return;
+            _book = null;
+        }
+
         /// <summary>Clear the resize hold, whichever way the drag ended.</summary>
         private void EndResizeHold()
         {
@@ -2422,9 +2489,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>ponytail: needs EmiSfx (Services/EmiDesk/EmiSfx.cs) - the pat sound.</summary>
         private void PlayPatSfx() { }
 
-        /// <summary>ponytail: needs EmiBook.Open (Services/EmiDesk/EmiBook.cs) - her manual.</summary>
-        private void OpenBook() { }
-
         /// <summary>ponytail: needs App.EmiDesk.Dismiss() - the hover x sends her away.</summary>
         private void Dismiss() { }
 
@@ -2445,6 +2509,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                 try { OnTearDownCore(); }
                 catch (Exception ex) { Log.Debug(ex, "[EmiDesk] teardown seam threw"); }
                 KillOptionsPanel();
+                // NOT in WPF's ShutDown, and deliberately: there the book is held by a static
+                // router and the App shutdown closes every window. This head has no shell, so a
+                // book left up would be a topmost window with two handlers pointing at a closed
+                // widget and no road back to a close button.
+                CloseBook();
                 StopIdleBeats();
                 StopAlive();
                 DisarmPet();
@@ -2467,6 +2536,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             {
                 _closingForGood = true;
                 KillOptionsPanel();
+                CloseBook();
                 StopIdleBeats();
                 StopAlive();
                 DisarmPet();


### PR DESCRIPTION
The book had twenty ponytail: notes and every one of the owner-shaped ones was
stale in the same way: they say "wired when the desk moves to Core" and
EmiDeskWindow has been ported on this head since wire/46. So EmiBookWindow now
takes the widget the WPF constructor always took, and four members stop being
stubs - Hold(bool) is HoldChromeForPanel again (the ? chip is still lit when you
come back out of the book), BodyScreenRect is read off her instead of a fixed
box on a pretend 1920 desk, and Moved/Resized are subscribed so the panel follows
her while she is dragged or resized. The owner stays NULLABLE for exactly one
reason - --render-view needs a parameterless constructor - which is the shape
wire/46 settled on for her options panel, and every owner call is `?.` with the
fallback the unowned book already used.

The chip that opens it. EmiDeskWindow.OpenBook() was an empty no-op with a live
caller: OnHelpClick has always tidied away the ring and the options panel and
then called into the dark. WPF routes that through EmiBook, a static router
holding the single instance and resolving the owner off App.EmiDesk; there is no
app shell here, so the widget keeps the instance itself - the same shape it
already uses for _options, and the widget IS the owner the router goes looking
for. A second open navigates rather than building a second panel, the window's
own Closed drops the reference so the next ? cannot GoTo a dead one, and the
book's close button routes back through her rather than folding itself, which is
what stops the desk holding a closed window. CloseBook() in the two teardown
roads is NOT in WPF's ShutDown and is written up as a deviation in the file: WPF
has an App shutdown that closes every window and this head does not, so a book
left behind would be a topmost panel with two handlers pointing at a closed
widget and no road back to a close button.

ALL THREE OF THE BOOK'S ANIMATIONS WERE INERT, and this is the same bug wire/61
measured next door. Avalonia resolves Setter(ScaleTransform.ScaleXProperty, …)
to TransformAnimator, which casts its target to Visual, so RunAsync(aScaleTransform)
throws InvalidCastException SYNCHRONOUSLY into the nearest catch. Measured here
on Avalonia 12.1.1 headless rather than assumed from the sibling finding: target
the transform and it throws with the message naming the cast; target the VISUAL
that owns it and the task completes, the animator writes through to that same
ScaleTransform instance (0.880 at 200 ms of a 400 ms CubicEaseOut ramp, same
object by reference at the end), and a later direct write still lands under the
fill - which is what the unfurl's reset and its catch both depend on. So the
book had been snapping open with no sweep, no CRT open and no seam flash at all
(the throw is on the line above the flash), and folding instantly out of the
catch. The fix is the ARGUMENT, not a timer: each host here owns exactly one
transform, which is why this could take the road BodyRoot's four independent
slots denied wire/61 - worth a look before a third Tween copy is written.

The reduced-motion gate is real. MotionFx is still head-side, but what it READS
is not: Controls/AmbientFxCanvas.Env in this assembly already carries the ported
gate off CoreSettings.Current.MotionLevel and the performance tier, so
AllowTransitions is MotionFx's own `Level != Off` and AllowAmbientLoops is Env's.
A reader who asked for no animation now gets a book that is simply there, which
is the behaviour the Unfurl doc comment has been promising while two `const bool
= true` quietly ignored it.

Fonts: half of that note was wrong too. The blocker is not EmiFace and not a move
to Core - both faces are already in the repo at Assets/emi/fonts/. What is
missing is an AvaloniaResource link for that directory in CCP.Avalonia.csproj,
which this layer does not own. Meanwhile the families are named as chains, which
is the road EmiRingWindow and EmiDeskWindow.axaml already take here: the body
copy picks up the mono face today (visible in the render), the pixel face falls
through until the link lands, and nothing is blank either way.

Still blocked, named symbols and head paths:

  EmiBookWindow.Book (the six-card stub deck)
      EmiBookCards.cs + the six EmiBookDeck.*.cs (ConditioningControlPanel/
      Services/EmiDesk/, 1,165 lines). PURE - the only non-Core reference in the
      whole set is Localization.Loc.Get, which is in Core. A git mv, and the
      largest single win left in the book.
  EmiBookWindow.StartClock / PaintStill / ShootFrame
      EmiBookDemos.cs + its six partials (1,879 lines) are pure C# EXCEPT that
      every Draw takes EmiPixelCanvas, and EmiPixel.cs is System.Windows.Media
      WriteableBitmap + Int32Rect. Portable behind a Core pixel-buffer type; the
      demos themselves need no edit.
  EmiBookWindow.RenderRail glyphs      EmiBookGlyphs.cs. Pure but for
      System.Windows.Media in its signatures - the same Core-colour-type problem
      EmiRingLayout has.
  EmiBookWindow.Place (side/width)     CCP.Core's EmiBookLayout is `internal` and
      CCP.Avalonia is not in Core/Properties/AssemblyInfo.cs's InternalsVisibleTo.
      One line in Core, which this layer does not own. Do NOT re-derive it.
  EmiBookWindow.SpeakMargin           the owner is here; EmiDeskWindow.SpeakLine
      and LineDraw are not, and they are blocked on EmiLineEngine + EmiChains.Player.
      Her Say and PlayChain are still no-ops, so a line handed over today would be
      swallowed rather than spoken.
  EmiBookWindow.Go / RenderButton's ghosting   EmiTargets.Find / EmiTargets.Open
      and MainWindow.StartTutorial (Services/EmiDesk/EmiTargets.cs).
  EmiBookWindow bookmark + NoteCard,
  EmiDeskWindow.OpenBook's card arg   EmiState.BookCard / NoteCodexOpened
      (Services/EmiDesk/EmiState.cs). The book opens at the first card every time
      until that lands.
  EmiBook.NoteSideChanged             the event is trivial; its one subscriber is
      the bubble dodge in EmiDeskWindow.Bubble.cs, not ported - so raising it
      today would reach nobody.
  ApplyFonts                          the csproj link above.

Handover, in the order it should be taken:

  1. git mv EmiBookCards.cs + EmiBookDeck.*.cs to Core. Pure, checked; it turns
     the six-card stub deck into the shipped book and needs no view edit beyond
     deleting EmiBookWindow.Book and pointing at EmiBookCards.
  2. One line in CCP.Core/Properties/AssemblyInfo.cs adding CCP.Avalonia to
     InternalsVisibleTo, then EmiBookLayout.Place replaces the Place() stand-in.
     Two-line layer, and it is the narrow book on a small laptop.
  3. Link Assets/emi/fonts/ as AvaloniaResource in CCP.Avalonia.csproj. Lights up
     the book, EmiRingWindow and the desk at once - all three already name the
     chains. Same layer could take Assets/web/arcademy/art/emi/ for wire/61's
     item (3).
  4. A Core pixel-buffer type, then EmiBookDemos + its six partials move and the
     stage stops being a placeholder still. The window's WriteableBitmap blow-up
     already works; only the painter is missing.
  5. Before writing a third Tween: re-check wire/61's two files against the
     measurement in Scale's doc comment here. RunAsync on the VISUAL was not
     tried there, and it may retire eighty lines.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU