### PR TITLE
feat(avalonia): Tube Fit hot-refreshes the live tube, and the Devices chat shortcut rebinds

### DIFF
--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -313,6 +315,24 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             _possessionGlitchTimer?.Stop();
             base.OnClosed(e);
         }
+
+        // =========================================================================================
+        //  Locating the live tube. WPF's App.AvatarWindow twin: the WPF head keeps a field on its
+        //  Application subclass, which is exactly the static service locator Core is not allowed to
+        //  have, so this head asks the window list instead.
+        // =========================================================================================
+
+        /// <summary>
+        /// The tube that is currently OPEN, or null. Avalonia's desktop lifetime populates
+        /// <c>Windows</c> on <c>Show()</c> and drops the entry on close, so this cannot go stale the
+        /// way a hand-maintained static field can - there is no lifecycle bookkeeping to get wrong,
+        /// and a constructed-but-never-shown tube (the <c>--render-view</c> path) is correctly not
+        /// "live". Null on a headless render and before the shell builds one, which every caller
+        /// treats as "there is nothing to refresh".
+        /// </summary>
+        public static AvatarTubeWindow? Live =>
+            (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)
+                ?.Windows.OfType<AvatarTubeWindow>().FirstOrDefault();
 
         // =========================================================================================
         //  Thread marshalling. WPF's own-thread mode (AppSettings.AvatarOwnThread) has no Avalonia
@@ -1394,14 +1414,21 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         /// <summary>Step through the unlocked avatar sets with the title-box arrows.</summary>
         private void SelectAvatarSet(int delta)
         {
-            // ponytail: the three things a SWITCH needs are here now (LoadAvatarPoses,
-            // ApplyAvatarTransform, UpdateTitleDisplay); the LIST of sets to step through is not.
-            // App.Mods.IsAvatarSetSupported and GetCustomAvatarSets (ModService.cs) decide which
-            // sets the active mod actually ships art for, and stepping onto a set with no PNG would
-            // leave the tube empty under a caption naming a persona who is not drawn. Both arrows
-            // are IsVisible=False in the XAML until WPF's UpdateNavigationArrows runs, so nothing
-            // reaches this today - the tube shows CoreSettings.Current.SelectedAvatarSet and stays
-            // on it.
+            // The old note here named App.Mods.IsAvatarSetSupported / GetCustomAvatarSets as the
+            // blocker. That is STALE: both are one-liners over ModManifest.SupportedAvatarSets and
+            // .CustomAvatarSets (ModService.cs:1268/1289), and the whole manifest is in Core -
+            // CoreMods.InstalledMods[ActiveModId].Manifest answers both today. The list of sets is
+            // not what is missing.
+            //
+            // ponytail: what is missing is the COMPANION COUPLING. WPF's SwitchToAvatarSet
+            // (AvatarTubeWindow.Avatar.cs:395) persists SelectedAvatarSet and switches the active
+            // companion in the same beat for sets 4+, because the tube's caption reads the persona
+            // behind the SET. CoreModsHooks.SwitchCompanion is the seam and no head seeds it, so an
+            // arrow here would write a shared setting and leave the app's active companion pointing
+            // somewhere else - a second writer for one setting, which is the trap this port keeps
+            // hitting. Both arrows are IsVisible=False in the XAML (WPF's UpdateNavigationArrows is
+            // what reveals them), so nothing reaches this today: the tube shows
+            // CoreSettings.Current.SelectedAvatarSet and stays on it.
         }
 
         /// <summary>Refresh the context menu's checkmarks and the remote-emote item swap.</summary>

--- a/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Views.AvatarTube;
 using ConditioningControlPanel.Avalonia.Views.Dialogs;
 using ConditioningControlPanel.Localization;
 using Serilog;
@@ -48,6 +49,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             TxtSpeechWakeWords.LostFocus += TxtSpeechWakeWords_LostFocus;
             CmbMicDevice.SelectionChanged += CmbMicDevice_SelectionChanged;
             BtnMicRefresh.Click += BtnMicRefresh_Click;
+            BtnChatShortcutDevices.Click += BtnChatShortcut_Click;
 
             SyncFromSettings();
             PopulateMicDevices();
@@ -113,6 +115,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
                 SetButtonLabel(BtnPauseKey, string.IsNullOrEmpty(s.PauseKey)
                     ? Loc.Get("btn_pause_key_unbound")
                     : $"⏸ {s.PauseKey}");
+
+                RefreshChatShortcutLabel();
             }
             catch (Exception ex)
             {
@@ -213,6 +217,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         // start / tracker-test / privacy / revoke buttons and the debug-cursor toggle all need
         // WebcamTrackingService + App.GazeCursor (ConditioningControlPanel/Services/Webcam/,
         // MainWindow.LabTab.cs), still in the WPF head. Their controls render inert.
+        //
+        // Re-checked against Core: CCP.Core/Services/Webcam/WebcamConsent.cs is there, but it is a
+        // READ predicate (IsCurrent) only. BtnWebcamRevokeConsent needs App.Webcam.RevokeConsent,
+        // which stops tracking, deletes the calibration file and disables the webcam features -
+        // four promises the dialog makes. Clearing the consent flag alone would keep three of them
+        // and still tell the user everything was undone, so the button stays inert until the
+        // service crosses.
 
         private void ChkBlinkRecalShortcut_Changed(object? sender, RoutedEventArgs e)
         {
@@ -349,10 +360,77 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         // keyboard hook (MainWindow.xaml.cs UpdatePanicKeyButton / _isCapturingPanicKey); the
         // buttons show the stored binding but cannot rebind it on this head.
 
-        // ponytail: BtnChatShortcutDevices / BtnCameraShortcutDevices need AvatarTubeWindow
-        // .FormatChatShortcut / SerializeModifiers / ApplyChatShortcutTo and GlobalHotkeyService
-        // (ConditioningControlPanel/Views/Windows/, /Services/), all Win32 and still in the WPF
-        // head - the dialog itself (Views/Dialogs/ChatShortcutCaptureDialog) is already ported, so
-        // this unblocks as soon as the modifier serialiser and the hotkey registrar move.
+        // =====================================================================================
+        //  the chat shortcut (MainWindow.SessionIO.cs BtnChatShortcut_Click / RefreshChatShortcutLabel)
+        // =====================================================================================
+
+        /// <summary>
+        /// Paints the row's pill with the combo actually stored. The label is a bare literal in the
+        /// XAML, not a <c>{loc:Str}</c>, so assigning .Text here is safe - and it has to be code
+        /// rather than a binding because the value is composed from two settings strings.
+        /// </summary>
+        private void RefreshChatShortcutLabel() =>
+            TxtChatShortcutLabelDevices.Text = AvatarTubeWindow.FormatChatShortcut();
+
+        /// <summary>
+        /// Opens the capture dialog, stores the captured combo and re-applies the binding without a
+        /// restart - WPF's BtnChatShortcut_Click (MainWindow.SessionIO.cs:1202) with its two
+        /// re-applications kept: the shell window (WPF passes <c>this</c>, i.e. MainWindow) and the
+        /// open tube, which is <see cref="AvatarTubeWindow.Live"/> here rather than App.AvatarWindow.
+        /// Awaited, not fire-and-forget: Avalonia's ShowDialog is async, and writing the setting
+        /// before the answer lands would store whatever the previous combo was.
+        ///
+        /// <para><b>ChatShortcutGlobal is stored but not registered.</b> The checkbox's "activate
+        /// from any app" half is GlobalHotkeyService, a Win32 RegisterHotKey that stays in the WPF
+        /// head. Storing the user's choice is still right - it is one settings file across both
+        /// heads, and WPF honours it - and the IN-WINDOW binding this method applies works on this
+        /// head either way, which is exactly what WPF falls back to when the flag is off.</para>
+        /// </summary>
+        private async void BtnChatShortcut_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // No owner means no modal dialog to show, so there is nothing to capture. WPF could
+                // not reach this state; here it is the headless/detached case.
+                if (TopLevel.GetTopLevel(this) is not Window owner) return;
+                var prompt = CoreSettings.Current.CompanionPrompt;
+                if (prompt == null) return;
+
+                var dlg = new ChatShortcutCaptureDialog { GlobalHotkey = prompt.ChatShortcutGlobal };
+                if (!await dlg.ShowDialog<bool>(owner)) return;
+
+                if (dlg.ResetToDefault)
+                {
+                    prompt.ChatShortcutKey = "T";
+                    prompt.ChatShortcutModifiers = "Control";
+                }
+                else
+                {
+                    prompt.ChatShortcutKey = dlg.CapturedKey.ToString();
+                    // Serialises "Windows", not Avalonia's "Meta", so a file written here still
+                    // parses on the WPF head.
+                    prompt.ChatShortcutModifiers = AvatarTubeWindow.SerializeModifiers(dlg.CapturedModifiers);
+                }
+                prompt.ChatShortcutGlobal = dlg.GlobalHotkey;
+                CoreSettings.Save();
+
+                AvatarTubeWindow.ApplyChatShortcutTo(owner);
+                AvatarTubeWindow.ApplyChatShortcutTo(AvatarTubeWindow.Live);
+                RefreshChatShortcutLabel();
+                Log.Information("Chat shortcut rebound to {Combo}", AvatarTubeWindow.FormatChatShortcut());
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Settings/Devices: chat shortcut rebind failed");
+            }
+        }
+
+        // ponytail: BtnCameraShortcutDevices stays inert, and NOT for the reason the old note gave.
+        // SerializeModifiers shipped with the tube, so the capture half would work - but the combo
+        // it stores drives MainWindow.ToggleWebcamFromHotkey (MainWindow.SessionIO.cs:1485), which
+        // toggles WebcamTrackingService. No webcam engine exists on this head at all (see the
+        // webcam note above), so a rebind here would let the user configure a key for a feature
+        // that cannot fire - and the row's own label would then report a binding that does nothing.
+        // The label is left at its XAML literal for the same reason. Unblocks with the tracker.
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
+using ConditioningControlPanel.Avalonia.Views.AvatarTube;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
 using Serilog;
@@ -42,7 +43,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    seam. Nothing loading falls back to the pose glyph and a nominal
     ///    <see cref="PlaceholderPixelWidth"/>x<see cref="PlaceholderPixelHeight"/>, so the preview
     ///    is never blank.
-    ///  - Still head-side, with a note: the tube window's <c>RefreshTubeLayout()</c>. The tube
+    ///  - <b>Save and Reset hot-refresh the live tube.</b>
+    ///    <c>AvatarTubeWindow.RefreshTubeLayout()</c> is on this head now, and
+    ///    <c>AvatarTubeWindow.Live</c> is the App.AvatarWindow twin that finds the open one, so the
+    ///    edit lands on screen while the dialog is still up instead of waiting for the tube's next
+    ///    construction. Null when no tube is open, which is a no-op rather than a failure. The tube
     ///    frame itself stays the placeholder capsule - that is markup this layer does not own.
     ///  - WPF's <c>LayoutTransform</c> has no Avalonia twin on a plain control, so the avatar scale
     ///    is a <c>RenderTransform</c> about the centre. It does not grow the parent Border, so a
@@ -473,9 +478,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                 "(scale {Scale:0.00}, attached {OffX}/{OffY}, detached {DetX}/{DetY})",
                 _modId, _scale, _offsetX, _offsetY, _detachedOffsetX, _detachedOffsetY);
 
-            // ponytail: needs the tube window's RefreshTubeLayout() to re-read the override live.
-            // CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs has no such method yet, so
-            // the saved layout is picked up on the tube's next construction rather than at once.
+            // Hot-refresh the open tube, exactly as WPF's App.AvatarWindow?.RefreshTubeLayout()
+            // does. Both sides read the same EffectiveTubeLayout, so this dialog's preview and the
+            // live tube now settle on the same numbers the instant Save is pressed.
+            AvatarTubeWindow.Live?.RefreshTubeLayout();
             Close();
         }
 
@@ -486,7 +492,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
             Log.Information("[TubeFit] Reset tube layout to mod default for mod {ModId}", _modId);
 
-            // ponytail: needs RefreshTubeLayout() - see BtnSave_Click.
+            AvatarTubeWindow.Live?.RefreshTubeLayout();
 
             // Reload the working values from the mod's shipped manifest so the preview follows.
             LoadWorkingValues(ManifestLayout());


### PR DESCRIPTION
wire/40 and wire/59 both landed tube members with no caller. This layer is the callers.

AvatarTubeWindow gains Live, the App.AvatarWindow twin. WPF keeps the open tube in a field on
its Application subclass - the static service locator Core is not allowed to have - so this head
asks Avalonia's desktop lifetime for its Windows and takes the AvatarTubeWindow out of it. That
cannot go stale the way a hand-maintained static can: the list is populated on Show() and the
entry drops on close, so a constructed-but-never-shown tube (the --render-view path) is correctly
not "live", and null before the shell builds one is a no-op for every caller. Program.cs:64 starts
the app with StartWithClassicDesktopLifetime, which is the lifetime the cast needs - checked,
because a miss would make this permanently null and every caller below a silent no-op.

TubeFitDialog's Save and Reset call RefreshTubeLayout on it, which is what WPF's
App.AvatarWindow?.RefreshTubeLayout() does at both sites. The dialog's preview and the live tube
already read the same EffectiveTubeLayout, so an edit now settles on both at once instead of
waiting for the tube's next construction.

DevicesSettingsSection's chat-shortcut row works. The pill is painted from FormatChatShortcut on
every load and settings replacement, and the button opens ChatShortcutCaptureDialog, stores the
captured combo through SerializeModifiers - which still writes "Windows", not Avalonia's "Meta",
so the file keeps parsing on the WPF head - and re-applies ApplyChatShortcutTo to both the shell
window and Live, which is WPF's two re-applications kept. Awaited, not fire-and-forget: Avalonia's
ShowDialog is async and writing the setting before the answer lands would store the previous
combo. ChatShortcutGlobal is STORED but not registered - RegisterHotKey stays in the WPF head.
Note the ceiling that leaves: this method is currently the ONLY thing that ever binds the combo on
the shell, because no MainShellWindow partial calls ApplyChatShortcutTo at startup the way WPF's
MainWindow does from Loaded. So until that one line lands the shortcut reaches the shell only
after the user has been through this dialog once; the tube binds itself in its own Loaded.

Three notes were stale or wrong and are rewritten rather than left to mislead the next pass.
BtnCameraShortcutDevices was blamed on SerializeModifiers, which shipped two layers ago; its real
blocker is that the combo drives MainWindow.ToggleWebcamFromHotkey and no webcam engine exists on
this head, so a rebind would configure a key that cannot fire. SelectAvatarSet was blamed on
App.Mods.IsAvatarSetSupported / GetCustomAvatarSets, which are one-liners over
ModManifest.SupportedAvatarSets / .CustomAvatarSets and fully answerable from Core today; the real
blocker is the companion coupling - WPF persists SelectedAvatarSet and switches the active
companion in the same beat, CoreModsHooks.SwitchCompanion is seeded by nobody, and an arrow here
would be a second writer for a shared setting. And WebcamConsent IS in Core but is a read
predicate only, so BtnWebcamRevokeConsent still needs App.Webcam.RevokeConsent - clearing the flag
alone keeps three of the four promises the revoke dialog makes.

The tube renders exactly as wire/59 left it and it still does not track a face: nothing here
reads a camera.

Still blocked:
- AvatarTubeWindow.ApplyChatShortcutTo(this) at shell startup, in
  CCP.Avalonia/Views/Windows/MainShellWindow.axaml.cs (WPF does it from MainWindow's Loaded).
  Not this layer's file; without it the shell has no chat binding until the first rebind.
- Services.GlobalHotkeyService (ConditioningControlPanel/Services/Input/GlobalHotkeyService.cs)
  - the "activate from any app" half of ChatShortcutGlobal. Win32 RegisterHotKey.
- MainWindow.ToggleWebcamFromHotkey / ApplyCameraShortcutTo / RefreshCameraShortcutLabel
  (ConditioningControlPanel/MainWindow/MainWindow.SessionIO.cs:1356/1485) and
  Services.Webcam.WebcamTrackingService - BtnCameraShortcutDevices and the whole webcam bar.
- App.Webcam.RevokeConsent (ConditioningControlPanel/Services/Webcam/) - BtnWebcamRevokeConsent.
- CoreModsHooks.SwitchCompanion has no seeder on any head - AvatarTubeWindow.SelectAvatarSet and
  the BtnPrevAvatar / BtnNextAvatar arrows, which stay IsVisible=False.
- Services.TierGate.DemandPremium and App.Autonomy.RefreshVoiceInputModes - ChkSpeechWakeWord /
  ChkSpeechPushToTalk, unchanged from the previous layer.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU