### PR TITLE
fix(avalonia): make the stale port notes true, and restore the four members they were hiding

### DIFF
--- a/CCP.Avalonia/Controls/AmbientFxCanvas.cs
+++ b/CCP.Avalonia/Controls/AmbientFxCanvas.cs
@@ -1170,8 +1170,11 @@ namespace ConditioningControlPanel.Avalonia.Controls
             public static Color FlashTintColor => ThemeColor("FxFlashTintColor");
 
             /// <summary>
-            /// FxTheme.MistOpacity. ponytail: needs <c>App.Mods.GetMistOpacity()</c>, which
-            /// CoreMods does not expose; 1.0 is what that call answers with no mod loaded.
+            /// FxTheme.MistOpacity. ponytail: the WPF original reads
+            /// <c>App.Mods.GetMistOpacity()</c>; <see cref="CoreMods"/> exposes no mist-opacity
+            /// provider, so there is nothing to call here yet - adding one is a Core change.
+            /// 1.0 is what the WPF call answers with no mod loaded, so this is the no-mod value
+            /// rather than an invented default.
             /// </summary>
             public static double MistOpacity => 1.0;
 

--- a/CCP.Avalonia/Helpers/ModArt.cs
+++ b/CCP.Avalonia/Helpers/ModArt.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Helpers
+{
+    /// <summary>
+    /// The head's half of <see cref="CoreModArt"/>: turn a Resources-relative logical name into a
+    /// decoded bitmap, mod override first, this head's shipped <c>avares://</c> copy second.
+    ///
+    /// <para>This is the Avalonia twin of the WPF head's
+    /// <c>Services.ModResourceResolver.ResolveImage</c>, split the way the seam requires - Core
+    /// answers "is there an override and where", and the decode plus the built-in fallback stay
+    /// here because <c>avares://</c> is this head's packaging and Core must never learn it.</para>
+    ///
+    /// <para>Order matters and is the WPF order: probing the shipped copy first would always hit
+    /// the bundled PNG and make mod art unreachable. Null means "neither exists", which every
+    /// caller must treat as the WPF null path (draw the glyph, collapse the plate) rather than as
+    /// a failure.</para>
+    ///
+    /// <para>ponytail: <c>TubeFitDialog</c>, <c>AvatarTubeWindow</c> and <c>ModCreatorWindow</c>
+    /// still carry private copies of this two-step; fold them in when a layer owns those files.
+    /// No decode cache yet - WPF's resolver keys one on (event skin, mod id, path), and every
+    /// caller here loads a handful of small PNGs once, so add one when a caller loads per-frame.
+    /// The event-skin tier of the WPF chain is missing too, and that half is Core's:
+    /// <see cref="CoreModArt"/> has no event-skin provider yet, so an event cannot outrank a mod
+    /// on this head.</para>
+    /// </summary>
+    internal static class ModArt
+    {
+        /// <summary>
+        /// The mod's override, else this head's shipped copy, else null.
+        /// </summary>
+        /// <param name="resourceName">
+        /// Forward-slash path relative to <c>Resources/</c>, e.g. "bubble.png",
+        /// "features/flash.png", "achievements/lv_10.png". Traversal is rejected inside
+        /// <see cref="CoreModArt.OverridePath"/>.
+        /// </param>
+        internal static Bitmap? TryLoad(string? resourceName)
+        {
+            if (string.IsNullOrWhiteSpace(resourceName)) return null;
+
+            var overridePath = CoreModArt.OverridePath(resourceName);
+            if (overridePath != null)
+            {
+                try { if (File.Exists(overridePath)) return new Bitmap(overridePath); }
+                catch (Exception ex) { Log.Warning(ex, "[ModArt] mod override {Path} would not load", overridePath); }
+            }
+
+            try
+            {
+                var uri = new Uri($"avares://CCP.Avalonia/Resources/{resourceName}");
+                if (!AssetLoader.Exists(uri)) return null;
+                using var stream = AssetLoader.Open(uri);
+                return new Bitmap(stream);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[ModArt] built-in {Name} would not load", resourceName);
+                return null;
+            }
+        }
+    }
+}

--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -1434,9 +1434,12 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         /// <summary>Refresh the context menu's checkmarks and the remote-emote item swap.</summary>
         private void UpdateQuickMenuState()
         {
-            // ponytail: needs App.Settings.Current.RemoteEmotePresets, App.Engine, App.Companion and
-            // AvatarTubeWindow.Reactions.cs's AvatarContextMenu_Opened, which retitles every item
-            // from live state on each open.
+            // ponytail: the settings half is NOT the blocker - RemoteEmotePresets is on
+            // CoreSettings.Current today. What is missing is the live state the menu titles read:
+            // App.Engine (running / paused) and App.Companion (her name and mood), neither of
+            // which has a seam, plus AvatarTubeWindow.Reactions.cs's AvatarContextMenu_Opened,
+            // which retitles every item on each open. Retitling from settings alone would print a
+            // menu that disagrees with what the engine is actually doing, so it stays inert.
         }
     }
 }

--- a/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs
@@ -29,8 +29,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>; <c>MouseLeftButtonUp</c> ->
     ///    <c>PointerReleased</c>; <c>Cursors.Hand</c> -> <c>StandardCursorType.Hand</c>;
     ///    <c>ToolTip =</c> -> <c>ToolTip.SetTip</c>; <c>App.Logger</c> -> Serilog's static Log.
-    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so the
-    ///    erase confirmation is not raised at all (see <see cref="DeleteSlot_Click"/>).
+    ///  - <c>MessageBox.Show</c> is <c>Dialogs.MessageDialog</c> on this head now. The erase
+    ///    confirmation is still not raised, but for the other reason: there is no erase to
+    ///    confirm (see <see cref="DeleteSlot_Click"/>).
     ///  - The constructor is <c>internal</c> and parameterless, as in WPF; that also makes it the
     ///    render constructor <c>--render-all</c> discovers.
     /// </summary>
@@ -365,9 +366,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             }
         }
 
-        // ponytail: needs ChaosMeta.DeleteSlot plus a confirmation dialog (WPF used MessageBox,
-        // which Avalonia has no equivalent of), wired when they move to Core. Erasing a save
-        // unprompted is worse than not erasing it, so this only logs until both exist.
+        // ponytail: the dialog half is done - Dialogs.MessageDialog.ConfirmAsync is this head's
+        // MessageBox and this window can own it. The remaining blocker is the erase itself:
+        // ChaosMeta.DeleteSlot lives in ConditioningControlPanel/Services/Chaos/ChaosUpgrades.cs,
+        // still WPF head-side with no seam. Prompting for a delete this head cannot perform would
+        // be worse than the log line, so the prompt waits for the service, not the other way
+        // round.
         private void DeleteSlot_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
         {
             e.Handled = true;   // don't let the click also select the card

--- a/CCP.Avalonia/Views/Controls/AppSettings/DataSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DataSettingsSection.axaml.cs
@@ -122,10 +122,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         private async void BtnExportPhrases_Click(object? sender, RoutedEventArgs e)
         {
             var settings = CoreSettings.Current;
-            if (TopLevel.GetTopLevel(this) is not { } top) return;
+            if (TopLevel.GetTopLevel(this) is not Window owner) return;
             _phraseBackupService ??= new PhraseBackupService();
 
-            var file = await top.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            var file = await owner.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
             {
                 Title = "Export Phrases",
                 SuggestedFileName = PhraseBackupService.GetExportFileName(),
@@ -141,12 +141,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             {
                 var count = _phraseBackupService.Export(settings, path);
                 Log.Information("Phrases exported: {Count} to {Path}", count, path);
-                // ponytail: WPF confirms with ShowStyledDialog ("Phrases Exported"); no styled
-                // message dialog on this head yet.
+                await Dialogs.MessageDialog.ShowAsync(owner, "Phrases Exported",
+                    $"Saved {count} phrase(s) to:\n{path}");
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to export phrases");
+                await Dialogs.MessageDialog.ShowAsync(owner, "Export Failed",
+                    $"Could not export phrases:\n{ex.Message}");
             }
         }
 
@@ -171,8 +173,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             if (!_phraseBackupService.Validate(path, out var error))
             {
                 Log.Warning("Phrase import rejected: {Error}", error);
-                // ponytail: WPF explains with ShowStyledDialog ("Import Failed"); no styled
-                // message dialog on this head yet.
+                await Dialogs.MessageDialog.ShowAsync(owner, "Import Failed",
+                    $"That file isn't a valid phrase backup:\n{error}");
                 return;
             }
 
@@ -192,10 +194,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
                 var count = _phraseBackupService.Import(settings, path);
                 CoreSettings.Save();
                 Log.Information("Phrases imported: {Count} from {Path}", count, path);
+                await Dialogs.MessageDialog.ShowAsync(owner, "Phrases Imported",
+                    $"Restored {count} phrase(s). You may need to reopen any open phrase editors to see them.");
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to import phrases");
+                await Dialogs.MessageDialog.ShowAsync(owner, "Import Failed",
+                    $"Could not import phrases:\n{ex.Message}");
             }
         }
 
@@ -252,7 +258,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
                 return;
             }
 
-            PerformFactoryReset();
+            if (!PerformFactoryReset(out var failure))
+            {
+                // The WPF head's set2_reset_failed_* box. It matters because the reset LOOKS like
+                // it worked otherwise: the app keeps running with the settings the user asked to
+                // be rid of and nothing on screen says why.
+                await Dialogs.MessageDialog.ShowAsync(owner,
+                    Loc.Get("set2_reset_failed_title"),
+                    Loc.GetF("set2_reset_failed_body", failure));
+            }
         }
 
         /// <summary>
@@ -264,9 +278,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         /// otherwise ack the new process straight back out), and the exit is hard because the
         /// normal shutdown saves settings — which would undo the reset. What stays, deliberately:
         /// assets, packs, mods, achievements, the account, crash logs and the daily .bak rotation.
+        ///
+        /// <para>Returns false, with the failure message, when settings.json could not be moved
+        /// aside — the one path where this method RETURNS instead of exiting, so the caller has to
+        /// tell the user. Every other path ends in <c>Environment.Exit</c>.</para>
         /// </summary>
-        private void PerformFactoryReset()
+        private bool PerformFactoryReset(out string failure)
         {
+            failure = "";
             var dir = CorePaths.UserData;
             var settingsPath = Path.Combine(dir, "settings.json");
             var stamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
@@ -329,9 +348,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
                 // The app keeps running on this path, so give it its saves back - a sealed service
                 // would silently stop persisting anything for the rest of the session.
                 CoreSettings.Service?.UnsealAfterFailedReset();
-                // ponytail: WPF also tells the user (MessageBox, set2_reset_failed_*); no styled
-                // message dialog on this head yet.
-                return;
+                failure = ex.Message;
+                return false;
             }
 
             // Belt and braces: a temp created by a save that was already mid-flight when the sweep
@@ -346,6 +364,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             // whole [RESET] trail above is lost exactly when it matters.
             try { Log.Information("[RESET] flushing log before exit"); Serilog.Log.CloseAndFlush(); } catch { }
             Environment.Exit(0);
+            return true;   // unreachable; Exit does not come back. Here for the compiler only.
         }
 
         private static string[] SafeGlob(string dir, string pattern)

--- a/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs
@@ -135,8 +135,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
         }
 
         /// <summary>The target's flat hue with its name on a strip.
-        /// ponytail: card art comes through ModResourceResolver (WPF head); the flat-hue branch
-        /// is the one the WPF control takes when there is no art, so it is the only one here.</summary>
+        /// <para>ponytail: the WPF ring paints a card PNG behind this, and the portable half of
+        /// that lookup is <c>CoreModArt.OverridePath</c> today (<c>Helpers.ModArt</c> is the
+        /// head-side loader). What is still missing is the NAME to look up: the WPF resolver is
+        /// handed a per-target art path that <c>Target</c> does not carry on this head, so there
+        /// is nothing to resolve yet. The flat-hue branch is the one the WPF control takes when a
+        /// target has no art, so it is not a stand-in - it is one of the two real
+        /// branches.</para></summary>
         private static Control BuildTileFace(Target t, bool locked)
         {
             var grid = new Grid();

--- a/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml.cs
@@ -229,8 +229,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
     {
         public string Label { get; init; } = "";
         public int Count { get; init; }
-        /// <summary>ponytail: badge art resolves through ModResourceResolver (WPF head); null
-        /// draws the empty badge tile until it moves to Core.</summary>
+        /// <summary>The feature icon: the active mod's override if it ships one, else this
+        /// head's own copy. Null draws the empty badge tile, which is the WPF path for a feature
+        /// whose PNG will not resolve.</summary>
         public IImage? Image { get; init; }
     }
 
@@ -238,8 +239,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
     /// Avalonia twin of ConditioningControlPanel/ViewModels/SeasonRecapViewModel.cs. Same property
     /// names and the same Loc keys; every helper it uses (SeasonNumbering, TitleTiers,
     /// SeasonFeatureKeys, SeasonRecapSnapshot) is already in CCP.Core. Only two things pin the
-    /// original to the WPF head: <c>Visibility</c> (bool here) and pack:// image paths (IImage,
-    /// null placeholders here).
+    /// original to the WPF head: <c>Visibility</c> (bool here) and pack:// image paths, which
+    /// become <c>CoreModArt</c> plus an <c>avares://</c> fallback through
+    /// <see cref="Helpers.ModArt"/>.
     /// </summary>
     public class SeasonRecapCardViewModel
     {
@@ -368,6 +370,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
                     {
                         Label = def != null ? Loc.Get(def.LabelLocKey) : kv.Key,
                         Count = kv.Value,
+                        // Mod-aware, as WPF is: SeasonFeatureKeys.ImagePath is already
+                        // Resources-relative ("features/flash.png"), which is exactly what the
+                        // override seam and this head's avares:// layout both take.
+                        Image = def != null ? Helpers.ModArt.TryLoad(def.ImagePath) : null,
                     };
                 })
                 .ToList();

--- a/CCP.Avalonia/Views/Controls/Studio/BrainDrainFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/BrainDrainFeatureControl.axaml.cs
@@ -9,11 +9,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
     /// Brain Drain panel, ported from the WPF head.
     ///
     /// What is real here: both slider read-outs, the clip-library readout's format string and the
-    /// empty-state banner it drives. What is not: everything the WPF code-behind reaches for -
-    /// App.Settings (BrainDrainEnabled / Intensity / HighRefresh / BlurStrength / MeltEnabled /
-    /// AllowOverlayCapture), App.BrainDrain (the clip scan, ReloadAudioFiles, Start/Stop),
-    /// BrainDrainService's folder paths, OverlayService.BrainDrainWithheld, the mod art resolver
-    /// and the Explorer shell-open. Each is a WPF-head service.
+    /// empty-state banner it drives.
+    ///
+    /// What is not, and WHY - the settings are the interesting case. BrainDrainEnabled, Intensity,
+    /// HighRefresh, BlurStrength, MeltEnabled and AllowOverlayCapture are all on
+    /// <c>CoreSettings.Current</c> today, so "needs App.Settings" would be a stale reading. They
+    /// stay unwired here on purpose: on WPF each of these writes is followed by a call into
+    /// App.BrainDrain (Start/Stop, ReloadAudioFiles, the overlay-capture re-arm), so a control
+    /// that wrote the setting alone would show BRAIN DRAIN as ON with nothing draining. The
+    /// genuinely absent pieces are App.BrainDrain, BrainDrainService's folder paths,
+    /// OverlayService.BrainDrainWithheld and the shell folder-open - all WPF-head services with
+    /// no seam. Mod art is NOT a blocker any more (CoreModArt plus Helpers.ModArt), but there is
+    /// no art in this panel's markup to write into.
     ///
     /// The clip count is a placeholder 0, which is also the honest default for a fresh install and
     /// is what puts the empty-state banner on screen in the render.
@@ -29,11 +36,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
 
             RefreshClipCount();
 
-            // ponytail: needs App.Settings, App.BrainDrain, Services.BrainDrainService,
-            // OverlayService and ModResourceResolver, wired when they move to Core. ChkEnable,
-            // ChkMelt, ChkHighRefresh, ChkAllowCapture, both sliders' setting writes,
-            // BtnOpenAudioFolder(Empty) and BtnRefreshAudio are inert until then, and
-            // WithheldNotice stays hidden (OverlayService.BrainDrainWithheld is false anyway).
+            // ponytail: needs App.BrainDrain, Services.BrainDrainService and OverlayService -
+            // NOT App.Settings, which is CoreSettings.Current today. See the class summary for
+            // why the settings writes are still deliberately absent. ChkEnable, ChkMelt,
+            // ChkHighRefresh, ChkAllowCapture, both sliders' setting writes, BtnOpenAudioFolder
+            // (Empty) and BtnRefreshAudio are inert until the service lands, and WithheldNotice
+            // stays hidden (OverlayService.BrainDrainWithheld is false anyway).
             this.FindControl<Button>("BtnRefreshAudio")!.Click += (_, _) => RefreshClipCount();
         }
 

--- a/CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs
@@ -36,8 +36,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - <c>ShowUsernamePanel</c>'s two title assignments are dropped: they set exactly the keys
     ///    the markup already binds.
     ///  - <c>SanitizeError</c> and <c>ShowError</c> are gone with their only callers. Both served
-    ///    the V2AuthService paths stubbed below, and WPF's <c>MessageBox</c> has no Avalonia
-    ///    equivalent and no package may be added; they return with the services.
+    ///    the V2AuthService paths stubbed below; they return with the services. (WPF's
+    ///    <c>MessageBox</c> is not what blocks them - <c>Dialogs.MessageDialog</c> is this head's
+    ///    equivalent and this dialog can own it.)
     ///  - <c>_firstProviderToken</c> is dropped: nothing can set it until the OAuth services move
     ///    to Core, and a field that is only ever null makes the stubs read as dead branches.
     ///
@@ -344,9 +345,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private static Task<bool> CheckNameAvailabilityAsync(string name) => Task.FromResult(true);
 
         /// <summary>
-        /// ponytail: needs V2AuthService.RegisterAsync / AuthenticateWith*Async plus App.Settings
-        /// and App.UnifiedUserId, wired when they move to Core. The guards and the loading state
-        /// are the original's; the account creation itself is what is missing.
+        /// ponytail: needs <c>ConditioningControlPanel/Services/Account/V2AuthService.cs</c>
+        /// (RegisterAsync / AuthenticateWith*Async) and <c>App.UnifiedUserId</c>; both are still
+        /// WPF head-side and neither has a seam. <c>CoreSettings.Current</c> covers the settings
+        /// half already, so settings are NOT what blocks this. Do not half-port it: the flow
+        /// carries an OAuth token and a password, and a partial that writes an identity without
+        /// the server's answer is worse than the stub. The guards and the loading state are the
+        /// original's; the account creation itself is what is missing.
         /// </summary>
         private void BtnConfirmUsername_Click()
         {
@@ -485,9 +490,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         }
 
         /// <summary>
-        /// ponytail: needs V2AuthService.LoginAsync plus App.Settings / App.UnifiedUserId, wired
-        /// when they move to Core. The password is still wiped immediately after the (absent) call,
-        /// as audit C1 requires, and the failure path back to the form is the original's.
+        /// ponytail: needs <c>ConditioningControlPanel/Services/Account/V2AuthService.cs</c>
+        /// (LoginAsync) and <c>App.UnifiedUserId</c>, both still WPF head-side with no seam.
+        /// <c>CoreSettings.Current</c> is not the blocker. The password is still wiped immediately
+        /// after the (absent) call, as audit C1 requires, and the failure path back to the form is
+        /// the original's.
         /// </summary>
         private void TryAccountLogin(string displayName, string password)
         {

--- a/CCP.Avalonia/Views/Dialogs/ProfileCustomizeDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ProfileCustomizeDialog.axaml.cs
@@ -19,8 +19,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/ProfileCustomizeDialog.xaml.cs. The tile
     /// builders, selection rules, pin cap and reset are the original's; <see cref="ProfileCosmetics"/>
-    /// is already in Core. What is not: Achievement, CosmeticsCatalog, WardrobeCatalog,
-    /// ModResourceResolver and the WardrobeEditorDialog all live in the WPF head, so
+    /// is already in Core. What is not: Achievement, CosmeticsCatalog, WardrobeCatalog and the
+    /// WardrobeEditorDialog all live in the WPF head (the mod-art resolver does NOT block anything
+    /// here any more - see <c>BuildPinTile</c> for the two things that do), so
     ///  - unlocked achievements arrive as (id, name) pairs instead of being resolved from Achievement.All,
     ///  - banners are the catalog's three generated gradients (no art file needed), avatar presets
     ///    are none (art needed), pins draw a trophy glyph where the achievement PNG would be,
@@ -372,8 +373,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private Border BuildPinTile(string achievementId, string name)
         {
             var content = new Grid();
-            // ponytail: needs ModResourceResolver + Resources/achievements/<png> (WPF head); a
-            // trophy glyph stands in for the art until the achievement assets move to Core.
+            // ponytail: the resolver is NOT the blocker (CoreModArt + Helpers.ModArt do it, and
+            // AchievementPopup already loads achievement art that way). Two other things are, and
+            // the second one is why restoring this would make the dialog WORSE:
+            //   1. this dialog is handed (Id, Name) tuples, not Achievements, so it has no
+            //      ImageName to resolve - the ctor and every caller would have to change;
+            //   2. WPF DROPS a pin tile whose art will not load (BuildPinTile returns null), and
+            //      only six achievement PNGs are linked into this head, so a faithful port would
+            //      hide almost every pin instead of showing it.
+            // The trophy glyph is therefore the deliberate answer, not a placeholder: it shows
+            // every unlocked achievement as pinnable. Restore the art and the drop rule together
+            // with the rest of the achievement assets, or not at all.
             content.Children.Add(new TextBlock
             {
                 Text = "🏆",

--- a/CCP.Avalonia/Views/Dialogs/UpdateFailedDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UpdateFailedDialog.axaml.cs
@@ -95,10 +95,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Failed to show update failure dialog; falling back to a message box");
-                // ponytail: needs a cross-platform MessageBox for the last-resort fallback WPF had
-                // (MessageBox.Show with the releases URL); this head has no modal box that works
-                // without an owner Window, which is exactly the case this catch handles.
+                Log.Warning(ex, "Failed to show update failure dialog; nothing left to show it in");
+                // ponytail: this head DOES have a message box now (Dialogs.MessageDialog), but it
+                // is a Window like the one that just failed to open, and MessageDialog.ShowAsync
+                // needs an owner - which is exactly what this catch has established it does not
+                // have. WPF's MessageBox.Show(releasesUrl) needed neither. A second Window here
+                // would fail the same way, so the log line is the record until this head grows an
+                // ownerless notification (a tray toast, or a Window shown with .Show()).
             }
         }
 

--- a/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml.cs
@@ -34,12 +34,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// shows a tab by flipping <c>IsVisible</c> and never re-attaches, so the whole seed re-runs on
     /// the IsVisible edge as well as on attach and on a settings-instance swap.</para>
     ///
-    /// <para><b>Dropped:</b> the mod-aware feature art (ModService.ModChanged -&gt;
-    /// ModResourceResolver repainting the hero and side takeover.png plates, including the
-    /// BambiSleep "bambi takeover.png" fork). Both plates are art-less on this head - see the
-    /// .axaml header - so there is nothing to repaint yet. ponytail: needs
-    /// ConditioningControlPanel/Helpers/ModResourceResolver.cs; restore together with the plates
-    /// when Resources/features ships here.</para>
+    /// <para><b>Dropped:</b> the mod-aware feature art (ModService.ModChanged -&gt; the resolver
+    /// repainting the hero and side takeover.png plates, including the BambiSleep
+    /// "bambi takeover.png" fork). ponytail: the resolver is NOT the blocker - CoreMods raises
+    /// ModChanged and <c>Helpers.ModArt.TryLoad("features/bambi takeover.png")</c> resolves
+    /// against art the csproj already links. The blocker is that both plates are art-less in
+    /// BambiTakeoverTabView.axaml (see its header), so there is no Image to repaint; restore the
+    /// markup and this handler in one change.</para>
     /// </summary>
     public partial class BambiTakeoverTabView : UserControl
     {
@@ -350,11 +351,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         /// <summary>
         /// The master switch. WPF gates it on a consent dialog, the Patreon check and the lockdown
-        /// refusal before it starts AutonomyService. None of those is on this head, so only the
-        /// half that cannot arm anything the user has not already agreed to is restored: turning it
-        /// OFF always writes, turning it ON writes only when consent is already on file.
+        /// refusal before it starts AutonomyService. The consent gate is the one of those three
+        /// that is real here, and it is the one that matters: the setting is not written until the
+        /// answer is in, so no path can arm her on a "yes" that never came.
+        ///
+        /// <para><b>Async, so the order is deliberate.</b> The WPF box was synchronous and the
+        /// checkbox stayed visibly on across it; here nothing is written before the await, and the
+        /// box is put back under <see cref="_isLoading"/> AFTER the answer either way — a repaint
+        /// during the modal cannot leave it disagreeing with the setting.</para>
         /// </summary>
-        private void ChkAutonomyEnabled_Changed(object? sender, RoutedEventArgs e)
+        private async void ChkAutonomyEnabled_Changed(object? sender, RoutedEventArgs e)
         {
             if (_isLoading) return;
             var s = CoreSettings.Current;
@@ -363,21 +369,47 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
             if (enabled && !s.AutonomyConsentGiven)
             {
-                // ponytail: WPF shows the Autonomy consent MessageBox here and writes
-                // AutonomyConsentGiven on Yes (MainWindow.Autonomy.cs:55). No ported dialog exists
-                // for it, and arming her without consent is not a safe default, so the box reverts.
-                _isLoading = true;
-                ChkAutonomyEnabled.IsChecked = false;
-                _isLoading = false;
-                Log.Information("Takeover master switch refused: no consent on file and no consent dialog on this head");
-                return;
+                // The WPF text verbatim (MainWindow.Autonomy.cs:55) - an English literal there
+                // too, with no loc key, so nothing is invented here.
+                var owner = TopLevel.GetTopLevel(this) as Window;
+                var consented = owner != null && await Dialogs.MessageDialog.ConfirmAsync(owner,
+                    "Enable Autonomy Mode",
+                    "AUTONOMY MODE\n\n" +
+                    "This feature allows the companion to autonomously trigger effects:\n" +
+                    "• Flash images\n" +
+                    "• Videos\n" +
+                    "• Subliminal messages\n" +
+                    "• Make comments\n\n" +
+                    "She will act on her own within your configured intensity settings.\n\n" +
+                    "You can disable this at any time. Videos triggered autonomously are skippable " +
+                    "unless you explicitly enable Strict Videos in the Takeover settings.\n\n" +
+                    "Do you consent to enable Autonomy Mode?");
+
+                // No owner is not a "yes". A headless host cannot ask, so it refuses, exactly as
+                // the mic-consent flow below does.
+                if (!consented)
+                {
+                    _isLoading = true;
+                    ChkAutonomyEnabled.IsChecked = false;
+                    _isLoading = false;
+                    Log.Information("Takeover master switch refused: consent declined or no window to ask in");
+                    return;
+                }
+
+                s.AutonomyConsentGiven = true;
             }
 
             s.AutonomyModeEnabled = enabled;
             CoreSettings.Save();
-            // ponytail: WPF then starts or stops App.Autonomy behind the Patreon / daily-free check,
-            // and refuses a stop while Lockdown is active (#514). Needs Services/AutonomyService.cs
-            // and Services/LockdownService.cs, neither on this head.
+            _isLoading = true;
+            ChkAutonomyEnabled.IsChecked = enabled;
+            _isLoading = false;
+            // ponytail: WPF then starts or stops App.Autonomy behind the Patreon / daily-free
+            // check, and refuses a STOP while Lockdown is active (#514). Needs
+            // Services/AutonomyService.cs and Services/LockdownService.cs, neither on this head
+            // and neither seamed. Note which way that refusal cuts: it holds Takeover ON, so its
+            // absence is permissive rather than dangerous - the user can always turn her off here,
+            // which is the safe direction to be wrong in.
             Log.Information("Autonomy Mode toggled: {Enabled} (setting only - no service on this head)", enabled);
         }
 

--- a/CCP.Avalonia/Views/Tabs/DeeperTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/DeeperTabView.axaml.cs
@@ -29,9 +29,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         // and MainWindow.DeeperFx, wired when the FX layer moves to Core. On WPF this rode
         // IsVisibleChanged; the Avalonia equivalent would be an IsVisibleProperty observer.
 
-        // ponytail: needs ModService + ModResourceResolver for the mod-aware deeper.png plates,
-        // wired when they move to Core. Both plates are art-less on this head anyway (see the
-        // .axaml header), so there is nothing to repaint yet.
+        // ponytail: the resolver is NOT the blocker - CoreMods answers the active mod and
+        // CoreModArt/Helpers.ModArt resolve "features/deeper.png", which IS linked into this
+        // head. What is missing is the target: both plates are art-less in DeeperTabView.axaml
+        // (see its header), so there is no Image or ImageBrush to write into. Restoring this
+        // means changing the .axaml and this file together.
 
         // ponytail: every handler below routes to MainWindow on WPF
         // (Window.GetWindow(this) is MainWindow mw -> mw.<same name>). Needs the

--- a/CCP.Avalonia/Views/Tabs/GradedIntakeTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/GradedIntakeTabView.axaml.cs
@@ -89,19 +89,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void ShowFrequency(int perHour) =>
             TxtPopQuizFrequency.Text = Loc.GetF("label_0_session_hr", perHour);
 
-        // ponytail: needs Services/Quiz/IntakeHostService (a WebView2 window) plus
-        // Services/IntakePassService and App.Ai for the tier gate in front of it -
-        // ConditioningControlPanel/MainWindow/MainWindow.Lab.cs:148. Nothing here can start a run,
-        // and a button that opens nothing is better than one that pretends the pass was spent.
+        // ponytail: the web view is NOT the blocker - this head ships Views/Controls/WebHost, a
+        // real Avalonia.Controls.WebView with a navigation gate and InvokeScriptAsync. What is
+        // missing is everything around it: Services/Quiz/IntakeHostService (the window and the
+        // page protocol), Services/IntakePassService (which spends the pass) and CoreAi for the
+        // tier gate in front of both - see ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
+        // :148. Nothing here can start a run, and a button that opens nothing is better than one
+        // that pretends the pass was spent.
         private void BtnStartIntake_Click(object? sender, RoutedEventArgs e) { }
 
         // ponytail: the classic AI quiz, ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
-        // (QuizWindow + App.Ai). The button is IsVisible="False" in the markup on both heads, so
-        // nothing can reach this today.
+        // (QuizWindow, which is unported; the AI half is CoreAi and does answer). The button is
+        // IsVisible="False" in the markup on both heads, so nothing can reach this today.
         private void BtnStartQuiz_Click(object? sender, RoutedEventArgs e) { }
 
-        // ponytail: needs App.PopQuiz - ConditioningControlPanel/Services/Quiz/PopQuizService.cs,
-        // which shows a WPF PopQuizWindow. Head-side by construction, not a settings write.
+        // ponytail: needs ConditioningControlPanel/Services/Quiz/PopQuizService.cs, which shows a
+        // WPF PopQuizWindow. Head-side by construction and unported; not a settings write, so
+        // CoreSettings is no help here.
         private void BtnTestPopQuiz_Click(object? sender, RoutedEventArgs e) { }
 
         private void ChkPopQuizEnabled_Changed(object? sender, RoutedEventArgs e)

--- a/CCP.Avalonia/Views/Tabs/SpiralTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/SpiralTabView.axaml.cs
@@ -492,11 +492,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// state.
         ///
         /// <para>ponytail: <c>SpiralEmbedView</c> (WebView2, Windows-only) becomes
-        /// <see cref="WebHost"/>, and four of its five members have no twin yet — <c>Start()</c>
-        /// (the runtime/environment handshake), <c>Navigated</c> (the splash's cue),
-        /// <c>Failed</c> (which handed the room to the waiting panel and latched
-        /// <c>_embedGaveUp</c> for the rest of the entry) and <c>PostState(block)</c> (which pushes
-        /// the descent block into the canvas). The URL is the real one and the lifecycle — built on
+        /// <see cref="WebHost"/>. <c>Start()</c> has no twin and needs none — WebHost probes for
+        /// an engine and navigates on <c>Source</c>. <c>PostState(block)</c> could be written
+        /// today against <c>WebHost.InvokeScriptAsync</c>, once the canvas page's message shape is
+        /// pinned down. What genuinely has no seam is the pair that report back:
+        /// <c>Navigated</c> (the splash's cue) and <c>Failed</c> (which handed the room to the
+        /// waiting panel and latched <c>_embedGaveUp</c> for the rest of the entry) — WebHost
+        /// wraps neither NavigationCompleted nor the failure signal, so nothing here can tell a
+        /// loaded page from a dead one. The URL is the real one and the lifecycle — built on
         /// entering the state, dropped on leaving it — is the real one.</para>
         /// </summary>
         private void EnsureEmbed()

--- a/CCP.Avalonia/Views/Tabs/StudioTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/StudioTabView.axaml.cs
@@ -15,6 +15,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
@@ -49,8 +50,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// <para><b>What is stubbed, and why.</b> Everything the WPF code-behind reaches into the app
     /// head for: <c>MainWindow.ToggleWallFeature</c> (the eleven wall modules' quick-toggle, which
     /// owns the session-lock refusal and the per-feature service start/stop),
-    /// <c>BarkService.NotifyFeatureOpened</c>, <c>ModResourceResolver</c> (the rack's feature art
-    /// and the door medallion), <c>MotionFx</c> and <c>PerimeterCometAdorner</c> (the detail
+    /// <c>BarkService.NotifyFeatureOpened</c>, the rack's feature art and the door medallion
+    /// (whose resolver is done - <c>CoreModArt</c> plus <c>Helpers.ModArt</c> - and whose art is
+    /// linked; what is missing is an Image target in the .axaml, see <c>RefreshRackArt</c> and
+    /// <c>ApplyDoorIcon</c>), <c>MotionFx</c> and <c>PerimeterCometAdorner</c> (the detail
     /// crossfade, the dot ping and the active tile's comet), and <c>HapticsTabView</c> with its
     /// <c>ChkHapticsEnabled</c> master box. Each is marked <c>ponytail:</c> at its site.</para>
     ///
@@ -77,12 +80,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             /// <summary>
             /// Filename under <c>Resources/features/</c> for this module's feature art, or null
             /// for the three modules that have never had any (Visuals, Scheduler, Ramp).
-            /// <para>ponytail: those files are not AvaloniaResources in this head and the
-            /// resolver that picks a mod's override for them is a WPF-head service, so nothing
-            /// decodes art here yet. The column is kept verbatim (case and all - the on-disk names
-            /// really are mixed) because it is still what decides which rows get the 56px active
-            /// TILE and which keep the plain strip, and it is what <c>RefreshRackArt</c> will read
-            /// when <c>ModResourceResolver</c> moves to Core.</para>
+            /// <para>ponytail: both halves of the lookup work now - the csproj links
+            /// <c>Assets/features/*.png</c> as <c>avares://CCP.Avalonia/Resources/features/</c>,
+            /// and <c>Helpers.ModArt.TryLoad</c> picks a mod's override over it. Nothing decodes
+            /// art here only because there is nowhere to put it (see <c>RefreshRackArt</c>). The
+            /// column is kept verbatim (case and all - the on-disk names really are mixed) because
+            /// it is what decides which rows get the 56px active TILE and which keep the plain
+            /// strip, and it is what <c>RefreshRackArt</c> will read.</para>
             /// </summary>
             public string? Art;
 
@@ -226,8 +230,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             // The active tile's plate. On WPF this layer is the module's feature art behind a
             // fade mask; here it is the same accent wash the art-less chips wear, so the checked
             // row still reads as a tile rather than as a taller strip.
-            // ponytail: swap for the ImageBrush of ModResourceResolver.ResolveImageDecoded(
-            // "features/" + e.Art, 256) when the resolver and the art move to this head.
+            // ponytail: the resolver and the art are BOTH here now - Helpers.ModArt.TryLoad(
+            // "features/" + e.Art) over CoreModArt, against Assets/features/*.png, which the
+            // csproj links. What is missing is the target: this layer is a LinearGradientBrush in
+            // this file, and swapping it for an ImageBrush per row means changing the row template
+            // in StudioTabView.axaml too. Do both together.
             _accentTints.Add(c =>
             {
                 TilePlateBrush.GradientStops[0].Color = WithAlpha(HueRotate(c, 38), 0x66);
@@ -299,7 +306,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             static void Try(Action a)
             {
                 try { a(); }
-                catch { /* ponytail: App.Logger?.Debug(...) on WPF; no logger on this head yet */ }
+                catch (Exception ex) { Log.Debug(ex, "[Studio] a mod-aware repaint step failed"); }
             }
         }
 
@@ -308,18 +315,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// painted with. A null resolve KEEPS the current art: "the new mod ships no override and
         /// the embedded file failed to decode this time" must cost nothing, and blanking the row
         /// would turn a transient decode failure into a permanently empty rack.
-        /// <para>ponytail: needs <c>Services.ModResourceResolver.ResolveImageDecoded</c> and the
-        /// <c>Resources/features/*.png</c> art as AvaloniaResources. Until both land there is no
-        /// ImageBrush to write into — the rows wear the accent wash instead — so this is a no-op
-        /// rather than a lie.</para>
+        /// <para>ponytail: neither the resolver nor the art blocks this any more —
+        /// <c>Helpers.ModArt.TryLoad("features/&lt;e.Art&gt;")</c> answers over
+        /// <see cref="CoreModArt"/>, and <c>Assets/features/*.png</c> is linked as
+        /// <c>avares://CCP.Avalonia/Resources/features/</c>. The blocker is the target: the rows
+        /// are painted with <c>TilePlateBrush</c>, a gradient built in this file, so there is no
+        /// ImageBrush to write into until the row template in StudioTabView.axaml grows one. A
+        /// no-op rather than a lie, and now a one-file-plus-markup job rather than a wait.</para>
         /// </summary>
         private void RefreshRackArt() { }
 
         /// <summary>
         /// The page-header door medallion. Same file the nav rail's Studio door uses, so a mod that
         /// reskins the rail reskins this too instead of leaving the header on stock art.
-        /// <para>ponytail: needs <c>Services.ModResourceResolver</c> and
-        /// <c>Resources/nav/door_studio.png</c>. The XAML's wash chip stands in until then.</para>
+        /// <para>ponytail: both halves resolve today —
+        /// <c>Helpers.ModArt.TryLoad("nav/door_studio.png")</c>, and <c>Assets/nav/</c> is linked
+        /// into this head. The blocker is that <c>ImgStudioDoorIcon</c> is a <c>Border</c> with an
+        /// emoji in it, not an <c>Image</c>: StudioTabView.axaml has to give it an Image (or take
+        /// an ImageBrush background) in the same change, and that file is markup this layer does
+        /// not own. The wash chip stands in until then.</para>
         /// </summary>
         private void ApplyDoorIcon() { }
 
@@ -662,9 +676,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
                 BorderThickness = new Thickness(1),
                 VerticalAlignment = VerticalAlignment.Center,
                 Margin = new Thickness(0, 0, 9, 0),
-                // ponytail: the module's feature art goes here as an unfrozen ImageBrush once
-                // ModResourceResolver and Resources/features/*.png reach this head; the emoji on
-                // the hue-wash is exactly the fallback WPF already shows for an art-less module.
+                // ponytail: the module's feature art goes here as an ImageBrush over
+                // Helpers.ModArt.TryLoad("features/" + e.Art) - both the loader and the art are
+                // here, this Background just has to become one. The emoji on the hue-wash is
+                // exactly the fallback WPF already shows for an art-less module, so a row without
+                // art keeps looking right either way.
                 Background = ChipHueWashBrush,
                 Child = new TextBlock
                 {

--- a/CCP.Avalonia/Views/Windows/AchievementPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/AchievementPopup.axaml.cs
@@ -1,10 +1,13 @@
 using System;
+using System.IO;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
@@ -20,7 +23,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - <c>SystemParameters.WorkArea</c> becomes <c>Screens.Primary.WorkingArea</c>, which is only
     ///    populated once the window has a platform handle, so placement moves to OnOpened.
     ///  - <c>MouseLeftButtonDown</c> becomes PointerPressed, wired in the constructor.
-    ///  - <c>App.Logger</c> calls are dropped; there is no logger on this head yet.
+    ///  - <c>App.Logger</c> becomes Serilog's static <c>Log</c>.
     /// </summary>
     public partial class AchievementPopup : Window
     {
@@ -29,7 +32,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private readonly DispatcherTimer _autoCloseTimer;
 
         /// <summary>Render/design constructor: sample data so --render-view can draw the popup.</summary>
-        internal AchievementPopup() : this("Good Girl", "The first time it stopped feeling like a choice.", "good_girl.png")
+        internal AchievementPopup() : this("Retinal Burn", "The first time it stopped feeling like a choice.", "retinal_burn.png")
         {
             // The fade-in cannot complete inside a headless render's two dispatcher passes, so the
             // PNG would capture a fully transparent window. Skip the animation for the render.
@@ -113,13 +116,32 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>
-        /// ponytail: needs Services.ModResourceResolver (mod override, then a pack:// resource) and
-        /// the Resources/achievements/ payload; both stay in the WPF head. The art box renders empty
-        /// until they move to Core, exactly as the WPF original does for a missing file.
+        /// The WPF chain, step for step: the mod's override first (probing the shipped copy first
+        /// would make mod art unreachable), then this head's <c>avares://</c> copy, then a loose
+        /// file on disk beside the exe (a content pack or hand-dropped art). Nothing found leaves
+        /// the art box empty, which is the WPF original's own path for a missing file.
+        ///
+        /// <para>ponytail: only six achievement PNGs are linked into this head - the six in
+        /// <c>Assets/achievements/</c>. Every other id resolves through the disk probe or not at
+        /// all, so most popups still show an empty plate. Linking the rest is a .csproj change,
+        /// which this layer does not own.</para>
         /// </summary>
         private void LoadAchievementImage(string imageName)
         {
-            _ = imageName;
+            var image = this.FindControl<Image>("AchievementImage");
+            if (image == null || string.IsNullOrWhiteSpace(imageName)) return;
+
+            var art = Helpers.ModArt.TryLoad($"achievements/{imageName}");
+            if (art != null) { image.Source = art; return; }
+
+            try
+            {
+                var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                                        "Resources", "achievements", imageName);
+                if (File.Exists(path)) image.Source = new Bitmap(path);
+                else Log.Warning("Achievement image not found: {Name}", imageName);
+            }
+            catch (Exception ex) { Log.Warning(ex, "Achievement image {Name} would not load", imageName); }
         }
 
         private void FadeOutAndClose()

--- a/CCP.Avalonia/Views/Windows/BubbleCountWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/BubbleCountWindow.axaml.cs
@@ -60,9 +60,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// <para><b>WebView2.</b> The original has no <c>wv2:WebView2</c> element in its XAML; browser
     /// mode builds a <c>BrowserVideoSurface</c> (a WebView2 host) in code and does
     /// <c>VideoContainer.Children.Add(...)</c>. The port mirrors that exactly with
-    /// <see cref="WebHost"/> - see <see cref="StartBrowserPlayback"/>. Everything the original did
-    /// through CoreWebView2 (the shared environment, InitAsync, Post, the WebMessage pump,
-    /// ProcessFailed) is a ponytail stub; the wrapper exposes none of it yet.</para>
+    /// <see cref="WebHost"/> - see <see cref="StartBrowserPlayback"/>. What the original did
+    /// through CoreWebView2 is a ponytail stub, but not for one reason any more: the shared
+    /// environment and InitAsync have no counterpart (WebHost probes and navigates on Source), the
+    /// Post could be written against <c>WebHost.InvokeScriptAsync</c> today, and the WebMessage
+    /// pump plus ProcessFailed are the real gap - WebHost wraps neither, so the page cannot report
+    /// anything back and the game clock has nothing to run on.</para>
     ///
     /// <para><b>Wired:</b> the pop sound (<c>CoreAudio.PlayOneShot</c> at the WPF
     /// <c>(master * bubbles) ^ 1.5</c> volume), the monitor set (<c>DualMonitorEnabled</c> from
@@ -73,7 +76,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// CreateManagedPlayer/ReleaseManagedPlayer, the wedge watchdog, the native poison cooldown,
     /// the bounded pumped Stop() batch, VideoView attach/detach and every message-pump wait that
     /// only existed to keep HwndHost teardown safe), BrowserVideoEngine/BrowserVideoGate,
-    /// ModResourceResolver, App.Achievements and VideoDiag. Each is marked at its site.</para>
+    /// App.Achievements and VideoDiag. Each is marked at its site. The mod art is NOT stubbed any
+    /// more - the bubble sprite loads through <c>CoreModArt</c> + <c>Helpers.ModArt</c>.</para>
     ///
     /// <para><c>Loaded</c> became <c>Opened</c>: WPF's Loaded fires synchronously inside Show(),
     /// which ShowOnAllMonitors' completion de-duplication leans on, and Avalonia's Opened is the
@@ -107,8 +111,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private bool _videoEnded = false;
         private bool _gameCompleted = false;
 
-        /// <summary>The bubble artwork, or null to draw the gradient ellipse fallback.
-        /// Always null today - see <see cref="LoadBubbleImage"/>.</summary>
+        /// <summary>The bubble artwork - the mod's override or this head's own bubble.png - or
+        /// null to draw the gradient ellipse fallback. See <see cref="LoadBubbleImage"/>.</summary>
         private IImage? _bubbleImage;
 
         // The web view surface, browser mode only. Mutually exclusive with the LibVLC player the
@@ -448,14 +452,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void StartBrowserPlayback()
         {
-            // ponytail: needs BrowserVideoEngine.BuildPageUrl to map the clip onto the player
-            // page's virtual host. Without it there is no page to navigate to, so the surface is
-            // built (that IS the port of VideoContainer.Children.Add(_browserSurface)) and left
-            // showing WebHost's fallback rather than a black rectangle.
+            // ponytail: needs BrowserVideoEngine.BuildPageUrl (WPF head) to map the clip onto the
+            // player page's virtual host, and WebHost has no virtual-host mapping to point it at
+            // either. Without both there is no page to navigate to, so the surface is built (that
+            // IS the port of VideoContainer.Children.Add(_browserSurface)) and left showing
+            // WebHost's fallback rather than a black rectangle.
             _browserSurface = new WebHost();
             _videoContainer.Children.Add(_browserSurface);
 
-            // ponytail: needs CoreWebView2. The original then did, in order:
+            // ponytail: needs a message pump. WebHost wraps Source, AllowNavigation,
+            // InvokeScriptAsync and HasEngine, but NOT NativeWebView.WebMessageReceived - and the
+            // page-to-app reports are what drive this whole game clock, so InvokeScriptAsync alone
+            // cannot stand in. The original did, in order:
             //   _browserSurface.Message += OnBrowserMessage        (WebMessageReceived pump:
             //       playing / timeupdate / ended / error / key reports drive the whole game clock)
             //   _browserSurface.ProcessFailed += OnBrowserProcessFailed
@@ -464,9 +472,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             //   await BrowserVideoEngine.SharedEnvironmentAsync()   (CoreWebView2Environment)
             //   await surface.InitAsync(env, mappings, startUrl, host)
             //       (EnsureCoreWebView2Async + SetVirtualHostNameToFolderMapping + Navigate)
-            // WebHost exposes only Source, so none of it can be expressed yet and none of it is
-            // invented here. Consequences: no audio routing, no first-frame watch, no page keys,
-            // and the clip never actually plays - the safety timer below is what ends the game.
+            // Two of those five could be written today (the load post through InvokeScriptAsync,
+            // the navigate through Source); the two event hookups and the virtual-host mapping
+            // have no twin, so nothing is invented here. Consequences: no audio routing, no
+            // first-frame watch, no page keys, and the clip never actually plays - the safety
+            // timer below is what ends the game.
 
             if (_isPrimary)
             {
@@ -513,10 +523,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             var surface = _browserSurface;
             if (surface == null) return;
             _browserSurface = null;
-            // ponytail: needs CoreWebView2 - the original detached Message/ProcessFailed, posted
-            // {type="stop"} and Dispose()d the WebView2, which is what actually ends the browser
-            // process. Removing the control from the tree is all WebHost allows today, so a
-            // WebKitGTK process may outlive the window until the wrapper grows a Dispose.
+            // ponytail: the stop post could go through WebHost.InvokeScriptAsync now, but the
+            // teardown that matters cannot: the original detached Message/ProcessFailed and
+            // Dispose()d the WebView2, which is what actually ends the browser process, and
+            // WebHost wraps neither the events nor a Dispose. Removing the control from the tree
+            // is all it allows, so a WebKitGTK process may outlive the window until the wrapper
+            // grows one.
             try { _videoContainer.Children.Remove(surface); } catch { }
         }
 
@@ -538,14 +550,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _targetBubbleCount = Math.Max(3, _targetBubbleCount);
         }
 
+        /// <summary>
+        /// The bubble sprite: the mod's <c>bubble.png</c> if it ships one, else this head's copy
+        /// (<c>Assets/bubble.png</c>, linked as <c>avares://CCP.Avalonia/Resources/bubble.png</c>).
+        /// Null keeps CountBubble's gradient ellipse, which is the WPF original's own fallback for
+        /// an image that will not load, so a miss degrades rather than blanks.
+        /// </summary>
         private void LoadBubbleImage()
         {
-            // ponytail: needs Services.ModResourceResolver (mod-overridable "bubble.png"), and the
-            // WPF fallback was a pack:// URI into the WPF assembly's Resources - neither exists
-            // here, and this layer may not add an AvaloniaResource to the csproj. _bubbleImage
-            // stays null, so every bubble draws CountBubble's gradient-ellipse fallback, which the
-            // WPF original also drew whenever the image failed to load.
-            _bubbleImage = null;
+            _bubbleImage = Helpers.ModArt.TryLoad("bubble.png");
         }
 
         private void StartSafetyTimer(double videoDurationSeconds)

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiRingWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiRingWindow.axaml.cs
@@ -937,9 +937,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
             catch { return null; }
         }
 
-        // ponytail: needs Services.ModResourceResolver.ResolveImageDecoded (WPF head), so a .ccpmod's
-        // own card art wins exactly like the dashboard. Every card therefore draws the flat hue tile
-        // - which is a road the WPF ring already takes for a target with no PNG.
+        // ponytail: the resolver half is done - CoreModArt.OverridePath answers the mod override
+        // and Helpers.ModArt decodes it against this head's avares:// copy. The blocker is the
+        // ARGUMENT: EmiRingCard carries no Resources-relative art path, so there is no name to
+        // hand either of them. Give the card its art path (the WPF ring reads one per target) and
+        // this becomes `Helpers.ModArt.TryLoad(slot.ArtPath)`. Until then every card draws the
+        // flat hue tile - a road the WPF ring already takes for a target with no PNG.
         private static IImage? LoadThumb(EmiRingCard slot) => null;
 
         // ---------------------------------------------------------------- animation

--- a/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
@@ -536,8 +536,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _txtWizardTitle.Text = Title;
 
             // --- step 1 ---
-            // ponytail: needs ModResourceResolver (and App.Mods.IsCCPDefault / IsSissyMode to pick
-            // between logo.png and logo2.png), wired when they move to Core. WPF re-calls this from
+            // ponytail: every piece of this resolves today - CoreMods.IsCCPDefault and
+            // CoreSettings.Current.IsSissyMode pick the file, Helpers.ModArt.TryLoad loads it, and
+            // Assets/logo.png + logo2.png are both linked into this head. It is left unwired only
+            // because ImgWelcomeLogo carries its own (identical, now stale) note in
+            // FirstRunWizard.axaml, which this layer does not own - restore both in one change so
+            // the markup and the code-behind cannot disagree. WPF re-calls ApplyStaticText from
             // ShowStep(1) so Back-navigation after a mod pick repaints the right wordmark.
 
             _txtAppTitle.Text = Loc.Get("app_title");
@@ -688,9 +692,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>
-        /// ponytail: needs App.Settings, App.ReleaseContent and ModPickerDialog
-        /// (ShouldDeferForOffline / ShouldReArmAfterOfflineShowing / MaxOfflineOffers), wired when
-        /// they move to Core. In WPF this is where the picker's one-shot offer is spent - at the
+        /// ponytail: settings and release content are NOT the blockers - CoreSettings.Current and
+        /// CoreReleaseContent both answer today. What is missing is the WPF ModPickerDialog's
+        /// offline policy (ShouldDeferForOffline / ShouldReArmAfterOfflineShowing /
+        /// MaxOfflineOffers); this head's ported Dialogs.ModPickerDialog does not carry it, and it
+        /// is the only part that matters. In WPF this is where the picker's one-shot offer is spent - at the
         /// moment the step is first shown, not when a download is queued - where a full/dev layout
         /// marks every card installed, and where offline is handled as a first-class state that
         /// hands the offer BACK rather than burning it. A reimplemented offline guard is how a
@@ -699,8 +705,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private void PrepareModStep() { }
 
         /// <summary>
-        /// ponytail: needs PendingModActivation, App.Mods and MainWindow.ActivateChosenMod, wired
-        /// when they move to Core. WPF hands the chosen mod to the EXACT existing switching path:
+        /// ponytail: needs PendingModActivation and MainWindow.ActivateChosenMod, both still WPF
+        /// head-side. CoreMods is not the gap - it reads the active mod but cannot SWITCH one, and
+        /// CoreModsHooks.SwitchCompanion is unseeded on this head, so there is no path to commit
+        /// through. WPF hands the chosen mod to the EXACT existing switching path:
         /// content on disk goes straight through ActivateChosenMod, content that must be fetched
         /// records the intent and starts the download, so the switch happens the moment the pack
         /// lands - even after this window is gone. Choosing a mod MEANS choosing to run it.

--- a/CCP.Avalonia/Views/Windows/SessionCompleteWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionCompleteWindow.axaml.cs
@@ -141,14 +141,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void LoadRandomCard()
         {
-            // ponytail: needs ConditioningControlPanel/Services/ModResourceResolver.cs
-            // (ResolveImage), which is WPF head-side - it returns a System.Windows.Media.ImageSource
-            // and reads App.LiveEvent / App.Mods - AND Cards/*.png, which CCP.Avalonia.csproj does
-            // not link as an AvaloniaResource. Nothing resolves a card, so the host Border
-            // collapses: that is the WPF null path, not a blank plate. CardImages stays because the
-            // mod path names are the compat surface.
-            _ = CardImages;
-            this.FindControl<Border>("CardBorder")!.IsVisible = false;
+            // ponytail: only the MOD half resolves. Helpers.ModArt asks CoreModArt for an override
+            // and then falls back to avares://, and Cards/*.png is NOT linked into this head - the
+            // csproj links Assets/features, /nav, /quests and the loose Assets/*.png, not Cards.
+            // So a .ccpmod that ships resources/Cards/hearth.png paints; a stock install collapses
+            // the Border, which is the WPF null path rather than a blank plate. Linking the stock
+            // cards is a .csproj change, which this layer does not own.
+            var card = Helpers.ModArt.TryLoad(CardImages[Random.Shared.Next(CardImages.Length)]);
+            if (card != null) this.FindControl<Image>("ImgCard")!.Source = card;
+            this.FindControl<Border>("CardBorder")!.IsVisible = card != null;
         }
 
         /// <summary>
@@ -201,8 +202,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                     return;
                 }
 
-                // Neither the file nor its folder survived (#998). WPF said so in a MessageBox;
-                // this head has no MessageBox stand-in, so it is logged.
+                // Neither the file nor its folder survived (#998). ponytail: WPF said so in a
+                // MessageBox, and Dialogs.MessageDialog.ShowAsync is this head's equivalent - but
+                // this method is sync and called from a row's click handler, so telling the user
+                // means making that path async. Logged until then; nothing is lost but the notice.
                 Log.Information("SessionCompleteWindow: media file and its folder are both gone: {Path}", path);
             }
             catch (Exception ex)


### PR DESCRIPTION
Sweep of the ponytail notes naming App.Settings / App.Mods / App.Logger /
ModResourceResolver / MessageBox / WebView2 across the twenty files that grep
hits. Every one was checked against Core and against the Avalonia tree rather
than believed; four of them turned out to be hiding real work.

Factory reset now tells the user when it fails. PerformFactoryReset returns
false with the message on the one path that returns instead of exiting, and
BtnFactoryReset_Click shows set2_reset_failed_title / _body - the WPF box. The
same file carried two more "no styled message dialog on this head yet" notes,
also stale: phrase export and import now confirm and explain through
MessageDialog, matching MainWindow.PresetIO.cs.

The Takeover master switch asks for consent instead of refusing. The old note
said no ported dialog existed; MessageDialog.ConfirmAsync does. The WPF consent
text is carried verbatim (an English literal there too, no loc key), the handler
is async, and NOTHING is written before the answer lands - AutonomyConsentGiven
and AutonomyModeEnabled are both set only on Yes. No owner window is treated as
No, matching the mic-consent flow beside it.

Mod art draws where it can. Helpers/ModArt.cs is the hoist TubeFitDialog's own
note asked for: CoreModArt.OverridePath, then this head's avares:// copy, in the
WPF order so a mod's art is reachable. Three views use it - AchievementPopup
(plus WPF's third step, a loose file beside the exe), the Season Recap badge row,
and BubbleCountWindow's bubble sprite. SessionCompleteWindow gets the mod half
only; Cards/*.png is not linked into this head, so a stock install still
collapses the Border, which is the WPF null path.

StudioTabView's repaint guard logs to Serilog instead of swallowing; "no logger
on this head yet" was wrong three heads ago.

Rewritten without restoring, each now naming what actually blocks it:
AvatarTubeWindow (settings are in Core; App.Engine / App.Companion are not),
LoginDialog x2 (V2AuthService and App.UnifiedUserId, not settings; do not
half-port an auth flow), BrainDrainFeatureControl (settings resolve, but writing
one without App.BrainDrain would show BRAIN DRAIN on with nothing draining),
UpdateFailedDialog (MessageDialog exists but needs an owner, which this catch
has just established there is not), DeeperTabView, StudioTabView x4,
BambiTakeoverTabView's art header, EmiRingPicker, EmiRingWindow,
ChaosSlotPickerWindow (dialog done, ChaosMeta.DeleteSlot still head-side),
AmbientFxCanvas, GradedIntakeTabView x3, SpiralTabView, BubbleCountWindow x6,
FirstRunWizard x3.

Deliberately NOT restored, reason written into each file:
- ProfileCustomizeDialog pin art. The resolver is not the blocker; the ctor
  takes (Id, Name) with no ImageName, and WPF DROPS a tile whose art will not
  load while only six achievement PNGs are linked here - a faithful port would
  hide almost every pin. The trophy glyph is the better answer, not a stub.
- FirstRunWizard's wordmark, StudioTabView's door medallion and rack art,
  DeeperTabView's and BambiTakeover's plates. Loader and art both resolve now;
  the missing half is an Image target in the .axaml, and this layer owns .cs
  only. Restoring the code alone would leave the markup's own note lying.

Note counts over the twenty owned files, comment lines naming each symbol,
before -> after: App.Settings 15 -> 11, App.Mods 9 -> 6, App.Logger 3 -> 3,
ModResourceResolver 22 -> 3, MessageBox 9 -> 5, WebView2 12 -> 9. Every survivor
was read: each either describes the WPF original or says outright that the
symbol is not the blocker.

Still blocked:
- Services/Account/V2AuthService.cs -> LoginDialog.BtnConfirmUsername_Click,
  LoginDialog.TryAccountLogin (CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs)
- App.UnifiedUserId -> same two
- Services/Chaos/ChaosUpgrades.cs ChaosMeta.DeleteSlot ->
  CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs DeleteSlot_Click
- App.BrainDrain, Services/BrainDrainService.cs, OverlayService.BrainDrainWithheld
  -> CCP.Avalonia/Views/Controls/Studio/BrainDrainFeatureControl.axaml.cs
- App.Engine, App.Companion ->
  CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs UpdateQuickMenuState
- NativeWebView.WebMessageReceived (unwrapped by Views/Controls/WebHost) ->
  BubbleCountWindow.StartBrowserPlayback / DisposeBrowserSurface,
  SpiralTabView.EnsureEmbed
- BrowserVideoEngine.BuildPageUrl, virtual-host mapping -> BubbleCountWindow
- Services/Quiz/IntakeHostService.cs, Services/IntakePassService.cs,
  Services/Quiz/PopQuizService.cs -> CCP.Avalonia/Views/Tabs/GradedIntakeTabView.axaml.cs
- PendingModActivation, MainWindow.ActivateChosenMod, ModPickerDialog's offline
  policy -> CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
- CoreMods mist-opacity provider (a Core change) ->
  CCP.Avalonia/Controls/AmbientFxCanvas.cs FxTheme.MistOpacity
- Cards/*.png and the remaining achievements/*.png as AvaloniaResources (.csproj)
  -> SessionCompleteWindow.LoadRandomCard, AchievementPopup.LoadAchievementImage
- an Image target in StudioTabView.axaml, DeeperTabView.axaml,
  BambiTakeoverTabView.axaml and FirstRunWizard.axaml (ImgWelcomeLogo)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU