### PR TITLE
feat(core): roadmap progress and diary move to Core; the Linux head keeps its own instance

### DIFF
--- a/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml.cs
@@ -31,8 +31,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
         public RampRackPanel()
         {
             AvaloniaXamlLoader.Load(this);
-            // ponytail: needs Controls.HelpPopover.Attach + Services.HelpContentService
-            // .GetContent("IntensityRamp") on HelpBtnStudioRamp, wired when they move to Core.
+            // ponytail: needs Controls/HelpPopover.cs ported to this head. HelpContentService
+            // is already in Core; the popover control is the only thing still missing, and
+            // it is what would call .GetContent("IntensityRamp") for HelpBtnStudioRamp.
         }
 
         /// <summary>The live control this panel hosts, for callers that need the real editor.</summary>

--- a/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml.cs
@@ -32,8 +32,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
         public SchedulerRackPanel()
         {
             AvaloniaXamlLoader.Load(this);
-            // ponytail: needs Controls.HelpPopover.Attach + Services.HelpContentService
-            // .GetContent("Scheduler") on HelpBtnStudioScheduler, wired when they move to Core.
+            // ponytail: needs Controls/HelpPopover.cs ported to this head. HelpContentService
+            // is already in Core; the popover control is the only thing still missing, and
+            // it is what would call .GetContent("Scheduler") for HelpBtnStudioScheduler.
         }
 
         /// <summary>The live control this panel hosts, for callers that need the real editor.</summary>

--- a/CCP.Avalonia/Views/Dialogs/RoadmapDiaryDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapDiaryDialog.axaml.cs
@@ -14,8 +14,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - BitmapImage -> Avalonia.Media.Imaging.Bitmap(path).
     ///  - The "Saved!" flash swaps the button's TextBlock text (the button holds a TextBlock, not
     ///    Content) and uses DispatcherTimer.RunOnce instead of a hand-rolled timer.
-    ///  - App.Roadmap (photo path resolution, note persistence) is a head service: see the
-    ///    ponytail stubs. A PhotoPath that is already absolute still loads.
+    ///  - App.Roadmap becomes MainShellWindow.Roadmap, this head's one RoadmapService (the service
+    ///    itself is now Core's). Photo-path resolution and note persistence are restored against it.
     /// </summary>
     public partial class RoadmapDiaryDialog : Window
     {
@@ -87,9 +87,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         {
             try
             {
-                // ponytail: needs RoadmapService.GetFullPhotoPath for a diary-relative path, wired when it moves to Core
-                var fullPath = _progress.PhotoPath;
-                if (!string.IsNullOrEmpty(fullPath) && Path.IsPathRooted(fullPath) && File.Exists(fullPath))
+                var fullPath = string.IsNullOrEmpty(_progress.PhotoPath)
+                    ? null
+                    : Windows.MainShellWindow.Roadmap.GetFullPhotoPath(_progress.PhotoPath);
+                if (!string.IsNullOrEmpty(fullPath) && File.Exists(fullPath))
                 {
                     _imgFullPhoto.Source = new Bitmap(fullPath);
                     _txtNoPhoto.IsVisible = false;
@@ -111,7 +112,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private void BtnSaveNote_Click()
         {
             var newNote = _txtUserNote.Text?.Trim();
-            // ponytail: needs RoadmapService.UpdateStepNote(_stepId, newNote), wired when it moves to Core
+            // Writes through the service, which persists immediately; it mutates the same
+            // RoadmapStepProgress this dialog holds when the step is a real one. The direct
+            // assignment stays for the render/design instance, whose progress the service has
+            // never heard of.
+            Windows.MainShellWindow.Roadmap.UpdateStepNote(_stepId, newNote);
             _progress.UserNote = newNote;
 
             // Visual feedback

--- a/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml.cs
@@ -17,7 +17,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/RoadmapStepPopup.xaml.cs. Deviations:
     ///  - <c>App.Logger</c> calls are dropped; the logger lives on the WPF App singleton.
-    ///  - <c>App.Roadmap.GetFullPhotoPath</c> is stubbed, so the thumbnail never loads yet and the
+    ///  - <c>App.Roadmap.GetFullPhotoPath</c> becomes <c>MainShellWindow.Roadmap</c>'s; the
     ///    checkmark stays. <see cref="LoadPhotoThumbnail"/> is otherwise the WPF body.
     ///  - <c>SystemParameters.WorkArea</c> -> <c>Screens.Primary.WorkingArea</c>, which is in
     ///    physical pixels, so the 20px margin and the window size are scaled before subtracting.
@@ -137,8 +137,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             {
                 if (string.IsNullOrEmpty(progress.PhotoPath)) return;
 
-                // ponytail: needs App.Roadmap (RoadmapService.GetFullPhotoPath), wired when it moves to Core
-                string? fullPath = null;
+                var fullPath = Windows.MainShellWindow.Roadmap.GetFullPhotoPath(progress.PhotoPath);
                 if (string.IsNullOrEmpty(fullPath) || !System.IO.File.Exists(fullPath)) return;
 
                 using var stream = System.IO.File.OpenRead(fullPath);

--- a/CCP.Avalonia/Views/Tabs/BlinkTrainerTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/BlinkTrainerTabView.axaml
@@ -139,8 +139,9 @@
               </StackPanel>
             </StackPanel>
 
-            <!-- Help button. ponytail: needs HelpContentService (WPF wires it in
-                 MainWindow.Presets.cs via SetHelpContent(..., "BlinkTrainer")). -->
+            <!-- Help button. ponytail: needs Controls/HelpPopover.cs ported to this head.
+                 HelpContentService is already in Core; WPF wires the two together in
+                 MainWindow.Presets.cs via SetHelpContent(..., "BlinkTrainer"). -->
             <Button x:Name="HelpBtnBlinkTrainer" Theme="{StaticResource HelpButtonStyle}"
                     HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,16,0"
                     Tag="BlinkTrainer"/>

--- a/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
@@ -76,8 +76,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             RoadmapPanel.IsVisible = true;
             BtnQuestSubDaily.Theme = TabTheme("TabButton");
             BtnQuestSubRoadmap.Theme = TabTheme("TabButtonActive");
-            // ponytail: needs RoadmapService (App.Roadmap), wired when it moves to Core. The panel
-            // shows its authored placeholders until then.
+            // ponytail: RoadmapService IS in Core now (CCP.Core/Services/RoadmapService.cs) and
+            // this head's instance is MainShellWindow.Roadmap. What is still missing is the VIEW
+            // half: RefreshRoadmapUI / GenerateRoadmapNodes from
+            // ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs, which paint
+            // TrackLockedOverlay, TxtLockReason, BadgeIndicator and a node per step. The panel
+            // shows its authored placeholders until that port lands.
         }
 
         private void OnTrackClick(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
@@ -86,8 +90,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             BtnTrack1.Theme = TabTheme(tag == "EmptyDoll" ? "TabButtonActive" : "TabButton");
             BtnTrack2.Theme = TabTheme(tag == "ObedientPuppet" ? "TabButtonActive" : "TabButton");
             BtnTrack3.Theme = TabTheme(tag == "SluttyBlowdoll" ? "TabButtonActive" : "TabButton");
-            // ponytail: needs RoadmapService (App.Roadmap) to repaint the nodes for the new track,
-            // wired when it moves to Core.
+            // ponytail: the nodes for the new track are not repainted - there are no generated
+            // nodes to repaint yet. Blocked on GenerateRoadmapNodes, not on the service:
+            // MainShellWindow.Roadmap answers GetTrackProgress / IsTrackUnlocked today.
         }
 
         private ControlTheme? TabTheme(string key) =>

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs
@@ -1,44 +1,55 @@
-// NOT PORTED from ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs (500 lines). Two
-// unrelated reasons, neither of them "wired when the models move to Core" - the models are ALREADY
-// there (CCP.Core/Models/RoadmapDefinition.cs carries RoadmapTrack and
-// RoadmapTrackDefinition.GetByTrack; CCP.Core/Models/RoadmapProgress.cs carries IsTrackUnlocked).
+// PARTIALLY PORTED from ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs (500 lines).
+// What this file now carries is the head's single RoadmapService instance. What it still does not
+// carry is the node painting, and the reasons are unchanged:
 //
 // 1. THE VIEW ALREADY DOES THE VIEW HALF. WPF's three chrome handlers hung off the shell because
 //    the Quests markup was inline in MainWindow.xaml. CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
 //    now owns them: ShowDailyWeekly() / ShowRoadmap() swap DailyWeeklyPanel and RoadmapPanel and
-//    restyle the two sub-tab buttons (lines 64-95), and the three track buttons restyle themselves.
-//    Restoring BtnQuestSubDaily_Click / BtnQuestSubRoadmap_Click / BtnTrack_Click here would be a
-//    second copy nothing routes to; _currentRoadmapTrack belongs with them, in that view.
+//    restyle the two sub-tab buttons, and the three track buttons restyle themselves. Restoring
+//    BtnQuestSubDaily_Click / BtnQuestSubRoadmap_Click / BtnTrack_Click here would be a second copy
+//    nothing routes to; _currentRoadmapTrack belongs with them, in that view.
 //
-// 2. EVERYTHING ELSE NEEDS THE SERVICE, NOT THE MODEL. App.Roadmap is
-//    ConditioningControlPanel/Services/RoadmapService.cs and has no seam: it owns the loaded
-//    RoadmapProgress instance, GetTrackProgress, IsTrackUnlocked against live progress, the
-//    photo-submission flow and the StepCompleted / TrackUnlocked events. Core has the SHAPES; it has
-//    no instance and no persistence for them, and RoadmapProgress is not a field of AppSettings. A
-//    CoreRoadmap seam over those four reads plus the two events would be the right fix - and it is
-//    a Core layer, not this one.
+// 2. THE SERVICE IS NOW IN CORE, so the old note's "needs a CoreRoadmap seam" is wrong and this
+//    file no longer waits on Core. RoadmapService lives at CCP.Core/Services/RoadmapService.cs and
+//    is head-agnostic: it reads and writes roadmap.json and the diary folder under
+//    CorePaths.UserData. What remains is a straight VIEW port - the node-per-step painting and the
+//    photo-submission flow - and it is a UI layer, not a Core one:
 //
-// Member by member:
-//   _currentRoadmapTrack, BtnQuestSubDaily_Click, BtnQuestSubRoadmap_Click, BtnTrack_Click
-//       -> QuestsTabView, per (1).
-//   RefreshRoadmapUI()
-//       Paints TxtRoadmapTrackName / TxtRoadmapTrackSubtitle from RoadmapTrackDefinition (Core,
-//       available) but needs App.Roadmap for GetTrackProgress, IsTrackUnlocked and
-//       Progress.HasCertifiedBlowdollBadge - the numbers, the locked overlay and the badge. The
-//       controls all exist in QuestsTabView.axaml (TrackLockedOverlay, RoadmapScrollContainer,
-//       TxtLockReason, BadgeIndicator).
+//   RefreshRoadmapUI()          numbers, the locked overlay and the badge, from Roadmap below.
+//                               Controls exist in QuestsTabView.axaml (TrackLockedOverlay,
+//                               RoadmapScrollContainer, TxtLockReason, BadgeIndicator).
 //   GenerateRoadmapNodes() / CreateRoadmapNode(…)   node-per-step, driven by per-step completion.
-//   RoadmapNode_Click(…) / ShowPhotoConfirmation(…) the photo-submission flow: a file picker plus
-//                                                   App.Roadmap's submit/confirm calls.
-//   RefreshRoadmapStats()                           aggregates across all three tracks.
-//   OnRoadmapStepCompleted(…) / OnRoadmapTrackUnlocked(…)  handlers for RoadmapService's two
-//                                                   events. Nothing to subscribe to.
+//   RoadmapNode_Click(…) / ShowPhotoConfirmation(…) file picker plus Roadmap.SubmitPhoto. Note the
+//                               picker is async on Avalonia: SubmitPhoto must be awaited behind the
+//                               answer, never fired beside it.
+//   RefreshRoadmapStats()       aggregates across all three tracks.
+//   OnRoadmapStepCompleted(…) / OnRoadmapTrackUnlocked(…)  subscribe to Roadmap.StepCompleted and
+//                               Roadmap.TrackUnlocked once the nodes exist to repaint.
+
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     public partial class MainShellWindow
     {
-        // Nothing here on purpose. Chrome: CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs.
-        // Data: needs a RoadmapService seam in Core.
+        private static RoadmapService? _roadmap;
+
+        /// <summary>
+        /// This head's one <see cref="RoadmapService"/>, the twin of WPF's <c>App.Roadmap</c>.
+        ///
+        /// <para>It lives here rather than as a static on the service itself precisely because WPF
+        /// constructs its own in <c>App</c>: a Core-side singleton would be a SECOND writer to the
+        /// same roadmap.json in the WPF process. One instance per head, and no head reaches into
+        /// another's.</para>
+        ///
+        /// <para>Static, not per-window, because the dialogs that need it (RoadmapStepPopup,
+        /// RoadmapDiaryDialog) are constructed without a shell in --render-view. Built on first
+        /// read on the UI thread, so no lock.</para>
+        ///
+        /// <para>Nothing disposes it on this head: the shell owns no Closed hook this layer may
+        /// edit. The service saves immediately on photo submission and on a note edit, so the only
+        /// thing a missed Dispose can lose is a StartStep timestamp within 30 s of exit.</para>
+        /// </summary>
+        internal static RoadmapService Roadmap => _roadmap ??= new RoadmapService();
     }
 }

--- a/CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs
@@ -317,9 +317,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnHelp_Click()
         {
-            // ponytail: needs HelpContentService + HelpVideoWindow, wired when they move to Core.
-            // The WPF original shows the tutorial clip when the "Modding" topic ships one and
-            // falls back to the coach-mark tutorial otherwise.
+            // WPF's order: prefer the tutorial clip when the topic ships one, else the coach-mark
+            // tutorial. Both halves are reachable now - HelpContentService is Core's, HelpVideoWindow
+            // is this head's - and "Modding" does ship a clip, so this always takes the video branch
+            // and the popup always lands in its fail-soft state (no video surface on this head:
+            // title, glyph and the topic blurb). Taken anyway because the other branch,
+            // LaunchTutorial, is still a stub, so the alternative here is a dead button.
+            var content = Services.HelpContentService.GetContent("Modding");
+            if (content.HasClip)
+            {
+                HelpVideoWindow.Show(content, this);
+                return;
+            }
             LaunchTutorial();
         }
 

--- a/CCP.Avalonia/Views/Windows/SessionEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionEditorWindow.axaml.cs
@@ -31,7 +31,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    real dialog later is a one-line swap at each site.
     ///  - Import/Export need <c>OpenFileDialog</c>/<c>SaveFileDialog</c> plus SessionFileService;
     ///    both are stubs. Save/Cancel are fully ported.
-    ///  - <c>BtnHelp</c>'s <c>HelpContentService</c> lookup and <c>HelpVideoWindow</c> hand-off is
+    ///  - <c>BtnHelp</c> keeps the coach-mark overlay instead of the clip on purpose; see the
+    ///    handler. The old note said the lookup and the hand-off were
     ///    a stub; the button opens the coach-mark overlay, which was WPF's own fallback.
     ///  - Mouse -> pointer: <c>DragMove</c> -> <c>BeginMoveDrag</c>, <c>CaptureMouse</c> ->
     ///    <c>e.Pointer.Capture</c>, <c>MouseRightButtonDown</c> -> <c>PointerPressed</c> filtered
@@ -170,9 +171,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnHelp_Click()
         {
-            // ponytail: needs HelpContentService + HelpVideoWindow, wired when they are ported.
-            // WPF preferred the tutorial clip when the topic shipped one and fell back to this
-            // overlay; the fallback is what runs until then.
+            // DELIBERATE DEVIATION, not a stub. WPF preferred the tutorial clip when the topic
+            // shipped one and fell back to this overlay. Both halves are reachable now
+            // (HelpContentService is Core's, HelpVideoWindow is this head's) and "SessionEditor"
+            // does ship a clip - but this head has no video surface, so taking the video branch
+            // would ALWAYS swap a working coach-mark walkthrough for a caption-only popup. Restore
+            // the WPF order only once a clip can actually play here.
             TutorialOverlay.IsVisible = true;
         }
 

--- a/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
@@ -261,9 +261,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnCalibrationHelp_Click()
         {
-            // ponytail: needs Services.HelpContentService.GetContent("WebcamCalibration") and the
-            // HelpVideoWindow popup (topmost:true so it layers above this fullscreen window),
-            // wired when the help service moves to Core.
+            // topmost: true so the popup layers above this full-screen calibration window.
+            // HelpContentService is Core's; HelpVideoWindow is this head's. The topic ships a clip
+            // that this head cannot play, so the popup takes its fail-soft branch - title, glyph
+            // and the topic's "what it does" blurb, video surface hidden. That is honest and it is
+            // strictly more than the nothing this button did before; WPF had no other fallback
+            // here either.
+            HelpVideoWindow.Show(Services.HelpContentService.GetContent("WebcamCalibration"), this, topmost: true);
         }
 
         // ─────────────────────────────────────────────────────────────────────

--- a/CCP.Core/Services/RoadmapService.cs
+++ b/CCP.Core/Services/RoadmapService.cs
@@ -1,8 +1,9 @@
 using System;
 using System.IO;
 using System.Text.Json;
-using System.Windows.Threading;
+using System.Threading;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Services;
 
@@ -33,7 +34,7 @@ public class RoadmapService : IDisposable
 {
     private readonly string _progressPath;
     private readonly string _diaryFolderPath;
-    private readonly DispatcherTimer _saveTimer;
+    private readonly Timer _saveTimer;
     private bool _isDirty;
     private bool _disposed;
 
@@ -47,29 +48,32 @@ public class RoadmapService : IDisposable
     public RoadmapService()
     {
         _progressPath = Path.Combine(
-            App.UserDataPath,
+            CorePaths.UserData,
             "roadmap.json");
 
         _diaryFolderPath = Path.Combine(
-            App.UserDataPath,
+            CorePaths.UserData,
             "roadmap_diary");
 
         Progress = LoadProgress();
         EnsureDiaryFolderExists();
 
-        // Auto-save every 30 seconds if dirty
-        _saveTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(30) };
-        _saveTimer.Tick += (s, e) =>
+        // Auto-save every 30 seconds if dirty. Was a WPF DispatcherTimer, so the tick ran on the
+        // UI thread and Save() could never serialize Progress while the UI mutated it. A
+        // System.Threading.Timer ticks on the thread pool, so the body hops back through
+        // CoreDispatch to keep that guarantee where a head has seeded a UI thread; unseeded (the
+        // Avalonia head today, the smoke runner, the tests) Post runs it in place, which is the
+        // same contract every other Core caller already has.
+        _saveTimer = new Timer(_ => CoreDispatch.Post(() =>
         {
             if (_isDirty)
             {
                 Save();
                 _isDirty = false;
             }
-        };
-        _saveTimer.Start();
+        }), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
 
-        App.Logger?.Information("RoadmapService initialized. Track1: {T1}, Track2: {T2}, Track3: {T3}",
+        Log.Information("RoadmapService initialized. Track1: {T1}, Track2: {T2}, Track3: {T3}",
             Progress.Track1Unlocked, Progress.Track2Unlocked, Progress.Track3Unlocked);
     }
 
@@ -87,7 +91,7 @@ public class RoadmapService : IDisposable
         }
         catch (Exception ex)
         {
-            App.Logger?.Error(ex, "Failed to load roadmap progress");
+            Log.Error(ex, "Failed to load roadmap progress");
         }
 
         return new RoadmapProgress();
@@ -108,7 +112,7 @@ public class RoadmapService : IDisposable
         }
         catch (Exception ex)
         {
-            App.Logger?.Error(ex, "Failed to save roadmap progress");
+            Log.Error(ex, "Failed to save roadmap progress");
         }
     }
 
@@ -123,7 +127,7 @@ public class RoadmapService : IDisposable
         }
         catch (Exception ex)
         {
-            App.Logger?.Error(ex, "Failed to create roadmap diary folder");
+            Log.Error(ex, "Failed to create roadmap diary folder");
         }
     }
 
@@ -211,7 +215,7 @@ public class RoadmapService : IDisposable
             }
 
             _isDirty = true;
-            App.Logger?.Information("Roadmap step started: {StepId}", stepId);
+            Log.Information("Roadmap step started: {StepId}", stepId);
         }
     }
 
@@ -222,7 +226,7 @@ public class RoadmapService : IDisposable
     {
         if (!IsStepActive(stepId))
         {
-            App.Logger?.Warning("Attempted to submit photo for non-active step: {StepId}", stepId);
+            Log.Warning("Attempted to submit photo for non-active step: {StepId}", stepId);
             return;
         }
 
@@ -275,7 +279,7 @@ public class RoadmapService : IDisposable
                         Progress.UnlockTrack(RoadmapTrack.ObedientPuppet);
                         unlockedNewTrack = true;
                         TrackUnlocked?.Invoke(this, RoadmapTrack.ObedientPuppet);
-                        App.Logger?.Information("Track 2 (Obedient Puppet) unlocked!");
+                        Log.Information("Track 2 (Obedient Puppet) unlocked!");
                     }
                     break;
 
@@ -285,7 +289,7 @@ public class RoadmapService : IDisposable
                         Progress.UnlockTrack(RoadmapTrack.SluttyBlowdoll);
                         unlockedNewTrack = true;
                         TrackUnlocked?.Invoke(this, RoadmapTrack.SluttyBlowdoll);
-                        App.Logger?.Information("Track 3 (Slutty Blowdoll) unlocked!");
+                        Log.Information("Track 3 (Slutty Blowdoll) unlocked!");
                     }
                     break;
 
@@ -296,7 +300,7 @@ public class RoadmapService : IDisposable
                         Progress.JourneyCompletedAt = DateTime.Now;
                         earnedBadge = true;
                         BadgeEarned?.Invoke(this, EventArgs.Empty);
-                        App.Logger?.Information("Certified Blowdoll badge earned!");
+                        Log.Information("Certified Blowdoll badge earned!");
                     }
                     break;
             }
@@ -308,7 +312,7 @@ public class RoadmapService : IDisposable
         // Fire completion event
         StepCompleted?.Invoke(this, new RoadmapStepCompletedEventArgs(stepDef, progress, unlockedNewTrack, earnedBadge));
 
-        App.Logger?.Information("Roadmap step completed: {StepId}, Time: {Minutes} mins",
+        Log.Information("Roadmap step completed: {StepId}, Time: {Minutes} mins",
             stepId, timeMinutes);
     }
 
@@ -332,7 +336,7 @@ public class RoadmapService : IDisposable
         }
         catch (Exception ex)
         {
-            App.Logger?.Error(ex, "Failed to save photo to diary: {Source}", sourcePhotoPath);
+            Log.Error(ex, "Failed to save photo to diary: {Source}", sourcePhotoPath);
             return "";
         }
     }
@@ -368,14 +372,14 @@ public class RoadmapService : IDisposable
         if (_disposed) return;
         _disposed = true;
 
-        _saveTimer.Stop();
+        _saveTimer.Dispose();
 
         if (_isDirty)
         {
             Save();
         }
 
-        App.Logger?.Information("RoadmapService disposed");
+        Log.Information("RoadmapService disposed");
     }
 
     #endregion

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -51,6 +51,7 @@ namespace ConditioningControlPanel.LinuxSmoke
             Scrubbing();
             Arithmetic();
             ConsentAndReports();
+            Roadmap();
 
             Console.WriteLine();
             if (_failures == 0)
@@ -378,6 +379,47 @@ namespace ConditioningControlPanel.LinuxSmoke
             Check("consent with a stale version is not current", !WebcamConsent.IsCurrent(cam));
             cam.WebcamConsentVersion = WebcamConsent.ConsentVersion;
             Check("consent with the contract version is current", WebcamConsent.IsCurrent(cam));
+        }
+
+        /// <summary>
+        /// RoadmapService moved into Core (wire/76). It is the first Core service that opens a
+        /// folder and a repeating timer in its constructor, so what is worth asserting off Windows
+        /// is that construction lands inside the sandboxed user-data tree rather than a Windows
+        /// path, that a fresh profile reads as the documented start state, and that Dispose is
+        /// clean - the autosave tick now hops through CoreDispatch, which is unseeded here.
+        /// </summary>
+        private static void Roadmap()
+        {
+            Console.WriteLine("\nRoadmap service");
+
+            using var roadmap = new RoadmapService();
+
+            Check("the diary folder is created under the sandboxed user data",
+                  Directory.Exists(roadmap.DiaryFolderPath) &&
+                  roadmap.DiaryFolderPath.StartsWith(CorePaths.UserData, StringComparison.Ordinal),
+                  roadmap.DiaryFolderPath);
+
+            Check("a fresh profile starts on track 1 only",
+                  roadmap.IsTrackUnlocked(Models.RoadmapTrack.EmptyDoll) &&
+                  !roadmap.IsTrackUnlocked(Models.RoadmapTrack.ObedientPuppet) &&
+                  !roadmap.IsTrackUnlocked(Models.RoadmapTrack.SluttyBlowdoll));
+
+            Check("the first step is active, the second locked",
+                  roadmap.IsStepActive("t1_step1") && roadmap.IsStepLocked("t1_step2"));
+
+            // The tick body runs through CoreDispatch.Post, which with no head attached runs in
+            // place. StartStep only dirties; proving the explicit Save round-trips is what tells
+            // us the file lands somewhere writable on Linux.
+            roadmap.StartStep("t1_step1");
+            roadmap.Save();
+            Check("progress round-trips to disk",
+                  File.Exists(Path.Combine(CorePaths.UserData, "roadmap.json")) &&
+                  new RoadmapService().GetStepProgress("t1_step1")?.StartedAt is not null);
+
+            Check("a relative diary photo resolves inside the diary folder",
+                  roadmap.GetFullPhotoPath("t1_step1_x.png").StartsWith(roadmap.DiaryFolderPath, StringComparison.Ordinal));
+            Check("an empty photo path resolves to empty, not to the folder itself",
+                  roadmap.GetFullPhotoPath("") == "");
         }
 
         /// <summary>Pure math must not drift with locale or floating-point defaults.</summary>


### PR DESCRIPTION
RoadmapService moves from the WPF head into CCP.Core/Services/RoadmapService.cs. Three
substitutions, no logic change: App.UserDataPath -> CorePaths.UserData (App.UserDataPath is
literally CorePaths.UserData, so the WPF paths are byte-identical), App.Logger -> Serilog
static Log, and the WPF DispatcherTimer autosave -> System.Threading.Timer, matching
SettingsService. The timer is the one thing worth reading twice: the DispatcherTimer ticked on
the UI thread, so Save() could never serialize RoadmapProgress while the UI mutated it. The
replacement ticks on the thread pool, so the tick body hops back through CoreDispatch.Post to
keep that guarantee. WPF seeds CoreDispatch, so the WPF save still lands on the WPF UI thread
exactly as before; the Avalonia head does not seed it yet, so there the tick runs in place on
the pool - the same contract every other unseeded Core caller already has.

App.xaml.cs:2107 needs no edit: RootNamespace is ConditioningControlPanel in both projects.

HelpContentService was ALREADY in Core (CCP.Core/Services/HelpContentService.cs); there is no
ConditioningControlPanel/Services/HelpContentService.cs to move. So the notes naming it as a
blocker were stale in two different ways and both are corrected rather than restored blindly:
RampRackPanel, SchedulerRackPanel and BlinkTrainerTabView are blocked on Controls/HelpPopover.cs,
which is not ported, and their notes now say only that. WebcamCalibrationWindow and
ModCreatorWindow now really open HelpVideoWindow - both had a dead button, so the popup fail-soft
state (title, glyph, topic blurb, video surface hidden) is strictly more than they showed before.

SessionEditorWindow deliberately does NOT take the video branch, and the reason is in the file.
WPF preferred the tutorial clip over the coach-mark overlay when the topic shipped one;
"SessionEditor" does ship one, and this head cannot play it, so restoring the WPF order would
always swap a working walkthrough for a caption-only popup. Restore it when a clip can play here.

The Avalonia head gets its own RoadmapService on MainShellWindow.Roadmap rather than a static on
the service: WPF constructs its own in App, so a Core-side singleton would be a second writer to
the same roadmap.json inside the WPF process. Against that instance, RoadmapDiaryDialog restores
diary photo resolution and note persistence, and RoadmapStepPopup restores its thumbnail. Both
short-circuit on an empty PhotoPath before touching the service, so --render-view never
constructs it or its diary folder.

CCP.LinuxSmoke asserts what could plausibly differ off Windows: the diary folder lands inside the
sandboxed CorePaths.UserData rather than a Windows path, a fresh profile reads as track 1 only
with t1_step1 active and t1_step2 locked, progress round-trips to disk through a second instance,
and photo paths resolve (empty in, empty out, not the folder itself). Verified to fail when broken.

Still blocked:
  CCP.Avalonia/Views/Windows/MainShellWindow.Roadmap.cs - RefreshRoadmapUI,
    GenerateRoadmapNodes, CreateRoadmapNode, RoadmapNode_Click, ShowPhotoConfirmation,
    RefreshRoadmapStats, OnRoadmapStepCompleted, OnRoadmapTrackUnlocked. A view port now, not a
    Core one; the service answers all of it. The photo picker is async on Avalonia, so
    SubmitPhoto must be awaited behind the answer, never fired beside it.
  CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs - ShowRoadmap and OnTrackClick paint no nodes,
    for the same reason.
  CCP.Avalonia/Views/Controls/Studio/{RampRackPanel,SchedulerRackPanel}.axaml.cs and
    CCP.Avalonia/Views/Tabs/BlinkTrainerTabView.axaml - need Controls/HelpPopover.cs ported.
  CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs - LaunchTutorial still needs the tutorial
    service and TutorialOverlay.
  Nothing disposes the Avalonia RoadmapService: the shell owns no Closed hook this layer may
    edit. Submit and note edits save immediately, so the loss surface is a StartStep timestamp
    within 30 s of exit.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU