### PR TITLE
feat(core): a tutorial seam, and the coach-mark overlay walks a real tour through it

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -68,6 +68,12 @@ namespace ConditioningControlPanel.Avalonia
                 // CCBill record file into a second tree. That is a fix to the class, in a later
                 // layer, not a seeding decision here.
 
+                // CoreTutorial stays unseeded, and that is the honest state rather than a gap:
+                // TutorialService and its twenty-two step lists are still in the WPF head, so this
+                // head has no tour to describe. Unseeded answers "not active, no step, 0 of 0", so
+                // TutorialOverlay draws nothing and every "bail while a tour is running" gate stays
+                // open. Seeding it with anything would put a tour on screen that nothing drives.
+
                 // CoreSpeech is deliberately left unseeded: there is no speech engine on this head
                 // yet, and the seam's unseeded answers (no mic, empty device list, NotProbed) are
                 // exactly what that is. Seeding it with anything else would be a lie.

--- a/CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs
@@ -10,6 +10,13 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using ConditioningControlPanel.Avalonia.Platform;
 
+// The step model now comes from the tutorial seam. Aliased to the names the WPF original uses so
+// this file still reads against ConditioningControlPanel/Windows/TutorialOverlay.xaml.cs line for
+// line - and so the mapping (Models.TutorialStep -> CoreTutorial.Step) is stated once, here.
+using TutorialStep = ConditioningControlPanel.CoreTutorial.Step;
+using TutorialStepPosition = ConditioningControlPanel.CoreTutorial.StepPosition;
+using TutorialAdvanceTrigger = ConditioningControlPanel.CoreTutorial.AdvanceTrigger;
+
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
     /// <summary>
@@ -23,15 +30,31 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// and why:
     ///
     /// <list type="bullet">
-    ///   <item><b>TutorialService / TutorialEventBus / TutorialStep.</b> All three live in the WPF
-    ///     head (Services/, Models/), which this head may not reference, so the overlay has no
-    ///     step source. <see cref="TutorialStep"/> and its two enums are copied as private nested
-    ///     types — the same call CornerGifWindow makes for CornerGifOverlaySetting — and they
-    ///     delete when the models reach Core. Next / Previous / Skip / Advance, the auto-advance
-    ///     subscriptions (OnButtonClick, OnTextEquals, OnSelectionEquals, OnSliderAtLeast,
-    ///     OnEvent), the WindowLoaded:* retarget and the app-shutdown teardown are all
-    ///     <c>ponytail:</c> stubs: every one of them is a call INTO the service, so porting the
-    ///     plumbing now would be writing against an API that does not exist yet.</item>
+    ///   <item><b>Live against the tutorial seam.</b> The card, the counter, the Next/Finish label,
+    ///     Previous, Skip and the follow-up buttons all read <c>CoreTutorial</c>, and the two
+    ///     verbs plus Escape call into it. On a head that seeds the seam (the WPF one does, from
+    ///     <c>App.SeedTutorialSeam</c>) the overlay walks a real tour; unseeded — which is this
+    ///     head today, because TutorialService and its step lists are still in the WPF head — the
+    ///     seam answers "no tour" and nothing is drawn but the sample card. Use the
+    ///     <see cref="TutorialOverlay(Window)"/> constructor for the live overlay; the
+    ///     parameterless one is the render proof's.</item>
+    ///
+    ///   <item><b>The auto-advance subscriptions are still stubs</b> (OnButtonClick, OnTextEquals,
+    ///     OnSelectionEquals, OnSliderAtLeast, OnEvent), and so is the WindowLoaded:* retarget.
+    ///     Those are not seam calls: each hooks a real control in a real window and the OnEvent one
+    ///     needs <c>TutorialEventBus</c>, which stayed in the WPF head. A step whose
+    ///     <c>Advance</c> is anything but Manual therefore shows no Next button and nothing
+    ///     advances it — it is honest about waiting and wrong about what it waits for, so it stops
+    ///     the tour rather than skipping a card. <c>AllowManualSkip</c> steps still have their
+    ///     "Skip step" button, which is the WPF escape hatch for exactly this.</item>
+    ///
+    ///   <item><b><c>TutorialStep.PrepareTargetWindowAction</c> did not cross.</b> It is an
+    ///     <c>Action&lt;System.Windows.Window&gt;</c> on Windows (DeeperTutorialPrep,
+    ///     CompanionTutorialPrep, AppSettingsTutorialPrep in Services/TutorialService.cs), so it
+    ///     cannot be seam data. Without it a step pointing INSIDE a default-collapsed drawer
+    ///     resolves its element but measures 0×0, and the settle timer runs out and draws the plain
+    ///     dim — the degraded path WPF already takes when an element cannot be found, not a
+    ///     crash.</item>
     ///
     ///   <item><b>SetWindowRgn / CreateRectRgn / CombineRgn — the click-through hole.</b> WPF
     ///     punched the spotlight rect out of the window's OS-level region, because a WPF layered
@@ -53,40 +76,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// </summary>
     public partial class TutorialOverlay : Window
     {
-        // ---- Copies of ConditioningControlPanel.Models.TutorialStep ------------------
-        // The originals live in the WPF head. Only the members this view reads are kept;
-        // PrepareTargetWindowAction is typed on Avalonia's Window instead of WPF's.
-
-        /// <summary>Copy of ConditioningControlPanel.Models.TutorialStepPosition.</summary>
-        private enum TutorialStepPosition { Top, Bottom, Left, Right, Center }
-
-        /// <summary>Copy of ConditioningControlPanel.Models.TutorialAdvanceTrigger.</summary>
-        private enum TutorialAdvanceTrigger { Manual, OnButtonClick, OnTextEquals, OnSelectionEquals, OnSliderAtLeast, OnEvent }
-
-        /// <summary>Copy of ConditioningControlPanel.Models.TutorialStep.</summary>
-        private sealed class TutorialStep
-        {
-            public string Id { get; set; } = "";
-            public string Title { get; set; } = "";
-            public string Description { get; set; } = "";
-            public string Icon { get; set; } = "";
-            public string? TargetElementName { get; set; }
-            public string? TargetWindowTypeName { get; set; }
-            public TutorialStepPosition TextPosition { get; set; } = TutorialStepPosition.Bottom;
-            public TutorialAdvanceTrigger AdvanceTrigger { get; set; } = TutorialAdvanceTrigger.Manual;
-            public bool AllowManualSkip { get; set; }
-            public bool IsFollowUpCard { get; set; }
-            /// <summary>True (default): the dim absorbs clicks outside the hole and the card.</summary>
-            public bool BlockBackgroundClicks { get; set; } = true;
-            public Action<Window>? PrepareTargetWindowAction { get; set; }
-            public Action<TutorialStep>? FollowUpAction1 { get; set; }
-            public Action<TutorialStep>? FollowUpAction2 { get; set; }
-            public Action<TutorialStep>? FollowUpAction3 { get; set; }
-            public string? FollowUpButton1Text { get; set; }
-            public string? FollowUpButton2Text { get; set; }
-            public string? FollowUpButton3Text { get; set; }
-        }
-
         // ---- Named parts ------------------------------------------------------------
 
         private readonly Canvas _spotlightCanvas;
@@ -115,18 +104,70 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private TutorialStep? _step;
         private bool _loaded;
 
+        /// <summary>True when this overlay is driving a real tour off <c>CoreTutorial</c>. False in
+        /// the render constructor, which owns its own sample step and must not ask the seam
+        /// anything — an unseeded seam would answer "0 of 0" and blank the sample card.</summary>
+        private readonly bool _live;
+
+        /// <summary>Once-per-step latch for <see cref="Advance"/>, exactly as WPF's
+        /// <c>_advanceFiredThisStep</c>: overlay-instance state, reset on every step change. The
+        /// brief called this portable; the original disagrees and it stays here, because the thing
+        /// being de-duplicated is one overlay's view of one card, not the service's cursor.</summary>
+        private bool _advanceFiredThisStep;
+
         /// <summary>Sample spotlight rect used by the render constructor, so the PNG exercises the
         /// spotlight path (geometry + glow ring + panel placement) and not just the plain dim.</summary>
         private Rect? _sampleTargetBounds;
+
+        /// <summary>The counter text the render constructor shows, since the seam has no tour to
+        /// count. Null on the live overlay, where the real "Step n of m" always wins.</summary>
+        private string? _sampleCounter;
 
         // Retry timer used by UpdateSpotlight when the target's bounds aren't measured yet. Held
         // so consecutive UpdateSpotlight calls can cancel the prior tick (otherwise they pile up
         // and fire stale layouts) and so teardown stops it on close.
         private DispatcherTimer? _spotlightDelayTimer;
 
-        /// <summary>Render constructor. Placeholder step data — the real text comes from
-        /// TutorialService, which is still head-side.</summary>
-        public TutorialOverlay()
+        /// <summary>
+        /// Render constructor. Sample step data, and NOT connected to the seam: RenderProof needs a
+        /// parameterless ctor, and a headless render must not be able to walk a live tour.
+        /// </summary>
+        public TutorialOverlay() : this(null, live: false)
+        {
+            // Placeholder: the first step of the full tour, re-pointed at a sample rect so the
+            // render draws a spotlight rather than the Center-positioned plain card.
+            _sampleCounter = "Step 1 of 6";
+            _step = new TutorialStep
+            {
+                Id = "welcome",
+                Icon = "~",
+                Title = "Welcome to Conditioning Control Panel!",
+                Description = "Everything lives behind seven doors down the left. This quick tour opens each " +
+                              "one so you know where things are.\n\n" +
+                              "You can replay it any time from the ? button in the title bar.",
+                TextPosition = TutorialStepPosition.Bottom,
+                TargetElementName = "SampleTarget",
+                Advance = TutorialAdvanceTrigger.Manual,
+                AllowManualSkip = true,
+            };
+            _sampleTargetBounds = new Rect(120, 90, 300, 64);
+        }
+
+        /// <summary>
+        /// The live overlay: it draws whatever tour <c>CoreTutorial</c> is running and measures its
+        /// spotlight against <paramref name="targetWindow"/>. Show it AFTER the tour has started,
+        /// as WPF does (MainWindow.StartTutorial calls Start then constructs) — the first card is
+        /// read on Loaded, and StepChanged carries every card after it.
+        ///
+        /// <para>Nothing on this head calls this yet: starting a tour is
+        /// <c>MainShellWindow.StartTutorial</c>, which is a different layer's file, and there is no
+        /// step source here to start. It is the entry point that layer needs.</para>
+        /// </summary>
+        public TutorialOverlay(Window targetWindow) : this(targetWindow, live: true)
+        {
+        }
+
+        private TutorialOverlay(Window? targetWindow, bool live)
         {
             AvaloniaXamlLoader.Load(this);
 
@@ -158,40 +199,63 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             KeyDown += OnKeyDown;
             Focusable = true;
 
-            // Placeholder: the first step of the full tour, re-pointed at a sample rect so the
-            // render draws a spotlight rather than the Center-positioned plain card.
-            _step = new TutorialStep
+            _live = live;
+            _targetWindow = targetWindow;
+
+            if (_live)
             {
-                Id = "welcome",
-                Icon = "~",
-                Title = "Welcome to Conditioning Control Panel!",
-                Description = "Everything lives behind seven doors down the left. This quick tour opens each " +
-                              "one so you know where things are.\n\n" +
-                              "You can replay it any time from the ? button in the title bar.",
-                TextPosition = TutorialStepPosition.Bottom,
-                TargetElementName = "SampleTarget",
-                AdvanceTrigger = TutorialAdvanceTrigger.Manual,
-                AllowManualSkip = true,
-            };
-            _sampleTargetBounds = new Rect(120, 90, 300, 64);
+                CoreTutorial.StepChanged += OnSeamStepChanged;
+                CoreTutorial.Finished += OnSeamFinished;
+            }
 
             Loaded += (_, _) =>
             {
                 _loaded = true;
                 UpdateOverlayPosition();
-                if (_step != null) UpdateStep(_step);
+                // Live: the tour has already started, so the first card is read here (WPF does the
+                // same on its own Loaded). Sample: _step was set by the render constructor.
+                var first = _live ? CoreTutorial.CurrentStep : _step;
+                if (first != null) UpdateStep(first);
             };
+        }
+
+        /// <summary>The tour moved. Raised synchronously by the head that owns it, and possibly off
+        /// the UI thread, so it hops back before touching a control.</summary>
+        private void OnSeamStepChanged(object? sender, TutorialStep step)
+        {
+            if (Dispatcher.UIThread.CheckAccess()) UpdateStep(step);
+            else Dispatcher.UIThread.Post(() => UpdateStep(step));
+        }
+
+        /// <summary>The tour ended, by any route. The overlay goes with it — WPF fades out over
+        /// 200ms and closes; the fade is dropped here for the reason in the header.</summary>
+        private void OnSeamFinished(object? sender, bool completed)
+        {
+            _ = completed;
+            if (Dispatcher.UIThread.CheckAccess()) Close();
+            else Dispatcher.UIThread.Post(Close);
         }
 
         protected override void OnClosed(EventArgs e)
         {
             try { _spotlightDelayTimer?.Stop(); } catch { /* already stopped */ }
             _spotlightDelayTimer = null;
+
+            if (_live)
+            {
+                CoreTutorial.StepChanged -= OnSeamStepChanged;
+                CoreTutorial.Finished -= OnSeamFinished;
+
+                // The window going away while the tour is still running is exactly what WPF's
+                // OnAppExit / OnMainWindowClosed handlers cover, and they Skip() for a reason: a
+                // tour with no overlay left is not running, and an IsActive stuck true would shut
+                // every "not while a tutorial is up" gate in the app for the rest of the session.
+                // Skip never latches the tour as completed, and the head guards re-entry, so the
+                // ordinary close-after-Finished path lands on a no-op.
+                if (CoreTutorial.IsActive) CoreTutorial.Skip();
+            }
+
             base.OnClosed(e);
-            // ponytail: needs TutorialService + TutorialEventBus, wired when they move to Core.
-            // WPF also unhooked StepChanged / TutorialCompleted / the static event bus / the
-            // Application.Exit + MainWindow.Closed shutdown handlers here; the static bus
-            // subscription outliving the window is what used to leave a zombie process.
         }
 
         private void OnKeyDown(object? sender, KeyEventArgs e)
@@ -247,9 +311,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // ponytail: needs TutorialService (CurrentSteps / CurrentStepIndex) and the
             // WindowLoaded:* bus event to know when to retarget; wired when they move to Core.
 
-            // ponytail: needs TutorialService (CurrentStepIndex, TotalSteps). Placeholder counter
-            // so the card is not left with the XAML's design-time text.
-            _txtStepCounter.Text = "Step 1 of 6";
+            // A new card: the once-per-step advance latch reopens. WPF does this inside
+            // SubscribeAdvanceTrigger, which is the only thing UpdateStep calls after this point
+            // that is still a stub here, so the reset moves up rather than getting lost with it.
+            _advanceFiredThisStep = false;
+
+            _txtStepCounter.Text = StepCounterText();
             _txtIcon.Text = step.Icon;
             _txtTitle.Text = step.Title;
             _txtDescription.Text = step.Description;
@@ -259,22 +326,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _btnSkipStep.IsVisible = step.AllowManualSkip && !step.IsFollowUpCard;
 
             // Manual advance trigger -> show Next; otherwise auto-advance handles it.
-            bool isManual = step.AdvanceTrigger == TutorialAdvanceTrigger.Manual;
+            bool isManual = step.Advance == TutorialAdvanceTrigger.Manual;
             _btnNext.IsVisible = isManual && !step.IsFollowUpCard;
-            // ponytail: needs TutorialService.IsLastStep for the "Finish" label.
-            _btnNext.Content = "Next";
+            // "Finish" only when the seam says there IS a last card to be on: unseeded, TotalSteps
+            // is 0 and IsLastStep is false, so the sample card keeps the honest "Next".
+            _btnNext.Content = _live && CoreTutorial.IsLastStep ? "Finish" : "Next";
 
             // Hide Previous in rails mode (going back is messy with state) and on follow-up cards.
-            // ponytail: needs TutorialService.IsFirstStep; the placeholder step is not the first.
-            _btnPrevious.IsVisible = isManual && !step.IsFollowUpCard;
+            // On the sample card there is nowhere to go back to either, so it hides there too.
+            _btnPrevious.IsVisible = isManual && !step.IsFollowUpCard && _live && !CoreTutorial.IsFirstStep;
 
             // Follow-up card mode renders a stacked button list inside the panel.
             if (step.IsFollowUpCard)
             {
                 _followUpPanel.IsVisible = true;
-                ConfigureFollowUpButton(_btnFollowUp1, step.FollowUpButton1Text, step.FollowUpAction1);
-                ConfigureFollowUpButton(_btnFollowUp2, step.FollowUpButton2Text, step.FollowUpAction2);
-                ConfigureFollowUpButton(_btnFollowUp3, step.FollowUpButton3Text, step.FollowUpAction3);
+                ConfigureFollowUpButton(_btnFollowUp1, step.FollowUp1Text, step.FollowUp1);
+                ConfigureFollowUpButton(_btnFollowUp2, step.FollowUp2Text, step.FollowUp2);
+                ConfigureFollowUpButton(_btnFollowUp3, step.FollowUp3Text, step.FollowUp3);
             }
             else
             {
@@ -295,19 +363,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 try { Focus(); } catch { /* window already closing */ }
             }, DispatcherPriority.Background);
 
-            // ponytail: needs TutorialService — SubscribeAdvanceTrigger hooked the target control
+            // ponytail: SubscribeAdvanceTrigger is head work, not a seam call — it hooks the target control
             // for OnButtonClick (Click + PreviewMouseLeftButtonUp + the parent window's Closing),
             // OnTextEquals (TextBox.TextChanged, with the numeric/substring match),
             // OnSelectionEquals (Selector.SelectionChanged, by Content or Tag) and
             // OnSliderAtLeast (advance on pointer release, not on every ValueChanged), and
-            // OnEvent came off the static TutorialEventBus. Without a service to call Next() on,
-            // every one of those subscriptions has nothing to do.
+            // OnEvent came off the static TutorialEventBus, which stayed in the WPF head. Every
+            // one of them needs a real control in a real window, which is why none of it crossed
+            // with the seam. The consequence is written into the class header.
         }
 
         /// <summary>The follow-up label comes from step data, which may contain an underscore, so
         /// it goes in a TextBlock: Avalonia parses "_" in a Button's string Content as an access
         /// key and would swallow it (CLAUDE.md trap 1).</summary>
-        private static void ConfigureFollowUpButton(Button btn, string? text, Action<TutorialStep>? handler)
+        private static void ConfigureFollowUpButton(Button btn, string? text, Action? handler)
         {
             if (string.IsNullOrEmpty(text) || handler == null)
             {
@@ -335,7 +404,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // Click-through hole only when the step is gated on a specific element interaction.
             // Manual steps and follow-up cards block all clicks (full opaque overlay).
-            bool clickThroughHole = step.AdvanceTrigger != TutorialAdvanceTrigger.Manual &&
+            bool clickThroughHole = step.Advance != TutorialAdvanceTrigger.Manual &&
                                     !step.IsFollowUpCard;
 
             if (step.IsFollowUpCard ||
@@ -364,9 +433,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 return;
             }
 
-            // Give the target window a chance to prepare itself (e.g. expand a collapsed drawer
-            // that contains TargetElementName). Wrapped so a buggy callback can't break the tour.
-            try { step.PrepareTargetWindowAction?.Invoke(_targetWindow); } catch { /* caller's bug */ }
+            // WPF gave the target window a chance to prepare itself here (expand the collapsed
+            // drawer that holds TargetElementName) via step.PrepareTargetWindowAction. That hook
+            // is an Action<System.Windows.Window> and did not cross with the seam - see the class
+            // header for what a step behind a collapsed drawer degrades to.
             try { _targetWindow.UpdateLayout(); } catch { /* not laid out yet */ }
 
             var targetElement = FindElementByName(_targetWindow, step.TargetElementName);
@@ -471,10 +541,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// settles).</summary>
         private bool PrepareDoorForStep(TutorialStep step)
         {
-            // ponytail: needs TutorialService.DoorTabKeyFor(step) and MainWindow.ExpandDoorForTab,
-            // wired when they move to Core. Until then no door is opened, so a step whose target
-            // sits behind a collapsed door falls through to the full-overlay path below — which is
-            // the same thing WPF does when the element cannot be found.
+            // ponytail: needs MainShellWindow.ExpandDoorForTab, which does not exist on this head
+            // (MainShellWindow.TabNavigation.cs has ShowTab, which also NAVIGATES — and a step can
+            // spotlight a nav entry filed under a door other than the tab it requires, so ShowTab
+            // would jump the user off the page the card is talking about). The door key itself is
+            // deliberately not on CoreTutorial.Step either: TutorialService.DoorTabKeyFor is a pure
+            // function of the step, but with no way to act on the answer a field carrying it would
+            // just be seam surface nothing reads.
+            //
+            // Until that method exists, no door is opened, so a step whose target sits behind a
+            // collapsed door falls through to the full-overlay path below — the same degraded card
+            // WPF draws when an element cannot be found.
             _ = step;
             return false;
         }
@@ -565,7 +642,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// <summary>WPF dimmed harder over MainWindow (0xA0) than over a dialog (0x70). Sample mode
         /// has no target, and the overlay's normal home is MainWindow, so it takes the same
         /// value.</summary>
-        private byte DimAlpha() => _targetWindow is null or MainWindow ? (byte)0xA0 : (byte)0x70;
+        private byte DimAlpha() => _targetWindow is null or MainWindow or MainShellWindow ? (byte)0xA0 : (byte)0x70;
 
         // ---- Window-level click-through ---------------------------------------------
 
@@ -682,7 +759,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private void CenterTextPanel()
         {
             _textPanel.HorizontalAlignment = HorizontalAlignment.Center;
-            if (_targetWindow is null or MainWindow)
+            // MainShellWindow beside MainWindow: on this head the app shell is the tour's home
+            // and the diagnostics MainWindow is not, so the centred card must follow the shell.
+            if (_targetWindow is null or MainWindow or MainShellWindow)
             {
                 _textPanel.VerticalAlignment = VerticalAlignment.Center;
                 _textPanel.Margin = new Thickness(0);
@@ -742,25 +821,49 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         // ---- Button handlers --------------------------------------------------------
 
-        // ponytail: all four need TutorialService (Next / Previous / Skip and the once-per-step
-        // advance guard), wired when it moves to Core.
-        private void NextStep() { }
-        private void PreviousStep() { }
-        private void SkipTutorial() { }
-        private void Advance() { }
+        /// <summary>"Step n of m" from the seam. The sample card has no tour behind it, so it keeps
+        /// the placeholder the render constructor set rather than reading 0 of 0.</summary>
+        private string StepCounterText()
+        {
+            if (!_live) return _sampleCounter ?? "";
+            return $"Step {CoreTutorial.CurrentStepIndex + 1} of {CoreTutorial.TotalSteps}";
+        }
 
-        // ponytail: needs TutorialService.CurrentStep to reach the live step's actions; the button
-        // labels and visibility above already come from the step object.
+        private void NextStep() => CoreTutorial.Next();
+        private void PreviousStep() => CoreTutorial.Previous();
+        private void SkipTutorial() => CoreTutorial.Skip();
+
+        /// <summary>
+        /// "Skip step", and the entry point an auto-advance trigger would use. Once per step, then
+        /// deferred: WPF cannot run Next() synchronously here because UpdateStep would then rewrite
+        /// the card in the middle of the click that asked for it, and the bubbling half of that
+        /// click never reaches the button underneath. The latch is set synchronously, so a second
+        /// press before the post lands does nothing.
+        /// </summary>
+        private void Advance()
+        {
+            if (_advanceFiredThisStep) return;
+            _advanceFiredThisStep = true;
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (CoreTutorial.IsActive) CoreTutorial.Next();
+            });
+        }
+
+        /// <summary>Runs the live step's follow-up action, not the card's — a branch card can be
+        /// clicked after the tour has moved on, and WPF reads CurrentStep here for that reason.
+        /// Falls back to the drawn step when no tour is running (the render's sample card).</summary>
         private void InvokeFollowUp(int which)
         {
-            if (_step is not { } step) return;
+            var step = (_live ? CoreTutorial.CurrentStep : null) ?? _step;
+            if (step is null) return;
             var action = which switch
             {
-                1 => step.FollowUpAction1,
-                2 => step.FollowUpAction2,
-                _ => step.FollowUpAction3,
+                1 => step.FollowUp1,
+                2 => step.FollowUp2,
+                _ => step.FollowUp3,
             };
-            action?.Invoke(step);
+            action?.Invoke();
         }
 
         /// <summary>Not a stub: UseShellExecute hands the URL to xdg-open on Linux exactly as it

--- a/CCP.Core/CoreTutorial.cs
+++ b/CCP.Core/CoreTutorial.cs
@@ -1,0 +1,190 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The tutorial seam: what a coach-mark overlay needs to draw a tour, and the verbs that move
+    /// it. The tour ITSELF - twenty-two step lists, the tab callbacks, the completion ledger -
+    /// stays in the head that owns them (<c>Services/TutorialService.cs</c> on Windows), because
+    /// every step is a sentence about that head's controls and half of them invoke head-side
+    /// navigation on activation.
+    ///
+    /// <para>What crosses is a per-step SNAPSHOT plus the cursor over the list. That is enough for
+    /// an overlay to render a card, place it, spotlight a named control, count the steps and walk
+    /// forwards, backwards or out - and it is deliberately not enough to author a tour, which is
+    /// the half that is not portable.</para>
+    ///
+    /// <para><b>What is NOT here, and why.</b> Nothing that names a window or a control type:
+    /// <c>TutorialStep.PrepareTargetWindowAction</c> is an <c>Action&lt;System.Windows.Window&gt;</c>
+    /// on Windows and would have to be a different type per head; the spotlight cut-out, the input
+    /// region and the sidebar door expansion are pixels and OS calls, so they stay in the overlay.
+    /// The auto-advance triggers cross only as the <see cref="AdvanceTrigger"/> ENUM - the actual
+    /// subscription hooks a real control on a real head, and that head calls <see cref="Next"/>
+    /// when it fires.</para>
+    ///
+    /// <para><b>Unseeded is "no tour".</b> Not active, no current step, index 0, 0 steps, first step
+    /// and not last. <see cref="Next"/>/<see cref="Previous"/>/<see cref="Skip"/>/<see cref="Start"/>
+    /// are silent no-ops. That is the truth on a head with no tutorial service, not a placebo: an
+    /// overlay reading this seam draws nothing and a "bail while a tour is running" gate stays
+    /// open. Nothing here throws, on any path.</para>
+    ///
+    /// <para>The <see cref="Step"/> snapshot and its two enums are NESTED on purpose. The Windows
+    /// head's own <c>TutorialStep</c> / <c>TutorialStepPosition</c> / <c>TutorialAdvanceTrigger</c>
+    /// live in <c>ConditioningControlPanel.Models</c> and are used unqualified from inside
+    /// <c>namespace ConditioningControlPanel.Services</c>. C# searches enclosing namespaces before
+    /// using-directives, so a top-level <c>ConditioningControlPanel.TutorialStep</c> declared here
+    /// would silently rebind every bare mention of it in that 3,196-line file. Nested, they can
+    /// only be named as <c>CoreTutorial.Step</c>.</para>
+    /// </summary>
+    public static class CoreTutorial
+    {
+        /// <summary>Where the card sits relative to the spotlit control. Mirrors
+        /// <c>Models.TutorialStepPosition</c>.</summary>
+        public enum StepPosition { Top, Bottom, Left, Right, Center }
+
+        /// <summary>What moves the tour off this step. Mirrors <c>Models.TutorialAdvanceTrigger</c>.
+        /// Only <see cref="Manual"/> is acted on in Core - it decides whether the card shows a Next
+        /// button; the rest tell the head's overlay which control to watch.</summary>
+        public enum AdvanceTrigger { Manual, OnButtonClick, OnTextEquals, OnSelectionEquals, OnSliderAtLeast, OnEvent }
+
+        /// <summary>
+        /// One card's worth of tour, as data. A SNAPSHOT: the head may project a fresh instance on
+        /// every read, so compare steps by <see cref="CurrentStepIndex"/>, never by reference.
+        /// </summary>
+        public sealed class Step
+        {
+            public string Id { get; init; } = "";
+            public string Title { get; init; } = "";
+            public string Description { get; init; } = "";
+            public string Icon { get; init; } = "";
+
+            /// <summary>The x:Name of the control to spotlight, or null for a centred card.</summary>
+            public string? TargetElementName { get; init; }
+
+            /// <summary>Type name of the window the target lives in, when it is not the one the
+            /// overlay is attached to. The retarget itself is head work.</summary>
+            public string? TargetWindowTypeName { get; init; }
+
+            public StepPosition TextPosition { get; init; } = StepPosition.Bottom;
+            public AdvanceTrigger Advance { get; init; } = AdvanceTrigger.Manual;
+
+            /// <summary>The card offers "Skip step" as well as waiting for the trigger.</summary>
+            public bool AllowManualSkip { get; init; }
+
+            /// <summary>A branch card: no Skip/Next row, a stack of follow-up buttons instead.</summary>
+            public bool IsFollowUpCard { get; init; }
+
+            /// <summary>True (default): the dim absorbs clicks outside the hole and the card.
+            /// False when the user must work something ON TOP of the overlay.</summary>
+            public bool BlockBackgroundClicks { get; init; } = true;
+
+            public string? FollowUp1Text { get; init; }
+            public string? FollowUp2Text { get; init; }
+            public string? FollowUp3Text { get; init; }
+
+            /// <summary>Already bound to their own step by the head that projected them, so they
+            /// take no argument where the head's originals take the step.</summary>
+            public Action? FollowUp1 { get; init; }
+            public Action? FollowUp2 { get; init; }
+            public Action? FollowUp3 { get; init; }
+        }
+
+        // ---- Seams the head assigns at startup ------------------------------------------
+
+        public static volatile Func<bool>? IsActiveProvider;
+        public static volatile Func<Step?>? CurrentStepProvider;
+        public static volatile Func<int>? CurrentStepIndexProvider;
+        public static volatile Func<int>? TotalStepsProvider;
+        public static volatile Action? NextAction;
+        public static volatile Action? PreviousAction;
+        public static volatile Action? SkipAction;
+
+        /// <summary>Start a tour by name - the head's tutorial-type name, e.g. "UpgradeTour". A
+        /// string and not an enum so Core carries no second copy of a list only the head can act
+        /// on; the head parses it and ignores a name it does not know.</summary>
+        public static volatile Action<string>? StartAction;
+
+        // ---- Readers --------------------------------------------------------------------
+
+        /// <summary>A tour is on screen right now. False unseeded, which is what keeps a
+        /// "not while a tutorial is running" gate open on a head that runs none.</summary>
+        public static bool IsActive
+        {
+            get { try { return IsActiveProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+
+        /// <summary>The card being shown, or null when no tour is running.</summary>
+        public static Step? CurrentStep
+        {
+            get { try { return CurrentStepProvider?.Invoke(); } catch { return null; } }
+        }
+
+        /// <summary>Zero-based cursor into the current tour. 0 unseeded.</summary>
+        public static int CurrentStepIndex
+        {
+            get { try { return CurrentStepIndexProvider?.Invoke() ?? 0; } catch { return 0; } }
+        }
+
+        /// <summary>How many cards the current tour has. 0 unseeded, which is what lets a caller
+        /// tell "no tour" from "a one-card tour".</summary>
+        public static int TotalSteps
+        {
+            get { try { return TotalStepsProvider?.Invoke() ?? 0; } catch { return 0; } }
+        }
+
+        /// <summary>Nothing to go back to. True unseeded (index 0), so a Previous button starts
+        /// hidden rather than offering a move that does nothing.</summary>
+        public static bool IsFirstStep => CurrentStepIndex <= 0;
+
+        /// <summary>The last card, so Next finishes the tour rather than advancing. False when
+        /// there is no tour at all - "Finish" over nothing is the state lie to avoid.</summary>
+        public static bool IsLastStep
+        {
+            get { var n = TotalSteps; return n > 0 && CurrentStepIndex >= n - 1; }
+        }
+
+        // ---- Verbs ----------------------------------------------------------------------
+
+        /// <summary>Advance, or finish on the last card. Silent when no tour is running.</summary>
+        public static void Next() { try { NextAction?.Invoke(); } catch { /* a tour never blocks on UI quirks */ } }
+
+        /// <summary>Back one card. Silent on the first card and when no tour is running.</summary>
+        public static void Previous() { try { PreviousAction?.Invoke(); } catch { /* see Next */ } }
+
+        /// <summary>Abandon the tour. Never latches it as completed - see the head's ledger.</summary>
+        public static void Skip() { try { SkipAction?.Invoke(); } catch { /* see Next */ } }
+
+        /// <summary>Start the named tour. A no-op when the head has no such tour, and unseeded.</summary>
+        public static void Start(string tourName)
+        {
+            if (string.IsNullOrWhiteSpace(tourName)) return;
+            try { StartAction?.Invoke(tourName); } catch { /* see Next */ }
+        }
+
+        // ---- Events the head forwards ---------------------------------------------------
+
+        /// <summary>The tour moved to a different card. Raised on the thread the head raised its
+        /// own event on - synchronously, because an overlay must have the new spotlight in place
+        /// before the user's next click, and a Post would reintroduce exactly that race.</summary>
+        public static event EventHandler<Step>? StepChanged;
+
+        /// <summary>The tour ended, by any route. The bool is <c>true</c> only for the last card
+        /// walked off the end; Escape, Skip and teardown all report <c>false</c>.</summary>
+        public static event EventHandler<bool>? Finished;
+
+        /// <summary>Head entry point for <see cref="StepChanged"/>. Swallows a subscriber's fault:
+        /// the Windows tutorial service invokes its own StepChanged unguarded, so a throwing Core
+        /// subscriber must not be able to break a WPF tour.</summary>
+        public static void RaiseStepChanged(object? sender, Step step)
+        {
+            try { StepChanged?.Invoke(sender, step); } catch { /* a subscriber's fault is not the tour's */ }
+        }
+
+        /// <summary>Head entry point for <see cref="Finished"/>. Swallows - see
+        /// <see cref="RaiseStepChanged"/>.</summary>
+        public static void RaiseFinished(object? sender, bool completed)
+        {
+            try { Finished?.Invoke(sender, completed); } catch { /* see above */ }
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -135,6 +135,33 @@ namespace ConditioningControlPanel.LinuxSmoke
                 CoreModerationLog.Record(ProhibitedCategory.Minor, "input", "smoke");
                 Check("CoreModerationLog records are silent no-ops with no log attached", true);
                 Check("CoreReleaseContent answers null with no pack service", CoreReleaseContent.GetPackInfo("mod-bambi") == null && CoreReleaseContent.GetStampFor("mod-bambi") == null);
+                // The tutorial seam (wire/77). Unseeded must read as "no tour" and never as a tour
+                // of length zero that is somehow running: an overlay believing IsActive here would
+                // draw a card over nothing, and a feature popup gated on it would never open again.
+                Check("CoreTutorial.IsActive is false with no tutorial service", !CoreTutorial.IsActive);
+                Check("CoreTutorial.CurrentStep is null with no tutorial service", CoreTutorial.CurrentStep == null);
+                Check("CoreTutorial counts 0 of 0 with no tutorial service", CoreTutorial.CurrentStepIndex == 0 && CoreTutorial.TotalSteps == 0);
+                // IsLastStep false with no tour is the point: "Finish" over nothing is the lie.
+                Check("CoreTutorial is on the first step and not the last with no tour", CoreTutorial.IsFirstStep && !CoreTutorial.IsLastStep);
+                CoreTutorial.Next(); CoreTutorial.Previous(); CoreTutorial.Skip(); CoreTutorial.Start("FullTour");
+                Check("CoreTutorial verbs are silent no-ops with no tutorial service", true);
+                var tutorialSteps = new[] { new CoreTutorial.Step { Id = "a" }, new CoreTutorial.Step { Id = "b" } };
+                int tutorialCursor = 1;
+                CoreTutorial.CurrentStepProvider = () => tutorialSteps[tutorialCursor];
+                CoreTutorial.CurrentStepIndexProvider = () => tutorialCursor;
+                CoreTutorial.TotalStepsProvider = () => tutorialSteps.Length;
+                CoreTutorial.PreviousAction = () => tutorialCursor--;
+                Check("CoreTutorial reports the seeded cursor", CoreTutorial.CurrentStep?.Id == "b" && CoreTutorial.IsLastStep && !CoreTutorial.IsFirstStep);
+                CoreTutorial.Previous();
+                Check("CoreTutorial.Previous reaches the seeded head", CoreTutorial.CurrentStep?.Id == "a" && CoreTutorial.IsFirstStep);
+                CoreTutorial.CurrentStepIndexProvider = () => throw new InvalidOperationException("boom");
+                Check("CoreTutorial swallows a throwing provider", CoreTutorial.CurrentStepIndex == 0);
+                CoreTutorial.StepChanged += (_, _) => throw new InvalidOperationException("boom");
+                CoreTutorial.RaiseStepChanged(null, tutorialSteps[0]);
+                CoreTutorial.RaiseFinished(null, true);
+                Check("CoreTutorial swallows a throwing subscriber", true);
+                CoreTutorial.CurrentStepProvider = null; CoreTutorial.CurrentStepIndexProvider = null;
+                CoreTutorial.TotalStepsProvider = null; CoreTutorial.PreviousAction = null;
                 // The mod-art seam (wire/37). Unseeded means "no mod overrides anything", which is
                 // what makes a head with no mod service draw its own shipped art rather than blank.
                 Check("CoreModArt.HasOverride is false with no mod layer", !CoreModArt.HasOverride("tube.png"));

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -368,6 +368,87 @@ namespace ConditioningControlPanel
                     case CoreSecrets.AuthToken: Services.SecureAuthTokenStore.Store(value); break;
                 }
             };
+            SeedTutorialSeam();
+        }
+
+        /// <summary>
+        /// The tutorial seam (CCP.Core/CoreTutorial.cs). <see cref="Tutorial"/> is built far later,
+        /// in OnStartup, so every provider reads it lazily - unseeded and pre-startup both answer
+        /// "no tour", which is the truth.
+        ///
+        /// <para><b>Start goes through MainWindow, not through the service.</b>
+        /// <c>Tutorial.Start(type)</c> alone would set IsActive, fire TutorialStarted and advance a
+        /// step list with NO overlay on screen, no tab callbacks configured and no narrator
+        /// attached - a tour that is running and invisible. <c>MainWindow.StartTutorial</c> is the
+        /// entry point that does all four (Settings.cs:538), and it is also idempotent: a second
+        /// call while an overlay is up returns without touching the service.</para>
+        ///
+        /// <para>The step projection is a fresh snapshot per read by design - see
+        /// <c>CoreTutorial.Step</c>. The follow-up actions are pre-bound to their own step, so a
+        /// Core-side card can invoke them without ever naming <c>TutorialStep</c>.</para>
+        /// </summary>
+        private static void SeedTutorialSeam()
+        {
+            CoreTutorial.IsActiveProvider = () => Tutorial?.IsActive == true;
+            CoreTutorial.CurrentStepProvider = () => ProjectTutorialStep(Tutorial?.CurrentStep);
+            CoreTutorial.CurrentStepIndexProvider = () => Tutorial?.CurrentStepIndex ?? 0;
+            CoreTutorial.TotalStepsProvider = () => Tutorial?.TotalSteps ?? 0;
+            CoreTutorial.NextAction = () => Tutorial?.Next();
+            CoreTutorial.PreviousAction = () => Tutorial?.Previous();
+            CoreTutorial.SkipAction = () => Tutorial?.Skip();
+            CoreTutorial.StartAction = name =>
+            {
+                if (!Enum.TryParse<TutorialType>(name, ignoreCase: true, out var type))
+                {
+                    Logger?.Warning("CoreTutorial.Start: no tour named {Tour}", name);
+                    return;
+                }
+                (Current?.MainWindow as MainWindow)?.StartTutorial(type);
+            };
+        }
+
+        /// <summary>The head's step -> the seam's snapshot. Null in, null out.</summary>
+        private static CoreTutorial.Step? ProjectTutorialStep(Models.TutorialStep? s)
+        {
+            if (s == null) return null;
+            return new CoreTutorial.Step
+            {
+                Id = s.Id,
+                Title = s.Title,
+                Description = s.Description,
+                Icon = s.Icon,
+                TargetElementName = s.TargetElementName,
+                TargetWindowTypeName = s.TargetWindowTypeName,
+                // Named, not cast: the two enums happen to agree ordinal for ordinal today, and a
+                // cast would keep compiling - and start placing cards on the wrong side - the day
+                // one of them gains a value in the middle.
+                TextPosition = s.TextPosition switch
+                {
+                    Models.TutorialStepPosition.Top    => CoreTutorial.StepPosition.Top,
+                    Models.TutorialStepPosition.Left   => CoreTutorial.StepPosition.Left,
+                    Models.TutorialStepPosition.Right  => CoreTutorial.StepPosition.Right,
+                    Models.TutorialStepPosition.Center => CoreTutorial.StepPosition.Center,
+                    _ => CoreTutorial.StepPosition.Bottom,
+                },
+                Advance = s.AdvanceTrigger switch
+                {
+                    Models.TutorialAdvanceTrigger.OnButtonClick     => CoreTutorial.AdvanceTrigger.OnButtonClick,
+                    Models.TutorialAdvanceTrigger.OnTextEquals      => CoreTutorial.AdvanceTrigger.OnTextEquals,
+                    Models.TutorialAdvanceTrigger.OnSelectionEquals => CoreTutorial.AdvanceTrigger.OnSelectionEquals,
+                    Models.TutorialAdvanceTrigger.OnSliderAtLeast   => CoreTutorial.AdvanceTrigger.OnSliderAtLeast,
+                    Models.TutorialAdvanceTrigger.OnEvent           => CoreTutorial.AdvanceTrigger.OnEvent,
+                    _ => CoreTutorial.AdvanceTrigger.Manual,
+                },
+                AllowManualSkip = s.AllowManualSkip,
+                IsFollowUpCard = s.IsFollowUpCard,
+                BlockBackgroundClicks = s.BlockBackgroundClicks,
+                FollowUp1Text = s.FollowUpButton1Text,
+                FollowUp2Text = s.FollowUpButton2Text,
+                FollowUp3Text = s.FollowUpButton3Text,
+                FollowUp1 = s.FollowUpAction1 == null ? null : () => s.FollowUpAction1(s),
+                FollowUp2 = s.FollowUpAction2 == null ? null : () => s.FollowUpAction2(s),
+                FollowUp3 = s.FollowUpAction3 == null ? null : () => s.FollowUpAction3(s),
+            };
         }
 
         #region Remote media handoff (Phase 1.5)
@@ -2114,6 +2195,23 @@ namespace ConditioningControlPanel
             ProgramRewards = new Services.Program.ProgramRewardService();
             SkillTree = new SkillTreeService();
             Tutorial = new TutorialService();
+            // Forward the tour's two outward events onto the seam so a Core-side overlay subscribes
+            // once, to Core, on every head. Synchronously and on the same thread the service raised
+            // on: the overlay must have the new spotlight in place before the user's next click.
+            // Both lambdas swallow - TutorialService invokes StepChanged unguarded, so a throwing
+            // Core subscriber would otherwise take a WPF tour down mid-step.
+            Tutorial.StepChanged += (s, step) =>
+            {
+                try { CoreTutorial.RaiseStepChanged(s, ProjectTutorialStep(step)!); }
+                catch { /* a tour never blocks on UI quirks */ }
+            };
+            // TutorialFinished, not TutorialCompleted: the pair fire together, and only this one
+            // carries whether the tour was walked to the end or abandoned.
+            Tutorial.TutorialFinished += (s, e) =>
+            {
+                try { CoreTutorial.RaiseFinished(s, e.Completed); }
+                catch { /* see above */ }
+            };
 
             // Award daily streak bonus now that SkillTree is available
             // (AchievementService runs UpdateDailyStreak in its constructor before SkillTree exists)


### PR DESCRIPTION
CoreTutorial carries the portable half of a guided tour: a per-step snapshot
(id, icon, title, description, target element name, card position, advance
trigger, the follow-up buttons and their pre-bound actions), the cursor over the
list (CurrentStepIndex, TotalSteps, IsFirstStep, IsLastStep), the three verbs
that move it (Next, Previous, Skip), Start by tour name, and the two events a
head forwards (StepChanged, Finished-with-completed). TutorialService itself did
NOT move and was never going to: twenty-two step lists, each a sentence about one
head's controls, with half of them invoking that head's navigation on activation.
Unseeded the seam answers "no tour" - not active, no step, 0 of 0, first and not
last, every verb a silent no-op - which is the truth on a head with no tutorial
service rather than a placebo, and nothing on any path throws.

Step, StepPosition and AdvanceTrigger are NESTED inside CoreTutorial on purpose.
The WPF head's own TutorialStep / TutorialStepPosition / TutorialAdvanceTrigger
live in ConditioningControlPanel.Models and are named unqualified from inside
namespace ConditioningControlPanel.Services; C# searches enclosing namespaces
before using-directives, so a top-level ConditioningControlPanel.TutorialStep
would have silently rebound every bare mention of it in that 3,196-line file.

The Windows head seeds it from App's static ctor (lazily - Tutorial is built much
later in OnStartup) and bridges StepChanged / TutorialFinished onto the seam right
where the service is constructed. Start goes through MainWindow.StartTutorial, not
through TutorialService.Start: the service call alone would set IsActive and walk a
step list with no overlay on screen, no tab callbacks configured and no narrator
attached - a tour that is running and invisible. The enum projections are written
as named switches rather than casts, so a value inserted into the middle of either
enum breaks the build instead of quietly moving cards to the wrong side of their
target. Both bridge lambdas swallow, because TutorialService invokes its own
StepChanged unguarded and a throwing Core subscriber must not be able to break a
WPF tour. The Avalonia head leaves the seam unseeded and says why.

Which half of TutorialOverlay is live: the CARD is, the RAILS are not. The step
text, icon, the real "Step n of m" counter, Next-vs-Finish, Previous hidden on the
first card, Skip, Escape, the follow-up buttons (read off the LIVE step, not the
drawn one) and the once-per-step Skip-step latch all work against the seam, and a
new TutorialOverlay(Window) constructor subscribes to StepChanged so the card
follows the tour. The overlay now also Skips a still-active tour when it is closed,
which is what WPF's app-exit handlers do and what keeps IsActive from sticking true
and shutting every "not while a tutorial is up" gate for the rest of the session.
The SPOTLIGHT is still visual only: no input region, so a click inside the lit hole
does not reach the control under it. Combined with the auto-advance subscriptions
still being absent, a step that waits for the user to click its target now stops
the tour instead of advancing - it is honest about waiting, and AllowManualSkip
steps keep their working "Skip step" button, but nothing on this head starts a tour
yet so no user meets that today. Nothing calls the live constructor: starting a tour
is MainShellWindow.StartTutorial, another layer's file.

Two things the brief proposed were checked against the WPF original and not done.
The once-per-step advance latch is overlay-instance state there
(_advanceFiredThisStep, reset per step), not service state, so it stayed in the
view. And no DoorTabKey was put on the snapshot: TutorialService.DoorTabKeyFor is
pure and would have crossed fine, but this head has no ExpandDoorForTab to act on
the answer, and ShowTab is not a substitute - it navigates, and a step can
spotlight a nav entry filed under a door other than the tab it requires, so using
it would jump the user off the page the card is talking about.

Still blocked:
  - CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs ApplyWindowSpotlightRegion -
    needs a rect input region on CCP.Avalonia/Platform/X11Overlay (XFixes can express
    it; SetClickThrough is whole-window only). Until then the hole is visual only.
  - CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs SubscribeAdvanceTrigger
    (OnButtonClick / OnTextEquals / OnSelectionEquals / OnSliderAtLeast) and the
    OnEvent bus - head work per control, plus TutorialEventBus, still at
    ConditioningControlPanel/Services/TutorialEventBus.cs.
  - CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs PrepareDoorForStep - needs
    MainShellWindow.ExpandDoorForTab, which does not exist on this head.
  - TutorialStep.PrepareTargetWindowAction - an Action<System.Windows.Window> in
    ConditioningControlPanel/Services/TutorialService.cs (DeeperTutorialPrep,
    CompanionTutorialPrep, AppSettingsTutorialPrep); cannot be seam data, so a step
    targeting a collapsed drawer degrades to the plain dim.
  - The WindowLoaded:* retarget in UpdateStep - needs the bus event and CurrentSteps.
  - CCP.Avalonia/Views/Windows/MainShellWindow.Settings.cs BtnTutorial*_Click and the
    eleven other CoreTutorial.Start("<TutorialType name>") call sites
    (UpdatesSettingsSection, NewEnhancementDialog, DeeperEditorWindow,
    AwarenessTabView, DeeperTabView, ModCreatorWindow, FirstRunWizard, EmiBookWindow)
    - files this layer does not own.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU