### PR TITLE
fix(avalonia): Emi parks bottom-right of the monitor the APP is on, not the primary

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
@@ -589,10 +589,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
 
         /// <summary>
         /// ponytail: needs EmiBookDemos / EmiDemoPainter / EmiPixelCanvas (WPF head,
-        /// Services/EmiDesk/), wired when they move to Core. The original owns ONE 30 fps
-        /// DispatcherTimer driving whichever painter the current card holds; with no painter on
-        /// this head there is nothing for a clock to drive, so the stage gets the one placeholder
-        /// still frame <see cref="PaintStill"/> draws and no timer is created at all.
+        /// Services/EmiDesk/), wired when they move to Core.
+        ///
+        /// <para>AUDITED 2026-09-04, and the blocker is THREE MEMBERS, not seven files.
+        /// EmiBookDemos.cs and its six partials (1,879 lines) name no head type at all, and
+        /// EmiPixelCanvas is a <c>uint[]</c> buffer with Clear / Px / Rect / RectA / Line and the
+        /// 200-line EmiPix helper on top of it - all pure. Its whole head coupling is the
+        /// <c>WriteableBitmap</c> field, the <c>Source</c> property and <c>Commit()</c>'s
+        /// <c>WritePixels(Int32Rect ...)</c>. Leave the buffer in Core and let each head wrap it in
+        /// its own bitmap - this window already builds an Avalonia WriteableBitmap and blows it up
+        /// in <see cref="PaintStill"/>, so the wrapper is written.</para>
+        ///
+        /// <para>The original owns ONE 30 fps DispatcherTimer driving whichever painter the current
+        /// card holds; with no painter on this head there is nothing for a clock to drive, so the
+        /// stage gets the one placeholder still frame <see cref="PaintStill"/> draws and no timer
+        /// is created at all.</para>
         /// </summary>
         private void StartClock()
         {
@@ -929,7 +940,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                     ToolTip.SetTip(chip, card.Title);
 
                     // ponytail: needs EmiBookGlyphs.For (WPF head; 16-cell glyphs blown up 2x with
-                    // nearest neighbour), wired when it moves to Core. With no glyph the original's
+                    // nearest neighbour). AUDITED 2026-09-04: that file does NOT move whole and
+                    // should not be asked to. Its 26 painters and the Disc / PlayHead / DownHead
+                    // primitives are pure and belong in Core beside the deck; For() and Build()
+                    // return System.Windows.Media.ImageSource and are the head's half by nature -
+                    // so this splits the same way EmiPixelCanvas does (see StartClock above), and
+                    // the two are one job. With no glyph the original's
                     // OWN fallback runs - a card with no glyph still gets a chip, because skipping
                     // it would silently drop a page out of the only navigation that names its
                     // destinations.
@@ -993,7 +1009,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <para>ponytail: the OWNER is here now, so this is one member away. What is missing is
         /// <c>EmiDeskWindow.SpeakLine</c> and the <c>LineDraw</c> record, and those are blocked on
         /// <c>EmiLineEngine</c> + <c>EmiChains.Player</c>
-        /// (ConditioningControlPanel/Services/EmiDesk/): the widget's <c>Say</c> and
+        /// (ConditioningControlPanel/Services/EmiDesk/). Of those two, AUDITED 2026-09-04, only
+        /// EmiChains is close: its whole head coupling is Player's DispatcherTimer, one seam swap.
+        /// EmiLineEngine reads App.Settings and calls App.EmiDesk.AskSituationOk(), which its own
+        /// header says do not exist without the shell - so the margin line is behind the shell, not
+        /// behind a move. Meanwhile the widget's <c>Say</c> and
         /// <c>PlayChain</c> are still no-ops on this head, so a line handed over would be swallowed
         /// rather than spoken. Priority 2, keyed "book.margin.&lt;id&gt;", face from the card - all
         /// of that is data this stub already carries, so only the delivery is missing.</para>
@@ -1208,6 +1228,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// ponytail: needs EmiBookCards and the six EmiBookDeck.* partials (WPF head,
         /// Services/EmiDesk/), wired when they move to Core - they are pure data and pure
         /// localization, so nothing but the move is in the way.
+        ///
+        /// <para>RE-AUDITED 2026-09-04 with the comments stripped, because a name-scan of those
+        /// seven files hits App.GetAllScreensCached, MainWindow.Lab.cs and LockdownService: every
+        /// one of those is PROSE inside the card copy's own citations. Strip <c>//</c> and
+        /// <c>///</c> lines and the head-name count over all 1,165 lines is ZERO; the only call
+        /// they make is Localization.Loc.Get, which is already in Core. Confirmed PURE - a git mv,
+        /// and still the largest single win left in the book.</para>
         ///
         /// <para>Six of the shipped cards, copied verbatim including their real key stems, so every
         /// string on screen is the shipped English or the reader's own language rather than a

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -642,7 +643,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// bottom right on the main window's monitor.
         /// </summary>
         // ponytail: needs EmiState (Services/EmiDesk/EmiState.cs) for the saved rect and the
-        // monitor name, which is not in Core. Until it is she is parked by default on every summon,
+        // monitor name. It is NOT in Core and it is NOT pure, but it is two seam swaps away and
+        // nothing else: App.UserDataPath -> CorePaths on line 231, and the 500 ms debounce's
+        // Application.Current.Dispatcher / DispatcherTimer -> CoreDispatch. Every other line of its
+        // 680 is Newtonsoft on a POCO. Until that lands she is parked by default on every summon,
         // which is what a first run does anyway. The WIDTH half of the WPF body is ported: it lives
         // in the setting, not in EmiState, and re-reading it here is what puts a change made while
         // she was away - the shrink offer, the settings slider - on her the next time she comes out.
@@ -670,16 +674,55 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
                                       (int)Math.Round(bodyTopPx - OverlayPad * s));
         }
 
-        /// <summary>Bottom right of the monitor she is on, with a comfortable margin.</summary>
-        // ponytail: WPF picked the monitor from App.MainWindowRef's HWND. No App shell on this head
-        // yet, so it is her own screen, then the primary.
+        /// <summary>
+        /// The window the app is showing right now, or null. WPF read the monitor off
+        /// <c>App.MainWindowRef</c>'s HWND; the desktop lifetime's <see cref="Window"/> is the same
+        /// thing on this head, and asking the lifetime rather than naming a shell type keeps this
+        /// true whichever window the app has up (the shell, the first-run wizard, none at all).
+        ///
+        /// <para>Null on the headless <c>--render-view</c> path, which has no desktop lifetime -
+        /// that is the branch the render exercises, and it falls through to her own screen.</para>
+        /// </summary>
+        private static Window? AppMainWindow
+        {
+            get
+            {
+                try
+                {
+                    return (Application.Current?.ApplicationLifetime
+                        as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug(ex, "[EmiDesk] main-window lookup failed");
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Bottom right of the monitor THE APP is on, with a comfortable margin - which is what the
+        /// name says and what WPF did. She has no meaningful position of her own on a first summon,
+        /// so parking her on her own screen put her on the primary monitor while the app sat on the
+        /// second one, and the reader had to go find her.
+        /// </summary>
         public void ParkBottomRightOfMain()
         {
             try
             {
                 var screens = Screens;
                 if (screens is null || screens.ScreenCount == 0) return;
-                var work = (screens.ScreenFromWindow(this) ?? screens.Primary)?.WorkingArea;
+                Screen? on = null;
+                var main = AppMainWindow;
+                // Its own try: a window that has not been shown yet has no platform impl to ask,
+                // and "the app has not got a monitor yet" is her own screen's cue, not an error.
+                if (main is not null)
+                {
+                    try { on = screens.ScreenFromWindow(main); }
+                    catch (Exception ex) { Log.Debug(ex, "[EmiDesk] main-window screen probe failed"); }
+                }
+
+                var work = (on ?? screens.ScreenFromWindow(this) ?? screens.Primary)?.WorkingArea;
                 if (work is null) return;
                 var wa = work.Value;
 
@@ -722,8 +765,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         }
 
         /// <summary>Persist where she is and how big, in physical pixels plus the monitor's name.</summary>
-        // ponytail: needs EmiState (Services/EmiDesk/EmiState.cs), which is not in Core. The
-        // geometry it would persist is BodyScreenRect plus Screens.ScreenFromPoint(...).DisplayName.
+        // ponytail: needs EmiState (Services/EmiDesk/EmiState.cs) - see RestorePlacement above for
+        // the exact two seam swaps that move it. The geometry it would persist is BodyScreenRect
+        // plus Screens.ScreenFromPoint(...).DisplayName.
         public void SavePlacement()
         {
         }
@@ -845,7 +889,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>True when something is on screen that an idle beat must not interrupt.</summary>
         private bool Busy()
         {
-            if (_transiting || InputLocked) return true;
+            // ChainLive is the WPF gate's `_player.IsLive` and is constant false on this head. It is
+            // in the expression anyway: this is the one place that decides whether an idle beat may
+            // interrupt her, and a gate that has to be REMEMBERED when the chain player lands is a
+            // gate that will be forgotten.
+            if (_transiting || ChainLive || InputLocked) return true;
             bool glass = false;
             try { OnGlassLiveQuery(ref glass); }
             catch (Exception ex) { Log.Debug(ex, "[EmiDesk] glass-live seam threw"); }
@@ -857,6 +905,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         // SwayCentreMinMs / SwayCentreMaxMs (Services/EmiDesk/), neither in Core. The two timers
         // themselves port straight across once those numbers do - the blink clock re-rolls its
         // jitter every tick so the cadence is 5200 +/- 600 ms and never a metronome.
+        //
+        // AUDITED 2026-09-04 rather than repeated, because "neither in Core" said nothing about how
+        // far away either one is, and they are close. EmiAlive.cs is 428 lines whose ONLY using is
+        // System, and its whole head coupling is two signatures - GazeTarget and WithinApproach
+        // take System.Windows.Point / Rect - so it is one Core geometry type away, the same single
+        // blocker EmiRingLayout has. EmiChains.cs is 654 lines whose only head type is the
+        // DispatcherTimer inside Player (its file probing is AppContext.BaseDirectory, which Core
+        // already uses in EmiProps), so it is ONE seam swap: a System.Threading.Timer ticking
+        // through CoreDispatch.Post. Neither is a re-derivation candidate - inlining these numbers
+        // here would be a second copy of a table EmiAlive's own header forbids retuning outside the
+        // plan, and it would still drive a PlayChain that no-ops and a SetPose with no art to swap.
         public void RestartIdleBeats()
         {
         }
@@ -2489,7 +2548,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// <summary>ponytail: needs EmiSfx (Services/EmiDesk/EmiSfx.cs) - the pat sound.</summary>
         private void PlayPatSfx() { }
 
-        /// <summary>ponytail: needs App.EmiDesk.Dismiss() - the hover x sends her away.</summary>
+        /// <summary>
+        /// ponytail: needs App.EmiDesk.Dismiss() - the hover x sends her away.
+        ///
+        /// <para>REFUSED as a view-local port, and the reason is written here so the next pass does
+        /// not re-open it. <c>RunDismiss</c> IS on this head (the FX region above), so the outro
+        /// itself could run from here - but that is the SMALLEST half of what the x does.
+        /// <c>EmiDeskService.Dismiss</c> also bumps <c>_summonGen</c> so a summon parked in a
+        /// nested pump cannot put her straight back, reconciles <c>IsOut</c> and raises
+        /// <c>OutChanged</c>, cancels the summon moment and the empty-library beat, stops the
+        /// nudges, and fires <c>dismissed</c> with the minutes she was out. A view-local dismissal
+        /// would take her off the screen while every one of those still believed she was on it -
+        /// a second, divergent copy of a service-owned behaviour, and the flag desync that
+        /// service's own code logs a warning about. It lands with EmiDeskService and nowhere
+        /// else.</para>
+        /// </summary>
         private void Dismiss() { }
 
         /// <summary>ponytail: needs App.EmiDesk.ResetOnboarding() - the QA gesture replay.</summary>


### PR DESCRIPTION
ParkBottomRightOfMain did not park her bottom right of main. WPF read the monitor
off App.MainWindowRef's HWND; the note here said "no App shell on this head yet,
so it is her own screen, then the primary" and that has been stale since the
shell landed - the desktop lifetime's MainWindow is exactly what App.MainWindowRef
was. On a first summon she has no meaningful position of her own, so "her own
screen" resolved to the primary and a two-monitor reader with the app on the
second one had her appear on the other side of the desk and had to go find her.
Asked through the lifetime rather than by naming MainShellWindow, so it stays
true whichever window the app has up; the probe has its own catch because a
window that is not shown yet has no platform impl to ask, and the whole chain
falls back to her own screen then the primary. The headless render exercises that
fallback - there is no desktop lifetime under --render-view - which is why the
PNG cannot prove this one.

Busy() gets ChainLive. WPF's gate is `_transiting || _player.IsLive ||
InputLocked` and the middle term was dropped as constant-false. It is the one
place that decides whether an idle beat may interrupt her, and a gate that has to
be REMEMBERED when the chain player lands is a gate that will be forgotten.

Dismiss() stays a stub and the file now says why, so a sixth pass does not
re-open it. RunDismiss IS on this head since wire/61, so the outro could run from
here - but that is the smallest half of what the hover x does. EmiDeskService.
Dismiss also bumps _summonGen so a summon parked in a nested pump cannot put her
straight back, reconciles IsOut and raises OutChanged, cancels the summon moment
and the empty-library beat, stops the nudges and fires `dismissed` with the
minutes she was out. A view-local dismissal would take her off screen while every
one of those still believed she was on it - a second divergent copy of a
service-owned behaviour, and the exact flag desync that service's own code logs a
warning about.

THE AUDIT, which is the rest of this layer. All 40 remaining notes across these
two files are blocked on a Core move, a csproj asset link, one line of Core's
InternalsVisibleTo, or the app shell - none of which this layer owns. So the
useful work was measuring HOW far away each one is, over all 42 files in
ConditioningControlPanel/Services/EmiDesk/, stripping comments first because a
raw name-scan of the book deck hits App.GetAllScreensCached and MainWindow.Lab.cs
and every one of those is prose inside the card copy's own citations:

  PURE - a git mv, nothing else in the way
    EmiBookCards.cs + EmiBookDeck.{Control,Desk,Machines,Overlays,Places,Setup}.cs
      1,165 lines, zero head names outside comments, one call: Loc.Get, in Core.
      Still the largest single win left in the book.
    EmiBookDemos.cs + its six partials   1,879 lines naming no head type at all;
      they are blocked only by their EmiPixelCanvas parameter (below).
    EmiNames.cs                          System / IO / Text / Loc, nothing else.

  ONE SEAM SWAP
    EmiChains.cs      654 lines whose only head type is the DispatcherTimer in
      Player. Its file probing is already AppContext.BaseDirectory, which Core
      uses in EmiProps. A System.Threading.Timer posting through CoreDispatch.Post
      and it moves - which lights up PlayChain, Say, the sway table and the blink.
    EmiState.cs       680 lines of Newtonsoft over a POCO. App.UserDataPath ->
      CorePaths (line 231) and the 500 ms debounce's Application.Current.Dispatcher
      -> CoreDispatch. Behind it: her saved rect, the bookmark, NotePet, the pins.
    EmiSfx.cs         App.Settings -> CoreSettings, App.Audio.PlayOneShot ->
      CoreAudio.PlayOneShot, signature already matching (wire/46's finding, held).

  ONE CORE GEOMETRY TYPE
    EmiAlive.cs       428 lines whose ONLY using is System. Its whole head
      coupling is two signatures - GazeTarget and WithinApproach take
      System.Windows.Point / Rect. Same single blocker as EmiRingLayout.cs, so one
      Core point/rect struct retires both.

  SPLITS, and both halves of the same job
    EmiPixel.cs       EmiPixelCanvas is a uint[] buffer (Clear/Px/Rect/RectA/Line)
      with the 200-line EmiPix helper on top, all pure. Head coupling: the
      WriteableBitmap field, Source, and Commit()'s WritePixels(Int32Rect). Leave
      the buffer in Core, let each head wrap it - THIS window already builds an
      Avalonia WriteableBitmap and blows it up, so the wrapper is written.
    EmiBookGlyphs.cs  26 painters plus Disc/PlayHead/DownHead are pure and belong
      beside the deck; For() and Build() return ImageSource and are the head's.

  HEAD, WITH ITS OWN BLOCKER FIRST
    EmiSuggester.cs   Compose() is pure in itself, but it calls EmiTargets.Find /
      All / OrderOf and EmiTargets is deeply head-bound - so the two move as one
      piece or the split comes first. Unchanged from wire/61's finding.

  HEAD, and not close
    EmiDeskService (77 hits), EmiOffers (38), EmiCodex, EmiChannels.* (51 across
    six files), EmiFace (pack:// FontFamily), EmiTargets, EmiLineEngine (reads
    App.Settings and calls App.EmiDesk.AskSituationOk, which its own header says
    do not exist without the shell), EmiKnock, EmiVox, EmiTourNarrator,
    EmiBarkBridge, EmiNudges, EmiGifRain, EmiBook.

Seven notes are rewritten with those measurements in place of "not in Core":
RestartIdleBeats, RestorePlacement, SavePlacement, the book's StartClock, its rail
glyphs, its deck and SpeakMargin - plus the Dismiss refusal above. The only other
change in either file is one using (Avalonia.Controls.ApplicationLifetimes).

The bare-type trap was run over every file bucketed PURE or one-swap, because a
plain API scan misses it: `Point` / `Rect` / `Color` / `Size` / `Thickness` /
`Brush` / `Vector` compile in the head through `global using System.Windows` and
fail in Core. Sixty-odd hits, every one of them EmiPixelCanvas's own `p.Rect(...)`
against uint colours. The buckets above hold.

Still blocked, named symbols and head paths:

  EmiDeskWindow.RestartIdleBeats / StopIdleBeats   EmiAlive + EmiChains, above.
      Not re-derivable here: inlining the numbers is a second copy of a table
      EmiAlive's own header forbids retuning outside the plan, and it would drive
      a PlayChain that no-ops and a SetPose with no art to swap.
  EmiDeskWindow.SavePlacement / RestorePlacement's rect   EmiState, above.
  EmiDeskWindow.PlayChain / Say / RunBodyMove / ChainLive  EmiChains.Player.
  EmiDeskWindow.DrawFace / SetPose / PaintOutfitOver
      EmiFace.PixelFont is head-side by nature; the pose art additionally needs an
      Assets/web/ AvaloniaResource link that CCP.Avalonia.csproj does not carry.
  EmiDeskWindow.LayoutProp / HideProp / StartAlive / StopAlive / CloseRing /
  TearDownVox / PetFromClick / CountPat / PlayPatSfx / Dismiss / ResetOnboarding /
  FireDeskEvent                                    the csproj art link, the four
      unported partials, and App.EmiDesk.
  EmiBookWindow.Book / StartClock / PaintStill / ShootFrame / RenderRail glyphs
      the deck, EmiPixel and EmiBookGlyphs moves above.
  EmiBookWindow.Place            CCP.Core's EmiBookLayout is `internal` and
      CCP.Avalonia is not in Core/Properties/AssemblyInfo.cs's InternalsVisibleTo.
      One line in Core. Do NOT re-derive it.
  EmiBookWindow.Go / TourReady / SpeakMargin / the bookmark / NoteSideChanged
      EmiTargets, EmiLineEngine, EmiState, EmiDeskWindow.Bubble.cs.
  ApplyFonts                     Assets/emi/fonts/ as AvaloniaResource.

Handover, in the order it should be taken:

  1. git mv EmiBookCards.cs + the six EmiBookDeck.*.cs to Core. Measured pure
     twice now. Deletes EmiBookWindow.Book and needs no other view edit.
  2. One line in CCP.Core/Properties/AssemblyInfo.cs adding CCP.Avalonia, then
     EmiBookLayout.Place replaces the Place() stand-in. Two-line layer, and it is
     the narrow book on a small laptop.
  3. EmiChains.cs to Core behind CoreDispatch. The biggest unlock in the set:
     PlayChain, Say, the sway cycle and the blink all hang off it, and four view
     stubs stop being stubs at once.
  4. A Core point/rect struct, then EmiAlive.cs and EmiRingLayout.cs both move.
  5. Split EmiPixel.cs and EmiBookGlyphs.cs in one layer; the demos follow free.
  6. Link Assets/emi/fonts/ and Assets/web/arcademy/art/emi/ in CCP.Avalonia.csproj
     - one layer lights the book, the ring, the desk and the props beat.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU