### PR TITLE
feat(avalonia): the companion bust, the season plate and the AI-permission grid read real state

### DIFF
--- a/CCP.Avalonia/Views/Controls/AdornedAvatar.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AdornedAvatar.axaml.cs
@@ -23,9 +23,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
     /// </summary>
     public partial class AdornedAvatar : UserControl
     {
-        // ponytail: WardrobeCatalog stays in the WPF head (pack:// art). Ratio copied; GetImage
-        // returns null until the catalogue moves to Core, so the plain avatar draws - the same
-        // quiet failure the WPF control documents for a missing PNG.
+        // ponytail: blocked on ConditioningControlPanel/Services/Profile/WardrobeCatalog.cs,
+        // which has not moved to Core. NOT on pack:// art, which the old note claimed: its
+        // ResolveArtPath reads plain files under <BaseDirectory>/Resources/cosmetics, so the
+        // loader half is portable and the DecoLayer Image below is already here to receive it.
+        // What is missing is the registry that maps a decoration id to a file. Until the
+        // catalogue crosses, GetImage returns null and the plain avatar draws - the same quiet
+        // failure the WPF control documents for a missing PNG.
         private const double AvatarCircleRatio = 0.70;
         private static IImage? GetImage(string? decorationId) => null;
 

--- a/CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml.cs
@@ -19,13 +19,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         public AudioSettingsSection()
         {
             AvaloniaXamlLoader.Load(this);
-            // ponytail: placeholder so the combo is not an empty pill; real list comes from the audio device service
+            // ponytail: placeholder so the combo is not an empty pill. CCP.Core/CoreAudio.cs is
+            // PLAYBACK only (PlayOneShot / Duck / Unduck / DuckGeneration) - it has no device
+            // enumeration seam at all, so there is nothing in Core to ask for the real list yet.
             var cmb = this.FindControl<ComboBox>("CmbAudioOutputDevice")!;
             cmb.ItemsSource = new[] { "Default" };
             cmb.SelectedIndex = 0;
         }
 
-        // ponytail: needs MainWindow's audio handlers (AudioService, NAudio devices), wired when they move to Core
+        // ponytail: needs a device seam on CCP.Core/CoreAudio.cs (it carries playback only) plus
+        // a Linux backend for it - NAudio is Windows-only, so this is a per-head implementation
+        // behind a Core interface, not a move.
         private void SliderMaster_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
         private void SliderVideoVolume_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }
         private void SliderDuck_Changed(object? sender, RangeBaseValueChangedEventArgs e) { }

--- a/CCP.Avalonia/Views/Controls/AppSettings/UpdatesSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/UpdatesSettingsSection.axaml.cs
@@ -39,19 +39,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
 
         /// <summary>
         /// Same dialog the post-update "What's New" popup uses, so the notes are never formatted
-        /// two different ways. No tour action yet: the upgrade tour is a MainWindow tutorial
-        /// partial on WPF and is not on this head.
+        /// two different ways - and, for the same reason, the same upgrade-tour offer, now routed
+        /// through <see cref="CoreTutorial"/>.
         /// </summary>
         private async void BtnViewPatchNotes_Click(object? sender, RoutedEventArgs e)
         {
             try
             {
                 if (TopLevel.GetTopLevel(this) is not Window owner) return;
+                // The upgrade-tour offer is the WPF original's, restored: CoreTutorial.Start
+                // takes the head's tutorial-type NAME, and an unseeded head simply does nothing -
+                // which is why offering it here is safe rather than a button that lies. Reading
+                // the notes late is exactly when someone wants the tour, and the startup showing
+                // is one-shot per version.
                 var dialog = new Dialogs.WhatsNewDialog(
                     Loc.GetF("set2_whats_new_title_0", CoreReleaseContent.AppVersion),
-                    CoreReleaseContent.PatchNotes);
-                // ponytail: WPF also offers the upgrade tour here (MainWindow.StartTutorial
-                // (TutorialType.UpgradeTour)); wired when the tutorial seam exists
+                    CoreReleaseContent.PatchNotes,
+                    tourAction: () => CoreTutorial.Start("UpgradeTour"),
+                    tourButtonText: "Show me around (60s)");
                 await dialog.ShowDialog(owner);
             }
             catch (Exception ex)

--- a/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
 using Serilog;
 
@@ -12,10 +13,22 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     ///
     /// <para>On WPF every control here is a one-line shim to the identically named
     /// <c>MainWindow.Patreon.cs</c> handler, which reads and writes
-    /// <c>App.Settings.Current.CompanionPrompt</c>. That host does not exist in this head, so each
-    /// handler keeps only the half that touches the view (showing the permissions panel, writing
-    /// the slider's percentage) and stubs the persistence. <see cref="ApplyTierGate"/> fails
-    /// closed, exactly as <c>TierGate.RequiresLab</c> does with no Patreon service alive.</para>
+    /// <c>App.Settings.Current.CompanionPrompt</c>. <c>CompanionPromptSettings</c> is in Core now
+    /// (CCP.Core/Models/CompanionPromptSettings.cs), so the effect permissions, the master switch
+    /// and the haptic cap are restored against <see cref="CoreSettings"/>: seeded under
+    /// <c>_isLoading</c> (WPF's <c>SyncLabEffectPermsUI</c>) and compared before writing, because
+    /// Avalonia raises <c>IsCheckedChanged</c> on a programmatic set too.</para>
+    ///
+    /// <para><b>Two writes are deliberately NOT restored.</b> Chat memory is refused - see
+    /// <see cref="ChkChatMemoryEnabled_Changed"/>. And WPF's <c>UpdateUnlockablesVisibility</c>
+    /// force-clear (which unticks <c>ChkCapEffects</c> once an account has lapsed) is not ported:
+    /// it is a WRITE decided by an entitlement this head cannot see, so here it would silently
+    /// destroy a paid-up user's setting on every launch. Seeding shows the stored truth; only a
+    /// head that can read Patreon may repair it.</para>
+    ///
+    /// <para><see cref="ApplyTierGate"/> still fails closed, exactly as <c>TierGate.RequiresLab</c>
+    /// does with no Patreon service alive, so the effect half stays disabled on this head and the
+    /// restored writes below are reachable only once an entitlement is seeded.</para>
     ///
     /// <para>Motion budget: zero.</para>
     /// </summary>
@@ -24,10 +37,72 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         /// <summary>Opacity of the effects half while it is behind the lockband.</summary>
         private const double LockedOpacity = 0.32;
 
+        /// <summary>Raised while the seed writes the controls, so an echo is not a user edit.</summary>
+        private bool _isLoading = true;
+
         public AiPermissionsGrid()
         {
             InitializeComponent();
+            SyncFromSettings();
             Loaded += (_, _) => ApplyTierGate();
+        }
+
+        protected override void OnAttachedToVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            SyncFromSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        // A cloud restore or a factory reset swaps the instance; repaint from it, on the UI thread.
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(SyncFromSettings);
+
+        /// <summary>
+        /// WPF's <c>MainWindow.SyncLabEffectPermsUI</c>: paint every control from the stored
+        /// permissions. Without this the grid showed its markup defaults, which is a control
+        /// lying about what the companion is actually allowed to do.
+        /// </summary>
+        internal void SyncFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                var p = CoreSettings.Current.CompanionPrompt;
+                if (p == null) return;
+
+                ChkCapEffects.IsChecked = p.AllowAiToControlEffects;
+                EffectPermsPanel.IsVisible = p.AllowAiToControlEffects;
+
+                ChkAllowFlash.IsChecked = p.AllowAiFlash;
+                ChkAllowVideo.IsChecked = p.AllowAiVideo;
+                ChkAllowAudio.IsChecked = p.AllowAiAudio;
+                ChkAllowBubbles.IsChecked = p.AllowAiBubbles;
+                ChkAllowSubliminal.IsChecked = p.AllowAiSubliminal;
+                ChkAllowOverlay.IsChecked = p.AllowAiOverlay;
+                ChkAllowLockCard.IsChecked = p.AllowAiLockCard;
+                ChkAllowBounce.IsChecked = p.AllowAiBounce;
+                ChkAllowHaptic.IsChecked = p.AllowAiHaptic;
+                ChkAllowGetBackToMe.IsChecked = p.AllowAiGetBackToMe;
+
+                SliderMaxHapticIntensity.Value = p.MaxAiHapticIntensity;
+                TxtMaxHapticIntensity.Text = $"{(int)(p.MaxAiHapticIntensity * 100)}%";
+
+                ChkChatMemoryEnabled.IsChecked = p.ChatMemoryEnabled;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("AiPermissionsGrid.SyncFromSettings failed: {E}", ex.Message);
+            }
+            finally
+            {
+                _isLoading = false;
+            }
         }
 
         /// <summary>Whether this account clears the Tier 2 bar.</summary>
@@ -67,7 +142,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 
         private void BtnClearChatMemory_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs CompanionBrain.ForgetConversation + a confirm dialog, wired when it moves to Core
+            // ponytail: needs a forget seam on CoreAi (CCP.Core/CoreAi.cs exposes only
+            // IsAvailable). The confirm half is ready - CCP.Avalonia/Views/Dialogs/MessageDialog -
+            // but the wipe half has nothing to call, so the button must stay inert.
         }
 
         private void BtnLabEffectsSetupLocal_Click(object? sender, RoutedEventArgs e)
@@ -75,33 +152,82 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
             // ponytail: needs the Engine Room deep link + LocalAiSetupWizard, wired when they are ported
         }
 
+        /// <summary>One handler for the ten effect boxes; the Tag names the permission, as on WPF.</summary>
         private void ChkAllowEffect_Changed(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs CompanionPromptSettings.AllowAi<Tag>, wired when settings move to Core
+            if (_isLoading) return;
+            if (sender is not CheckBox cb) return;
+            var p = CoreSettings.Current.CompanionPrompt;
+            if (p == null) return;
+            var on = cb.IsChecked == true;
+            switch (cb.Tag as string)
+            {
+                case "Flash":       if (p.AllowAiFlash == on) return; p.AllowAiFlash = on; break;
+                case "Video":       if (p.AllowAiVideo == on) return; p.AllowAiVideo = on; break;
+                case "Audio":       if (p.AllowAiAudio == on) return; p.AllowAiAudio = on; break;
+                case "Bubbles":     if (p.AllowAiBubbles == on) return; p.AllowAiBubbles = on; break;
+                case "Subliminal":  if (p.AllowAiSubliminal == on) return; p.AllowAiSubliminal = on; break;
+                case "Overlay":     if (p.AllowAiOverlay == on) return; p.AllowAiOverlay = on; break;
+                case "LockCard":    if (p.AllowAiLockCard == on) return; p.AllowAiLockCard = on; break;
+                case "Bounce":      if (p.AllowAiBounce == on) return; p.AllowAiBounce = on; break;
+                case "Haptic":      if (p.AllowAiHaptic == on) return; p.AllowAiHaptic = on; break;
+                case "GetBackToMe": if (p.AllowAiGetBackToMe == on) return; p.AllowAiGetBackToMe = on; break;
+                default: return;
+            }
+            CoreSettings.Save();
         }
 
         private void ChkCapEffects_Changed(object? sender, RoutedEventArgs e)
         {
+            if (_isLoading) return;
             var on = ChkCapEffects.IsChecked == true;
             if (on && !IsLabEntitled)
             {
-                // A refusal must not write: put the switch back and leave the panel closed.
-                ChkCapEffects.IsChecked = false;
+                // A refusal must not write: put the switch back and leave the panel closed. The
+                // guard is raised around the snap-back because Avalonia re-enters this handler on
+                // a programmatic set, and that re-entry would otherwise persist false.
+                _isLoading = true;
+                try { ChkCapEffects.IsChecked = false; }
+                finally { _isLoading = false; }
                 return;
             }
             EffectPermsPanel.IsVisible = on;
-            // ponytail: needs CompanionPromptSettings.AllowAiToControlEffects, wired when settings move to Core
+
+            var p = CoreSettings.Current.CompanionPrompt;
+            if (p == null || p.AllowAiToControlEffects == on) return;
+            p.AllowAiToControlEffects = on;
+            CoreSettings.Save();
         }
 
+        /// <summary>
+        /// REFUSED, not stubbed. The box is SEEDED from settings so it tells the truth, but the
+        /// write is snapped back, because unticking this on WPF is a PROMISE to erase what is
+        /// already on disk (<c>App.Brain.ForgetConversation</c> plus
+        /// <c>AiServiceStrategy.ClearLocalHistory</c> - companion/session.json and the live turn
+        /// log), not merely to stop persisting new turns. <see cref="CoreAi"/> exposes only
+        /// <c>IsAvailable</c>; there is no forget seam, so persisting "memory off" here would
+        /// leave a switch reading "erased" over a transcript that is still there. Restore the
+        /// write the day CoreAi grows a forget action - together with it, never before.
+        /// </summary>
         private void ChkChatMemoryEnabled_Changed(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs CompanionPromptSettings.ChatMemoryEnabled + the brain wipe, wired when they move to Core
+            if (_isLoading) return;
+            var p = CoreSettings.Current.CompanionPrompt;
+            if (p == null) return;
+            if ((ChkChatMemoryEnabled.IsChecked == true) == p.ChatMemoryEnabled) return;
+            _isLoading = true;
+            try { ChkChatMemoryEnabled.IsChecked = p.ChatMemoryEnabled; }
+            finally { _isLoading = false; }
         }
 
         private void SliderMaxHapticIntensity_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
         {
             TxtMaxHapticIntensity.Text = $"{(int)(e.NewValue * 100)}%";
-            // ponytail: needs CompanionPromptSettings.MaxAiHapticIntensity, wired when settings move to Core
+            if (_isLoading) return;
+            var p = CoreSettings.Current.CompanionPrompt;
+            if (p == null || Math.Abs(p.MaxAiHapticIntensity - e.NewValue) < 0.0001) return;
+            p.MaxAiHapticIntensity = e.NewValue;
+            CoreSettings.Save();   // the debounced save: a slider fires per tick
         }
     }
 }

--- a/CCP.Avalonia/Views/Controls/Companion/AwarenessPrivacyView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AwarenessPrivacyView.axaml.cs
@@ -190,7 +190,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// <summary>Mirror of the head's dial enum, <c>CompanionVmPrimitives.cs:AwarenessIntensity</c>.
     /// NOT <c>Services/Awareness/AwarenessIntensity.cs</c>, which is a different enum
     /// (Off/Subtle/Chatty/Unhinged) with the same name.</summary>
-    // ponytail: local twin; delete when CompanionVmPrimitives.cs moves to Core.
+    // ponytail: local twin of the enum in ConditioningControlPanel/Views/Controls/Companion/
+    // CompanionVmPrimitives.cs (the WPF file, not this head's same-named one, which does not carry
+    // it). Delete when that enum reaches Core.
     public enum AwarenessIntensity
     {
         Off,

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml
@@ -391,7 +391,7 @@
                                  the brush's Viewbox at a square centred on the art's own opaque
                                  bounds; on Avalonia that is ImageBrush.SourceRect - see
                                  CompanionHeroCard.axaml.cs · CentrePortrait. -->
-                            <Ellipse Margin="3" IsVisible="{Binding Portrait, Converter={x:Static ObjectConverters.IsNotNull}}">
+                            <Ellipse x:Name="PortraitFill" Margin="3" IsVisible="{Binding Portrait, Converter={x:Static ObjectConverters.IsNotNull}}">
                                 <Ellipse.Fill>
                                     <ImageBrush Source="{Binding Portrait}"
                                                 Stretch="Uniform" AlignmentX="Center" AlignmentY="Center"/>

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml.cs
@@ -1,13 +1,17 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Helpers;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
 using Serilog;
@@ -30,9 +34,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// <para>The mod repaint is wired: <see cref="CoreMods.ModChanged"/> is the authoritative
     /// "the art answers differently now" signal, and the only one this tab gets, so the hook is
     /// taken on Loaded and released on Unloaded exactly as the WPF original does with
-    /// <c>App.Mods.ModChanged</c>. What it can re-read is still thin — see
-    /// <see cref="ApplyAvatarArt"/> — and the portrait's optical centring is stubbed, see
-    /// <see cref="CentrePortrait"/>.</para>
+    /// <c>App.Mods.ModChanged</c>. It re-reads the bust for real now: <see cref="ApplyAvatarArt"/>
+    /// resolves the same <c>avatar[N]_pose1.png</c> the WPF runtime viewmodel does, through
+    /// <see cref="CoreModArt"/> + <see cref="ModArt"/>, and <see cref="CentrePortrait"/> then
+    /// crops it the way WPF's measured Viewbox does. What is still head-only is the rest of
+    /// <c>Sync()</c> — her name, mod chip and flavour — named at <see cref="ApplyAvatarArt"/>.</para>
     /// </summary>
     public partial class CompanionHeroCard : UserControl
     {
@@ -40,6 +46,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 
         /// <summary>Guards the ModChanged hook: Loaded fires again on every re-parent.</summary>
         private bool _modHooked;
+
+        /// <summary>How much of the ring's inner diameter the figure's own INK may occupy.</summary>
+        private const double PortraitInkFill = 0.86;
+
+        /// <summary>Width the opaque-bounds scan runs at; below this the art is scanned as-is.</summary>
+        private const int PortraitProbeWidth = 96;
+
+        /// <summary>Alpha at or below which a pixel counts as transparent padding.</summary>
+        private const byte PortraitAlphaFloor = 8;
 
         public CompanionHeroCard()
         {
@@ -161,11 +176,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 
             try
             {
-                // ponytail: the Sync() half needs ConditioningControlPanel/Views/Controls/Companion/
-                // Runtime/CompanionHeroRuntimeVm.Sync, which reads App.Companion, App.AvatarWindow
-                // and CompanionRuntimeContext.Navigator - head navigation, not a mod lookup, so it
-                // cannot cross to Core as it stands. The hook below it is live, so the moment a
-                // portable hero viewmodel exists this method re-reads on every mod switch.
+                // WPF's CompanionHeroRuntimeVm.LoadPortrait, minus the head types: the pose file
+                // is a plain Resources-relative name, so the mod override is CoreModArt's and the
+                // shipped copy is this head's avares:// one - both inside ModArt.TryLoad.
+                // GetAvatarSetForLevel returns a constant 7 since level gating was removed
+                // (AvatarTubeWindow.Avatar.cs), so the "< 1" branch does not need the player level.
+                var set = CoreSettings.Current.SelectedAvatarSet;
+                if (set < 1) set = 7;
+                var name = set == 1 ? "avatar_pose1.png" : $"avatar{set}_pose1.png";
+
+                if (ViewModel is { } vm) vm.Portrait = ModArt.TryLoad(name);
+
+                // ponytail: the REST of Sync() - her name, mod chip and flavour - needs
+                // ConditioningControlPanel/Views/Controls/Companion/Runtime/CompanionHeroRuntimeVm.cs,
+                // which reads App.Companion, App.AvatarWindow and CompanionRuntimeContext.Navigator:
+                // head navigation, not a mod lookup, so it cannot cross to Core as it stands.
                 CentrePortrait();
             }
             catch (Exception ex)
@@ -175,16 +200,115 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         }
 
         /// <summary>
-        /// Points the portrait brush at a square centred on the art's own opaque bounds.
+        /// Points the portrait brush at a square centred on the art's own opaque bounds - WPF's
+        /// measured <c>Viewbox</c>, which on Avalonia is <c>ImageBrush.SourceRect</c>.
+        ///
+        /// <para>Avalonia refuses an <c>x:Name</c> on a brush (AVLN2000), so the brush is reached
+        /// through the Ellipse that owns it. The Ellipse's name is resolved with
+        /// <c>FindControl</c> because this control loads with <c>AvaloniaXamlLoader.Load</c> and
+        /// the generated name fields are therefore never assigned.</para>
         /// </summary>
         private void CentrePortrait()
         {
-            // ponytail: blocked on CompanionHeroCard.axaml, which this layer does not own. WPF
-            // points a NAMED ImageBrush's Viewbox at the ink; the Avalonia XAML dropped every
-            // x:Name on non-controls (illegal there), so there is no brush to give a SourceRect to
-            // before the pixel probe (OpaqueBounds/InkViewbox, PortraitInkFill=0.86, alpha floor 8,
-            // 96px probe -> Bitmap.CopyPixels) is even relevant. The placeholder viewmodel ships
-            // Portrait=null and the vector disc needs no centring, so nothing is visibly wrong yet.
+            if (!Dispatcher.UIThread.CheckAccess()) { Dispatcher.UIThread.Post(CentrePortrait); return; }
+
+            try
+            {
+                if (this.FindControl<Ellipse>("PortraitFill")?.Fill is not ImageBrush brush) return;
+                brush.SourceRect = InkViewbox(ViewModel?.Portrait as Bitmap);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("Companion hero: portrait centring failed: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// The relative source rect that puts <paramref name="bmp"/>'s opaque bounds dead centre in
+        /// a square viewport, at <see cref="PortraitInkFill"/> of its width. A SQUARE region, not
+        /// the ink rectangle, so <c>Stretch=Uniform</c> into the round hole is exact; it may run
+        /// off the source, which is what lets a tall thin figure sit in a circle un-widened.
+        /// Falls back to the whole image whenever the art cannot be measured.
+        /// </summary>
+        internal static global::Avalonia.RelativeRect InkViewbox(Bitmap? bmp)
+        {
+            var whole = new global::Avalonia.RelativeRect(0, 0, 1, 1, global::Avalonia.RelativeUnit.Relative);
+            if (bmp == null) return whole;
+
+            double w = bmp.PixelSize.Width, h = bmp.PixelSize.Height;
+            if (w <= 0 || h <= 0) return whole;
+
+            if (OpaqueBounds(bmp) is not { } f) return whole;
+
+            // fractions back onto the source's own pixel grid, where "square" means something
+            double side = Math.Max(f.W * w, f.H * h) / PortraitInkFill;
+            if (side <= 0) return whole;
+
+            double cx = (f.X + f.W / 2) * w, cy = (f.Y + f.H / 2) * h;
+            return new global::Avalonia.RelativeRect((cx - side / 2) / w, (cy - side / 2) / h, side / w, side / h,
+                                    global::Avalonia.RelativeUnit.Relative);
+        }
+
+        /// <summary>
+        /// The bounding box of everything that is not transparent padding, as fractions of the
+        /// image. Null when it cannot be read, or when the art is transparent end to end.
+        /// The scan runs on a <see cref="PortraitProbeWidth"/>-wide copy, which is what WPF's
+        /// TransformedBitmap buys there. Avalonia's <c>Bitmap.CopyPixels</c> only fills a raw
+        /// buffer in the bitmap's OWN format (there is no FormatConvertedBitmap equivalent), so a
+        /// source with no alpha channel is answered null - "cannot be measured", i.e. the whole
+        /// image - rather than scanned as if byte 3 meant something.
+        /// </summary>
+        private static (double X, double Y, double W, double H)? OpaqueBounds(Bitmap bmp)
+        {
+            IntPtr buffer = IntPtr.Zero;
+            try
+            {
+                var fmt = bmp.Format;
+                if (fmt != PixelFormat.Bgra8888 && fmt != PixelFormat.Rgba8888) return null;
+
+                int sw = bmp.PixelSize.Width, sh = bmp.PixelSize.Height;
+                int pw = Math.Min(sw, PortraitProbeWidth);
+                int ph = Math.Max(1, (int)Math.Round(sh * (pw / (double)sw)));
+
+                using var probe = pw < sw
+                    ? bmp.CreateScaledBitmap(new global::Avalonia.PixelSize(pw, ph))
+                    : null;
+                var src = (Bitmap?)probe ?? bmp;
+                pw = src.PixelSize.Width;
+                ph = src.PixelSize.Height;
+
+                int stride = pw * 4, size = stride * ph;
+                buffer = Marshal.AllocHGlobal(size);
+                src.CopyPixels(new global::Avalonia.PixelRect(0, 0, pw, ph), buffer, size, stride);
+
+                var row = new byte[stride];
+                int minX = pw, minY = ph, maxX = -1, maxY = -1;
+                for (int y = 0; y < ph; y++)
+                {
+                    Marshal.Copy(buffer + y * stride, row, 0, stride);
+                    for (int x = 0; x < pw; x++)
+                    {
+                        if (row[x * 4 + 3] <= PortraitAlphaFloor) continue;   // alpha is byte 3 in both formats
+                        if (x < minX) minX = x;
+                        if (x > maxX) maxX = x;
+                        if (y < minY) minY = y;
+                        if (y > maxY) maxY = y;
+                    }
+                }
+
+                if (maxX < minX || maxY < minY) return null;   // nothing opaque to centre on
+                return ((double)minX / pw, (double)minY / ph,
+                        (maxX - minX + 1) / (double)pw, (maxY - minY + 1) / (double)ph);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("Companion hero: opaque-bounds probe failed: {E}", ex.Message);
+                return null;
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero) Marshal.FreeHGlobal(buffer);
+            }
         }
     }
 
@@ -220,8 +344,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         public string Name { get; init; } = "Bambi";
         public string ModName { get; init; } = "BAMBI SLEEP";
         public string Flavor { get; init; } = "Gains bonus XP from Pink Filter intensity. Currently plotting something.";
-        /// <summary>Companion bust. Null renders the gradient placeholder disc.</summary>
-        public IImage? Portrait { get; init; }
+        private IImage? _portrait;
+
+        /// <summary>
+        /// Companion bust. Null renders the gradient placeholder disc. Settable and notifying, not
+        /// <c>init</c>: the view re-resolves it from the mod layer on Loaded and on every
+        /// <see cref="CoreMods.ModChanged"/>, and the change is what re-runs the optical centring.
+        /// </summary>
+        public IImage? Portrait
+        {
+            get => _portrait;
+            set => Set(ref _portrait, value);
+        }
 
         // ---- state ----
         public bool IsCompanionEnabled { get; init; } = true;

--- a/CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs
@@ -2,6 +2,8 @@ using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 {
@@ -9,11 +11,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// PHASE 5 (G3): the custom keyword-trigger + Screen OCR editors, rescued from the
     /// permanently-Collapsed <c>PatreonTabView</c> and mounted on the Awareness tab.
     ///
-    /// <para>Ported from the WPF code-behind. The WPF version is pure re-hosting: every handler
-    /// forwards to a <c>MainWindow</c> method that reads <c>App.Settings</c>,
-    /// <c>KeywordTriggerService</c>, <c>App.ScreenOcr</c> and <c>App.KeywordHighlight</c>. None of
-    /// those are in Core, so here the sliders keep their own value labels (the same format strings
-    /// MainWindow uses) and everything else is a stub.</para>
+    /// <para>Ported from the WPF code-behind, where every handler forwards to a
+    /// <c>MainWindow</c> method. Those handlers split cleanly in two, and so does this port.</para>
+    ///
+    /// <para><b>Restored:</b> the four sliders and the two master-driven detail sections. Their
+    /// state is plain <c>AppSettings</c>, which is in Core, so they are seeded from
+    /// <see cref="CoreSettings"/> and write back through it - the same fields and the same clamps
+    /// as <c>MainWindow.KeywordTriggers.cs</c>. The panel used to hardcode both masters ON, which
+    /// showed the detail rows over a source that was switched off.</para>
+    ///
+    /// <para><b>Still stubbed:</b> everything that needs a live service - <c>App.ScreenOcr</c>,
+    /// <c>App.KeywordHighlight</c> and the trigger-row builder. Named at each one below.</para>
     /// </summary>
     public partial class KeywordTriggersPanel : UserControl
     {
@@ -22,6 +30,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         private readonly StackPanel _screenOcrIntervalPanel;
         private readonly TextBlock _txtHighlightOffHint;
         private readonly StackPanel _highlightDurationPanel;
+
+        /// <summary>Raised while the seed writes the sliders, so an echo is not a user edit.</summary>
+        private bool _isLoading = true;
 
         public KeywordTriggersPanel()
         {
@@ -33,24 +44,123 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
             _txtHighlightOffHint = this.FindControl<TextBlock>("TxtHighlightOffHint")!;
             _highlightDurationPanel = this.FindControl<StackPanel>("HighlightDurationPanel")!;
 
-            // Value labels: formats copied from MainWindow.KeywordTriggers.cs, which owns them on WPF.
-            Track("SliderKeywordBufferTimeout", "TxtKeywordBufferTimeout", v => $"{v / 1000.0:F1}s");
-            Track("SliderKeywordSessionMultiplier", "TxtKeywordSessionMultiplier", v => $"{v:F1}x");
-            Track("SliderScreenOcrInterval", "TxtScreenOcrInterval", v => $"{v}s");
-            Track("SliderKeywordHighlightDuration", "TxtKeywordHighlightDuration", v => $"{v:0.0}s");
-
-            // ponytail: needs MainWindow.BtnAddKeywordTrigger_Click / BtnImportFromCustomTriggers_Click
-            // (KeywordTriggerService + the trigger row builder), wired when they move to Core.
+            // ponytail: the PRESET half is in Core already (CCP.Core/Services/
+            // KeywordTriggerPresetService.cs, CCP.Core/Models/KeywordTrigger.cs). What is missing
+            // is MainWindow.KeywordTriggers.cs's row BUILDER - it constructs WPF rows into
+            // TriggerRowsHost and has no Avalonia twin - and the editor dialog those rows open.
             this.FindControl<Button>("BtnAddKeywordTrigger")!.Click += (_, _) => { };
             this.FindControl<Button>("BtnImportFromCustomTriggers")!.Click += (_, _) => { };
-            // ponytail: needs App.ScreenOcr / App.KeywordHighlight for the two ComboBoxes.
+            // ponytail: needs App.ScreenOcr / App.KeywordHighlight. Both are live Win32/OCR
+            // services with no Core seam at all (there is no CoreOcr), so these two combos have
+            // nothing to push a mode to on this head. Deliberately NOT persisted meanwhile: a
+            // combo that stores a mode nothing reads is a control claiming a setting took effect.
             this.FindControl<ComboBox>("CmbOcrConfirmation")!.SelectionChanged += (_, _) => { };
             this.FindControl<ComboBox>("CmbOcrHighlightMode")!.SelectionChanged += (_, _) => { };
 
-            // ponytail: on WPF the SIGNAL SOURCES / SAFETY masters on the Awareness tab drive these
-            // from settings at load. Placeholder: both masters on, so the detail rows render.
-            SetScreenOcrDetail(true);
-            SetHighlightDetail(true);
+            SyncFromSettings();
+
+            var sliders = new[]
+            {
+                "SliderKeywordBufferTimeout", "SliderKeywordSessionMultiplier",
+                "SliderScreenOcrInterval", "SliderKeywordHighlightDuration",
+            };
+            foreach (var name in sliders)
+                this.FindControl<Slider>(name)!.ValueChanged += OnSliderChanged;
+        }
+
+        protected override void OnAttachedToVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            SyncFromSettings();
+        }
+
+        protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+        {
+            if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnCurrentReplaced() => Dispatcher.UIThread.Post(SyncFromSettings);
+
+        /// <summary>
+        /// WPF's <c>SyncKeywordRescuePanelUi</c> half that this control owns: the four slider
+        /// positions and the two master-driven sections. The clamps are the WPF ones, so a
+        /// settings file written by a build with different bounds cannot throw a slider out of
+        /// range here either.
+        /// </summary>
+        internal void SyncFromSettings()
+        {
+            _isLoading = true;
+            try
+            {
+                var s = CoreSettings.Current;
+                Set("SliderKeywordBufferTimeout", Math.Clamp(s.KeywordBufferTimeoutMs, 1000, 10000));
+                Set("SliderKeywordSessionMultiplier", Math.Clamp(s.KeywordSessionMultiplier, 1.0, 3.0));
+                Set("SliderScreenOcrInterval", Math.Clamp(s.ScreenOcrIntervalMs / 1000.0, 2, 10));
+                Set("SliderKeywordHighlightDuration", Math.Clamp(s.KeywordHighlightDurationMs / 1000.0, 0.3, 5.0));
+
+                // The masters themselves live on the Awareness tab; this panel only follows them.
+                SetScreenOcrDetail(s.ScreenOcrEnabled);
+                SetHighlightDetail(s.KeywordHighlightEnabled);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("KeywordTriggersPanel.SyncFromSettings failed: {E}", ex.Message);
+            }
+            finally
+            {
+                _isLoading = false;
+            }
+
+            void Set(string name, double value)
+            {
+                var slider = this.FindControl<Slider>(name)!;
+                slider.Value = value;
+                UpdateLabel(name, value);   // ValueChanged does not fire when the value is unchanged
+            }
+        }
+
+        /// <summary>
+        /// The four sliders' single editor. WPF keeps four one-line handlers; the fields differ but
+        /// the shape does not, so one switch is the whole of it.
+        /// </summary>
+        private void OnSliderChanged(object? sender, RangeBaseValueChangedEventArgs e)
+        {
+            if (sender is not Slider slider || slider.Name is not { } name) return;
+            UpdateLabel(name, e.NewValue);
+            if (_isLoading) return;
+
+            var s = CoreSettings.Current;
+            switch (name)
+            {
+                case "SliderKeywordBufferTimeout":
+                    var buffer = (int)e.NewValue;
+                    if (s.KeywordBufferTimeoutMs == buffer) return;
+                    s.KeywordBufferTimeoutMs = buffer;
+                    break;
+                case "SliderKeywordSessionMultiplier":
+                    if (Math.Abs(s.KeywordSessionMultiplier - e.NewValue) < 0.0001) return;
+                    s.KeywordSessionMultiplier = e.NewValue;
+                    break;
+                case "SliderScreenOcrInterval":
+                    var ocr = (int)e.NewValue * 1000;
+                    if (s.ScreenOcrIntervalMs == ocr) return;
+                    s.ScreenOcrIntervalMs = ocr;
+                    // ponytail: WPF also pushes the new interval into the running scanner
+                    // (App.ScreenOcr.UpdateInterval). No OCR service and no Core seam for one on
+                    // this head, so there is nothing running to re-time - the stored value is the
+                    // whole effect here, which is why this is a restore and not a half-port.
+                    break;
+                case "SliderKeywordHighlightDuration":
+                    var ms = (int)(e.NewValue * 1000);
+                    if (s.KeywordHighlightDurationMs == ms) return;
+                    s.KeywordHighlightDurationMs = ms;
+                    break;
+                default:
+                    return;
+            }
+            CoreSettings.Save();
         }
 
         /// <summary>Follows the Screen OCR master: detail rows when on, the "needs source" hint when off.</summary>
@@ -89,11 +199,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
             }
         }
 
-        private void Track(string slider, string label, Func<double, string> format)
+        /// <summary>Value labels; formats copied from MainWindow.KeywordTriggers.cs, which owns
+        /// them on WPF.</summary>
+        private void UpdateLabel(string sliderName, double value)
         {
-            var s = this.FindControl<Slider>(slider)!;
-            var t = this.FindControl<TextBlock>(label)!;
-            s.ValueChanged += (_, e) => t.Text = format(e.NewValue);
+            var (label, text) = sliderName switch
+            {
+                "SliderKeywordBufferTimeout" => ("TxtKeywordBufferTimeout", $"{(int)value / 1000.0:F1}s"),
+                "SliderKeywordSessionMultiplier" => ("TxtKeywordSessionMultiplier", $"{value:F1}x"),
+                "SliderScreenOcrInterval" => ("TxtScreenOcrInterval", $"{(int)value}s"),
+                "SliderKeywordHighlightDuration" => ("TxtKeywordHighlightDuration", $"{value:0.0}s"),
+                _ => (null, null),
+            };
+            if (label == null) return;
+            var block = this.FindControl<TextBlock>(label);
+            if (block != null) block.Text = text;
         }
     }
 }

--- a/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs
@@ -316,7 +316,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// </summary>
     public sealed class MemoryDiaryViewModel : CompanionObservable
     {
-        // ponytail: copy of the head's FactOrdering.FilterKeys; delete when CompanionVmPrimitives moves to Core
+        // ponytail: copy of FactOrdering.FilterKeys from ConditioningControlPanel/Views/Controls/
+        // Companion/CompanionVmPrimitives.cs (the WPF one - this head's same-named file next door
+        // holds only CompanionRelayCommand/CompanionObservable and does NOT carry FactOrdering).
+        // Delete this copy when that class reaches Core.
         private static readonly string[] FilterKeys = { "all", "boundary", "joke", "preference", "goal", "moment" };
 
         private readonly List<MemoryFact> _all;
@@ -378,7 +381,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         public string StorageLinkLabel { get; init; } = Loc.Get("companion_memory_storage_link");
         public string ForgetEverythingLabel { get; init; } = Loc.Get("companion_memory_forget_everything");
 
-        // ponytail: needs a shell "open folder" on CorePaths' companion dir, wired when the diary moves to Core
+        // ponytail: the PATH is not the blocker - CorePaths answers it today. What is missing is
+        // a head-side "reveal in file manager": Avalonia has no launcher for a directory
+        // (TopLevel.Launcher opens files and URIs), so this needs an xdg-open shim in
+        // CCP.Avalonia/Helpers before the command can do anything but lie about opening.
         public ICommand? OpenStorageFolderCommand => null;
         public ICommand ForgetEverythingCommand { get; }
 

--- a/CCP.Avalonia/Views/Controls/DailyQuestCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/DailyQuestCard.axaml.cs
@@ -231,7 +231,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
         /// Seat the fill against the track's CURRENT width. Called both from Apply (which can run
         /// before the tab has ever been measured, in which case the track is 0 wide and this is a
         /// no-op) and from the track's SizeChanged, which is what finally lands it.
-        /// ponytail: needs MotionFx.BarFill for the tween, wired when it moves to Core; the width
+        /// ponytail: MotionFx is NOT coming to Core - it is WPF Storyboard code and Core has no
+        /// UI at all, so "wired when it moves" was never true. The Avalonia shape is a table of
+        /// tween closures stepped off one shared ~16ms DispatcherTimer (CCP.Avalonia/Views/Windows/
+        /// ChaosHudWindow.axaml.cs is the worked example); Animation.RunAsync cannot be used here
+        /// because TransformAnimator seizes the target visual's RenderTransform. The width
         /// is set directly here, so the bar is correct but never animates.
         /// </summary>
         private void ApplyFraction()
@@ -249,7 +253,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
 
         // ---- INTERACTION ---------------------------------------------------------
 
-        // ponytail: needs MotionFx.HoverLift + the reduced-motion gate, wired when it moves to
+        // ponytail: MotionFx.HoverLift is WPF Storyboard code and stays head-side; the Avalonia
+        // shape is the shared-DispatcherTimer tween named above. The reduced-motion gate itself is
+        // NOT blocked - CoreSettings.Current.MotionLevel is in Core today. What is missing is
         // Core. The glow still attaches and clears; it just arrives at full strength instead of
         // blooming over 180ms.
         private void OnCardPointerEntered(object? sender, PointerEventArgs e)

--- a/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs
@@ -18,9 +18,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
     ///
     /// PORTED from ConditioningControlPanel/Views/Controls/EmiRingPicker.xaml.cs. The WPF control
     /// keeps no list of its own: the tiles ARE <c>EmiState.Pins</c>, written through
-    /// <c>EmiSuggester</c>. Those, <c>EmiTargets</c> and <c>ModResourceResolver</c> are all in the
-    /// WPF head, so this port carries a PLACEHOLDER catalogue and pin set (see the ponytail note)
-    /// that must be deleted, not kept, when the store moves to Core.
+    /// <c>EmiSuggester</c>. <c>EmiSuggester</c> and <c>EmiTargets</c> are still WPF-head only, so
+    /// this port carries a PLACEHOLDER catalogue and pin set (see the ponytail note) that must be
+    /// deleted, not kept, when the store moves to Core. <c>ModResourceResolver</c> is NOT a
+    /// blocker any more - <see cref="CoreModArt"/> plus <c>Helpers.ModArt</c> answer that half on
+    /// this head; what is missing is the per-target art NAME, see <c>BuildTileFace</c>.
     /// </summary>
     public partial class EmiRingPicker : UserControl
     {

--- a/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/SeasonRecapCard.axaml.cs
@@ -279,8 +279,26 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
             },
         });
 
-        /// <summary>ponytail: RecapBackgrounds.ForMod names a pack:// resource; null until the art ships in Core.</summary>
-        public IImage? BackgroundImage => null;
+        private IImage? _background;
+        private bool _backgroundProbed;
+
+        /// <summary>
+        /// The season's neon plate. <c>RecapBackgrounds.ForMod</c> is in Core (Models/SeasonRecap.cs)
+        /// and names a plain Resources-relative file, so the WPF <c>pack://</c> half is just
+        /// <see cref="Helpers.ModArt"/>: the active mod's override first, this head's linked
+        /// <c>avares://</c> copy second, null when neither exists (the card then shows its gradient).
+        /// Decoded once - the card re-reads this property on every binding pass.
+        /// </summary>
+        public IImage? BackgroundImage
+        {
+            get
+            {
+                if (_backgroundProbed) return _background;
+                _backgroundProbed = true;
+                _background = Helpers.ModArt.TryLoad(RecapBackgrounds.ForMod(CoreMods.ActiveModId));
+                return _background;
+            }
+        }
 
         // ---------- header ----------
         public int SeasonNumber => SeasonNumbering.ToSeasonNumber(_s.SeasonKey);

--- a/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/RampRackPanel.axaml.cs
@@ -31,7 +31,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
         public RampRackPanel()
         {
             AvaloniaXamlLoader.Load(this);
-            // ponytail: needs Controls/HelpPopover.cs ported to this head. HelpContentService
+            // ponytail: blocked ONLY on the popover control - ConditioningControlPanel/Views/
+            // Controls/HelpPopover.cs has no Avalonia twin. HelpContentService
             // is already in Core; the popover control is the only thing still missing, and
             // it is what would call .GetContent("IntensityRamp") for HelpBtnStudioRamp.
         }

--- a/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Studio/SchedulerRackPanel.axaml.cs
@@ -32,7 +32,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Studio
         public SchedulerRackPanel()
         {
             AvaloniaXamlLoader.Load(this);
-            // ponytail: needs Controls/HelpPopover.cs ported to this head. HelpContentService
+            // ponytail: blocked ONLY on the popover control - ConditioningControlPanel/Views/
+            // Controls/HelpPopover.cs has no Avalonia twin. HelpContentService
             // is already in Core; the popover control is the only thing still missing, and
             // it is what would call .GetContent("Scheduler") for HelpBtnStudioScheduler.
         }


### PR DESCRIPTION
CompanionHeroCard now draws her actual bust instead of the vector placeholder disc. The
blocker the old note named was the markup: WPF points a NAMED ImageBrush's Viewbox at the
art's opaque bounds, and the Avalonia port had dropped every x:Name on a brush (AVLN2000),
so there was nothing to give a SourceRect to. Naming the Ellipse that OWNS the brush fixes
it. ApplyAvatarArt then resolves the same avatar[N]_pose1.png the WPF runtime viewmodel
does - CoreModArt for the mod override, Helpers.ModArt for this head's avares:// copy - and
CentrePortrait ports the measured crop: a 96px probe for the opaque bounds, then a square
source rect at 0.86 ink fill. Avalonia has no FormatConvertedBitmap, so a source with no
alpha channel is answered "cannot be measured" (the whole image) rather than scanned as if
byte 3 meant something. Portrait stopped being init-only; the existing ModChanged hook and
PropertyChanged plumbing were already correct and now have something to react to.

SeasonRecapCard's plate was two lines away the whole time: RecapBackgrounds.ForMod is in
Core and names a plain Resources-relative file, so the pack:// half is just ModArt.TryLoad.
Decoded once, not per binding pass.

AiPermissionsGrid was showing markup defaults over stored permissions - a grid lying about
what the companion may do. CompanionPromptSettings is in Core, so the effect grid, the
master switch and the haptic cap are seeded from CoreSettings and write back through it,
with the _isLoading guard raised around the tier refusal's snap-back because Avalonia
re-enters the handler on a programmatic set. WPF's UpdateUnlockablesVisibility force-clear
is deliberately NOT ported: it is a write decided by an entitlement this head cannot see,
so here it would destroy a paid-up user's setting on every launch.

KeywordTriggersPanel hardcoded both signal masters ON, which drew the OCR interval row over
a scanner that is switched off. The four sliders and both detail sections now come from
CoreSettings with the WPF clamps, and write back through it.

UpdatesSettingsSection offers the upgrade tour again. "Wired when the tutorial seam exists"
was stale - CoreTutorial.Start takes the head's tutorial-type name, and an unseeded head
does nothing, which is exactly what makes the offer safe.

Refused, with the reason written into the file: AiPermissionsGrid's chat-memory switch. The
box is seeded so it tells the truth, but the WRITE is snapped back, because unticking it on
WPF is a promise to erase companion/session.json and the live turn log, and CoreAi exposes
only IsAvailable. Persisting "memory off" without a forget seam is a switch reading "erased"
over a transcript that is still there.

Nine notes were rewritten rather than restored, each naming the symbol and head path that
blocks it now. Four were actively wrong: AdornedAvatar's WardrobeCatalog art is on-disk
files under Resources/cosmetics, not pack://; DailyQuestCard's MotionFx is WPF Storyboard
code that cannot "move to Core" at all, so the note now names the shared-DispatcherTimer
tween pattern; EmiRingPicker's ModResourceResolver is CoreModArt today for the art half;
and both CompanionVmPrimitives notes were ambiguous now that this head has a file of that
name which does NOT carry FactOrdering or AwarenessIntensity.

Still blocked:
- CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs - IsLabEntitled (needs
  PatreonService.HasLabAccess in Core); BtnClearChatMemory_Click and the ChatMemoryEnabled
  write (need a forget action on CCP.Core/CoreAi.cs).
- CCP.Avalonia/Views/Controls/Companion/CompanionHeroCard.axaml.cs - the rest of Sync():
  her name, mod chip and flavour, which need CompanionHeroRuntimeVm (App.Companion,
  App.AvatarWindow, CompanionRuntimeContext.Navigator).
- CCP.Avalonia/Views/Controls/Companion/KeywordTriggersPanel.axaml.cs - the trigger row
  builder in MainWindow.KeywordTriggers.cs and the two OCR combos (no CoreOcr seam).
- CCP.Avalonia/Views/Controls/AdornedAvatar.axaml.cs - GetImage, on
  ConditioningControlPanel/Services/Profile/WardrobeCatalog.cs reaching Core.
- CCP.Avalonia/Views/Controls/AppSettings/AudioSettingsSection.axaml.cs - device
  enumeration; CCP.Core/CoreAudio.cs is playback only and NAudio is Windows-only.
- CCP.Avalonia/Views/Controls/Studio/{RampRackPanel,SchedulerRackPanel}.axaml.cs - the "?"
  buttons, on ConditioningControlPanel/Views/Controls/HelpPopover.cs having no twin here.
- CCP.Avalonia/Views/Controls/Companion/MemoryDiaryView.axaml.cs - OpenStorageFolderCommand
  needs an xdg-open shim in CCP.Avalonia/Helpers; CorePaths already answers the path.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU