### PR TITLE
feat(avalonia): tab feature art repaints on a mod switch; emote slots and mic sensitivity round-trip settings

### DIFF
--- a/CCP.Avalonia/Views/Tabs/AppSettingsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AppSettingsTabView.axaml.cs
@@ -44,8 +44,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// <c>ScrollChangedEventArgs.VerticalChange</c> -&gt; <c>OffsetDelta.Y</c>,
     /// <c>Dispatcher.BeginInvoke</c> -&gt; <c>Dispatcher.UIThread.Post</c>,
     /// <c>Visibility != Visible</c> -&gt; <c>!IsVisible</c>.
-    /// The WPF <c>App.Logger</c> calls are dropped: the logger is not on this head and the
-    /// catches exist to swallow, not to report.</para>
+    /// The WPF <c>App.Logger</c> calls are dropped because the catches exist to swallow, not to
+    /// report - NOT because there is no logger: Serilog's static <c>Log</c> is this head's
+    /// replacement for <c>App.Logger</c> and every other file here uses it.</para>
     /// </summary>
     public partial class AppSettingsTabView : UserControl
     {

--- a/CCP.Avalonia/Views/Tabs/AwarenessTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AwarenessTabView.axaml.cs
@@ -396,10 +396,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         // ------------------------------------------------------------------ still head-side
 
+        /// <summary>
+        /// WPF: MainWindow.Settings.cs:660 -&gt; StartAwarenessTutorial() -&gt;
+        /// StartTutorial(TutorialType.Awareness). The seam takes the tour by name and the head
+        /// parses it, so this is the whole call. This head does NOT seed
+        /// CoreTutorial.StartAction today, so the button reaches the seam and no tour appears -
+        /// the seam's documented no-op, not a wrong action, and one seeding line away from real.
+        ///
+        /// ponytail: the WPF version also hooks TutorialCompleted once, to pop the Puppy preset's
+        /// editor when the tour is finished rather than skipped. That half needs
+        /// ConditioningControlPanel/Views/Dialogs/AwarenessPresetDetailDialog.xaml, which has no
+        /// Avalonia twin; CoreTutorial.Finished carries the completed/skipped bool it would need.
+        /// </summary>
         private void BtnAwarenessTutorial_Click(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs TutorialService, which drives an overlay window. Head-side.
-        }
+            => CoreTutorial.Start("Awareness");
 
         private void BtnGateUnlock_Click(object? sender, RoutedEventArgs e)
         {
@@ -407,10 +417,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             // RefreshPremiumGate to raise or drop the AwarenessGate overlay in the first place.
         }
 
+        /// <summary>
+        /// WPF: MainWindow.Awareness.cs:1175. Its SECOND branch is ported verbatim - reveal, scroll
+        /// to and pulse the custom-trigger drawer, which KeywordTriggersPanel.RevealTriggerEditor
+        /// already does on this head and which is idempotent by design, because "nothing visibly
+        /// happened" is how this link got reported as a dead click in the first place.
+        ///
+        /// ponytail: WPF PREFERS a first branch when a preset is installed - open that preset's
+        /// inline editor. KeywordTriggerPresetService is in Core
+        /// (CCP.Core/Services/KeywordTriggerPresetService.cs), so the lookup is available; what is
+        /// missing is the dialog, ConditioningControlPanel/Views/Dialogs/AwarenessPresetDetailDialog.xaml,
+        /// which has no Avalonia twin. Falling through to the drawer is WPF's own no-preset path,
+        /// so the link is never dead and never lands somewhere wrong.
+        /// </summary>
         private void LnkAwarenessAdvanced_Click(object? sender, RoutedEventArgs e)
-        {
-            // ponytail: needs App.KeywordPresets to pick the installed preset and open its editor
-            // dialog; falls back to the custom-trigger drawer when nothing is installed.
-        }
+            => KeywordPanel?.RevealTriggerEditor();
     }
 }

--- a/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml
@@ -28,12 +28,14 @@
        RenderTransformOrigin="0,0.5"     -> "0%,50%" (same reason)
 
      Dropped, each for a reason that is not a shortcut:
-       pack:// takeover art (hero strip, ImgBambiTakeoverDesc, side plate) - this head ships no
-         Resources/features PNGs yet (LockdownTabView / SheListeningTabView precedent). All three
-         plates keep their geometry, border, mask and scrim and stand in a faded emoji; the named
-         Image hook ImgBambiTakeoverDesc is kept, Source-less, so the art is a one-line re-add.
+       pack:// takeover art (hero strip, ImgBambiTakeoverDesc, side plate) - RESTORED. All three
+         are painted from code-behind (ApplyFeatureArt) through Helpers.ModArt.TryLoad, which is
+         the mod override first and this head's linked Assets/features copy second, and the whole
+         BambiSleep "bambi takeover.png" / "takeover.png" fork comes with it. The wash, the faded
+         emoji and the scrim stay underneath as the no-art fallback.
        x:Name on the two ImageBrushes (TakeoverHeroArtBrush / TakeoverSideArtBrush) - AVLN2000,
-         only a StyledElement can be named; moot once the art under them is gone.
+         only a StyledElement can be named, so the two BORDERS carry the names instead
+         (TakeoverHeroArt / TakeoverSideArt) and the brushes are built in code.
        feat:AdaptiveSideArt.CollapseBelow and hover:HoverPop.IsEnabled - attached behaviours that
          live in the WPF head. The 3*/2* split with MaxWidth="780" is kept verbatim.
        x:FieldModifier="internal" - no host re-publishes these fields on this head. The x:Names are
@@ -111,7 +113,8 @@
                 <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
                         BorderBrush="{StaticResource TabHueBorderBrush}" BorderThickness="2" Margin="0,0,0,10">
                     <Grid>
-                        <Border CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                        <Border x:Name="TakeoverHeroArt"
+                                CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
                                 Background="{StaticResource TabHueWashBrush}">
                             <Border.OpacityMask>
                                 <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
@@ -792,7 +795,8 @@
                          Background to CornerRadius but does NOT clip child content, so a child
                          Image would square off the rounded corners (round-2 lesson). -->
                     <StackPanel Grid.Column="1" Margin="10,0,0,0">
-                        <Border CornerRadius="14" BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
+                        <Border x:Name="TakeoverSideArt"
+                                CornerRadius="14" BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
                                 Background="{StaticResource TabHueWashBrush}"
                                 MinHeight="200" MaxHeight="300" Margin="0,0,0,10">
                             <Grid>

--- a/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/BambiTakeoverTabView.axaml.cs
@@ -34,13 +34,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// shows a tab by flipping <c>IsVisible</c> and never re-attaches, so the whole seed re-runs on
     /// the IsVisible edge as well as on attach and on a settings-instance swap.</para>
     ///
-    /// <para><b>Dropped:</b> the mod-aware feature art (ModService.ModChanged -&gt; the resolver
-    /// repainting the hero and side takeover.png plates, including the BambiSleep
-    /// "bambi takeover.png" fork). ponytail: the resolver is NOT the blocker - CoreMods raises
-    /// ModChanged and <c>Helpers.ModArt.TryLoad("features/bambi takeover.png")</c> resolves
-    /// against art the csproj already links. The blocker is that both plates are art-less in
-    /// BambiTakeoverTabView.axaml (see its header), so there is no Image to repaint; restore the
-    /// markup and this handler in one change.</para>
+    /// <para><b>Feature art is wired.</b> <see cref="CoreMods.ModChanged"/> is the repaint signal
+    /// and <see cref="Helpers.ModArt.TryLoad"/> the resolver - mod override first, this head's
+    /// linked <c>Assets/features</c> copy second - so the hero strip, the description thumb and the
+    /// side plate all repaint on a mod switch, BambiSleep's "bambi takeover.png" fork included.
+    /// WPF's DecodePixelWidth hints (480 / 800) have no Avalonia equivalent on a brush, so one
+    /// decode feeds all three.</para>
     /// </summary>
     public partial class BambiTakeoverTabView : UserControl
     {
@@ -100,19 +99,59 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             ChkMantraChant.IsCheckedChanged += ChkMantraChant_Changed;
 
             SyncFromSettings();
+            ApplyFeatureArt();
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
             if (CoreSettings.Service is { } svc) svc.CurrentReplaced += OnCurrentReplaced;
+            CoreMods.ModChanged += OnModChanged;
             SyncFromSettings();
+            ApplyFeatureArt();
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             if (CoreSettings.Service is { } svc) svc.CurrentReplaced -= OnCurrentReplaced;
+            CoreMods.ModChanged -= OnModChanged;
             base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>ModChanged can be raised off the UI thread, so the repaint is marshalled.</summary>
+        private void OnModChanged(object? sender, Models.ModPackage mod) =>
+            Dispatcher.UIThread.Post(ApplyFeatureArt);
+
+        /// <summary>
+        /// WPF: MainWindow.xaml.cs:2633 picks the path and BambiTakeoverTabView.xaml.cs:87 repaints
+        /// the two brushes. BambiSleep ships its own takeover art under a different name, so the
+        /// fork is on the ACTIVE MOD ID, not on the resolver.
+        /// </summary>
+        private static string TakeoverArtPath =>
+            string.Equals(CoreMods.ActiveModId, Models.BuiltInMods.BambiSleepId, StringComparison.OrdinalIgnoreCase)
+                ? "features/bambi takeover.png"
+                : "features/takeover.png";
+
+        /// <summary>
+        /// Repaints the hero strip, the description thumb and the side plate. A null resolve is
+        /// left alone deliberately, exactly as the WPF version does: the plate degrades to its
+        /// authored wash + glyph rather than to an empty rectangle.
+        /// </summary>
+        private void ApplyFeatureArt()
+        {
+            var art = Helpers.ModArt.TryLoad(TakeoverArtPath);
+            if (art == null) return;
+
+            TakeoverHeroArt.Background = new global::Avalonia.Media.ImageBrush(art)
+            {
+                Stretch = global::Avalonia.Media.Stretch.UniformToFill,
+                AlignmentX = global::Avalonia.Media.AlignmentX.Right,
+            };
+            TakeoverSideArt.Background = new global::Avalonia.Media.ImageBrush(art)
+            {
+                Stretch = global::Avalonia.Media.Stretch.UniformToFill,
+            };
+            ImgBambiTakeoverDesc.Source = art;
         }
 
         /// <summary>The shell shows a tab by flipping IsVisible, never by re-attaching. This is the

--- a/CCP.Avalonia/Views/Tabs/DeeperTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/DeeperTabView.axaml
@@ -14,13 +14,14 @@
        <ContentPresenter/>               ->  Content/ContentTemplate TemplateBinding (trap 6)
        DataTrigger placeholder overlay   ->  TextBox.Watermark (native, one attribute)
 
-     Dropped, each for a reason that is not a shortcut:
-       both deeper.png ImageBrush plates - this head ships no Resources/ PNGs yet
-         (AiPermissionsGrid precedent). The hero keeps its fade, the side plate keeps its
-         frame and gets a faded 🌊 the way SystemFeatureControl:221 does. Re-add as an
-         avares:// ImageBrush when the art moves.
-       x:Name on those two ImageBrushes  - AVLN2000, only a StyledElement can be named.
-       Border.OpacityMask                - moot once the art under it is gone.
+     Restored since the port:
+       both deeper.png plates - Assets/features/deeper.png is linked into this head, so
+         DeeperHeroArt and DeeperSideArt are named BORDERS painted from code-behind through
+         Helpers.ModArt.TryLoad + CoreMods.ModChanged (mod override first). The accent wash,
+         the 🌊 and the scrim stay underneath as the no-art fallback.
+       x:Name on those two ImageBrushes  - still AVLN2000; only a StyledElement can be named,
+         which is why the BORDER carries the name and the brush is built in code.
+       Border.OpacityMask                - kept; Avalonia has OpacityMask on Visual.
        feat:AdaptiveSideArt.CollapseBelow - attached behaviour lives in the WPF head.
        PanningMode, VirtualizingPanel.*, ScrollViewer.CanContentScroll and the ItemsControl's
          inner-ScrollViewer template - the outer ScrollViewer already scrolls the page.
@@ -322,10 +323,9 @@
                     <!-- Art plate. Spans both columns and is declared first, so the identity block
                          and the action cluster draw over it. Right-aligned at a fixed 240 - well
                          under the width the action cluster already gives the Auto column, so the
-                         span can never inflate it.
-                         ponytail: the deeper.png ImageBrush + its left-fade OpacityMask are
-                         dropped - this head ships no Resources/ PNGs. Only the accent wash is
-                         drawn. Re-add as an avares:// ImageBrush when the art moves. -->
+                         span can never inflate it. The accent wash below is the no-art
+                         fallback; DeeperHeroArt overwrites it with deeper.png when the art
+                         resolves. -->
                     <Border Grid.Column="0" Grid.ColumnSpan="2"
                             CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right">
                         <Border.Background>
@@ -334,6 +334,16 @@
                                 <GradientStop Color="#387B5CFF" Offset="1"/>
                             </LinearGradientBrush>
                         </Border.Background>
+                    </Border>
+                    <Border x:Name="DeeperHeroArt" Grid.Column="0" Grid.ColumnSpan="2"
+                            CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                            Opacity="0.9">
+                        <Border.OpacityMask>
+                            <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                <GradientStop Color="#00000000" Offset="0"/>
+                                <GradientStop Color="#E6000000" Offset="0.55"/>
+                            </LinearGradientBrush>
+                        </Border.OpacityMask>
                     </Border>
 
                     <!-- Identity: drifting glyph + title/BETA + one-line pitch. A Grid (not a
@@ -820,11 +830,10 @@
 
                 <!-- SIDE ART. Top-pinned with a fixed 520px height (same as AwarenessTabView's side
                      plate) so it sits directly under the hero bar.
-                     ponytail: the deeper.png ImageBrush is dropped - this head ships no Resources/
-                     PNGs. The plate keeps its frame, its accent wash and its scrim, and carries a
-                     faded glyph the way SystemFeatureControl:221 does. Re-add as an avares://
-                     ImageBrush when the art moves. -->
-                <Border Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
+                     Background is set from code-behind (deeper.png, mod override first); the
+                     accent wash, the faded glyph and the scrim below are the no-art fallback. -->
+                <Border x:Name="DeeperSideArt"
+                        Grid.Column="1" Margin="10,0,0,0" CornerRadius="14"
                         BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
                         Background="{StaticResource DeeperHueWashBrush}"
                         VerticalAlignment="Top" Height="520">

--- a/CCP.Avalonia/Views/Tabs/DeeperTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/DeeperTabView.axaml.cs
@@ -3,9 +3,11 @@ using System.Collections.ObjectModel;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
+using Avalonia;
 using Avalonia.Media;
+using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
@@ -14,26 +16,61 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     ///
     /// The WPF code-behind is a pure relay: every handler is
     /// <c>if (Window.GetWindow(this) is MainWindow mw) mw.&lt;same name&gt;(...)</c>, plus the
-    /// mod-aware feature art and the FX lifecycle hook. None of that can move yet, so the
-    /// handlers are stubs with identical names so the eventual wiring diffs cleanly.
+    /// mod-aware feature art and the FX lifecycle hook. The relay targets have not moved, so the
+    /// handlers are stubs with identical names so the eventual wiring diffs cleanly - but the
+    /// FEATURE ART is real again: Helpers.ModArt.TryLoad plus CoreMods.ModChanged is the same
+    /// answer WPF's ModResourceResolver gives, and Assets/features/deeper.png is linked here.
     /// </summary>
     public partial class DeeperTabView : UserControl
     {
         public DeeperTabView()
         {
-            AvaloniaXamlLoader.Load(this);
+            // InitializeComponent, NOT AvaloniaXamlLoader.Load: the loader does not assign the
+            // generated x:Name fields, so DeeperHeroArt/DeeperSideArt would be permanently null
+            // and ApplyFeatureArt would be a silent no-op (CLAUDE.md porting trap 7).
+            InitializeComponent();
             DataContext = new DeeperTabViewModel();
+            ApplyFeatureArt();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            CoreMods.ModChanged += OnModChanged;
+            ApplyFeatureArt();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            CoreMods.ModChanged -= OnModChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>ModChanged can be raised off the UI thread, so the repaint is marshalled.</summary>
+        private void OnModChanged(object? sender, ModPackage mod) =>
+            Dispatcher.UIThread.Post(ApplyFeatureArt);
+
+        /// <summary>
+        /// The two deeper.png plates, mod override first - the split of WPF's ModResourceResolver
+        /// repaint across the seam. A null answer leaves the authored wash, glyph and scrim, which
+        /// is what the resolver's own null path does.
+        /// </summary>
+        private void ApplyFeatureArt()
+        {
+            var art = Helpers.ModArt.TryLoad("features/deeper.png");
+            if (art == null) return;
+
+            DeeperHeroArt.Background = new ImageBrush(art)
+            {
+                Stretch = Stretch.UniformToFill,
+                AlignmentX = AlignmentX.Right,
+            };
+            DeeperSideArt.Background = new ImageBrush(art) { Stretch = Stretch.UniformToFill };
         }
 
         // ponytail: needs MainWindow.OnDeeperTabVisibilityChanged (the header glyph's drift clock)
         // and MainWindow.DeeperFx, wired when the FX layer moves to Core. On WPF this rode
         // IsVisibleChanged; the Avalonia equivalent would be an IsVisibleProperty observer.
-
-        // ponytail: the resolver is NOT the blocker - CoreMods answers the active mod and
-        // CoreModArt/Helpers.ModArt resolve "features/deeper.png", which IS linked into this
-        // head. What is missing is the target: both plates are art-less in DeeperTabView.axaml
-        // (see its header), so there is no Image or ImageBrush to write into. Restoring this
-        // means changing the .axaml and this file together.
 
         // ponytail: every handler below routes to MainWindow on WPF
         // (Window.GetWindow(this) is MainWindow mw -> mw.<same name>). Needs the

--- a/CCP.Avalonia/Views/Tabs/ExclusivesTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/ExclusivesTabView.axaml.cs
@@ -17,8 +17,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// aurora at 0.55, copied from StartExclusivesMotion - canvas composition, not service logic).
     /// Everything else is a stub or a placeholder.</para>
     ///
-    /// <para>Dropped outright: <c>LoadBackdrop</c> (needs ModResourceResolver and a Resources/ PNG
-    /// this head does not ship), the <c>ModChanged</c> subscription that re-ran it, and
+    /// <para>Dropped: <c>LoadBackdrop</c> and the <c>ModChanged</c> subscription that re-ran it.
+    /// ponytail: the resolver is NOT the blocker - <c>Helpers.ModArt.TryLoad</c> plus
+    /// <c>CoreMods.ModChanged</c> answer it, and the picture exists at
+    /// <c>Assets/exclusives/vault_backdrop.png</c>. Two things are missing and neither is in this
+    /// file: <c>Assets/exclusives/**</c> is not among the <c>AvaloniaResource</c> globs in
+    /// CCP.Avalonia.csproj, so <c>avares://CCP.Avalonia/Resources/exclusives/vault_backdrop.png</c>
+    /// does not resolve; and the markup has no <c>VaultBackdrop</c> Image to paint into - the
+    /// spotlight carries <c>TxtSpotArtGlyph</c> instead. Link the folder, add the Image, then this
+    /// is four lines. Also dropped:
     /// <c>RoundClipOnResize</c> - WPF's ClipToBounds is rectangular, so a rounded host needed clip
     /// geometry tracked against every resize; an Avalonia Border clips its child to its own
     /// CornerRadius, so the helper has no work left. Its two other callers were MainWindow's card
@@ -60,9 +67,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// <summary>
         /// Paints the spotlight and fills the shelf with sample cards.
         ///
-        /// ponytail: needs ExclusiveFeature.All, DailyFreeService, VaultLivery and FxTheme, all
-        /// pinned to the WPF head (the registry's gate probe reads App.Patreon). Wired when they
-        /// move to Core. The rows are the real registry's first six entries with their real loc
+        /// ponytail: DailyFreeService is NOT a blocker any more - it is in Core
+        /// (CCP.Core/Services/DailyFreeService.cs). What is still head-side is the registry itself,
+        /// ConditioningControlPanel/Models/ExclusiveFeature.cs (its gate probe reads App.Patreon),
+        /// plus ConditioningControlPanel/Features/VaultLivery.cs and
+        /// ConditioningControlPanel/Services/FxTheme.cs. The rows are the real registry's first six entries with their real loc
         /// keys, spread across every branch the card template carries - tier 1, tier 2, untiered,
         /// NEW, BETA, no badge, a locked veil and both entitlement chips - so the render proof
         /// exercises the markup rather than one happy path.
@@ -106,8 +115,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         /// <summary>
         /// WPF: <c>MainWindow.OpenExclusiveSpotlight()</c>, i.e. ShowTab(ExclusiveFeature.All[0].Key).
-        /// ponytail: needs the tab host and the ExclusiveFeature registry, wired when they move to
-        /// Core - so the hero is inert here rather than navigating somewhere wrong.
+        /// ponytail: needs the shell's tab host and
+        /// ConditioningControlPanel/Models/ExclusiveFeature.cs (for All[0].Key) - so the hero is
+        /// inert here rather than navigating somewhere wrong.
         /// </summary>
         private static void OpenSpotlight() { }
     }
@@ -173,8 +183,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// <summary>
         /// The card's resting rim. WPF takes the untiered one from the active mod's accent
         /// (ExclusiveEdgeDefault) and overwrites a tiered card's with the constant vault livery.
-        /// ponytail: needs FxTheme + VaultLivery for the mod-aware half; the literals here are the
-        /// Bambi accent and the vault gold those two produce by default.
+        /// ponytail: the untiered rim is reachable today - CoreMods.AccentColorHex plus
+        /// CoreMods.TryParseHexColor is what FxTheme's ExclusiveEdgeDefault reduces to. The tiered
+        /// rim still needs ConditioningControlPanel/Features/VaultLivery.cs. Both literals here are
+        /// what those two produce with the default mod, so nothing reads wrong meanwhile.
         /// </summary>
         public IBrush EdgeBrush => Tier > 0 ? Brush("#66FFC94E") : Brush("#4DB478FF");
 

--- a/CCP.Avalonia/Views/Tabs/HapticsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/HapticsTabView.axaml
@@ -36,12 +36,18 @@
                                             property. Re-add when it moves to Core.
        feat:AdaptiveSideArt.CollapseBelow-> dropped with the side-art column, see below.
 
-     ponytail: the features/vibe.png plates (hero ImageBrush, side-art column, ImgHapticsVibeDesc,
-     ImgVideoHapticSync) are dropped - this head ships no Resources/features PNGs, so all four have
-     nothing to paint, and the mod-art repaint in the WPF code-behind needs ModResourceResolver,
-     which is still in the WPF head. WPF's AdaptiveSideArt.CollapseBelow=1000 collapses that column
-     at the width this head renders at anyway, so the Tier-1 region is a single column here.
-     Re-add as avares:// ImageBrushes when the art moves, and restore the 3*/2* grid with it. -->
+     features/vibe.png plates: the hero (HapticsHeroArt) and the Video-Haptic-Sync thumb
+     (ImgVideoHapticSync) are RESTORED - Assets/features/vibe.png is linked into this head and
+     Helpers.ModArt.TryLoad + CoreMods.ModChanged replace ModResourceResolver. WPF's
+     ImgHapticsVibeDesc is NOT ported and should not be: it is a 0x0 collapsed compat shim that
+     exists only so the shared MainWindow.xaml.cs partial has something to write .Source on.
+
+     ponytail: the Tier-1 SIDE-ART COLUMN is still dropped, and it is markup, not art - it needs the
+     3*/2* ColumnDefinitions restored around the Tier-1 StackPanel below plus the scrim Border
+     (ConditioningControlPanel/Views/Tabs/HapticsTabView.xaml:901). WPF's
+     AdaptiveSideArt.CollapseBelow=1000 collapses that column at the width this head renders at
+     anyway, so nothing is visibly missing at 1100px. -->
+
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -482,6 +488,21 @@
                                 BorderBrush="{StaticResource TabHueBorderBrush}" BorderThickness="2"
                                 Margin="0,0,0,10">
                             <Grid ColumnDefinitions="*,Auto">
+
+                                <!-- Hero plate. Background, not a child Image: a Border clips its
+                                     Background to CornerRadius but never its children. Painted in
+                                     code (HapticsHeroArt) so a mod's features/vibe.png outranks the
+                                     shipped copy. -->
+                                <Border x:Name="HapticsHeroArt" Grid.Column="0" Grid.ColumnSpan="2"
+                                        CornerRadius="0,16,16,0" Width="240" HorizontalAlignment="Right"
+                                        Opacity="0.9">
+                                    <Border.OpacityMask>
+                                        <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                            <GradientStop Color="#00000000" Offset="0"/>
+                                            <GradientStop Color="#E6000000" Offset="0.55"/>
+                                        </LinearGradientBrush>
+                                    </Border.OpacityMask>
+                                </Border>
 
                                 <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="18,0,10,0">
                                     <TextBlock Text="{loc:Str tab_haptics}" FontSize="17" FontWeight="Bold"
@@ -1131,8 +1152,14 @@
                                                     <Button x:Name="HelpBtnVideoHapticSync" Grid.Column="1"
                                                             Theme="{StaticResource HelpButtonStyle}" Tag="VideoHapticSync"
                                                             Margin="0,0,10,0" VerticalAlignment="Top"/>
-                                                    <!-- ponytail: ImgVideoHapticSync dropped with the other vibe.png
-                                                         plates; the WPF head repaints it on a mod switch. -->
+                                                    <!-- Source is set in code so a mod's override wins;
+                                                         WPF repaints the same Image on a mod switch. -->
+                                                    <Border Grid.Column="2" CornerRadius="8" ClipToBounds="True"
+                                                            Width="56" Height="56" VerticalAlignment="Top"
+                                                            BorderBrush="{StaticResource TabHueBorderBrush}"
+                                                            BorderThickness="1">
+                                                        <Image x:Name="ImgVideoHapticSync" Stretch="UniformToFill"/>
+                                                    </Border>
                                                 </Grid>
 
                                                 <TextBlock x:Name="TxtAudioSyncDisabledHint" Grid.Row="1"

--- a/CCP.Avalonia/Views/Tabs/HapticsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/HapticsTabView.axaml.cs
@@ -1,7 +1,11 @@
 using System.Collections.Generic;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
@@ -9,11 +13,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// Ported from ConditioningControlPanel/Views/Tabs/HapticsTabView.xaml.cs.
     ///
     /// <para>On WPF this file is a forwarding shim: every handler hands straight to the MainWindow
-    /// partial (MainWindow/MainWindow.Haptics.cs), which owns all the state, and Loaded/Unloaded
-    /// repaint the vibe.png plates through ModResourceResolver on a mod switch. None of that can
-    /// come across yet - MainWindow, HapticService, HapticDeviceManager, ModService and
-    /// ModResourceResolver all still live in the WPF head - so the 34 forwards are stubs with the
-    /// same names, and the art hooks are gone with the art (see the .axaml header).</para>
+    /// partial (ConditioningControlPanel/MainWindow/MainWindow.Haptics.cs), which owns all the
+    /// state. That partial has not moved, so the 34 forwards are stubs with the same names.</para>
+    ///
+    /// <para><b>The art hooks are real again.</b> WPF's Loaded/Unloaded pair repainted the vibe.png
+    /// plates through ModResourceResolver; here <see cref="Helpers.ModArt.TryLoad"/> answers the
+    /// same question (mod override first, this head's avares:// copy second) and
+    /// <see cref="CoreMods.ModChanged"/> is the repaint signal. Neither the resolver nor the art
+    /// is the blocker any more - Assets/features/vibe.png is linked into this head.</para>
     /// </summary>
     public partial class HapticsTabView : UserControl
     {
@@ -88,6 +95,43 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             // WPF fills this from the live device list; one entry so the themed ComboBox draws text.
             CmbPatternToy.Items.Add(new ComboBoxItem { Content = "Lush 3" });
             CmbPatternToy.SelectedIndex = 0;
+
+            ApplyFeatureArt();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            CoreMods.ModChanged += OnModChanged;
+            ApplyFeatureArt();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            CoreMods.ModChanged -= OnModChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>ModChanged can be raised off the UI thread, so the repaint is marshalled.</summary>
+        private void OnModChanged(object? sender, ModPackage mod) =>
+            Dispatcher.UIThread.Post(ApplyFeatureArt);
+
+        /// <summary>
+        /// The two vibe.png plates, mod override first. A null answer means neither the mod nor this
+        /// head has the picture; the authored bare surface then stands, which is what WPF's resolver
+        /// falls back to as well.
+        /// </summary>
+        private void ApplyFeatureArt()
+        {
+            var art = Helpers.ModArt.TryLoad("features/vibe.png");
+            if (art == null) return;
+
+            HapticsHeroArt.Background = new ImageBrush(art)
+            {
+                Stretch = Stretch.UniformToFill,
+                AlignmentX = AlignmentX.Right,
+            };
+            ImgVideoHapticSync.Source = art;
         }
 
         // ponytail: every handler below forwards to MainWindow on WPF

--- a/CCP.Avalonia/Views/Tabs/LeaderboardTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/LeaderboardTabView.axaml.cs
@@ -177,9 +177,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         /// <summary>
         /// Repaints the segmented Monthly/All-Time pill, as UpdateLeaderboardModeButtons does.
-        /// Gold for the active All-Time half is a literal there too. The mod accent (App.Mods
-        /// .GetAccentColorHex) is not on this seam, so the pink comes from the theme resource the
-        /// markup already uses; that is the same colour until a mod repaints it.
+        /// Gold for the active All-Time half is a literal there too.
+        ///
+        /// ponytail: the mod accent IS on the seam - <c>CoreMods.AccentColorHex</c> plus
+        /// <c>CoreMods.TryParseHexColor</c> is what WPF's <c>App.Mods.GetAccentColorHex</c>
+        /// reduces to, and this method just has not been switched over. The theme resource used
+        /// here is the same colour until a mod repaints it, so nothing reads wrong meanwhile; the
+        /// change is two lines plus a <c>CoreMods.ModChanged</c> repaint.
         /// </summary>
         private void UpdateModeButtons()
         {

--- a/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
@@ -100,13 +100,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         // ---- STUBS ----------------------------------------------------------------
 
-        // ponytail: needs QuestService, wired when it moves to Core.
+        // ponytail: needs ConditioningControlPanel/Services/Progression/QuestService.cs
+        // (RerollDailyQuest) plus the reroll budget on Models/QuestProgress.CanRerollWeekly.
         private void OnDailyCardRerollRequested(object? sender, EventArgs e) { }
 
-        // ponytail: needs QuestService, wired when it moves to Core.
+        // ponytail: needs ConditioningControlPanel/Services/Progression/QuestService.cs
+        // (RerollWeeklyQuest), as MainWindow.QuestsTab.cs:62 calls it.
         private void RerollWeekly() { }
 
-        // ponytail: needs QuestStreakService, wired when it moves to Core.
+        // ponytail: there is NO QuestStreakService - the name in the note this replaces does not
+        // exist anywhere in the repo. The streak fix is
+        // ConditioningControlPanel/Services/Progression/SkillTreeService.cs:423 (UseStreakShield,
+        // for the charge count) plus the signed-in check, painted by
+        // ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs:748. The dates it writes,
+        // AppSettings.StreakShieldUsedDates, are already in Core.
         private void FixStreak() { }
 
         // ---- STREAK CALENDAR ------------------------------------------------------
@@ -115,7 +122,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// Placeholder streak strip: seven day pips across the canvas, the first four stamped.
         /// The WPF original paints this from MainWindow on every quest refresh; painting a sample
         /// here keeps the 50px band from rendering as an unexplained blank in the render proof.
-        /// ponytail: needs QuestStreakService for the real days, wired when it moves to Core.
+        /// ponytail: half of the real calendar is reachable - AppSettings.StreakShieldUsedDates is
+        /// in Core. The completion dates are not: they are QuestService.Progress
+        /// .DailyQuestCompletionDates from
+        /// ConditioningControlPanel/Services/Progression/QuestService.cs. WPF paints the whole
+        /// CURRENT MONTH day by day (MainWindow.QuestsTab.cs:563), not seven pips, so this
+        /// placeholder is a different shape as well as different data.
         /// </summary>
         private void PaintStreakCalendar()
         {

--- a/CCP.Avalonia/Views/Tabs/RemoteControlTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/RemoteControlTabView.axaml
@@ -24,7 +24,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
-             xmlns:tabs="clr-namespace:ConditioningControlPanel.Avalonia.Views.Tabs"
+             xmlns:models="clr-namespace:ConditioningControlPanel.Models;assembly=CCP.Core"
              x:Class="ConditioningControlPanel.Avalonia.Views.Tabs.RemoteControlTabView"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
@@ -448,7 +448,7 @@
                                         </ItemsPanelTemplate>
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="tabs:EmotePresetSample">
+                                        <DataTemplate x:DataType="models:EmotePreset">
                                             <Grid Margin="0,0,12,0" Width="80">
                                                 <StackPanel HorizontalAlignment="Center">
                                                     <Button Theme="{StaticResource EmoteCircleButtonStyle}"

--- a/CCP.Avalonia/Views/Tabs/RemoteControlTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/RemoteControlTabView.axaml.cs
@@ -1,39 +1,101 @@
-using System.Collections.Generic;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
     public partial class RemoteControlTabView : UserControl
     {
+        /// <summary>True while the seed writes the controls, so no handler mistakes the echo for a
+        /// user edit. Starts TRUE, the directory's established pattern (AwarenessTabView,
+        /// BambiTakeoverTabView): the .axaml wires IsCheckedChanged itself, so the moment any box
+        /// here is given IsChecked="True" in markup the handler fires from inside
+        /// InitializeComponent, before the ctor has read settings - and would save the markup
+        /// default over the user's file.</summary>
+        private bool _isLoading = true;
+
         public RemoteControlTabView()
         {
-            AvaloniaXamlLoader.Load(this);
+            InitializeComponent(); // generated: loads the XAML AND fills the x:Name fields
 
-            // Placeholder data. On WPF these come from App.Settings.Current.RemoteEmotePresets and
-            // from the live command feed; both live behind services that are still in the WPF head.
-            // They are seeded here so --render-all can prove the emote ControlThemes actually draw -
-            // an empty ItemsControl would hide a template-less button (CLAUDE.md trap 4).
-            this.FindControl<ItemsControl>("LstEmotePresets")!.ItemsSource = new List<EmotePresetSample>
-            {
-                new("👋", "hi bambi"),
-                new("💗", "good girl"),
-                new("😈", "deeper"),
-                new("🌀", "drop"),
-                new("🔔", "focus"),
-            };
-            this.FindControl<ListBox>("LstRemoteCommandLog")!.ItemsSource = new List<string>
+            // The emote slots are AppSettings.RemoteEmotePresets, which is in Core - the same five
+            // EmotePreset instances the WPF picker binds (MainWindow.Settings.cs:93). OnDeserialized
+            // has already padded/truncated to exactly 5, so the ItemsControl never sees an odd count,
+            // and an unseeded head gets DefaultRemoteEmotePresets().
+            var s = CoreSettings.Current;
+            LstEmotePresets.ItemsSource = s.RemoteEmotePresets;
+            ChkStopEffectsOnRemoteDisconnect.IsChecked = s.StopEffectsOnRemoteDisconnect;
+            ChkRemoteShareAvatar.IsChecked = s.RemoteShareAvatar;
+            _isLoading = false;
+
+            // Placeholder feed. On WPF the log is written by RemoteControlService
+            // (ConditioningControlPanel/Services/RemoteControlService.cs), which is head-side: it
+            // owns the HTTP session, the poll loop and the code minting. Seeded so --render-all
+            // proves the row template actually draws (CLAUDE.md trap 4).
+            LstRemoteCommandLog.ItemsSource = new[]
             {
                 "20:14  controller connected",
                 "20:14  tier set to Light",
             };
         }
 
-        // ponytail: every handler below routes to MainWindow on WPF (Window.GetWindow(this) is
-        // MainWindow mw -> mw.<same name>). Needs the MainWindow.RemoteControl partial, wired when
-        // RemoteControlService moves to Core. Names kept identical so that wiring diffs cleanly.
+        // Pure settings round-trip, as MainWindow.RemoteControl.cs:297 does it.
+        private void ChkStopEffectsOnRemoteDisconnect_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var want = ChkStopEffectsOnRemoteDisconnect.IsChecked ?? false;
+            if (CoreSettings.Current.StopEffectsOnRemoteDisconnect == want) return;
+            CoreSettings.Current.StopEffectsOnRemoteDisconnect = want;
+            CoreSettings.Save();
+        }
+
+        // Settings half of MainWindow.RemoteControl.cs:309. The other half pushes the new value to a
+        // LIVE controller within one poll instead of ~15s; that needs App.RemoteControl
+        // (ConditioningControlPanel/Services/RemoteControlService.cs), and no session can exist on
+        // this head, so the privacy setting is stored honestly and no push is being skipped.
+        private void ChkRemoteShareAvatar_Changed(object? sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var want = ChkRemoteShareAvatar.IsChecked ?? false;
+            if (CoreSettings.Current.RemoteShareAvatar == want) return;
+            CoreSettings.Current.RemoteShareAvatar = want;
+            CoreSettings.Save();
+        }
+
+        // View half of MainWindow.RemoteControl.cs:647 - reveal the opt-in form, then pre-populate.
+        private void ChkOptIntoDirectory_Changed(object? sender, RoutedEventArgs e)
+        {
+            var checkedNow = ChkOptIntoDirectory.IsChecked == true;
+            OptInFormPanel.IsVisible = checkedNow;
+            if (checkedNow) PopulateOptInFormFromSavedSettings();
+        }
+
+        // Mirrors MainWindow.RemoteControl.cs:660. SavedDirectoryTags is on AppSettings, in Core.
+        private void PopulateOptInFormFromSavedSettings()
+        {
+            var saved = CoreSettings.Current.SavedDirectoryTags;
+            if (saved == null) return;
+            foreach (var cb in new[]
+            {
+                ChkTagBimbo, ChkTagDrone, ChkTagTrance, ChkTagFeminization, ChkTagSubmission,
+                ChkTagDegradation, ChkTagAudioOk, ChkTagSoftOnly, ChkTagLockdownOk, ChkTagChastity,
+            })
+            {
+                cb.IsChecked = cb.Tag is string tag && saved.Contains(tag);
+            }
+        }
+
+        // REFUSED, not merely missing: on WPF this handler is a premium gate that mints a session
+        // code for someone else to drive this app (MainWindow.RemoteControl.cs:35 -
+        // TierGate.RequiresPremium, revert-then-refuse). Persisting the flag here would leave a
+        // toggle reading "remote control on" with no gate consulted and no session behind it. Needs
+        // ConditioningControlPanel/Services/RemoteControlService.cs and TierGate.
+        private void ChkRemoteControlEnabled_Changed(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: the rest forward to MainWindow on WPF (Window.GetWindow(this) is MainWindow mw
+        // -> mw.<same name>) and need ConditioningControlPanel/Services/RemoteControlService.cs -
+        // the session code, the share link, the command push and the directory listing. Names kept
+        // identical so that wiring diffs cleanly.
         private void BtnCopyRemoteCode_Click(object? sender, RoutedEventArgs e) { }
         private void BtnCopyRemoteLink_Click(object? sender, RoutedEventArgs e) { }
         private void BtnEditEmoteCancel_Click(object? sender, RoutedEventArgs e) { }
@@ -44,21 +106,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void BtnGateUnlock_Click(object? sender, RoutedEventArgs e) { }
         private void BtnStopRemote_Click(object? sender, RoutedEventArgs e) { }
         private void ChkOptInTag_Click(object? sender, RoutedEventArgs e) { }
-        private void ChkOptIntoDirectory_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkRemoteControlEnabled_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkRemoteShareAvatar_Changed(object? sender, RoutedEventArgs e) { }
-        private void ChkStopEffectsOnRemoteDisconnect_Changed(object? sender, RoutedEventArgs e) { }
         private void CmbRemoteTier_SelectionChanged(object? sender, SelectionChangedEventArgs e) { }
         private void TierCard_Click(object? sender, PointerReleasedEventArgs e) { }
         private void TxtEditEmoteText_TextChanged(object? sender, TextChangedEventArgs e) { }
         private void TxtEmoteCustom_KeyDown(object? sender, KeyEventArgs e) { }
         private void TxtOptInStatus_TextChanged(object? sender, TextChangedEventArgs e) { }
     }
-
-    /// <summary>
-    /// Stand-in for the WPF head's <c>Models/AppSettings.cs:EmotePreset</c>, which has not moved to
-    /// Core yet. Only the two members the preset DataTemplate binds; swap the x:DataType for the
-    /// real type when the model lands.
-    /// </summary>
-    public sealed record EmotePresetSample(string Icon, string Text);
 }

--- a/CCP.Avalonia/Views/Tabs/SheListeningTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/SheListeningTabView.axaml
@@ -8,11 +8,13 @@
        helpers:EmojiTextBlock            -> TextBlock (Avalonia renders colour emoji natively)
        Image + EmojiToImageSource        -> TextBlock with the emoji (CLAUDE.md trap 3)
        Content="..." on a Button         -> a TextBlock child (Avalonia parses "_" as an access key)
-       ImageBrush + BitmapImage pack://  -> dropped (ponytail: Resources/features/audio_whispers.png
-                                            does not ship in CCP.Avalonia; the hero keeps its bare
-                                            surface and the side plate keeps the wash + scrim, the
-                                            same call as LockCardFeatureControl)
-       Border.OpacityMask gradient       -> dropped with the art it masked
+       ImageBrush + BitmapImage pack://  -> the two Borders are NAMED (SheListeningHeroArt,
+                                            SheListeningSideArt) and painted in code-behind through
+                                            Helpers.ModArt.TryLoad("features/audio_whispers.png"),
+                                            which is the mod override first and this head's
+                                            avares:// copy second. DecodePixelWidth has no Avalonia
+                                            equivalent on a brush, so both decode at full size.
+       Border.OpacityMask gradient       -> kept; Avalonia has OpacityMask on Visual
        LinearGradientBrush "0,1"/"0,0"   -> "0%,100%"/"0%,0%" (RelativePoint needs the % form)
        local TabHue* brushes             -> SectionHueStudio{,Border,Wash}Brush from Theme/Brushes.xaml.
                                             Byte-identical colours (#FFFF7E6B / #40FF7E6B / the same
@@ -49,6 +51,19 @@
                 <Border Height="72" CornerRadius="16" Background="{DynamicResource SurfaceBgBrush}"
                         BorderBrush="{StaticResource SectionHueStudioBorderBrush}" BorderThickness="2" Margin="0,0,0,12">
                     <Grid>
+                        <!-- Hero plate. The art is painted in code (SheListeningHeroArt.Background)
+                             so a mod's features/audio_whispers.png outranks the shipped copy; the
+                             OpacityMask is the WPF gradient, which Avalonia supports on any Visual. -->
+                        <Border x:Name="SheListeningHeroArt" CornerRadius="0,16,16,0"
+                                Width="240" HorizontalAlignment="Right" Opacity="0.9">
+                            <Border.OpacityMask>
+                                <LinearGradientBrush StartPoint="0%,0%" EndPoint="100%,0%">
+                                    <GradientStop Color="#00000000" Offset="0"/>
+                                    <GradientStop Color="#E6000000" Offset="0.55"/>
+                                </LinearGradientBrush>
+                            </Border.OpacityMask>
+                        </Border>
+
                         <StackPanel VerticalAlignment="Center" Margin="18,0,0,0">
                             <TextBlock Text="She's Listening" FontSize="17" FontWeight="Bold"
                                        Foreground="{StaticResource TextLightBrush}"/>
@@ -387,10 +402,13 @@
                         </Border>
                     </StackPanel>
 
-                    <!-- SIDE ART. Plate dropped (see header); the wash and the scrim keep the card's
-                         shape. Pinned top with the authored fixed height - column 0 is far taller
-                         than any plate should be. -->
-                    <Border Grid.Column="1" Margin="12,0,0,0" CornerRadius="14"
+                    <!-- SIDE ART. The plate is the Border's BACKGROUND, not a child Image: a Border
+                         clips its Background to CornerRadius but not its child content, so a child
+                         Image would square off the rounded corners (the WPF file's round-2 lesson).
+                         Painted in code; the wash below stays as the no-art fallback. Pinned top
+                         with the authored fixed height - column 0 is far taller than any plate. -->
+                    <Border x:Name="SheListeningSideArt"
+                            Grid.Column="1" Margin="12,0,0,0" CornerRadius="14"
                             BorderThickness="2" BorderBrush="{StaticResource VelvetCardBorderBrush}"
                             Background="{StaticResource SectionHueStudioWashBrush}"
                             VerticalAlignment="Top" Height="520">

--- a/CCP.Avalonia/Views/Tabs/SheListeningTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/SheListeningTabView.axaml.cs
@@ -1,5 +1,8 @@
 using System;
 using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Threading;
+using ConditioningControlPanel.Models;
 
 namespace ConditioningControlPanel.Avalonia.Views.Tabs
 {
@@ -11,41 +14,101 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// push-to-talk, headphone barge-in) are owned by Settings &gt; Devices since Phase 2 of the UX
     /// restructure and appear here only as read-only chips.
     ///
-    /// <para><b>Every handler on the WPF head is a one-line shim</b> - it looks up the hosting
-    /// MainWindow and forwards to a MainWindow partial (SL_Mantras_Changed, SL_Calibrate_Click,
-    /// OpenDeviceSettings, ToggleVoiceMic, SL_MicSensitivity_Changed, BtnTestVoice_Click,
-    /// BtnGateUnlock_Click, SL_RevokeMicConsent_Click). None of those partials is on this head, so
-    /// each one is a stub here; there is no view-only handler to port. The sensitivity readout is
-    /// the exception: painting a percentage next to the slider is pure view state, so it is real.</para>
+    /// <para><b>What is real here.</b> The mic-sensitivity dial is a stored threshold on
+    /// <see cref="AppSettings.SpeechLoudnessThreshold"/> (Core), so its load, its readout and its
+    /// save are the WPF round-trip verbatim - see <see cref="SensToThreshold"/>. The two
+    /// audio_whispers plates are painted through <see cref="Helpers.ModArt.TryLoad"/> and repainted
+    /// on <see cref="CoreMods.ModChanged"/>, which is the WPF ModResourceResolver behaviour split
+    /// across the seam.</para>
     ///
-    /// <para>The mod-aware feature art (ModService.ModChanged -&gt; ModResourceResolver repainting
-    /// the two audio_whispers.png plates) is dropped with the plates themselves - see the XAML
-    /// header. ponytail: restore both together when Resources/features ships on this head.</para>
+    /// <para><b>What is deliberately still a stub.</b> The remaining buttons forward to
+    /// ConditioningControlPanel/MainWindow/MainWindow.SheListening.cs, which owns the mic itself
+    /// (App.Speech), the wake-word calibration and the premium gate - none of that is on this head.
+    /// <c>ChkSL_Mantras</c> is REFUSED rather than stubbed-with-persistence: on WPF
+    /// (MainWindow.SheListening.cs:51) turning it on opens MicConsentDialog and reverts the box when
+    /// consent is declined. Writing the setting here would record "spoken mantras on" with the
+    /// consent gate never shown. <c>BtnSL_MicMaster</c> is refused for the sibling reason - it would
+    /// read "Stop listening" over a device nothing has opened.</para>
     /// </summary>
     public partial class SheListeningTabView : UserControl
     {
+        // MainWindow.SheListening.cs:406 - the slider's two ends, copied so the stored threshold
+        // means the same thing on both heads.
+        private const double LoudThrAtMinSens = 0.045; // slider 0%
+        private const double LoudThrAtMaxSens = 0.004; // slider 100%
+
+        private static double SensToThreshold(double sens)
+            => LoudThrAtMinSens - (LoudThrAtMinSens - LoudThrAtMaxSens) * (Math.Clamp(sens, 0, 100) / 100.0);
+        private static double ThresholdToSens(double thr)
+            => Math.Clamp((LoudThrAtMinSens - thr) / (LoudThrAtMinSens - LoudThrAtMaxSens) * 100.0, 0, 100);
+
+        private bool _isLoading;
+
         public SheListeningTabView()
         {
             InitializeComponent(); // generated: loads the XAML and fills the x:Name fields
 
-            // ponytail: each of these needs the MainWindow.SheListening partial (mic service, wake
-            // calibration, premium gate, consent store); wired when they move to Core.
+            // Refused, not missing - see the class note. Each would need
+            // ConditioningControlPanel/MainWindow/MainWindow.SheListening.cs (App.Speech, the wake
+            // calibration, the premium gate, MicConsentDialog).
             BtnSL_MicMaster.Click += (_, _) => { };          // mw.ToggleVoiceMic()
             BtnSL_OpenDeviceSettings.Click += (_, _) => { }; // mw.OpenDeviceSettings()
             BtnSL_Calibrate.Click += (_, _) => { };          // mw.SL_Calibrate_Click(...)
             BtnSL_TestMantra.Click += (_, _) => { };         // mw.BtnTestVoice_Click(...)
             BtnSL_RevokeConsent.Click += (_, _) => { };      // mw.SL_RevokeMicConsent_Click(...)
             BtnSL_GateUnlock.Click += (_, _) => { };         // mw.BtnGateUnlock_Click(...)
-            ChkSL_Mantras.IsCheckedChanged += (_, _) => { }; // mw.SL_Mantras_Changed(...)
+            ChkSL_Mantras.IsCheckedChanged += (_, _) => { }; // mw.SL_Mantras_Changed(...) - consent gate
 
-            // View-only half of SL_MicSensitivity_Changed: the readout beside the slider. Format
-            // copied verbatim from MainWindow.SheListening.cs:427 - Math.Round, not a truncating
-            // cast, so 49.6 reads 50 the way it does on WPF. The settings write that handler also
-            // does is the stubbed half.
-            SldSL_MicSensitivity.ValueChanged += (_, e) => TxtSL_MicSensitivity.Text = $"{(int)Math.Round(e.NewValue)}%";
+            // MainWindow.SheListening.cs:419, both halves. The readout uses Math.Round, not a
+            // truncating cast, so 49.6 reads 50 the way it does on WPF.
+            SldSL_MicSensitivity.ValueChanged += (_, e) =>
+            {
+                TxtSL_MicSensitivity.Text = $"{(int)Math.Round(e.NewValue)}%";
+                if (_isLoading) return;
+                CoreSettings.Current.SpeechLoudnessThreshold = SensToThreshold(e.NewValue);
+                CoreSettings.Save();
+            };
 
-            // Placeholder start value; the real one comes from settings when the mic service lands.
-            SldSL_MicSensitivity.Value = 50;
+            _isLoading = true;
+            SldSL_MicSensitivity.Value = ThresholdToSens(CoreSettings.Current.SpeechLoudnessThreshold);
+            _isLoading = false;
+
+            ApplyFeatureArt();
+        }
+
+        protected override void OnAttachedToVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            CoreMods.ModChanged += OnModChanged;
+            ApplyFeatureArt();
+        }
+
+        protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+        {
+            CoreMods.ModChanged -= OnModChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        /// <summary>ModChanged can be raised off the UI thread, so the repaint is marshalled.</summary>
+        private void OnModChanged(object? sender, ModPackage mod) =>
+            Dispatcher.UIThread.Post(ApplyFeatureArt);
+
+        /// <summary>
+        /// The WPF ImageBrush pair, resolved mod-first. A null answer means neither the mod nor this
+        /// head has the picture, and the authored surface - a bare hero, the wash on the side card -
+        /// stands, which is what WPF's resolver falls back to as well.
+        /// </summary>
+        private void ApplyFeatureArt()
+        {
+            var art = Helpers.ModArt.TryLoad("features/audio_whispers.png");
+            if (art == null) return;
+
+            SheListeningHeroArt.Background = new ImageBrush(art)
+            {
+                Stretch = Stretch.UniformToFill,
+                AlignmentX = AlignmentX.Right,
+            };
+            SheListeningSideArt.Background = new ImageBrush(art) { Stretch = Stretch.UniformToFill };
         }
     }
 }


### PR DESCRIPTION
Mod art. Four tabs drew a bare surface where WPF drew a picture, and the note
in each said the resolver was the blocker. It is not: Helpers.ModArt.TryLoad
plus CoreMods.ModChanged is the same answer ModResourceResolver gives, split
across the seam, and the art is already linked. What actually blocked them was
a missing target in the markup, which a code-only layer could not add. Deeper
(hero + side plate), BambiTakeover (hero strip + description thumb + side
plate, BambiSleep's "bambi takeover.png" fork included), She's Listening (hero
+ side plate) and Haptics (hero + the Video-Haptic-Sync thumb) now name the
Border or Image and paint it from code, mod override first, repainting on
ModChanged and unsubscribing on detach. Every authored wash, glyph and scrim
stays underneath as the no-art fallback, which is the WPF null path. WPF's
ImgHapticsVibeDesc is deliberately NOT ported: it is a 0x0 collapsed compat
shim that exists only so a shared partial has something to write .Source on.

Remote Control. EmotePreset is in Core, so the five emote slots bind
CoreSettings.Current.RemoteEmotePresets instead of a local sample record, and
the DataTemplate's x:DataType carries ";assembly=CCP.Core". The two privacy
toggles round-trip settings for real, the directory opt-in form reveals itself
and pre-populates from SavedDirectoryTags, and the file moved off
AvaloniaXamlLoader.Load onto InitializeComponent so its x:Name fields are not
silently null. ChkRemoteControlEnabled stays REFUSED: on WPF it is a premium
gate that mints a session code for a stranger to drive the app, and a toggle
reading "on" with no gate consulted and no session behind it is worse than an
inert one.

She's Listening. The mic-sensitivity dial is a stored threshold, so its load,
its readout and its save are the WPF round-trip verbatim, SensToThreshold
constants included. ChkSL_Mantras and BtnSL_MicMaster stay refused for the
sibling reason - one is a mic-consent gate, the other would read "Stop
listening" over a device nothing opened.

Awareness. LnkAwarenessAdvanced_Click is WPF's own no-preset branch,
KeywordPanel.RevealTriggerEditor(), which this head already ships, so the link
is no longer a dead click. BtnAwarenessTutorial_Click now routes to
CoreTutorial.Start("Awareness"); this head does not seed CoreTutorial
.StartAction, so that one reaches the seam and shows no tour yet - the note
above it says exactly that.

Notes. Six files carried claims that are false today and each is rewritten to
name the blocker that is real now, with its head path: DailyFreeService is in
Core, Serilog's static Log replaces App.Logger, CoreMods.AccentColorHex is the
mod accent the Leaderboard pill says it cannot reach, and there is no
QuestStreakService anywhere in the repo - the streak fix is SkillTreeService
.UseStreakShield and the calendar is QuestService.Progress
.DailyQuestCompletionDates over a whole month, not seven pips.

Still blocked:
- ExclusivesTabView.LoadBackdrop - Assets/exclusives/** is not among the
  AvaloniaResource globs in CCP.Avalonia.csproj (outside this layer), and the
  markup has no VaultBackdrop Image; the picture itself exists.
- HapticsTabView Tier-1 side-art column - needs the 3*/2* ColumnDefinitions and
  the scrim Border restored in CCP.Avalonia/Views/Tabs/HapticsTabView.axaml.
- CoreTutorial.StartAction is unseeded on this head, so no tour runs.
- ConditioningControlPanel/Services/RemoteControlService.cs - the session code,
  the share link, the command push, the directory listing.
- ConditioningControlPanel/MainWindow/MainWindow.SheListening.cs and
  Views/Dialogs/MicConsentDialog - the mic itself and its consent gate.
- ConditioningControlPanel/Views/Dialogs/AwarenessPresetDetailDialog.xaml - the
  preferred branch of LnkAwarenessAdvanced_Click and the post-tour editor pop.
- ConditioningControlPanel/Services/Progression/QuestService.cs and
  SkillTreeService.cs - quest rerolls, the streak fix, the real calendar.
- ConditioningControlPanel/Models/ExclusiveFeature.cs,
  Features/VaultLivery.cs, Services/FxTheme.cs - the vault registry and livery.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU