### PR TITLE
feat(avalonia): dialogs get their art, their guard prompt and their logs back

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/AwarenessAppPickerDialog.axaml.cs
@@ -3,15 +3,11 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading.Tasks;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
-using Avalonia.Media;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Services.Awareness;
 
@@ -47,13 +43,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// <list type="bullet">
     ///   <item>WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>; the caller uses
     ///   <c>ShowDialog&lt;bool?&gt;</c>. <see cref="Result"/> is unchanged.</item>
-    ///   <item><c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so
-    ///   <see cref="Ask"/> is the same minimal stand-in <see cref="TextEditorDialog"/> uses. It is
-    ///   async, so <c>Row_Unchecked</c> became one async handler over both tick directions.</item>
-    ///   <item><c>AwarenessPrivacyRules.IsGroupToken</c>/<c>ChipLabelKey</c> are pure string logic
-    ///   pinned to the WPF head (their class reads <c>App.Logger</c> and <c>AppSettings</c>), so
-    ///   <see cref="GroupTokens"/> below mirrors those two members verbatim. The real fix is moving
-    ///   them to Core, which this port may not touch.</item>
+    ///   <item><c>MessageBox.Show</c> becomes <see cref="MessageDialog"/>, this head's message box.
+    ///   It is async, so <c>Row_Unchecked</c> became one async handler over both tick directions.
+    ///   The guard prompt reads OK/Cancel rather than WPF's OS-supplied Yes/No, and those two
+    ///   labels are localised where the old hand-rolled stand-in's English "Yes"/"No" were not.
+    ///   The guard prompt passes <c>defaultToCancel</c>, which is the WPF call's
+    ///   <c>MessageBoxResult.No</c>: Enter, Cancel and the window X all KEEP the guard, and only
+    ///   an explicit OK drops one.</item>
+    ///   <item><c>AwarenessPrivacyRules.IsGroupToken</c>/<c>ChipLabelKey</c> are called directly:
+    ///   the class is in Core now (CCP.Core/Services/Awareness/AwarenessPrivacyRules.cs), so the
+    ///   verbatim mirror this port used to carry is gone. A group token's meaning is therefore
+    ///   decided in exactly one place again.</item>
     /// </list>
     /// </summary>
     public partial class AwarenessAppPickerDialog : Window
@@ -146,8 +146,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private AwarenessPickRow MakeRow(string raw, bool isListed)
         {
-            bool group = GroupTokens.IsGroupToken(raw);
-            var labelKey = GroupTokens.ChipLabelKey(raw);
+            bool group = AwarenessPrivacyRules.IsGroupToken(raw);
+            var labelKey = AwarenessPrivacyRules.ChipLabelKey(raw);
 
             return new AwarenessPickRow
             {
@@ -188,19 +188,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                 return;
             }
 
-            var answer = await Ask(
+            // defaultToCancel is the WPF call's MessageBoxResult.No: Enter must KEEP the guard.
+            var answer = await MessageDialog.ConfirmAsync(this,
                 Loc.Get("companion_awareness_picker_drop_guard_title"),
                 Loc.GetF("companion_awareness_picker_drop_guard", row.Label),
-                ("Yes", true), ("No", false));
+                defaultToCancel: true);
 
-            if (answer == true)
+            if (answer)
             {
                 row.IsListed = false;
                 return;
             }
 
-            // Anything but an explicit Yes keeps the guard, matching MessageBoxResult.No as the
-            // WPF default - dismissing the prompt must never disarm one.
+            // Anything but an explicit OK keeps the guard, matching MessageBoxResult.No as the
+            // WPF default - Cancel and the window X both answer false, so dismissing the prompt
+            // can never disarm one.
             // Put the tick back without re-entering this handler.
             _suppressPrompt = true;
             try { box.IsChecked = true; row.IsListed = true; }
@@ -221,9 +223,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             var clean = AwarenessText.SanitizeRuleEntry(_txtNewItem.Text);
             if (clean == null)
             {
-                await Ask(Loc.Get("title_confirm"),
-                    Loc.Get("companion_awareness_picker_bad_entry"),
-                    (Loc.Get("btn_ok"), true));
+                await MessageDialog.ShowAsync(this, Loc.Get("title_confirm"),
+                    Loc.Get("companion_awareness_picker_bad_entry"));
                 return;
             }
 
@@ -267,96 +268,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             Close(false);
         }
 
-        /// <summary>
-        /// Minimal stand-in for WPF's MessageBox, which Avalonia has no equivalent of. Copied from
-        /// <see cref="TextEditorDialog"/> rather than shared, because making it shared would mean
-        /// editing a sibling view another agent may be holding. Each button carries the value
-        /// Close() hands back; dismissing the window yields null. Buttons hold a TextBlock, not
-        /// Content, for the access-key reason in the AXAML header. The app has no btn_yes/btn_no loc
-        /// keys - WPF got those strings from the OS - so Yes and No are English here.
-        /// </summary>
-        private Task<bool?> Ask(string title, string message, params (string Label, bool? Value)[] buttons)
-        {
-            var row = new StackPanel
-            {
-                Orientation = Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Right,
-                Spacing = 8,
-                Margin = new Thickness(0, 16, 0, 0)
-            };
-
-            var dialog = new Window
-            {
-                Title = title,
-                SizeToContent = SizeToContent.WidthAndHeight,
-                CanResize = false,
-                ShowInTaskbar = false,
-                WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                Background = Background,
-                Content = new StackPanel
-                {
-                    Margin = new Thickness(20),
-                    Children =
-                    {
-                        new TextBlock
-                        {
-                            Text = message,
-                            Foreground = Brushes.White,
-                            FontSize = 13,
-                            TextWrapping = TextWrapping.Wrap,
-                            MaxWidth = 360
-                        },
-                        row
-                    }
-                }
-            };
-
-            foreach (var (label, value) in buttons)
-            {
-                var button = new Button
-                {
-                    Content = new TextBlock { Text = label },
-                    Padding = new Thickness(14, 6),
-                    Cursor = new Cursor(StandardCursorType.Hand)
-                };
-                button.Click += (_, _) => dialog.Close(value);
-                row.Children.Add(button);
-            }
-
-            return dialog.ShowDialog<bool?>(this);
-        }
     }
 
-    /// <summary>
-    /// The two pure members of the head's <c>AwarenessPrivacyRules</c> that this dialog needs,
-    /// copied verbatim (constants included). That class cannot be referenced from here: it reads
-    /// <c>App.Logger</c> and <c>AppSettings</c>, so it is pinned to the WPF head, and this port may
-    /// touch neither the head nor Core. Deleting this mirror is the same change as moving
-    /// <c>IsGroupToken</c>/<c>ChipLabelKey</c> into CCP.Core.
-    /// </summary>
-    internal static class GroupTokens
-    {
-        private const string GroupPasswordManagers = "@passwords";
-        private const string GroupBanking = "@banking";
-        private const string GroupEmailTitles = "@email-titles";
-
-        private static bool TokenIs(string? entry, string token) =>
-            string.Equals(entry?.Trim(), token, StringComparison.OrdinalIgnoreCase);
-
-        /// <summary>True when this entry is one of the seeded group tokens rather than a typed substring.</summary>
-        public static bool IsGroupToken(string? entry) =>
-            !string.IsNullOrWhiteSpace(entry) && entry.TrimStart().StartsWith("@", StringComparison.Ordinal) &&
-            (TokenIs(entry, GroupPasswordManagers) || TokenIs(entry, GroupBanking) || TokenIs(entry, GroupEmailTitles));
-
-        /// <summary>The loc key naming a deny entry in the panel — a friendly label for a group token.</summary>
-        public static string ChipLabelKey(string? entry) => (entry ?? string.Empty).Trim().ToLowerInvariant() switch
-        {
-            GroupPasswordManagers => "companion_awareness_deny_passwords",
-            GroupBanking => "companion_awareness_deny_banking",
-            GroupEmailTitles => "companion_awareness_deny_email",
-            _ => string.Empty
-        };
-    }
 
     /// <summary>Strings from CCP.Core's Loc. See the porting notes in the repo-root CLAUDE.md
     /// for why {loc:Str} becomes a binding. The four strings the code-behind sets directly are not

--- a/CCP.Avalonia/Views/Dialogs/KnowledgeLinkEditorDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/KnowledgeLinkEditorDialog.axaml
@@ -7,9 +7,11 @@
            The original is a latent WPF bug: a loc auto-pass swallowed the literal enum value, so it
            only parses while the active language is English ("Height"); de.json gives "Höhe".
        MessageBox.Show(validation)      -> the inline TxtError TextBlock below, which occupies the
-           row 3 spacer the original left empty. Avalonia has no MessageBox, and this is the same
-           shape UrlPromptDialog already uses. The hardcoded "Validation Error" caption has no
-           equivalent and drops out. -->
+           row 3 spacer the original left empty. This head does have a message box now
+           (Views/Dialogs/MessageDialog) - the inline label is the deliberate choice over it, the
+           same shape UrlPromptDialog uses: a validation message belongs next to the field that
+           failed, not behind a modal you must dismiss before you can fix it. The hardcoded
+           "Validation Error" caption has no equivalent and drops out. -->
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="ConditioningControlPanel.Avalonia.Views.Dialogs.KnowledgeLinkEditorDialog"

--- a/CCP.Avalonia/Views/Dialogs/MessageDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/MessageDialog.axaml.cs
@@ -24,7 +24,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             showCancel: true)
         { }
 
-        public MessageDialog(string title, string message, bool showCancel)
+        public MessageDialog(string title, string message, bool showCancel, bool defaultToCancel = false)
         {
             InitializeComponent();
 
@@ -32,10 +32,22 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             this.FindControl<TextBlock>("TxtTitle")!.Text = title;
             this.FindControl<TextBlock>("TxtMessage")!.Text = message;
 
+            var ok = this.FindControl<Button>("BtnOk")!;
             var cancel = this.FindControl<Button>("BtnCancel")!;
             cancel.IsVisible = showCancel;
             cancel.Click += (_, _) => Close(false);
-            this.FindControl<Button>("BtnOk")!.Click += (_, _) => Close(true);
+            ok.Click += (_, _) => Close(true);
+
+            // WPF's MessageBox.Show takes a defaultResult, and a guard prompt passes No so that
+            // Enter keeps the guard. IsDefault lives on OK in the markup, so it has to MOVE, not
+            // just lose focus: leaving it on OK would let Enter answer yes to the one question
+            // where a stray keypress must not.
+            if (showCancel && defaultToCancel)
+            {
+                ok.IsDefault = false;
+                cancel.IsDefault = true;
+                Opened += (_, _) => cancel.Focus();
+            }
         }
 
         /// <summary>Tells the user something. One OK button, so the result is true unless they
@@ -44,7 +56,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             => await new MessageDialog(title, message, showCancel: false).ShowDialog<bool?>(owner) == true;
 
         /// <summary>Asks the user something. True only on OK - Cancel and the X both answer false.</summary>
-        public static async Task<bool> ConfirmAsync(Window owner, string title, string message)
-            => await new MessageDialog(title, message, showCancel: true).ShowDialog<bool?>(owner) == true;
+        /// <param name="defaultToCancel">
+        /// Puts Enter on Cancel instead of OK, for a question where the safe answer is "no": the
+        /// port of a WPF <c>MessageBox.Show(..., MessageBoxResult.No)</c>. Leave it false for the
+        /// rest, which defaulted to the first button.
+        /// </param>
+        public static async Task<bool> ConfirmAsync(Window owner, string title, string message,
+                                                    bool defaultToCancel = false)
+            => await new MessageDialog(title, message, showCancel: true, defaultToCancel)
+                .ShowDialog<bool?>(owner) == true;
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/ModManagerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ModManagerDialog.axaml.cs
@@ -14,6 +14,7 @@ using Avalonia.Platform.Storage;
 using ConditioningControlPanel.Avalonia.Views.Windows;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -235,9 +236,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                     UseShellExecute = true,
                 });
             }
-            catch
+            catch (Exception ex)
             {
-                // WPF logged through App.Logger here; the head has no logger yet.
+                // The button just does nothing when no handler is registered for an https URI.
+                Log.Warning(ex, "[ModManager] Could not open the web catalogue");
             }
         }
 

--- a/CCP.Avalonia/Views/Dialogs/ModPickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ModPickerDialog.axaml.cs
@@ -26,10 +26,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - <c>Brush.Freeze()</c> has no Avalonia equivalent (immutability is <c>ToImmutable()</c> on
     ///    the concrete brush); the accent is built once per card and never mutated, so it is
     ///    dropped rather than emulated.
-    ///  - <c>ArtUri</c> was a <c>pack://</c> URI into the WPF assembly's Resource items. This head
-    ///    ships no such assets, so the card exposes an <see cref="Art"/> image that is null today
-    ///    and the accent-framed tile behind it is what draws — the same thing WPF shows before the
-    ///    bitmap resolves.
+    ///  - <c>ArtUri</c> was a <c>pack://</c> URI bound straight to <c>Image.Source</c>, never
+    ///    routed through <c>ModResourceResolver</c>. The same six PNGs are linked into this head
+    ///    under <c>avares://CCP.Avalonia/Resources/</c>, and <see cref="Art"/> loads them through
+    ///    <c>Helpers.ModArt.TryLoad</c> - so a mod MAY now override a pass card, which the WPF
+    ///    pack:// path did not allow. Null still draws the accent-framed tile alone, as WPF does
+    ///    before the bitmap resolves.
     /// </summary>
     public sealed class ModPickerCard : INotifyPropertyChanged
     {
@@ -41,8 +43,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         public string Description { get; init; } = "";
 
         /// <summary>
-        /// ponytail: needs the mod card art as an avares:// AvaloniaResource, wired when the
-        /// Resources/intake/ art moves off the WPF head. Null draws the accent-framed tile.
+        /// The pass-card art, mod override first (a tier WPF's bare pack:// URI did not have).
+        /// Null when neither the override nor the shipped copy loads, and the accent-framed tile
+        /// is then the whole card - not a failure.
         /// </summary>
         public IImage? Art { get; init; }
 
@@ -176,8 +179,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// One built-in mod's presentation data. Copied from
     /// ConditioningControlPanel/Dialogs/ModPackCatalog.cs (only the fields this screen reads): the
     /// catalogue lives in the WPF head next to the dialogs, not in CCP.Core, and neither may be
-    /// touched by this port. <c>ArtUri</c> is dropped — its pack:// URIs point into the WPF
-    /// assembly, so nothing here could resolve one.
+    /// touched by this port. WPF's <c>ArtUri</c> becomes <see cref="ArtName"/>: the same file,
+    /// named the way <c>Helpers.ModArt</c> wants it rather than as a <c>pack://</c> URI.
     /// </summary>
     public sealed class ModPickerCatalogEntry
     {
@@ -189,6 +192,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
         public string NameLocKey { get; init; } = "";
         public string DescriptionLocKey { get; init; } = "";
+
+        /// <summary>
+        /// The card's art, as a forward-slash path under <c>Resources/</c> - the shape
+        /// <c>Helpers.ModArt.TryLoad</c> takes, so an active mod may override it.
+        /// </summary>
+        public string ArtName { get; init; } = "";
 
         /// <summary>Mod accent colour, for the card's art frame.</summary>
         public string AccentHex { get; init; } = "#FF69B4";
@@ -223,6 +232,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             new ModPickerCatalogEntry
             {
                 ModId = BuiltInMods.CCPDefaultId,
+                ArtName = "logo.png",
                 PackId = null, // ships in the box — the neutral baseline is what "skip everything" gives you
                 NameLocKey = "modpicker_name_ccp_default",
                 DescriptionLocKey = "modpicker_desc_ccp_default",
@@ -232,6 +242,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             new ModPickerCatalogEntry
             {
                 ModId = BuiltInMods.BambiSleepId,
+                ArtName = "intake/pass_card_bambi.png",
                 PackId = CoreReleaseContent.PackModBambi,
                 NameLocKey = "label_bambi_sleep",
                 DescriptionLocKey = "modpicker_desc_bambi",
@@ -241,6 +252,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             new ModPickerCatalogEntry
             {
                 ModId = BuiltInMods.SissyHypnoId,
+                ArtName = "intake/pass_card_sissy.png",
                 PackId = CoreReleaseContent.PackModSissy,
                 NameLocKey = "label_sissy_hypno",
                 DescriptionLocKey = "modpicker_desc_sissy",
@@ -250,6 +262,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             new ModPickerCatalogEntry
             {
                 ModId = BuiltInMods.LockedId,
+                ArtName = "intake/pass_card_circe.png",
                 PackId = CoreReleaseContent.PackModLocked,
                 NameLocKey = "modpicker_name_circe",
                 DescriptionLocKey = "modpicker_desc_circe",
@@ -260,6 +273,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             new ModPickerCatalogEntry
             {
                 ModId = BuiltInMods.DronificationId,
+                ArtName = "intake/pass_card_drone.png",
                 PackId = CoreReleaseContent.PackModDrone,
                 NameLocKey = "modpicker_name_drone",
                 DescriptionLocKey = "modpicker_desc_drone",
@@ -271,6 +285,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             new ModPickerCatalogEntry
             {
                 ModId = BuiltInMods.InfectionControlId,
+                ArtName = "intake/pass_card_infection.png",
                 PackId = CoreReleaseContent.PackModInfection,
                 NameLocKey = "modpicker_name_infection",
                 DescriptionLocKey = "modpicker_desc_infection",
@@ -437,6 +452,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                     PackId = entry.PackId,
                     Name = Loc.Get(entry.NameLocKey),
                     Description = Loc.Get(entry.DescriptionLocKey),
+                    Art = Helpers.ModArt.TryLoad(entry.ArtName),
                     AccentBrush = accent,
                     PremiumNote = entry.PremiumProgramNote ? Loc.Get("modpicker_note_premium_programs") : "",
                     VoiceNote = entry.NoVoiceNote ? Loc.Get("modpicker_note_no_voice") : ""

--- a/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/RoadmapStepPopup.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -16,7 +17,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// Popup window shown when a roadmap step is completed.
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/RoadmapStepPopup.xaml.cs. Deviations:
-    ///  - <c>App.Logger</c> calls are dropped; the logger lives on the WPF App singleton.
+    ///  - <c>App.Logger</c> becomes Serilog's static <c>Log</c>, which every head configures.
     ///  - <c>App.Roadmap.GetFullPhotoPath</c> becomes <c>MainShellWindow.Roadmap</c>'s; the
     ///    checkmark stays. <see cref="LoadPhotoThumbnail"/> is otherwise the WPF body.
     ///  - <c>SystemParameters.WorkArea</c> -> <c>Screens.Primary.WorkingArea</c>, which is in
@@ -147,9 +148,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                 _photoEllipse.IsVisible = true;
                 _checkmarkIcon.IsVisible = false;
             }
-            catch
+            catch (Exception ex)
             {
-                // Keep showing checkmark icon
+                // Keep showing the checkmark icon - a step whose photo will not decode still
+                // reports as completed, which is what the popup is for.
+                Log.Warning(ex, "[RoadmapStepPopup] Could not load the step photo thumbnail");
             }
         }
 

--- a/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TextEditorDialog.axaml.cs
@@ -20,8 +20,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// PORTED from ConditioningControlPanel/Dialogs/TextEditorDialog.xaml.cs. Deviations:
     ///  - WPF's <c>DialogResult</c> property becomes <c>Close(bool)</c> plus a <c>_dialogResult</c>
     ///    field, because Avalonia carries the result through <c>ShowDialog&lt;bool?&gt;</c>.
-    ///  - <c>MessageBox.Show</c> has no Avalonia equivalent and no package may be added, so
-    ///    <see cref="Ask"/> below is a minimal stand-in.
+    ///  - <c>MessageBox.Show</c> normally becomes <see cref="MessageDialog"/>, this head's message
+    ///    box - but not here. The unsaved-changes prompt is the one call site with THREE answers
+    ///    (Save / Discard / cancel the close), and MessageDialog is deliberately two-button, so
+    ///    <see cref="Ask"/> below stays until either that prompt loses an answer or MessageDialog
+    ///    grows a button set. Wiring it to the two-button dialog would silently drop Cancel and
+    ///    close a window the user asked to keep open.
     ///  - <c>OnClosing</c> cannot prompt synchronously: it cancels the close, awaits the prompt and
     ///    closes again. <c>_dialogResult</c> is what stops it prompting twice.
     ///  - The <c>ItemsSource = null; ItemsSource = _items;</c> refresh hacks are gone. TextItem
@@ -252,9 +256,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         }
 
         /// <summary>
-        /// Minimal stand-in for WPF's MessageBox, which Avalonia has no equivalent of. Each button
-        /// carries the value Close() hands back; dismissing the window yields null, matching the
-        /// Cancel button. Buttons hold a TextBlock, not Content, for the access-key reason above.
+        /// The three-answer prompt <see cref="MessageDialog"/> deliberately does not offer. Each
+        /// button carries the value Close() hands back; dismissing the window yields null, matching
+        /// the Cancel button - so a dismissed prompt cancels the close rather than discarding the
+        /// edits. Buttons hold a TextBlock, not Content, for the access-key reason above.
         /// The app has no btn_yes/btn_no loc keys - WPF got those strings from the OS - so Yes and
         /// No are English here. btn_ok and btn_cancel do exist and are used.
         /// </summary>

--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml
@@ -23,11 +23,14 @@
      is not what the WPF dialog shows. Naming the key here is the smallest fix that does not touch
      a file another layer owns; drop it if the implicit ControlTheme is ever added.
 
-     The two Image elements are placeholder Borders. tube.png / tube2.png and the four avatar
-     poses come from Services.ModResourceResolver (WPF head, pack:// URIs) and this head ships no
-     Resources/ PNGs yet - see the ponytail notes in the code-behind. Everything the dialog exists
-     to show (the nested-Viewbox tube geometry, the margin formulas, the scale transform and the
-     readouts) still runs against the placeholders. -->
+     The two Image elements are Borders, not Images, because each one paints EITHER real art or a
+     placeholder. tube.png / tube2.png and the four avatar poses load through Helpers.ModArt
+     (CoreModArt override first, then this head's avares:// copy of the same file), and a loaded
+     bitmap becomes the Border's Uniform ImageBrush inside the box WPF's <Image> occupied, with the
+     gradient, the frame and the file-name label dropped. A slot that will not load keeps the
+     placeholder, so the dialog never goes blank - and everything it exists to show (the
+     nested-Viewbox geometry, the margin formulas, the scale transform, the readouts) runs either
+     way. -->
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
@@ -140,9 +143,17 @@
                         <Grid Width="780" Height="1020" ClipToBounds="True">
                             <Viewbox Stretch="Uniform">
                                 <Grid Width="780" Height="1080" ClipToBounds="False">
-                                    <!-- Stands in for <Image x:Name="PreviewTube"/>. Its margin is
-                                         retargeted in code so the attached/detached switch moves the
-                                         tube exactly as swapping tube.png for tube2.png does. -->
+                                    <!-- WPF's PreviewTube, verbatim: no size, Uniform, centred in
+                                         this 780x1080 grid. tube.png and tube2.png are both 2048
+                                         square and carry the attached/detached difference inside
+                                         the art, so swapping the Source is the whole switch. -->
+                                    <Image x:Name="PreviewTubeImage" Stretch="Uniform"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           IsVisible="False"/>
+
+                                    <!-- Shown only when neither the mod nor this head has the art.
+                                         Its margin is retargeted in code so the attached/detached
+                                         switch still MOVES something on a head with no PNGs. -->
                                     <Border x:Name="PreviewTube" Width="330" Height="980"
                                             HorizontalAlignment="Left" VerticalAlignment="Top"
                                             CornerRadius="165" BorderThickness="10"

--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -8,7 +7,6 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using ConditioningControlPanel.Avalonia.Views.AvatarTube;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
@@ -91,6 +89,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private readonly bool _portraitMode;
         /// <summary>The four loaded poses; a slot is null when neither the mod nor this head has it.</summary>
         private readonly Bitmap?[] _poses = new Bitmap?[4];
+        /// <summary>Attached and detached tube art, decoded once. Both are 2048 square, and
+        /// UpdatePreview runs on every slider tick - loading them per tick would decode 16MB a
+        /// frame during a drag. Sampled at open, so a mod swap mid-dialog is not seen, exactly
+        /// like the poses beside them.</summary>
+        private readonly Bitmap?[] _tubes = new Bitmap?[2];
         /// <summary>Drawn in place of a pose that would not load, so the stepper still reads.</summary>
         private static readonly string[] PoseGlyphs = { "🧍", "🙋", "💃", "🧎" };
         /// <summary>The XAML gradient and its frame, kept so a null pose puts the placeholder back.
@@ -106,6 +109,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         private readonly Slider _sldScale;
         private readonly Slider _sldOffsetX;
         private readonly Slider _sldOffsetY;
+        private readonly Image _previewTubeImage;
         private readonly Border _previewTube;
         private readonly Border _previewAvatarBorder;
         private readonly Border _previewAvatar;
@@ -132,6 +136,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _sldScale = this.FindControl<Slider>("SldScale")!;
             _sldOffsetX = this.FindControl<Slider>("SldOffsetX")!;
             _sldOffsetY = this.FindControl<Slider>("SldOffsetY")!;
+            _previewTubeImage = this.FindControl<Image>("PreviewTubeImage")!;
             _previewTube = this.FindControl<Border>("PreviewTube")!;
             _previewAvatarBorder = this.FindControl<Border>("PreviewAvatarBorder")!;
             _previewAvatar = this.FindControl<Border>("PreviewAvatar")!;
@@ -234,53 +239,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// </summary>
         private void LoadPoses()
         {
+            _tubes[0] = Helpers.ModArt.TryLoad("tube.png");
+            _tubes[1] = Helpers.ModArt.TryLoad("tube2.png");
+
             string prefix = _avatarSet == 1 ? "avatar_pose" : $"avatar{_avatarSet}_pose";
 
             for (int i = 0; i < _poses.Length; i++)
             {
-                _poses[i] = TryLoadImage($"{prefix}{i + 1}.png");
+                _poses[i] = Helpers.ModArt.TryLoad($"{prefix}{i + 1}.png");
 
                 if (_poses[i] == null && _avatarSet > 1)
-                    _poses[i] = TryLoadImage($"avatar_pose{i + 1}.png");
+                    _poses[i] = Helpers.ModArt.TryLoad($"avatar_pose{i + 1}.png");
             }
 
             // Land on the first pose that actually loaded, so the preview opens on art.
             for (int i = 0; i < _poses.Length; i++)
             {
                 if (_poses[i] != null) { _poseIndex = i; break; }
-            }
-        }
-
-        /// <summary>
-        /// The mod's override first (<see cref="CoreModArt"/>), then this head's own shipped copy
-        /// under <c>avares://</c>. Null when neither exists. Never throws: a mod's broken PNG
-        /// degrades to the built-in exactly as ModResourceResolver.LoadFrozen does, and a missing
-        /// built-in degrades to the glyph.
-        ///
-        /// ponytail: private because TubeFitDialog is the seam's first consumer on this head. Hoist
-        /// it to a head-wide helper when a second view (Flash, BubblePop, Video, Studio, Spiral,
-        /// AchievementPopup ...) wants the same two-step.
-        /// </summary>
-        private static Bitmap? TryLoadImage(string resourceName)
-        {
-            var overridePath = CoreModArt.OverridePath(resourceName);
-            if (overridePath != null)
-            {
-                try { if (File.Exists(overridePath)) return new Bitmap(overridePath); }
-                catch (Exception ex) { Log.Warning(ex, "[TubeFit] mod override {Path} would not load", overridePath); }
-            }
-
-            try
-            {
-                var uri = new Uri($"avares://CCP.Avalonia/Resources/{resourceName}");
-                if (!AssetLoader.Exists(uri)) return null;
-                using var stream = AssetLoader.Open(uri);
-                return new Bitmap(stream);
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "[TubeFit] built-in {Name} would not load", resourceName);
-                return null;
             }
         }
 
@@ -309,9 +284,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
           {
             bool useAttachedLayout = !_detachedMode || ModOverridesAttachedTubeOnly();
 
-            // Tube frame
+            // Tube. Real art goes into the Image WPF uses - unsized, Uniform, centred - because
+            // the attached/detached difference lives INSIDE tube.png vs tube2.png; the box and the
+            // margin swap below are the placeholder's way of showing that switch when the art is
+            // missing, and applying them to the art would move the tube twice.
+            var tubeName = useAttachedLayout ? "tube.png" : "tube2.png";
+            var tube = _tubes[useAttachedLayout ? 0 : 1];
+
+            _previewTubeImage.Source = tube;
+            _previewTubeImage.IsVisible = tube != null;
+            _previewTube.IsVisible = tube == null;
             _previewTube.Margin = useAttachedLayout ? AttachedTubeMargin : DetachedTubeMargin;
-            _txtTubeName.Text = useAttachedLayout ? "tube.png" : "tube2.png";
+            _txtTubeName.Text = tubeName;
 
             // Avatar pose. A loaded bitmap paints the box; a null slot keeps the XAML gradient and
             // the glyph, so the preview never goes blank on a head that is missing the art.

--- a/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Input.Platform;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -9,13 +12,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// PORTED from ConditioningControlPanel/Dialogs/UpdateNotificationDialog.xaml.cs. Deviations:
     ///  - <c>DialogResult</c> becomes <c>Close(bool)</c>; Avalonia carries the result through
     ///    <c>ShowDialog&lt;bool?&gt;</c>.
-    ///  - <c>UpdateService.GetCurrentVersion()</c>, <c>UpdateService.ReleasesPageUrl</c> and
-    ///    <c>BrowserLauncher</c> live in the WPF head, so they are stubbed (see below).
+    ///  - <c>UpdateService.GetCurrentVersion()</c> becomes <c>CoreReleaseContent.AppVersion</c>,
+    ///    which answers "0.0.0" on a head that seeded no provider - the same string the stub used
+    ///    to hardcode, so nothing regresses when the seam is unseeded.
+    ///  - <c>UpdateService.ReleasesPageUrl</c> is <c>ReleaseLinks.ReleasesPageUrl</c> in Core, and
+    ///    <c>BrowserLauncher</c>'s two steps (open, else copy) are the platform Launcher plus the
+    ///    clipboard - the same pair <see cref="UpdateFailedDialog"/> uses. Neither needed the WPF
+    ///    head after all.
     ///  - The version/size/notes strings are English literals in the WPF original too - there are
     ///    no loc keys for them - so they are copied verbatim rather than invented.
     /// </summary>
     public partial class UpdateNotificationDialog : Window
     {
+        // Same address, same Core constant UpdateFailedDialog reads.
+        private const string ReleasesPageUrl = ConditioningControlPanel.Services.ReleaseLinks.ReleasesPageUrl;
+
         /// <summary>
         /// Whether the user chose to install the update
         /// </summary>
@@ -34,8 +45,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         {
             AvaloniaXamlLoader.Load(this);
 
-            // ponytail: needs UpdateService.GetCurrentVersion(), wired when UpdateService moves to Core
-            const string currentVersion = "0.0.0";
+            var currentVersion = CoreReleaseContent.AppVersion;
 
             this.FindControl<TextBlock>("TxtVersionInfo")!.Text =
                 $"Version {updateInfo.Version} is now available.\n" +
@@ -90,10 +100,35 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// Opens the GitHub releases page so the user can install the update by hand. The dialog
         /// stays open - they may still want the automatic install if the browser route falls over.
         /// </summary>
-        private void LinkManualDownload_Click()
+        private async void LinkManualDownload_Click()
         {
-            // ponytail: needs BrowserLauncher.OpenUrlOrPrompt(UpdateService.ReleasesPageUrl,
-            // "open the download page"), wired when both move to Core
+            // BrowserLauncher's two steps, and the second one is the point: Launcher REPORTS
+            // failure rather than throwing when nothing handles the URI (no xdg-open, no default
+            // browser), so the result is checked as well as the exception and the link still
+            // reaches the clipboard on a machine with no usable browser.
+            var opened = false;
+            try
+            {
+                opened = await Launcher.LaunchUriAsync(new Uri(ReleasesPageUrl));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to open the releases page");
+            }
+
+            if (opened) return;
+
+            Log.Warning("Could not open the releases page; copying the link instead");
+            try
+            {
+                if (Clipboard is not null) await Clipboard.SetTextAsync(ReleasesPageUrl);
+            }
+            catch (Exception ex)
+            {
+                // The clipboard can be held by another app - say nothing, the dialog stays open
+                // and the automatic install is still one button away.
+                Log.Warning(ex, "Failed to copy the releases link to the clipboard");
+            }
         }
 
         private void BtnLater_Click()

--- a/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -20,7 +21,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - <c>MouseLeftButtonDown</c> + <c>DragMove()</c> -> <c>PointerPressed</c> + <c>BeginMoveDrag</c>.
     ///  - Newtonsoft's <c>JObject</c> -> <c>System.Text.Json</c>: the head has no Newtonsoft
     ///    reference and one bool read does not justify adding one.
-    ///  - <c>App.Logger</c> in the availability catch is dropped; the logger is on the WPF App.
+    ///  - <c>App.Logger</c> in the availability catch becomes Serilog's static <c>Log</c>.
     ///  - <c>ConfigureForNewUser</c> no longer re-assigns TxtSubtitle.Text. The WPF body set it to
     ///    the very key the XAML already carries, and assigning over a <c>{loc:Str}</c> binding is
     ///    undone on the next language change (see CLAUDE.md).
@@ -132,6 +133,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             }
             catch (Exception ex)
             {
+                Log.Warning(ex, "[UsernamePicker] Display-name availability check failed");
                 SetAvailabilityStatus(Loc.GetF("login_could_not_check", ex.Message), Brushes.Orange, false);
             }
         }


### PR DESCRIPTION
The mod picker draws its six pass cards again. Their art was never blocked -
Assets/logo.png and Assets/intake/pass_card_*.png are already linked into this
head as avares:// resources - so the entry carries an ArtName and the card loads
it through Helpers.ModArt. Note this ADDS a tier WPF did not have: ModPackCatalog
bound its pack:// URI straight to Image.Source, never through
ModResourceResolver, so a mod could not override a pass card there and now can.
Null still draws the accent tile alone, as WPF does before a bitmap resolves.

TubeFitDialog gets the tube, and with it the thing the dialog exists to show:
the avatar now sits INSIDE the tube instead of beside a gradient placeholder.
Its private two-step loader is deleted in favour of Helpers.ModArt.TryLoad. The
markup gained WPF's actual PreviewTube - an unsized, Uniform, centred Image -
because tube.png and tube2.png are 2048 square and carry the attached/detached
difference inside the art; painting that art into the 330x980 placeholder box
and its margin swap would have moved the tube twice. Both tubes are decoded once
in LoadPoses beside the poses, not per UpdatePreview, because UpdatePreview runs
on every slider tick and those two PNGs are 16MB decoded. The placeholder Border
and its retargeted margin survive for a head with no PNGs, and now show only then.

AwarenessAppPickerDialog loses two copies. AwarenessPrivacyRules.IsGroupToken /
ChipLabelKey are in CCP.Core now, so the verbatim mirror the port carried is
gone and a group token means one thing in one place again; and the hand-rolled
message box becomes MessageDialog, which also localises the buttons its English
"Yes"/"No" did not. The WPF call passes MessageBoxResult.No as its defaultResult
so that Enter KEEPS a shipped deny group, and MessageDialog's IsDefault sits on
OK - so ConfirmAsync gained a defaultToCancel that MOVES IsDefault to Cancel and
focuses it. Without that, this port would have let Enter disarm the password-
manager, banking and email-title guards, which is the one thing the prompt
exists to prevent. Cancel, Escape's absence and the window X all still keep it;
only an explicit OK drops one.

UpdateNotificationDialog stops lying about its version and its download link.
CoreReleaseContent.AppVersion answers the version (and answers "0.0.0" unseeded,
the exact string the stub hardcoded), ReleaseLinks.ReleasesPageUrl is in Core,
and BrowserLauncher's two steps are the platform Launcher plus the clipboard -
the same pair UpdateFailedDialog next door already uses. "Prefer to install it
yourself" was a dead link; it opens the page now, and copies it when nothing
handles an https URI.

Three catch blocks that said the head has no logger now log through Serilog's
static Log (ModManagerDialog's catalogue button, RoadmapStepPopup's photo
thumbnail, UsernamePickerDialog's availability check).

Notes rewritten rather than restored, because the claim was stale but the
refusal is right: TextEditorDialog keeps its own three-button Ask - the
unsaved-changes prompt is the one call site with THREE answers (Save / Discard /
cancel the close) and MessageDialog is deliberately two-button, so wiring it
would silently drop Cancel and close a window the user asked to keep open.
KnowledgeLinkEditorDialog keeps its inline validation label over a modal: a
validation message belongs next to the field that failed.

Comment lines naming a blocked symbol, before -> after: App.Logger 7 -> 4,
ModResourceResolver 2 -> 0, MessageBox 22 -> 19, App.Settings 4 -> 4,
App.Mods 3 -> 3, WebView2 0 -> 0.

Still blocked:
- Views/Dialogs/LoginDialog.axaml.cs - V2AuthService, V2DeviceCodeService,
  App.Discord/Patreon/SubscribeStar: all still in ConditioningControlPanel/
  Services/Account/. Verified, the notes are accurate.
- Views/Dialogs/LocalAiSetupWizard.axaml.cs - OllamaSetupService
  (ConditioningControlPanel/Services/AIService/OllamaSetupService.cs).
- Views/Dialogs/ModManagerDialog.axaml.cs - ModManagerService does not exist
  under either root; the install/uninstall/activate/export bodies need whatever
  replaces it, plus MainWindow.ShareModToCatalogueAsync and ModCreatorWindow.
- Views/Dialogs/ModPickerDialog.axaml.cs - ReleaseContentService.IsFullInstall /
  FetchManifestAsync / RequestPackAsync (ConditioningControlPanel/Services/
  Content/ReleaseContentService.cs). Only the art half moved here.
- Views/Dialogs/ProfileCustomizeDialog.axaml.cs, WardrobeEditorDialog.axaml.cs -
  CosmeticsCatalog and WardrobeCatalog (ConditioningControlPanel/Services/
  Profile/). The pin-tile refusal in ProfileCustomizeDialog is deliberate and
  left standing: restoring the art without the achievement PNGs would hide
  almost every pin.
- Views/Dialogs/AttentionTargetEditorDialog.axaml.cs BtnTest - FloatingText is a
  Win32 layered click-through window (bucket E), not a settings problem.
- Views/Dialogs/LinkPhoneDialog.axaml.cs - V2AuthService.AuthorizeMobileLinkAsync
  plus a QR encoder.
- Views/Dialogs/CataloguePickerDialog.axaml.cs - an http image fetch off the UI
  thread; WPF's BitmapImage did it inline and Avalonia's Bitmap needs a stream.
- CCP.Avalonia/Helpers/ModArt.cs - its ponytail note still names TubeFitDialog
  as carrying a private copy of the two-step. That copy is gone as of this
  layer; the file is outside this layer's directory, so the line is stale until
  a layer owns Helpers/.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU