### PR TITLE
fix(avalonia): the mute prompt finds its own owner, and four Emi notes stop naming the wrong blocker

### DIFF
--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiBookWindow.axaml.cs
@@ -878,15 +878,40 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         }
 
         /// <summary>
-        /// ponytail: needs MainWindow, SessionEngine.Active and App.Tutorial - the same three
-        /// conditions EmiOffers.TourFeasible checks, minus the "already done" latch - wired when
-        /// they move to Core. True here, so a tour card renders lit rather than permanently ghosted.
+        /// Can the walk-through actually run? WPF's answer is <c>EmiOffers.TourFeasible</c>
+        /// (ConditioningControlPanel/Services/EmiDesk/EmiOffers.cs), four conditions.
+        ///
+        /// <para>ponytail: the old note here said all four need "a move to Core", and THREE of them
+        /// no longer do - RE-AUDITED 2026-09-04 against Core rather than believed:</para>
+        /// <list type="bullet">
+        ///   <item><c>Application.Current.MainWindow is MainWindow</c> resolves: the desktop
+        ///         lifetime's MainWindow is what <c>App.MainWindowRef</c> was, the resolution
+        ///         <c>EmiDeskWindow.AppMainWindow</c> already uses.</item>
+        ///   <item><c>SessionEngine.Active?.IsRunning</c> is <c>CoreSession.IsEngineRunning</c>,
+        ///         in Core. Unseeded on this head, and "no session is running" is the truth here,
+        ///         not a placebo.</item>
+        ///   <item><c>App.Tutorial?.IsActive</c> is <c>CoreTutorial.IsActive</c>, in Core since the
+        ///         tutorial seam landed. Also unseeded here - CCP.Avalonia/App.axaml.cs says why:
+        ///         TutorialService and its twenty-two step lists are still in the WPF head.</item>
+        ///   <item><c>EmiState.HasTourDone(tour)</c>, the already-walked latch, is the one that is
+        ///         genuinely still head-side (Services/EmiDesk/EmiState.cs).</item>
+        /// </list>
+        /// <para>So this is NOT restored, and deliberately: all three resolvable conditions are
+        /// constant-false on this head, so evaluating them would change nothing a reader can see
+        /// while implying the fourth was checked too. The thing that would make the button honest
+        /// is <see cref="Go"/> being able to START a tour, and it cannot - see there. It stays lit
+        /// so the card renders in its full shape, which is what the render proves.</para>
         /// </summary>
         private static bool TourReady() => true;
 
-        // ponytail: needs EmiTargets.Open and MainWindow.StartTutorial (both WPF head), wired when
-        // they move to Core. Everything the button does is a detour into the app, so there is
-        // nothing view-local left to port here.
+        /// <summary>
+        /// ponytail: the tour half is NOT blocked on a move any more and the old note was wrong to
+        /// say so. <c>CoreTutorial.Start(tourName)</c> is in Core; what is missing is that this head
+        /// leaves the seam UNSEEDED (CCP.Avalonia/App.axaml.cs), so <c>Start</c> is a silent no-op
+        /// and calling it would give a button that looks like it walked you somewhere. The door half
+        /// is <c>EmiTargets.Open</c> (ConditioningControlPanel/Services/EmiDesk/EmiTargets.cs),
+        /// which is deeply head-bound and moves with EmiSuggester. Both ends of the button are a
+        /// detour into the app, so there is still nothing view-local to port here.
         private void Go()
         {
             var cards = Book.All;

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiDeskWindow.axaml
@@ -23,9 +23,13 @@
 
      The window is a pad bigger than EMI on every side so her FX have room; that pad is
      Background-less on purpose. ponytail: on X11 a transparent Avalonia window still EATS the
-     clicks that fell through the pad on Windows (layered-window alpha hit-testing), and
-     Platform/X11Overlay.SetClickThrough is whole-window only - shaping input to the BodyRoot rect
-     needs an input-shape-region API the shim does not have yet. Its own layer. -->
+     clicks that fell through the pad on Windows (layered-window alpha hit-testing).
+     POSSIBLE, and blocked on one member rather than on a service: Platform/X11Overlay exposes
+     SetClickThrough(TopLevel, bool), which is whole-window only, and shaping input to BodyRoot's
+     rect needs SetInputRegion(TopLevel, IReadOnlyList<PixelRect>) beside it. The XFixes call is
+     already there - SetClickThrough builds a region and only ever builds the EMPTY one - so this
+     is a Platform/ layer, not a view one, and BodyRoot moves with ApplyBodyWidth so the region
+     has to be re-set on every resize. -->
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiMutePromptWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiMutePromptWindow.axaml.cs
@@ -1,7 +1,10 @@
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
 {
@@ -62,10 +65,56 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         /// an explicit answer - dismissing the window included - comes back
         /// <see cref="EmiMuteChoice.Keep"/>.
         /// </summary>
-        // ponytail: needs App.MainWindowRef for WPF's ownerless CenterScreen fallback, wired when
-        // the app shell moves to Core. Avalonia's ShowDialog requires an owner, so the caller
-        // passes the one it already has.
         public static Task<EmiMuteChoice> Ask(Window owner) =>
             new EmiMutePromptWindow().ShowDialog<EmiMuteChoice>(owner);
+
+        /// <summary>
+        /// Ask with no owner in hand - WPF's own call shape (<c>EmiMutePromptWindow.Ask()</c> from
+        /// <c>EmiDeskService</c>), which set <c>Owner = App.MainWindowRef</c> and fell back to
+        /// <c>WindowStartupLocation.CenterScreen</c> when there was no main window.
+        ///
+        /// <para>The note here used to say this needed <c>App.MainWindowRef</c> "when the app shell
+        /// moves to Core". That has been stale since the shell landed: the desktop lifetime's
+        /// <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/> IS what
+        /// <c>App.MainWindowRef</c> was, and it is asked for through the lifetime rather than by
+        /// naming <c>MainShellWindow</c> so it stays true whichever window the app has up. Same
+        /// resolution <c>EmiDeskWindow.AppMainWindow</c> uses.</para>
+        ///
+        /// <para>WPF's ownerless branch cannot be ported: Avalonia's <c>ShowDialog</c> REQUIRES an
+        /// owner, and there is nothing to be modal to when the app is showing no window at all - or
+        /// is holding one that is not visible. Avalonia refuses that outright ("Cannot show window
+        /// with non-visible owner.", read out of Avalonia.Controls 12.1.1) where WPF accepted it,
+        /// and the lifetime's MainWindow is exactly that between construction and Show, and again
+        /// whenever the shell is hidden to the tray. So the guard is <c>IsVisible</c>, not null -
+        /// null alone would leave a FAULTED task on the two paths she is most likely to arrive on.
+        /// Both answer <see cref="EmiMuteChoice.Keep"/> - not a refusal to ask so much as the file's
+        /// own rule, that a question which was never put is never consent to being silenced. It is
+        /// also the branch the headless render takes, which has no desktop lifetime.</para>
+        ///
+        /// <para>Uncalled on this head: the one caller is <c>EmiDeskService.MaybeAskAboutMuting</c>
+        /// (ConditioningControlPanel/Services/EmiDesk/EmiDeskService.cs), which moves with the
+        /// shell. It exists so that caller lands with no owner-threading edit.</para>
+        /// </summary>
+        public static Task<EmiMuteChoice> Ask()
+        {
+            Window? main = null;
+            try
+            {
+                main = (Application.Current?.ApplicationLifetime
+                    as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+            }
+            catch (System.Exception ex)
+            {
+                Log.Debug(ex, "[EmiDesk] mute prompt owner lookup failed");
+            }
+
+            if (main is null || !main.IsVisible)
+            {
+                Log.Debug("[EmiDesk] no visible window to own the mute prompt; keeping the avatar");
+                return Task.FromResult(EmiMuteChoice.Keep);
+            }
+
+            return Ask(main);
+        }
     }
 }

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiOptionsWindow.axaml.cs
@@ -626,8 +626,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
         ///         the window can never hold the keyboard, so a local <c>KeyDown</c> here would not
         ///         be the same feature and is not offered as one.</item>
         /// </list>
-        /// <para>The honest replacement is a compositor-side dismissal (an X11 pointer grab, or a
-        /// layer-shell surface on Wayland), which is its own layer.</para>
+        /// <para>ponytail: POSSIBLE in principle and NOT a compositor's to grant, which the old
+        /// wording here had backwards. Neither half is a "hook" problem on X11: the primitive to
+        /// evaluate is a POINTER GRAB (<c>XGrabPointer</c>, or a passive XI2 grab), a client-side
+        /// ask this process can make for itself - unlike <c>SetWindowsHookEx</c>, which is what
+        /// makes the WPF original unportable. It belongs beside <c>SetClickThrough</c> in
+        /// CCP.Avalonia/Platform/X11Overlay.cs, which exposes no grab today, so it is a Platform/
+        /// layer rather than a view one. Wayland is the case that really does need the compositor:
+        /// there the answer is a layer-shell surface, not a grab.</para>
+        ///
+        /// <para>Escape stays lost either way while this window is <c>ShowActivated="False"</c> and
+        /// never holds focus - a local <c>KeyDown</c> here would receive nothing. The ring's own
+        /// recovery (a click landing INSIDE the window's transparent gaps folds it) does not
+        /// transfer: this panel is opaque edge to edge, so there is no in-window click that means
+        /// "dismiss".</para>
         ///
         /// <para>WPF's <c>OnGlobalDown</c>, <c>OnGlobalKey</c> and the <c>Post</c> helper that
         /// marshalled them back onto the UI thread go with the hooks: they existed only to be

--- a/CCP.Avalonia/Views/Windows/EmiDesk/EmiRingWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/EmiDesk/EmiRingWindow.axaml.cs
@@ -59,10 +59,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows.EmiDesk
     ///  - <b>Click-through.</b> On Windows a layered window does not hit-test fully transparent
     ///    pixels, which is what let a click land on the desktop THROUGH a gap in the fan. X11 hit
     ///    tests the whole rectangle, and <c>X11Overlay.SetClickThrough</c> is all-or-nothing - the
-    ///    whole window, which would kill the cards too. ponytail: needs X11Overlay to take a
-    ///    REGION (XFixes can express it; the shim's own doc note says so), and that is its own
-    ///    layer. Until then a click in a gap does not reach the desktop - but it is no longer
-    ///    swallowed either, see <see cref="InstallHooks"/>.
+    ///    whole window, which would kill the cards too. ponytail: POSSIBLE, and blocked on one
+    ///    member the shim does not expose yet, not on a service:
+    ///    <c>X11Overlay.SetInputRegion(TopLevel, IReadOnlyList&lt;PixelRect&gt;)</c>, the cards'
+    ///    own rectangles. <c>SetClickThrough</c> already builds an XFixes region and passes it to
+    ///    <c>XFixesSetWindowShapeRegion</c> - it just only ever builds the EMPTY one - and that
+    ///    method's own doc says a non-empty region is strictly more capable than
+    ///    <c>WS_EX_TRANSPARENT</c>. It is a CCP.Avalonia/Platform/ change, not a view one. Until
+    ///    then a click in a gap does not reach the desktop - but it is no longer swallowed
+    ///    either, see <see cref="InstallHooks"/>.
     ///  - <b>The global hooks.</b> <c>GlobalMouseHook</c> / <c>GlobalKeyboardHook</c> are
     ///    <c>SetWindowsHookEx</c>, which has NO equivalent on this head, and with them goes
     ///    <c>_hotPx</c> - the frozen rect snapshot existed only to answer the hook thread. The half


### PR DESCRIPTION
EmiMutePromptWindow.Ask() comes back in WPF's own call shape. The note said it
needed App.MainWindowRef "when the app shell moves to Core"; that has been stale
since the shell landed - the desktop lifetime's MainWindow IS App.MainWindowRef,
the same resolution EmiDeskWindow.AppMainWindow already uses, asked through the
lifetime rather than by naming MainShellWindow. WPF's ownerless CenterScreen
branch genuinely cannot be ported (Avalonia's ShowDialog requires an owner, and
with no window up there is nothing to be modal to), so that path answers Keep -
which is this file's own rule, that a question never put is not consent to being
silenced. Uncalled on this head: the caller is EmiDeskService.MaybeAskAboutMuting
and moves with the shell. It exists so that port needs no owner-threading edit.

EmiBookWindow.TourReady's note was wrong about three of its four conditions.
Re-audited against Core rather than believed: Application.Current.MainWindow
resolves through the lifetime; SessionEngine.Active.IsRunning is
CoreSession.IsEngineRunning, in Core; App.Tutorial.IsActive is
CoreTutorial.IsActive, in Core since the tutorial seam landed. Only
EmiState.HasTourDone is still head-side. It is NOT restored anyway, and the note
now says why: all three resolvable conditions are constant-false on this head
(both seams are deliberately unseeded, see App.axaml.cs), so evaluating them
would change nothing a reader can see while implying the fourth was checked too.
What would make WALK ME THROUGH IT honest is Go() being able to start a tour, and
Go()'s note was wrong in the same direction: CoreTutorial.Start IS in Core, and
what blocks it is that this head leaves the seam unseeded, so calling it gives a
button that looks like it walked you somewhere. EmiTargets.Open, the door half,
is unchanged and moves with EmiSuggester.

The two overlay notes now name the member instead of the shape. Both the ring's
gaps and the widget's transparent pad are category "possible, blocked on one
member Platform/X11Overlay does not expose yet", not blocked on a service:
X11Overlay.SetInputRegion(TopLevel, IReadOnlyList<PixelRect>). SetClickThrough
already builds an XFixes region and hands it to XFixesSetWindowShapeRegion - it
only ever builds the EMPTY one - and its own doc says a non-empty region is
strictly more capable than WS_EX_TRANSPARENT. A Platform/ layer, not a view one,
and on the widget the region has to be re-set on every ApplyBodyWidth.

EmiOptionsWindow's hook note had the ownership backwards. It called the honest
replacement "a compositor-side dismissal (an X11 pointer grab...)"; a pointer
grab is exactly the opposite - XGrabPointer, or a passive XI2 grab, is a
client-side ask this process can make for itself, which is what separates it from
SetWindowsHookEx and is what the ring layer's own handover said. It belongs
beside SetClickThrough in X11Overlay, which exposes no grab today. Wayland is the
case that really does need the compositor, and there the answer is layer-shell.
The note also now records that the ring's recovery does not transfer: that window
folds on a click landing in its transparent gaps, and this panel is opaque edge
to edge, so no in-window click means "dismiss". Escape stays lost either way
while the window is ShowActivated="False" and never holds focus.

THE SWEEP. Comment lines naming App.Settings / App.Mods / App.Logger /
ModResourceResolver / MessageBox / WebView2 over the five files: 1 / 0 / 0 / 1 /
0 / 1 before, identical after. All three survivors were read and all three
describe the WPF ORIGINAL rather than this head's blocker (EmiLineEngine reads
App.Settings; the WPF ring's card art comes from ModResourceResolver; the widget
hosts no WebView2). Nothing to restore there.

The brief's mod-art hint does not apply to this directory, checked both halves:
EmiRingWindow builds its cards in code, so there is no missing Image target, and
EmiDeskWindow.axaml already carries BodyImage, PropImage and OutfitOverImage.
What blocks those is the ART - Assets/emi/fonts/ and Assets/web/arcademy/art/emi/
exist in the repo and CCP.Avalonia.csproj links neither, which is a csproj this
layer does not own.

The x:Name hazard was checked across all five files: every one loads with
AvaloniaXamlLoader.Load(this) and every one reaches its controls through
FindControl. The names that are markup-only here (Root, ResizeGlyph, StageFrame,
CatchStrip, Panel, Bd, Chrome, and the template internals) are markup-only in the
WPF originals too - grepped, not assumed.

Also re-verified as still blocked, so a seventh pass does not re-open them:
EmiDeskWindow.Glass.cs stays head-bound (EmiChannels across six files, App.Video,
App.EmiDesk); CCP.Core's EmiBookLayout is still internal with CCP.Avalonia absent
from Core/Properties/AssemblyInfo.cs; CoreTutorial and CoreSession are seeded
nowhere on this head; EmiDebug's only WPF callers are in the unported Alive.cs.

Still blocked, named symbols and head paths:

  EmiBookWindow.Go / TourReady   ConditioningControlPanel/Services/EmiDesk/
      EmiState.cs HasTourDone, EmiTargets.Open, and a CoreTutorial seed in
      CCP.Avalonia/App.axaml.cs (not this layer's file).
  EmiBookWindow.Place            CCP.Core/Properties/AssemblyInfo.cs, one line.
  EmiRingWindow gap click-through,
  EmiDeskWindow pad click-through
                                 CCP.Avalonia/Platform/X11Overlay.cs
                                 SetInputRegion, above.
  EmiOptionsWindow.InstallHooks /
  RemoveHooks / UpdateHotRects   the same file's missing pointer grab, above.
  Everything else in these five files is unchanged from the audit in 98161ef8 and
      its measurements hold.

Handover, resuming 98161ef8's numbered list unchanged (1 the EmiBookCards +
EmiBookDeck.* git mv, 2 Core's InternalsVisibleTo then EmiBookLayout.Place, 3
EmiChains behind CoreDispatch, 4 a Core point/rect struct then EmiAlive and
EmiRingLayout, 5 the EmiPixel / EmiBookGlyphs split, 6 the two csproj asset
links), plus:

  7. X11Overlay.SetInputRegion(TopLevel, IReadOnlyList<PixelRect>) and a pointer
     grab beside it. One Platform/ layer pays off three view notes at once - the
     ring's gaps, the widget's pad, and the options panel's click-away.

Not reached, and NOT because they were skipped: every remaining note in these
five files is blocked on one of 1-7. This directory no longer holds a layer's
worth of view work; the next pass here should be one of those seven, not another
sweep.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU