### PR TITLE
feat(avalonia): the Deeper editor's three help panels and its gaze-rect picker open, and one fence serves both windows

### DIFF
--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.RuleEditor.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.RuleEditor.cs
@@ -12,6 +12,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models.Deeper;
 using Serilog;
@@ -32,7 +33,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
     ///   Mouse capture on a handle        -> e.Pointer.Capture(handle)
     ///   ActualWidth/Height               -> Bounds.Width / Bounds.Height
     ///   CheckBox.Click                   -> IsCheckedChanged
-    ///   MessageBox.Show                  -> Serilog (no message box on this head)
+    ///   MessageBox.Show                  -> Views/Dialogs/MessageDialog.ShowAsync, awaited. "Avalonia
+    ///                                       has no MessageBox" was true when this file was written
+    ///                                       and has not been since that dialog landed
     /// </summary>
     public partial class DeeperEditorWindow
     {
@@ -350,10 +353,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         };
 
         // -- Help popups: list every trigger / action with its description ----
-        // ponytail: needs a message box. The text is still assembled from the same keys and
-        // argument order, so wiring a real dialog later is a one-line swap at each site.
+        // RESTORED. The note here said these "need a message box", which stopped being true when
+        // Views/Dialogs/MessageDialog landed: three panels of user-facing help text were being
+        // assembled in full and then written to the DEBUG LOG, so the three "?" buttons ran a
+        // visible amount of work and showed the user nothing. MessageDialog scrolls and caps at
+        // 640px, which is what these need - the trigger list is long. Argument order is WPF's
+        // (message first, title second) re-stated as ShowAsync(owner, title, message).
 
-        private void BtnTriggerHelp_Click(object? sender, RoutedEventArgs e)
+        private async void BtnTriggerHelp_Click(object? sender, RoutedEventArgs e)
         {
             var isAudio = _enhancement?.MediaType == MediaTypes.Audio;
             var types = isAudio ? TriggerTypesForAudio : TriggerTypesForVideo;
@@ -366,11 +373,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                     sb.Append("  ").AppendLine(desc);
                 sb.AppendLine();
             }
-            Log.Debug("DeeperEditor: trigger help ({Title}) needs a message box:\n{Body}",
-                Loc.Get("deeper_editor_help_browse_triggers"), sb.ToString().TrimEnd());
+            await MessageDialog.ShowAsync(this, Loc.Get("deeper_editor_help_browse_triggers"),
+                sb.ToString().TrimEnd());
         }
 
-        private void BtnActionHelp_Click(object? sender, RoutedEventArgs e)
+        private async void BtnActionHelp_Click(object? sender, RoutedEventArgs e)
         {
             var sb = new StringBuilder();
             foreach (var a in AllActionTypes)
@@ -381,13 +388,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                     sb.Append("  ").AppendLine(desc);
                 sb.AppendLine();
             }
-            Log.Debug("DeeperEditor: action help ({Title}) needs a message box:\n{Body}",
-                Loc.Get("deeper_editor_help_browse_actions"), sb.ToString().TrimEnd());
+            await MessageDialog.ShowAsync(this, Loc.Get("deeper_editor_help_browse_actions"),
+                sb.ToString().TrimEnd());
         }
 
-        private void BtnRegionHelp_Click(object? sender, RoutedEventArgs e)
-            => Log.Debug("DeeperEditor: region help ({Title}) needs a message box:\n{Body}",
-                Loc.Get("deeper_editor_help_region"), Loc.Get("deeper_editor_help_region_body"));
+        private async void BtnRegionHelp_Click(object? sender, RoutedEventArgs e)
+            => await MessageDialog.ShowAsync(this, Loc.Get("deeper_editor_help_region"),
+                Loc.Get("deeper_editor_help_region_body"));
 
         private void BtnDeleteRule_Click(object? sender, RoutedEventArgs e)
         {
@@ -1597,22 +1604,84 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         // Gaze rect picker
         // ---------------------------------------------------------------------------------
 
+        private GazePickerWindow? _gazePickerWindow;
+
         /// <summary>
-        /// ponytail: needs GazePickerWindow plus the Win32 screen placement the WPF version used -
-        /// PreviewHost.PointToScreen for the two corners and VisualTreeHelper.GetDpi(this) to
-        /// convert them back to device-independent units. Avalonia has Screens/Scaling equivalents,
-        /// but the picker window itself is not ported, so this is a named stub: the "Pick on video…"
-        /// button exists and is hit-testable, and the rect stays whatever the four x/y/w/h boxes
-        /// and the 3x3 preset grid put there.
+        /// RESTORED. The note here claimed "the picker window itself is not ported"; it is, and it
+        /// always was on this branch - <c>Views/Deeper/GazePickerWindow.axaml.cs</c>, right beside
+        /// this file, complete with its eight resize handles, Done/Cancel and normalised
+        /// <c>ResultRect</c>. Nothing was blocking this but the note.
+        ///
+        /// <para>Screen placement is the one real deviation. WPF read the two corners with
+        /// <c>PreviewHost.PointToScreen</c> and divided by <c>VisualTreeHelper.GetDpi(this)</c> to
+        /// get WPF's DIP <c>Left</c>/<c>Top</c>. Avalonia's <c>PointToScreen</c> already answers in
+        /// device pixels and <c>Window.Position</c> takes device pixels, so the origin needs NO
+        /// conversion - only the size does, because <c>Width</c>/<c>Height</c> are DIPs.
+        /// <c>TopLevel.RenderScaling</c> is the DpiScale of that pair.</para>
+        ///
+        /// <para>The write-back is WPF's, elementwise into the array the caller's getter hands us:
+        /// the picker cloned its input, so assigning the reference would update nothing.</para>
         /// </summary>
         private void BeginGazePick(Func<double[]> rectGetter)
         {
-            _ = rectGetter;
-            Log.Debug("DeeperEditor: gaze rect picker needs GazePickerWindow + screen placement");
+            EndGazePick(commit: false);
+
+            var current = rectGetter();
+            if (current == null || current.Length < 4)
+                current = new[] { 0.25, 0.25, 0.5, 0.5 };
+
+            try
+            {
+                var origin = PreviewHost.PointToScreen(new Point(0, 0));
+                var far = PreviewHost.PointToScreen(
+                    new Point(PreviewHost.Bounds.Width, PreviewHost.Bounds.Height));
+                var scale = RenderScaling <= 0 ? 1.0 : RenderScaling;
+
+                var picker = new GazePickerWindow(current)
+                {
+                    Position = origin,
+                    Width = (far.X - origin.X) / scale,
+                    Height = (far.Y - origin.Y) / scale,
+                };
+                _gazePickerWindow = picker;
+                picker.Closed += (_, _) =>
+                {
+                    if (!ReferenceEquals(_gazePickerWindow, picker)) return;
+                    _gazePickerWindow = null;
+                    if (!picker.Committed) return;
+
+                    var result = picker.ResultRect;
+                    var tgt = rectGetter();
+                    if (tgt != null && tgt.Length >= 4 && result.Length >= 4)
+                    {
+                        tgt[0] = result[0];
+                        tgt[1] = result[1];
+                        tgt[2] = result[2];
+                        tgt[3] = result[3];
+                    }
+                    MarkDirty();
+                    if (_selectedRule != null) BuildTriggerFields();
+                    ScheduleValidation();
+                };
+                picker.Show(this);
+            }
+            catch (Exception ex)
+            {
+                _gazePickerWindow = null;
+                Log.Debug("DeeperEditor: BeginGazePick failed: {Error}", ex.Message);
+            }
         }
 
-        /// <summary>Force-closes any open picker. A no-op while <see cref="BeginGazePick"/> is a
-        /// stub, but every selection path calls it, so it stays named and called.</summary>
-        private void EndGazePick(bool commit) { _ = commit; }
+        /// <summary>Force-closes any open picker. The Closed handler reads <c>Committed</c>, which
+        /// only the picker's own Done/Enter sets, so closing from here never applies a rect.</summary>
+        private void EndGazePick(bool commit)
+        {
+            _ = commit;
+            var w = _gazePickerWindow;
+            if (w == null) return;
+            _gazePickerWindow = null;
+            try { w.Close(); }
+            catch { /* a picker already gone is the state we wanted */ }
+        }
     }
 }

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.Unified.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.Unified.cs
@@ -32,7 +32,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
     ///   Cursors.Hand / SizeAll / SizeWE       -> new Cursor(StandardCursorType.*)
     ///   Panel.SetZIndex(v, n)                 -> v.ZIndex = n
     ///   Visibility                            -> IsVisible
-    ///   TutorialEventBus.Emit                 -> stubbed (App-level service)
+    ///   TutorialEventBus.Emit                 -> a named no-op; Core carries no event bus by
+    ///                                            design, see EmitTutorialEvent at the foot
     ///   App.Logger                            -> Serilog.Log
     /// </summary>
     public partial class DeeperEditorWindow
@@ -1069,9 +1070,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             => double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
 
         /// <summary>
-        /// ponytail: needs TutorialEventBus (App-level service in the WPF head). The editor emitted
-        /// "EffectAdded" / "RuleAdded" so the interactive tutorial could advance a step; nothing in
-        /// the Avalonia head listens yet, so the calls are kept as named no-ops rather than deleted.
+        /// ponytail: the editor emitted "EffectAdded" / "RuleAdded" so the interactive tutorial
+        /// could advance a step. Kept as named no-ops rather than deleted, because the call SITES
+        /// are the portable half and finding them again later is the expensive part.
+        ///
+        /// <para>Blocked on <c>TutorialEventBus</c>
+        /// (<c>ConditioningControlPanel/Services/TutorialEventBus.cs</c>), and note what that is
+        /// NOT: the overlay is ported
+        /// (<c>CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs</c>) and <c>CoreTutorial</c> is
+        /// the seam, so "wired when the tutorial moves to Core" is no longer the story.
+        /// <c>CoreTutorial</c> carries no event bus ON PURPOSE - the OnEvent advance trigger crosses
+        /// as an enum and the subscription hooks a real control on a real head - so a seam to emit
+        /// into would have to be added to Core first, not merely used.</para>
         /// </summary>
         private static void EmitTutorialEvent(string name) { _ = name; }
     }

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml
@@ -10,8 +10,11 @@
        Image + EmojiToImageSource (x5)     -> plain TextBlock (Avalonia draws colour emoji natively)
        Line X1/X2/Y1/Y2                    -> StartPoint / EndPoint
        wv2:WebView2 x:Name="BrowserPreview"-> controls:WebHost - Microsoft.Web.WebView2 is Windows-only
-       vlc:VideoView x:Name="VideoPreview" -> a labelled Border; LibVLCSharp.WPF cannot be referenced
-                                              from a net8.0 head and no package may be added here
+       vlc:VideoView x:Name="VideoPreview" -> controls:WebHost as well. A local clip is navigated to
+                                              and the engine wraps it in its own <video> media
+                                              document, so the two branches share one surface; the
+                                              Border named VideoPreview is now only the no-engine /
+                                              not-a-video fallback
        ContextMenu x:Shared="False"        -> inlined as <Canvas.ContextMenu> and, for the hero
                                               "+ Effect" button, a <MenuFlyout>. Avalonia has no
                                               x:Shared and no FindResource-a-menu; item names and
@@ -183,12 +186,20 @@
                                FontSize="12" FontWeight="SemiBold"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
 
-                    <!-- Browser zoom cluster: page-zooms the embedded preview. Visibility tracks
-                         BrowserPreview so it disappears in video-file / audio modes. -->
+                    <!-- Browser zoom cluster: page-zooms the embedded preview in WPF. HIDDEN here,
+                         and not because of a mode. AdjustPreviewZoom is a stub that only logs -
+                         NativeWebView has no zoom factor at all, and CSS zoom through the script
+                         channel is not a substitute (per-document, lost on the next navigation, and
+                         it does not scale a fullscreened video). WPF's binding was
+                         IsVisible="{Binding #BrowserPreview.IsVisible}"; restore that line and this
+                         cluster comes back the moment the buttons do something. Two enabled buttons
+                         that log is a toolbar lying about what it offers, which is why they are not
+                         merely disabled. Same call, same reason, in EnhancementPlayerWindow's
+                         ShowMediaPaneFor. -->
                     <StackPanel Grid.Row="0" Grid.Column="2" x:Name="PreviewZoomCluster"
                                 Orientation="Horizontal" VerticalAlignment="Center"
                                 Margin="8,0,0,0"
-                                IsVisible="{Binding #BrowserPreview.IsVisible}">
+                                IsVisible="False">
                         <TextBlock Text="🔍" FontSize="12" VerticalAlignment="Center" Margin="0,0,4,0"/>
                         <Button x:Name="BtnPreviewZoomOut" Content="−"
                                 ToolTip.Tip="{loc:Str deeper_zoom_out_tt}"
@@ -309,13 +320,20 @@
                 <Border Grid.Row="0" Background="{DynamicResource DeeperPreviewSurfaceBgBrush}" Margin="10,10,10,5"
                         CornerRadius="8">
                     <Grid x:Name="PreviewHost">
-                        <!-- ponytail: was <vlc:VideoView x:Name="VideoPreview"/>. LibVLCSharp.WPF is
-                             a WPF assembly and LibVLCSharp.Avalonia is a package this layer may not
-                             add, so local video preview is a labelled surface, not a picture. -->
+                        <!-- Was <vlc:VideoView x:Name="VideoPreview"/>. LibVLCSharp is NOT what
+                             blocks local video any more: since wire/78 a local clip plays through
+                             BrowserPreview below, which the engine wraps in its own <video> media
+                             document. This Border is now the FALLBACK surface for the two cases
+                             that have no picture - a machine with no web engine, and a source whose
+                             extension is not video - and InitializeVideo writes the reason into the
+                             TextBlock for whichever it is. The literal here is only what shows if
+                             the Border is ever made visible by some other path; it is a plain
+                             literal and not {loc:Str} precisely so that assignment is not the
+                             "local value under a live binding" trap. -->
                         <Border x:Name="VideoPreview" IsVisible="False"
                                 Background="{DynamicResource DeeperWaveformBgBrush}">
                             <TextBlock x:Name="TxtVideoPreviewStub"
-                                       Text="Video preview needs LibVLCSharp.Avalonia"
+                                       Text="No video preview for this source."
                                        Foreground="{DynamicResource TextMutedBrush}"
                                        FontSize="12" FontStyle="Italic"
                                        HorizontalAlignment="Center" VerticalAlignment="Center"/>

--- a/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperEditorWindow.axaml.cs
@@ -78,10 +78,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
     ///         drove), and AddScriptToExecuteOnDocumentCreatedAsync.</item>
     ///   <item><b>Win32.</b> <c>WindowChromeHelper.ApplyDarkTitleBar</c> (DwmSetWindowAttribute),
     ///         <c>RestoreOwnerOnClose</c>, <c>System.Windows.Forms.Screen.FromHandle</c> +
-    ///         <c>WindowInteropHelper</c> (the borderless-fullscreen preview window) and
-    ///         <c>VisualTreeHelper.GetDpi</c> (the gaze picker's screen placement).</item>
-    ///   <item><b>App services.</b> App.Tutorial + TutorialOverlay, App.DeeperPlayer /
-    ///         App.DeeperHost, the haptics bus and GazePickerWindow. App.EnhancementLibrary is
+    ///         <c>WindowInteropHelper</c> (the borderless-fullscreen preview window).
+    ///         <c>VisualTreeHelper.GetDpi</c> is NOT one of these any more: TopLevel.RenderScaling
+    ///         is its twin and the gaze picker uses it - see BeginGazePick in the RuleEditor
+    ///         partial.</item>
+    ///   <item><b>App services.</b> App.DeeperPlayer / App.DeeperHost and the haptics bus.
+    ///         GazePickerWindow is NOT one - it is ported, beside this file, and now wired.
+    ///         App.Tutorial is the CoreTutorial seam and TutorialOverlay is ported; what stops the
+    ///         tutorial here is that nothing SEEDS that seam on this head - see
+    ///         <see cref="StartEditorTutorial"/>. App.EnhancementLibrary is
     ///         head-only too, but the five members the editor needs from it are inlined in the
     ///         file-ops region, so Save / Save As / Export / Swap / Change media / drag-drop are
     ///         real, and the unsaved-changes guard on swap, drop-load and close asks
@@ -543,11 +548,21 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
 
             _ = InitializePreviewAsync();
 
-            // ponytail: needs TutorialEventBus + App.Tutorial + TutorialOverlay + App.Settings.
-            // The WPF Loaded handler dispatched the interactive tutorial's Part 2 (queued by the
-            // New Enhancement dialog) and, failing that, auto-launched the first-run editor
-            // coachmarks once. Neither service exists on this head, so both are dropped here and
-            // BtnEditorHelp is inert; nothing else in the editor depended on them.
+            // ponytail: the WPF Loaded handler dispatched the interactive tutorial's Part 2 (queued
+            // by the New Enhancement dialog) and, failing that, auto-launched the first-run editor
+            // coachmarks once. THREE of the four things that note used to name have arrived and are
+            // not the blocker any more: App.Settings is CoreSettings, App.Tutorial is CoreTutorial,
+            // and TutorialOverlay is ported (CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs,
+            // live ctor TutorialOverlay(Window)). What is actually left is two things:
+            //   1. CoreTutorial is UNSEEDED on this head - see CCP.Avalonia/App.axaml.cs:71. The
+            //      step lists live in ConditioningControlPanel/Services/TutorialService.cs, so
+            //      CoreTutorial.Start(name) is a silent no-op and a live overlay would open a dim
+            //      sheet over a blank card. See StartEditorTutorial for the shape to restore.
+            //   2. The Part 2 hand-off needs TutorialEventBus.PendingPart2Tutorial
+            //      (ConditioningControlPanel/Services/TutorialEventBus.cs) and CoreTutorial
+            //      deliberately carries no event bus, so there is no seam to read it from.
+            // The first-run auto-launch's "shown once" flag is NOT a blocker: WPF used
+            // AppSettings.HasSeenDeeperEditorIntro and that is in Core (AppSettings.cs:7938).
         }
 
         private void BtnEditorHelp_Click(object? sender, RoutedEventArgs e)
@@ -555,11 +570,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             StartEditorTutorial();
         }
 
-        /// <summary>ponytail: needs App.Tutorial + TutorialOverlay, wired when the tutorial service
-        /// moves to Core. The "?" button is present and hit-testable but opens nothing.</summary>
+        /// <summary>
+        /// ponytail: the "?" button is present and hit-testable and opens nothing. The old note here
+        /// said this waits on "App.Tutorial + TutorialOverlay, wired when the tutorial service moves
+        /// to Core" and BOTH halves of that are now wrong: <c>CoreTutorial</c> is the seam and
+        /// <c>CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs</c> is the ported overlay, with a
+        /// live <c>TutorialOverlay(Window)</c> constructor that walks whatever tour the seam runs.
+        ///
+        /// <para>The single blocker is that NOTHING SEEDS the seam on this head - see
+        /// <c>CCP.Avalonia/App.axaml.cs:71</c>. The twenty-two step lists are sentences about WPF
+        /// controls and stay in <c>ConditioningControlPanel/Services/TutorialService.cs</c>, so
+        /// <c>CoreTutorial.Start("DeeperEditorTutorial")</c> is a silent no-op today. Showing the
+        /// overlay anyway is the failure to avoid: it would dim the editor behind an empty card.
+        /// The four lines to write once a tour exists, WPF's shape with that one guard added:</para>
+        /// <code>
+        /// if (CoreTutorial.IsActive) CoreTutorial.Skip();
+        /// CoreTutorial.Start("DeeperEditorTutorial");
+        /// if (!CoreTutorial.IsActive) return;   // unseeded seam: do not dim over nothing
+        /// new TutorialOverlay(this).Show();
+        /// </code>
+        /// </summary>
         private void StartEditorTutorial()
         {
-            Log.Debug("DeeperEditor: editor tutorial requested; App.Tutorial is not on this head");
+            Log.Debug("DeeperEditor: editor tutorial requested; CoreTutorial is unseeded on this head");
         }
 
         private void LoadEnhancement(Enhancement enhancement, string? filePath)
@@ -709,7 +742,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 // first can start navigating before the predicate is in place.
                 var pinned = uri.Host;
                 BrowserPreview.AllowNavigation = u =>
-                    u.Scheme == Uri.UriSchemeHttps && HostsMatchIgnoringWww(u.Host, pinned);
+                    u.Scheme == Uri.UriSchemeHttps && DeeperPreview.HostsMatchIgnoringWww(u.Host, pinned);
                 BrowserPreview.Source = uri;
                 _browserNavigated = true;
                 _browserPollDisabled = false;
@@ -729,35 +762,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             return Task.CompletedTask;
         }
 
-        /// <summary>Host equality that ignores a leading "www.", the same fence the player uses.
-        /// Deliberately NOT a domain-suffix match: a subdomain is a different host here, because
-        /// this pins to one page's host rather than admitting a whole domain the way the
-        /// allowlist did.</summary>
-        private static bool HostsMatchIgnoringWww(string? a, string? b)
-        {
-            static string Strip(string? h) =>
-                (h ?? "").StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? h![4..] : (h ?? "");
-            var (x, y) = (Strip(a), Strip(b));
-            return x.Length > 0 && x.Equals(y, StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Addresses the page's LARGEST &lt;video&gt;, which was BrowserVideoTimeSource's rule too:
-        /// a HypnoTube page carries preview thumbnails that are also video elements, and the first
-        /// in document order is routinely not the one being watched. Returns "" when the page has
-        /// no video yet, so a caller can tell "did nothing" from "did it".
-        ///
-        /// The one-shot <c>_ccpScrolled</c> flag replaces WPF's injected scrollIntoView poller: HT
-        /// stacks promo banners above the player, so without it the preview lands at scrollTop=0
-        /// with the video offscreen. It lives on the element, so a navigation resets it for free.
-        /// </summary>
-        private static string BrowserVideoScript(string tail) =>
-            "(function(){var l=null,a=0;document.querySelectorAll('video').forEach(function(v){"
-            + "var s=(v.clientWidth||0)*(v.clientHeight||0); if(s>=a){a=s;l=v;}});"
-            + "if(!l)return '';"
-            + "if(!l._ccpScrolled){l._ccpScrolled=1;try{l.scrollIntoView({block:'center'});}catch(e){}}"
-            + "return " + tail + ";})()";
-
         /// <summary>
         /// BrowserVideoTimeSource's poll, minus the WebView2 binding: read currentTime, duration and
         /// paused off the page each tick so the read-out, the playhead and every duration-derived
@@ -774,8 +778,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             _browserPollInFlight = true;
             try
             {
-                var raw = await BrowserPreview.InvokeScriptAsync(
-                    BrowserVideoScript("l.currentTime+'|'+(l.duration||0)+'|'+(l.paused?0:1)"));
+                var raw = await BrowserPreview.InvokeScriptAsync(DeeperPreview.ReadTime(scrollIntoView: true));
 
                 // Re-checked AFTER the await, not only before it: a late answer from a page that
                 // has since been blanked would rebuild the timeline against a dead duration, and a
@@ -783,7 +786,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 // pointer. WPF's handler took the same three guards before touching anything.
                 if (!_browserNavigated || _isScrubbing || _fsTransitionInFlight) return;
 
-                var parts = Unquote(raw).Split('|');
+                var parts = DeeperPreview.Unquote(raw).Split('|');
                 if (parts.Length != 3) return;
 
                 if (double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var dur)
@@ -825,7 +828,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 {
                     _pauseLocalPreviewOnce = false;
                     _ = BrowserPreview.InvokeScriptAsync(
-                        BrowserVideoScript("(l.autoplay=false,l.pause(),'ok')"));
+                        DeeperPreview.Invoke("l.autoplay=false;l.pause();", scrollIntoView: true));
                     playing = false; // don't flash ⏸ for one tick over a video we are pausing
                 }
                 if (playing != _isPlaying)
@@ -844,11 +847,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             }
             finally { _browserPollInFlight = false; }
         }
-
-        /// <summary>WebView2 hands back a JSON literal (a string arrives quoted); WebKitGTK hands
-        /// back the raw value. Strip one layer of quotes so the caller sees the same on both.</summary>
-        private static string Unquote(string? s)
-            => string.IsNullOrEmpty(s) ? "" : (s.Length >= 2 && s[0] == '"' && s[^1] == '"' ? s[1..^1] : s);
 
         /// <summary>
         /// Blanks the preview page and closes the fence behind it. The gate is narrowed to
@@ -882,12 +880,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         /// The web engine wraps a navigated media file in its own <c>&lt;video&gt;</c> media
         /// document (the sibling player's <c>LoadLocalVideo</c> ships on exactly that), and this
         /// window already drives and reads a page's largest <c>&lt;video&gt;</c> through
-        /// <see cref="BrowserVideoScript"/>. So the local branch JOINS the browser branch rather
+        /// <see cref="DeeperPreview.LargestVideo"/>. So the local branch JOINS the browser branch rather
         /// than growing a parallel one: duration, playhead, play/pause and seek all describe the
         /// real file, and <see cref="PollBrowserTimeAsync"/> is the LengthChanged / TimeChanged /
         /// EndReached triple in one place.
         ///
-        /// <para>The same one-file fence the player uses. <see cref="IsLocalFile"/> proves a file is
+        /// <para>The same one-file fence the player uses, and now literally the same code - both
+        /// windows' gates are <see cref="DeeperPreview"/>'s. <see cref="IsLocalFile"/> proves a file is
         /// THERE, not that it is media, so the extension is checked BEFORE the engine is pointed at
         /// anything - a shared .ccpenh.json naming /etc/passwd would otherwise be rendered as a
         /// page - and the gate then pins the engine to that one file for the rest of the load.</para>
@@ -903,7 +902,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             PreviewPlaceholder.IsVisible = false;
 
             string? full = null;
-            if (IsLocalVideoFile(path))
+            if (DeeperPreview.IsLocalVideoFile(path))
             {
                 try { full = IOPath.GetFullPath(path); } catch { full = null; }
             }
@@ -930,14 +929,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             BrowserPreview.IsVisible = true;
 
             // Assigned BEFORE Source, like the remote branch: the gate is read at navigation time.
-            // Inlined rather than pulled out as a helper because the sibling player already carries
-            // its own copy of this comparison - see the handover note about that fold.
-            BrowserPreview.AllowNavigation = u =>
-            {
-                if (!u.IsFile) return false;
-                try { return string.Equals(IOPath.GetFullPath(u.LocalPath), full, StringComparison.Ordinal); }
-                catch { return false; }
-            };
+            // Pinned into a non-nullable local because the lambda outlives this method's flow
+            // analysis - the same shape the player's local-video fence uses.
+            var pinnedFile = full;
+            BrowserPreview.AllowNavigation = u => u.IsFile && DeeperPreview.PathsEqual(u.LocalPath, pinnedFile);
             BrowserPreview.Source = new Uri(full);
             _browserNavigated = true;
             _browserPollDisabled = false;
@@ -1054,7 +1049,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             if (_browserNavigated)
             {
                 _ = BrowserPreview.InvokeScriptAsync(
-                    BrowserVideoScript(_isPlaying ? "(l.pause(),'ok')" : "(l.play(),'ok')"));
+                    DeeperPreview.Invoke(_isPlaying ? "l.pause();" : "l.play();", scrollIntoView: true));
                 return;
             }
             // Nothing to play and no clock to run: leave the glyph alone. A press then reads as
@@ -1087,8 +1082,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             TxtCurrentTime.Text = FormatTime(_currentSeconds);
             if (_browserNavigated && _totalSeconds > 0)
             {
-                _ = BrowserPreview.InvokeScriptAsync(BrowserVideoScript(string.Format(
-                    CultureInfo.InvariantCulture, "(l.currentTime={0:0.###},'ok')", _currentSeconds)));
+                _ = BrowserPreview.InvokeScriptAsync(DeeperPreview.Invoke(string.Format(
+                    CultureInfo.InvariantCulture, "l.currentTime={0:0.###};", _currentSeconds),
+                    scrollIntoView: true));
             }
             // ponytail: LOCAL AUDIO needs a decoder's seek - the WPF version pushed the new position
             // to AudioFileReader.CurrentTime here. Local video seeks through the branch above,
@@ -2447,9 +2443,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 UpdateTitle();
 
                 // ponytail: WPF also set TutorialEventBus.LastSavedEnhancementPath and emitted
-                // "FileSaved" so the HT walkthrough could advance to its follow-up card.
-                // TutorialEventBus is head-only (ConditioningControlPanel/Services/TutorialEventBus.cs)
-                // and no tutorial runs on this head, so there is nothing listening to notify.
+                // "FileSaved" so the HT walkthrough could advance to its follow-up card. Still
+                // blocked, and the blocker is NOT "the tutorial has not been ported" - the overlay
+                // has been (CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs) and CoreTutorial is
+                // the seam. It is that CoreTutorial deliberately carries NO event bus: the
+                // OnEvent advance trigger crosses as an enum only, and the publisher side stays in
+                // ConditioningControlPanel/Services/TutorialEventBus.cs. Nothing here can emit, and
+                // with the seam unseeded on this head nothing would be listening either.
             }
             catch (Exception ex)
             {
@@ -2810,7 +2810,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
 
             // Just relink: point the open project at the new media.
             _enhancement.MediaSource = newSource;
-            _enhancement.MediaType = isLocal && !IsLocalVideoFile(newSource) ? MediaTypes.Audio : MediaTypes.Video;
+            _enhancement.MediaType = isLocal && !DeeperPreview.IsLocalVideoFile(newSource) ? MediaTypes.Audio : MediaTypes.Video;
             MarkDirty();
             RefreshLinkedFilesUi();
             TeardownPreview();
@@ -2880,7 +2880,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         {
             if (string.IsNullOrWhiteSpace(path)) return false;
             var ext = IOPath.GetExtension(path).ToLowerInvariant();
-            return IsLocalVideoFile(path)
+            return DeeperPreview.IsLocalVideoFile(path)
                 || ext is ".mp3" or ".wav" or ".flac" or ".ogg" or ".m4a" or ".aac";
         }
 
@@ -2910,19 +2910,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 return !_isDirty;
             }
             return true; // discard
-        }
-
-        /// <summary>
-        /// Extension gate for a local media path. It already existed here to pick MediaType on a
-        /// media swap; <see cref="InitializeVideo"/> now also uses it as the pre-flight that keeps
-        /// a non-media file from being rendered as a page. Not a content sniff - the cheap half of
-        /// "is this media", run before the path reaches the engine.
-        /// </summary>
-        private static bool IsLocalVideoFile(string path)
-        {
-            if (string.IsNullOrWhiteSpace(path)) return false;
-            var ext = IOPath.GetExtension(path).ToLowerInvariant();
-            return ext is ".mp4" or ".webm" or ".mkv" or ".mov" or ".avi" or ".m4v";
         }
 
         private static string FormatTime(double seconds)

--- a/CCP.Avalonia/Views/Deeper/DeeperPreview.cs
+++ b/CCP.Avalonia/Views/Deeper/DeeperPreview.cs
@@ -1,0 +1,104 @@
+using System;
+using IOPath = System.IO.Path;
+
+namespace ConditioningControlPanel.Avalonia.Views.Deeper
+{
+    /// <summary>
+    /// The one definition of everything <see cref="DeeperEditorWindow"/>'s preview and
+    /// <see cref="EnhancementPlayerWindow"/>'s video pane both need to drive a page through
+    /// <c>WebHost.InvokeScriptAsync</c> behind a navigation fence.
+    ///
+    /// <para>This exists because the two windows had grown five copies of the same rules:
+    /// <see cref="HostsMatchIgnoringWww"/> and <see cref="Unquote"/> byte for byte, the
+    /// largest-&lt;video&gt; finder four times over with four different tails, a path comparison the
+    /// editor inlined and the player named <c>PathsEqual</c>, and the media extension list twice.
+    /// Three of those are SECURITY predicates: a fence that drifts on one window and not the other
+    /// is the failure this collapses, not a tidiness one. wire/69 spotted the drift and owned only
+    /// one of the two files; this layer owns both.</para>
+    ///
+    /// <para>Deliberately NOT in CCP.Core. Nothing here is portable logic the engine wants - it is
+    /// this head's WebKitGTK quirks (the quote stripping) and this head's narrower re-statement of
+    /// rules Core already owns properly. Core's <c>UrlSafety.HostMatches</c> +
+    /// <c>DeeperConfig.PreviewHostAllowlist</c> and <c>UrlSafety.IsSafeLocalAbsolute</c> ARE those
+    /// rules; they are <c>internal</c> and CCP.Avalonia is not named in
+    /// CCP.Core/Properties/AssemblyInfo.cs, which is the only reason these narrower stand-ins exist
+    /// at all. When that one line lands, this class shrinks rather than growing.</para>
+    /// </summary>
+    internal static class DeeperPreview
+    {
+        // ---- Fences ---------------------------------------------------------------------
+
+        /// <summary>Host equality that ignores a leading "www." (the sites in the original
+        /// allowlist redirect between the two forms). Deliberately NOT a domain-suffix match: a
+        /// subdomain is a DIFFERENT host here, because both callers pin to the host of the one page
+        /// the project named rather than admitting a whole domain the way the allowlist did.</summary>
+        internal static bool HostsMatchIgnoringWww(string? a, string? b)
+        {
+            static string Strip(string? h) =>
+                (h ?? "").StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? h![4..] : (h ?? "");
+            var (x, y) = (Strip(a), Strip(b));
+            return x.Length > 0 && x.Equals(y, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Full-path equality for the local-file fence. Full paths on both sides because
+        /// the engine round-trips the URL through file:// encoding and hands <c>LocalPath</c> back
+        /// in a form that only matches after normalisation. A path that will not normalise is not
+        /// the file that was pinned.</summary>
+        internal static bool PathsEqual(string? candidate, string pinnedFullPath)
+        {
+            if (string.IsNullOrEmpty(candidate)) return false;
+            try { return string.Equals(IOPath.GetFullPath(candidate), pinnedFullPath, StringComparison.Ordinal); }
+            catch { return false; }
+        }
+
+        /// <summary>Extension gate for a local media path. Not a content sniff - the cheap half of
+        /// "is this media", run BEFORE a path reaches the engine, so a shared .ccpenh.json naming
+        /// /etc/passwd is not rendered as a page. The list matches the project model's, which is why
+        /// .mkv and .avi are in it even though a media document may show black for them.</summary>
+        internal static bool IsLocalVideoFile(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            var ext = IOPath.GetExtension(path).ToLowerInvariant();
+            return ext is ".mp4" or ".webm" or ".mkv" or ".mov" or ".avi" or ".m4v";
+        }
+
+        // ---- The script channel ---------------------------------------------------------
+
+        /// <summary>Binds <c>l</c> to the page's LARGEST &lt;video&gt;, which was
+        /// BrowserVideoTimeSource's rule too: a HypnoTube page carries preview thumbnails that are
+        /// also video elements, and the first in document order is routinely not the one being
+        /// watched. Answers "" when the page has no video at all, so a caller can tell "did
+        /// nothing" from "did it".</summary>
+        private const string Find =
+            "(function(){var l=null,a=0;document.querySelectorAll('video').forEach(function(v){"
+            + "var s=(v.clientWidth||0)*(v.clientHeight||0); if(s>=a){a=s;l=v;}});"
+            + "if(!l)return '';";
+
+        /// <summary>One-shot, in place of WPF's injected scrollIntoView poller: HT stacks promo
+        /// banners above the player, so without it the preview lands at scrollTop=0 with the video
+        /// offscreen. The flag lives on the element, so a navigation resets it for free.</summary>
+        private const string ScrollOnce =
+            "if(!l._ccpScrolled){l._ccpScrolled=1;try{l.scrollIntoView({block:'center'});}catch(e){}}";
+
+        /// <summary>Wraps <paramref name="body"/> - JS statements, with <c>l</c> bound, carrying
+        /// their own <c>return</c> - in the finder.</summary>
+        internal static string LargestVideo(string body, bool scrollIntoView = false)
+            => Find + (scrollIntoView ? ScrollOnce : "") + body + "})()";
+
+        /// <summary>"currentTime|duration|paused" off the page's largest video, or "".</summary>
+        internal static string ReadTime(bool scrollIntoView = false)
+            => LargestVideo("return l.currentTime+'|'+(l.duration||0)+'|'+(l.paused?0:1);", scrollIntoView);
+
+        /// <summary>Runs <paramref name="statements"/> against <c>l</c> and answers "ok", so a
+        /// caller can tell a page that acted from one with no video (which answers "").</summary>
+        internal static string Invoke(string statements, bool scrollIntoView = false)
+            => LargestVideo(statements + "return 'ok';", scrollIntoView);
+
+        // ---- The answer -----------------------------------------------------------------
+
+        /// <summary>WebView2 hands back a JSON literal (a string arrives quoted); WebKitGTK hands
+        /// back the raw value. Strip one layer of quotes so the caller sees the same on both.</summary>
+        internal static string Unquote(string? s)
+            => string.IsNullOrEmpty(s) ? "" : (s.Length >= 2 && s[0] == '"' && s[^1] == '"' ? s[1..^1] : s);
+    }
+}

--- a/CCP.Avalonia/Views/Deeper/EnhancementPlayerWindow.axaml
+++ b/CCP.Avalonia/Views/Deeper/EnhancementPlayerWindow.axaml
@@ -185,9 +185,9 @@
                     </DockPanel>
                 </StackPanel>
 
-                <!-- Right: browser zoom cluster (video mode only) + source pill + Change popover.
-                     The WPF cluster bound its Visibility to VideoPane's; here ShowMediaPaneFor sets
-                     both in the same statement, which is the same rule without a binding. -->
+                <!-- Right: browser zoom cluster + source pill + Change popover. In WPF the cluster
+                     bound its Visibility to VideoPane's; here ShowMediaPaneFor pins it HIDDEN in
+                     BOTH modes, because AdjustVideoZoom only logs - see its comment for why. -->
                 <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
                     <StackPanel x:Name="BrowserZoomCluster" Orientation="Horizontal"
                                 VerticalAlignment="Center" Margin="0,0,8,0"

--- a/CCP.Avalonia/Views/Deeper/EnhancementPlayerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/EnhancementPlayerWindow.axaml.cs
@@ -402,7 +402,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         public void OpenLocalMediaFile(string path)
         {
             if (string.IsNullOrWhiteSpace(path)) return;
-            if (IsLocalVideoFile(path)) LoadLocalVideo(path);
+            if (DeeperPreview.IsLocalVideoFile(path)) LoadLocalVideo(path);
             else LoadAudio(path);
             TryAutoLoadEnhancement(path);
         }
@@ -467,14 +467,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             => !string.IsNullOrWhiteSpace(path)
                && path.EndsWith(".ccpenh.json", StringComparison.OrdinalIgnoreCase);
 
-        // The canonical check lives in EnhancementResolver so the player and the video bridge agree.
-        private static bool IsLocalVideoFile(string path)
-        {
-            if (string.IsNullOrWhiteSpace(path)) return false;
-            var ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
-            return ext is ".mp4" or ".webm" or ".mkv" or ".mov" or ".avi" or ".m4v";
-        }
-
         // ====================================================================================
         // File pickers
         // ====================================================================================
@@ -502,7 +494,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 });
                 if (files.Count == 0) return;
                 var path = files[0].TryGetLocalPath() ?? files[0].Path.ToString();
-                if (IsLocalVideoFile(path)) LoadLocalVideo(path);
+                if (DeeperPreview.IsLocalVideoFile(path)) LoadLocalVideo(path);
                 else LoadAudio(path);
                 TryAutoLoadEnhancement(path);
             }
@@ -640,8 +632,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         private void BtnCreateNewEnhancement_Click()
         {
             if (string.IsNullOrEmpty(_lastMediaPathForCreateNew)) return;
-            // ponytail: needs EnhancementLibrary.CreateBlank + DeeperEditorWindow, wired when they
-            // move to Core / are ported.
+            // ponytail: DeeperEditorWindow is NOT the blocker - it is ported and beside this file.
+            // EnhancementLibrary.CreateBlank is, and it is still head-only
+            // (ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs): it is what turns a
+            // bare media path into a blank Enhancement with the right MediaType, metadata defaults
+            // and empty lanes, and the editor's ctor takes an Enhancement, not a path. See
+            // JumpToEditorForCurrentEnhancement for the other half of the route.
             Log.Debug("EnhancementPlayer(Avalonia): create-new is a stub for {Path}", _lastMediaPathForCreateNew);
         }
 
@@ -681,7 +677,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
 
                 // Extension AND rooted-path check before anything reaches the engine. File.Exists
                 // upstream only proves a file is there, not that it is media.
-                if (!IsLocalVideoFile(path) || !System.IO.Path.IsPathRooted(path))
+                if (!DeeperPreview.IsLocalVideoFile(path) || !System.IO.Path.IsPathRooted(path))
                 {
                     Log.Warning("EnhancementPlayer: rejected non-video local MediaSource");
                     _txtVideoStatus.Text = Loc.Get("deeper_player_video_no_video");
@@ -701,7 +697,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 // Full path, because the engine round-trips the URL through file:// encoding and
                 // hands LocalPath back in a form that only matches after normalisation.
                 var full = System.IO.Path.GetFullPath(path);
-                _videoBrowser.AllowNavigation = u => u.IsFile && PathsEqual(u.LocalPath, full);
+                _videoBrowser.AllowNavigation = u => u.IsFile && DeeperPreview.PathsEqual(u.LocalPath, full);
                 _videoBrowser.Source = new Uri(full);
                 _videoNavigated = true;
             }
@@ -710,13 +706,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 Log.Warning(ex, "EnhancementPlayer: local video load failed");
                 _txtVideoStatus.Text = Loc.Get("deeper_player_video_no_video");
             }
-        }
-
-        private static bool PathsEqual(string? a, string b)
-        {
-            if (string.IsNullOrEmpty(a)) return false;
-            try { return string.Equals(System.IO.Path.GetFullPath(a), b, StringComparison.Ordinal); }
-            catch { return false; }
         }
 
         private void LoadVideoUrl(string url)
@@ -758,7 +747,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 // because the sites in the original allowlist redirect between the two forms.
                 var pinned = uri.Host;
                 _videoBrowser.AllowNavigation = u =>
-                    u.Scheme == Uri.UriSchemeHttps && HostsMatchIgnoringWww(u.Host, pinned);
+                    u.Scheme == Uri.UriSchemeHttps && DeeperPreview.HostsMatchIgnoringWww(u.Host, pinned);
                 _videoBrowser.Source = uri;
                 _videoNavigated = true;
             }
@@ -767,17 +756,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
                 Log.Warning(ex, "EnhancementPlayer: video load failed");
                 _txtVideoStatus.Text = Loc.Get("deeper_player_video_no_video");
             }
-        }
-
-        /// <summary>Host equality that ignores a leading "www.". Not a domain-suffix match: a
-        /// subdomain is a DIFFERENT host here on purpose, since this pins to one page's host rather
-        /// than admitting a whole domain the way the allowlist did.</summary>
-        private static bool HostsMatchIgnoringWww(string? a, string? b)
-        {
-            static string Strip(string? h) =>
-                (h ?? "").StartsWith("www.", StringComparison.OrdinalIgnoreCase) ? h![4..] : (h ?? "");
-            var (x, y) = (Strip(a), Strip(b));
-            return x.Length > 0 && x.Equals(y, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsRemoteVideoUrl(string? source)
@@ -827,7 +805,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             // letting the poll correct it would show ⏸ / LIVE / "Playing" in the meantime, and on
             // a page that never grows a video element it would never be corrected at all.
             var want = !_isPlaying;
-            if (Unquote(await _videoBrowser.InvokeScriptAsync(VideoScript(want ? "play()" : "pause()"))) != "ok")
+            if (DeeperPreview.Unquote(await _videoBrowser.InvokeScriptAsync(
+                    DeeperPreview.Invoke(want ? "l.play();" : "l.pause();"))) != "ok")
                 return;
             _isPlaying = want;
             _txtPlayPauseGlyph.Text = _isPlaying ? "⏸" : "▶";
@@ -838,7 +817,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         private void BtnStop_Click()
         {
             if (_isVideoMode && _videoNavigated)
-                _ = _videoBrowser.InvokeScriptAsync(VideoScript("pause(); l.currentTime=0"));
+                _ = _videoBrowser.InvokeScriptAsync(DeeperPreview.Invoke("l.pause(); l.currentTime=0;"));
             _isPlaying = false;
             _currentSec = 0;
             _txtPlayPauseGlyph.Text = "▶";
@@ -848,25 +827,23 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             UpdateStatusPill();
         }
 
-        /// <summary>
-        /// Addresses the page's largest &lt;video&gt;, which is BrowserVideoTimeSource's rule too:
-        /// a HypnoTube page carries preview thumbnails that are also video elements, and the first
-        /// one in document order is routinely not the one being watched.
-        /// </summary>
-        private static string VideoScript(string tail) =>
-            "(function(){var l=null,a=0;document.querySelectorAll('video').forEach(function(v){"
-            + "var s=(v.clientWidth||0)*(v.clientHeight||0); if(s>=a){a=s;l=v;}});"
-            + "if(!l)return '';l." + tail + ";return 'ok';})()";
-
         private void BtnEyeTracking_Click()
         {
-            // ponytail: needs WebcamTrackingService (start/stop, IsConsentCurrent). Left whole
-            // rather than half-restored ON PURPOSE: the portable half of this button is the label
-            // and the pill, and a button that reads "eye tracking: on" with no camera open — or,
-            // worse, one that reaches a start path around the first-time consent prompt this head
-            // has no MessageBox for — is worse than a button that does nothing. Restore the
-            // consent gate and the camera together or not at all. Keys the WPF prompts use:
-            // deeper_player_eye_tracking_unavailable / _first_time / _confirm_start / _start_failed_fmt.
+            // ponytail: needs WebcamTrackingService (start/stop, IsConsentCurrent), which is
+            // head-only at ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs.
+            // Left whole rather than half-restored ON PURPOSE: the portable half of this button is
+            // the label and the pill, and a button that reads "eye tracking: on" with no camera
+            // open is worse than a button that does nothing. Restore the consent gate and the
+            // camera together or not at all.
+            //
+            // ONE HALF OF THE OLD REASON IS NOW WRONG and is corrected rather than deleted, because
+            // it is the kind of claim that gets copied: "the first-time consent prompt this head
+            // has no MessageBox for". Views/Dialogs/MessageDialog exists and ConfirmAsync is
+            // exactly that prompt. The prompt is not the blocker; the tracker is. Note also that
+            // the gate must be AWAITED - a straight transcription of the WPF prompt flips the
+            // toggle before the answer lands, which turns a consent gate into a no-op.
+            // Keys the WPF prompts use: deeper_player_eye_tracking_unavailable / _first_time /
+            // _confirm_start / _start_failed_fmt.
             Log.Debug("EnhancementPlayer(Avalonia): eye tracking toggle is a stub");
         }
 
@@ -892,14 +869,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         private async void BtnPictureInPicture_Click()
         {
             if (!_videoBrowser.HasEngine) return;
-            var result = Unquote(await _videoBrowser.InvokeScriptAsync(
-                "(function(){var l=null,a=0;document.querySelectorAll('video').forEach(function(v){"
-                + "var s=(v.clientWidth||0)*(v.clientHeight||0); if(s>=a){a=s;l=v;}});"
-                + "if(!l)return 'no video on page';"
-                + "try{ if(document.pictureInPictureElement){document.exitPictureInPicture();return 'exit';}"
-                + "if(!document.pictureInPictureEnabled)return 'picture-in-picture not supported by this engine';"
-                + "l.requestPictureInPicture().catch(function(){});return 'enter';}"
-                + "catch(e){return e.name+': '+e.message;}})()"));
+            var result = DeeperPreview.Unquote(await _videoBrowser.InvokeScriptAsync(
+                DeeperPreview.LargestVideo(
+                    "try{ if(document.pictureInPictureElement){document.exitPictureInPicture();return 'exit';}"
+                    + "if(!document.pictureInPictureEnabled)return 'picture-in-picture not supported by this engine';"
+                    + "l.requestPictureInPicture().catch(function(){});return 'enter';}"
+                    + "catch(e){return e.name+': '+e.message;}")));
+            // The shared finder answers "" for a page with no video where this site's own copy
+            // answered 'no video on page'. Mapped back here rather than parameterising the finder
+            // for one caller: the event-log line is what makes a press on a videoless page visible.
+            if (result.Length == 0) result = "no video on page";
             // ponytail: requestPictureInPicture is a promise, so an ASYNC rejection (Chromium's
             // "requires user activation") is swallowed by that .catch and reads as 'enter' here.
             // Reporting it needs WebMessageReceived, which NativeWebView has — a bridge worth
@@ -955,12 +934,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             _pollInFlight = true;
             try
             {
-                var raw = await _videoBrowser.InvokeScriptAsync(
-                    "(function(){var l=null,a=0;document.querySelectorAll('video').forEach(function(v){"
-                    + "var s=(v.clientWidth||0)*(v.clientHeight||0); if(s>=a){a=s;l=v;}});"
-                    + "return l?(l.currentTime+'|'+(l.duration||0)+'|'+(l.paused?0:1)):'';})()");
+                var raw = await _videoBrowser.InvokeScriptAsync(DeeperPreview.ReadTime());
 
-                var parts = Unquote(raw).Split('|');
+                var parts = DeeperPreview.Unquote(raw).Split('|');
                 if (parts.Length != 3) return;
                 // A video element answered, so the page is up: "Loading video…" is now false. WPF
                 // hid this on NavigationCompleted; there the pane was Edge's own media viewer, so
@@ -990,13 +966,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             finally { _pollInFlight = false; }
         }
 
-        /// <summary>WebView2 returns a JSON literal (a string comes back quoted); WebKitGTK returns
-        /// the raw value. Strip one layer of quotes so the caller sees the same thing on both.</summary>
-        private static string Unquote(string? s)
-        {
-            if (string.IsNullOrEmpty(s)) return "";
-            return s.Length >= 2 && s[0] == '"' && s[^1] == '"' ? s[1..^1] : s;
-        }
 
         private void UpdateMiniTimelineReadout()
         {
@@ -1185,8 +1154,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             _audioFileRow.IsVisible = !isVideo;
             _audioPane.IsVisible = !isVideo;
             _videoPane.IsVisible = isVideo;
-            // The WPF cluster bound its Visibility to VideoPane's; same rule, set here.
-            _browserZoomCluster.IsVisible = isVideo;
+            // The WPF cluster bound its Visibility to VideoPane's. Pinned HIDDEN here, and not
+            // because of the mode: AdjustVideoZoom only logs, since NativeWebView has no zoom
+            // factor and CSS zoom through the script channel is not a substitute. Two enabled
+            // buttons that do nothing is a toolbar lying about what it offers. Put `isVideo` back
+            // the moment zoom is real. Same call and same reason in DeeperEditorWindow.axaml's
+            // PreviewZoomCluster.
+            _browserZoomCluster.IsVisible = false;
             _volumePanel.IsVisible = !isVideo;
             _btnPictureInPicture.IsVisible = isVideo;
         }
@@ -1348,9 +1322,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
         {
             var enh = _loadedEnhancement;
             if (enh == null) return;
-            // ponytail: needs DeeperEditorWindow (not ported) and MainWindow.OpenDeeperEditorFromPlayer,
-            // wired when the editor is ported. The WPF path deduped against every open editor
-            // window whose LoadedFilePath matched, then routed through the main window.
+            // ponytail: "DeeperEditorWindow (not ported)" is WRONG and has been for several
+            // layers - it is Views/Deeper/DeeperEditorWindow, beside this file, with a public
+            // (Enhancement, string? filePath) ctor and a LoadedFilePath property, which is both
+            // halves of WPF's dedupe. Two things genuinely stop a straight restore, and neither is
+            // the editor:
+            //   1. The route. WPF went through MainWindow.OpenDeeperEditorFromPlayer ->
+            //      OpenDeeperFile, which RE-READS the file from disk and refreshes the Deeper
+            //      library list when the editor closes. CCP.Avalonia/Views/Windows/MainShellWindow
+            //      has no twin, and it is not a file this layer owns.
+            //   2. Handing the editor this window's own _loadedEnhancement instead would share one
+            //      mutable object between two windows: every edit in the editor would silently
+            //      rewrite the enhancement THIS player is running, with no save and no reload. WPF
+            //      never did that. A restore therefore has to re-read the .ccpenh.json (the same
+            //      EnhancementSerializer + EnhancementValidator pair LoadEnhancementFile uses) and
+            //      pass the fresh instance - the dedupe walk over the lifetime's Windows and
+            //      Activate() is the easy half.
+            // The rule-id argument has nowhere to land in either case: the editor has no
+            // "select this rule on open" entry point on this head.
             Log.Debug("EnhancementPlayer(Avalonia): editor jump is a stub (path {Path}, rule {Rule})",
                 _loadedFilePath, ruleId);
         }
@@ -1619,8 +1608,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             // playhead moves and nothing else does.
             if (_isVideoMode && _videoNavigated)
             {
-                _ = _videoBrowser.InvokeScriptAsync(VideoScript(
-                    "currentTime=" + _currentSec.ToString("0.###", CultureInfo.InvariantCulture)));
+                _ = _videoBrowser.InvokeScriptAsync(DeeperPreview.Invoke(
+                    "l.currentTime=" + _currentSec.ToString("0.###", CultureInfo.InvariantCulture) + ";"));
             }
         }
 

--- a/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Deeper/NewEnhancementDialog.axaml.cs
@@ -11,11 +11,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
     /// PORTED from ConditioningControlPanel/Views/Deeper/NewEnhancementDialog.xaml.cs. Deviations:
     ///  - DialogResult becomes Close(bool); callers use ShowDialog&lt;bool&gt;.
     ///  - OpenFileDialog becomes the StorageProvider file picker.
-    ///  - The three interactive tutorials and the last-directory memory are stubs:
-    ///    ConditioningControlPanel/Services/TutorialService.cs (TutorialType, TutorialEventBus),
-    ///    ConditioningControlPanel/TutorialOverlay and
-    ///    ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs all still live in the WPF
-    ///    head. AppSettings does NOT: the HypnoTube flow's one settings write is restored below.
+    ///  - The three interactive tutorials and the last-directory memory are stubs. AppSettings is
+    ///    NOT what blocks them - the HypnoTube flow's one settings write is restored below - and
+    ///    nor is the overlay, which is ported
+    ///    (CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs). See StartInteractiveTutorial and
+    ///    BrowseAsync for what each one is actually waiting on.
     /// </summary>
     public partial class NewEnhancementDialog : Window
     {
@@ -87,12 +87,35 @@ namespace ConditioningControlPanel.Avalonia.Views.Deeper
             StartInteractiveTutorial();
         }
 
+        /// <summary>
+        /// ponytail: still a no-op, but NOT for the reason the old note gave. TutorialOverlay is
+        /// ported (CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs, live ctor
+        /// <c>TutorialOverlay(Window)</c>) and App.Tutorial is now the <c>CoreTutorial</c> seam,
+        /// so the two things that note named as head-only are both here. What blocks it:
+        ///
+        /// <list type="number">
+        ///   <item>Nothing seeds <c>CoreTutorial</c> on this head (CCP.Avalonia/App.axaml.cs:71) -
+        ///     the step lists are sentences about WPF controls and stay in
+        ///     ConditioningControlPanel/Services/TutorialService.cs. <c>Start</c> is a silent
+        ///     no-op, so showing the overlay would dim this dialog behind an empty card, which is
+        ///     worse than the button doing nothing visible.</item>
+        ///   <item>Part 2 needs <c>TutorialEventBus.PendingPart2Tutorial</c>
+        ///     (ConditioningControlPanel/Services/TutorialEventBus.cs). <c>CoreTutorial</c> carries
+        ///     no event bus by design, so that hand-off has no seam at all - it is an addition to
+        ///     Core, not a call into it. The WPF original sets it in BtnCreate_Click, after
+        ///     validation, precisely so a fumbled first click cannot leave the flag armed forever.</item>
+        /// </list>
+        ///
+        /// <para>Part 1's whole visible effect - pick the media type, pre-fill the source - already
+        /// happens in the three callers. Restore as:
+        /// <c>if (CoreTutorial.IsActive) CoreTutorial.Skip(); CoreTutorial.Start(part1); if
+        /// (!CoreTutorial.IsActive) return; new TutorialOverlay(this).Show();</c> - where
+        /// <c>part1</c> is the WPF <c>TutorialType</c> name as a string
+        /// ("DeeperEditorInteractiveLocalVideo" / "…LocalAudio" / "…HT"), since the seam takes a
+        /// name rather than an enum Core refuses to copy.</para>
+        /// </summary>
         private void StartInteractiveTutorial()
         {
-            // ponytail: needs ConditioningControlPanel/Services/TutorialService.cs (TutorialType,
-            // TutorialEventBus.PendingPart2Tutorial) and ConditioningControlPanel/TutorialOverlay,
-            // both still in the WPF head. Without them the three "walk me through" buttons still
-            // pick the media type and pre-fill the source, which is Part 1's whole visible effect.
         }
 
         private void BtnCreate_Click()


### PR DESCRIPTION
Four concerns, all inside Views/Deeper/, all found by disbelieving a note.

The fold wire/69 could not do. It owned one of the two windows; this layer owns
both, so the duplicated preview plumbing collapses into DeeperPreview.cs. There
were FIVE copies, not three: HostsMatchIgnoringWww and Unquote byte for byte,
the largest-<video> finder four times over with four different tails, the
full-path comparison the editor inlined and the player called PathsEqual, and
the media extension list twice. Three of those are security predicates and a
fence that drifts on one window and not the other is the real hazard here, not
the line count. The class is deliberately NOT in Core: it is WebKitGTK quote
stripping plus this head's narrower stand-ins for rules Core already owns
properly (UrlSafety.HostMatches / IsSafeLocalAbsolute), which exist only
because CCP.Avalonia is not in CCP.Core/Properties/AssemblyInfo.cs. Two emitted
scripts changed bytes without changing behaviour: the editor's "(l.pause(),
'ok')" comma expressions became "l.pause();return 'ok';", and the player's poll
gained the finder's early "if(!l)return ''" in place of its ternary. Picture-in-
picture answered 'no video on page' where the shared finder answers ""; that is
mapped back in the caller so the event-log line survives. Every assembled
string was read against the original - none of it was RUN, see below.

Three help panels that were writing to the log. BtnTriggerHelp, BtnActionHelp
and BtnRegionHelp assembled a full bulleted list of every trigger or action
with its description and then handed it to Log.Debug, because the file header
said "MessageBox.Show -> Serilog (no message box on this head)". That has been
false since Views/Dialogs/MessageDialog landed; it scrolls and caps at 640px,
which is exactly what a list that long needs. Awaited, owner=this, WPF's
argument order restated.

The gaze-rect picker was never blocked. Its note said "the picker window itself
is not ported" - GazePickerWindow.axaml.cs sits in the same directory, complete,
and renders its eight handles and toolbar in --render-all. BeginGazePick and
EndGazePick are restored to WPF's shape, including the elementwise write-back
(the picker clones its input, so assigning the reference would update nothing)
and the dedupe-by-identity in the Closed handler. One real deviation: WPF read
two corners with PointToScreen and divided both by VisualTreeHelper.GetDpi.
Avalonia's PointToScreen already answers in device pixels and Window.Position
takes device pixels, so only the SIZE is converted, by TopLevel.RenderScaling.

Two zoom clusters stop pretending. AdjustPreviewZoom and AdjustVideoZoom only
log - NativeWebView has no zoom factor, and CSS zoom through the script channel
is per-document and does not scale a fullscreened video - yet both toolbars
drew an enabled -/+ pair. wire/69 flagged that the editor's cluster had also
become visible in local-video mode, since local video now shares BrowserPreview.
Both are hidden, at whichever end wins: markup in the editor, ShowMediaPaneFor
in the player, each carrying the one-line restore. A toolbar offering two
buttons that do nothing is the same kind of lie as a transport over silence.

Notes rewritten rather than restored, with the blocker that is true TODAY. The
tutorial notes named four things and three had arrived: App.Settings is
CoreSettings, App.Tutorial is CoreTutorial, and TutorialOverlay is ported at
CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs with a live
TutorialOverlay(Window) ctor. What actually blocks it is that NOTHING SEEDS
CoreTutorial on this head (App.axaml.cs:71) - the step lists are sentences about
WPF controls - so Start() is a silent no-op and showing the overlay anyway would
dim the window behind an empty card. The four-line restore is written into
StartEditorTutorial and NewEnhancementDialog.StartInteractiveTutorial, guard
included. Part 2's hand-off is separately blocked: CoreTutorial carries no event
bus by design, so TutorialEventBus.PendingPart2Tutorial has no seam to use, only
one to add. HasSeenDeeperEditorIntro is NOT a blocker - it is in Core at
AppSettings.cs:7938. The player's editor-jump note claimed "DeeperEditorWindow
(not ported)"; it is ported and beside it, and the two things that do block a
restore are named instead - the MainShellWindow route that re-reads the file and
refreshes the library, and the fact that handing the editor this window's own
_loadedEnhancement would share one mutable object between two windows. The eye-
tracking refusal STANDS (WebcamTrackingService is head-only) but half its stated
reason was wrong: "the first-time consent prompt this head has no MessageBox
for" - MessageDialog.ConfirmAsync is that prompt, and the note now says the
gate must be awaited or it flips the toggle before the answer lands.

The editor's .axaml literal "Video preview needs LibVLCSharp.Avalonia" is gone.
LibVLC has not been the blocker since wire/78 - a local clip plays through
BrowserPreview - and that Border is now only the no-engine / not-a-video
fallback, which is what its comment and its default text say.

Before/after for the requested comment-line count (App.Settings, App.Mods,
App.Logger, ModResourceResolver, MessageBox, WebView2): 30 -> 30. The number is
not the story. Every remaining hit is DOCUMENTARY - "WPF used WebView2 here",
"App.Logger -> Serilog.Log" in a deviations table - not a stale claim about what
is missing. The two that WERE false claims (RuleEditor's "no message box on this
head", the player's consent-prompt line) are corrected, and the fold's new file
adds one documentary WebView2 mention of its own.

Verified: core-guards pass, CCP.Core and CCP.Avalonia build with 0 errors,
--smoke passes, --render-all stays 189/189, and DeeperEditorWindow,
EnhancementPlayerWindow, NewEnhancementDialog and GazePickerWindow were rendered
and read - the editor and player toolbars have lost their zoom clusters and the
gaze picker draws its rect, handles and toolbar. What the renders do NOT prove:
no machine in reach has webkit2gtk, so not one line of the folded script channel
executed - the JS identity was established by reading the assembled strings, not
by running them. The renders also cannot show the three help dialogs (they need
a click), the gaze picker's SCREEN PLACEMENT over the preview host (the render
draws it standalone), or that the picker's rect writes back into a trigger.

Still blocked:
- CCP.Core/Properties/AssemblyInfo.cs does not name CCP.Avalonia, so
  UrlSafety.HostMatches + DeeperConfig.PreviewHostAllowlist and
  UrlSafety.IsSafeLocalAbsolute stay out of reach and DeeperPreview keeps its
  narrower stand-ins. One line, and it shrinks that file rather than growing it.
- ConditioningControlPanel/Services/TutorialService.cs - its step lists are what
  would seed CoreTutorial; nothing here can seed it.
- ConditioningControlPanel/Services/TutorialEventBus.cs - no Core seam exists to
  emit into or to read PendingPart2Tutorial from.
- ConditioningControlPanel/Services/Deeper/EnhancementLibrary.cs - CreateBlank,
  FindMatch, PromoteToLibrary. Costs create-new, resolver tier 2 and the
  editor's third media probe.
- ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs - eye
  tracking stays whole rather than half-restored.
- A media decoder for local AUDIO - CCP.Avalonia.csproj is not owned here.
- CCP.Avalonia/Views/Windows/MainShellWindow - the player's editor-jump route.

Handover for the next pass at Views/Deeper/, breadth-first and unreached:
1. DeeperEditorWindow.axaml.cs local-audio group (:107, :951, :1047, :1075,
   :1093, :3107, :3215 in wire/78's numbering) - decoder-blocked, unchanged.
2. The fullscreen-reparent region at the foot of DeeperEditorWindow.axaml.cs
   and its player twin - refused on the engine, notes already true.
3. EnhancementPlayerWindow's audio ladder (LoadAudio, Play, SliderVolume,
   the two seeks) - one blocker, EnhancementAudioPlayer + AudioWaveformCache.
4. UnsavedChangesDialog still lives at the foot of DeeperEditorWindow.axaml.cs
   and wants moving to Views/Dialogs/ with a btn_discard loc key; both targets
   are outside this directory.
5. NOT REACHED AT ALL and clean on inspection: DeeperEditorWindow.ItemsList.cs,
   .LaneChrome.cs, .Ruler.cs, .MultiSelect.cs and .MetadataDrawer.cs - the last
   confirmed member-for-member complete by four layers running.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU