### PR TITLE
feat(avalonia): reduced motion reaches the fuse, the wizard and the tease card; the quick-recal tip stops teaching a dead key

### DIFF
--- a/CCP.Avalonia/Views/Windows/BugReportWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/BugReportWindow.axaml.cs
@@ -73,9 +73,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // WPF ran this from Loaded. The preview is filled here so the headless render shows it.
             RefreshPreview();
-            // ponytail: needs BugReportService.SubmitAsync, wired when it moves to Core. Until then
-            // Send stays disabled (XAML) and the status line says so; label_coming_soon is the
-            // closest existing key.
+            // ponytail: needs BugReportService.SubmitAsync from
+            // ConditioningControlPanel/Services/BugReportService.cs, which is pinned to the head by
+            // App.Mods and its crash-log reader, not by anything WPF. Until then Send stays disabled
+            // (XAML) and the status line says so; label_coming_soon is the closest existing key.
             _txtStatus.Text = Loc.Get("label_coming_soon");
             Opened += (_, _) => _txtDescription.Focus();
         }
@@ -102,8 +103,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void RefreshPreview()
         {
-            // ponytail: needs BugReportService.CreateDraft/RenderPreview, wired when it moves to Core.
-            // Until then the metadata is what this process can see and the counts are zero.
+            // ponytail: needs BugReportService.CreateDraft/RenderPreview
+            // (ConditioningControlPanel/Services/BugReportService.cs). Until then the metadata is
+            // what this process can see and the counts are zero.
+            //
+            // DO NOT "fix" active_mod by writing CoreMods.ActiveModId here. BugReportService
+            // .ResolveActiveModId is a PRIVACY rule, not a lookup: a mod that is not built-in is
+            // reported as the literal "custom-mod", because a locally authored mod id narrowly
+            // identifies its author in a small community, and "unknown" is the no-mod-layer answer.
+            // Restoring the line means restoring that three-branch rule (CoreMods.InstalledMods
+            // carries ModPackage.IsBuiltIn, so it is expressible) - and this preview is what the
+            // user reads before consenting to send, so it must show exactly what would be sent.
             var appVersion = typeof(BugReportWindow).Assembly.GetName().Version?.ToString(3) ?? "?";
             _txtMetadataSummary.Text =
                 $"app_version : {appVersion}\n" +

--- a/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml.cs
@@ -3,13 +3,16 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Avalonia;
 using Avalonia.Animation;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Animation.Easings;
 using Avalonia.Styling;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Controls;
 using ConditioningControlPanel.Services.Descent;
 using Serilog;
+using MotionLevel = ConditioningControlPanel.Models.MotionLevel;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
 {
@@ -28,9 +31,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - WPF's <c>BeginAnimation(OpacityProperty, …)</c> becomes an Avalonia <c>Animation</c>
     ///    run from code (<see cref="FadeTo"/>), with <c>FillMode.Forward</c> so the ramp sticks at
     ///    its end value the way WPF's does.
-    ///  - <c>MotionFx.Level</c>, <c>DescentRoomSfx</c>, <c>App.DescentMigration</c>,
-    ///    <c>App.DescentCountdown</c>, <c>App.ProfileSync</c> and <c>Application.Current.MainWindow</c>
-    ///    are all still in the WPF head, so each is a stub below.
+    ///  - <c>MotionFx.Level</c> is <see cref="AmbientFxCanvas.Env"/>.<c>Level</c> here, which reads
+    ///    the same <c>CoreSettings.Current.MotionLevel</c>. Reduced motion is therefore REAL on this
+    ///    head and the Core timelines get the flag they expect.
+    ///  - <c>Application.Current.MainWindow</c> is the desktop lifetime's <c>MainWindow</c>, and
+    ///    Avalonia has no settable <c>Owner</c>, so ownership is <c>Show(parent)</c>.
+    ///  - <c>DescentRoomSfx</c>, <c>App.DescentMigration</c>, <c>App.DescentCountdown</c> and
+    ///    <c>App.ProfileSync</c> are still in the WPF head, so each is a stub below.
     ///  - <c>DescentFuseCopy</c> is likewise still in the WPF head; its two sentences are inlined.
     /// </summary>
     public partial class DescentFuseWindow : Window
@@ -51,8 +58,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private const double CatchUpFadeSeconds = 0.8;
 
-        // ponytail: needs DescentFuseCopy (WPF head, Services/Descent), inlined verbatim until it
-        // moves to Core. Two sentences, and between them every word the show says.
+        // ponytail: needs ConditioningControlPanel/Services/Descent/DescentFuseCopy.cs, inlined
+        // verbatim until it moves to Core. Two sentences, and between them every word the show
+        // says. The class itself is portable - static strings, no WPF - so this is a git mv, not a
+        // port; Core's own DescentFuseHandoff already cites DescentFuseCopy.ShowAwaits by name.
         private const string ShowAwaitsLine = "The ceremony awaits.";
         private const string IgnitionCopyLine = "Year One. The spiral is yours.";
 
@@ -97,13 +106,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _backdropLayer = this.FindControl<Border>("BackdropLayer")!;
             _showLine = this.FindControl<TextBlock>("ShowLine")!;
 
-            // ponytail: needs MotionFx (WPF head, Helpers), wired when it moves to Core. Full
-            // motion is the honest default — a stub that claimed "reduced" would silently drop the
-            // whole show on every machine.
-            _reduced = false;
+            // MotionFx.Level != MotionLevel.Full, verbatim. MotionFx itself is WPF Storyboard code
+            // and stays head-side, but its DECISION is CoreSettings.Current.MotionLevel, which this
+            // head already reads through AmbientFxCanvas.Env. The flag is threaded into every Core
+            // timeline call below, so "Reduced" now really does shorten the show here.
+            // The one WPF input with no twin is the OS animation-effects cap (MotionFx.ResolveLevel
+            // forces Reduced when it is off); Avalonia exposes no cross-platform equivalent, and
+            // that cap can only ever REMOVE motion, so its absence shows what the user picked.
+            _reduced = AmbientFxCanvas.Env.Level != MotionLevel.Full;
 
-            // ponytail: needs DescentFuseStageVisual (WPF DrawingVisual), wired when the show is
-            // redrawn for this head. StageHost is left empty; every other layer is real.
+            // ponytail: needs ConditioningControlPanel/Controls/DescentFuseStageVisual.cs, a WPF
+            // DrawingVisual that cannot cross - it is redrawn for this head, not moved. StageHost
+            // is left empty; every other layer is real.
 
             if (kind == DescentShowKind.Ignition)
             {
@@ -115,7 +129,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             if (kind == DescentShowKind.Live)
             {
-                // ponytail: needs App.DescentMigration.HoldOffers, wired when it moves to Core.
+                // ponytail: needs DescentMigrationService.HoldOffers from
+                // ConditioningControlPanel/Services/Descent/DescentMigrationService.cs (reached as
+                // App.DescentMigration). No Core seam exposes it.
                 // Holding the ceremony back until the light returns is choreography, not defence:
                 // without it an offer answered during the drain drops the ceremony on top of a
                 // crack that is four seconds from finishing.
@@ -147,9 +163,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
                 var window = new DescentFuseWindow(kind);
 
-                // ponytail: needs the app shell to own a main window here (WPF set Owner from
-                // Application.Current.MainWindow). Ownerless is correct until the shell exists.
-                window.Show();
+                // WPF: `if (main != null && main.IsLoaded && !ReferenceEquals(main, window))
+                // window.Owner = main;`. Avalonia's Owner is read-only - ownership is passed to
+                // Show - so the same guards pick between the two overloads.
+                //
+                // IsVisible, not WPF's IsLoaded, and the difference matters: Avalonia's
+                // Show(parent) THROWS when the parent is not visible, and a shell minimized to the
+                // tray is loaded but not visible - which is exactly the state the app is in when a
+                // countdown reaches zero unattended. A throw here is caught below and answers null,
+                // i.e. the show silently never opens. Ownerless is a fine fallback: this is a
+                // fullscreen topmost window, not a dialog.
+                var main = (global::Avalonia.Application.Current?.ApplicationLifetime
+                    as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+                if (main is { IsVisible: true } && !ReferenceEquals(main, window)) window.Show(main);
+                else window.Show();
                 window.Activate();
 
                 Log.Information("[Fuse] {Kind} show opened ({Motion}).",
@@ -242,7 +269,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             if (frame.Stage == DescentFuseStage.Crack && !_crackSounded)
             {
                 _crackSounded = true;
-                // ponytail: needs DescentRoomSfx (WPF head), wired when audio moves to Core.
+                // ponytail: needs DescentRoomSfx.PlayCrack from
+                // ConditioningControlPanel/Services/Descent/DescentRoomSfx.cs. It cannot come over
+                // as-is: it reads App.DescentCountdown.AudioEnabled and resolves its file through
+                // ChaosSfx.ResolvePath, neither of which is in Core. CoreAudio.PlayOneShot is the
+                // seam it would use - and is itself unseeded on this head (App.axaml.cs), so the
+                // sting would still be silent.
             }
 
             if (frame.Stage >= DescentFuseStage.Bloom && !_backdropRaised)
@@ -255,8 +287,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 if (_kind == DescentShowKind.Live && !_witnessedMarked)
                 {
                     _witnessedMarked = true;
-                    // ponytail: needs App.DescentCountdown.MarkLastNightWitnessed, wired when the
-                    // countdown service moves to Core.
+                    // ponytail: needs DescentCountdownService.MarkLastNightWitnessed from
+                    // ConditioningControlPanel/Services/Descent/DescentCountdownService.cs. The
+                    // keepsake it writes is a settings field, but nothing in Core owns the write.
                 }
 
                 // The light is back, so the door may open.
@@ -277,12 +310,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             if (frame.SinceBloom < 0) return;
 
-            // ponytail: needs App.DescentMigration.IsCeremonyOpen — false here, so this head always
-            // walks the timeout branch and shows the standing line rather than crossfading.
+            // ponytail: needs DescentMigrationService.IsCeremonyOpen
+            // (ConditioningControlPanel/Services/Descent/DescentMigrationService.cs) — false here,
+            // so this head always walks the timeout branch and shows the standing line rather than
+            // crossfading. That is the contract's own no-offer path, not a fake one: the ceremony
+            // really is still coming on the next sync, so nothing is written and nothing loops.
             switch (_handoff.Advance(frame.SinceBloom, ceremonyOpen: false))
             {
                 case DescentHandoffAction.Resync:
-                    // ponytail: needs App.ProfileSync.SyncProfileAsync, wired when sync moves to Core.
+                    // ponytail: needs ProfileSyncService.SyncProfileAsync from
+                    // ConditioningControlPanel/Services/Settings/ProfileSyncService.cs. No Core seam.
                     break;
 
                 case DescentHandoffAction.CrossfadeToCeremony:
@@ -387,7 +424,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             if (!_holdingOffers) return;
             _holdingOffers = false;
-            // ponytail: needs App.DescentMigration.ReleaseOffers, wired when it moves to Core.
+            // ponytail: needs DescentMigrationService.ReleaseOffers - the paired release for the
+            // HoldOffers above, same file, same missing seam.
         }
 
         private void SafeClose()

--- a/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
@@ -5,6 +5,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -12,6 +14,8 @@ using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Threading;
+using Avalonia.Styling;
+using ConditioningControlPanel.Avalonia.Controls;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
 using Serilog;
@@ -643,15 +647,49 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>
-        /// ponytail: needs MotionFx.AllowTransitions (the reduced-motion gate), wired when it moves
-        /// to Core. The WPF original fades the step in over 140ms and simply swaps at MotionLevel
-        /// Off; the swap is what happens here, which is also the only behaviour a headless render
-        /// can capture - a step starting at Opacity 0 photographs blank.
+        /// The only motion on this screen, and it is gated, exactly as WPF has it: at MotionLevel
+        /// Off the page simply swaps. No loop, so there is nothing for the motion kill-switch to
+        /// stop.
+        ///
+        /// <para><c>MotionFx</c> itself is WPF Storyboard code and is NOT coming to Core, but its
+        /// DECISION is <c>CoreSettings.Current.MotionLevel</c>, which this head already reads
+        /// through <see cref="AmbientFxCanvas.Env"/> - so the gate is the real one.
+        /// <c>MotionFx.AllowTransitions</c> is <c>Level != Off</c>.</para>
+        ///
+        /// <para>The animation ends at 1 and stays there (<c>FillMode.Forward</c>), and a throw
+        /// lands on the swap rather than leaving a step parked at Opacity 0 - the wizard is the
+        /// first thing a new install sees, so an invisible page here is unrecoverable.</para>
         /// </summary>
         private void FadeInCurrentStep()
         {
             var host = _step == 1 ? (Control)_step1 : _step == 2 ? _step2 : _step3;
-            host.Opacity = 1;
+
+            if (AmbientFxCanvas.Env.Level == MotionLevel.Off)
+            {
+                host.Opacity = 1;
+                return;
+            }
+
+            try
+            {
+                host.Opacity = 0;
+                _ = new Animation
+                {
+                    Duration = TimeSpan.FromMilliseconds(140),
+                    Easing = new QuadraticEaseOut(),
+                    FillMode = FillMode.Forward,
+                    Children =
+                    {
+                        new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(OpacityProperty, 0d) } },
+                        new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(OpacityProperty, 1d) } },
+                    },
+                }.RunAsync(host);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[FirstRun] Step fade failed, swapping instead: {Error}", ex.Message);
+                host.Opacity = 1;
+            }
         }
 
         // ------------------------------------------------------------------ step 2: mod pick

--- a/CCP.Avalonia/Views/Windows/GoonTestWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/GoonTestWindow.axaml.cs
@@ -42,8 +42,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _btnTearDown = this.FindControl<Button>("BtnTearDown")!;
             _txtStatus = this.FindControl<TextBlock>("TxtStatus")!;
 
-            // ponytail: needs GoonTestPanel (+ GoonGameService/GoonMatchService), wired when they
-            // move to Core. The WPF original built two panels with different sim seeds — 1337 and
+            // ponytail: needs GoonTestPanel from ConditioningControlPanel/GoonTestPanel.cs, which
+            // is a WPF UserControl built entirely in code (System.Windows.Controls, 1,120 lines) -
+            // it is a REDRAW for this head, not a move. The services behind it are head-side too:
+            // ConditioningControlPanel/Services/GoonGame/GoonGameService.cs and .../
+            // GoonMatchService.cs. Core already holds the pure half (GoonContracts, GoonDraft,
+            // GoonMatchTypes, GoonRng, GoonScoring, GoonWire), so the ENGINE is not the blocker -
+            // the transport-owning service and the WPF panel are.
+            // The WPF original built two panels with different sim seeds — 1337 and
             // 8675309 — because two sides posting the SAME round time make every sudden-death
             // round a draw and the ladder never resolves. Keep the two seeds different when this
             // comes back.
@@ -81,8 +87,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnCreateLoopback_Click()
         {
-            // ponytail: needs GoonLoopbackTransport.CreatePair + GoonMatchService, wired when they
-            // move to Core. The profile index maps 1 -> Relay(), 2 -> Instant(), default -> P2P().
+            // ponytail: needs GoonLoopbackTransport.CreatePair from
+            // ConditioningControlPanel/Services/GoonGame/GoonLoopbackTransport.cs plus
+            // GoonMatchService, same directory. Neither is in Core and no Core seam names them.
+            // The profile index maps 1 -> Relay(), 2 -> Instant(), default -> P2P().
             //
             // ORDER MATTERS when this comes back. AdoptLobby BEFORE ConnectAsync: the hello is sent
             // from the transport's connected state change, and a hello that lands while the peer is
@@ -93,15 +101,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnOutage_Click()
         {
-            // ponytail: needs GoonLoopbackPair.SimulateOutage(20000), wired when it moves to Core.
+            // ponytail: needs GoonLoopbackPair.SimulateOutage(20000) from
+            // ConditioningControlPanel/Services/GoonGame/GoonLoopbackTransport.cs.
             // Expect Wobbly at 15 s and Dead/abandon at 60 s once it is back.
             Stub("Simulate 20s Outage");
         }
 
         private void BtnTearDown_Click()
         {
-            // ponytail: needs GoonTestPanel.LeaveAsync + the loopback dispose chain, wired when
-            // they move to Core.
+            // ponytail: needs GoonTestPanel.LeaveAsync (ConditioningControlPanel/GoonTestPanel.cs)
+            // plus the loopback dispose chain in Services/GoonGame/GoonLoopbackTransport.cs.
             Stub("Tear Down Both");
         }
 

--- a/CCP.Avalonia/Views/Windows/LockCardWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/LockCardWindow.axaml.cs
@@ -52,8 +52,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// </summary>
     public partial class LockCardWindow : Window
     {
-        // ponytail: needs LockCardService, wired when it moves to Core. Placeholder card so the
-        // render (and any manual run) shows the real layout with real strings.
+        // ponytail: needs ConditioningControlPanel/Services/LockCard/LockCardService.cs, which is
+        // pinned to the head by App.* and the WPF window itself. Placeholder card so the render
+        // (and any manual run) shows the real layout with real strings.
         private const int SampleRepeats = 3;
 
         /// <summary>
@@ -67,6 +68,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// <summary>Exactly one card owns the keyboard; every other monitor is a read-only mirror
         /// that echoes what the primary types.</summary>
         private bool _isPrimary = true;
+
+        /// <summary>A test card awards no XP and notifies no service - WPF's own gate.</summary>
+        private bool _isTest;
 
         // Per-session config (mutable: the WPF original pooled windows and reconfigured on reuse).
         private string _phrase = "";
@@ -501,11 +505,27 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             var completionTime = (DateTime.Now - _startTime).TotalSeconds;
 
-            // ponytail: needs App.Progression (AddXP, XPSource.LockCard), App.Achievements
-            // (TrackLockCardCompletion) and App.LockCard (NotifyCompleted); wired when they move to
-            // Core. The XP formula and the strict 1.5x multiplier live with them, not with the view.
-            Log.Information("Lock Card completed - {Repeats} repeats in {Time:F1}s with {Errors} errors",
-                _requiredRepeats, completionTime, _totalErrors);
+            // The XP award, WPF's body verbatim including the !_isTest gate and the strict 1.5x
+            // multiplier. App.Progression is CoreProgression here; the WPF call is already a
+            // null-conditional fire-and-forget, and unseeded (this head today) the seam is the same
+            // no-op, so restoring it cannot mis-award - it only starts working the day a head seeds
+            // progression. XPSource.LockCard crosses as its member NAME: the enum is declared inside
+            // Services/Companion/CompanionService.cs, which cannot move, so CoreProgression takes a
+            // string and the seeding head parses it.
+            if (!_isTest)
+            {
+                var xpAmount = (50 * _requiredRepeats) + 200;
+                if (_strictMode) xpAmount = (int)(xpAmount * 1.5);
+                CoreProgression.AddXP(xpAmount, "LockCard");
+            }
+
+            // ponytail: the other two calls stay stubbed and have no Core seam to reach through.
+            // App.Achievements.TrackLockCardCompletion(completionTime, _totalCharsTyped,
+            //   _totalErrors, _requiredRepeats) - ConditioningControlPanel/Services/Progression/AchievementService.cs
+            // App.LockCard.NotifyCompleted(_phrase, _totalErrors, _requiredRepeats) (!_isTest only)
+            //   - ConditioningControlPanel/Services/LockCard/LockCardService.cs
+            Log.Information("Lock Card completed - {Repeats} repeats in {Time:F1}s with {Errors} errors{Test}",
+                _requiredRepeats, completionTime, _totalErrors, _isTest ? " (TEST)" : "");
 
             foreach (var window in Fanout())
             {
@@ -862,7 +882,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             try
             {
-                var primary = Build(phrase, repeats, strictMode, voiceMode, isPrimary: true);
+                var primary = Build(phrase, repeats, strictMode, voiceMode, isTest, isPrimary: true);
                 primary.Show();
 
                 // One cover per monitor when the user asked for it. Avalonia has no screen list
@@ -873,7 +893,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                     var primaryScreen = all.FirstOrDefault(s => s.IsPrimary) ?? all.FirstOrDefault();
                     foreach (var screen in all.Where(s => s != primaryScreen))
                     {
-                        var mirror = Build(phrase, repeats, strictMode, voiceMode, isPrimary: false);
+                        var mirror = Build(phrase, repeats, strictMode, voiceMode, isTest, isPrimary: false);
                         mirror.Show();
                         // The .axaml opens Maximized, and a maximized X11 window ignores Position.
                         // Un-maximize, place it on the target screen, re-maximize: the WM then
@@ -903,9 +923,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// and before <c>Show()</c> so <see cref="IsAnyOpen"/> is already true for a caller that
         /// polls it the moment <see cref="ShowOnAllMonitors"/> returns.
         /// </summary>
-        private static LockCardWindow Build(string phrase, int repeats, bool strictMode, bool voiceMode, bool isPrimary)
+        private static LockCardWindow Build(string phrase, int repeats, bool strictMode, bool voiceMode, bool isTest, bool isPrimary)
         {
-            var window = new LockCardWindow { _isPrimary = isPrimary };
+            var window = new LockCardWindow { _isPrimary = isPrimary, _isTest = isTest };
             window.Configure(phrase, repeats, strictMode, voiceMode);
             _allWindows.Add(window);
             return window;

--- a/CCP.Avalonia/Views/Windows/MantraWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MantraWindow.axaml.cs
@@ -22,9 +22,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    come from <c>CoreSettings.Current</c> (MantraPool, MantraDefaultCount) rather than an
     ///    invented English line; <see cref="SampleStreak"/> still drives the warm palette so the
     ///    render shows a live scene rather than a cold empty one.
-    ///  - Five WPF Storyboards (pulse, shake, letter-pulse, wrong-shake, glow) are dropped:
-    ///    Avalonia has no Storyboard and every one of them is begun from a service event that is
-    ///    stubbed above. ponytail: re-add as Avalonia Animations when MantraService reaches Core.
+    ///  - Five WPF Storyboards (pulse, shake, letter-pulse, wrong-shake, glow) are dropped, and
+    ///    MantraService is NOT what blocks four of them - it is that Avalonia's
+    ///    <c>TransformAnimator</c> seizes the target's <c>RenderTransform</c> and throws on a
+    ///    code-held <c>Transform</c>, so a ported shake/pulse has to be a tween stepped off a
+    ///    shared ~16ms <c>DispatcherTimer</c> (ChaosHudWindow is the worked example in this head).
+    ///    Letter-pulse is blocked differently and permanently: its target is a <c>Run</c>, which is
+    ///    not a <c>Visual</c>, so no Avalonia <c>Animation</c> can address it at all - the
+    ///    stepped-timer colour hop already in <see cref="UpdateHighlights"/> is its replacement.
     ///  - <c>DispatcherTimer</c> exists in Avalonia; the float timer is stopped in
     ///    <c>OnClosed</c> as well as <c>CleanupAndClose</c>, because --render-all closes the
     ///    window externally and a 16ms tick would outlive the view in that shared process.
@@ -208,8 +213,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 };
                 timer.Start();
 
-                // ponytail: the WPF LetterPulseStoryboard fired here; re-add as an Avalonia
-                // Animation alongside the other four.
+                // The WPF LetterPulseStoryboard fired here. It cannot be an Avalonia Animation:
+                // the target is the Run above and Animation.RunAsync takes a Visual. The DispatcherTimer
+                // colour hop immediately above IS the port of it, stepped rather than animated.
             }
 
             _prevMatchCount = matchCount;

--- a/CCP.Avalonia/Views/Windows/MediaHistoryWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MediaHistoryWindow.axaml.cs
@@ -109,8 +109,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         /// <summary>
         /// WPF read <c>App.MediaHistory.GetSnapshot()</c> and subscribed to EntryAdded / Cleared.
-        /// ponytail: needs MediaHistoryService, wired when it moves to Core. Until then these
-        /// placeholder rows let the list, the filters and the preview all draw their real states.
+        /// ponytail: needs ConditioningControlPanel/Services/Media/MediaHistoryService.cs. Until
+        /// then these placeholder rows let the list, the filters and the preview all draw their
+        /// real states.
         /// </summary>
         private static List<MediaHistoryRow> LoadRows()
         {
@@ -222,8 +223,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             }
             _previewMissing.IsVisible = false;
 
-            // ponytail: the video and animated-GIF branches need a media stack (WPF used
-            // MediaElement and XamlAnimatedGif); wired when one is chosen for the Avalonia head.
+            // ponytail: the video and animated-GIF branches need a media stack. WPF used
+            // MediaElement and XamlAnimatedGif, both WPF-only; the Avalonia head has picked no
+            // replacement yet and adding one is a CCP.Avalonia.csproj change, which no view layer
+            // owns. A still Bitmap of frame 1 is deliberately NOT drawn for the GIF case - a frozen
+            // frame in a preview pane labelled "preview" reads as a broken animation, and the
+            // missing-media plate says the truth.
             if (row.IsVideo)
             {
                 _previewImage.IsVisible = false;

--- a/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/PopQuizWindow.axaml.cs
@@ -24,8 +24,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - The 200ms <c>_keepOnTopTimer</c> is dropped entirely. Both halves of it are gone: the
     ///    topmost re-assert is covered by the property above, and the "self-close once the main
     ///    window is genuinely gone" watchdog reads <c>App.MainWindowRef</c>.
-    ///    ponytail: needs App.MainWindowRef, wired when the shell moves to Core. Dropping it also
-    ///    means nothing here can outlive the window during --render-all.
+    ///    App.MainWindowRef is NOT the blocker - it resolves here as the desktop lifetime's
+    ///    <c>MainWindow</c>, the same lookup EmiMutePromptWindow.Ask uses. The watchdog stays
+    ///    DROPPED on purpose: a 200ms static timer is the only thing in this file that can outlive
+    ///    the window, and under --render-all (no lifetime, no shell) it would tick forever against
+    ///    a null MainWindow and close every rendered quiz. Restore it with the shell, not before.
     ///  - <c>PopQuizQuestion</c> is copied to the bottom of this file: it lives in the WPF head's
     ///    PopQuizService and this project may not reference that, same as TextEditorDialog's
     ///    TextItem.
@@ -61,8 +64,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             IsOpen = true;
 
-            // ponytail: needs AvatarWindow.IsMuted / SetMuteAvatar from
-            // ConditioningControlPanel/Windows/AvatarWindow.xaml.cs (head-side). WPF muted the
+            // ponytail: needs App.AvatarWindow.IsMuted / SetMuteAvatar - the type is
+            // AvatarTubeWindow, ConditioningControlPanel/AvatarTube/AvatarTubeWindow.*.cs (there is
+            // no AvatarWindow.xaml.cs; App.xaml.cs:952 is where the name comes from). WPF muted the
             // avatar for the whole quiz so her z-order work could not cover this window, and
             // restored it in OnClosed.
 
@@ -169,7 +173,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // first Complete just dequeued (same #462 class as the lock-card fix).
             _answered = true;
             // ponytail: needs InteractionQueueService.Complete(InteractionType.PopQuiz) from
-            // ConditioningControlPanel/Services/InteractionQueueService.cs — still head-side.
+            // ConditioningControlPanel/Services/UI/InteractionQueueService.cs — still head-side,
+            // and no Core seam names an interaction queue.
             Close();
         }
 
@@ -264,11 +269,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             IsOpen = false;
 
-            // ponytail: restoring the avatar mute state needs AvatarWindow.IsMuted /
-            // SetMuteAvatar from ConditioningControlPanel/Windows/AvatarWindow.xaml.cs, and the
-            // safety net `if (!_answered) InteractionQueue.Complete(...)` needs
-            // ConditioningControlPanel/Services/InteractionQueueService.cs. Both head-side. _answered is deliberately NOT set here — that flag is what tells the
-            // safety net an unanswered quiz still owes a Complete.
+            // ponytail: restoring the avatar mute state needs App.AvatarWindow (AvatarTubeWindow,
+            // ConditioningControlPanel/AvatarTube/) and the safety net
+            // `if (!_answered) InteractionQueue.Complete(...)` needs
+            // ConditioningControlPanel/Services/UI/InteractionQueueService.cs. Both head-side.
+            // _answered is deliberately NOT set here — that flag is what tells the safety net an
+            // unanswered quiz still owes a Complete.
 
             base.OnClosed(e);
         }

--- a/CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml.cs
@@ -20,14 +20,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// folder. That is deliberate rather than lazy - see the note on ShowIfFirstTime.
     ///
     /// PORTED from ConditioningControlPanel/Windows/ProgramsIntroPopup.xaml.cs. Deviations:
-    ///  - <c>ShowIfFirstTime</c> is dropped, not stubbed: every line of it is App.Settings /
-    ///    App.Programs / App.Mods / Dispatcher gating, none of which exists here, and an empty
-    ///    gate that silently never shows the card would be worse than no gate. It comes back with
-    ///    those services.
+    ///  - <c>ShowIfFirstTime</c> is dropped, not stubbed. App.Settings and App.Mods are NOT the
+    ///    blockers any more (CoreSettings / CoreMods answer both), but App.Programs is:
+    ///    ConditioningControlPanel/Services/Program/ProgramService.cs is head-side and the gate is
+    ///    "has a program been started", which nothing here can answer. An empty gate that silently
+    ///    never shows the card would be worse than no gate.
     ///  - <c>ProgramDefinition</c> is in the WPF head, so <see cref="Featured"/> is a local
     ///    stand-in holding exactly the four fields the card dresses itself from.
-    ///  - <c>ProgramArt.Sigil/DayPlate</c> is a head service: the sigil stays hidden and the rail
-    ///    shows its gradient, glow and program title, which is what the WPF fallback plate draws.
+    ///  - <c>ProgramArt.Sigil/DayPlate</c> stays unresolved, blocked on the unlinked
+    ///    <c>Assets/programs</c> art rather than on the resolver - see the note at its call site.
+    ///    The sigil stays hidden and the rail shows its gradient, glow and program title, which is
+    ///    what the WPF fallback plate draws.
     ///  - <c>PreviewKeyDown</c> -&gt; <c>KeyDown</c>; <c>DragMove()</c> -&gt; <c>BeginMoveDrag(e)</c>.
     /// </summary>
     public partial class ProgramsIntroPopup : Window
@@ -84,10 +87,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 for (int i = 1; i <= 4; i++)
                     this.FindControl<TextBlock>("Bullet" + i)!.Foreground = accent;
 
-                // ponytail: needs ProgramArt.Sigil / ProgramArt.DayPlate, wired when they move to
-                // Core. The sigil Rectangle stays hidden (its Fill would be `accent` and its
-                // OpacityMask an ImageBrush over that art); the rail still draws its gradient, glow
-                // and title, which is what the WPF shared-fallback-plate path looks like.
+                // ponytail: the sigil Rectangle stays hidden, and NOT for the reason the old note
+                // gave. Avalonia has OpacityMask on Visual, and Helpers.ModArt.TryLoad is already
+                // this head's ModResourceResolver.ResolveImage - so the mask itself is portable.
+                // Two things actually block it:
+                //   1. Assets/programs (sigil_*.png, plate_default.png) is NOT linked into
+                //      CCP.Avalonia.csproj, so avares://CCP.Avalonia/Resources/programs/... does
+                //      not exist and TryLoad returns null for every one. A csproj this layer does
+                //      not own; see Assets/README.md for the Link= shape.
+                //   2. ProgramArt's key is Slug(program.Id) and DayPlate's is the session
+                //      template's display name - both off ProgramDefinition, which is head-side
+                //      (Featured below carries four display fields, not an Id or a day list).
+                // The rail still draws its gradient, glow and title, which is what the WPF
+                // shared-fallback-plate path looks like.
                 this.FindControl<Rectangle>("ArtGlow")!.Fill = GlowBrush(accent);
 
                 var title = this.FindControl<TextBlock>("TxtArtProgramTitle")!;

--- a/CCP.Avalonia/Views/Windows/QuizReportWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuizReportWindow.axaml.cs
@@ -226,7 +226,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// <summary>
     /// Copied from ConditioningControlPanel/Services/Quiz/QuizService.cs: the report's payload
     /// types live in the WPF head, not in CCP.Core, and neither may be touched by this port.
-    /// ponytail: needs QuizService, delete these three when the quiz types move to Core.
+    /// ponytail: delete these three when the quiz payload types move out of
+    /// ConditioningControlPanel/Services/Quiz/QuizService.cs into Core. QuizService itself is not
+    /// what is needed here - only its nested QuizCategory / QuizDifficulty / QuizReport shapes are.
     /// </summary>
     public enum QuizCategory
     {

--- a/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs
@@ -66,7 +66,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         /// <summary>
         /// WPF read <c>App.SessionLog.LoadRecentLogs()</c>.
-        /// ponytail: needs SessionLogService, wired when it moves to Core. Until then this returns
+        /// ponytail: needs ConditioningControlPanel/Services/Session/SessionLogService.cs. Until then this returns
         /// placeholder rows so the window renders the populated state rather than the empty one.
         /// </summary>
         private static List<HistoryRow> LoadRecentRows() => new()
@@ -91,8 +91,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // still in the WPF head, so LoadRecentRows below fabricates its rows, and a HistoryRow
             // carries none of the XP, difficulty or media list a Recap needs. Building one from a
             // row would open a recap reading "0 XP, no media" over a session that had both, which
-            // is a window that lies. Wire this when SessionLogService reaches Core and a row can
-            // carry its real log.
+            // is a window that lies. Wire this when
+            // ConditioningControlPanel/Services/Session/SessionLogService.cs reaches Core and a row
+            // can carry its real log.
         }
     }
 

--- a/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Styling;
+using ConditioningControlPanel.Avalonia.Controls;
 using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Windows
@@ -141,16 +142,27 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>
-        /// Arms the sheen sweep. The WPF original gates it on PerformanceProfile.AllowGlow AND
-        /// MotionFx.AllowAmbientLoops, and leaves the card on its static livery rim when either
-        /// says no.
-        /// ponytail: needs MotionFx/PerformanceProfile, gate the sweep when they move to Core
-        /// (FeatureCard/SplitFeatureCard run their loops ungated here for the same reason).
+        /// Arms the sheen sweep, gated exactly as WPF gates it: the performance tier has to allow
+        /// glow AND the motion setting has to allow ambient loops. When either says no the card
+        /// keeps a STATIC accent (the livery rim and its drop shadow), which is the resting look -
+        /// never "the same thing, slower".
+        ///
+        /// <para>WPF asks two services; this head asks <see cref="AmbientFxCanvas.Env"/>, which
+        /// carries both verbatim over the same <c>CoreSettings</c> fields. The conjunction collapses:
+        /// <c>AllowGlow(tier)</c> is <c>tier != Performance</c>, which is <c>Env.AllowAmbientMotion</c>,
+        /// and <c>Env.AllowAmbientLoops</c> is <c>Level == Full &amp;&amp; AllowAmbientMotion(tier)</c> -
+        /// so <c>AllowAmbientLoops</c> alone IS the WPF pair, not a weakened stand-in.</para>
         /// </summary>
         private void StartShimmer()
         {
             try
             {
+                if (!AmbientFxCanvas.Env.AllowAmbientLoops)
+                {
+                    _shimmerHost.IsVisible = false;
+                    return;
+                }
+
                 if (_shimmerBar.RenderTransform is not TransformGroup group) return;
                 var slide = group.Children.OfType<TranslateTransform>().FirstOrDefault();
                 if (slide is null) return;

--- a/CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/TutorialOverlay.axaml.cs
@@ -308,8 +308,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // WPF retargeted here when step.TargetWindowTypeName named a different window, and
             // drew a clean centered "next up" card while that window was still opening.
-            // ponytail: needs TutorialService (CurrentSteps / CurrentStepIndex) and the
-            // WindowLoaded:* bus event to know when to retarget; wired when they move to Core.
+            // ponytail: CurrentStepIndex is NOT the blocker - CoreTutorial.CurrentStepIndex is in
+            // Core and StepCounterText below already reads it. What is missing is the STEP LIST
+            // (CoreTutorial exposes CurrentStep only, so "the next step's TargetWindowTypeName"
+            // cannot be looked ahead) and the WindowLoaded:* bus event that says the other window
+            // has opened - ConditioningControlPanel/Services/TutorialEventBus.cs, which has no Core
+            // seam to emit into. Both live with
+            // ConditioningControlPanel/Services/TutorialService.cs.
 
             // A new card: the once-per-step advance latch reopens. WPF does this inside
             // SubscribeAdvanceTrigger, which is the only thing UpdateStep calls after this point

--- a/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
@@ -41,9 +41,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// FitCerrolazaPolynomial, FitRidge, EvalPolynomial, BuildAxisCorrection, FitAxisTrim,
     /// ~1,300 lines of OpenCvSharp-free maths that still needs <c>WebcamCalibrationData</c> from
     /// the WPF head), the gesture warm-up waiters, <c>RunBubbleTestAsync</c>,
-    /// <c>CalibrationSoundService</c>, <c>App.GazeCursor</c>, <c>App.Settings</c>,
-    /// <c>App.Notifications</c>, <c>App.Logger</c> and the HelpContentService/HelpVideoWindow
-    /// popup.</para>
+    /// <c>CalibrationSoundService</c> (ConditioningControlPanel/Services/CalibrationSoundService.cs)
+    /// and <c>App.GazeCursor</c> (Services/Tracking/GazeDebugCursorService.cs, a WPF window).
+    /// <c>App.Webcam</c> is ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs.
+    /// <b>Three names that used to be on this list are not blockers any more</b> and were removed
+    /// rather than left to mislead: <c>App.Settings</c> is <see cref="CoreSettings"/>,
+    /// <c>App.Logger</c> is Serilog's static <c>Log</c>, and the HelpContentService/HelpVideoWindow
+    /// popup is RESTORED and live (see BtnHelp below - the service is in Core and the window sits
+    /// in this same folder). <c>App.Notifications</c> is the one head service left in that group:
+    /// ConditioningControlPanel/Services/NotificationService.cs.</para>
     ///
     /// Other deviations:
     ///  - WPF's <c>DialogResult</c> becomes <c>Close(bool)</c>, as in TextEditorDialog.
@@ -169,8 +175,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void Window_Loaded(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.Webcam (IsRunning gate + OnRawIris / OnHeadPose /
-            // OnTrackingStateChanged subscriptions), wired when the webcam service moves to Core.
+            // ponytail: needs App.Webcam - ConditioningControlPanel/Services/Webcam/
+            // WebcamTrackingService.cs - for the IsRunning gate and the OnRawIris / OnHeadPose /
+            // OnTrackingStateChanged subscriptions. It is head-only by construction (its capture
+            // stack is Windows-side) and no Core seam names a tracker.
             // The WPF original bails to ShowError when tracking is not running; with no service to
             // ask, the intro is shown unconditionally so the view still has a first frame.
 
@@ -191,9 +199,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             IsShowing = false;
             StopRingPulse();
             _verifyCountdownTimer?.Stop();
-            // ponytail: needs App.Webcam / App.GazeCursor to unsubscribe the iris + pose streams
-            // and release the "calibration-verify" and "calibration-bubbletest" cursor keys and the
-            // gaze attractor, wired when those services move to Core.
+            // ponytail: needs WebcamTrackingService / GazeDebugCursorService (paths in the header)
+            // to unsubscribe the iris + pose streams and release the "calibration-verify" and
+            // "calibration-bubbletest" cursor keys and the gaze attractor.
         }
 
         private void Window_KeyDown(object? sender, KeyEventArgs e)

--- a/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs
@@ -57,8 +57,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             base.OnOpened(e);
 
-            // ponytail: needs WebcamTrackingService (IsRunning / Calibration / OnGazeMove /
-            // OnTrackingStateChanged), wired when it moves to Core. With it back, this checks
+            // ponytail: needs ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
+            // (IsRunning / Calibration / OnGazeMove / OnTrackingStateChanged). It is head-only by
+            // construction and no Core seam names a tracker. With it back, this checks
             // both preconditions, subscribes OnGazeMove and closes the window when the service
             // stops. Without it there is no tracking to visualise, which is exactly the WPF
             // original's first error path, so it takes that path verbatim.

--- a/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs
@@ -42,8 +42,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // Discoverability: this window is the one place every user of Quick Recal provably
             // reaches, so it is where the global chord gets taught. The real line quotes the
             // user's own (rebindable) camera shortcut alongside it.
-            // ponytail: needs MainWindow.QuickRecalHotkeyHint, wired when the hotkey map moves to Core
-            _txtHotkeyHint.Text = "Tip: the same quick recal runs from anywhere with the global quick-recal chord.";
+            // The tip is HIDDEN on this head rather than worded, and the old note named the wrong
+            // blocker. MainWindow.QuickRecalHotkeyHint (MainWindow/MainWindow.xaml.cs:1263) is just
+            // Loc.GetF("webcam_quick_recal_hotkey_hint", QuickRecalHotkeyChord, CameraShortcutChord),
+            // the key is in CCP.Core/Localization/Languages/*.json, and both chords are derivable
+            // here (the quick-recal one is a constant, the camera one reads
+            // CoreSettings.Current.CompanionPrompt.CameraShortcut*). So it is writable today.
+            // What stops it is that BOTH chords are Win32 RegisterHotKey registrations in
+            // ConditioningControlPanel/Services/Input/GlobalHotkeyService.cs, and this head installs no
+            // global hotkey of any kind - "runs from anywhere with Ctrl+Alt+G" would be teaching a
+            // key that does nothing. An empty hint is a gap; a taught dead key is a lie.
+            _txtHotkeyHint.IsVisible = false;
 
             // WPF closed with `DialogResult = _completedOk`, but the error panel is only ever
             // shown on a failure path, so that flag was false every time this button was
@@ -56,8 +65,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             base.OnOpened(e);
 
-            // ponytail: needs WebcamTrackingService (IsRunning / Calibration / OnGazeMove /
-            // SetRuntimeOffset) + CalibrationSoundService. With those back this shows the dot,
+            // ponytail: needs ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
+            // (IsRunning / Calibration / OnGazeMove / SetRuntimeOffset) plus
+            // ConditioningControlPanel/Services/CalibrationSoundService.cs. Neither is in Core and
+            // no Core seam names a tracker. With those back this shows the dot,
             // samples for 2 s, takes the per-axis median after dropping the saccade onto the
             // dot, and writes (window centre - median) as the runtime offset. Without them
             // there is nothing to sample, so the window just parks in its opening state.


### PR DESCRIPTION
Correction to the brief first: wire/84 is 0f46bc8d, and it carries NO "files
not reached" list - it names still-blocked SYMBOLS, not unswept files. So the
resume point had to be derived: every file in this directory that carries a
note and is absent from that commit's 13-file stat. That is what this layer
worked, breadth-first.

MotionFx was never the blocker it was named as, in three files. MotionFx is WPF
Storyboard code and is not coming to Core, but its DECISION is
CoreSettings.Current.MotionLevel, which this head has read since
AmbientFxCanvas.Env landed. DescentFuseWindow's `_reduced = false` becomes
`Env.Level != MotionLevel.Full`, and because that flag is threaded into every
DescentFuseTimeline / DescentIgnitionTimeline call, picking Reduced now really
does shorten the show here rather than being silently ignored. FirstRunWizard
gets WPF's 140ms step fade back with WPF's own gate (Off swaps, everything else
fades), FillMode.Forward so it sticks, and a catch that lands on the swap - an
invisible first page on a new install is unrecoverable. TeaseRevealPopup's
sheen sweep is gated again: WPF asks AllowGlow(tier) AND AllowAmbientLoops, and
that conjunction collapses exactly to Env.AllowAmbientLoops, so this is the WPF
pair rather than a weakened stand-in. The one WPF input with no twin anywhere is
the OS animation-effects cap, which can only ever REMOVE motion - noted in place.

The fuse takes an owner, with the guard Avalonia needs rather than WPF's. WPF
sets Owner when the main window IsLoaded; Avalonia has no settable Owner and
Show(parent) THROWS when the parent is not visible, so the guard is
`main is { IsVisible: true }`. A shell minimized to tray is loaded and not
visible - the exact state the app is in when a countdown reaches zero unattended
- and with IsLoaded the throw would be swallowed by Open()'s catch and the
fullscreen show would silently never appear. Ownerless stays the fallback.

The quick-recal tip is HIDDEN, and its note named the wrong blocker.
MainWindow.QuickRecalHotkeyHint is one Loc.GetF over a key that is already in
CCP.Core/Localization/Languages/*.json, and both chords are derivable here, so
it was writable today. What stops it is that BOTH chords are Win32 RegisterHotKey
registrations in Services/Input/GlobalHotkeyService.cs and this head installs no
global hotkey of any kind. An empty hint is a gap; a taught dead key is a lie.

LockCardWindow routes its XP through CoreProgression, gate included. WPF's body
verbatim: !_isTest, (50 * repeats) + 200, x1.5 for strict. _isTest existed only
as an unstored parameter on ShowOnAllMonitors, so it is threaded through Build
into the window. This awards nothing today - CoreProgression is unseeded on this
head - which is precisely why it is safe: the WPF call is a null-conditional
fire-and-forget too, so the restored call is the same no-op until a head seeds
progression, and no control on screen reads it. The other two calls stay
stubbed and now name their files. XPSource.LockCard crosses as a member NAME
because the enum is declared inside CompanionService.cs, which cannot move.

BugReportWindow's active_mod line is left alone ON PURPOSE, and the note now
says why in the file: BugReportService.ResolveActiveModId is a PRIVACY rule, not
a lookup - a mod that is not built-in is reported as the literal "custom-mod",
because a locally authored mod id narrowly identifies its author in a small
community. Writing CoreMods.ActiveModId there would be the obvious "fix" and
would leak that id into a preview the user reads as their consent to send.

Notes rewritten to name the blocker that is true today, with exact head paths.
GoonTestWindow: the engine half is already in Core (GoonContracts, GoonDraft,
GoonMatchTypes, GoonRng, GoonScoring, GoonWire) - what blocks it is
GoonTestPanel.cs, a 1,120-line WPF UserControl built in code, which is a REDRAW
not a move, plus GoonMatchService / GoonLoopbackTransport. WebcamCalibrationWindow's
header listed App.Settings, App.Logger and the HelpContentService/HelpVideoWindow
popup as stubbed; all three are wrong - the first two are CoreSettings and
Serilog, and the help popup is live in that same file at BtnHelp. TutorialOverlay
claimed it needed CurrentStepIndex, which is in Core and which StepCounterText
already reads; the real gaps are the step LIST and TutorialEventBus's
WindowLoaded:* event. ProgramsIntroPopup blamed ProgramArt and the resolver;
Avalonia has OpacityMask and Helpers.ModArt IS ModResourceResolver here, so the
real blockers are that Assets/programs is unlinked in a csproj no view owns and
that ProgramArt keys off head-side ProgramDefinition. MantraWindow blamed
MantraService for five dropped Storyboards; four are blocked by Avalonia's
TransformAnimator seizing RenderTransform, and letter-pulse is blocked
permanently because its target is a Run, which is not a Visual - the stepped
DispatcherTimer already in UpdateHighlights IS its port. PopQuizWindow's
App.MainWindowRef note was stale (it resolves through the lifetime); the
watchdog stays dropped because a 200ms static timer would tick against a null
MainWindow under --render-all and close every rendered quiz. Also corrected:
"AvatarWindow.xaml.cs" does not exist - the type is AvatarTubeWindow under
AvatarTube/. MediaHistoryWindow, SessionLogHistoryWindow, QuizReportWindow,
WebcamGazeTrackerWindow: path-only precision.

Read and found ALREADY PRECISE, so the next pass can skip them: LayeredAudioWindow,
QuizCategoryEditorWindow, AchievementPopup, PinkRushPopup, CornerGifWindow, the
rest of TutorialOverlay (its spotlight/X11 notes are the best in the directory),
and the eleven .axaml notes, every one of which is "local style copy, hoist to
Theme/Styles.xaml when a second view needs it" - design debt, not a blocker, and
Theme/ is not this layer's to touch.

The x:Name hazard was checked on every file touched: all load with
AvaloniaXamlLoader.Load(this) and all reach controls through FindControl. No new
generated-field access was introduced.

Requested comment-line counts over this directory (App.Settings / App.Mods /
App.Logger / ModResourceResolver / MessageBox / WebView2), EmiDesk and
MainShellWindow excluded: 13/10/11/3/11/11 before, 13/11/11/4/11/11 after. The
two +1s are documentary lines this layer WROTE - BugReportWindow noting the
service is pinned head-side by App.Mods, and ProgramsIntroPopup noting that
Helpers.ModArt is this head's ModResourceResolver. Every survivor was read and
every one describes the WPF original or a deviation table, not a missing thing.

Verified: core-guards pass, CCP.Core and CCP.Avalonia build with 0 errors,
--smoke passes, --render-all stays 189/189, and DescentFuseWindow, FirstRunWizard,
TeaseRevealPopup, LockCardWindow and WebcamQuickRecalWindow were rendered and
read - the fuse blooms with its standing line, the wizard's step 1 is fully
opaque (so the fade neither blanks nor un-hides: ShowStep hides by IsVisible,
which FillMode.Forward cannot outrank), the tease card keeps its livery, the
lock card draws its phrase, and the quick-recal window no longer carries the tip.
What the renders do NOT prove: that the 140ms fade MOVES (a render cannot show
motion); the fuse's Reduced branch or its Show(main) path, since --render-view
constructs the window directly and never calls Open(); that the XP call fires,
since CoreProgression is unseeded here; and that the shimmer gate flips - it was
read under the default Full/Quality, not under Performance or Reduced.

Still blocked, exact symbols and head paths:
  DescentFuseCopy, DescentRoomSfx.PlayCrack,
  DescentMigrationService.HoldOffers / ReleaseOffers / IsCeremonyOpen,
  DescentCountdownService.MarkLastNightWitnessed
                                      ConditioningControlPanel/Services/Descent/
  ProfileSyncService.SyncProfileAsync  ConditioningControlPanel/Services/Settings/
  DescentFuseStageVisual               ConditioningControlPanel/Controls/ (WPF DrawingVisual - redraw)
  GoonTestPanel                        ConditioningControlPanel/GoonTestPanel.cs (WPF UserControl - redraw)
  GoonGameService, GoonMatchService,
  GoonLoopbackTransport                ConditioningControlPanel/Services/GoonGame/
  WebcamTrackingService                ConditioningControlPanel/Services/Webcam/
  GazeDebugCursorService               ConditioningControlPanel/Services/Tracking/
  CalibrationSoundService              ConditioningControlPanel/Services/CalibrationSoundService.cs
  NotificationService                  ConditioningControlPanel/Services/
  GlobalHotkeyService                  ConditioningControlPanel/Services/Input/
  MantraService                        ConditioningControlPanel/Services/MantraService.cs
  BugReportService                     ConditioningControlPanel/Services/BugReportService.cs
  LockCardService, AchievementService   .../Services/LockCard/, .../Services/Progression/
  InteractionQueueService              ConditioningControlPanel/Services/UI/
  MediaHistoryService, SessionLogService, ProgramService, QuizService
                                       .../Services/Media|Session|Program|Quiz/
  TutorialService, TutorialEventBus    ConditioningControlPanel/Services/
  X11Overlay rect input region         CCP.Avalonia/Platform/X11Overlay.cs (TutorialOverlay's spotlight)
  Assets/programs, Assets/Cards        not linked in CCP.Avalonia.csproj
  a media decoder for video/GIF        CCP.Avalonia.csproj, not owned here

Handover for the next pass at Views/Windows/. NOT reached, all still carrying
notes: EmiCodexWindow, ModCreatorWindow (14 notes, the largest left),
MiniPlayerWindow, FeatureIntroPopup, SplashScreen, SessionEditorWindow,
SettingsPaletteWindow, HelpVideoWindow, FeatureSettingsPopup, HapticsSetupWindow,
SessionCompleteWindow, ItemUnlockedPopup, QuestCompletePopup, AnnouncementPopup,
BubbleCountResultWindow, DescentCeremonyWindow, EasterEggWindow. QuizWindow (20
notes) and BubbleCountWindow (19) are the two biggest counts in the directory and
should be LAST: both were swept in faffa2bf and f9cb9288, and everything left in
them is LibVLC / CoreWebView2 / HWND-blocked, so a pass there buys notes about a
media stack this head has not chosen.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU