### PR TITLE
feat(avalonia): five Chaos stubs turn out to be content, not services - sfx, tips, boon colours, rank copy and the pin-on-top read

### DIFF
--- a/CCP.Avalonia/Views/Chaos/ChaosBoonColors.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosBoonColors.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+
+namespace ConditioningControlPanel.Avalonia.Views.Chaos
+{
+    /// <summary>
+    /// The Rabbit Hole's payload-based COLOR LANGUAGE, copied id for id from
+    /// ConditioningControlPanel/Chaos/ChaosBoonColors.cs. Every boon belongs to a family by what it
+    /// DOES (electric / pleasure / economy / mind / risk), and that one colour drives the draft
+    /// card and the sidebar tile. Unmapped ids fall back to the caller's own colour, so neutral
+    /// mechanics keep their green and nothing regresses.
+    ///
+    /// <para>Why it is copied rather than referenced or hoisted: the head's class is a data table
+    /// wrapped in <c>System.Windows.Media.Color</c> and <c>SkiaSharp.SKColor</c>, neither of which
+    /// resolves in Core - so the TABLE is portable and the TYPE is not. The two chaos windows both
+    /// need it (<c>ChaosOverlayWindow</c>'s draft cards through <c>ForOrDefault</c>,
+    /// <c>ChaosHudWindow</c>'s tiles through <c>ChaosSidebarBoon.AccentBrush</c>, which calls
+    /// <c>BrushForOrDefault</c>), which is why this is one file next to them and not a private copy
+    /// in each.</para>
+    ///
+    /// <para>ponytail: the right home is a Core table of plain RGB triples with each head wrapping
+    /// its own colour type - CCP.Core/Services/Chaos/, beside ChaosTuning. Until that exists this
+    /// file and ConditioningControlPanel/Chaos/ChaosBoonColors.cs must be edited together; the head's
+    /// own comment already calls itself "the single source of truth", and it is, for the ids.
+    /// The Skia half (<c>SkForOrDefault</c>) is deliberately absent - this head has no SkiaSharp.</para>
+    /// </summary>
+    internal static class ChaosBoonColors
+    {
+        public static readonly Color Electric = Color.FromRgb(0x42, 0xDC, 0xE6);  // cyan — E-Stim / lightning / freeze
+        public static readonly Color Pleasure = Color.FromRgb(0xFF, 0x4D, 0xC4);  // hot pink — buzz / rabbits / touch
+        public static readonly Color Economy  = Color.FromRgb(0xFF, 0xC8, 0x3D);  // gold — drops / luck / payout
+        public static readonly Color Mind     = Color.FromRgb(0xB9, 0x8C, 0xFF);  // purple — perception / trance / intrusion
+        public static readonly Color Risk     = Color.FromRgb(0xFF, 0x5A, 0x5A);  // red — sins / gambles / last-second
+        public static readonly Color Neutral  = Color.FromRgb(0x9C, 0xE8, 0xA0);  // green — pure mechanics
+
+        private static readonly Dictionary<string, Color> Map = new(StringComparer.OrdinalIgnoreCase)
+        {
+            // ⚡ Electric
+            ["e_stim"] = Electric, ["overload"] = Electric, ["tail_plug"] = Electric, ["unleashed"] = Electric,
+            ["electrified_rabbits"] = Electric, ["body_buzz"] = Electric, ["aftermath"] = Electric,
+            ["freeze_trigger"] = Electric, ["freeze"] = Electric, ["snap_field"] = Electric, ["size_queen"] = Electric,
+            // 💗 Pleasure
+            ["vibe_popping"] = Pleasure, ["afterglow"] = Pleasure, ["rabbit_caller"] = Pleasure, ["gg_rabbits"] = Pleasure,
+            ["the_spanker"] = Pleasure, ["intrusive_thoughts"] = Pleasure, ["casting_couch"] = Pleasure,
+            ["porn_dvd"] = Pleasure, ["the_pull"] = Pleasure, ["chain_reaction"] = Pleasure,
+            // 💰 Economy
+            ["rabbits_foot"] = Economy, ["gold_digger"] = Economy, ["golden_touch"] = Economy, ["drip_feed"] = Economy,
+            ["welcome_shower"] = Economy, ["heavy_drop"] = Economy, ["taking_chances"] = Economy,
+            // 🧠 Mind
+            ["blindfold"] = Mind, ["blank_eyes"] = Mind, ["the_urge"] = Mind, ["slowburner"] = Mind,
+            ["bright_colors"] = Mind, ["skipping_stone"] = Mind, ["slow_fuses"] = Mind, ["slow_recovery"] = Mind,
+            ["pendulum_swing"] = Mind, ["focus_here"] = Mind, ["breast_enlargement"] = Mind,
+            // 🔥 Risk
+            ["hair_trigger"] = Risk, ["playing_fire"] = Risk, ["cam_girl"] = Risk, ["double_or_nothing"] = Risk,
+            ["last_breath"] = Risk, ["surrender"] = Risk,
+        };
+
+        /// <summary>The family colour for <paramref name="id"/>, or <paramref name="fallback"/> if unmapped.</summary>
+        public static Color ForOrDefault(string? id, Color fallback)
+            => (id != null && Map.TryGetValue(id, out var c)) ? c : fallback;
+
+        // WPF froze each brush and cached it; an ImmutableSolidColorBrush is already frozen, so the
+        // cache is only about allocation - one brush per family, built once.
+        private static readonly Dictionary<Color, IBrush> BrushCache = new();
+
+        /// <summary>An immutable accent brush for <paramref name="id"/>, or <paramref name="fallback"/>
+        /// if unmapped.</summary>
+        public static IBrush BrushForOrDefault(string? id, IBrush fallback)
+        {
+            if (id == null || !Map.TryGetValue(id, out var c)) return fallback;
+            if (!BrushCache.TryGetValue(c, out var b)) { b = new ImmutableSolidColorBrush(c); BrushCache[c] = b; }
+            return b;
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Chaos/ChaosHubWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosHubWindow.axaml.cs
@@ -32,7 +32,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     ///    state each builder branches on (equipped / owned / locked / rank-locked / empty;
     ///    trained-on / trained-off / untrained; seen / unseen / sin; sewn / for-sale / rank-short
     ///    / hazy), so the render proves the builders rather than one branch of them.
-    ///    ponytail: needs the Chaos services, wired when they move to Core.
+    ///    ponytail: needs the Chaos services. Every one of them is under
+    ///    ConditioningControlPanel/Services/Chaos/ - ChaosUpgrades.cs (<c>ChaosMeta</c>),
+    ///    ChaosMetaStore.cs, ChaosLifetimeBoons.cs, ChaosBubbleVariants.cs, ChaosRanks.cs,
+    ///    ChaosLessons.cs, ChaosModeService.cs, ChaosRevealService.cs - except <c>ChaosArt</c>,
+    ///    which is ConditioningControlPanel/Services/Chaos/ChaosArt.cs but returns
+    ///    <c>System.Windows.Media.ImageSource</c>, so only its path half can ever move. The
+    ///    per-member notes below name the symbol; this is where to find it.
     ///  - The four partials the WPF class spans (Bench / Reveals / Lessons / Debug) are NOT in
     ///    this layer. <c>BuildBench</c> is inlined here because <c>ImprovementsHost</c> must not
     ///    render empty; the reveal framework, the lesson gates and the CCP_CHAOS_DEBUG strip are
@@ -1679,8 +1685,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             _dollhouseView.IsVisible = true;
         }
 
-        /// <summary>Straight into a descent. WPF also detached the companion for the handoff.
-        /// ponytail: needs App.AvatarWindow, wired when it moves to Core.</summary>
+        /// <summary>Straight into a descent. WPF also detached the companion for the handoff
+        /// (<c>App.AvatarWindow?.SetChaosRunActive(true)</c>).
+        /// <para>ponytail: NOT a Core move - <c>App.AvatarWindow</c> is an
+        /// <c>AvatarTubeWindow</c>, a window, and windows do not move to Core. What this needs is
+        /// on this head: <c>SetChaosRunActive</c> on
+        /// CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs (it has no such member yet) and
+        /// an owner holding the live instance.</para></summary>
         private void Menu_FallIn_Click(object? sender, RoutedEventArgs e) => FallIn();
 
         private void Menu_Dollhouse_Click(object? sender, RoutedEventArgs e)
@@ -1918,7 +1929,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
         private void SetFullscreen(bool on) => WindowState = on ? WindowState.Maximized : WindowState.Normal;
 
         /// <summary>WPF also detached the companion tube while maximized (it is anchored to the
-        /// main window). ponytail: needs App.AvatarWindow, wired when it moves to Core.</summary>
+        /// main window). ponytail: same head-side blocker as <see cref="Menu_FallIn_Click"/> -
+        /// <c>SetChaosRunActive</c> on CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs,
+        /// plus an owner for the live instance. Nothing here is waiting on Core.</summary>
         private void OnHubStateChanged(WindowState state) => _optFullscreen.IsChecked = state == WindowState.Maximized;
 
         /// <summary>Re-open the spoiler-free rules card on demand. WPF showed ChaosIntroWindow
@@ -1938,11 +1951,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             foreach (var t in grp.Children.OfType<ToggleButton>()) t.IsChecked = t.Tag?.ToString() == tag;
         }
 
-        /// <summary>WPF: <c>ChaosRanks.RankLockedTip</c> / <c>RankSpecifics(rank)</c>.
-        /// ponytail: needs ChaosRanks, wired when it moves to Core.</summary>
-        private const string RankLockedTip = "she'll show you this one when you've fallen further.";
+        /// <summary>WPF: <c>ChaosRanks.RankLockedTip</c> / <c>ChaosRanks.RankSpecifics(rank)</c>.
+        /// Both are shipped COPY plus the rank threshold table, i.e. content rather than
+        /// behaviour, so they are reproduced verbatim here instead of approximated - the two
+        /// strings that stood here before were invented and read nothing like hers.
+        /// ponytail: the only head-side part left is the live descent count -
+        /// <c>ChaosMeta.State.RunsCompleted</c> in
+        /// ConditioningControlPanel/Services/Chaos/ChaosUpgrades.cs; <see cref="Sample"/>'s
+        /// stands in, and the swap is one expression.</summary>
+        private const string RankLockedTip = "she'll sell this to someone deeper.";
 
-        private static string RankSpecifics(string rank) => $"reach {rank} to be shown this.";
+        /// <summary><c>ChaosRanks.Thresholds</c>, verbatim: lifetime completed descents per rank.
+        /// Keyed by the capitalized rank word because that is what <c>SampleBoon.RankFloor</c>
+        /// carries here (the head passes the <c>ChaosRank</c> enum and calls <c>Name()</c>).</summary>
+        private static readonly Dictionary<string, int> RankThresholds = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Curious"] = 0, ["Tempted"] = 3, ["Slipping"] = 10,
+            ["Entranced"] = 25, ["Devoted"] = 50, ["Claimed"] = 100,
+        };
+
+        private static string RankSpecifics(string rank) =>
+            $"unlocks at {rank}: {(RankThresholds.TryGetValue(rank, out var need) ? need : 0)} descents "
+            + $"finished. you've finished {Sample.RunsCompleted}.";
 
         // ============================ sample data ============================
         // Everything below stands in for the Chaos services. It is deliberately shaped to hit

--- a/CCP.Avalonia/Views/Chaos/ChaosHudWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosHudWindow.axaml.cs
@@ -33,8 +33,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     ///    binds to <see cref="ChaosHudState"/> at the bottom of this file instead - the same
     ///    property names and the same computed text, filled with sample values that hit every
     ///    visual branch (a hot streak, a low-focus warning, filled toy AND accessory groups,
-    ///    run picks, modifiers, a feed). ponytail: needs ChaosRunState + ChaosModeService, wired
-    ///    when the Chaos services move to Core.
+    ///    run picks, modifiers, a feed). ponytail: needs <c>ChaosRunState</c> (and
+    ///    <c>ChaosSidebarBoon</c>) from ConditioningControlPanel/Services/Chaos/ChaosModels.cs and
+    ///    <c>ChaosModeService</c> from ConditioningControlPanel/Services/Chaos/ChaosModeService.cs.
+    ///    Those paths are where every "needs ChaosX" note below points; they are not repeated.
     ///  - <b>Win32.</b> The WPF window P/Invoked <c>GetWindowLong</c>/<c>SetWindowLong</c> to add
     ///    <c>WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE</c>, and <c>SetWindowPos(HWND_TOPMOST)</c> via
     ///    <c>ChaosWindowZ</c>. Both map without a shim: the ex-styles are
@@ -168,9 +170,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             { Children = { _streakScale, _streakRot, _streakJitter } };
             _panel.RenderTransform = _panelSlide;
 
-            // ponytail: needs ChaosWindowZ (Free Desktop runs aren't pinned above other apps),
-            // wired when it moves to Core. Topmost="True" in the XAML is the pinned default; on
-            // X11 Avalonia maps it to _NET_WM_STATE_ABOVE, which is the right mechanism.
+            // WPF: Topmost = ChaosWindowZ.BornTopmost, which is its PinTopmost field, which
+            // ChaosModeService.StartRun sets from AppSettings.ChaosPinOnTop. That setting is in
+            // Core and this window only exists during a run, so the read below IS the value WPF
+            // would be holding - a player who turned pin-on-top off is no longer overruled by the
+            // XAML's Topmost="True" (which stays as the pinned default). On X11 Avalonia maps
+            // Topmost to _NET_WM_STATE_ABOVE, which is the right mechanism.
+            Topmost = CoreSettings.Current.ChaosPinOnTop;
             _state = state;
             DataContext = state;
 
@@ -1159,11 +1165,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
         /// (<c>_NET_WM_STATE_ABOVE</c>), and toggling it re-asserts the state, so no shim is
         /// needed. Ordering against our OTHER overlays would be
         /// <c>X11Overlay.RestackAbove</c>; this HUD never did that on Windows either.
-        /// ponytail: needs ChaosWindowZ for the Free Desktop demotion, wired when it moves to
-        /// Core - until then the HUD stays pinned in every mode.</para></summary>
+        ///
+        /// <para>The demote branch is real now. <c>ChaosWindowZ.RaiseTopmost</c> reads
+        /// <c>PinTopmost</c> - and ONLY that, never <c>DesktopMode</c> - to choose between
+        /// re-asserting and dropping the window out of the topmost band; <c>PinTopmost</c> is set
+        /// from <c>AppSettings.ChaosPinOnTop</c> in <c>ChaosModeService.StartRun</c>, and that
+        /// setting is in Core. So the un-pinned run demotes here exactly as it does on
+        /// Windows.</para></summary>
         public void RaiseToTopmost()
         {
-            try { Topmost = false; Topmost = true; }
+            try
+            {
+                if (!CoreSettings.Current.ChaosPinOnTop) { Topmost = false; return; }
+                Topmost = false; Topmost = true;
+            }
             catch (Exception ex) { Log.Debug("ChaosHud raise: {E}", ex.Message); }
         }
 
@@ -1415,6 +1430,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             var s = new ChaosHudState { ElapsedSec = 372 };
             s.ActiveSidebarToys.Add(new ChaosHudBoon
             {
+                // ponytail: "toy_wand" / "acc_collar" are invented sample ids, not real boon ids
+                // (those are e_stim, the_spanker, tail_plug, gold_digger ... - see
+                // ChaosBoonColors.cs). So neither tile is in the family-colour table and both
+                // render on the category fallback, which means the render CANNOT prove
+                // AccentBrush's lookup. Swap in real ids when ChaosSidebarBoon lands and the
+                // sample can be built from the real catalogue instead of guessed at.
                 Id = "toy_wand", Glyph = "🪄", Name = "Wand", Level = 3,
                 Desc = "a long press winds it up; let go and the nearest treat pops paid.",
                 Flavor = "it hums when you hold it too long.",
@@ -1448,9 +1469,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
 
     /// <summary>One tile in the HUD: a pocket toy, an accessory, a run pick or a modifier.
     /// The port of <c>ChaosSidebarBoon</c>, minus the WPF Visibility properties (bools here) and
-    /// with Avalonia brushes. ponytail: needs ChaosSidebarBoon + ChaosBoonColors, wired when the
-    /// Chaos services move to Core - the payload-family colour lookup is the fallback palette
-    /// below until then.</summary>
+    /// with Avalonia brushes. The payload-family colour lookup is real now: the head's
+    /// <c>AccentBrush</c> calls <c>ChaosBoonColors.BrushForOrDefault</c> over the category
+    /// fallback - not visible from ChaosHudWindow.xaml.cs, which is why the old note said the
+    /// fallback palette WAS the lookup - and that table is copied into ChaosBoonColors.cs beside
+    /// this file. ponytail: still needs <c>ChaosSidebarBoon</c> itself
+    /// (ConditioningControlPanel/Services/Chaos/ChaosModels.cs) to carry real run data into these
+    /// tiles; every value below is sample.</summary>
     public sealed class ChaosHudBoon
     {
         public string Id { get; init; } = "";
@@ -1476,8 +1501,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
         public bool HasFlavor => !string.IsNullOrEmpty(Flavor);
         public bool HasExtra => !string.IsNullOrEmpty(Extra);
 
-        public IBrush AccentBrush =>
-            IsEmptySlot ? EmptyAccent : IsModifier ? ModAccent : IsCurse ? CurseAccent : Level > 0 ? PocketAccent : BoonAccent;
+        /// <summary>The category fallback, then the payload-based colour language over it -
+        /// <c>ChaosSidebarBoon.AccentBrush</c>'s exact shape, including its "an empty slot keeps
+        /// the fallback" branch. The lookup used to be missing, so every tile drew its category
+        /// colour and a mapped boon never showed its family.</summary>
+        public IBrush AccentBrush
+        {
+            get
+            {
+                var fallback = IsEmptySlot ? EmptyAccent : IsModifier ? ModAccent
+                             : IsCurse ? CurseAccent : Level > 0 ? PocketAccent : BoonAccent;
+                return IsEmptySlot ? fallback : ChaosBoonColors.BrushForOrDefault(Id, fallback);
+            }
+        }
         public IBrush TileBackBrush =>
             IsEmptySlot ? Brushes.Transparent : IsModifier ? ModBack : IsCurse ? CurseBack : Level > 0 ? PocketBack : BoonBack;
         public double TileOpacity => IsEmptySlot ? 0.55 : 1.0;

--- a/CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml
+++ b/CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml
@@ -50,6 +50,19 @@
         <SolidColorBrush x:Key="TextDim" Color="#AAB8B8D0"/>
     </Window.Resources>
 
+    <Window.Styles>
+        <!-- The chaos hover-card chrome. WPF set these four on every ToolTip ChaosTips built;
+             one selector here covers the boon cards AND the two ToolTip.Tip strings below.
+             Same values as ChaosHudWindow's, and non-layered for the same reason: an Avalonia
+             tip is not a layered HWND, so it cannot collide with one. -->
+        <Style Selector="ToolTip">
+            <Setter Property="Background" Value="#F2151226"/>
+            <Setter Property="BorderBrush" Value="#55FF69B4"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="10,8"/>
+        </Style>
+    </Window.Styles>
+
     <Grid>
         <!-- dim backdrop (only for draft/results; hidden during countdown) -->
         <Rectangle x:Name="Backdrop" Fill="Black" Opacity="0.72" IsVisible="False"/>

--- a/CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml.cs
@@ -13,6 +13,9 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using ConditioningControlPanel.Avalonia.Platform;
+// ContentLocator: Core's two-root probe (install dir, then the downloaded content pack). The
+// chaos cue resolver ends on exactly this call in the head.
+using ConditioningControlPanel.Services;
 // ChaosConversation / ChaosConversationLine / ChaosSpeaker are ALREADY in Core, so the story card
 // binds the real narrative model rather than a stand-in.
 using ConditioningControlPanel.Services.Chaos;
@@ -72,11 +75,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     /// reveal, the auto-resume tick, the post-pick confirm beat and the score tally are logic, and
     /// they port one for one.</para>
     ///
-    /// <para><b>Services.</b> <c>ChaosSfx</c>, <c>ChaosArt</c>, <c>ChaosTips</c>,
-    /// <c>ChaosBoonColors</c>, <c>ChaosMeta</c>, <c>ChaosLessons</c>, <c>ChaosRanks</c>,
-    /// <c>ChaosGlyphs</c>, <c>ChaosNarrator</c>, <c>ChaosAnnouncerOverlay</c>, <c>ChaosWindowZ</c>,
-    /// <c>ChaosModeService</c>, <c>RevealService</c> and <c>App.Bark</c> all still live in the WPF
-    /// head, which this project may not reference. They are stubbed in the Stubs region below,
+    /// <para><b>Services.</b> Five of these are no longer stubs, because they turned out to be
+    /// content or a settings read rather than a service: <c>ChaosSfx</c> (ContentLocator +
+    /// CoreAudio + the master-volume curve), <c>ChaosTips</c> (40 lines of control composition),
+    /// <c>ChaosBoonColors</c> (an id table, now ChaosBoonColors.cs beside this file),
+    /// <c>ChaosRanks</c>'s two members (shipped copy) and <c>ChaosWindowZ.BornTopmost</c>
+    /// (<c>AppSettings.ChaosPinOnTop</c>). <c>ChaosArt</c>, <c>ChaosMeta</c>,
+    /// <c>ChaosLessons</c>, <c>ChaosGlyphs</c>, <c>ChaosNarrator</c>,
+    /// <c>ChaosAnnouncerOverlay</c>, <c>ChaosModeService</c>, <c>RevealService</c> and
+    /// <c>App.Bark</c> still live in the WPF
+    /// head - all under ConditioningControlPanel/Services/Chaos/ except <c>ChaosWindowZ</c> and
+    /// <c>ChaosAnnouncerOverlay</c>, which are ConditioningControlPanel/Chaos/ - and this project
+    /// may not reference it. They are stubbed in the Stubs region below,
     /// shaped so every call site ports unchanged. <c>ChaosBoon</c>, <c>ChaosRarity</c>,
     /// <c>ChaosRank</c> and the run snapshot are local stand-ins for the same reason;
     /// <c>ChaosConversation</c> and friends are already in Core and are used for real, as is
@@ -1483,11 +1493,69 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
 
         private enum ChaosAnnounceKind { Willpower, Temptation }
 
+        /// <summary>
+        /// Not a stub any more: all thirteen cues in this window fire for real. The head's
+        /// <c>Services/Chaos/ChaosSfx.cs</c> is a resolve plus a one-shot, and BOTH halves are
+        /// portable now - <see cref="ContentLocator"/> is in Core and is the exact fallback that
+        /// class ends on, <see cref="CoreAudio.PlayOneShot"/> is the seam its
+        /// <c>App.Audio.PlayOneShot("chaos-sfx")</c> becomes, and the master-volume curve reads
+        /// <c>CoreSettings.Current.MasterVolume</c>, which is the same property WPF reads. The
+        /// candidate lists and scales below are copied cue for cue.
+        ///
+        /// <para>ponytail: the one half still missing is the MOD OVERRIDE. WPF resolves through
+        /// <c>ModResourceResolver.ResolveAudioPath</c>, which probes the active mod's
+        /// <c>resources/sounds/</c> (with a .wav/.mp3 swap) before falling back to
+        /// ContentLocator. <c>CoreModArt.OverridePath</c> is NOT that seam - App.xaml.cs seeds it
+        /// from <c>ModResourceResolver.ResolveUri</c>, the IMAGE chain - so a mod's replacement
+        /// cue is not heard here. It needs a sounds twin of that provider in
+        /// CCP.Core/CoreModArt.cs, seeded from <c>ResolveAudioPath</c>; a stock install already
+        /// sounds right.</para>
+        ///
+        /// <para>Unseeded <c>CoreAudio</c> is silence, which is what this head is until a backend
+        /// lands - and exactly what the stub gave. Nothing here can be louder than the user's
+        /// master volume, and a missing file is still a silent no-op.</para>
+        /// </summary>
         private static class ChaosSfx
         {
-            public static void Play(string key, float volume) { }
-            public static void PlayBoonReveal(bool rare) { }
-            public static void PlayBoonPicked() { }
+            /// <summary>Generic one-shot: <c>Resources/sounds/chaos/{name}.mp3</c>, silent when
+            /// the asset is absent.</summary>
+            public static void Play(string key, float volume) => PlayFirstAvailable(new[] { $"chaos/{key}.mp3" }, volume);
+
+            /// <summary>A bright "dling" for rare, a dull "thud" otherwise - with the same
+            /// bundled fallbacks and the same two scales as the head.</summary>
+            public static void PlayBoonReveal(bool rare) => PlayFirstAvailable(
+                rare ? new[] { "chaos/dling.mp3", "chime1.mp3" }
+                     : new[] { "chaos/thud.mp3", "bubbles/Pop2.mp3" },
+                rare ? 0.6f : 0.65f);
+
+            public static void PlayBoonPicked() => PlayFirstAvailable(new[] { "chaos/boon_pick.mp3", "chime2.mp3" }, 0.7f);
+
+            /// <summary>First candidate that exists on disk wins; a miss in all of them is
+            /// silence, never an exception.</summary>
+            private static void PlayFirstAvailable(string[] candidates, float scale)
+            {
+                try
+                {
+                    foreach (var rel in candidates)
+                    {
+                        // Reject traversal before touching the disk, as ResolveAudioPath does.
+                        if (rel.Contains("..") || System.IO.Path.IsPathRooted(rel)) continue;
+                        var path = ContentLocator.Resolve(System.IO.Path.Combine(
+                            "Resources", "sounds", rel.Replace('/', System.IO.Path.DirectorySeparatorChar)));
+                        if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path)) continue;
+                        CoreAudio.PlayOneShot(path, Volume(scale), "chaos-sfx");
+                        return;
+                    }
+                }
+                catch (Exception ex) { Log.Debug("ChaosSfx resolve failed: {E}", ex.Message); }
+            }
+
+            /// <summary>The head's own curve: master volume times the cue's scale.</summary>
+            private static float Volume(float scale)
+            {
+                try { return Math.Clamp(CoreSettings.Current.MasterVolume / 100f * scale, 0f, 1f); }
+                catch { return scale; }
+            }
         }
 
         private static class ChaosArt
@@ -1498,15 +1566,56 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             public static Bitmap? ResolveRecap() => null;
         }
 
+        /// <summary>Real now. <c>Services/Chaos/ChaosTips.cs</c> is 40 lines of WPF control
+        /// composition and nothing else - no service, no state - so it ports as-is and the draft
+        /// cards get their hover card back instead of nothing. The chrome it set per-tooltip is
+        /// the <c>ToolTip</c> selector in this window's Styles instead, exactly as
+        /// <c>ChaosHudWindow.AttachTip</c> does it; <c>ToolTipService</c>'s show delay and duration
+        /// have no Avalonia twin worth a converter here.
+        /// <para>ponytail: this and <c>ChaosHudWindow.AttachTip</c> are now the same builder in two
+        /// files. Collapse them into one <c>Views/Chaos/ChaosTips.cs</c> the moment a third caller
+        /// appears - not before, because the head's own class is the source both are copying and a
+        /// third copy is where drift starts.</para></summary>
         private static class ChaosTips
         {
-            public static void Attach(Control target, string name, string desc, Color accent, string? flavor) { }
+            public static void Attach(Control target, string title, string? desc,
+                                      string? extra = null, Color? accent = null, string? flavor = null)
+            {
+                var a = accent ?? Color.FromRgb(0xFF, 0x69, 0xB4);
+                var sp = new StackPanel { MaxWidth = 260 };
+                sp.Children.Add(new TextBlock
+                {
+                    Text = title, FontWeight = FontWeight.Bold, FontSize = 13,
+                    Foreground = new SolidColorBrush(a),
+                });
+                if (!string.IsNullOrWhiteSpace(desc))
+                    sp.Children.Add(new TextBlock
+                    {
+                        Text = desc, FontSize = 12, TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 3, 0, 0),
+                        Foreground = new SolidColorBrush(Color.FromArgb(0xDD, 0xE0, 0xE0, 0xF0)),
+                    });
+                if (!string.IsNullOrWhiteSpace(flavor))
+                    sp.Children.Add(new TextBlock
+                    {
+                        Text = flavor, FontStyle = FontStyle.Italic, FontSize = 11,
+                        TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 2, 0, 0),
+                        Foreground = new SolidColorBrush(Color.FromArgb(0xCC, 0xB0, 0xB0, 0xC8)),
+                    });
+                if (!string.IsNullOrWhiteSpace(extra))
+                    sp.Children.Add(new TextBlock
+                    {
+                        Text = extra, FontSize = 12, TextWrapping = TextWrapping.Wrap,
+                        Margin = new Thickness(0, 3, 0, 0),
+                        Foreground = new SolidColorBrush(Color.FromRgb(0xFF, 0xD7, 0x00)),
+                    });
+                ToolTip.SetTip(target, sp);
+            }
         }
 
-        private static class ChaosBoonColors
-        {
-            public static Color ForOrDefault(string id, Color fallback) => fallback;
-        }
+        // ChaosBoonColors is no longer stubbed here: the head's class is a pure id -> family
+        // colour table, so it is copied whole into ChaosBoonColors.cs beside this file and the
+        // two call sites above now bind to that. Draft cards get their real family colour.
 
         private static class ChaosNarrator
         {
@@ -1519,11 +1628,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             public static void Announce(string text, ChaosAnnounceKind kind, string? artKey = null) { }
         }
 
+        /// <summary>Real now, not a stand-in. The head's <c>ChaosWindowZ.BornTopmost</c> is its
+        /// <c>PinTopmost</c> field, and the ONE place that writes it is
+        /// <c>ChaosModeService.StartRun</c>: <c>PinTopmost = App.Settings.Current.ChaosPinOnTop</c>
+        /// (reset to true when the run ends). That setting is in Core, and these windows only exist
+        /// during a run, so reading it here IS the value WPF would be holding. A player who turned
+        /// pin-on-top off was previously ignored - the XAML's <c>Topmost="True"</c> won.
+        /// <para>ponytail: <c>ChaosWindowZ.DesktopMode</c> is NOT reproduced and is not needed for
+        /// this - <c>RaiseTopmost</c> never reads it; it branches on <c>PinTopmost</c> alone.
+        /// What stays head-side is the Win32 <c>SetWindowPos</c> re-assert itself, which Avalonia's
+        /// <c>Topmost</c> covers on X11 (<c>_NET_WM_STATE_ABOVE</c>).</para></summary>
         private static class ChaosWindowZ
         {
-            /// <summary>WPF read the live run's flavour; Story descents are born topmost and Free
-            /// Desktop runs are not. True matches the XAML's Topmost.</summary>
-            public static bool BornTopmost => true;
+            public static bool BornTopmost => CoreSettings.Current.ChaosPinOnTop;
         }
 
         private static class ChaosModeService
@@ -1587,13 +1704,30 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             public const string Xp = "🕰";
         }
 
+        /// <summary>Not a stub any more. Both members this view calls are shipped COPY rather
+        /// than behaviour, so they are reproduced verbatim from
+        /// ConditioningControlPanel/Services/Chaos/ChaosRanks.cs instead of stood in for.
+        /// <c>Line</c> returned <c>""</c> before, which drew an empty row inside the rank card.
+        /// ponytail: the REST of that class - <c>For</c>, <c>Thresholds</c>, <c>RankSpecifics</c>,
+        /// <c>CapstoneLockedTip</c> - reads <c>ChaosMeta.State</c> and stays head-side. This view
+        /// calls none of it.</summary>
         private static class ChaosRanks
         {
             /// <summary>The head's <c>ChaosRanks.NameLower</c> is this exact mapping for all six
-            /// ranks. The one-line rank blurb is content that lives with it and is NOT reproduced
-            /// here. ponytail: needs ChaosRanks, wired when it moves to Core.</summary>
+            /// ranks.</summary>
             public static string NameLower(ChaosRank r) => r.ToString().ToLowerInvariant();
-            public static string Line(ChaosRank r) => "";
+
+            /// <summary>The one dim line under the bare rank word on the rank card. Ships
+            /// verbatim, as it does in the head.</summary>
+            public static string Line(ChaosRank r) => r switch
+            {
+                ChaosRank.Tempted   => "tempted. three times down. you can stop calling it curiosity.",
+                ChaosRank.Slipping  => "slipping. the climb out takes longer every time. you noticed. you came anyway.",
+                ChaosRank.Entranced => "entranced. you don't fall anymore. you arrive.",
+                ChaosRank.Devoted   => "devoted. the dollhouse keeps a room warm for you now. it always knew it would.",
+                ChaosRank.Claimed   => "claimed. it stopped counting your visits a long time ago. so did you.",
+                _                   => "",
+            };
         }
 
         /// <summary>The companion's reactive line. ponytail: needs App.Bark, wired when the bark

--- a/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosSlotPickerWindow.axaml.cs
@@ -21,7 +21,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     ///
     /// PORTED from ConditioningControlPanel/Chaos/ChaosSlotPickerWindow.xaml.cs. Deviations:
     ///  - <c>ChaosMeta</c> / <c>ChaosMetaStore</c> / <c>ChaosRanks</c> are WPF-head services, so
-    ///    the picker draws <see cref="SampleSummaries"/> and the delete action is a stub. The
+    ///    the picker draws <see cref="SampleSummaries"/> and the delete action is a stub. Where
+    ///    they live, so the notes below do not have to repeat it:
+    ///    ConditioningControlPanel/Services/Chaos/ChaosUpgrades.cs (<c>ChaosMeta</c>),
+    ///    .../ChaosMetaStore.cs and .../ChaosRanks.cs. The
     ///    three card shapes (a live save, an empty slot, a stitched-shut slot) are all exercised
     ///    by that sample, so the render still proves every builder.
     ///  - <c>DialogResult = x; Close()</c> -> <c>Close(x)</c>; <see cref="Pick"/> is async, because


### PR DESCRIPTION
Sweep of every ponytail note under CCP.Avalonia/Views/Chaos/, markup and
code-behind, eight files and 60 markers. Three earlier layers (wire/45, 52, 71,
80) had already done the animation and settings work here and every note they
left was checked again against Core and against the head rather than believed.
None of them was stale in the usual way. What they were was too pessimistic:
five things filed under "needs a WPF-head Chaos service" are not services at
all, and they are restored.

ChaosSfx: all thirteen cues in ChaosOverlayWindow fire for real. The head's
class is a resolve plus a one-shot and both halves are portable now -
ContentLocator is in Core and is the exact fallback that class ends on,
CoreAudio.PlayOneShot is what its App.Audio.PlayOneShot("chaos-sfx") becomes,
and the master-volume curve reads CoreSettings.Current.MasterVolume, the same
property WPF reads. Candidate lists and scales copied cue for cue, traversal
rejected before touching the disk as ResolveAudioPath does. The half still
missing is the MOD OVERRIDE, and the note now names why CoreModArt is not it:
App.xaml.cs seeds CoreModArt.OverridePathProvider from
ModResourceResolver.ResolveUri, the IMAGE chain, so a mod's replacement cue is
not heard. A stock install already sounds right.

ChaosWindowZ.BornTopmost is AppSettings.ChaosPinOnTop. ChaosModeService.StartRun
is the one place that writes PinTopmost, from that setting, and it is in Core -
so both the HUD and the overlay now honour a player who turned pin-on-top off
instead of being overruled by the XAML's Topmost="True". RaiseToTopmost gets its
demote branch for the same reason: ChaosWindowZ.RaiseTopmost branches on
PinTopmost alone and never reads DesktopMode, which is why DesktopMode is not
reproduced and is not needed.

ChaosBoonColors is an id -> family colour TABLE wrapped in a WPF Color, so the
table is portable and the type is not. It is copied whole into
Views/Chaos/ChaosBoonColors.cs - one file, because BOTH windows need it: the
overlay's draft cards through ForOrDefault, and ChaosHudWindow's tiles through
ChaosSidebarBoon.AccentBrush, which calls BrushForOrDefault. That last one is
worth naming: the HUD note said its category palette WAS the payload lookup, and
that is wrong - the call is in ChaosModels.cs, invisible from
ChaosHudWindow.xaml.cs, so the tiles were missing the family colour entirely.
Its AccentBrush now has WPF's exact shape, empty-slot branch included.

ChaosTips is forty lines of control composition, no service and no state, so the
draft cards get their hover card back; its chrome is a ToolTip selector added to
ChaosOverlayWindow.axaml, matching what ChaosHudWindow already does, which also
gives the two existing ToolTip.Tip strings there the chaos chrome. It and
ChaosHudWindow.AttachTip are deliberately left as two copies with a note saying
to collapse them the moment a third caller appears.

ChaosRanks.Line was returning "" and drawing an empty row inside the recap's
rank card; the six blurbs ship verbatim. In the hub, RankLockedTip and
RankSpecifics were INVENTED strings that read nothing like hers - both are
shipped copy plus the threshold table, so both are now verbatim, with
Sample.RunsCompleted standing in for ChaosMeta.State.RunsCompleted.

Notes rewritten rather than restored. App.AvatarWindow's two notes said "wired
when it moves to Core", which is wrong advice: it is an AvatarTubeWindow, and
windows do not move to Core - what they need is SetChaosRunActive on
CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs, which has no such
member, plus an owner. The head paths for every remaining "needs ChaosX" note
are now stated once per file header instead of at thirty call sites. The HUD's
sample carries a new note that "toy_wand"/"acc_collar" are invented ids, in no
family, so no render can prove the lookup above them.

Verified: core-guards pass, Core and the Avalonia head build with 0 errors,
--smoke passes, --render-all stays 189/189, and the four Chaos PNGs were read.
What the renders do NOT prove: no sound (CoreAudio is unseeded on this head, and
the render pumps no audio), no tooltip (tips do not render), no rank card (the
sample recap has no rank-up), no dollhouse rank tooltips (the hub renders its
menu view), and no boon family colour (the HUD's two sample ids are unmapped and
the overlay's parameterless ctor draws the recap, not a draft). Each of those is
a table lookup or a settings read behind a call site that ports one for one.

The overlay's Win32 notes, in the three buckets the brief asks for, unchanged
from wire/71 and re-checked: click-through, the topmost band, the toolwindow and
no-activate styles and the raise are ALREADY possible and already done, via
X11Overlay.SetClickThrough plus Topmost / ShowInTaskbar / ShowActivated /
TransparencyLevelHint - and the topmost half got strictly better this layer. The
countdown skip hooks need a member X11Overlay does not expose:
WatchRawInput(Action) : IDisposable, an XISelectEvents for
XI_RawButtonPress|XI_RawKeyPress on the root window of its own display
connection - its own layer, X11-only by construction, unprovable by a render and
to be exercised in a nested compositor. Everything else is head-side Chaos
services.

Still blocked:
- ConditioningControlPanel/Services/Chaos/ChaosArt.cs (returns ImageSource; only
  PathFor/FilePath can move) -> ChaosHudWindow.axaml.cs portrait host,
  ChaosHubWindow.axaml.cs GlyphIcon / SetupMenuMotion / MenuArt_Click /
  HowToImageBox, ChaosOverlayWindow.axaml.cs ChaosArt.Resolve
- ConditioningControlPanel/Services/Chaos/ChaosUpgrades.cs (ChaosMeta) ->
  ChaosHubWindow Buy_Click / BoonUnlock_Click / BoonUpgrade_Click / bench buys,
  ChaosSlotPickerWindow DeleteSlot_Click, ChaosOverlayWindow's ChaosMeta.Save
- ConditioningControlPanel/Services/Chaos/ChaosMetaStore.cs ->
  ChaosSlotPickerWindow SampleSummaries
- ConditioningControlPanel/Services/Chaos/ChaosModeService.cs ->
  ChaosHudWindow BtnHero/BtnResume/BtnExit/BtnCloseMode/PocketTile_Click,
  ChaosHubWindow StoryModeEnabled / BtnBegin_Click
- ConditioningControlPanel/Services/Chaos/ChaosModels.cs (ChaosRunState,
  ChaosSidebarBoon, ChaosBoon, ChaosRarity, ChaosRank) -> ChaosHudState and the
  overlay's RunSummary
- ConditioningControlPanel/Services/Chaos/ChaosLessons.cs, ChaosRevealService.cs,
  ChaosBubbleVariants.cs, ChaosNarrator.cs, ChaosTips.cs (the rest of it)
- ConditioningControlPanel/Chaos/ChaosAnnouncerOverlay.cs, ChaosIntroWindow.cs
- a sounds twin of CoreModArt.OverridePathProvider in CCP.Core/CoreModArt.cs,
  seeded from ModResourceResolver.ResolveAudioPath -> ChaosSfx mod overrides
- X11Overlay.WatchRawInput -> ChaosOverlayWindow InstallCountdownSkipHooks
- SetChaosRunActive on CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
  -> ChaosHubWindow Menu_FallIn_Click, OnHubStateChanged
- SkiaSharp (the menu fog, the logo glint, the heat-bar shimmer) and a
  looping/fading audio seam for chaos/menu_theme.mp3 -> ChaosHubWindow

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU