### PR TITLE
fix(avalonia): the tube's chat log opens from its own menu and no longer closes itself; nine port notes stop blaming the wrong thing

### DIFF
--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml
@@ -51,9 +51,10 @@
                                           ponytail: the WPF loader re-rendered each history line as
                                           Inlines with clickable video links; link detection is lost.
        Window.CommandBindings          -> dropped. Avalonia has no CommandBindings.
-                                          ponytail: AvatarTubeWindow.OpenChatCommand (the user's
-                                          Ctrl+T chat shortcut) has no host here; needs a KeyBinding
-                                          once ApplyChatShortcutTo moves to Core.
+                                          The user's chat shortcut is NOT lost with them:
+                                          ApplyChatShortcutTo (code-behind) builds the KeyBinding
+                                          from CompanionPrompt.ChatShortcutKey and this window runs
+                                          it from Loaded. Nothing to restore here.
        gif: xmlns                      -> dropped; the WPF XAML declares it and never uses it.
        FontFamily="Segoe UI"           -> dropped; the head ships Inter and picks it in App.axaml. -->
 <Window xmlns="https://github.com/avaloniaui"
@@ -118,10 +119,10 @@
         <Viewbox x:Name="ContentViewbox" Stretch="Uniform" ClipToBounds="False">
             <!-- Design canvas at fixed reference size - will be scaled -->
             <Grid Width="780" Height="1080" ClipToBounds="False">
-            <!-- Tube frame FIRST (behind) - Z-Index 0 implicit.
-                 ponytail: WPF loaded pack://application:,,,/Resources/tube.png. This head ships no
-                 image assets and SetTubeStyle (mod-aware tube art) lives in the Windowing partial,
-                 so the frame is left sourceless and the tube reads as empty in the render. -->
+            <!-- Tube frame FIRST (behind) - Z-Index 0 implicit. Sourceless in markup ON PURPOSE:
+                 WPF's pack:// URI becomes a mod-aware lookup, so SetTubeStyle (code-behind) points
+                 this at the active mod's tube.png / tube2.png and falls back to this head's own
+                 avares:// copy. Setting a Source here would win over a mod's chamber art. -->
             <Image x:Name="ImgTubeFrame"
                    Stretch="Uniform"
                    HorizontalAlignment="Center"
@@ -348,9 +349,11 @@
                         <MenuItem x:Name="MenuItemPersonality" Header="{loc:Str section_personality}" Foreground="{DynamicResource PinkBrush}"/>
                         <MenuItem x:Name="MenuItemMute" Header="{loc:Str section_mute_avatar}"/>
                         <!-- Emote MenuItems replace the 5 items above (Engine, TriggerMode, BambiTakeover,
-                             Personality, Mute) whenever a remote controller is connected. Header strings
-                             and Tag references are populated in AvatarContextMenu_Opened from
-                             App.Settings.Current.RemoteEmotePresets. -->
+                             Personality, Mute) whenever a remote controller is connected. On WPF their
+                             headers are filled in AvatarContextMenu_Opened from RemoteEmotePresets.
+                             They stay IsVisible="False" on this head: the presets are in Core, but the
+                             swap is driven by App.RemoteControl.ControllerConnected and each item sends
+                             through MainWindow.SendEmoteAndReportAsync, both head-side. -->
                         <MenuItem x:Name="MenuItemEmote1" Header="" IsVisible="False"/>
                         <MenuItem x:Name="MenuItemEmote2" Header="" IsVisible="False"/>
                         <MenuItem x:Name="MenuItemEmote3" Header="" IsVisible="False"/>

--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -14,8 +14,8 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
 using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Helpers;
 using ConditioningControlPanel.Avalonia.Platform;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
@@ -92,7 +92,9 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
     /// attach/detach/scale/position/fullscreen windowing (Windowing.cs) stay in the WPF head.
     /// The whole <c>App.*</c> service-subscription block (Video, BubbleCount, Flash, Subliminal,
     /// Bubbles, Achievements, Progression, Companion, WindowAwareness, MindWipe, BrainDrain,
-    /// ModerationCounter, Mods) is still one stub: none of those services are in Core.</para>
+    /// ModerationCounter, Mods) is still one stub. Twelve of those have no seam at all; the two
+    /// that do are no help to it - <c>CoreMods</c> raises ModChanged but not the avatar events
+    /// these handlers wanted, and <c>CoreProgression</c> is write-only (AddXP, no level event).</para>
     ///
     /// <para><b>The tube does not track a face.</b> Nothing here reads a camera. The webcam face
     /// tracker that drives the avatar's gaze on the WPF head is a device, so it stays in a head;
@@ -221,6 +223,13 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             _speechBubble.PointerEntered += (_, _) => _isMouseOverSpeechBubble = true;
             _speechBubble.PointerExited += (_, _) => _isMouseOverSpeechBubble = false;
             this.FindControl<Button>("BtnCloseChatHistory")!.Click += (_, _) => HideChatHistory();
+            // The quick menu's own way into the log - WPF's MenuItemShowChatHistory_Click. Looked up
+            // without the null-forgiving `!` because this is the first CHILD of the ContextMenu the
+            // ctor reaches, and a name-scope miss inside a menu would throw here and drop the whole
+            // window out of --render-all rather than lose one menu item.
+            var showLog = this.FindControl<MenuItem>("MenuItemShowChatHistory");
+            if (showLog != null) showLog.Click += (_, _) => ShowChatHistory();
+            else Log.Warning("AvatarTubeWindow: MenuItemShowChatHistory not found; chat log unreachable from the menu");
             _btnSendChat.Click += (_, _) => SendChat();
             _txtUserInput.KeyDown += (_, e) => { if (e.Key == Key.Enter) SendChat(); };
 
@@ -229,8 +238,8 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             this.FindControl<Border>("BtnNextAvatar")!.PointerPressed += (_, _) => SelectAvatarSet(+1);
             this.FindControl<ContextMenu>("AvatarContextMenu")!.Opened += (_, _) => UpdateQuickMenuState();
 
-            // Setup pose switching timer (only for static avatars). Created, never started: the
-            // poses it would cycle load in AvatarTubeWindow.Avatar.cs.
+            // Pose switching for static avatars. ApplyAvatarSet below starts it only when more than
+            // one pose actually loaded - a set that ships one PNG has nothing to rotate between.
             _poseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
             _poseTimer.Tick += (_, _) => AdvancePose();
 
@@ -245,14 +254,18 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             LocalizationManager.Instance.LanguageChanged += OnTubeLanguageChanged;
 
             // ponytail: still needs AvatarTubeWindow.Avatar.cs for the ANIMATED avatar (level 20+
-            // GIF sets, which need an Avalonia GIF decoder) and the emotive-portrait crossfade, and
-            // App.Mods.IsAvatarSetSupported / GetCustomAvatarSets for the set ARROWS - see
+            // GIF sets, which need an Avalonia GIF decoder) and the emotive-portrait crossfade. The
+            // set ARROWS are blocked on the companion coupling, NOT on the set list - see
             // SelectAvatarSet. The static four-pose path below is the one every set-1 user is on.
 
-            // ponytail: needs the ~14 App.* services the WPF constructor subscribed to (Video,
-            // BubbleCount, Flash, Subliminal, Bubbles, Achievements, Progression, Companion,
-            // WindowAwareness, MindWipe, BrainDrain, ModerationCounter, Mods, MainWindow.EngineStopped),
-            // wired when they move to Core. Their handlers all live in the Reactions/Speech partials.
+            // ponytail: the ~14 App.* services the WPF constructor subscribed to (Video, BubbleCount,
+            // Flash, Subliminal, Bubbles, Achievements, Progression, Companion, WindowAwareness,
+            // MindWipe, BrainDrain, ModerationCounter, Mods, MainWindow.EngineStopped). Two of those
+            // names DO have seams and still do not help: CoreMods raises ModChanged but none of the
+            // avatar-set handlers hang off it, and CoreProgression is write-only (AddXP, no level
+            // event), so the caption cannot re-read itself when she levels. The other twelve are
+            // head-side services in ConditioningControlPanel/Services/ with no seam at all, and
+            // their handlers live in the Reactions/Speech partials that did not port.
 
             // ponytail: the WPF ctor also started four timers here - a 2s greeting, the idle-giggle,
             // the trigger and the random-bubble loops. Deliberately NOT started: every one of them
@@ -363,6 +376,13 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         /// (the only part of that partial the XAML's own controls need).</summary>
         public void ShowChatHistory()
         {
+            // The log TAKES OVER the bubble, so the running line's auto-hide has to be cancelled
+            // first: that Tick sets IsVisible = false unconditionally and would close the log under
+            // the user a few seconds after they opened it. WPF's EnterChatHistoryMode kills the
+            // same two timers for the same reason.
+            _speechTimer?.Stop();
+            _isGiggling = false;
+
             _isShowingChatHistory = true;
 
             // Show empty-state hint when there are no captured messages yet.
@@ -374,11 +394,12 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             // Hide the per-message AI badge when showing the chat history list (mixed AI + user lines).
             _aiBadge.IsVisible = false;
 
-            // Enlarge bubble for the chat history layout.
-            // ponytail: WPF followed this with ApplySpeechBubblePlacement(), which recomputes the
-            // margin from MaxWidth so a 600px bubble does not hang off the canvas. That method is in
-            // AvatarTubeWindow.Windowing.cs, so the bubble keeps its XAML margin here.
+            // Enlarge the bubble for the chat-history layout and RE-PLACE it: the attached margin
+            // is derived from MaxWidth (a 600px bubble gives the seam up rather than hang off the
+            // canvas), so widening without recomputing lands the panel clipped. The old note here
+            // blamed Windowing.cs; ApplySpeechBubblePlacement came across with RefreshTubeLayout.
             _speechBubble.MaxWidth = 600;
+            ApplySpeechBubblePlacement();
             _speechBubble.IsVisible = true;
 
             // Auto-scroll to most recent message.
@@ -443,8 +464,14 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             var remaining = _cooldownEndsAt.Value - DateTime.UtcNow;
             if (remaining.TotalSeconds <= 0)
             {
-                // ponytail: needs App.ModerationCounter - WPF probed GetState() here so the counter
-                // itself raised CooldownEnded. Without it, end the cooldown locally.
+                // ponytail: the CLASS is not the blocker - ModerationCounter and its
+                // CooldownStarted / CooldownEnded events are in
+                // CCP.Core/Services/Moderation/ModerationCounter.cs already. What is missing is the
+                // app's SINGLE instance (App.ModerationCounter, built in App.xaml.cs) and a seam
+                // for it: a second instance here would keep a second sliding window and split the
+                // persisted moderation-counter.json, letting a cooldown be dodged by opening the
+                // tube - which is exactly why CoreModerationLog exists rather than a `new`. So the
+                // cooldown is ended locally instead of by probing GetState().
                 OnCooldownEnded();
                 return;
             }
@@ -954,36 +981,13 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         }
 
         /// <summary>
-        /// The mod's override first (<see cref="CoreModArt"/>), then this head's own shipped copy
-        /// under <c>avares://</c>. Null when neither exists, which every caller treats as "draw
-        /// nothing here" rather than as a failure. Never throws: a mod's broken PNG degrades to the
-        /// built-in, and a missing built-in degrades to an empty slot.
-        /// <para>ponytail: the same two-step as TubeFitDialog.TryLoadImage. Second copy, so this is
-        /// the point where it earns a head-wide helper - it wants a file of its own, and this layer
-        /// owns one file.</para>
+        /// The mod's override first, then this head's own shipped copy under <c>avares://</c>, else
+        /// null - which every caller treats as "draw nothing here" rather than as a failure.
+        /// <para>This WAS a private copy of that two-step; <c>Helpers/ModArt.TryLoad</c> is the
+        /// head-wide one and is byte-for-byte the same chain, so the copy is deleted rather than
+        /// kept in sync. TubeFitDialog and ModCreatorWindow still carry theirs.</para>
         /// </summary>
-        private static Bitmap? TryLoadImage(string resourceName)
-        {
-            var overridePath = CoreModArt.OverridePath(resourceName);
-            if (overridePath != null)
-            {
-                try { if (File.Exists(overridePath)) return new Bitmap(overridePath); }
-                catch (Exception ex) { Log.Warning(ex, "[Tube] mod override {Path} would not load", overridePath); }
-            }
-
-            try
-            {
-                var uri = new Uri($"avares://CCP.Avalonia/Resources/{resourceName}");
-                if (!AssetLoader.Exists(uri)) return null;
-                using var stream = AssetLoader.Open(uri);
-                return new Bitmap(stream);
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "[Tube] built-in {Name} would not load", resourceName);
-                return null;
-            }
-        }
+        private static Bitmap? TryLoadImage(string resourceName) => ModArt.TryLoad(resourceName);
 
         /// <summary>
         /// Per-set framing: sets 2+ read 12% bigger and 10px right, and Locked's set 1 ("The Lure")
@@ -1395,8 +1399,11 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         {
             var point = e.GetCurrentPoint(this);
             if (point.Properties.IsRightButtonPressed) return; // Avalonia opens the ContextMenu itself
-            // ponytail: needs AvatarTubeWindow.Avatar.cs (BounceAvatar) and Reactions.cs
-            // (ImgAvatar_MouseLeftButtonDown -> click bark + pose change), wired when they move to Core.
+            // ponytail: needs ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Avatar.cs
+            // (BounceAvatar - the click squash, which on this head would be a hand-stepped tween on
+            // AvatarBounceHost's RenderTransform, not an Animation) and .Reactions.cs
+            // (ImgAvatar_MouseLeftButtonDown - the click bark, which needs BarkService). Neither
+            // partial is a Core move: both reach App.* services throughout.
         }
 
         /// <summary>Send whatever is in the input box to the companion.</summary>
@@ -1406,9 +1413,14 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             if (string.IsNullOrWhiteSpace(input)) return;
             AddToChatHistory(input, isUser: true);
             _txtUserInput.Text = string.Empty;
-            // ponytail: needs AvatarTubeWindow.ChatInput.cs (moderation guard, AI inference,
-            // typewriter reply, TTS) and App.ModerationCounter, wired when they move to Core. The
-            // user's line still lands in the log so the view is honest about what it did.
+            // ponytail: needs ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
+            // (the moderation guard, the AI request, the typewriter reply and TTS) plus
+            // the app's single App.ModerationCounter instance for the cooldown CooldownTick above
+            // paints - the counter CLASS is in Core, the instance and its seam are not; see that
+            // method. Nothing is INFERRED here, so nothing leaves the process and there is no
+            // request for the guard to refuse; the user's line lands in the local log and that is
+            // the whole of what this does. CoreModerationLog is the seam for the RECORD half when
+            // there is a request to record - it is not the counter, and cannot gate one.
         }
 
         /// <summary>Step through the unlocked avatar sets with the title-box arrows.</summary>
@@ -1434,12 +1446,31 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         /// <summary>Refresh the context menu's checkmarks and the remote-emote item swap.</summary>
         private void UpdateQuickMenuState()
         {
-            // ponytail: the settings half is NOT the blocker - RemoteEmotePresets is on
-            // CoreSettings.Current today. What is missing is the live state the menu titles read:
-            // App.Engine (running / paused) and App.Companion (her name and mood), neither of
-            // which has a seam, plus AvatarTubeWindow.Reactions.cs's AvatarContextMenu_Opened,
-            // which retitles every item on each open. Retitling from settings alone would print a
-            // menu that disagrees with what the engine is actually doing, so it stays inert.
+            // Deliberately inert, and the reason is NOT the one an earlier note gave. Settings and
+            // two seams would in fact answer several of WPF's labels today - CoreSession.IsEngineRunning
+            // for the Engine item (WPF proxies it off App.Flash.IsRunning), CoreAi.IsAvailable for the
+            // "talk to" item, TriggerModeEnabled / AutonomyModeEnabled / AvatarMuted / SubAudioMuted
+            // for the rest, and RemoteEmotePresets for the emote swap.
+            //
+            // What is missing is the OTHER half: not one of these MenuItems has a Click handler on
+            // this head, because every action behind them - MainWindow's engine start/stop, the
+            // Takeover gate, the personality submenu, the browser pause, App.RemoteControl's emote
+            // send - is head-side. Retitling an item to "STOP ENGINE" in red while clicking it does
+            // nothing is strictly worse than the static label it carries now: the menu would report
+            // live state it cannot act on. Restore the labels WITH their handlers, not before.
+            //
+            // ponytail: needs MainWindow.StartEngine / StopEngine with ChatInput.cs's #479 guards
+            // (IsEngineStopLocked plus App.Lockdown.NotifyEscapeAttempt - the tube's Stop is the
+            // same escape as main's and must count the same), App.Patreon.HasPremiumAccess,
+            // App.RemoteControl.ControllerConnected, and ChatInput.cs's PopulatePersonalityMenu.
+            //
+            // The Mute item is the one that LOOKS free - IsMuted already reads
+            // CoreSettings.Current.AvatarMuted and GigglePriority honours it, so a two-line flip
+            // would work. It is left out anyway: WPF's MenuItemMute_Click ends with
+            // MainWindow.SyncQuickControlsUI, and the companion room's own mute switch
+            // (MainShellWindow.CompanionRoom.cs SetAvatarMuted) reads the setting once at load. A
+            // flip here would leave that switch showing the opposite of the truth until the shell
+            // is rebuilt, which is a control lying about state in a file this layer does not own.
         }
     }
 }

--- a/CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs
@@ -78,16 +78,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         private enum AssetType { Image, Video }
         private enum RoundOutcome { Correct, Wrong, Timeout }
 
-        /// <summary>ponytail: needs Lab/GazeMinigame/GazeMinigameSettings.cs:GazePackRole,
-        /// wired when it moves to Core.</summary>
+        /// <summary>ponytail: a copy of GazePackRole from
+        /// ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs. Deleted when that
+        /// file moves to CCP.Core/Lab/GazeMinigame/ - see the twin below for why it has not.</summary>
         private enum GazePackRole { Off, Focus, Ignore }
 
-        /// <summary>ponytail: needs Lab/GazeMinigame/GazeMinigameSettings.cs:GazeVibrationMode,
-        /// wired when it moves to Core.</summary>
+        /// <summary>ponytail: a copy of GazeVibrationMode from
+        /// ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs. Deleted with the twin.</summary>
         private enum GazeVibrationMode { None, OnCorrect, OnWrong }
 
-        /// <summary>ponytail: needs Lab/GazeMinigame/GazeMinigameSettings.cs:GazeRewardEffect,
-        /// wired when it moves to Core.</summary>
+        /// <summary>ponytail: a copy of GazeRewardEffect from
+        /// ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs. Deleted with the twin.</summary>
         private enum GazeRewardEffect { None, Flashes, Bubbles, Audio, MindWipe, OverlayPulse }
 
         private sealed record RoundSpec(AssetType Type, string CorrectPath, string NoisePath,
@@ -172,11 +173,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
             public const int PassTimeMin = 3, PassTimeMax = 30;
             public const int WrongHoldMinMs = 0, WrongHoldMaxMs = 2000;
 
-            /// <summary>ponytail: needs GazeMinigameSettings.Load (Newtonsoft + CorePaths),
-            /// wired when it moves to Core. Defaults until then.</summary>
+            /// <summary>ponytail: the real Load is in
+            /// ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs and reads the
+            /// shared gaze-minigame-settings.json. Defaults until that file is in Core; see the
+            /// class remarks for why this twin must not read it instead.</summary>
             public static GazeMinigameSettings Load() => new();
 
-            /// <summary>ponytail: needs GazeMinigameSettings.Save, wired when it moves to Core.</summary>
+            /// <summary>Clamp only. ponytail: the real Save is in the same head file; writing the
+            /// shared JSON from this shape would drop the user's Packs list - see the class remarks.</summary>
             public void Save() => Clamp();
 
             private void Clamp()
@@ -512,8 +516,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
                 CornerRadius = new CornerRadius(6, 6, 0, 0),
                 ClipToBounds = true,
             };
-            // ponytail: needs GazePackLibrary.ThumbnailPath; it is a one-liner over ImagePaths,
-            // so it is inlined rather than dragged across.
+            // GazePackLibrary.ThumbnailPath verbatim - it is one line over ImagePaths, so it is
+            // inlined rather than dragged across. Nothing is blocked here; it dies with the twin.
             var thumbPath = pack.ImagePaths.Count > 0 ? pack.ImagePaths[0] : null;
             if (thumbPath != null)
             {
@@ -627,19 +631,22 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
             SaveSelection();
         }
 
-        /// <summary>ponytail: needs GazeMinigameSettings.Packs persistence (GazePackRef),
-        /// wired when it moves to Core. The in-memory _roles map is already authoritative
-        /// for this session.</summary>
+        /// <summary>ponytail: the Packs list (GazePackRef) that would persist these roles is on the
+        /// head's GazeMinigameSettings, not on this twin, so a role survives the session only. The
+        /// in-memory _roles map is authoritative while the window is open.</summary>
         private void SaveSelection() => _settings.Save();
+
+        /// <summary>Whether a gaze tracker is reachable from this head. Constant false until a
+        /// tracker seam exists; a single named gate so restoring one is one edit, not a hunt.
+        /// <para>Checked against the WPF original before leaving it false: there is no mouse or
+        /// keyboard fallback to restore. GameSide has exactly one writer there, OnGazeSideChanged,
+        /// fed by App.Webcam.OnGazeSide - so with no tracker no input can move a round.</para></summary>
+        private static bool HasGazeTracker => false;
 
         /// <summary>Why Start is disabled on this head, stated once so the summary line, the
         /// opening banner and the post-calibration banner cannot drift apart. Phrased as a
         /// missing capability rather than something the user forgot to do - there is no
         /// calibration they could run that would make the game playable here.</summary>
-        /// <summary>Whether a gaze tracker is reachable from this head. Constant false until a
-        /// tracker seam exists; a single named gate so restoring one is one edit, not a hunt.</summary>
-        private static bool HasGazeTracker => false;
-
         private const string NoTrackerReason =
             "This build has no webcam gaze tracker yet, so the game can't tell which side you're looking at — Start stays off until one is available.";
 
@@ -839,8 +846,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
                 _txtVibrationStatus.Text = "";
                 return;
             }
-            // ponytail: needs App.Haptics.IsConnected, wired when it moves to Core. Until then
-            // the honest answer is the not-connected one.
+            // ponytail: needs App.Haptics.IsConnected - HapticService lives in
+            // ConditioningControlPanel/Services/Haptics/HapticService.cs and does NOT move: it owns
+            // BLE/websocket devices. Core carries the provider INTERFACES only
+            // (CCP.Core/Services/Haptics/IHapticProvider.cs), no instance and no seam. Until one
+            // exists the not-connected line is the honest answer, and it matches FireVibration.
             _txtVibrationStatus.Text = "Haptic device not connected — setting saved but no vibration will fire.";
         }
 
@@ -1002,7 +1012,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
 
             // WPF also suspended the main-session FlashService here so its random flashes
             // don't pop over the gaze targets (bug #202), restoring it in Window_Closing.
-            // ponytail: needs App.Flash, wired when it moves to Core.
+            // ponytail: needs App.Flash (ConditioningControlPanel/Services/Flash/FlashService.cs), which
+            // owns the flash overlay windows and has no seam. Unreachable anyway - Start is gated.
 
             BeginCountdown();
         }
@@ -1131,8 +1142,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
             }
             else
             {
-                // ponytail: needs LibVLCSharp's VideoView (and VideoService.SharedLibVLC),
-                // wired when video playback moves to Core. A glyph holds the pane meanwhile.
+                // ponytail: video rounds need a player CCP.Avalonia does not have. LibVLCSharp is
+                // not a Core move - it is a package reference this head lacks, and adding one is a
+                // .csproj change. This head's actual video path is the WebHost control (a real
+                // Avalonia WebView playing a file:// page's <video>), which DeeperEditorWindow
+                // proves for ONE pane; two side-by-side WebHosts are untested. A glyph holds the
+                // pane meanwhile - and nothing reaches it, because Start is gated.
                 var leftView = GlyphBlock("🎬");
                 var rightView = GlyphBlock("🎬");
                 _leftPane.Children.Add(leftView);
@@ -1177,7 +1192,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         /// WPF tore down two LibVLC players here with the hard-won STOP → DETACH → DISPOSE
         /// ordering and message-pump waits between each step. Nothing to tear down until
         /// video playback exists on this head.
-        /// ponytail: needs LibVLCSharp, wired when video playback moves to Core.
+        /// ponytail: nothing to restore until this head has a video player at all - see
+        /// AdvanceRound's video branch for what that would be.
         /// </summary>
         private void DisposeCurrentRoundPlayers(bool synchronous = false) { }
 
@@ -1330,7 +1346,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
 
         /// <summary>
         /// WPF posted HapticEventKind.GazeReward so the Haptics tab's "Gaze reward" routing row
-        /// decides how it feels. ponytail: needs App.Haptics, wired when it moves to Core.
+        /// decides how it feels. ponytail: needs a seam over App.Haptics
+        /// (ConditioningControlPanel/Services/Haptics/HapticService.cs); it owns the device, so it
+        /// does not move to Core. UpdateVibrationStatus already tells the user nothing will fire.
         /// </summary>
         private static void FireVibration(string tag)
             => Log.Debug("GazeMinigame: vibration {Tag} suppressed (haptics not on this head)", tag);


### PR DESCRIPTION
Sweep of Views/AvatarTube/ and Views/Lab/GazeMinigame/ - both files, markup and
code-behind. Every note was checked against Core and against the Avalonia tree
rather than believed; three were hiding real work and the rest are rewritten to
name what actually blocks them. One symbol they all blamed - ModerationCounter -
turned out to be in Core already; what is missing there is the instance.

The chat history is reachable and no longer eats itself. Three separate defects
in one method. ShowChatHistory was public and nothing called it, because
MenuItemShowChatHistory carried no Click - wired now, and looked up WITHOUT the
null-forgiving `!` since it is the first ContextMenu CHILD this ctor reaches and
a namescope miss there would throw and drop the whole window out of
--render-all. Proved non-null by temporarily throwing on the null branch and
re-rendering, because this head configures no Serilog sink, so the warning
branch is invisible. It widens the bubble to 600 and now RE-PLACES it: the
attached margin is derived from MaxWidth, so widening without recomputing lands
the panel clipped. The old note blamed Windowing.cs; ApplySpeechBubblePlacement
crossed with RefreshTubeLayout in wire/59 and sits 400 lines below the note.
And it now stops the auto-hide timer first, as WPF's EnterChatHistoryMode does:
that Tick sets IsVisible = false unconditionally, so opening the log while she
was speaking would have closed it under the user seconds later.

The tube's private art loader is deleted in favour of Helpers/ModArt.TryLoad.
Byte-for-byte the same CoreModArt-then-avares chain; TryLoadImage is one
delegating line, so the two cannot drift. TubeFitDialog and ModCreatorWindow
still carry theirs, and ModArt.cs's own note still names this file - that note
is outside this layer.

Deliberately NOT restored, both reasons written into the file. The quick menu
stays inert: settings plus CoreSession.IsEngineRunning and CoreAi.IsAvailable
would in fact answer most of WPF's labels today, but not one of those MenuItems
has a Click handler on this head, and an item retitled "STOP ENGINE" in red that
does nothing when clicked is worse than the static label it carries. The Mute
item is the one that looks free - IsMuted already reads AvatarMuted and
GigglePriority honours it - and is left out anyway: WPF ends that handler with
MainWindow.SyncQuickControlsUI, and MainShellWindow.CompanionRoom's own mute
switch reads the setting once at load, so a flip here would leave that switch
showing the opposite of the truth. SelectAvatarSet stays refused as wire/74 left
it. The gaze minigame's Start gate stays as wire/72 left it, and the WPF
original was re-read to be sure: GameSide has exactly one writer there,
OnGazeSideChanged off App.Webcam.OnGazeSide, so there is no mouse or keyboard
fallback to restore - that is now stated on HasGazeTracker itself.

Notes rewritten because they named the wrong blocker or a move that will never
happen. The markup claimed ImgTubeFrame is sourceless because this head ships no
image assets; it is sourceless because SetTubeStyle points it at the MOD's
tube.png first, and a Source in markup would win over a mod's chamber. The
markup claimed the chat shortcut has no host "once ApplyChatShortcutTo moves to
Core" - it is in the code-behind and runs from Loaded. The class header and ctor
said none of the fourteen subscribed services are in Core: CoreMods and
CoreProgression exist and still do not help, the first raising no avatar event
and the second being write-only, which is the useful half to record. The gaze
file's LibVLC notes said video "moves to Core" - it is a package this head does
not reference, a .csproj change, and this head's real video path is the WebHost
control that DeeperEditorWindow proves for one pane. Its haptics note said the
same of App.Haptics, which owns BLE devices and cannot move; Core carries the
provider interfaces only. Its ThumbnailPath note read as a blocker over code
that already inlines it. A doubled <summary> on HasGazeTracker is un-doubled.

Note counts across both directories, comment lines naming each symbol, before ->
after: App.Settings 2 -> 1, App.Mods 3 -> 2, App.Logger 2 -> 2,
ModResourceResolver 0 -> 0, MessageBox 2 -> 2, WebView2 0 -> 0. Every survivor
describes the WPF original or says outright that the symbol is not the blocker.

Still blocked:
- WebcamTrackingService (ConditioningControlPanel/Services/Webcam/) - the gaze
  stream, the Start preconditions, App.Webcam.Calibration. The whole minigame.
- ConditioningControlPanel/Lab/GazeMinigame/GazeMinigameSettings.cs and
  GazePackLibrary.cs -> CCP.Core/Lab/GazeMinigame/. Until they move, the settings
  twin, SampleLibrary/SampleRole and the ThumbnailPath inline all stay.
- App.Haptics (ConditioningControlPanel/Services/Haptics/HapticService.cs),
  App.Flash (ConditioningControlPanel/Services/Flash/FlashService.cs), App.Bubbles.SpawnOnce,
  App.MindWipe.TriggerOnce, App.Overlay.PulseOverlays - the vibration modes and
  four of the five reward effects.
- a video player in CCP.Avalonia.csproj (LibVLCSharp, or a second WebHost) and an
  animated-GIF decoder -> GazeMinigameWindow video/GIF rounds.
- Resources/AwarenessPresets/audio/ and Resources/sounds/ as AvaloniaResources
  (.csproj) -> PlayRewardAudio and AvatarTubeWindow.PlayGiggleSound are wired and
  silent on a stock install.
- CCP.Avalonia/Views/Windows/MainShellWindow.LabTab.cs BtnGazeMinigame_Click -
  still the only reason the minigame window is unreachable from the shell.
- MainWindow.StartEngine / StopEngine with ChatInput.cs's #479 guards
  (IsEngineStopLocked + App.Lockdown.NotifyEscapeAttempt), App.Patreon.HasPremiumAccess,
  App.RemoteControl.ControllerConnected, ChatInput.cs PopulatePersonalityMenu ->
  AvatarTubeWindow.UpdateQuickMenuState and every item in that menu.
- a seam over the app's single App.ModerationCounter instance (built in
  ConditioningControlPanel/App.xaml.cs:2240). The CLASS is already in
  CCP.Core/Services/Moderation/ModerationCounter.cs with its CooldownStarted /
  CooldownEnded events, so `new` is not the answer - a second sliding window would
  split the persisted moderation-counter.json and let a cooldown be dodged by
  opening the tube. -> SendChat's guard and the cooldown CooldownTick paints.
- CoreModsHooks.SwitchCompanion has no seeder -> SelectAvatarSet, unchanged.
- ArcademyHostService.WalletOwnsSku(SkuTubeMidnight) -> the midnight glass pair.
- CCP.Avalonia/Helpers/ModArt.cs still names AvatarTubeWindow as carrying a
  private copy of TryLoad; it no longer does. Not this layer's file.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU