### PR TITLE
feat(avalonia): the tier badge wears its real neon sign, and the spiral glyph breathes

### DIFF
--- a/CCP.Avalonia/Controls/AmbientFxCanvas.cs
+++ b/CCP.Avalonia/Controls/AmbientFxCanvas.cs
@@ -1160,6 +1160,24 @@ namespace ConditioningControlPanel.Avalonia.Controls
             /// <summary>MotionFx.AllowParticles.</summary>
             public static bool AllowParticles => AllowAmbientLoops && MaxAmbientParticles(CurrentTier) > 0;
 
+            /// <summary>
+            /// MotionFx.AllowTransitions. Interaction motion - hover, press, entrances, a stamp
+            /// landing - is 80-400ms and runs at every level except Off, which is a different
+            /// question from <see cref="AllowAmbientLoops"/> and must not be answered with it.
+            /// </summary>
+            public static bool AllowTransitions => Level != MotionLevel.Off;
+
+            /// <summary>PerformanceProfile.AllowGlow, verbatim.</summary>
+            public static bool AllowGlow(PerformanceTier tier) => tier != PerformanceTier.Performance;
+
+            /// <summary>PerformanceProfile.MaxGlowBlurRadius, verbatim. Only consulted when
+            /// <see cref="AllowGlow"/> already said yes, hence no Performance arm.</summary>
+            public static double MaxGlowBlurRadius(PerformanceTier tier) => tier switch
+            {
+                PerformanceTier.Balanced => 18,
+                _ => 24,
+            };
+
             // FxTheme's colours are read, not computed: it writes four Color keys into the app
             // resources from the mod palette and every consumer reads them back. Theme/Colors.xaml
             // already carries the keys, so this is that same read path - and nothing on this head

--- a/CCP.Avalonia/Controls/SpiralGlyph.cs
+++ b/CCP.Avalonia/Controls/SpiralGlyph.cs
@@ -41,14 +41,20 @@ namespace ConditioningControlPanel.Avalonia.Controls
     ///
     /// <para><b>Deviations from the WPF original:</b></para>
     /// <list type="bullet">
-    ///   <item>ponytail: needs <c>MotionFx.AllowAmbientLoops</c> (the reduced-motion gate, still in
-    ///     the WPF head), so <see cref="RefreshMotion"/> currently only asks whether the glyph is
-    ///     loaded and visible and the breath always runs. Restore the gate when MotionFx moves to
-    ///     Core — the call site is already there, and the hosts already call this method.</item>
-    ///   <item>ponytail: <c>SpiralRailHost.StageNumeral</c> is a WPF-head control's static, so the
-    ///     numeral table is copied into <see cref="StageNumeral"/> verbatim. Delete the copy and
-    ///     call the shared one when the rail host lands on this head or in Core — the two must not
-    ///     drift apart.</item>
+    ///   <item>The reduced-motion gate IS wired: <see cref="RefreshMotion"/> asks
+    ///     <c>AmbientFxCanvas.Env.AllowAmbientLoops</c>, this head's copy of
+    ///     <c>MotionFx</c>/<c>PerformanceProfile</c> over the real <c>CoreSettings.Current</c>.
+    ///     ponytail: the only missing half is WPF's cap of MotionLevel to Reduced on the OS
+    ///     animation flag, which Avalonia does not expose and which can only ever REMOVE motion
+    ///     (recorded on <c>Env.Level</c>). The gate is read at Loaded / IsVisible / an explicit
+    ///     <see cref="RefreshMotion"/>, never polled — a live MotionLevel change reaches a glyph
+    ///     that re-shows, and the hosts must call this method the way WPF re-armed from
+    ///     MainWindow.UiUpdates.CmbMotionLevel_SelectionChanged.</item>
+    ///   <item>ponytail: <c>SpiralRailHost.StageNumeral</c> lives in
+    ///     <c>ConditioningControlPanel/Controls/SpiralRailHost.cs</c>, a <c>System.Windows</c>
+    ///     Control, so the numeral table is copied into <see cref="StageNumeral"/> verbatim. The
+    ///     table is pure and belongs in Core; delete the copy and call the shared one when it
+    ///     lands there — the two must not drift apart.</item>
     ///   <item>WPF <c>Timeline.SetDesiredFrameRate(24)</c> has no Avalonia twin; the breath runs at
     ///     the compositor's rate.</item>
     /// </list>
@@ -105,7 +111,10 @@ namespace ConditioningControlPanel.Avalonia.Controls
 
             _breath = new ScaleTransform(1, 1);
             RenderTransformOrigin = RelativePoint.Center;
-            RenderTransform = _breath;
+            // A GROUP even for one child: TransformAnimator resolves the transform by walking a
+            // TransformGroup's Children for the type owning the animated property, which is the
+            // shape TierBadge proved against Avalonia 12.1.1. See RefreshMotion.
+            RenderTransform = new TransformGroup { Children = { _breath } };
 
             _arm = new Path
             {
@@ -190,8 +199,9 @@ namespace ConditioningControlPanel.Avalonia.Controls
         /// A 40px circle has room for a glyph and not for "Crush Depth", so the stage rides as a
         /// numeral and the name rides a tooltip on the surfaces with room for one. n = 0 is the
         /// real pre-begin rung and reads as a dot.
-        /// ponytail: verbatim copy of <c>SpiralRailHost.StageNumeral</c> (WPF head); call the
-        /// shared one when the rail host reaches this head or Core.
+        /// ponytail: verbatim copy of <c>SpiralRailHost.StageNumeral</c>
+        /// (<c>ConditioningControlPanel/Controls/SpiralRailHost.cs</c>, a WPF Control); the table
+        /// is pure and belongs in Core. Call the shared one once it lands there.
         /// </summary>
         internal static string StageNumeral(int n) => n switch
         {
@@ -303,8 +313,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
         {
             try
             {
-                // ponytail: needs MotionFx.AllowAmbientLoops, wired when it moves to Core
-                bool wanted = IsVisible && IsLoaded;
+                bool wanted = IsVisible && IsLoaded && AmbientFxCanvas.Env.AllowAmbientLoops;
                 if (!wanted) { StopBreath(); return; }
                 if (_breathing) return;
                 _breathing = true;
@@ -338,7 +347,13 @@ namespace ConditioningControlPanel.Avalonia.Controls
                         },
                     },
                 };
-                _ = breathe.RunAsync(_breath, _breathClock.Token);
+                // The GLYPH, not _breath. Avalonia's TransformAnimator is handed the host Visual
+                // and resolves the transform itself, walking that visual's RenderTransform for the
+                // child whose type matches the animated property's owner. Handed the transform it
+                // casts straight to Visual and throws InvalidCastException - into the catch below,
+                // which is how this control shipped with a breath that never once ran. TierBadge
+                // carries the same note against the same Avalonia 12.1.1 behaviour.
+                _ = breathe.RunAsync(this, _breathClock.Token);
             }
             catch (Exception ex) { Log.Debug("[Spiral] glyph motion: {E}", ex.Message); }
         }

--- a/CCP.Avalonia/Controls/TierBadge.cs
+++ b/CCP.Avalonia/Controls/TierBadge.cs
@@ -7,6 +7,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Styling;
 using Serilog;
 
@@ -34,16 +36,19 @@ namespace ConditioningControlPanel.Avalonia.Controls
     ///
     /// <para><b>Deviations from the WPF original</b>, all of them forced by what this head has:</para>
     /// <list type="bullet">
-    ///   <item>ponytail: the three sign PNGs (<c>tier_badge_t1/t2.png</c>, <c>free_today_stamp.png</c>)
-    ///     are <c>pack://</c> resources of the WPF head and this head ships no <c>Resources/</c>
-    ///     art, so each sign is drawn as a vector stand-in - a rounded plate in the tier's livery
-    ///     carrying the words the PNG bakes in, at the PNG's own aspect (2.045 / 2.344 / 1.991).
-    ///     Swap the two plates for an <c>Image</c> on an <c>avares://</c> bitmap when the art
-    ///     moves; every other number here already matches the original.</item>
-    ///   <item>ponytail: needs <c>MotionFx</c> (the reduced-motion gate) and <c>PerformanceProfile</c>
-    ///     (AllowGlow / MaxGlowBlurRadius), both still in the WPF head, so this badge always hums
-    ///     and always wears its glow. Restore the gates in <see cref="AmbientAllowed"/> and
-    ///     <see cref="GlowAllowed"/> when they move to Core - the call sites are already there.</item>
+    ///   <item>The three sign PNGs DO ship on this head - <c>CCP.Avalonia.csproj</c> links
+    ///     <c>..\Assets\features\*.png</c> to <c>avares://CCP.Avalonia/Resources/features/</c> -
+    ///     so the badge draws the real art, loaded once for the app the way the WPF original loads
+    ///     its <c>pack://</c> copy. Direct, NOT through <c>Helpers.ModArt</c>: tier livery is
+    ///     commerce chrome and the WPF badge deliberately does not route it through
+    ///     <c>ModResourceResolver</c>, so a mod cannot restyle an entitlement badge. The vector
+    ///     stand-in stays behind it as the missing-art fallback (WPF collapses the badge instead;
+    ///     keeping the plate is strictly the gentler failure and the code was already here).</item>
+    ///   <item>The reduced-motion and glow gates are wired: <see cref="AmbientAllowed"/> and
+    ///     <see cref="GlowAllowed"/> ask <c>AmbientFxCanvas.Env</c>, this head's copy of
+    ///     <c>MotionFx</c>/<c>PerformanceProfile</c> over the real <c>CoreSettings.Current</c>.
+    ///     ponytail: the one half still missing is WPF's cap of MotionLevel to Reduced on the OS
+    ///     animation flag, which Avalonia does not expose and which can only ever REMOVE motion.</item>
     ///   <item>WPF <c>Timeline.SetDesiredFrameRate(24)</c> has no Avalonia twin; the ambient clocks
     ///     run at the compositor's rate.</item>
     /// </list>
@@ -93,17 +98,22 @@ namespace ConditioningControlPanel.Avalonia.Controls
         /// behind" - recognisable, but plainly overruled.</summary>
         private const double DimmedTierOpacity = 0.35;
 
-        /// <summary>The blur the WPF badge lands on when PerformanceProfile is unavailable.</summary>
+        /// <summary>The blur the WPF badge lands on when PerformanceProfile throws.</summary>
         private const double GlowBlur = 18;
 
-        /// <summary>Aspect ratios of the three sign PNGs, so the vector plates match their boxes.</summary>
+        /// <summary>Aspect ratios of the three sign PNGs, used only when the art fails to load and
+        /// the vector plates stand in for it. With the art present the bitmap's own aspect wins.</summary>
         private const double AspectT1 = 2.045;
         private const double AspectT2 = 2.344;
         private const double AspectStamp = 1.991;
 
-        /// <summary>The sign plates, standing in for the PNGs (see the class remarks).</summary>
+        /// <summary>The sign plates. Each hosts the real PNG when it loads and the vector
+        /// stand-in when it does not (see the class remarks); the Border stays either way,
+        /// because it is what carries the transforms, the glow and the layout box.</summary>
         private readonly Border _tierSign;
         private readonly Border _stampSign;
+        private readonly Image _tierImage;
+        private readonly Image _stampImage;
         private readonly TextBlock _tierWords;
         private readonly TextBlock _stampWords;
         private readonly Ellipse _glintA;
@@ -150,6 +160,9 @@ namespace ConditioningControlPanel.Avalonia.Controls
             // state a badge declared in XAML and painted later (the vault spotlight, the dashboard
             // reveal face) sits in until its first refresh.
             IsVisible = false;
+
+            _tierImage = BuildSignImage();
+            _stampImage = BuildSignImage();
 
             _tierWords = new TextBlock
             {
@@ -254,8 +267,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
         }
 
         /// <summary>
-        /// Test seam: forces the motion decision instead of asking <c>MotionFx</c>, which in a test
-        /// host answers from a null <c>App.Settings</c> and would always say Full. Null (the
+        /// Test seam: forces the motion decision instead of asking the live settings. Null (the
         /// default) means "ask the app", which is what ships.
         /// </summary>
         internal bool? MotionOverride { get; set; }
@@ -269,18 +281,28 @@ namespace ConditioningControlPanel.Avalonia.Controls
         internal Border StampSign => _stampSign;
         internal double TierTilt => Tier >= 2 ? TiltT2 : TiltT1;
 
-        private bool AmbientAllowed
+        /// <summary>
+        /// MotionFx.AllowAmbientLoops, through this head's copy of it
+        /// (<see cref="AmbientFxCanvas.Env"/> over the real <c>CoreSettings.Current</c>).
+        /// Read at Loaded / a state change / IsVisible, never polled: a live MotionLevel change
+        /// reaches a badge that re-shows, and a host wanting more must call
+        /// <see cref="StartMotion"/> the way WPF re-armed from
+        /// MainWindow.UiUpdates.CmbMotionLevel_SelectionChanged.
+        /// </summary>
+        private bool AmbientAllowed => MotionOverride ?? AmbientFxCanvas.Env.AllowAmbientLoops;
+
+        /// <summary>PerformanceProfile.AllowGlow at the live tier, through the same copy.</summary>
+        private static bool GlowAllowed => AmbientFxCanvas.Env.AllowGlow(AmbientFxCanvas.Env.CurrentTier);
+
+        /// <summary>The WPF badge's blur: the tier's ceiling, itself capped at 22.</summary>
+        private static double GlowBlurRadius
         {
             get
             {
-                if (MotionOverride is bool forced) return forced;
-                // ponytail: needs MotionFx.AllowAmbientLoops, wired when it moves to Core
-                return true;
+                try { return Math.Min(22, AmbientFxCanvas.Env.MaxGlowBlurRadius(AmbientFxCanvas.Env.CurrentTier)); }
+                catch { return GlowBlur; }
             }
         }
-
-        // ponytail: needs PerformanceProfile.AllowGlow, wired when it moves to Core
-        private static bool GlowAllowed => true;
 
         // =====================================================================================
         //  state
@@ -348,7 +370,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
                     _tierSign.Effect = new DropShadowEffect
                     {
                         Color = tier >= 2 ? GlowT2 : GlowT1,
-                        BlurRadius = GlowBlur,
+                        BlurRadius = GlowBlurRadius,
                         OffsetX = 0,
                         OffsetY = 0,
                         Opacity = 1.0,
@@ -374,14 +396,26 @@ namespace ConditioningControlPanel.Avalonia.Controls
         }
 
         /// <summary>
-        /// The livery the PNG bakes in: plate, rim, ink and the words.
-        /// ponytail: the whole method collapses to <c>_tierImage.Source = &lt;avares bitmap&gt;</c>
-        /// when the art ships on this head.
+        /// The sign itself: the tier's PNG, or the vector plate that stands in for a PNG that
+        /// would not load - plate, rim, ink and the words the art bakes in.
         /// </summary>
         private void PaintSign(int tier)
         {
+            if (TierArt(tier) is { } art)
+            {
+                _tierImage.Source = art;
+                // The art carries its own rim and ground; a Border rim around it would frame the
+                // sign in a rectangle the PNG does not have.
+                _tierSign.Child = _tierImage;
+                _tierSign.Background = null;
+                _tierSign.BorderThickness = default;
+                return;
+            }
+
             bool prime = tier >= 2;
             var ink = prime ? GlowT2 : GlowT1;
+            _tierSign.Child = _tierWords;
+            _tierSign.BorderThickness = new Thickness(2);
             _tierSign.BorderBrush = new SolidColorBrush(ink);
             _tierSign.Background = new SolidColorBrush(Color.FromArgb(0xE6, 0x0D, 0x0B, 0x14));
             _tierWords.Foreground = new SolidColorBrush(ink);
@@ -402,7 +436,25 @@ namespace ConditioningControlPanel.Avalonia.Controls
                 return;
             }
 
-            _stampRotate.Angle = StampBakedTilt + (tier >= 2 ? StampExtraTiltT2 : StampExtraTiltT1);
+            // The PNG is already pre-tilted ~8 degrees, so with the real art the code adds only the
+            // token counter-lean, exactly as the WPF badge does. The vector plate has no baked
+            // lean, so it carries those 8 degrees itself.
+            var stampArt = StampArt();
+            if (stampArt != null)
+            {
+                _stampImage.Source = stampArt;
+                _stampSign.Child = _stampImage;
+                _stampSign.Background = null;
+                _stampSign.BorderThickness = default;
+            }
+            else
+            {
+                _stampSign.Child = _stampWords;
+                _stampSign.BorderThickness = new Thickness(3);
+            }
+
+            _stampRotate.Angle = (stampArt != null ? 0 : StampBakedTilt)
+                                 + (tier >= 2 ? StampExtraTiltT2 : StampExtraTiltT1);
             _stampSign.IsVisible = true;
 
             // The thunk fires on the state CHANGE only. A repaint (mod switch, entitlement
@@ -419,8 +471,7 @@ namespace ConditioningControlPanel.Avalonia.Controls
         {
             try
             {
-                // ponytail: needs MotionFx.AllowTransitions, wired when it moves to Core
-                bool allow = MotionOverride ?? true;
+                bool allow = MotionOverride ?? AmbientFxCanvas.Env.AllowTransitions;
 
                 _thunk?.Cancel();
                 _thunk = null;
@@ -703,16 +754,17 @@ namespace ConditioningControlPanel.Avalonia.Controls
 
         private void ApplyWidth(double width)
         {
-            // WPF gets the height from Stretch=Uniform on the bitmap; a vector plate has to be
-            // told, so each sign keeps its PNG's aspect (see the class remarks).
+            // WPF gets the height from Stretch=Uniform on the bitmap; a Border has to be told, so
+            // each sign is boxed at its art's own aspect - and at the measured constant when the
+            // art is missing and the vector plate is standing in.
             _tierSign.Width = width;
-            _tierSign.Height = width / (Tier >= 2 ? AspectT2 : AspectT1);
+            _tierSign.Height = width / Aspect(TierArt(Tier), Tier >= 2 ? AspectT2 : AspectT1);
             _tierWords.FontSize = Math.Max(7, Math.Round(width * 0.125));
 
             // The stamp is deliberately a touch bigger than what it covers, and lands down-left of
             // it, so it reads as a second pass with a real rubber stamp rather than a swapped layer.
             _stampSign.Width = width * 1.06;
-            _stampSign.Height = width * 1.06 / AspectStamp;
+            _stampSign.Height = width * 1.06 / Aspect(StampArt(), AspectStamp);
             _stampSign.Margin = new Thickness(0, width * 0.09, width * 0.10, 0);
             _stampWords.FontSize = Math.Max(7, Math.Round(width * 0.15));
 
@@ -722,6 +774,74 @@ namespace ConditioningControlPanel.Avalonia.Controls
             _glintB.Width = _glintB.Height = dot * 0.8;
             _glintA.Margin = new Thickness(0, width * 0.10, width * 0.12, 0);
             _glintB.Margin = new Thickness(0, width * 0.30, width * 0.72, 0);
+        }
+
+        /// <summary>The bitmap's own aspect, or the measured constant when there is no bitmap.</summary>
+        private static double Aspect(Bitmap? art, double fallback)
+        {
+            var size = art?.Size ?? default;
+            return size.Width > 0 && size.Height > 0 ? size.Width / size.Height : fallback;
+        }
+
+        private static Image BuildSignImage() => new()
+        {
+            Stretch = Stretch.Uniform,
+            IsHitTestVisible = false,
+        };
+
+        // =====================================================================================
+        //  art - loaded once for the whole app, exactly as the WPF badge loads its pack:// copy
+        // =====================================================================================
+
+        private static Bitmap? _artT1, _artT2, _artStamp;
+        private static bool _artT1Tried, _artT2Tried, _artStampTried;
+
+        private static Bitmap? TierArt(int tier)
+        {
+            if (tier >= 2)
+            {
+                if (!_artT2Tried) { _artT2Tried = true; _artT2 = Load("tier_badge_t2.png"); }
+                return _artT2;
+            }
+            if (!_artT1Tried) { _artT1Tried = true; _artT1 = Load("tier_badge_t1.png"); }
+            return _artT1;
+        }
+
+        private static Bitmap? StampArt()
+        {
+            if (!_artStampTried) { _artStampTried = true; _artStamp = Load("free_today_stamp.png"); }
+            return _artStamp;
+        }
+
+        /// <summary>
+        /// Loads a badge PNG once and shares it with every badge in the app. Never throws: art
+        /// that will not load costs the card nothing but the sign's photograph, and the vector
+        /// plate takes over (see <see cref="PaintSign"/>).
+        ///
+        /// <para>Deliberately NOT <c>Helpers.ModArt.TryLoad</c>: that helper probes the active
+        /// mod's override first, and tier livery is commerce chrome that stays constant across
+        /// mods - the WPF badge reaches straight past ModResourceResolver for the same reason.</para>
+        ///
+        /// <para>ponytail: the fields are plain statics, written from the UI thread on the first
+        /// badge to ask. Every caller is a measure or an apply pass, so there is no second writer;
+        /// make them Lazy if a background loader ever wants one.</para>
+        /// </summary>
+        private static Bitmap? Load(string file)
+        {
+            try
+            {
+                var uri = new Uri("avares://CCP.Avalonia/Resources/features/" + file);
+                if (!AssetLoader.Exists(uri)) return null;
+                using var stream = AssetLoader.Open(uri);
+                // Never drawn wider than MaxBadgeWidth, and the stamp at 1.06x of it; decode to
+                // twice that so it stays crisp on a 200% display without carrying a 900px bitmap.
+                return Bitmap.DecodeToWidth(stream, 420);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("TierBadge art missing: {File} ({E})", file, ex.Message);
+                return null;
+            }
         }
 
         private static Ellipse BuildGlint() => new()

--- a/CCP.Avalonia/Controls/TierFxBorder.cs
+++ b/CCP.Avalonia/Controls/TierFxBorder.cs
@@ -244,11 +244,23 @@ namespace ConditioningControlPanel.Avalonia.Controls
 
         /// <summary>
         /// The reduced-motion gate, asked in one place and answered in one place. The WPF head
-        /// reads <c>MotionFx.AllowAmbientLoops</c> - the user's MotionLevel capped by the OS
-        /// animation flag, AND a performance tier that permits ambient motion.
-        /// ponytail: needs MotionFx/PerformanceProfile, wired when they move to Core.
+        /// reads <c>MotionFx.AllowAmbientLoops</c> - the user's MotionLevel AND a performance tier
+        /// that permits ambient motion - and this is that same decision:
+        /// <see cref="AmbientFxCanvas.Env"/> is the head's copy of MotionFx/PerformanceProfile,
+        /// reading the real <c>MotionLevel</c> and <c>PerformanceMode</c> off
+        /// <c>CoreSettings.Current</c>.
+        ///
+        /// <para>ponytail: the ONE half still missing is WPF's cap of MotionLevel to Reduced when
+        /// the OS animation flag is off - Avalonia exposes no cross-platform twin, and that cap can
+        /// only ever remove motion (recorded on <c>Env.Level</c>). Nothing else here is blocked.</para>
+        ///
+        /// <para>Read at Start/Resume and on the way back into visibility, never polled: no host on
+        /// this head re-calls <see cref="Resume"/> when the user changes MotionLevel, so a live
+        /// change reaches a card that re-shows rather than one already on screen. WPF had the same
+        /// shape and re-armed from MainWindow.UiUpdates.CmbMotionLevel_SelectionChanged; a twin of
+        /// that choke point is what closes the gap.</para>
         /// </summary>
-        internal static bool AmbientAllowed => true;
+        internal static bool AmbientAllowed => AmbientFxCanvas.Env.AllowAmbientLoops;
     }
 
     /// <summary>

--- a/CCP.Avalonia/Helpers/ModArt.cs
+++ b/CCP.Avalonia/Helpers/ModArt.cs
@@ -20,13 +20,30 @@ namespace ConditioningControlPanel.Avalonia.Helpers
     /// caller must treat as the WPF null path (draw the glyph, collapse the plate) rather than as
     /// a failure.</para>
     ///
-    /// <para>ponytail: <c>TubeFitDialog</c>, <c>AvatarTubeWindow</c> and <c>ModCreatorWindow</c>
-    /// still carry private copies of this two-step; fold them in when a layer owns those files.
-    /// No decode cache yet - WPF's resolver keys one on (event skin, mod id, path), and every
-    /// caller here loads a handful of small PNGs once, so add one when a caller loads per-frame.
-    /// The event-skin tier of the WPF chain is missing too, and that half is Core's:
-    /// <see cref="CoreModArt"/> has no event-skin provider yet, so an event cannot outrank a mod
-    /// on this head.</para>
+    /// <para><b>Three private copies are still out there, and all three are BYTE-FOR-BYTE this
+    /// method</b> - same order, same catches, same log shape - so folding each one in is a delete
+    /// plus a call-site rename, not a port:</para>
+    /// <list type="bullet">
+    ///   <item><c>TubeFitDialog.TryLoadImage</c> (CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs)</item>
+    ///   <item><c>AvatarTubeWindow.TryLoadImage</c> (CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs)</item>
+    ///   <item><c>ModCreatorWindow.TryLoadSlotHint</c> (CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs)</item>
+    /// </list>
+    /// <para>Six <c>Views/Features/*FeatureControl.axaml.cs</c> notes and
+    /// <c>EmiRingWindow.LoadThumb</c> still point a future wirer at
+    /// "TubeFitDialog.TryLoadImage is the decode pattern"; THIS is the answer they should name.
+    /// None of those files is reachable from Helpers/, so the layer that owns them makes the swap.</para>
+    ///
+    /// <para>ponytail: no decode cache, and that is a decision rather than a gap. WPF's resolver
+    /// keys one on (event skin, mod id, path) because it serves per-frame art; every caller here
+    /// loads a handful of small PNGs once at build-time of a view. Add one the first time a caller
+    /// loads inside a render or a tick. <c>Controls/TierBadge</c> keeps its own three-bitmap cache
+    /// and does NOT come through here on purpose - tier livery is commerce chrome that a mod must
+    /// not be able to restyle, which is why the WPF badge also reaches past ModResourceResolver.</para>
+    ///
+    /// <para>ponytail: the event-skin tier of the WPF chain is missing, and that half is Core's -
+    /// <see cref="CoreModArt"/> has no event-skin provider, so an event cannot outrank a mod on
+    /// this head. Needs a provider on CCP.Core/Services/CoreModArt.cs before anything here can
+    /// use it.</para>
     /// </summary>
     internal static class ModArt
     {


### PR DESCRIPTION
The tier badge's art. Its note said the three sign PNGs are pack:// resources of
the WPF head and "this head ships no Resources/ art", so both plates were vector
stand-ins. That was flatly false: CCP.Avalonia.csproj links ..\Assets\features\*.png
to avares://CCP.Avalonia/Resources/features/, which is where tier_badge_t1.png,
tier_badge_t2.png and free_today_stamp.png live. The badge now loads all three once
for the app - the WPF loader's shape, its 420px decode width and its never-throws
contract - and hosts them inside the same Borders, so the transforms, the glow and
the layout box are untouched. Direct through AssetLoader, deliberately NOT through
Helpers/ModArt: tier livery is commerce chrome and the WPF badge reaches straight
past ModResourceResolver so a mod cannot restyle an entitlement badge. Two knock-ons
the vector plate needed and the art does not: the box takes its aspect from the
bitmap rather than the three measured constants (2.346 measured vs 2.344 assumed),
and the FREE TODAY stamp drops the 8 degrees of baked lean it was adding by hand,
because the PNG carries that lean itself - the composed angle is now the WPF one.
The vector plate stays behind it as the missing-art path; WPF collapses the badge
there, and keeping the plate is the gentler failure for chrome.

The three motion gates. TierBadge.AmbientAllowed, TierBadge.GlowAllowed,
TierFxBorder.AmbientAllowed and SpiralGlyph.RefreshMotion all returned a hardcoded
true and all four notes said "wired when MotionFx/PerformanceProfile move to Core".
wire/60 already put that decision in this head as AmbientFxCanvas.Env, over the real
CoreSettings.Current, so all four now ask it: MotionLevel.Full plus a tier that
permits ambient motion, and PerformanceProfile.AllowGlow at the live tier. Env gains
AllowTransitions, AllowGlow and MaxGlowBlurRadius, each verbatim from the WPF file,
which is also what puts the badge's DropShadow on the tier's blur ceiling capped at
22 instead of a flat 18. Interaction motion is asked separately from ambient motion,
as MotionFx does: the stamp's thunk runs at Reduced and stops only at Off.

The spiral glyph's breath had never once run. It called
breathe.RunAsync(_breath, token) on a code-behind-held ScaleTransform;
TransformAnimator casts its target straight to Visual, so the InvalidCastException
landed in the surrounding catch and the glyph sat at rest forever. It animates the
glyph now, with _breath inside a TransformGroup, which is the shape TierBadge
already documents as verified against Avalonia 12.1.1. Proved with a throwaway
headless probe (reverted): pumping the render timer moves ScaleX 1.0000 -> 1.0002
with the fix and leaves it at exactly 1.0000 with the old target restored, so the
check can actually fail.

ModArt's handover note. It named three views still carrying private copies; all
three are byte-for-byte this method, so the note now says that, names each one with
its head path and method, and records that six Views/Features/*FeatureControl notes
plus EmiRingWindow.LoadThumb still point a wirer at TubeFitDialog.TryLoadImage when
this is the answer. No decode cache added, and the note says why rather than leaving
it as a gap: every caller loads a handful of small PNGs once at view build time.

Still blocked:
  - The OS reduced-motion cap. WPF caps MotionLevel to Reduced on
    SystemParameters.ClientAreaAnimation; Avalonia exposes no cross-platform twin.
    Recorded on AmbientFxCanvas.Env.Level; it can only ever remove motion.
  - No motion-level choke point on this head. All four gates are read at Loaded, at
    a state change and on the way back into visibility, never polled, so a live
    MotionLevel change reaches a control that re-shows rather than one on screen.
    WPF re-armed from MainWindow.UiUpdates.CmbMotionLevel_SelectionChanged; a twin
    of that would call SpiralGlyph.RefreshMotion / TierBadge.StartMotion /
    TierFxBorder.Resume (CCP.Avalonia/Views/Windows/MainShellWindow.*).
  - SpiralGlyph.StageNumeral is still a verbatim copy of SpiralRailHost.StageNumeral
    (ConditioningControlPanel/Controls/SpiralRailHost.cs, a System.Windows Control).
    The table is pure and belongs in CCP.Core.
  - CoreModArt has no event-skin provider (CCP.Core/Services/CoreModArt.cs), so an
    event cannot outrank a mod for art on this head.
  - AmbientFxCanvas.Env.MistOpacity is still 1.0: CoreMods exposes no mist-opacity
    provider, and adding one is a Core change.
  - VatGlassCanvas needs CoreMods.AccentLightColorHexProvider for the live-event tint.
  - Folding TubeFitDialog.TryLoadImage, AvatarTubeWindow.TryLoadImage and
    ModCreatorWindow.TryLoadSlotHint into Helpers/ModArt.TryLoad needs the layer that
    owns those three views.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU