### PR TITLE
feat(avalonia): the shell opens the first-run wizard on a fresh install

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/ContentPolicyWarningDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ContentPolicyWarningDialog.axaml.cs
@@ -7,6 +7,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// <summary>
     /// CCBill compliance — moderation escalation warning modal. Shown once per threshold-cross
     /// by the moderation counter; ShowDialog&lt;bool&gt; yields true on OK.
+    ///
+    /// <para>NO CALLER ON THIS HEAD. The WPF call site is
+    /// <c>AvatarTube/AvatarTubeWindow.xaml.cs:WireModerationCounter</c> -&gt;
+    /// <c>OnWarningTriggered</c>, which subscribes to <c>App.ModerationCounter.WarningTriggered</c>
+    /// and shows this with the state's <c>HitsInLastTenMinutes</c>. The Avalonia AvatarTubeWindow
+    /// is ported and its cooldown half is live, but the counter SINGLETON is not: ModerationCounter
+    /// itself is in Core (CCP.Core/Services/Moderation/ModerationCounter.cs) while the app's one
+    /// instance is built in ConditioningControlPanel/App.xaml.cs and has no seam. There is
+    /// therefore no <c>WarningTriggered</c> to subscribe to, and constructing a second counter
+    /// here to raise one would split the persisted sliding window - which is precisely how a
+    /// cooldown gets dodged by opening the tube. Blocked on a seam for App.ModerationCounter, not
+    /// on this dialog.</para>
     /// </summary>
     public partial class ContentPolicyWarningDialog : Window
     {

--- a/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml.cs
@@ -14,6 +14,20 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - The MessageBox in Accept() guarded a path the UI already blocks (Confirm disabled and
     ///    Enter ignored outside 2-20 characters), so it is a plain return here.
     /// The parameterless constructor is the real "welcome" mode and doubles as the render ctor.
+    ///
+    /// <para>NO CALLER ON THIS HEAD, and not for want of one being written. All three WPF call
+    /// sites are blocked on code that is still Windows-only:</para>
+    /// <list type="bullet">
+    /// <item><c>MainWindow.Browser.cs:BtnChangeDisplayName_Click</c> and
+    /// <c>BtnDeleteProfile_Click</c> - both need <c>App.ProfileSync</c>
+    /// (ConditioningControlPanel/Services/Settings/ProfileSyncService.cs, no Core seam) for
+    /// <c>ChangeDisplayNameAsync</c> / <c>DeleteAccountAsync</c>, and both hang off DiscordTabView,
+    /// which is not converted. MainShellWindow.Browser.cs already lists them as blocked.</item>
+    /// <item><c>Services/Account/AccountService.cs:PromptForRegistrationAsync</c> - AccountService
+    /// is a static WPF-head class that has not been ported or moved to Core at all.</item>
+    /// </list>
+    /// <para>Wiring the dialog to anything else would open a name prompt whose answer nothing can
+    /// send, which is worse than a dialog nobody can reach.</para>
     /// </summary>
     public partial class DisplayNameDialog : Window
     {

--- a/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UpdateNotificationDialog.axaml.cs
@@ -21,6 +21,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    head after all.
     ///  - The version/size/notes strings are English literals in the WPF original too - there are
     ///    no loc keys for them - so they are copied verbatim rather than invented.
+    ///
+    /// <para>NO CALLER ON THIS HEAD, and both WPF call sites are out of reach rather than merely
+    /// unwritten. They are <c>ConditioningControlPanel/App.xaml.cs:ShowUpdateNotification</c> and
+    /// <c>CheckForUpdatesManuallyAsync</c>; both set <c>App.IsUpdateDialogActive</c> around the
+    /// modal and both route "Install" into <c>DownloadAndRunInstallerAsync</c>, which drives the
+    /// Inno Setup installer. The Avalonia twin of that file is <c>CCP.Avalonia/App.axaml.cs</c>,
+    /// off-limits to this layer. Two things would still be missing if it were not: there is no
+    /// <c>UpdateService</c> in Core, so nothing on this head can produce a real <see cref="UpdateInfo"/>
+    /// to show, and there is no installer to run - the manual "check for updates" button in
+    /// Views/Controls/AppSettings/UpdatesSettingsSection.axaml.cs is already a documented stub for
+    /// that reason. Wiring the dialog to a fabricated UpdateInfo would announce a release that
+    /// cannot be installed.</para>
     /// </summary>
     public partial class UpdateNotificationDialog : Window
     {

--- a/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
@@ -29,6 +29,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// ponytail: the display-name endpoint is hardcoded here exactly as in WPF. It belongs behind a
     /// Core API client; hoist it when a second view needs the same call.
+    ///
+    /// <para>NO CALLER ON THIS HEAD. The one WPF call site is
+    /// <c>Services/Account/AccountService.cs:AuthenticateV2Async</c>, inside its
+    /// <c>authResponse.NeedsRegistration</c> branch: it opens this picker, re-authenticates with
+    /// the chosen name, and - this is the load-bearing half - LOGS THE PROVIDER OUT when the user
+    /// cancels, so a half-registered account cannot be left orphaned. AccountService is a static
+    /// class in the WPF head with no Avalonia twin and nothing in Core, and neither
+    /// <c>V2AuthService</c> nor <c>App.Patreon</c> / <c>App.Discord</c> has a seam. There is no
+    /// authentication flow on this head to hang the picker off; opening it from anywhere else
+    /// would collect a name with no registration behind it and no logout to undo it.</para>
     /// </summary>
     public partial class UsernamePickerDialog : Window
     {

--- a/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
@@ -293,8 +294,27 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// welcome heading, the active mod the cards pre-select against, the real pack ids and sizes
     /// (see <see cref="ModPacks"/>), and the pack-installed signal.</para>
     ///
-    /// <para>What does not survive: <see cref="Run"/> (it drives <c>MainWindow</c>'s folder picker
-    /// and <c>TutorialService</c>), <see cref="PrepareModStep"/> (the offline-offer bookkeeping is
+    /// <para><see cref="Run"/> is now real, and <c>MainShellWindow.FirstRun.cs</c> calls it: the
+    /// shell claims the gate in its constructor and opens this window once it is on screen. Both
+    /// of the wizard's outgoing actions land on this head - the content-folder picker is
+    /// <c>MainShellWindow.RequestPickAssetsFolder</c> and the short walk is
+    /// <c>CoreTutorial.Start("ShortWalk")</c>, a seam this head has not seeded, so that button
+    /// reaches the tour service and no tour appears (the same state AwarenessTabView and
+    /// ModCreatorWindow are in).</para>
+    ///
+    /// <para>KNOWN AND ACCEPTED, now that a fresh install actually walks these three steps: step 2
+    /// takes a mod choice that <see cref="CommitModChoice"/> does not commit, and its hint copy
+    /// ("Downloads carry on in the background", "you can switch any time from the title bar")
+    /// describes a mod system this head does not have at all - <c>CoreMods</c> is unseeded, and
+    /// the shell's own mod switcher (<c>BtnManageMods_Click</c>,
+    /// <c>ModSelectorCombo_SelectionChanged</c>) is a stub for the same reason. Nothing is
+    /// downloaded, charged, consented to or falsely reported as installed: the cards read their
+    /// state from <c>CoreReleaseContent</c>'s stamps, which answer "unknown" unseeded rather than
+    /// guessing. This is the mod seam's gap showing through, not a defect this screen introduces,
+    /// and it is worth less than an install with no onboarding at all - but it is the first thing
+    /// to fix once a mod service reaches Core.</para>
+    ///
+    /// <para>What does not survive: <see cref="PrepareModStep"/> (the offline-offer bookkeeping is
     /// <c>ModPickerDialog</c>'s, and reimplementing it is how a modular install loses its mod media)
     /// and <see cref="CommitModChoice"/> (<c>PendingModActivation</c> and
     /// <c>ModManagerService.ActivateMod</c>). Each is a stub naming what it needs.</para>
@@ -351,8 +371,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// <summary>
         /// The only constructor. WPF's took the owning MainWindow so the mod commit could call
         /// back into it; nothing here can, so it takes nothing - which is also what
-        /// <c>--render-all</c> needs to discover the view. Internal for the same reason
-        /// TextEditorDialog's render constructor is: no production caller ships the placeholder.
+        /// <c>--render-all</c> needs to discover the view. The owner is passed to
+        /// <c>ShowDialog</c> by <see cref="Run"/> instead, which is all Avalonia needs it for.
         /// </summary>
         internal FirstRunWizard()
         {
@@ -425,9 +445,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         /// <summary>
         /// First launch? Reads <c>Welcomed</c> and latches it (plus the assets-prompt one-shot),
-        /// exactly where <c>WelcomeDialog.ShowIfNeeded</c> used to. On this head that dialog still
-        /// carries its own copy of the latch and has no caller: whoever wires startup calls ONE of
-        /// the two, never both, or the second sees an already-claimed flag and shows nothing.
+        /// exactly where <c>WelcomeDialog.ShowIfNeeded</c> used to. That dialog carries a SECOND
+        /// copy of the same latch, and only one of the two may ever be called or the second sees
+        /// an already-claimed flag and shows nothing. SETTLED, and it is WPF's answer: the wizard
+        /// owns the latch. <c>MainShellWindow.FirstRun.cs</c> calls this and nothing else;
+        /// <c>WelcomeDialog.ShowIfNeeded</c> stays deliberately uncalled on this head.
         ///
         /// <para>Three flags are spent here rather than when the window opens, on purpose:</para>
         /// <list type="bullet">
@@ -501,12 +523,61 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>
-        /// ponytail: needs MainWindow (BtnPickAssetsFolder_Click, StartTutorial) and
-        /// TutorialService, wired when they move to Core. WPF opens the wizard modally and then, at
-        /// Dispatcher Normal priority (never Loaded - Loaded-priority work is starved in this app),
-        /// runs the content-folder picker first and the SHORT WALK tutorial second.
+        /// Opens the wizard modally on <paramref name="owner"/> and performs whatever the user
+        /// asked for on the way out: the content-folder picker FIRST (it is a modal too, so it
+        /// must not race the tour), then the short walk. Never throws - a first-run screen must
+        /// never be the reason a fresh install fails to start.
+        ///
+        /// <para>WPF's <c>Run(MainWindow)</c> is synchronous because <c>ShowDialog</c> is;
+        /// Avalonia's is awaitable, so this returns a Task and the caller awaits it. The tail runs
+        /// straight after the await rather than from a second dispatcher post: WPF needed the post
+        /// only to get off <c>ShowDialog</c>'s nested message loop, and <c>await</c> already is
+        /// that. The picker is awaited before the tour starts, which is what WPF's one shared
+        /// action bought.</para>
+        ///
+        /// <para><c>StartTutorial(TutorialType.ShortWalk)</c> becomes
+        /// <c>CoreTutorial.Start("ShortWalk")</c> - the seam takes the head's tutorial-type name as
+        /// a string. This head seeds no <c>StartAction</c>, so that call is a silent no-op today
+        /// and the button starts no tour; it reaches the real seam, which is the same state every
+        /// other tour button on this head is in.</para>
         /// </summary>
-        public static void Run(object owner) { }
+        public static async Task Run(MainShellWindow owner)
+        {
+            FirstRunWizard? wizard = null;
+            try
+            {
+                MainShellWindow.IsStartupDialogShowing = true;
+                wizard = new FirstRunWizard();
+                await wizard.ShowDialog(owner);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[FirstRun] The first-run wizard failed to show");
+            }
+            finally
+            {
+                MainShellWindow.IsStartupDialogShowing = false;
+            }
+
+            if (wizard == null) return;
+
+            if (wizard.PickAssetsFolderRequested)
+            {
+                try { await owner.RequestPickAssetsFolder(); }
+                catch (Exception ex) { Log.Warning(ex, "[FirstRun] Assets folder picker failed"); }
+            }
+
+            if (wizard.StartTourRequested)
+            {
+                // The SHORT WALK, not the door-by-door tour: seven cards, about ninety seconds,
+                // and it teaches the app rather than the furniture. Somebody who has just been
+                // shown all seven doors on the screen behind this button does not need them named
+                // again. The full tour is the first row in the ? panel, which is what the wizard's
+                // outro says.
+                try { CoreTutorial.Start("ShortWalk"); }
+                catch (Exception ex) { Log.Warning(ex, "[FirstRun] Could not start the short walk"); }
+            }
+        }
 
         // ------------------------------------------------------------------ copy
 

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.FirstRun.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.FirstRun.cs
@@ -1,0 +1,93 @@
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.xaml.cs:539-605 - the first-launch
+// branch of InitializeUI, which is the ONLY thing that ever opens the first-run wizard.
+//
+// WHY THIS PARTIAL EXISTS AT ALL: FirstRunWizard was a finished, rendered, fully ported view that
+// nothing in this head constructed. `--render-all` drew it every build and no user could ever
+// reach it, because the one line that opens it lives in the shell's constructor and had not been
+// written. This file is that line plus the wait it needs.
+//
+// WHAT IS FAITHFUL:
+//   * The gate is claimed in the CONSTRUCTOR (HookFirstRun runs from MainShellWindow's ctor),
+//     exactly where WPF claims it, so the Welcomed / FirstRunAssetsPromptShown / LastSeenVersion
+//     latch happens at the same instant relative to everything else on the launch path.
+//   * The wizard opens LATER, once the window is actually on screen, and hands the first run back
+//     if it never gets there. WPF polls IsLoaded for up to 10s for the same reason; Avalonia gives
+//     us the Opened event instead, so the poll collapses into one handler.
+//   * The post is at DispatcherPriority.Normal, never Loaded. WPF's comment on that line is
+//     load-bearing: this app keeps the dispatcher busy enough that Loaded-priority work is starved
+//     and the first-launch tour silently never started.
+//
+// WHAT IS DELIBERATELY NOT PORTED:
+//   * The 30s `App.IsUpdateDialogActive` wait. That flag lives in ConditioningControlPanel/
+//     App.xaml.cs and this head never shows an update dialog at all (UpdateNotificationDialog has
+//     no caller here - see its own file for why), so waiting on it would be waiting on a constant.
+//   * `App.EmiDesk.Fire("firstLaunchEver") / ReleaseHold(...)`. There is no EmiDesk seam in Core -
+//     CCP.Core/Services/EmiDesk/ carries the book's layout and text, not the desk - so the HOLD
+//     has nothing to hold back on this head. Nothing talks over the wizard here either way.
+//   * `QueueEmiKnock(knockSeenVersion)`, listed as dropped in MainShellWindow.axaml.cs already.
+//   * The whole `else` branch (ShowWhatsNewIfNeeded / TryPresentSeasonRecap / the upgrader's
+//     ModPickerDialog). MainShellWindow.Marquee.cs documents why those three are still stubs:
+//     they need App.Achievements, App.Seasons and App.xaml.cs's startup-dialog queue. One
+//     consequence worth naming: LastSeenVersion is therefore only ever stamped by the first-run
+//     gate below, never on an upgrade launch. That is pre-existing and this file does not
+//     worsen it - the fix is ShowWhatsNewIfNeeded, not a second stamp here.
+
+using System;
+using Avalonia.Threading;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Windows
+{
+    public partial class MainShellWindow
+    {
+        /// <summary>
+        /// Called once from the constructor. Claims the first-run flags if this is a fresh
+        /// install, and arms the one-shot that opens the wizard when the shell is on screen.
+        ///
+        /// <para>On a render, a --nav-check or any other head that seeded no settings service,
+        /// <see cref="FirstRunWizard.ShouldRunAndClaim"/> returns false and nothing is armed -
+        /// which is what keeps a modal out of a headless run and keeps CI off a real profile.</para>
+        /// </summary>
+        private void HookFirstRun()
+        {
+            try
+            {
+                if (!FirstRunWizard.ShouldRunAndClaim()) return;
+                Opened += OnFirstRunShellOpened;
+            }
+            catch (Exception ex)
+            {
+                // A first-run screen must never be the reason a fresh install fails to start.
+                Log.Warning(ex, "[FirstRun] Could not arm the first-run wizard");
+            }
+        }
+
+        private void OnFirstRunShellOpened(object? sender, EventArgs e)
+        {
+            Opened -= OnFirstRunShellOpened;   // one launch, one wizard
+
+            // Normal, never Loaded - see the header. Posting also gets us off the Opened callback
+            // before a modal takes the loop.
+            Dispatcher.UIThread.Post(async () =>
+            {
+                try
+                {
+                    // ShowDialog throws on an owner that is not VISIBLE, and "loaded" is not the
+                    // same question. If the shell never actually made it onto the screen, hand the
+                    // flags back rather than spending a first run nobody was shown.
+                    if (!IsVisible)
+                    {
+                        FirstRunWizard.HandBackFirstRun("shell window never became visible");
+                        return;
+                    }
+
+                    await FirstRunWizard.Run(this);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "[FirstRun] The first-run wizard failed to run");
+                }
+            }, DispatcherPriority.Normal);
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.axaml.cs
@@ -91,6 +91,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             AddHandler(DragDrop.DragEnterEvent, Window_DragEnter);
             AddHandler(DragDrop.DragOverEvent, Window_DragOver);
             AddHandler(DragDrop.DragLeaveEvent, Window_DragLeave);
+
+            // First launch? WPF claims the Welcomed latch from MainWindow's constructor
+            // (MainWindow.xaml.cs:555) and opens the wizard once the window is up. Same here -
+            // see MainShellWindow.FirstRun.cs, which owns both halves.
+            HookFirstRun();
         }
 
         // ---- window-level drag and drop ------------------------------------------------------

--- a/CCP.Avalonia/Views/Windows/SplashScreen.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SplashScreen.axaml.cs
@@ -28,6 +28,19 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - The shimmer sweep moved into the XAML as a Style.Animations block.
     ///  - The named <c>ScaleTransform</c> became a field: Avalonia generates fields only for
     ///    named Controls, so the transform is built here and assigned to ProgressFill.
+    ///
+    /// <para>NO CALLER ON THIS HEAD, and the call site is not missing - it is out of reach. WPF
+    /// owns the splash entirely from <c>ConditioningControlPanel/App.xaml.cs</c>: the field
+    /// <c>_splash</c> (line 83), <c>_splash = SplashScreen.ShowOnOwnThread()</c> in OnStartup
+    /// (line 1539), the <c>SetProgress</c> calls threaded through service initialisation, and
+    /// <c>FadeOutAndClose</c> when the main window appears. The Avalonia twin of that file is
+    /// <c>CCP.Avalonia/App.axaml.cs</c>, and the splash belongs in
+    /// <c>OnFrameworkInitializationCompleted</c> immediately before
+    /// <c>desktop.MainWindow = new MainShellWindow()</c> - not on MainShellWindow, which by
+    /// definition exists only after the startup this window is meant to cover. That file is
+    /// off-limits to this layer, so the call is named here rather than put somewhere it would be
+    /// a defect. There is also nothing yet for <c>SetProgress</c> to report: this head's startup
+    /// is one settings service and five seam assignments, all synchronous.</para>
     /// </summary>
     public partial class SplashScreen : Window
     {


### PR DESCRIPTION
FirstRunWizard was a finished, rendered, fully ported view that nothing in
CCP.Avalonia ever constructed: the one line that opens it lives in the shell's
constructor and had not been written, so every Linux install was a fresh install
with no onboarding at all. MainShellWindow.FirstRun.cs is that line plus the wait
it needs - HookFirstRun() runs from the shell ctor and claims the gate exactly
where MainWindow.xaml.cs:555 claims it, then a one-shot Opened handler posts at
DispatcherPriority.Normal (never Loaded, per the WPF comment about starved
Loaded-priority work) and opens the wizard once the window is genuinely visible.
A shell that never becomes visible hands the first run back rather than spending
flags on a screen nobody saw. FirstRunWizard.Run is now real: modal on the owner
with IsStartupDialogShowing set around it, then the content-folder picker
(MainShellWindow.RequestPickAssetsFolder) awaited BEFORE the short walk
(CoreTutorial.Start("ShortWalk")), so the folder dialog cannot race the tour.
Not ported, each named in the file: the 30s App.IsUpdateDialogActive wait (this
head shows no update dialog), the EmiDesk firstLaunchEver HOLD (no seam in Core),
QueueEmiKnock, and the whole upgrader else branch.

THE LATCH DECISION. Welcomed exists in two places on this head and only one may
ever be called. Settled as WPF settles it: FirstRunWizard.ShouldRunAndClaim owns
it, and Views/Dialogs/WelcomeDialog.ShowIfNeeded stays deliberately uncalled.
FirstRunWizard's own stale note ("whoever wires startup calls ONE of the two")
is corrected to record the decision. WelcomeDialog.axaml.cs is NOT touched here -
it is not this layer's file - so for whoever owns it: ShowIfNeeded is now dead
code, and it carries a hazard the wizard's gate does not, in that it reads
CoreSettings.Current without checking CoreSettings.Service, so a caller added on
a head that seeded no settings service would latch Welcomed on a throwaway.

Accepted, not hidden: a fresh install now walks three steps of which step 2 takes
a mod choice CommitModChoice does not commit, and its copy describes a mod system
this head does not have (CoreMods unseeded; the shell's own switcher is a stub for
the same reason). Nothing is downloaded, charged or falsely reported installed -
the cards read CoreReleaseContent stamps, which answer "unknown" unseeded. Written
into the class doc as the first thing to fix when a mod service reaches Core.

Still blocked, each with the reason written into its own file:
  * Views/Windows/SplashScreen.axaml.cs - the call site is CCP.Avalonia/App.axaml.cs,
    immediately before `desktop.MainWindow = new MainShellWindow()` (WPF:
    App.xaml.cs:83 _splash, :1539 ShowOnOwnThread). Off-limits to this layer, and
    it does not belong on MainShellWindow, which exists only after the startup the
    splash covers.
  * Views/Dialogs/UpdateNotificationDialog.axaml.cs - both WPF sites are
    App.xaml.cs:ShowUpdateNotification and CheckForUpdatesManuallyAsync. Off-limits,
    and there is no UpdateService in Core to produce a real UpdateInfo and no
    installer for "Install" to run.
  * Views/Dialogs/DisplayNameDialog.axaml.cs - MainWindow.Browser.cs's
    BtnChangeDisplayName_Click / BtnDeleteProfile_Click need App.ProfileSync
    (Services/Settings/ProfileSyncService.cs, no seam) and live on the unconverted
    DiscordTabView; Services/Account/AccountService.cs:PromptForRegistrationAsync
    is in a class not ported at all.
  * Views/Dialogs/UsernamePickerDialog.axaml.cs - AccountService.AuthenticateV2Async,
    whose cancel path logs the provider out to prevent an orphaned half-registration.
    No auth flow exists here to hang it off.
  * Views/Dialogs/ContentPolicyWarningDialog.axaml.cs - AvatarTubeWindow.xaml.cs's
    WireModerationCounter needs the App.ModerationCounter SINGLETON, which has no
    seam. The class is in Core; a second instance would split the persisted sliding
    window and let a cooldown be dodged by opening the tube.

One note for another owner: MainShellWindow.Marquee.cs says "Nothing on this head
SETS IsStartupDialogShowing yet". FirstRunWizard.Run now does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU