### PR TITLE
feat(avalonia): the Workshop drawer opens onto its six real cells

### DIFF
--- a/CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml.cs
@@ -23,6 +23,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls
     ///   SetProgress(0..1)  — fills the foreground ring clockwise.
     ///   StartPulse() / StopPulse() — gentle scale-pulse animation, useful
     ///                                 to signal "look here" on first appear.
+    ///
+    /// <para><b>Nothing on this head constructs this control, and that is not an oversight.</b>
+    /// Its only caller is <c>AttentionCheckService.EnsureWindow()</c>
+    /// (ConditioningControlPanel/Services/AttentionCheckService.cs:339), which is not ported and
+    /// cannot be until three things exist here: the gaze feed it drives the ring from
+    /// (<c>App.Webcam.OnGazeMove</c> / WebcamTrackingService — no webcam engine on this head at
+    /// all), a topmost, non-activating, hit-test-invisible transparent window to host it, and the
+    /// <c>HwndSource</c> WM_DPICHANGED swallow hook that keeps a re-show off the render thread.
+    /// Giving it any other entry point would put a ring on screen that fills from nothing and
+    /// scores a check the user was never actually measured on, so it stays unreached. Wire it
+    /// from the ported AttentionCheckService, not from a view.</para>
     /// </summary>
     public partial class AttentionCheckControl : UserControl
     {

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionRoomAnchors.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionRoomAnchors.cs
@@ -1,0 +1,40 @@
+// PORTED verbatim (namespace aside) from
+// ConditioningControlPanel/Views/Controls/Companion/CompanionRoomAnchors.cs. Constants only, so
+// there was nothing to translate; it crosses now because WorkshopRuntimeVm needs the exact same
+// key strings the WPF deep links use.
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
+{
+    /// <summary>
+    /// The names zones use to point at each other across the page.
+    ///
+    /// <para>A deep link that misses is silent — the drawer opens, nothing scrolls, and it looks
+    /// like the affordance simply does not work. These constants exist so a caller cannot mistype
+    /// an anchor, and so the wiring pass has one place to keep in step when a Workshop cell is
+    /// renamed or localized.</para>
+    ///
+    /// <para>They are <see cref="IWorkshopCellVm.Key"/> values, NOT headings. The wiring pass split
+    /// the two: <see cref="WorkshopAccordion"/> reveals by key and renders <c>Title</c>, so a cell's
+    /// heading can be translated (and re-worded) without any of these links following it into the
+    /// wrong language. The keys are ASCII, uppercase and deliberately not user-visible.</para>
+    /// </summary>
+    public static class CompanionRoomAnchors
+    {
+        /// <summary>The roster pigeonhole — where the hero's Switch chip lands.</summary>
+        public const string WorkshopRosterCell = "ROSTER";
+
+        /// <summary>The awareness cooldown pigeonhole — where Z5's "fine-tuning ↓" lands.</summary>
+        public const string WorkshopAwarenessCell = "AWARENESS FINE-TUNING";
+
+        /// <summary>Behaviour sliders + the two shortcut editors.</summary>
+        public const string WorkshopBehaviorCell = "BEHAVIOR";
+
+        /// <summary>Trigger mode, its interval, and the phrase shelf.</summary>
+        public const string WorkshopTriggersCell = "TRIGGERS & PHRASES";
+
+        /// <summary>The per-mod Hypnotube link pool.</summary>
+        public const string WorkshopLibraryCell = "HER LIBRARY";
+
+        /// <summary>Community prompt browse / import / export / installed list.</summary>
+        public const string WorkshopCommunityCell = "COMMUNITY";
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/CompanionRoomPreviewWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/CompanionRoomPreviewWindow.axaml.cs
@@ -17,6 +17,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// The strip, the current-state label and the width toggle cross as they are. What does not:
     /// <c>MockCompanionRoomVm</c> and <c>ICompanionRoomVm</c> live in the WPF head, so
     /// <see cref="ShowVariant"/> re-labels the strip but cannot yet swap the page's state.</para>
+    ///
+    /// <para><b>Nothing constructs this window here — and nothing constructs it on WPF either.</b>
+    /// Checked before assuming: its one entry point is
+    /// <c>CompanionRoomPreview.MaybeShow()</c> (ConditioningControlPanel/Views/Controls/Companion/
+    /// CompanionRoomPreview.cs), which is <c>#if DEBUG</c>, gated on <c>CCP_CTAB_PREVIEW=1</c>, and
+    /// whose own doc comment says "Nothing calls it today"; the session driver calls
+    /// <see cref="Launch"/> directly instead. So this is not an orphaned feature a user has lost —
+    /// it is a debug harness that is deliberately unreachable from a normal run, and porting
+    /// MaybeShow would only move the same uncalled hop across. If it ever should open from the app,
+    /// the arming call belongs in App.axaml.cs's startup, exactly where WPF left the hole.</para>
     /// </summary>
     public partial class CompanionRoomPreviewWindow : Window
     {

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopBehaviorCell.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopBehaviorCell.axaml.cs
@@ -89,6 +89,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
                 SliderBubbleDurationCompanion.Value = s.BubbleDurationSeconds;
                 TxtBubbleDurationCompanion.Text = $"{(int)s.BubbleDurationSeconds}s";
 
+                // The chat pill's label. WPF's RefreshChatShortcutLabel writes THIS TextBlock and
+                // the Devices one from the same combo (MainWindow.SessionIO.cs:1326/1332); the
+                // markup's "Ctrl+T" is only the design-time placeholder, and leaving it there once
+                // the cell is on screen would show every user the default whatever they had bound.
+                RefreshChatShortcutLabel();
+
+                // TxtCameraShortcutLabel keeps its XAML literal on purpose: the combo it would
+                // report drives WebcamTrackingService, which does not exist on this head, so there
+                // is no live binding for it to be honest about. Same call as the camera pill's.
+
                 // ChkPauseBrowserCompanion is deliberately NOT seeded: WPF restores it only from a
                 // session snapshot (MainWindow.Patreon.cs:1923), never from settings.
 
@@ -108,6 +118,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
             }
             finally { _isLoading = false; }
         }
+
+        /// <summary>
+        /// Repaints the chat pill from the saved combo. Called on every sync and again by the host
+        /// after a rebind — WPF's MainWindow.SessionIO.cs:1326 does exactly this to the same
+        /// TextBlock. The literal in the markup is a placeholder, not a binding, so assigning
+        /// .Text here is safe (nothing on this control carries {loc:Str}).
+        /// </summary>
+        internal void RefreshChatShortcutLabel() =>
+            TxtChatShortcutLabel.Text = AvatarTube.AvatarTubeWindow.FormatChatShortcut();
 
         private void SliderIdleInterval_ValueChanged(object? sender, RangeBaseValueChangedEventArgs e)
         {

--- a/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopRuntimeVm.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/Runtime/WorkshopRuntimeVm.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using ConditioningControlPanel.Localization;
+
+namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime
+{
+    /// <summary>
+    /// The six re-parented legacy controls, held together so the drawer has one accessor for them.
+    ///
+    /// <para>PORTED from ConditioningControlPanel/Views/Controls/Companion/Runtime/WorkshopRuntimeVm.cs.
+    /// Each cell is a real UserControl containing the actual moved markup — not a copy — so there is
+    /// exactly one instance of every control.</para>
+    /// </summary>
+    public sealed class WorkshopShelfParts
+    {
+        public WorkshopRosterCell Roster { get; } = new();
+        public WorkshopBehaviorCell Behavior { get; } = new();
+        public WorkshopTriggersCell Triggers { get; } = new();
+        public WorkshopLibraryCell Library { get; } = new();
+        public WorkshopCommunityCell Community { get; } = new();
+        public WorkshopAwarenessCell Awareness { get; } = new();
+    }
+
+    /// <summary>
+    /// Z8 — The Workshop, carrying the real controls.
+    ///
+    /// <para>"nothing was deleted. it just stopped being the front door." Each cell hands the drawer
+    /// a live control through <see cref="IWorkshopCellVm.Content"/>, which is what makes the six
+    /// finished cells in this folder reachable: without a viewmodel the accordion draws an empty
+    /// drawer and every one of them is an orphan.</para>
+    ///
+    /// <para><b>Anchor vs heading.</b> <see cref="IWorkshopCellVm.Key"/> is the deep-link identity
+    /// (<see cref="CompanionRoomAnchors"/>) and <c>Title</c> is the localizable heading. Keeping
+    /// the two apart is what lets a Workshop heading be translated without silently breaking the
+    /// hero's Switch chip and Z5's "fine-tuning ↓".</para>
+    ///
+    /// <para><b>Deviation from WPF.</b> The original routes <c>FocusCellCommand</c> through
+    /// <c>CompanionRuntimeContext.Navigator</c>, part of the ICompanionRoomVm layer that stays in
+    /// the head. Here the host passes its own reveal action in — the same behaviour, one
+    /// indirection shorter.</para>
+    /// </summary>
+    public sealed class WorkshopRuntimeVm : CompanionObservable, IWorkshopAccordionVm
+    {
+        private bool _isExpanded;
+
+        public WorkshopRuntimeVm(Action<string?> revealCell)
+        {
+            Parts = new WorkshopShelfParts();
+
+            Cells = new IWorkshopCellVm[]
+            {
+                Cell(CompanionRoomAnchors.WorkshopRosterCell, "companion_workshop_cell_roster", Parts.Roster),
+                Cell(CompanionRoomAnchors.WorkshopBehaviorCell, "companion_workshop_cell_behavior", Parts.Behavior),
+                Cell(CompanionRoomAnchors.WorkshopTriggersCell, "companion_workshop_cell_triggers", Parts.Triggers),
+                Cell(CompanionRoomAnchors.WorkshopLibraryCell, "companion_workshop_cell_library", Parts.Library),
+                Cell(CompanionRoomAnchors.WorkshopCommunityCell, "companion_workshop_cell_community", Parts.Community),
+                Cell(CompanionRoomAnchors.WorkshopAwarenessCell, "companion_workshop_cell_awareness", Parts.Awareness)
+            };
+
+            FocusCellCommand = new RevealCommand(revealCell);
+        }
+
+        /// <summary>
+        /// The one command on this page that needs its CommandParameter — the cell key the heading
+        /// button passes. This head's <see cref="CompanionRelayCommand"/> ported only the
+        /// no-parameter shape, and widening a primitive every companion zone shares for one caller
+        /// is not worth the blast radius; four lines here are.
+        /// </summary>
+        private sealed class RevealCommand : ICommand
+        {
+            private readonly Action<string?> _reveal;
+            public RevealCommand(Action<string?> reveal) => _reveal = reveal;
+            public bool CanExecute(object? parameter) => true;
+            public void Execute(object? parameter) => _reveal(parameter as string);
+            public event EventHandler? CanExecuteChanged { add { } remove { } }
+        }
+
+        /// <summary>The live controls, for a host that wants to reach one directly.</summary>
+        public WorkshopShelfParts Parts { get; }
+
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set => Set(ref _isExpanded, value);
+        }
+
+        public string DrawerNote => Loc.Get("companion_workshop_drawer_note");
+        public IReadOnlyList<IWorkshopCellVm> Cells { get; }
+        public ICommand FocusCellCommand { get; }
+
+        private static CompanionWorkshopCell Cell(string key, string titleKey, object content) =>
+            new(Loc.Get(titleKey)) { Key = key, Content = content };
+    }
+}

--- a/CCP.Avalonia/Views/Controls/Companion/WorkshopAccordion.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/WorkshopAccordion.axaml.cs
@@ -1,7 +1,9 @@
 using System;
 using Avalonia.Controls;
 using Avalonia.Threading;
+using ConditioningControlPanel.Avalonia.Views.Controls.Companion.Runtime;
 using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
 {
@@ -16,6 +18,95 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
             // the XAML AND assigns the x:Name fields. Load() alone leaves Drawer and CellHost null,
             // which compiles and then NREs the first time ExpandAndReveal runs.
             InitializeComponent();
+
+            // Composition, the thing that was missing: WPF builds the six cells in
+            // CompanionRoomRuntimeVm and hands them to this drawer. That runtime layer hangs off
+            // ICompanionRoomVm and is still in the head, so — like every other zone on this page —
+            // the drawer seeds itself instead. Without this the six finished cells in
+            // Runtime/ are constructed by nothing and the drawer opens empty.
+            var vm = new WorkshopRuntimeVm(ExpandAndReveal);
+            DataContext = vm;
+            WireCellHostActions(vm.Parts);
+        }
+
+        /// <summary>
+        /// The cells hoist their outbound actions as events for a host to wire — the port's
+        /// replacement for WPF's <c>Window.GetWindow(this) is MainWindow mw</c> forward. This is
+        /// that host. Only the actions whose targets exist on this head are connected; the rest
+        /// stay unsubscribed on purpose rather than being faked (see the note below).
+        /// </summary>
+        private void WireCellHostActions(WorkshopShelfParts parts)
+        {
+            parts.Behavior.ChatShortcutRequested += async (_, _) => await RebindChatShortcutAsync();
+
+            // Deliberately NOT wired, each for the reason a previous layer already recorded:
+            //
+            //  · Behavior.CameraShortcutRequested — the combo drives MainWindow.SessionIO.cs:1485
+            //    ToggleWebcamFromHotkey / WebcamTrackingService, and no webcam engine exists on this
+            //    head, so a rebind would configure a key for a feature that cannot fire. Same
+            //    refusal as DevicesSettingsSection.axaml.cs's BtnCameraShortcutDevices.
+            //  · Behavior.PauseBrowserChanged — WPF mutes and suspends the live WebView2
+            //    (MainWindow.Patreon.cs); this drawer holds no WebHost to suspend, and a switch
+            //    that flips with nothing behind it would report a paused browser that is playing.
+            //  · Roster.CompanionCardClicked / PersonalityAssignRequested — MainWindow's
+            //    CompanionCard_Click / BtnCompanionPersonality_Click (MainWindow.Patreon.cs), which
+            //    switch the active companion through App.Companion. No seam on this head.
+            //  · Library.AddVideoLinkRequested — MainWindow's per-mod Hypnotube link pool.
+            //  · Community.Browse/Import/Export/RefreshPromptsRequested — the community-prompt
+            //    service, still in the WPF head.
+        }
+
+        /// <summary>
+        /// Port of WPF's MainWindow.SessionIO.cs:1202 <c>BtnChatShortcut_Click</c>, reached here
+        /// from the Behavior cell's shortcut pill. Identical to the twin already restored on
+        /// DevicesSettingsSection — the same settings write, the same two re-applications — because
+        /// WPF's one handler serves both surfaces and repaints both labels
+        /// (MainWindow.SessionIO.cs:1326/1332).
+        ///
+        /// <para>The system-wide half of the toggle (GlobalHotkeyService, a Win32 RegisterHotKey)
+        /// stays in the WPF head; the flag is still stored, since it is one settings file across
+        /// both heads, and the in-window binding applied here is exactly what WPF falls back to
+        /// when the flag is off.</para>
+        /// </summary>
+        private async System.Threading.Tasks.Task RebindChatShortcutAsync()
+        {
+            try
+            {
+                // Avalonia throws on a non-visible owner, and the shell can be loaded-but-hidden in
+                // the tray. No visible window means no modal to show and nothing to capture.
+                if (TopLevel.GetTopLevel(this) is not Window owner || !owner.IsVisible) return;
+                var prompt = CoreSettings.Current.CompanionPrompt;
+                if (prompt == null) return;
+
+                var dlg = new Dialogs.ChatShortcutCaptureDialog { GlobalHotkey = prompt.ChatShortcutGlobal };
+                if (!await dlg.ShowDialog<bool>(owner)) return;
+
+                if (dlg.ResetToDefault)
+                {
+                    prompt.ChatShortcutKey = "T";
+                    prompt.ChatShortcutModifiers = "Control";
+                }
+                else
+                {
+                    prompt.ChatShortcutKey = dlg.CapturedKey.ToString();
+                    // Serialises "Windows", not Avalonia's "Meta", so a file written here still
+                    // parses on the WPF head.
+                    prompt.ChatShortcutModifiers =
+                        AvatarTube.AvatarTubeWindow.SerializeModifiers(dlg.CapturedModifiers);
+                }
+                prompt.ChatShortcutGlobal = dlg.GlobalHotkey;
+                CoreSettings.Save();
+
+                AvatarTube.AvatarTubeWindow.ApplyChatShortcutTo(owner);
+                AvatarTube.AvatarTubeWindow.ApplyChatShortcutTo(AvatarTube.AvatarTubeWindow.Live);
+                (DataContext as WorkshopRuntimeVm)?.Parts.Behavior.RefreshChatShortcutLabel();
+                Log.Information("Chat shortcut rebound to {Combo}",
+                                AvatarTube.AvatarTubeWindow.FormatChatShortcut());
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Workshop: chat shortcut rebind failed");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The Companion room drew an empty Workshop. WorkshopAccordion had no
DataContext, so the six finished cells in Views/Controls/Companion/Runtime -
roster, behavior, triggers, library, community and awareness fine-tuning,
each already carrying its restored CoreSettings logic - were constructed by
nothing at all. WPF composes them in CompanionRoomRuntimeVm, which hangs off
the ICompanionRoomVm layer still in the head, so the drawer now seeds itself
the way every other zone on that page does: WorkshopRuntimeVm builds the six,
hands each to its cell through IWorkshopCellVm.Content, and the accordion sets
it in its ctor. CompanionRoomAnchors crosses verbatim because the keys are the
deep-link identities FindCellContainer matches on, and a mistyped anchor is a
link that silently misses. FocusCellCommand takes the reveal action from the
host rather than a navigator; the one deviation, since the navigator half of
ICompanionRoomVm has no source here. All six are composed, not the four this
layer was assigned: a Workshop showing four of its six pigeonholes is a lie
about its own shape, and Community and Triggers are the same call site. The
new file takes the same path and name as its WPF original, so a sibling layer
doing the same thing collides loudly instead of landing a duplicate type.

The Behavior cell chat pill now works. Clicking it opens
ChatShortcutCaptureDialog and writes the combo, awaited, exactly as the twin
already restored on DevicesSettingsSection does - WPF has one handler
(MainWindow.SessionIO.cs:1202) serving both surfaces and repainting both
labels. TxtChatShortcutLabel is repainted from the saved combo on every sync
too; it had been left at the markup placeholder "Ctrl+T", which would have
shown every user the default whatever they had bound the moment the cell
became visible. The global half of the toggle is stored but not registered
(GlobalHotkeyService is Win32), which is what WPF falls back to when it is off.

Two orphans are reported rather than wired, with the reason written into each
file. AttentionCheckControl: its only caller is AttentionCheckService, which
needs a gaze feed, a click-through topmost window and a WM_DPICHANGED hook -
any other entry point would put a ring on screen that scores a check nobody
was measured on. CompanionRoomPreviewWindow: uncalled on WPF too - its entry
point is #if DEBUG, env-gated and documents "Nothing calls it today". A third,
KnowledgeLinkEditorDialog, is already wired at CompanionPromptEditorDialog
.axaml.cs:256 and was never an orphan.

Still blocked:
- WorkshopRosterCell.CompanionCardClicked / PersonalityAssignRequested ->
  MainWindow.CompanionCard_Click / BtnCompanionPersonality_Click
  (ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs); switching the
  active companion needs App.Companion, which has no seam.
- WorkshopBehaviorCell.CameraShortcutRequested -> MainWindow.SessionIO.cs:1485
  ToggleWebcamFromHotkey / WebcamTrackingService. Same refusal already recorded
  for BtnCameraShortcutDevices: no webcam engine on this head.
- WorkshopBehaviorCell.PauseBrowserChanged -> the live WebView2 suspend in
  MainWindow.Patreon.cs. No WebHost in this drawer to suspend, and a switch
  with nothing behind it would report a paused browser that is playing.
- WorkshopLibraryCell.AddVideoLinkRequested -> MainWindow's per-mod Hypnotube
  link pool.
- WorkshopCommunityCell.Browse/Import/Export/RefreshPromptsRequested -> the
  community-prompt service in the WPF head.
- CompanionPromptEditorDialog (the parent that opens KnowledgeLinkEditorDialog)
  is itself unconstructed here: its WPF opener is MainWindow.Patreon.cs:1100
  BtnCustomizeCompanion_Click, reached from CompanionDepthRuntimeVms.cs:243
  OpenPromptEditor. Neither is ported; both are MakeHerYoursView's territory.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU