### PR TITLE
feat(avalonia): the Bimbo Journal paints real steps, and three roadmap dialogs stop being unreachable

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/ProgramEnrollDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ProgramEnrollDialog.axaml.cs
@@ -33,6 +33,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    <c>ToImmutable()</c>.
     ///  - PreviewKeyDown -> KeyDown, DragMove() -> BeginMoveDrag(e).
     /// </summary>
+    // STILL UNREACHABLE, blocked on an unported caller — not on this dialog.
+    // Its only WPF call site is BtnProgramEnroll_Click in
+    // ConditioningControlPanel/MainWindow/MainWindow.ProgramsTab.cs:2010, and this head's
+    // CCP.Avalonia/Views/Windows/MainShellWindow.ProgramsTab.cs is a wholesale stub for a reason
+    // stronger than a missing seam: ProgramDefinition, ProgramEnrollment and ProgramService are
+    // all still in ConditioningControlPanel/Models/Program/ and Services/Program/, so there is no
+    // ProgramDefinition on this head to hand the constructor and no ProgramService to enrol into.
+    // `grep -rl "ProgramDefinition" CCP.Core` returning nothing is the check. Inventing a
+    // different entry point would produce an enrol button with nothing behind it.
     public partial class ProgramEnrollDialog : Window
     {
         private readonly ProgramEnrollInfo _program;

--- a/CCP.Avalonia/Views/Tabs/QuestsTabView.Roadmap.cs
+++ b/CCP.Avalonia/Views/Tabs/QuestsTabView.Roadmap.cs
@@ -1,0 +1,412 @@
+// PORTED from ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs (RefreshRoadmapUI,
+// GenerateRoadmapNodes, CreateRoadmapNode, RoadmapNode_Click, ShowPhotoConfirmation,
+// RefreshRoadmapStats — lines 78-431).
+//
+// WHY IT LIVES HERE AND NOT ON THE SHELL. On WPF the roadmap markup is inline in MainWindow.xaml,
+// so the painter hung off MainWindow and reached the controls through QuestsTab.*. On this head
+// the markup is this view's own, and a UserControl's x:Name fields are private to it — the shell
+// cannot reach RoadmapNodesPanel at all. MainShellWindow.Roadmap.cs says the same thing about the
+// three chrome handlers, and this is the rest of that sentence.
+//
+// THE SERVICE IS REAL. RoadmapService is CCP.Core/Services/RoadmapService.cs and this head's one
+// instance is MainShellWindow.Roadmap, so every number, photo and gate below is the user's own —
+// nothing here is placeholder data. That is what makes RoadmapStartDialog, RoadmapConfirmDialog
+// and RoadmapDiaryDialog reachable: before this file, all three were fully ported windows that
+// nothing in CCP.Avalonia ever constructed.
+//
+// Deviations from the WPF original:
+//  - MouseLeftButtonUp -> PointerReleased, filtered on InitialPressMouseButton == Left so a
+//    right-click drag off a node cannot open a step.
+//  - Microsoft.Win32.OpenFileDialog -> StorageProvider.OpenFilePickerAsync, which is async. The
+//    whole click path is therefore async, and every dialog result is AWAITED BEFORE the thing it
+//    gated runs: StartStep only after the start dialog answers true, SubmitPhoto only after the
+//    confirm dialog answers true AND Confirmed. Firing either beside its answer would turn the
+//    confirmation into decoration.
+//  - MessageBox.Show -> MessageDialog.ShowAsync, this head's replacement.
+//  - ShowDialog needs a VISIBLE owner on Avalonia (a shell minimised to tray is loaded but not
+//    visible and Avalonia throws), so every open goes through OwnerWindow().
+//  - The active node's pulse is an Avalonia Animation on Opacity. Opacity is not a transform, so
+//    the TransformAnimator trap in CLAUDE.md does not apply here.
+//  - Colours that WPF read off Application.Current.Resources are read off this control's
+//    resource chain instead, with the same keys and the same literal fallbacks.
+//
+// ponytail: the WPF painter's App.Achievements celebration on a completed step is not here —
+// that is OnRoadmapStepCompleted (MainWindow.Roadmap.cs:452), a subscription this file does not
+// take, and it needs App.Achievements plus the sound service, neither of which is in Core.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform.Storage;
+using Avalonia.Styling;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Avalonia.Views.Windows;
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Tabs
+{
+    public partial class QuestsTabView
+    {
+        private RoadmapTrack _currentRoadmapTrack = RoadmapTrack.EmptyDoll;
+
+        /// <summary>
+        /// Cancels the active step's pulse when the nodes are rebuilt. WPF needs no equivalent:
+        /// its TimeManager holds animation clocks weakly, so a Storyboard on a detached Ellipse
+        /// stops on its own. Avalonia's animator subscribes to the global clock and HOLDS its
+        /// target, so an infinite RunAsync on a node that has been cleared out of
+        /// RoadmapNodesPanel keeps ticking on a dead subtree forever — one leaked node per track
+        /// click, sub-tab click and photo submit.
+        /// </summary>
+        private CancellationTokenSource? _pulseCts;
+
+        private static RoadmapService Roadmap => MainShellWindow.Roadmap;
+
+        /// <summary>The window this view sits in, or null when it is not on screen. Null is the
+        /// answer a tray-minimised shell gives, and every caller below simply does nothing —
+        /// which is correct: none of these paths can run without a user clicking a node.</summary>
+        private Window? OwnerWindow() =>
+            TopLevel.GetTopLevel(this) is Window { IsVisible: true } w ? w : null;
+
+        private IBrush Brush(string key, Color fallback) =>
+            this.TryFindResource(key, out var v) && v is IBrush b ? b : new SolidColorBrush(fallback);
+
+        // ---- the panel ------------------------------------------------------------
+
+        internal void RefreshRoadmapUI()
+        {
+            var trackDef = RoadmapTrackDefinition.GetByTrack(_currentRoadmapTrack);
+            if (trackDef == null) return;
+
+            TxtRoadmapTrackName.Text = trackDef.Name;
+            TxtRoadmapTrackSubtitle.Text = trackDef.Subtitle;
+
+            var (completed, total) = Roadmap.GetTrackProgress(_currentRoadmapTrack);
+            TxtRoadmapTrackProgress.Text = $"{completed} / {total} steps completed";
+
+            bool isUnlocked = Roadmap.IsTrackUnlocked(_currentRoadmapTrack);
+            TrackLockedOverlay.IsVisible = !isUnlocked;
+            RoadmapScrollContainer.IsVisible = isUnlocked;
+
+            if (!isUnlocked)
+            {
+                TxtLockReason.Text = _currentRoadmapTrack switch
+                {
+                    RoadmapTrack.ObedientPuppet => "Complete Track 1 Boss to unlock",
+                    RoadmapTrack.SluttyBlowdoll => "Complete Track 2 Boss to unlock",
+                    _ => "Track locked",
+                };
+            }
+
+            BadgeIndicator.IsVisible = _currentRoadmapTrack == RoadmapTrack.SluttyBlowdoll
+                                       && Roadmap.Progress.HasCertifiedBlowdollBadge;
+
+            GenerateRoadmapNodes();
+            RefreshRoadmapStats();
+        }
+
+        private void GenerateRoadmapNodes()
+        {
+            _pulseCts?.Cancel();
+            _pulseCts = new CancellationTokenSource();
+
+            RoadmapNodesPanel.Children.Clear();
+
+            var trackDef = RoadmapTrackDefinition.GetByTrack(_currentRoadmapTrack);
+            foreach (var step in RoadmapStepDefinition.GetStepsForTrack(_currentRoadmapTrack))
+                RoadmapNodesPanel.Children.Add(CreateRoadmapNode(step, trackDef));
+        }
+
+        private Border CreateRoadmapNode(RoadmapStepDefinition step, RoadmapTrackDefinition? trackDef)
+        {
+            bool isCompleted = Roadmap.IsStepCompleted(step.Id);
+            bool isActive = Roadmap.IsStepActive(step.Id);
+            bool isLocked = !isCompleted && !isActive;
+            var progress = Roadmap.GetStepProgress(step.Id);
+            bool isBoss = step.StepType == RoadmapStepType.Boss;
+
+            var accent = new SolidColorBrush(
+                Color.Parse(string.IsNullOrEmpty(trackDef?.AccentColor) ? "#FF69B4" : trackDef!.AccentColor));
+            var panelAccent = Brush("PanelAccentBrush", Color.FromRgb(0x3D, 0x3D, 0x60));
+            var gold = new SolidColorBrush(Colors.Gold);
+
+            var container = new Border
+            {
+                Width = 150,
+                Height = 240,
+                Margin = new Thickness(10, 0, 10, 0),
+                CornerRadius = new CornerRadius(15),
+                Background = Brush("PanelBgBrush", Color.FromRgb(0x25, 0x25, 0x42)),
+                BorderThickness = new Thickness(isBoss ? 3 : 2),
+                BorderBrush = isBoss ? gold : (isActive ? accent : panelAccent),
+                Cursor = new Cursor(StandardCursorType.Hand),
+                Tag = step.Id,
+            };
+
+            var stack = new StackPanel
+            {
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
+
+            // ---- photo circle
+            var circle = new Grid { Width = 80, Height = 80 };
+            var bgEllipse = new Ellipse
+            {
+                Fill = Brush("DarkerBgBrush", Color.FromRgb(0x1A, 0x1A, 0x2E)),
+                Stroke = isActive ? accent : panelAccent,
+                StrokeThickness = isActive ? 3 : 2,
+            };
+            circle.Children.Add(bgEllipse);
+
+            if (isCompleted)
+            {
+                if (!string.IsNullOrEmpty(progress?.PhotoPath))
+                {
+                    try
+                    {
+                        var fullPath = Roadmap.GetFullPhotoPath(progress!.PhotoPath!);
+                        if (!string.IsNullOrEmpty(fullPath) && File.Exists(fullPath))
+                        {
+                            // DecodePixelWidth = 100 in the original; Avalonia's equivalent is
+                            // DecodeToWidth on the load, which does the same downscale on decode.
+                            using var fs = File.OpenRead(fullPath);
+                            var bitmap = Bitmap.DecodeToWidth(fs, 100);
+                            circle.Children.Add(new Ellipse
+                            {
+                                Width = 74,
+                                Height = 74,
+                                HorizontalAlignment = HorizontalAlignment.Center,
+                                VerticalAlignment = VerticalAlignment.Center,
+                                Fill = new ImageBrush(bitmap) { Stretch = Stretch.UniformToFill },
+                            });
+                        }
+                    }
+                    catch (Exception ex) { Log.Debug("Roadmap thumbnail failed: {Error}", ex.Message); }
+                }
+
+                circle.Children.Add(new TextBlock
+                {
+                    Text = "✓",
+                    FontSize = 20,
+                    FontWeight = FontWeight.Bold,
+                    Foreground = new SolidColorBrush(Colors.LimeGreen),
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    VerticalAlignment = VerticalAlignment.Bottom,
+                    Margin = new Thickness(0, 0, 5, 5),
+                });
+            }
+            else if (isLocked)
+            {
+                circle.Children.Add(new TextBlock
+                {
+                    Text = "🔒",
+                    FontSize = 28,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+            }
+            else
+            {
+                circle.Children.Add(new TextBlock
+                {
+                    Text = "📷",
+                    FontSize = 28,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                });
+
+                _ = new Animation
+                {
+                    Duration = TimeSpan.FromSeconds(0.8),
+                    Easing = new LinearEasing(),
+                    IterationCount = IterationCount.Infinite,
+                    PlaybackDirection = PlaybackDirection.Alternate,
+                    Children =
+                    {
+                        new KeyFrame { Cue = new Cue(0d), Setters = { new Setter(OpacityProperty, 0.5) } },
+                        new KeyFrame { Cue = new Cue(1d), Setters = { new Setter(OpacityProperty, 1.0) } },
+                    },
+                }.RunAsync(bgEllipse, _pulseCts?.Token ?? CancellationToken.None);
+            }
+
+            // ---- objective box, above the circle
+            var requirement = step.PhotoRequirement ?? "";
+            if (requirement.StartsWith("Photo: ", StringComparison.Ordinal)) requirement = requirement.Substring(7);
+            if (requirement.Length > 50) requirement = requirement.Substring(0, 47) + "...";
+
+            stack.Children.Add(new Border
+            {
+                Background = new SolidColorBrush(Color.FromArgb(0xCC, 0x1A, 0x1A, 0x2E)),
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(6, 3, 6, 3),
+                Margin = new Thickness(0, 0, 0, 8),
+                MaxWidth = 140,
+                Child = new TextBlock
+                {
+                    Text = requirement,
+                    Foreground = new SolidColorBrush(Color.FromRgb(0xCC, 0xCC, 0xCC)),
+                    FontSize = 9,
+                    TextWrapping = TextWrapping.Wrap,
+                    TextAlignment = TextAlignment.Center,
+                },
+            });
+
+            stack.Children.Add(circle);
+
+            stack.Children.Add(new TextBlock
+            {
+                Text = isBoss ? "BOSS" : $"Step {step.StepNumber}",
+                Foreground = isBoss ? gold : new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88)),
+                FontSize = 11,
+                FontWeight = isBoss ? FontWeight.Bold : FontWeight.Normal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 10, 0, 2),
+            });
+
+            stack.Children.Add(new TextBlock
+            {
+                Text = step.Title,
+                Foreground = new SolidColorBrush(Colors.White),
+                FontSize = 12,
+                FontWeight = FontWeight.SemiBold,
+                TextAlignment = TextAlignment.Center,
+                TextWrapping = TextWrapping.Wrap,
+                MaxWidth = 120,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            });
+
+            if (isCompleted && !string.IsNullOrEmpty(progress?.UserNote))
+            {
+                var note = progress!.UserNote!;
+                if (note.Length > 35) note = note.Substring(0, 32) + "...";
+
+                stack.Children.Add(new Border
+                {
+                    Background = new SolidColorBrush(Color.FromArgb(0x80, 0x25, 0x25, 0x42)),
+                    CornerRadius = new CornerRadius(4),
+                    Padding = new Thickness(6, 3, 6, 3),
+                    Margin = new Thickness(0, 8, 0, 0),
+                    MaxWidth = 140,
+                    Child = new TextBlock
+                    {
+                        Text = $"\"{note}\"",
+                        Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88)),
+                        FontSize = 9,
+                        FontStyle = FontStyle.Italic,
+                        TextWrapping = TextWrapping.Wrap,
+                        TextAlignment = TextAlignment.Center,
+                    },
+                });
+            }
+
+            container.Child = stack;
+            container.PointerReleased += RoadmapNode_Click;
+            return container;
+        }
+
+        // ---- the click ------------------------------------------------------------
+
+        private async void RoadmapNode_Click(object? sender, PointerReleasedEventArgs e)
+        {
+            if (e.InitialPressMouseButton != MouseButton.Left) return;
+
+            try
+            {
+                if ((sender as Border)?.Tag is not string stepId || stepId.Length == 0) return;
+
+                var stepDef = RoadmapStepDefinition.GetById(stepId);
+                if (stepDef == null) return;
+
+                var owner = OwnerWindow();
+                if (owner == null) return;
+
+                var progress = Roadmap.GetStepProgress(stepId);
+
+                // Completed: the diary, read-only.
+                if (progress?.IsCompleted == true)
+                {
+                    await new RoadmapDiaryDialog(stepId, stepDef, progress).ShowDialog(owner);
+                    return;
+                }
+
+                // THE GATE. A step that is neither completed nor active is locked, and the WPF
+                // path stops here with a message rather than opening the start dialog. It comes
+                // over with the call: a start dialog reachable on a locked step would let a user
+                // stamp step 5 before step 1.
+                if (!Roadmap.IsStepActive(stepId))
+                {
+                    await MessageDialog.ShowAsync(owner, "Step Locked",
+                        Loc.Get("msg_complete_the_previous_steps_first"));
+                    return;
+                }
+
+                if (await new RoadmapStartDialog(stepDef).ShowDialog<bool?>(owner) != true) return;
+
+                // Records the start time. Only after the dialog said yes.
+                Roadmap.StartStep(stepId);
+
+                var files = await owner.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = $"Select Photo for: {stepDef.Title}",
+                    AllowMultiple = false,
+                    FileTypeFilter = new[]
+                    {
+                        new FilePickerFileType("Image files")
+                        {
+                            Patterns = new[] { "*.jpg", "*.jpeg", "*.png", "*.gif", "*.bmp" },
+                        },
+                        new FilePickerFileType("All files") { Patterns = new[] { "*" } },
+                    },
+                });
+                if (files.Count != 1 || files[0].TryGetLocalPath() is not { } path) return;
+
+                await ShowPhotoConfirmation(stepId, stepDef, path, owner);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Roadmap node click failed");
+            }
+        }
+
+        private async Task ShowPhotoConfirmation(string stepId, RoadmapStepDefinition stepDef,
+            string photoPath, Window owner)
+        {
+            var confirm = new RoadmapConfirmDialog(stepDef.Title, stepDef.PhotoRequirement);
+            if (await confirm.ShowDialog<bool?>(owner) != true || !confirm.Confirmed) return;
+
+            string? note = null;
+            var noteDialog = new InputDialog(Loc.Get("title_add_note"), Loc.Get("msg_add_note_prompt"), "");
+            if (await noteDialog.ShowDialog<bool?>(owner) == true && !string.IsNullOrEmpty(noteDialog.ResultText))
+                note = noteDialog.ResultText;
+
+            Roadmap.SubmitPhoto(stepId, photoPath, note);
+            RefreshRoadmapUI();
+        }
+
+        // ---- the stats strip ------------------------------------------------------
+
+        private void RefreshRoadmapStats()
+        {
+            var progress = Roadmap.Progress;
+
+            TxtRoadmapTotalSteps.Text = $"{progress.TotalStepsCompleted} / 21";
+            TxtRoadmapPhotos.Text = progress.TotalPhotosSubmitted.ToString();
+            TxtRoadmapJourneyDays.Text = progress.JourneyStartedAt.HasValue
+                ? ((int)(DateTime.Now - progress.JourneyStartedAt.Value).TotalDays).ToString()
+                : "--";
+        }
+    }
+}

--- a/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml
+++ b/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml
@@ -597,11 +597,13 @@
                 <Button x:Name="HelpBtnRoadmap" Theme="{StaticResource HelpButtonStyle}"
                         HorizontalAlignment="Right" VerticalAlignment="Top" Tag="Roadmap"/>
                 <StackPanel>
-                  <TextBlock x:Name="TxtRoadmapTrackName" Text="{loc:Str btn_the_empty_doll}"
+                  <!-- Text is written by RefreshRoadmapUI (QuestsTabView.Roadmap.cs); a {loc:Str}
+                       binding here would overwrite it on the next language change. -->
+                  <TextBlock x:Name="TxtRoadmapTrackName" Text="The Empty Doll"
                              Foreground="{DynamicResource PinkBrush}" FontSize="20" FontWeight="Bold"/>
-                  <TextBlock x:Name="TxtRoadmapTrackSubtitle" Text="{loc:Str label_gateway_phase}"
+                  <TextBlock x:Name="TxtRoadmapTrackSubtitle" Text="Gateway Phase"
                              Foreground="{DynamicResource TextMutedBrush}" FontSize="14"/>
-                  <TextBlock x:Name="TxtRoadmapTrackProgress" Text="{loc:Str label_0_7_steps_completed}"
+                  <TextBlock x:Name="TxtRoadmapTrackProgress" Text="0 / 7 steps completed"
                              Foreground="{DynamicResource TextMutedBrush}" FontSize="12" Margin="0,5,0,0"/>
                 </StackPanel>
                 <StackPanel x:Name="BadgeIndicator" Orientation="Horizontal"
@@ -619,7 +621,7 @@
               <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
                 <TextBlock Text="&#x1F512;" FontSize="44" HorizontalAlignment="Center"/>
                 <TextBlock x:Name="TxtLockReason"
-                           Text="{loc:Str label_complete_the_previous_track_to_unlock}"
+                           Text="Complete the previous track to unlock"
                            Foreground="White" FontSize="16" Margin="0,15,0,0"
                            HorizontalAlignment="Center"/>
               </StackPanel>

--- a/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/QuestsTabView.axaml.cs
@@ -76,23 +76,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
             RoadmapPanel.IsVisible = true;
             BtnQuestSubDaily.Theme = TabTheme("TabButton");
             BtnQuestSubRoadmap.Theme = TabTheme("TabButtonActive");
-            // ponytail: RoadmapService IS in Core now (CCP.Core/Services/RoadmapService.cs) and
-            // this head's instance is MainShellWindow.Roadmap. What is still missing is the VIEW
-            // half: RefreshRoadmapUI / GenerateRoadmapNodes from
-            // ConditioningControlPanel/MainWindow/MainWindow.Roadmap.cs, which paint
-            // TrackLockedOverlay, TxtLockReason, BadgeIndicator and a node per step. The panel
-            // shows its authored placeholders until that port lands.
+            // The view half landed: QuestsTabView.Roadmap.cs paints the header, the lock overlay,
+            // the badge and a node per step off the real RoadmapService in Core, exactly where
+            // WPF's BtnQuestSubRoadmap_Click calls RefreshRoadmapUI.
+            RefreshRoadmapUI();
         }
 
         private void OnTrackClick(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
         {
-            var tag = (sender as Button)?.Tag as string;
-            BtnTrack1.Theme = TabTheme(tag == "EmptyDoll" ? "TabButtonActive" : "TabButton");
-            BtnTrack2.Theme = TabTheme(tag == "ObedientPuppet" ? "TabButtonActive" : "TabButton");
-            BtnTrack3.Theme = TabTheme(tag == "SluttyBlowdoll" ? "TabButtonActive" : "TabButton");
-            // ponytail: the nodes for the new track are not repainted - there are no generated
-            // nodes to repaint yet. Blocked on GenerateRoadmapNodes, not on the service:
-            // MainShellWindow.Roadmap answers GetTrackProgress / IsTrackUnlocked today.
+            // Verbatim MainWindow.Roadmap.cs:62 - parse the Tag, and do NOTHING at all when it
+            // does not parse. The restyle sits inside that guard for the same reason it does in
+            // WPF: an unrecognised Tag must not leave all three buttons drawn inactive over the
+            // nodes of a track nobody selected.
+            if ((sender as Button)?.Tag is not string tag
+                || !Enum.TryParse<Models.RoadmapTrack>(tag, out var track)) return;
+
+            _currentRoadmapTrack = track;
+
+            BtnTrack1.Theme = TabTheme(track == Models.RoadmapTrack.EmptyDoll ? "TabButtonActive" : "TabButton");
+            BtnTrack2.Theme = TabTheme(track == Models.RoadmapTrack.ObedientPuppet ? "TabButtonActive" : "TabButton");
+            BtnTrack3.Theme = TabTheme(track == Models.RoadmapTrack.SluttyBlowdoll ? "TabButtonActive" : "TabButton");
+
+            RefreshRoadmapUI();
         }
 
         private ControlTheme? TabTheme(string key) =>

--- a/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
@@ -299,7 +299,68 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void MysteryRevealFace_Click(object? sender, PointerReleasedEventArgs e) { }   // mw.CardMystery_Click(...)
         private void CardVault_Click(object? sender, RoutedEventArgs e) { }           // mw.CardVault_Click(...)
         private void CardJustDrop_Click(object? sender, RoutedEventArgs e) { }        // mw.CardJustDrop_Click(...)
-        private void ImgLogo_MouseLeftButtonDown(object? sender, PointerPressedEventArgs e) { } // mw.ImgLogo_MouseLeftButtonDown(...)
+        /// <summary>
+        /// WIRED (the easter egg half only). WPF's handler
+        /// (MainWindow.UiUpdates.cs:1210) does four things: an achievement track, a bark
+        /// notify, the 100-clicks-in-60-seconds easter egg, and a click pulse. Only the egg
+        /// is portable today - App.Achievements and App.Bark are still head-side services -
+        /// and it needs nothing but a clock, so it runs here rather than waiting on them.
+        ///
+        /// The counter lives on this view and not on the shell because this view owns the
+        /// click: the shell's copy would be a second set of fields nothing increments.
+        ///
+        /// ponytail: needs App.Achievements.TrackAvatarClick and App.Bark.NotifyAvatarClicked
+        /// (ConditioningControlPanel/Services/Progression/AchievementService.cs and
+        /// Services/Bark/BarkService.cs); neither is in Core. The click pulse is a
+        /// ScaleTransform animation on ImgLogo and is left out with them.
+        /// </summary>
+        private async void ImgLogo_MouseLeftButtonDown(object? sender, PointerPressedEventArgs e)
+        {
+            if (_easterEggTriggered) return;
+
+            var now = DateTime.Now;
+            if (_easterEggFirstClick == DateTime.MinValue || (now - _easterEggFirstClick).TotalSeconds > 60)
+            {
+                _easterEggFirstClick = now;
+                _easterEggClickCount = 1;
+                return;
+            }
+
+            _easterEggClickCount++;
+            if (_easterEggClickCount < 100) return;
+
+            _easterEggTriggered = true;
+            await ShowEasterEgg();
+        }
+
+        /// <summary>
+        /// PORTED from MainWindow.UiUpdates.ShowEasterEgg. Deviations, all of them a service
+        /// this head does not have:
+        ///  - <c>App.ProfileSync.RecordEasterEggReadAsync</c> is head-side, so the reader count
+        ///    stays -1, which is exactly what the WPF path passes when ProfileSync is null. The
+        ///    window hides its reader line on a non-positive count, so nothing invents a number.
+        ///  - <c>App.AvatarWindow.PlayNoteClip</c> plus the <c>NewYearNoteReactionSeen</c> latch
+        ///    are skipped together. Skipping BOTH is deliberate: latching the flag without the
+        ///    clip actually playing would burn a once-ever moment on silence.
+        ///  - <c>ShowDialog</c> is async here and needs a VISIBLE owner - a shell minimised to
+        ///    the tray is loaded but not visible and Avalonia throws on it.
+        /// </summary>
+        private async System.Threading.Tasks.Task ShowEasterEgg()
+        {
+            try
+            {
+                if (TopLevel.GetTopLevel(this) is not Window owner || !owner.IsVisible) return;
+                await new Views.Windows.EasterEggWindow(-1).ShowDialog(owner);
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Warning(ex, "Easter egg window failed to open");
+            }
+        }
+
+        private int _easterEggClickCount;
+        private DateTime _easterEggFirstClick = DateTime.MinValue;
+        private bool _easterEggTriggered;
         /// <summary>Weekly intake pass card face (the flipped-over centre logo tile). Sits INSIDE
         /// LogoBrandFrame, so the click would otherwise bubble on into the logo's click-pulse
         /// easter egg; MainWindow's handler marks the event handled to stop that.</summary>

--- a/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/DescentCeremonyWindow.axaml.cs
@@ -42,6 +42,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    SizeChangedEventArgs is the same shape), and reads <c>e.NewSize.Height</c> exactly as
     ///    the original did.
     ///  - <c>Visibility</c> → <c>IsVisible</c> throughout.
+    ///
+    /// <para><b>STILL UNREACHABLE, AND THAT IS THE DESIGN.</b> Checked against both WPF call
+    /// sites, neither of which exists on this head:</para>
+    /// <list type="bullet">
+    ///   <item><c>DescentMigrationService.OfferReceived</c>
+    ///   (ConditioningControlPanel/Services/Descent/DescentMigrationService.cs:392) builds the
+    ///   offer and opens the window. Nothing in CCP.Core names <c>DescentMigrationService</c> or
+    ///   <c>DescentMigrationOffer</c>, so there is no offer on this head to open it with.</item>
+    ///   <item><see cref="ForceCloseAll"/> is called from <c>StopEngineCore</c>
+    ///   (ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs:520) on the panic path, and
+    ///   this head's MainShellWindow.StartStop.cs carries no <c>StopEngine</c> at all — the panic
+    ///   path is not ported. <see cref="ForceCloseAll"/> stays public and ready for it.</item>
+    /// </list>
+    /// <para>Reaching it any other way was considered and REFUSED. This window asks a one-way,
+    /// once-per-account question, and the write that answers it is
+    /// <c>DescentMigrationService.ApplyChoice</c> — head-side. A menu item or debug flag that
+    /// opened it here would take a user through a ceremony that says a permanent choice was made
+    /// and then make none of it. The right unblock is DescentMigrationService reaching Core, with
+    /// the offer arriving from a real sync response, exactly as the paragraph above describes.</para>
     /// </summary>
     public partial class DescentCeremonyWindow : Window
     {

--- a/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/DescentFuseWindow.axaml.cs
@@ -39,6 +39,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///  - <c>DescentRoomSfx</c>, <c>App.DescentMigration</c>, <c>App.DescentCountdown</c> and
     ///    <c>App.ProfileSync</c> are still in the WPF head, so each is a stub below.
     ///  - <c>DescentFuseCopy</c> is likewise still in the WPF head; its two sentences are inlined.
+    ///
+    /// <para><b>STILL UNREACHABLE — blocked on unported callers, not on this window.</b>
+    /// <see cref="Open"/> is complete and takes its owner correctly; what is missing is everything
+    /// that would call it. All four WPF call sites were checked:</para>
+    /// <list type="bullet">
+    ///   <item><c>DescentShowDirector</c>
+    ///   (ConditioningControlPanel/Services/Descent/DescentShowDirector.cs:156/233/406) opens the
+    ///   Live, CatchUp and Ignition shows. CCP.Core/Services/Descent/ carries the SHOW — the
+    ///   timelines and the handoff this file already uses — but not the director and not
+    ///   <c>DescentCountdownService</c>, so nothing on this head knows a countdown reached zero.
+    ///   That is also what MainShellWindow.DescentFuse.cs is waiting on.</item>
+    ///   <item><see cref="ForceCloseAll"/> is the panic path's
+    ///   (MainWindow.StartStop.cs:525), and this head has no <c>StopEngine</c> to call it from.</item>
+    /// </list>
+    /// <para>The gate is the director's, not this window's: it opens the Live show only when the
+    /// countdown phase reaches Zero. Opening the show from anywhere else would put a fullscreen
+    /// topmost surface over the user with no countdown behind it, so no substitute entry point
+    /// was invented.</para>
     /// </summary>
     public partial class DescentFuseWindow : Window
     {

--- a/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs
@@ -22,6 +22,24 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    may reference neither. The formatting it does — duration, media counts, status — is
     ///    ported verbatim, so restoring the <c>HistoryRow(SessionLog)</c> constructor when the model
     ///    reaches Core is a one-liner.
+    ///
+    /// <para><b>DELIBERATELY STILL UNREACHABLE.</b> Its WPF call site is
+    /// <c>MainWindow.Presets.BtnSessionHistory_Click</c>, and the button that raises it —
+    /// <c>BtnSessionHistory</c> — is already in this head's Views/Tabs/PresetsTabView.axaml with no
+    /// Click handler. Wiring those two together is a one-liner and is REFUSED, because
+    /// <see cref="LoadRecentRows"/> below has no data source on this head: WPF reads
+    /// <c>App.SessionLog.LoadRecentLogs()</c> from
+    /// ConditioningControlPanel/Services/Session/SessionLogService.cs, which is not in CCP.Core,
+    /// so the list is three fabricated sessions seeded for the render proof. A "Recent Sessions"
+    /// button that opens invented dates, durations and media counts is a window that LIES about
+    /// the user's own history — worse than a button that does nothing, and not something a
+    /// reviewer or a render can catch, since the fake rows look exactly like real ones.</para>
+    ///
+    /// <para>What unblocks it: <c>SessionLogService</c> and <c>Models.SessionLog</c> reaching Core.
+    /// At that point <see cref="LoadRecentRows"/> becomes a real read, the
+    /// <c>HistoryRow(SessionLog)</c> constructor comes back, and the wiring is
+    /// <c>BtnSessionHistory.Click += … new SessionLogHistoryWindow().ShowDialog(owner)</c> in
+    /// PresetsTabView's constructor, guarded on a VISIBLE owner.</para>
     /// </summary>
     public partial class SessionLogHistoryWindow : Window
     {


### PR DESCRIPTION
The roadmap panel drew authored placeholders and nothing else: RoadmapStartDialog,
RoadmapConfirmDialog and RoadmapDiaryDialog were fully ported windows that nothing in
CCP.Avalonia ever constructed, because the node that opens them was never painted.
QuestsTabView.Roadmap.cs is that painter, ported from MainWindow.Roadmap.cs 78-431 against
the real RoadmapService in Core: the track header, the lock overlay and its reason, the
badge, a node per step with the user's own photo thumbnail and note, and the stats strip.
It lives on the view and not on the shell because a UserControl's x:Name fields are private
to it - the shell cannot reach RoadmapNodesPanel at all.

Clicking a node carries the WPF gates with it: a completed step opens the diary, a step
that is neither completed nor active stops at "Complete the previous steps first" instead
of the start dialog, and StartStep and SubmitPhoto each run only AFTER their dialog has
answered - the file picker is async here, so firing either beside its answer would have
turned the confirmation into decoration. Four TextBlocks lose their {loc:Str} binding
because the painter writes them: a live binding under a local value is undone on the next
language change, which would have put track 1's name over track 3's nodes. WPF wrote
English literals into all four, so no localisation the running app ever had is lost.

The active step's pulse is cancelled before the nodes are rebuilt. WPF needs no equivalent
- its TimeManager holds animation clocks weakly - but Avalonia's animator holds its target,
so an infinite RunAsync on a node cleared out of the panel would tick on a dead subtree
forever, one leak per track click, sub-tab click and photo submit.

EasterEggWindow gets its call site back. The 100-clicks-in-60-seconds counter is pure and
needed nothing, so it runs on SettingsTabView, which owns the logo click on this head. The
reader count stays -1 - the WPF value when ProfileSync is null - so the window hides that
line rather than inventing a number, and the once-ever note clip is skipped together with
its latch so a missing clip cannot burn the moment on silence.

Still blocked:
- SessionLogHistoryWindow - REFUSED, not blocked. Views/Tabs/PresetsTabView.axaml already
  carries BtnSessionHistory and wiring it is a one-liner, but LoadRecentRows has no data
  source on this head (Services/Session/SessionLogService.cs is not in Core) and returns
  three fabricated sessions seeded for the render proof. A "Recent Sessions" button that
  opens invented dates and durations lies about the user's own history. The reason is
  written into CCP.Avalonia/Views/Windows/SessionLogHistoryWindow.axaml.cs.
- DescentCeremonyWindow - unreachable by design. Its only builder is
  DescentMigrationService.OfferReceived (WPF Services/Descent/DescentMigrationService.cs);
  neither it nor DescentMigrationOffer is in Core. Any invented entry point would walk a
  user through a one-way account choice whose write, ApplyChoice, is still head-side.
- DescentFuseWindow - Open is complete; DescentShowDirector and DescentCountdownService are
  not in Core, so nothing on this head knows a countdown reached zero. The IsVisible owner
  guard from the last wave is untouched.
- Both descent windows' ForceCloseAll are called from StopEngineCore, and
  CCP.Avalonia/Views/Windows/MainShellWindow.StartStop.cs carries no StopEngine at all -
  the panic path is not ported.
- ProgramEnrollDialog - BtnProgramEnroll_Click needs ProgramService, and ProgramDefinition,
  ProgramEnrollment and ProgramService are all still in ConditioningControlPanel/Models/
  Program/ and Services/Program/. Nothing in CCP.Core names any of them.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU