### PR TITLE
fix(avalonia): the haptics wizard stops claiming two toys are paired; the One Account CTA opens, and mod audio previews play

### DIFF
--- a/CCP.Avalonia/Views/Windows/FeatureIntroPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/FeatureIntroPopup.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Shapes;
 using Avalonia.Input;
 using Avalonia.Layout;
@@ -50,9 +51,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     ///    seam and is wired at both WPF sites. <c>App.IsUpdateDialogActive</c> and
     ///    <c>MainWindow.IsStartupDialogShowing</c> have no seam in Core and are still missing, each
     ///    marked where it belongs, so a card can still land on top of a startup modal.
-    ///  - <c>popup.ShowDialog()</c> needs an owner on Avalonia, so an ownerless call shows the
-    ///    card modelessly - which also means <c>_opening</c> clears when Show() returns rather
-    ///    than when the card closes.
+    ///  - <c>popup.ShowDialog()</c> needs a VISIBLE owner on Avalonia (not merely a loaded one -
+    ///    a shell minimised to tray is loaded and not visible, and ShowDialog throws on it), so
+    ///    without one the card is shown modelessly - which also means <c>_opening</c> clears when
+    ///    Show() returns rather than when the card closes.
+    ///  - The One Account card's CTA is live: <c>Launcher.LaunchUriAsync</c> stands in for
+    ///    <c>Helpers.BrowserLauncher</c> and <c>MainShellWindow.RetireWebBannerBeat</c> is the
+    ///    ported twin, so acting on the card still retires the banner beat.
     ///  - <c>CardShadow</c> loses its x:Name: an Effect is not in the XAML name scope, so the
     ///    accent recolour reaches it through <c>CardBorder.Effect</c>.
     ///  - <c>Dispatcher.BeginInvoke</c> -&gt; <c>Dispatcher.UIThread.Post</c>;
@@ -244,9 +249,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                         // queue time so a card that never opened cannot spend its sibling's turn.
                         if (doorKey != null) _doorSlotsSpentThisLaunch.Add(doorKey);
 
-                        // Avalonia's ShowDialog needs a real owner; without one the card is shown
-                        // modelessly rather than not at all.
-                        if (owner is { IsLoaded: true }) await popup.ShowDialog(owner);
+                        // Avalonia's ShowDialog needs a VISIBLE owner, not merely a loaded one -
+                        // it throws on a parent that is not visible, and a shell minimised to tray
+                        // is loaded-and-not-visible. That is the exact state a paced card lands in,
+                        // and the throw would be swallowed by the catch below, so the card would
+                        // silently never appear while its "seen" flag had already been spent.
+                        // Without a visible owner it is shown modelessly rather than not at all.
+                        if (owner is { IsVisible: true }) await popup.ShowDialog(owner);
                         else popup.Show();
                     }
                     catch (Exception ex)
@@ -738,15 +747,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
                 Footer = "The new Web door above Settings takes you there any time.",
                 ActionLabel = "Open the web app",
                 DismissLabel = "Later",
-                // WPF opens MainWindow.WebAppUrl through Helpers.BrowserLauncher - not Process.Start,
-                // because the no-default-browser machines are exactly who must not see this fail -
-                // and acting on the card also retires the One Account banner beat.
-                // ponytail: needs Helpers.BrowserLauncher.OpenUrlOrPrompt
-                // (ConditioningControlPanel/Helpers/BrowserLauncher.cs), the MainWindow.WebAppUrl
-                // constant (ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs:640 -
-                // NOT to be copied here) and MainWindow.RetireWebBannerBeat. Kept non-null so the
-                // card still shows its CTA.
-                OnAction = () => { }
+                // WPF opens MainWindow.WebAppUrl through Helpers.BrowserLauncher - not
+                // Process.Start, because the no-default-browser machines are exactly who must not
+                // see this fail - and acting on the card also retires the One Account banner beat.
+                //
+                // Both halves are on this head. Launcher.LaunchUriAsync is what every other opener
+                // here uses (MainShellWindow.Presets.cs, ModManagerDialog, LoginDialog) and is the
+                // BrowserLauncher equivalent; MainShellWindow.RetireWebBannerBeat is internal and
+                // already ported. The URL is the same literal the rest of this head writes inline -
+                // the constant it mirrors is MainWindow.TabNavigation.cs:640 on the WPF side, which
+                // a WebNudgeTests assertion pins there and which this head cannot reference.
+                OnAction = () =>
+                {
+                    var shell = global::Avalonia.Application.Current?.ApplicationLifetime
+                        is IClassicDesktopStyleApplicationLifetime desktop
+                        ? desktop.MainWindow as MainShellWindow
+                        : null;
+
+                    try { _ = shell?.Launcher.LaunchUriAsync(new Uri("https://app.cclabs.app")); }
+                    catch (Exception ex) { Log.Warning(ex, "Feature intro: web app link failed to open"); }
+
+                    shell?.RetireWebBannerBeat();
+                }
             },
 
             [FeatureIntroPopup.CelebrationKey] = new FeatureIntroContent

--- a/CCP.Avalonia/Views/Windows/HapticsSetupWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/HapticsSetupWindow.axaml.cs
@@ -24,8 +24,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// fallbacks, which never fired in the real app.)
     ///
     /// What is still NOT ported: the device half. <c>App.Haptics</c> (HapticService) and
-    /// <c>PatreonService</c> have no seam in Core, so the connect, the premium gate and the test
-    /// buzz are stubs. Each is marked.
+    /// <c>PatreonService</c> have no seam in Core, so there is no transport to open and no premium
+    /// answer to read. Connect and Test Buzz therefore report WPF's own FAILURE outcome rather than
+    /// a placeholder success - see <see cref="BtnConnect_Click"/> for why a fabricated device list
+    /// was removed. Nothing on page 3 claims a device is paired.
     ///
     /// Strings that the WPF code-behind ASSIGNS to a control carrying <c>{loc:Str}</c> are bound
     /// here instead (<see cref="BindLoc"/>): Avalonia keeps the XAML binding alive under a local
@@ -123,23 +125,41 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         // ------------------------------------------------------------------ page 3
 
+        /// <summary>
+        /// WPF's own failure branch, which is the TRUE outcome on a head with no haptic stack:
+        /// nothing connected, no devices, and the per-provider hint that tells the author what to
+        /// check. <see cref="ApplyProviderSettings"/> is deliberately NOT called from here - the
+        /// provider choice is already written when the page advances (BtnNext_Click), which is
+        /// where WPF writes it too on the path that never reaches a service.
+        ///
+        /// <para>ponytail: previously this showed <c>wizard_connect_ok</c> plus two fabricated
+        /// device names to exercise the list template. That was a control lying about state - the
+        /// wizard said "connected, 2 toys found" with no transport open and the premium gate never
+        /// consulted, and <c>_connected = true</c> swapped Connect for Done, so the author left
+        /// believing their toy was paired. Replaced with the failure the head can honestly report.
+        /// The real handler needs ConditioningControlPanel/Services/Haptics/HapticService.cs
+        /// (ConnectAsync / ConnectedDevices), and its gate needs
+        /// ConditioningControlPanel/Services/Account/PatreonService.cs (HasPremiumAccess) OR
+        /// DailyFreeService.IsFreeToday("haptics") - DailyFreeService is in Core, HasPremiumAccess
+        /// has no seam, and half a premium gate is not a gate, so the gate is not attempted here.
+        /// Its strings, when it lands, are "gate_premium_locked" / "msg_haptic_feedback_patreon_only".
+        /// The "connected but zero toys yet" branch (wizard_connect_no_toys) is a live-transport
+        /// state and cannot be reached without one.</para>
+        /// </summary>
         private void BtnConnect_Click()
         {
-            // ponytail: needs ConditioningControlPanel/Services/Haptics/HapticService.cs
-            // (ConnectAsync/ConnectedDevices) and ConditioningControlPanel/Services/Account/
-            // PatreonService.cs (HasPremiumAccess) for the premium gate - neither has a seam among
-            // the ten in Core, and DailyFreeService alone cannot answer the gate. Until then the
-            // page shows a placeholder result so the device-list template is actually exercised.
-            // The real handler also has a failure path: ShowResult(false, "wizard_connect_failed",
-            // <"wizard_fail_hint_lovense" | "wizard_fail_hint_intiface" | "wizard_fail_hint_generic">,
-            // empty), and a premium gate on "gate_premium_locked" /
-            // "msg_haptic_feedback_patreon_only" — WPF's FailureHint(), not carried as dead code.
-            ApplyProviderSettings();
-            _connected = true;
-            ShowResult(true, "wizard_connect_ok", "wizard_connect_ok_hint",
-                       new[] { "Sample Toy (placeholder)", "Sample Toy 2 (placeholder)" });
+            _connected = false;
+            ShowResult(false, "wizard_connect_failed", FailureHint(), Array.Empty<string>());
             UpdateChrome();
         }
+
+        /// <summary>Per-provider "what to check", ported verbatim from WPF's FailureHint().</summary>
+        private string FailureHint() => _provider switch
+        {
+            WizardProvider.Lovense => "wizard_fail_hint_lovense",
+            WizardProvider.Buttplug => "wizard_fail_hint_intiface",
+            _ => "wizard_fail_hint_generic"
+        };
 
         /// <summary>
         /// Keys rather than strings, unlike the WPF original: the two TextBlocks it writes carry

--- a/CCP.Avalonia/Views/Windows/ItemUnlockedPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ItemUnlockedPopup.axaml.cs
@@ -140,8 +140,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// Paints the item art, or a gift glyph when the PNG never landed. "No art" is a normal
         /// path, not an error - what must never happen is a broken-image box in the toast.
         ///
-        /// ponytail: needs Services.WardrobeCatalog.GetImage(item.Id), which resolves pack:// art in
-        /// the WPF head. Until it moves to Core every toast takes the gift-glyph branch.
+        /// ponytail: the note that stood here said WardrobeCatalog resolves pack:// art. It does
+        /// not - ConditioningControlPanel/Services/Profile/WardrobeCatalog.cs reads
+        /// Resources/cosmetics/&lt;mod&gt;/&lt;id&gt;.png OFF DISK from AppContext.BaseDirectory, on
+        /// purpose, so art that never shipped degrades instead of throwing a resource URI. Two real
+        /// blockers follow from that. The registry half (registry.json parsing, Find, the unlock
+        /// gates) is portable and belongs in Core; the same file's GetImage is WPF - BitmapImage,
+        /// DecodePixelWidth, Freeze - so the type has to be SPLIT, not moved. And the art itself is
+        /// linked only by ConditioningControlPanel.csproj (Assets/cosmetics -&gt; Resources/cosmetics
+        /// as Content); CCP.Avalonia.csproj links no cosmetics at all, so even a ported GetImage
+        /// would find nothing on this head. Until both, every toast takes the gift-glyph branch,
+        /// which is the WPF null path rather than a broken-image box.
         /// </summary>
         private void LoadItemArt()
         {

--- a/CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs
@@ -65,10 +65,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// are Core's (ModManifest / ModPackage) and the active mod comes from the CoreMods seam, which
     /// answers "the built-in default" on a head with no mod layer, so the ctor touches no disk.
     ///
+    /// Audio PREVIEW plays for real through <see cref="CoreAudio"/> - see
+    /// <see cref="ToggleAudioPreview"/>, which keeps only the half the seam can honestly do.
+    ///
     /// Stubbed, all with a ponytail marker at the call site: everything reaching App.*, a service,
-    /// NAudio, or one of the nine per-panel partial classes
+    /// or one of the ten per-panel partial classes
     /// (ModCreatorWindow.Pools.cs, .Personalities.cs, .Advanced.cs, .Barks.cs, .Mantras.cs,
-    /// .EventAudio.cs, .Portraits.cs, .Emotes.cs, .UiArt.cs / .ArtFraming.cs), which are their own
+    /// .EventAudio.cs, .Portraits.cs, .Emotes.cs, .UiArt.cs, .ArtFraming.cs), which are their own
     /// port layers. Their sidebar entries stay - they are part of this view's chrome - and each
     /// draws a "ported in a later layer" panel rather than a dead click.
     /// </summary>
@@ -1298,16 +1301,34 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             _voiceLinesPanel?.Children.Add(row);
         }
 
+        /// <summary>
+        /// Preview an author-picked clip. WPF resolves the same two shapes - a fixed slot key, or a
+        /// voice line's direct path - and plays the file raw, at its own level, NOT scaled by the
+        /// master volume: this is the author checking what they just picked, not the app talking.
+        ///
+        /// <para>ponytail: this is PLAY only, and the method name is now a half-truth. WPF's other
+        /// half is a stop - the button becomes ⏹, a second click stops it, and StopAudioPreview
+        /// kills it on Reset All and on close. <see cref="CoreAudio"/> carries PlayOneShot / Duck /
+        /// Unduck and NOTHING that stops or cancels a one-shot, so a ⏹ glyph here would be a
+        /// button that cannot do what it shows. Dropped rather than mimed; the cost is that two fast
+        /// clicks overlap two previews and a preview outlives this window. Wiring it needs a
+        /// cancel on CCP.Core/CoreAudio.cs, which this layer does not own.</para>
+        /// </summary>
         private void ToggleAudioPreview(string keyOrPath, Button playBtn)
         {
-            // ponytail: needs an audio player, wired when playback moves behind a Core interface.
-            // The WPF version drives NAudio's WaveOutEvent/AudioFileReader directly, flips the
-            // button glyph to ⏹ while playing and restores it from PlaybackStopped.
+            var filePath = _audioSlots.TryGetValue(keyOrPath, out var slotPath) ? slotPath : keyOrPath;
+            if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath)) return;
+
+            CoreAudio.PlayOneShot(filePath, 1f, "modcreator-preview");
         }
 
+        /// <summary>
+        /// ponytail: nothing to stop - see <see cref="ToggleAudioPreview"/>. Kept as the call site
+        /// WPF has (OnClosed, Reset All) so the stop lands in one place the day
+        /// CCP.Core/CoreAudio.cs grows a cancel.
+        /// </summary>
         private void StopAudioPreview()
         {
-            // ponytail: needs an audio player - see ToggleAudioPreview.
         }
 
         private void LoadAudioFromResources(string resourcesDir)
@@ -1828,9 +1849,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             clearBtn.Click += (_, _) => ClearImageSlot(resourceKey);
             borderHolder.Children.Add(clearBtn);
 
-            // ponytail: needs ModCreatorWindow.ArtFraming.cs for the "Frame" affordance, which the
-            // WPF head adds here for slots whose path paints a framed surface. SlotIsFramable
-            // returns false until that layer lands, so nothing is added.
+            // ponytail: the DECISION is already portable - WPF's SlotIsFramable is one line,
+            // ModArtFramingRegistry.FramableBindingsFor(resourceKey).Any(), and that registry is in
+            // Core (CCP.Core/Services/ModArtFraming.cs). What is missing is where the affordance
+            // LEADS: ConditioningControlPanel/Windows/ModCreatorWindow.ArtFraming.cs is a
+            // drag-a-preview cropping editor, ~400 lines of WPF, a redraw and not a move. A "Frame"
+            // button with nothing behind it is worse than no button, so nothing is added here until
+            // that panel is ported.
 
             var border = new Border
             {
@@ -1974,14 +1999,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         }
 
         /// <summary>
-        /// ponytail: needs ModImageSlotRules (ModCreatorWindow.UiArt.cs) plus a message box, wired
-        /// when that layer lands. The WPF gate hard-rejects a file whose format does not match the
-        /// slot's filename, then asks before accepting anything oversized.
+        /// ponytail: NOT blocked on a message box - this head ships Views/Dialogs/MessageDialog.
+        /// Two other things block it. First, the rules: ModImageSlotRules is pure C# (Path,
+        /// FileInfo, invariant formatting) but is declared inside
+        /// ConditioningControlPanel/Windows/ModCreatorWindow.UiArt.cs, a WPF partial, so reaching it
+        /// means moving that type to Core - not copying it here, which is the duplication this split
+        /// exists to prevent. Second, half of the WPF gate is a CONFIRM ("this is 6.2 MB, use it
+        /// anyway?") and MessageDialog is async, so this synchronous bool cannot carry it; the
+        /// caller chain from the Browse handler down through SetImageSlot has to become async first.
+        /// The hard-reject half alone would be honest, but it still needs the rules type.
         /// </summary>
         private bool PassesImageSlotChecks(string key, string filePath) => true;
 
-        /// <summary>ponytail: needs ModCreatorWindow.ArtFraming.cs - drops the crop stored for a
-        /// slot whose image just changed or was cleared.</summary>
+        /// <summary>
+        /// WPF drops the crop stored for a slot whose image just changed or was cleared - left
+        /// behind, it silently re-attaches to whatever the author picks next, and to a manifest that
+        /// no longer ships the file it was measured against.
+        ///
+        /// <para>ponytail: correctly empty TODAY rather than blocked. The framing dictionary lives in
+        /// ConditioningControlPanel/Windows/ModCreatorWindow.ArtFraming.cs and there is no port of it
+        /// here, so nothing in this window holds a crop to drop - ApplyPanelSectionsToManifest never
+        /// writes ModManifest.ArtFraming either. The body arrives with that panel; the call sites
+        /// (SetImageSlot, ClearImageSlot) are already in the WPF places.</para>
+        /// </summary>
         private void DropArtFraming(string key) { }
 
         private void ClearImageSlot(string key)

--- a/CCP.Avalonia/Views/Windows/QuizWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/QuizWindow.axaml.cs
@@ -154,10 +154,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             IsOpen = true;
 
-            // ponytail: needs AvatarWindow.IsMuted / SetMuteAvatar from
-            // ConditioningControlPanel/Windows/AvatarWindow.xaml.cs - WPF muted the avatar for the
+            // ponytail: needs App.AvatarWindow.IsMuted / SetMuteAvatar - there is NO
+            // ConditioningControlPanel/Windows/AvatarWindow.xaml.cs, which is what this note used
+            // to claim. The type is AvatarTubeWindow and the two members are at
+            // ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs:1523/1528, where
+            // the mute is CoreWebView2.IsMuted on the hosted browser. This head's
+            // CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs exposes a read-only IsMuted
+            // over CoreSettings.AvatarMuted and no setter at all (same gap MainShellWindow.
+            // Companion.cs:121 records), so there is nothing to call. WPF muted the avatar for the
             // whole run so her z-order work could not cover the quiz, and restored the previous
-            // state on close. This head's avatar is AvatarTubeWindow, which carries no mute yet.
+            // state on close.
 
             AvaloniaXamlLoader.Load(this);
             // ponytail: the playDrone track (Resources/sounds/"00 Bimbo Drone.mp3") is a LOOP over a

--- a/CCP.Avalonia/Views/Windows/SessionEditorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/SessionEditorWindow.axaml.cs
@@ -1029,17 +1029,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnImport_Click()
         {
-            // ponytail: needs SessionFileService + a StorageProvider file picker, wired when the
-            // service moves to Core. WPF filtered on *.session.json, validated the file, mapped it
-            // through TimelineSession.FromSession and reported with msg_invalid_session_file /
-            // msg_failed_to_import_session / msg_imported_session.
+            // ponytail: the picker is NOT the blocker - StorageProvider.OpenFilePickerAsync is on
+            // this head (ModCreatorWindow uses it). The blocker is the file FORMAT. A .session.json
+            // is Session/SessionSettings shaped, written by
+            // ConditioningControlPanel/Services/Session/SessionFileService.cs and mapped in through
+            // ConditioningControlPanel/Models/TimelineSession.cs; both are head-side, and the
+            // _session field below is EditorSession, a local stand-in whose JSON is a DIFFERENT
+            // shape. Reading a real .session.json into it would silently drop every per-feature
+            // setting the editor does not model, and the author would then save that loss back.
+            // Blocked until TimelineSession + SessionFileService reach Core, not until a picker does.
+            // WPF reported with msg_invalid_session_file / msg_failed_to_import_session /
+            // msg_imported_session.
             Log.Information("session editor: import is not wired on this head yet");
         }
 
         private void BtnExport_Click()
         {
-            // ponytail: needs SessionFileService.ExportSession + GetExportFileName and a save
-            // picker, wired when the service moves to Core (msg_session_exported_to on success).
+            // ponytail: same format blocker as BtnImport_Click, and worse in this direction -
+            // serialising EditorSession would put a file named *.session.json on disk that the
+            // Windows head cannot read back, so the author would ship a broken export believing it
+            // worked. Needs SessionFileService.ExportSession + GetExportFileName
+            // (ConditioningControlPanel/Services/Session/SessionFileService.cs) in Core; the save
+            // picker itself is already available here. (msg_session_exported_to on success.)
             _session.Name = TxtSessionName.Text ?? string.Empty;
             _session.Description = TxtDescription.Text ?? string.Empty;
             Log.Information("session editor: export is not wired on this head yet");

--- a/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/TeaseRevealPopup.axaml.cs
@@ -95,7 +95,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             try
             {
                 var popup = new TeaseRevealPopup(teaseTier);
-                if (owner is { IsLoaded: true }) popup.ShowDialog(owner);
+                // IsVisible, not IsLoaded: Avalonia's ShowDialog throws on an owner that is not
+                // visible, and a shell minimised to tray is loaded-and-not-visible. With IsLoaded
+                // the throw lands in the catch below and the teaser silently never opens; with
+                // IsVisible it falls through to the modeless Show(), which is the intended
+                // worst case.
+                if (owner is { IsVisible: true }) popup.ShowDialog(owner);
                 else popup.Show();
             }
             catch (Exception ex)


### PR DESCRIPTION
Correction to the brief first: wire/87's "not reached" handover was derived
from its own 16-file stat and so re-listed everything wire/84 (0f46bc8d) had
already done. The union of the two sweeps covers all but seven files in this
directory. The genuinely untouched ones are AnnouncementPopup, MyReportsWindow,
WebcamLoadingSplash, HelpVideoWindow, BubbleCountResultWindow, and the code-
behind halves of HapticsSetupWindow and ModCreatorWindow - which is where this
layer worked. The first five were read end to end against their WPF originals
and are complete and precise; nothing to do there, and the next pass can skip
them.

The haptics wizard was lying, and that is the one real bug here. BtnConnect_Click
showed wizard_connect_ok with two fabricated device names ("Sample Toy
(placeholder)"), set _connected = true and swapped Connect for Done - so on a
head with no transport open and no premium gate consulted, an author left page 3
believing their toy was paired. The stated reason was to exercise the device-list
template. Replaced with WPF's own failure branch, which is the TRUE outcome here:
ShowResult(false, "wizard_connect_failed", FailureHint(), empty), with WPF's
per-provider FailureHint ported verbatim. ApplyProviderSettings is deliberately
NOT called from the new body - the provider choice is already written when the
page advances, which is where WPF writes it on the path that never reaches a
service. WPF's own first line is `if (_connecting || App.Haptics == null) return`,
so silence would also have been faithful; the failure card is the same truth with
feedback. The gate itself is still not attempted: HasPremiumAccess
(ConditioningControlPanel/Services/Account/PatreonService.cs) has no seam and
DailyFreeService alone answers only half of WPF's `Patreon.HasPremiumAccess ||
DailyFree.IsFreeToday("haptics")` - half a premium gate is not a gate.

Two ShowDialog owner guards tested the wrong property. FeatureIntroPopup and
TeaseRevealPopup both had `owner is { IsLoaded: true }`, and Avalonia's
ShowDialog throws on an owner that is not VISIBLE. A shell minimised to tray is
loaded-and-not-visible, which is exactly the state a paced intro card lands in;
the throw was swallowed by each opener's catch, so the card silently never
appeared - and in FeatureIntroPopup's case its SeenFeatureIntros flag had
already been spent, making the miss permanent. Both now guard on IsVisible and
fall through to the modeless Show(), which is what the ownerless branch was
always for. Same finding wire/87 made on DescentFuseWindow; these are the last
two IsLoaded guards in this directory.

The One Account card's CTA does its whole WPF job. Its note said the WebAppUrl
constant was "NOT to be copied here" and that BrowserLauncher and
RetireWebBannerBeat were missing; two of the three are wrong.
Launcher.LaunchUriAsync is this head's BrowserLauncher and is already how
MainShellWindow.Presets.cs, ModManagerDialog, LoginDialog and six other files
open a link, all of them with the same app.cclabs.app literal inline;
MainShellWindow.RetireWebBannerBeat is internal and already ported. So acting on
the card now opens the web app AND retires the One Account banner beat, which is
the point of the beat - it must stop nagging someone who has been. The WPF
constant stays where WebNudgeTests pins it.

Mod audio previews play, and only the half CoreAudio can honestly do.
ToggleAudioPreview's note asked for "an audio player, wired when playback moves
behind a Core interface" - that happened; CoreAudio.PlayOneShot is the seam, and
the WPF body's file resolution (a fixed slot key, or a voice line's direct path)
and its raw un-master-scaled level port straight across. What does NOT port is
the stop: CoreAudio carries PlayOneShot / Duck / Unduck and nothing that cancels
a one-shot, so WPF's stop glyph would be a button that cannot do what it shows.
Dropped rather than mimed, with the cost written down (two fast clicks overlap;
a preview outlives the window) and StopAudioPreview kept as the call site the
cancel lands in. Nothing plays today - this head seeds no PlayOneShotProvider -
which is the same reason wire/87 could safely restore LockCardWindow's XP call.

Notes rewritten to name the blocker that is true today. ModCreatorWindow's
PassesImageSlotChecks blamed "a message box"; this head ships
Views/Dialogs/MessageDialog, and the real blockers are that ModImageSlotRules is
pure C# trapped inside a WPF partial (ConditioningControlPanel/Windows/
ModCreatorWindow.UiArt.cs) so reaching it is a Core move not a copy, and that
half the WPF gate is a CONFIRM while MessageDialog is async - the caller chain
has to become async before a synchronous bool gate can be honest. The "Frame"
affordance blamed ModCreatorWindow.ArtFraming.cs for the DECISION, which is
actually one line over ModArtFramingRegistry.FramableBindingsFor and has been in
Core since CCP.Core/Services/ModArtFraming.cs landed; what is missing is where
the button LEADS, a drag-a-preview cropping editor that is a redraw.
DropArtFraming is correctly empty rather than blocked - no framing state exists
in this window to drop. ItemUnlockedPopup claimed WardrobeCatalog "resolves
pack:// art"; it reads Resources/cosmetics off disk from AppContext.BaseDirectory
on purpose, so the blockers are that the type must be SPLIT (registry parsing is
portable, GetImage is BitmapImage) and that CCP.Avalonia.csproj links no
cosmetics at all. SessionEditorWindow's import/export blamed a missing
StorageProvider picker - the picker is here; the blocker is that _session is
EditorSession, a local stand-in, so an import would silently drop every
per-feature setting it does not model and an export would write a
*.session.json the Windows head cannot read. QuizWindow named
ConditioningControlPanel/Windows/AvatarWindow.xaml.cs, which does not exist; the
members are AvatarTubeWindow.ChatInput.cs:1523/1528.

The x:Name hazard was swept mechanically over every file in this directory:
each .axaml's x:Name set cross-referenced against bare field access in its
code-behind. Two candidates, both false positives and neither in this layer's
scope (DescentCeremonyWindow's names collide with its Copy constants;
EmiBookWindow's "Nudges"). No file in scope reaches a generated field, and
nothing added here does.

Verified: core-guards pass, CCP.Core and CCP.Avalonia build with 0 errors,
--smoke passes, --render-all stays 189/189, and HapticsSetupWindow,
ModCreatorWindow and FeatureIntroPopup were rendered and read - the wizard's
provider page draws its three cards, the Mod Creator draws its rail and status
bar (Images 0/89, Audio 0/14), and the One Account card draws its glyph rail and
both buttons. What the renders do NOT prove: the haptics page 3 at all, since
--render-view constructs the window on page 1 and BtnConnect_Click is never
reached; that the CTA opens a browser or retires the beat, since OnAction fires
only on a click and MainWindow is null under --render-view; that a preview
sounds, since nothing seeds CoreAudio.PlayOneShotProvider on this head; and the
two IsVisible guards, which live in static openers that --render-view bypasses.

Still blocked, exact symbols and head paths:
  HapticService.ConnectAsync / ConnectedDevices / TestAsync
                                       ConditioningControlPanel/Services/Haptics/
  PatreonService.HasPremiumAccess      ConditioningControlPanel/Services/Account/
  a cancel/stop for a one-shot         CCP.Core/CoreAudio.cs
  ModImageSlotRules                    .../Windows/ModCreatorWindow.UiArt.cs (pure C#, needs a Core move)
  the art-framing crop editor          .../Windows/ModCreatorWindow.ArtFraming.cs (WPF redraw)
  the nine other ModCreatorWindow panel partials
                                       ConditioningControlPanel/Windows/ModCreatorWindow.*.cs
  Achievement.All                      ConditioningControlPanel/Models/Achievement.cs
  a step-activation callback           CCP.Core/CoreTutorial.cs (Step has no RequiresTab)
  WardrobeCatalog (split: registry -> Core, GetImage stays)
                                       ConditioningControlPanel/Services/Profile/
  Assets/cosmetics                     not linked in CCP.Avalonia.csproj
  TimelineSession, SessionFileService  .../Models/, .../Services/Session/
  App.IsUpdateDialogActive, MainWindow.IsStartupDialogShowing
                                       ConditioningControlPanel/App.xaml.cs, MainWindow/
  AvatarTubeWindow mute setter         CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
  QuizService (all of it)              ConditioningControlPanel/Services/Quiz/

Handover for the next pass at Views/Windows/. Everything in this directory
outside EmiDesk/ and MainShellWindow.* has now been read at least once across
wire/84, wire/87 and this layer. Complete and precise, skip them:
AnnouncementPopup, MyReportsWindow, WebcamLoadingSplash, HelpVideoWindow,
BubbleCountResultWindow, LayeredAudioWindow, QuizCategoryEditorWindow,
AchievementPopup, PinkRushPopup, CornerGifWindow, SessionCompleteWindow,
QuestCompletePopup, MediaHistoryWindow, QuizReportWindow, WebcamGazeTrackerWindow,
WebcamQuickRecalWindow. QuizWindow (16 notes) and BubbleCountWindow (16) remain
the two biggest counts and remain the wrong place to work: every note in both was
read this pass and every one resolves to QuizService, LibVLC/VideoService, a
CoreWebView2 message pump or an X11 focus-policy capability, and they are the
best-written notes in the directory already. The next real work here is not notes
at all - it is ModCreatorWindow's ten unported panel partials (~4,000 WPF lines),
which is a port project rather than a sweep, and EmiDesk/ (24 + 15 + 9 + 3
notes), which this layer did not own.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU