### PR TITLE
feat(avalonia): three dead dialog buttons do their job, and five notes stop naming a type that does not exist

### DIFF
--- a/CCP.Avalonia/Views/Dialogs/CompanionPromptEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CompanionPromptEditorDialog.axaml.cs
@@ -21,7 +21,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///  - <c>NullOrEmptyToCollapsedConverter</c> is gone: the XAML uses Avalonia's built-in
     ///    <c>StringConverters.IsNotNullOrEmpty</c> on <c>IsVisible</c>.
     ///  - Settings load and save for real against <see cref="CoreSettings"/>, knowledge links
-    ///    included; the community-prompt lookup and the moderation log are still stubs.
+    ///    included, and every flagged field is recorded through <see cref="CoreModerationLog"/>.
+    ///    The community-prompt lookup is the one stub left (see <c>UpdateActivePromptBadge</c>).
     ///  - <c>PromptValidator</c> lives in Core and runs for real on Save.
     ///  - <c>MessageBox.Show</c> becomes this head's <see cref="MessageDialog"/>, which is awaited,
     ///    so Remove / Reset All / Cancel are async void. Its two-button shape covers the Yes/No

--- a/CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml.cs
@@ -25,8 +25,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    indistinguishable from one that failed.
     ///  - <c>Unloaded</c> -> <c>Closed</c> for stopping the timer. --render-all runs every view in
     ///    one process; a 1s timer still ticking against a closed window is pure noise.
-    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>; Serilog is dropped, the head has no
-    ///    reference to it and the stub has nothing to log.
+    ///  - <c>DragMove()</c> -> <c>BeginMoveDrag(e)</c>. No logging: the stub has nothing to log
+    ///    (Serilog IS referenced by this head — the earlier note saying otherwise was wrong).
+    ///
+    /// <para><b>Nothing opens this window, on purpose.</b> The Settings tab's "Link phone" button
+    /// is refused at <c>CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs</c> precisely because the
+    /// dialog would open and display <c>ABCDEF</c> as if it were a live one-time auth code. Do not
+    /// add a call site before <c>V2AuthService.AuthorizeMobileLinkAsync</c> is reachable — a
+    /// render-only placeholder is safe, a shown one is not.</para>
     /// </summary>
     public partial class LinkPhoneDialog : Window
     {

--- a/CCP.Avalonia/Views/Dialogs/ModManagerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ModManagerDialog.axaml.cs
@@ -28,10 +28,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    which is exactly what <c>App.Mods</c> answered before its service came up.
     ///  - <c>ModPackCatalog</c> is a WPF-head type, so the mod-id → pack-id mapping comes from
     ///    <see cref="ModPacks"/>, its twin on this head.
-    ///  - Installing, uninstalling, activating for real, exporting and sharing all need
-    ///    <c>ModManagerService</c> / the catalogue client, which stay in the WPF head; each is a
-    ///    stub with a <c>ponytail:</c> marker. Activation still flips in memory, so the star, the
-    ///    active indicator and the button rules behave.
+    ///  - Installing, uninstalling, activating for real, exporting and sharing all need the WRITE
+    ///    half of <c>ConditioningControlPanel/Services/ModService.cs</c> (WPF reaches it as
+    ///    <c>App.Mods</c>) or the catalogue client. There is no "ModManagerService" - earlier notes
+    ///    here named a type that exists nowhere in the repo. <see cref="CoreMods"/> is the seam,
+    ///    and it carries read-side providers only, so each write is a stub with a
+    ///    <c>ponytail:</c> marker naming the ModService member it wants. Activation still flips in
+    ///    memory, so the star, the active indicator and the button rules behave.
     ///  - The release-content event plumbing (<c>SubscribeToPackEvents</c>,
     ///    <c>OnPackProgressChanged</c>, <c>OnPackInstalled</c>, <c>OnModAvailabilityChanged</c>,
     ///    <c>RefreshListKeepingSelection</c>, <c>MarshalToUi</c>) is dropped rather than stubbed:
@@ -464,9 +467,12 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         {
             if (_selectedMod == null) return;
 
-            // ponytail: needs ModManagerService.ActivateMod + SettingsService persistence, wired
-            // when they move to Core. The in-memory switch below is what the rest of the dialog
-            // reads, so the star, the indicator and the button rules all still behave.
+            // ponytail: needs ModService.ActivateMod (ConditioningControlPanel/Services/
+            // ModService.cs) - CoreMods is read-only, it has no write-side provider for this.
+            // CoreSettings.Current.ActiveModId + Save IS reachable here and is deliberately NOT
+            // written: persisting an id no service on this head can load would hand the WPF head a
+            // mod switch this one only mimed. The in-memory switch below is what the rest of the
+            // dialog reads, so the star, the indicator and the button rules all still behave.
             _activeModId = _selectedMod.Id;
 
             ModWasChanged = true;
@@ -488,7 +494,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 
             if (!confirmed) return;
 
-            // ponytail: needs ModManagerService.UninstallMod (it deletes the folder and drops the
+            // ponytail: needs ModService.UninstallMod (it deletes the folder and drops the
             // mod from InstalledMods) plus the CoreSettings.ActiveModId write WPF does when the
             // uninstalled mod was the active one. The listing is the service's dictionary now, so
             // there is nothing local to remove and the row correctly stays until it really goes.
@@ -517,7 +523,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _btnInstall.IsEnabled = false;
             try
             {
-                // ponytail: needs ModManagerService.InstallModAsync, wired when it moves to Core.
+                // ponytail: needs ModService.InstallModAsync (ConditioningControlPanel/Services/
+                // ModService.cs); CoreMods carries no write-side provider for it.
                 // WPF then refreshed the list and reported msg_mod_installed_successfully /
                 // msg_failed_to_install_mod. Deliberately silent rather than showing either of
                 // those: a real-looking result for work that did not happen is worse than none.
@@ -551,8 +558,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _btnExport.IsEnabled = false;
             try
             {
-                // ponytail: needs ModManagerService.ExportCurrentAsModAsync, wired when it moves to
-                // Core. Silent for the same reason as the install path above; WPF reported
+                // ponytail: needs ModService.ExportCurrentAsModAsync (ConditioningControlPanel/
+                // Services/ModService.cs), same missing write half as install.
+                // Silent for the same reason as the install path above; WPF reported
                 // msg_mod_exported_to / msg_export_failed here.
                 await Task.CompletedTask;
             }
@@ -570,9 +578,28 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             dialog.ShowDialog(this);
         }
 
-        private void BtnCreate_Click()
+        /// <summary>
+        /// WPF's <c>new ModCreatorWindow { Owner = this }.ShowDialog()</c>. The window IS on this
+        /// head (<c>Views/Windows/ModCreatorWindow.axaml</c>) and this is its first call site here.
+        /// Avalonia's ShowDialog is async and throws on an owner that is not on screen, so the
+        /// visibility guard is the twin of WPF's implicit "Owner is showing".
+        ///
+        /// <para>That window still carries its own stubs (several panel partials, audio preview,
+        /// art framing) and says so in its own notes. Opening it is still the right call: every
+        /// section it cannot edit is visibly absent rather than misreported, and its save path
+        /// writes a real mod.json.</para>
+        /// </summary>
+        private async void BtnCreate_Click()
         {
-            // ponytail: ModCreatorWindow is not ported to this head yet; WPF opened it modally here.
+            try
+            {
+                if (!IsVisible) return;
+                await new ModCreatorWindow().ShowDialog(this);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "[ModManager] Mod creator failed to open");
+            }
         }
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/ProfileCustomizeDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ProfileCustomizeDialog.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -19,9 +20,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///
     /// PORTED from ConditioningControlPanel/Dialogs/ProfileCustomizeDialog.xaml.cs. The tile
     /// builders, selection rules, pin cap and reset are the original's; <see cref="ProfileCosmetics"/>
-    /// is already in Core. What is not: Achievement, CosmeticsCatalog, WardrobeCatalog and the
-    /// WardrobeEditorDialog all live in the WPF head (the mod-art resolver does NOT block anything
-    /// here any more - see <c>BuildPinTile</c> for the two things that do), so
+    /// is already in Core. What is not: Achievement, CosmeticsCatalog and WardrobeCatalog live in
+    /// the WPF head (the mod-art resolver does NOT block anything here any more - see
+    /// <c>BuildPinTile</c> for the two things that do), so
     ///  - unlocked achievements arrive as (id, name) pairs instead of being resolved from Achievement.All,
     ///  - banners are the catalog's three generated gradients (no art file needed), avatar presets
     ///    are none (art needed), pins draw a trophy glyph where the achievement PNG would be,
@@ -492,9 +493,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             _txtWardrobeSlots.Foreground = Muted;
         }
 
-        private void BtnArrange_Click()
+        /// <summary>
+        /// Opens the Wardrobe editor on the SAME draft instance, exactly as WPF does — it edits the
+        /// transform fields in place and snapshots them on open, so its own Cancel is the undo and
+        /// this method has nothing to write back.
+        ///
+        /// WPF also handed it the hero card's measured avatar and pixel size; this head has neither
+        /// on the dialog, so the editor takes its documented fallbacks (no avatar art, a typical
+        /// windowed hero for the stage). ponytail: pass the live values through if
+        /// ProfileCustomizeDialog ever measures the card. The sprites are still placeholder Borders
+        /// there until <c>Services/Profile/WardrobeCatalog</c> crosses — the arrangement is real,
+        /// the picture is not.
+        /// </summary>
+        private async void BtnArrange_Click()
         {
-            // ponytail: needs WardrobeEditorDialog (WPF head, bucket E drag/rotate canvas), ported separately
+            try
+            {
+                if (!IsVisible) return;   // ShowDialog throws on an owner that is not on screen
+                await new WardrobeEditorDialog(_draft, null).ShowDialog(this);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("ProfileCustomizeDialog: wardrobe editor failed: {E}", ex.Message);
+            }
         }
 
         // ============================== footer ==============================

--- a/CCP.Avalonia/Views/Dialogs/ProfilePrivacyDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/ProfilePrivacyDialog.axaml.cs
@@ -2,6 +2,8 @@ using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using ConditioningControlPanel.Avalonia.Views.Controls;
+using ConditioningControlPanel.Services;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Dialogs
 {
@@ -34,9 +36,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
             this.FindControl<Button>("BtnClose")!.Click += (_, _) => Close();
         }
 
-        private void BtnJoinDiscord_Click()
+        /// <summary>
+        /// WPF hopped through <c>MainWindow.BtnDiscord_Click</c>, whose entire body is
+        /// <c>Process.Start(DiscordLinks.Invite)</c> plus a log line — so the hop was never the
+        /// blocker and nothing here is waiting on Core. <see cref="DiscordLinks"/> is in Core
+        /// already; <c>TopLevel.Launcher</c> is this head's shell-execute.
+        /// </summary>
+        private async void BtnJoinDiscord_Click()
         {
-            // ponytail: needs MainWindow.BtnDiscord_Click (opens the invite URL), wired when it moves to Core
+            try
+            {
+                if (await Launcher.LaunchUriAsync(new Uri(DiscordLinks.Invite)))
+                    Log.Information("Opened Discord invite link");
+                else
+                    Log.Warning("Nothing on this system handled the Discord invite URI");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to open Discord link");
+            }
         }
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs
@@ -45,8 +45,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    <c>AvatarTubeWindow.RefreshTubeLayout()</c> is on this head now, and
     ///    <c>AvatarTubeWindow.Live</c> is the App.AvatarWindow twin that finds the open one, so the
     ///    edit lands on screen while the dialog is still up instead of waiting for the tube's next
-    ///    construction. Null when no tube is open, which is a no-op rather than a failure. The tube
-    ///    frame itself stays the placeholder capsule - that is markup this layer does not own.
+    ///    construction. Null when no tube is open, which is a no-op rather than a failure.
+    ///  - <b>The tube frame is real too.</b> <c>PreviewTubeImage</c> draws tube.png / tube2.png
+    ///    through the same seam; the placeholder capsule Border behind it shows only on a head
+    ///    with no PNGs.
     ///  - WPF's <c>LayoutTransform</c> has no Avalonia twin on a plain control, so the avatar scale
     ///    is a <c>RenderTransform</c> about the centre. It does not grow the parent Border, so a
     ///    scaled avatar expands symmetrically rather than upward.


### PR DESCRIPTION
Join Discord, Arrange and Create New were empty bodies behind notes that were
each wrong about what blocked them.

ProfilePrivacyDialog's Join Discord opens the invite. The note asked for
"MainWindow.BtnDiscord_Click, wired when it moves to Core" - but that method's
entire body is Process.Start(DiscordLinks.Invite) plus a log line, DiscordLinks
has been in Core all along, and TopLevel.Launcher is this head's shell-execute.
The hop through MainWindow was never the blocker. A launcher that reports no
handler logs a warning rather than pretending it opened something.

ProfileCustomizeDialog's Arrange opens the Wardrobe editor. The note called
WardrobeEditorDialog a WPF-head bucket-E canvas "ported separately"; it is in
the same directory, ported, and its drag/scale/rotate/flip maths is real. It
edits the same draft instance in place and snapshots on open, so its own Cancel
is the undo. Its sprites are still placeholder Borders until WardrobeCatalog
crosses - the arrangement is real, the picture is not - and the class doc now
says that rather than claiming the dialog is absent. WPF also passed the hero
card's measured avatar and pixel size, which this head does not carry on the
dialog, so the editor takes its documented fallbacks.

ModManagerDialog's Create New opens ModCreatorWindow. "Not ported to this head
yet" was false: Views/Windows/ModCreatorWindow.axaml has been here for layers
and this is its first call site. It still carries its own stubs (panel
partials, audio preview, art framing) and the note says so - every section it
cannot edit is visibly absent rather than misreported, and its save path writes
a real mod.json.

Five notes in ModManagerDialog asked for "ModManagerService", which exists
nowhere in either root. The real type is ConditioningControlPanel/Services/
ModService.cs, reached as App.Mods, and CoreMods is its seam - carrying
read-side providers only, which is why install / uninstall / activate / export
stay stubs. The activate stub also now records why the ONE half it could do is
refused: CoreSettings.ActiveModId is writable here, and persisting an id no
service on this head can load would hand the WPF head a mod switch this one
only mimed.

Two stale doc lines corrected: CompanionPromptEditorDialog's said the
moderation log was a stub while CoreModerationLog.RecordEdit has been wired at
its Save since the seam landed, and TubeFitDialog's said the tube frame was
still a placeholder capsule after wire/83 gave it PreviewTubeImage - the render
shows the real tube. LinkPhoneDialog's "Serilog is dropped, the head has no
reference to it" was wrong, and its doc now states plainly that nothing opens
that window on purpose, so no one adds the call site the Settings tab already
refused: it displays ABC-DEF and a QR as if they were a live one-time auth code.

Still blocked, unchanged and verified against both roots this pass:
- Views/Dialogs/ModManagerDialog.axaml.cs - ModService.ActivateMod /
  UninstallMod / InstallModAsync / ExportCurrentAsModAsync (Services/
  ModService.cs); MainWindow.ShareModToCatalogueAsync, GetCatalogueRecord and
  CreateCatalogueStatusBadge for the share button and the status pill;
  ReleaseContentService.RequestPackAsync for BtnDownloadPack.
- Views/Dialogs/ModPickerDialog.axaml.cs - ReleaseContentService.IsFullInstall /
  FetchManifestAsync / RequestPackAsync (Services/Content/).
- Views/Dialogs/LoginDialog.axaml.cs - V2AuthService, V2DeviceCodeService
  (Services/Account/).
- Views/Dialogs/LinkPhoneDialog.axaml.cs - V2AuthService.AuthorizeMobileLinkAsync
  plus a QR encoder. Deliberately has no call site until then.
- Views/Dialogs/LocalAiSetupWizard.axaml.cs - OllamaSetupService
  (Services/AIService/).
- Views/Dialogs/ProfileCustomizeDialog.axaml.cs, WardrobeEditorDialog.axaml.cs -
  CosmeticsCatalog, WardrobeCatalog, WardrobeStageGeometry (Services/Profile/).
  The pin-tile refusal stands.
- Views/Dialogs/CompanionPromptEditorDialog.axaml.cs - CommunityPromptService
  (Services/Companion/), for the active-prompt badge and for dropping the
  community id when "use custom prompt" is un-ticked.
- Views/Dialogs/CompanionPhraseEditorDialog.axaml.cs - CompanionPhraseService
  and BarkService (Services/Companion/): voice-line and bark rows.
- Views/Dialogs/AwarenessPresetDetailDialog.axaml.cs - KeywordTriggerService
  (Services/KeywordTriggerService.cs) for ResolveAudioPath.
- Views/Dialogs/AttentionTargetEditorDialog.axaml.cs BtnTest - FloatingText, a
  Win32 layered click-through window (bucket E).
- Views/Dialogs/UpdateFailedDialog.axaml.cs catch - still needs an OWNERLESS
  notification, not a message box; MessageDialog is a Window and this catch has
  established there is none to own it.
- Views/Dialogs/TextEditorDialog.axaml.cs and CompanionPromptEditorDialog's
  OnClosing - a THREE-button prompt. MessageDialog is deliberately two-button.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU