### PR TITLE
feat(core): TierGate decides entitlement in Core; the heads seed the account bars and the refusal

### DIFF
--- a/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
@@ -268,9 +268,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         //  voice modes
         // =====================================================================================
 
-        // ponytail: ChkSpeechWakeWord / ChkSpeechPushToTalk need TierGate.DemandPremium
-        // (ConditioningControlPanel/Services/TierGate.cs) and App.Autonomy.RefreshVoiceInputModes
-        // (ConditioningControlPanel/Services/Autonomy/), both still in the WPF head. They are
+        // ponytail: ChkSpeechWakeWord / ChkSpeechPushToTalk need App.Autonomy.RefreshVoiceInputModes
+        // (ConditioningControlPanel/Services/Autonomy/), still in the WPF head. TierGate is not the
+        // blocker any more - CCP.Core/Services/TierGate.cs - but the mic half is. They are
         // seeded above and left without a write handler: a toggle that saved the flag but could
         // neither charge the premium bar nor open the mic would be a lie in both directions.
         // BtnSetPttKey likewise needs MainWindow's global-hook key capture.

--- a/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/Companion/AiPermissionsGrid.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services;
 using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
@@ -26,9 +27,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
     /// destroy a paid-up user's setting on every launch. Seeding shows the stored truth; only a
     /// head that can read Patreon may repair it.</para>
     ///
-    /// <para><see cref="ApplyTierGate"/> still fails closed, exactly as <c>TierGate.RequiresLab</c>
-    /// does with no Patreon service alive, so the effect half stays disabled on this head and the
-    /// restored writes below are reachable only once an entitlement is seeded.</para>
+    /// <para><see cref="ApplyTierGate"/> and the master toggle's refusal now call the real
+    /// <c>TierGate</c> (CCP.Core/Services/TierGate.cs), not a local stand-in. It still fails
+    /// closed here - this head seeds no <c>CoreEntitlement</c> providers, so there is no account
+    /// to read - but the band copy and the refusal are the shipped ones, and the day a head seeds
+    /// an entitlement this control opens with no further edit.</para>
     ///
     /// <para>Motion budget: zero.</para>
     /// </summary>
@@ -105,28 +108,26 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
             }
         }
 
-        /// <summary>Whether this account clears the Tier 2 bar.</summary>
-        // ponytail: needs PatreonService.HasLabAccess, wired when it moves to Core. Fails closed.
-        internal bool IsLabEntitled => false;
-
         /// <summary>
         /// Paints the Tier 2 verdict onto the effects half: disabled and dimmed under a violet
         /// lockband when the account does not clear the bar, untouched when it does. Deliberately
         /// does NOT touch the memory half - chat memory is Tier 1.
+        ///
+        /// <para>The verdict is <see cref="TierGate.RequiresLab"/> itself now (it is in Core, over
+        /// the <c>CoreEntitlement</c> seam), band copy included - so this band and the refusal
+        /// toast cannot say different things. Unseeded on this head, so still closed.</para>
         /// </summary>
         internal void ApplyTierGate()
         {
             try
             {
-                var allowed = IsLabEntitled;
-                // Same sentence TierGate.RequiresLab formats, so this band and the toast agree.
-                var reason = allowed ? string.Empty
-                    : Loc.GetF("tiergate_denied_lab", Loc.Get("lab_ai_effects_memory_title"));
+                var verdict = TierGate.RequiresLab(Loc.Get("lab_ai_effects_memory_title"));
+                var allowed = verdict.Allowed;
 
                 EffectsGateHost.IsEnabled = allowed;
                 EffectsGateHost.Opacity = allowed ? 1.0 : LockedOpacity;
                 EffectsLockBand.IsVisible = !allowed;
-                TxtEffectsLockCopy.Text = reason;
+                TxtEffectsLockCopy.Text = verdict.Reason;
             }
             catch (Exception ex)
             {
@@ -181,7 +182,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.Companion
         {
             if (_isLoading) return;
             var on = ChkCapEffects.IsChecked == true;
-            if (on && !IsLabEntitled)
+            // WPF's own guard, verbatim (MainWindow.Patreon.cs:1662). DemandLab both decides and
+            // tells; with no entitlement seeded on this head it denies and only logs, which is a
+            // quieter refusal than Windows gives but the same refusal.
+            if (on && !TierGate.DemandLab(Loc.Get("lab_ai_effects_memory_title")))
             {
                 // A refusal must not write: put the switch back and leave the panel closed. The
                 // guard is raised around the snap-back because Avalonia re-enters this handler on

--- a/CCP.Avalonia/Views/Tabs/BlinkTrainerTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/BlinkTrainerTabView.axaml.cs
@@ -26,8 +26,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
 
         // ponytail: needs MainWindow's blink-trainer handlers -
         // ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs, the gaze calibration
-        // window, the overlay session and TierGate (Services/TierGate.cs). All four are still
-        // WPF-head; none has a Core seam. This is the same refusal the gaze minigame took in
+        // window and the overlay session. TierGate is NO LONGER a blocker here - it is in Core
+        // (CCP.Core/Services/TierGate.cs) over the CoreEntitlement seam; the other three are still
+        // WPF-head with no Core seam. This is the same refusal the gaze minigame took in
         // d5f2ac87 and BubblePopFeatureControl takes at its own site: a trainer that looks started
         // while nothing tracks the eyes is worse than a gesture that does nothing.
         private void BlinkTrainerMixOptionMix_Click(object? sender, PointerReleasedEventArgs e) { }

--- a/CCP.Avalonia/Views/Tabs/PlayTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/PlayTabView.axaml.cs
@@ -8,6 +8,8 @@ using Avalonia.VisualTree;
 using ConditioningControlPanel.Avalonia.Controls;
 using ConditioningControlPanel.Avalonia.Helpers;
 using ConditioningControlPanel.Avalonia.Views.Windows;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services;
 using ConditioningControlPanel.Models;
 using Serilog;
 
@@ -270,23 +272,29 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void BtnOpenDeviceSettings_Click(object? sender, RoutedEventArgs e) => Owner?.ShowTab("appsettings");
 
         /// <summary>
-        /// REFUSED ON THE GATE, and the old note named the wrong blocker. The window is ported and
-        /// it is honest: CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow disables Start and
-        /// says why, because with no tracker every round would resolve 0 >= 0 into GOOD GIRL. So
-        /// the minigame is not what stops this door. The gate is:
-        /// <c>TierGate.DemandLab(Loc.Get("label_gaze_minigame"))</c> (MainWindow.LabTab.cs:770) —
-        /// Tier 2, checked before the window is constructed. ConditioningControlPanel/Services/
-        /// TierGate.cs is head-side and there is no entitlement seam in Core, so a faithful port of
-        /// that line is <c>false</c> on this head, exactly as AiPermissionsGrid.IsLabEntitled fails
-        /// closed. Opening the window anyway would be a paid Lab door with its gate removed.
-        /// Restore this the day an entitlement seam exists, and not before it.
+        /// RESTORED, on the condition the previous note set: "the day an entitlement seam exists".
+        /// It does — <c>TierGate</c> is CCP.Core/Services/TierGate.cs over <c>CoreEntitlement</c> —
+        /// so this is MainWindow.LabTab.cs:770 verbatim: Tier 2 checked BEFORE the window is
+        /// constructed, because the Lab smokescreen is a tab-wide overlay and not a gate on this
+        /// door. The window itself is ported and honest (GazeMinigameWindow disables Start and says
+        /// why, since with no tracker every round would resolve 0 >= 0 into GOOD GIRL).
+        ///
+        /// <para>This head seeds no entitlement, so the gate denies and the window does not open -
+        /// which is the WPF answer with no Patreon service, not a new refusal.</para>
         /// </summary>
-        private void BtnGazeMinigame_Click(object? sender, RoutedEventArgs e) { }
+        private void BtnGazeMinigame_Click(object? sender, RoutedEventArgs e)
+        {
+            if (!TierGate.DemandLab(Loc.Get("label_gaze_minigame"))) return;
+            // A non-modal Show still needs a visible owner; the shell can be minimised to tray.
+            if (Owner is not { IsVisible: true } owner) return;
+            new Lab.GazeMinigame.GazeMinigameWindow().Show(owner);
+        }
 
         /// <summary>The only Focus Gaze switch in the app. ponytail: needs
-        /// ConditioningControlPanel/Services/Tracking/GazeFocusService.cs, WebcamTrackingService and
-        /// TierGate - MainWindow.LabTab.cs:817 gates the ON edge on Tier 2 and on webcam consent
-        /// before it arms anything, and there is nothing safe to write without them. Turning the box
+        /// ConditioningControlPanel/Services/Tracking/GazeFocusService.cs and WebcamTrackingService.
+        /// The Tier 2 half is available now (TierGate is CCP.Core/Services/TierGate.cs), but
+        /// MainWindow.LabTab.cs:817 gates the ON edge on the tier AND on webcam consent before it
+        /// arms anything, and there is nothing safe to write without them. Turning the box
         /// OFF is never gated on WPF either, but there is no consumer here to release.</summary>
         private void ChkFocusGaze_Changed(object? sender, RoutedEventArgs e) { }
 

--- a/CCP.Avalonia/Views/Tabs/RemoteControlTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/RemoteControlTabView.axaml.cs
@@ -88,8 +88,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         // REFUSED, not merely missing: on WPF this handler is a premium gate that mints a session
         // code for someone else to drive this app (MainWindow.RemoteControl.cs:35 -
         // TierGate.RequiresPremium, revert-then-refuse). Persisting the flag here would leave a
-        // toggle reading "remote control on" with no gate consulted and no session behind it. Needs
-        // ConditioningControlPanel/Services/RemoteControlService.cs and TierGate.
+        // toggle reading "remote control on" with no gate consulted and no session behind it.
+        // TierGate is no longer the blocker - it is Core now (CCP.Core/Services/TierGate.cs) and
+        // would refuse correctly here - but the REFUSAL is only half the handler. Still needs
+        // ConditioningControlPanel/Services/RemoteControlService.cs for the session the ON edge
+        // starts, so the refusal stands: a gate with nothing behind it is still a lying toggle.
         private void ChkRemoteControlEnabled_Changed(object? sender, RoutedEventArgs e) { }
 
         // ponytail: the rest forward to MainWindow on WPF (Window.GetWindow(this) is MainWindow mw

--- a/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
@@ -150,7 +150,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         // the wiring is a rename away once those partials reach Core.
         //
         // ponytail: needs MainWindow (PremiumRail, DashboardFx, Browser, Login, HomeAudio,
-        // ProgramsTab, TeaseCard, TabNavigation), PremiumFeature and TierGate - all WPF-head.
+        // ProgramsTab, TeaseCard, TabNavigation) and PremiumFeature - both WPF-head. TierGate is NOT
+        // among them any more: CCP.Core/Services/TierGate.cs, over the CoreEntitlement seam.
         //
         // "LinkPhoneDialog and LayeredAudioWindow, none of them on this head" was FALSE and is
         // gone: both are ported (CCP.Avalonia/Views/Dialogs/LinkPhoneDialog.axaml.cs and

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionRoom.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.CompanionRoom.cs
@@ -50,9 +50,9 @@
 //                            SetAwarenessEnabled and EnsureAwarenessV2Consent below: there is no
 //                            observer on this head to start, so the setting write and the consent
 //                            record are the whole of what can be honoured.
-//   the premium bar        - Services.TierGate.DemandPremium
-//                            (ConditioningControlPanel/Services/TierGate.cs), the ON-edge gate in
-//                            SetAwarenessEnabled.
+// RESTORED since: the premium bar. TierGate is in Core (CCP.Core/Services/TierGate.cs) over the
+// CoreEntitlement seam, so SetAwarenessEnabled's ON-edge gate is the real one. This head seeds no
+// entitlement providers, so it denies - the same answer WPF gives with no Patreon service.
 //   AwarenessSettingsPanel - the legacy cooldown sliders' host, inside
 //                            CCP.Avalonia/Views/Controls/Companion/; CompanionTabView publishes
 //                            none of the room's cells (MainShellWindow.CompanionTab.cs).
@@ -134,6 +134,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // Turning it OFF is deliberately never gated: whatever her account is doing, the
             // switch that closes her eyes is on screen and it works.
+            //
+            // The entitlement bar, ON edge only (#1047), restored from MainWindow.CompanionRoom.cs:210
+            // now that TierGate is in Core. Asked BEFORE the consent dialog, as it is there and for
+            // the reason given there: it is rude to walk someone through a privacy explanation for a
+            // door that will not open. Unseeded on this head, so it currently denies - which is the
+            // WPF behaviour with no Patreon service, not a new refusal.
+            if (enabled && !Services.TierGate.DemandPremium(Loc.Get("tab_awareness"), "awareness"))
+                return false;
+
             if (enabled && !await AwarenessConsentDialog.EnsureConsentAsync(this, s))
             {
                 // Declined (or the dialog could not open). Nothing is written and nothing starts.

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.PlayTab.cs
@@ -8,8 +8,9 @@
 // wall that would then draw every card unlocked.
 //
 // What each member needs, exactly:
-//   RefreshPlayCards        - Services.TierGate.RequiresLab / RequiresPremium
-//                             (ConditioningControlPanel/Services/TierGate.cs) for eight verdicts;
+//   RefreshPlayCards        - Services.TierGate.RequiresLab / RequiresPremium for eight verdicts,
+//                             which IS available now (CCP.Core/Services/TierGate.cs, over the
+//                             CoreEntitlement seam) - the rest of the member is not:
 //                             MainWindow.PremiumRail.cs's SetLockband / SetLockbandVisible to paint
 //                             one; App.Patreon.HasPremiumAccess / HasLabAccess
 //                             (ConditioningControlPanel/Services/Account/PatreonService.cs) for the

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.SheListening.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.SheListening.cs
@@ -26,9 +26,10 @@
 //     StudioTab cases already there.
 //
 // STILL HEAD-SIDE, each with the exact symbol and where it lives today:
-//   DemandSheListeningPremium  - Services.TierGate.DemandPremium
-//                                (ConditioningControlPanel/Services/TierGate.cs). With it,
-//                                ToggleVoiceMic's arming half and the SheListeningGate veil.
+//   DemandSheListeningPremium  - nothing any more: TierGate is CCP.Core/Services/TierGate.cs.
+//                                Still unwired here only because its two readers below,
+//                                ToggleVoiceMic's arming half and the SheListeningGate veil, are
+//                                blocked on the mic services listed next.
 //   ToggleVoiceMic             - App.Autonomy.RefreshVoiceInputModes / StopVoiceInput
 //   DisarmVoiceMic               (ConditioningControlPanel/Services/AutonomyService.cs),
 //                                App.Speech.StopListening
@@ -45,8 +46,8 @@
 //                                CoreSpeech carries no wake engine, only the recognizer's status.
 //   UpdateMicPill              - MainShellWindow.PrivacyPill.cs, still a stub.
 //   SetSheListeningStatusPulse - MainShellWindow.SheListeningFx.cs, still a stub.
-//   RefreshPremiumRail         - MainShellWindow.PremiumRail.cs / RefreshPremiumGate, both
-//   RefreshPremiumGate           TierGate again.
+//   RefreshPremiumRail         - MainShellWindow.PremiumRail.cs / RefreshPremiumGate, neither of
+//   RefreshPremiumGate           which this layer owns. TierGate itself is no longer the blocker.
 // Every one of those calls is DROPPED from the restored bodies below, never faked.
 
 using System;

--- a/CCP.Core/CoreEntitlement.cs
+++ b/CCP.Core/CoreEntitlement.cs
@@ -1,0 +1,60 @@
+using System;
+using ConditioningControlPanel.Services;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The entitlement seam: the two account bars <see cref="TierGate"/> decides against, the
+    /// daily-free rotation it ORs in, and the surface that TELLS the user about a refusal.
+    ///
+    /// <para>Deciding is policy over account state and is portable, so <see cref="TierGate"/> now
+    /// lives in Core. Everything it needed from the head is here: the answers come from
+    /// <c>PatreonService</c> and <c>DailyFreeService</c>'s instance, and the refusal is a toast
+    /// plus an EMI Desk beat - a window, a notification host and an analytics sink, none of which
+    /// belong in an engine.</para>
+    ///
+    /// <para><b>Unseeded, every bar answers false and the refusal is log-only.</b> That is the
+    /// safe direction and not merely the convenient one: a gate that cannot read an account must
+    /// DENY, because the alternative is a head with no Patreon service handing out Tier 2. It is
+    /// also exactly what the WPF original did when <c>App.Patreon</c> was null. A provider that
+    /// THROWS reads as denied for the same reason.</para>
+    ///
+    /// <para>An unseeded denial is still written to the log by <see cref="TierGate.ShowDenied"/>;
+    /// only the user-facing half goes quiet. A silent refusal is a worse experience than a toast,
+    /// but it is not an unsafe one.</para>
+    /// </summary>
+    public static class CoreEntitlement
+    {
+        /// <summary>Tier 1+ ("premium"): pledge, whitelist, SubscribeStar or the grace cache.</summary>
+        public static volatile Func<bool>? HasPremiumProvider;
+
+        /// <summary>Tier 2+ ("Lab"), whitelist folded in as permanent tier 2.</summary>
+        public static volatile Func<bool>? HasLabProvider;
+
+        /// <summary>DailyFreeService.IsFreeToday - "is this feature the free one today?".</summary>
+        public static volatile Func<string?, bool>? IsFreeTodayProvider;
+
+        /// <summary>The head's refusal surface. No-op with no head: the gate still denies.</summary>
+        public static volatile Action<TierVerdict>? ShowDeniedHandler;
+
+        public static bool HasPremium
+        {
+            get { try { return HasPremiumProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+
+        public static bool HasLab
+        {
+            get { try { return HasLabProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+
+        public static bool IsFreeToday(string? featureKey)
+        {
+            try { return IsFreeTodayProvider?.Invoke(featureKey) ?? false; } catch { return false; }
+        }
+
+        public static void ShowDenied(TierVerdict verdict)
+        {
+            try { ShowDeniedHandler?.Invoke(verdict); } catch { }
+        }
+    }
+}

--- a/CCP.Core/Services/TierGate.cs
+++ b/CCP.Core/Services/TierGate.cs
@@ -1,6 +1,7 @@
 using System;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using Serilog;
 
 namespace ConditioningControlPanel.Services
 {
@@ -34,25 +35,25 @@ namespace ConditioningControlPanel.Services
     /// One truth for "may this account open that?", so launch handlers, CLI switches and card
     /// lockbands cannot drift apart the way the Lab smokescreen and the Goon host bar did.
     ///
-    /// Deliberately thin: it consults <see cref="PatreonService"/> and nothing else. Every other
+    /// Deliberately thin: it consults <see cref="CoreEntitlement"/> and nothing else. Every other
     /// entitlement source (whitelist, SubscribeStar, the 14-day grace) is already folded into
-    /// HasPremiumAccess / HasLabAccess, so reading settings here would only re-introduce the stale
-    /// second opinion this class exists to delete.
+    /// <c>PatreonService.HasPremiumAccess</c> / <c>HasLabAccess</c> behind that seam, so reading
+    /// settings here would only re-introduce the stale second opinion this class exists to delete.
     ///
     /// Two bars, and the names lie about which is which: "premium" in this codebase means TIER 1
-    /// (<see cref="PatreonService.HasPremiumAccess"/>, and <see cref="PatreonService.HasAiAccess"/>
-    /// resolves to the same thing despite the name); tier 2 is
-    /// <see cref="PatreonService.HasLabAccess"/>.
+    /// (<c>PatreonService.HasPremiumAccess</c>, and <c>HasAiAccess</c> resolves to the same thing
+    /// despite the name); tier 2 is <c>PatreonService.HasLabAccess</c>.
     ///
-    /// Fails CLOSED when App.Patreon is null — during startup, or if the service failed to
-    /// construct, a missing gate must not read as an open door.
+    /// Fails CLOSED when the entitlement seam is unseeded — a head with no account service, or a
+    /// WPF startup that has not reached the seeding block, must not read as an open door. That is
+    /// the same behaviour the original had when <c>App.Patreon</c> was null.
     /// </summary>
     public static class TierGate
     {
         /// <summary>Tier 1+ ("premium"): any pledge, whitelist, SubscribeStar, or the grace cache.</summary>
         public static TierVerdict RequiresPremium(string featureName)
         {
-            var allowed = App.Patreon?.HasPremiumAccess == true;
+            var allowed = CoreEntitlement.HasPremium;
             return new TierVerdict(allowed, featureName, PatreonTier.Level1,
                 allowed ? string.Empty : Loc.GetF("tiergate_denied_premium", featureName));
         }
@@ -66,8 +67,8 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public static TierVerdict RequiresPremium(string featureName, string dailyKey)
         {
-            var allowed = App.Patreon?.HasPremiumAccess == true
-                          || App.DailyFree?.IsFreeToday(dailyKey) == true;
+            var allowed = CoreEntitlement.HasPremium
+                          || CoreEntitlement.IsFreeToday(dailyKey);
             return new TierVerdict(allowed, featureName, PatreonTier.Level1,
                 allowed ? string.Empty : Loc.GetF("tiergate_denied_premium", featureName));
         }
@@ -75,7 +76,7 @@ namespace ConditioningControlPanel.Services
         /// <summary>Tier 2+ ("Lab"): the real T2 bar, whitelist folded in as permanent tier 2.</summary>
         public static TierVerdict RequiresLab(string featureName)
         {
-            var allowed = App.Patreon?.HasLabAccess == true;
+            var allowed = CoreEntitlement.HasLab;
             return new TierVerdict(allowed, featureName, PatreonTier.Level2,
                 allowed ? string.Empty : Loc.GetF("tiergate_denied_lab", featureName));
         }
@@ -87,8 +88,8 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public static TierVerdict RequiresLab(string featureName, string dailyKey)
         {
-            var allowed = App.Patreon?.HasLabAccess == true
-                          || App.DailyFree?.IsFreeToday(dailyKey) == true;
+            var allowed = CoreEntitlement.HasLab
+                          || CoreEntitlement.IsFreeToday(dailyKey);
             return new TierVerdict(allowed, featureName, PatreonTier.Level2,
                 allowed ? string.Empty : Loc.GetF("tiergate_denied_lab", featureName));
         }
@@ -118,30 +119,21 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// The refusal surface: a toast whose action button opens the App Info &amp; Data popup,
-        /// which is where every other gated door already sends people (Programs, Blink Trainer,
-        /// the For You feed all call ShowAppInfoPopup). Non-blocking on purpose - a modal would
-        /// fight for focus with the window the click was about to open.
+        /// The refusal surface. Logging it is the engine's half and always happens; SHOWING it is
+        /// the head's, through <see cref="CoreEntitlement.ShowDeniedHandler"/> - on WPF a toast
+        /// whose action button opens the App Info &amp; Data popup, which is where every other
+        /// gated door already sends people, plus the EMI Desk beat. Non-blocking on purpose - a
+        /// modal would fight for focus with the window the click was about to open.
+        ///
+        /// With no head attached the refusal is log-only. The door still does not open: only the
+        /// telling is lost, never the denying.
         ///
         /// Never throws: a gate that crashes the handler is worse than one that only logs.
         /// </summary>
         public static void ShowDenied(in TierVerdict verdict)
         {
-            App.Logger?.Information("TierGate: blocked {Feature} (needs {Required})", verdict.Feature, verdict.Required);
-            try
-            {
-                App.Notifications?.Show(verdict.Reason, NotificationType.Warning, TimeSpan.FromSeconds(8),
-                    Loc.Get("tiergate_see_tiers"), () => App.MainWindowRef?.ShowAppInfoPopup());
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Debug("TierGate: denial toast failed: {E}", ex.Message);
-            }
-
-            // EMI Desk (MOMENTS 4.B): the ONE refusal surface in the app, so the one place she can
-            // see a locked door being tried. verdict.Feature is already a localized display name.
-            try { App.EmiDesk?.Fire("premiumTeaseSeen", new { target = verdict.Feature?.ToLowerInvariant() }); }
-            catch { }
+            Log.Information("TierGate: blocked {Feature} (needs {Required})", verdict.Feature, verdict.Required);
+            CoreEntitlement.ShowDenied(verdict);
         }
     }
 }

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -104,6 +104,28 @@ namespace ConditioningControlPanel.LinuxSmoke
                 CoreAudio.Duck(95); CoreAudio.Unduck();
                 Check("CoreAudio ducking is a no-op with no audio", CoreAudio.DuckGeneration == 0);
                 Check("CoreAi.IsAvailable is false with no head", !CoreAi.IsAvailable);
+                // The entitlement seam (wire/99). TierGate is Core policy now; the account bars and
+                // the refusal surface are the head's. Unseeded MUST deny - a gate that fails open on
+                // a head with no account service hands out Tier 2 for free.
+                Check("TierGate.RequiresPremium denies with no entitlement seeded",
+                      !TierGate.RequiresPremium("Smoke").Allowed);
+                Check("TierGate.RequiresLab denies with no entitlement seeded",
+                      !TierGate.RequiresLab("Smoke").Allowed);
+                Check("the daily-free overload does not open the door either",
+                      !TierGate.RequiresPremium("Smoke", "voice").Allowed);
+                Check("TierGate.DemandPremium refuses and does not throw with no refusal surface",
+                      !TierGate.DemandPremium("Smoke"));
+                Check("TierGate.DemandLab refuses and does not throw with no refusal surface",
+                      !TierGate.DemandLab("Smoke", "dtrh"));
+                // A provider that THROWS must read as denied, not as an unhandled exception.
+                CoreEntitlement.HasLabProvider = () => throw new InvalidOperationException("smoke");
+                Check("a throwing entitlement provider reads as denied", !TierGate.RequiresLab("Smoke").Allowed);
+                // ...and the seam must actually be CONSULTED, or "denies" would only prove the
+                // class hardcodes false. Flip it, check, put it back.
+                CoreEntitlement.HasLabProvider = () => true;
+                Check("a seeded entitlement opens the Lab bar", TierGate.RequiresLab("Smoke").Allowed);
+                CoreEntitlement.HasLabProvider = null;
+                Check("clearing the provider closes it again", !TierGate.RequiresLab("Smoke").Allowed);
                 // The progression seam (wire/35). A head with no XP service is a real state, so
                 // the only thing to assert unseeded is that awarding is silent and does not throw
                 // - a minigame must still finish its flow on a head that keeps no score.

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -330,6 +330,31 @@ namespace ConditioningControlPanel
             // The engine-running flag, for the feature cards that only live-apply while a session
             // is up. The engine stays here; the flag is the whole seam.
             CoreSession.IsEngineRunningProvider = () => IsEngineRunning;
+            // The entitlement seam, for TierGate (now CCP.Core/Services/TierGate.cs). Deciding is
+            // policy and moved; the two account bars, the daily-free wheel and the refusal toast
+            // stay here. Every one is a lambda, not an eager read: Patreon, DailyFree and
+            // Notifications are all constructed in OnStartup, long after this ctor runs, and until
+            // they are the seam answers false - which is deny, the direction a gate must fail.
+            CoreEntitlement.HasPremiumProvider = () => Patreon?.HasPremiumAccess == true;
+            CoreEntitlement.HasLabProvider = () => Patreon?.HasLabAccess == true;
+            CoreEntitlement.IsFreeTodayProvider = key => DailyFree?.IsFreeToday(key) == true;
+            CoreEntitlement.ShowDeniedHandler = verdict =>
+            {
+                try
+                {
+                    Notifications?.Show(verdict.Reason, NotificationType.Warning, TimeSpan.FromSeconds(8),
+                        Loc.Get("tiergate_see_tiers"), () => MainWindowRef?.ShowAppInfoPopup());
+                }
+                catch (Exception ex)
+                {
+                    Logger?.Debug("TierGate: denial toast failed: {E}", ex.Message);
+                }
+
+                // EMI Desk (MOMENTS 4.B): the ONE refusal surface in the app, so the one place she
+                // can see a locked door being tried. verdict.Feature is a localized display name.
+                try { EmiDesk?.Fire("premiumTeaseSeen", new { target = verdict.Feature?.ToLowerInvariant() }); }
+                catch { }
+            };
             // The app's one moderation log. Read lazily on every call because ModerationLog is
             // constructed in OnStartup, long after this ctor - and it is declared null! until then.
             CoreModerationLog.InstanceProvider = () => ModerationLog;


### PR DESCRIPTION
The split the brief predicted holds exactly. A dry-run `git mv` into Core produced errors on
`App.*` and `NotificationType` and NOTHING else - `Loc`, `PatreonTier` and `DailyFreeService` all
already resolve there - so DECIDING moved and TELLING stayed.

WHAT MOVED
  ConditioningControlPanel/Services/TierGate.cs -> CCP.Core/Services/TierGate.cs (rename, 68%).
  `TierVerdict`, the four `Requires*` overloads and the four `Demand*` wrappers are unchanged
  policy; all 55 WPF call sites compile untouched, because RootNamespace is the same in both
  projects.

WHERE THE LINE IS, AND WHY
  Above the line (Core): the two bars, the daily-free OR, the verdict struct, the refusal
  sentence, and the log line for a blocked feature. All of it is arithmetic over account state.
  Below the line (head): reading the account (PatreonService, DailyFree's instance) and SHOWING
  the refusal - a toast with an action button that opens a window, plus the EMI Desk beat. A
  notification host, a window and an analytics sink are three things an engine must not own.

  New seam CCP.Core/CoreEntitlement.cs: `HasPremiumProvider`, `HasLabProvider`,
  `IsFreeTodayProvider`, `ShowDeniedHandler`. Unseeded, every bar answers FALSE and the refusal
  is log-only. That is the safe direction and not merely the convenient one - a gate that cannot
  read an account must deny - and it is the same answer the original gave when `App.Patreon` was
  null, which the existing Windows test asserts. A provider that THROWS reads as denied too.
  `TierGate.ShowDenied` keeps its Serilog line in Core, so an unseeded denial is still visible:
  only the telling is lost, never the denying.

  The WPF head seeds all four as lambdas, not eager reads - Patreon, DailyFree and Notifications
  are all built in OnStartup, long after that ctor block runs. The Avalonia head seeds NOTHING,
  deliberately: it has no Patreon service, no DailyFree instance and no toast host, so there is
  nothing to seed and inventing one would be the fail-open this port refuses.

CONSUMERS WIRED
  AiPermissionsGrid (Avalonia) - `ApplyTierGate` now paints the real `TierGate.RequiresLab`
  verdict, band copy included, so the band and the toast cannot drift; and `ChkCapEffects_Changed`
  uses `TierGate.DemandLab`, WPF's own guard verbatim. Deletes the local `IsLabEntitled => false`.
  MainShellWindow.CompanionRoom (Avalonia) - `SetAwarenessEnabled` regains its ON-edge premium
  gate, asked BEFORE the consent dialog for the reason the WPF file gives: it is rude to walk
  someone through a privacy explanation for a door that will not open. OFF is still never gated.
  PlayTabView.BtnGazeMinigame_Click (Avalonia) - restored on the exact condition its own refusal
  note set ("the day an entitlement seam exists"): DemandLab, then the ported window, with a
  visible-owner guard because the shell can be minimised to tray.

  Seven other notes that named TierGate as a blocker are corrected rather than restored: it is no
  longer what stops any of them, and leaving those notes would cost the next wave seven
  re-investigations.

Still blocked:
  RemoteControlTabView.ChkRemoteControlEnabled_Changed - ConditioningControlPanel/Services/
    RemoteControlService.cs. The gate half exists now; the session half does not, and a gate with
    nothing behind it is still a toggle that lies. The deliberate refusal STANDS, note updated.
  MainShellWindow.SheListening DemandSheListeningPremium / ToggleVoiceMic / DisarmVoiceMic -
    App.Autonomy.RefreshVoiceInputModes + StopVoiceInput (ConditioningControlPanel/Services/
    Autonomy/), App.Speech.StopListening, LockCardWindow.DisableVoiceForAll.
  DevicesSettingsSection ChkSpeechWakeWord / ChkSpeechPushToTalk - the same Autonomy pair.
  MainShellWindow.PlayTab.RefreshPlayCards - MainWindow.PremiumRail.cs SetLockband /
    SetLockbandVisible, Services.Arcademy.ArcademyHostService.DoorAvailable,
    Services.JustDrop.JustDropService.DoorAvailable, App.IntakePass.
  MainShellWindow.NavPremiumTags.IsNavEntryLocked - Models.ExclusiveFeature (head-side roster).
  AiPermissionsGrid.BtnEffectsLockCta_Click - MainWindow.ShowAppInfoPopup.

Verified: core-guards, Core build, full solution build (EnableWindowsTargeting), LinuxSmoke exit 0
with eight new assertions including a seam FLIP (seeded provider opens the Lab bar, null closes it
again, a throwing provider denies) so "denies" is not merely proof the class hardcodes false;
--smoke; --render-all 189/189; --nav-check.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU