### PR TITLE
feat(core): CoreWebcam seam - the camera controls now say they are unavailable instead of sitting inert

### DIFF
--- a/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/DevicesSettingsSection.axaml.cs
@@ -50,9 +50,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
             CmbMicDevice.SelectionChanged += CmbMicDevice_SelectionChanged;
             BtnMicRefresh.Click += BtnMicRefresh_Click;
             BtnChatShortcutDevices.Click += BtnChatShortcut_Click;
+            BtnWebcamRevokeConsent.Click += BtnWebcamRevokeConsent_Click;
 
             SyncFromSettings();
             PopulateMicDevices();
+            RefreshWebcamAvailability();
         }
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -213,17 +215,92 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         //  webcam
         // =====================================================================================
 
-        // ponytail: the webcam engine bar's device/monitor combos, the calibrate / quick-recal /
-        // start / tracker-test / privacy / revoke buttons and the debug-cursor toggle all need
-        // WebcamTrackingService + App.GazeCursor (ConditioningControlPanel/Services/Webcam/,
-        // MainWindow.LabTab.cs), still in the WPF head. Their controls render inert.
-        //
-        // Re-checked against Core: CCP.Core/Services/Webcam/WebcamConsent.cs is there, but it is a
-        // READ predicate (IsCurrent) only. BtnWebcamRevokeConsent needs App.Webcam.RevokeConsent,
-        // which stops tracking, deletes the calibration file and disables the webcam features -
-        // four promises the dialog makes. Clearing the consent flag alone would keep three of them
-        // and still tell the user everything was undone, so the button stays inert until the
-        // service crosses.
+        /// <summary>
+        /// The engine bar's honest half, now that <see cref="CoreWebcam"/> exists: with no webcam
+        /// engine on this head every control that would talk to one is DISABLED and the reason is
+        /// stated, rather than left enabled-and-inert. A greyed button with a written reason is the
+        /// difference between "this build can't" and "this build is broken".
+        ///
+        /// <para>The three checkboxes above are untouched on purpose - blink-to-recalibrate, drift
+        /// correction and gaze restriction are pure settings writes on a file both heads share, and
+        /// WPF honours them. Storing a preference is not the same as promising a camera.</para>
+        ///
+        /// <para>ponytail: the device/monitor combos, calibrate, quick-recal, start tracking,
+        /// tracker test and the debug cursor stay stubs even once a head seeds the seam - each needs
+        /// the per-frame gaze/iris/pose feed, which <see cref="CoreWebcam"/> deliberately does not
+        /// carry (see the class doc there for why splitting state from frames would be worse than
+        /// carrying neither). <c>App.GazeCursor</c> is additionally a WPF window
+        /// (Services/Tracking/GazeDebugCursorService.cs).</para>
+        ///
+        /// <para>The status pill is likewise left at its <c>rf_webcam_stopped</c> literal: it would
+        /// need <c>OnTrackingStateChanged</c> to stay true, and a pill read once at construction is
+        /// a pill that lies the moment tracking starts.</para>
+        /// </summary>
+        private void RefreshWebcamAvailability()
+        {
+            bool has = CoreWebcam.IsAvailable;
+
+            CmbWebcamDevice.IsEnabled = has;
+            BtnWebcamDeviceRefresh.IsEnabled = has;
+            CmbWebcamMonitor.IsEnabled = has;
+            BtnWebcamReviewPrivacy.IsEnabled = has;
+            BtnWebcamDebugCalibrate.IsEnabled = has;
+            BtnWebcamDebugQuickRecal.IsEnabled = has;
+            BtnWebcamDebugStart.IsEnabled = has;
+            BtnWebcamDebugTrackerTest.IsEnabled = has;
+            BtnWebcamRevokeConsent.IsEnabled = has;
+            ChkWebcamDebugCursor.IsEnabled = has;   // IsEnabled only - never IsChecked, which would fire the handler
+
+            if (!has)
+                AppendWebcamDebugLog("No webcam tracking engine on this build — camera controls are unavailable.");
+        }
+
+        /// <summary>
+        /// MainWindow.LabTab.cs:1159, with the WPF <c>MessageBox.Show(..., OKCancel, Warning,
+        /// MessageBoxResult.Cancel)</c> as <see cref="MessageDialog.ConfirmAsync"/> with
+        /// <c>defaultToCancel</c> — same wording, same safe default.
+        ///
+        /// <para><b>Awaited, and the revoke happens strictly after the answer.</b> Avalonia's
+        /// ShowDialog is async; revoking first and asking second would make the confirmation
+        /// decorative on the one control in this section that deletes user data.</para>
+        ///
+        /// <para>Gated on <see cref="CoreWebcam.IsAvailable"/> a second time even though the button
+        /// is disabled without it: <see cref="CoreWebcam.RevokeConsent"/> is a no-op unseeded, so
+        /// running the rest would print "consent revoked" over a consent record still on disk.
+        /// Clearing <c>WebcamConsentGiven</c> here instead is exactly the half-measure the old note
+        /// refused — it would keep three of the dialog's four promises and claim all four.</para>
+        ///
+        /// <para>ponytail: WPF also unchecks the debug cursor and refreshes three blink-trainer rows
+        /// (RefreshBlinkTrainerWebcamColumn / RefreshBlinkTrainerStatusRow /
+        /// ApplyBlinkTrainerStageMode). The cursor toggle and the blink trainer are both still
+        /// WPF-head, so there is nothing here to re-read.</para>
+        /// </summary>
+        private async void BtnWebcamRevokeConsent_Click(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (!CoreWebcam.IsAvailable) return;
+                if (TopLevel.GetTopLevel(this) is not Window owner || !owner.IsVisible) return;
+
+                bool ok = await MessageDialog.ConfirmAsync(owner, "Revoke webcam consent",
+                    "Revoke webcam consent?\n\n" +
+                    "This will:\n" +
+                    "  • Stop webcam tracking immediately\n" +
+                    "  • Delete your calibration data\n" +
+                    "  • Disable Focus Gaze and any webcam triggers\n" +
+                    "  • Clear your consent record\n\n" +
+                    "You'll be re-prompted to consent and recalibrate the next time you enable a webcam feature.",
+                    defaultToCancel: true);
+                if (!ok) return;
+
+                CoreWebcam.RevokeConsent();
+                AppendWebcamDebugLog("Consent revoked. Calibration deleted; webcam features disabled.");
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Webcam revoke consent failed");
+            }
+        }
 
         private void ChkBlinkRecalShortcut_Changed(object? sender, RoutedEventArgs e)
         {
@@ -428,9 +505,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
         // ponytail: BtnCameraShortcutDevices stays inert, and NOT for the reason the old note gave.
         // SerializeModifiers shipped with the tube, so the capture half would work - but the combo
         // it stores drives MainWindow.ToggleWebcamFromHotkey (MainWindow.SessionIO.cs:1485), which
-        // toggles WebcamTrackingService. No webcam engine exists on this head at all (see the
-        // webcam note above), so a rebind here would let the user configure a key for a feature
-        // that cannot fire - and the row's own label would then report a binding that does nothing.
-        // The label is left at its XAML literal for the same reason. Unblocks with the tracker.
+        // toggles WebcamTrackingService. CoreWebcam.IsAvailable is false on this head (see
+        // RefreshWebcamAvailability above), so a rebind here would let the user configure a key for
+        // a feature that cannot fire - and the row's own label would then report a binding that does
+        // nothing. The label is left at its XAML literal for the same reason. Not merely disabled
+        // like the engine bar: the seam carries no toggle, so there is no start/stop to gate on.
+        // Unblocks with the tracker.
     }
 }

--- a/CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs
@@ -636,11 +636,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         /// in-memory _roles map is authoritative while the window is open.</summary>
         private void SaveSelection() => _settings.Save();
 
-        /// <summary>Whether a gaze tracker is reachable from this head. Constant false until a
-        /// tracker seam exists; a single named gate so restoring one is one edit, not a hunt.
+        /// <summary>Whether a gaze tracker is reachable from this head. Constant false; a single
+        /// named gate so restoring one is one edit, not a hunt.
         /// <para>Checked against the WPF original before leaving it false: there is no mouse or
         /// keyboard fallback to restore. GameSide has exactly one writer there, OnGazeSideChanged,
-        /// fed by App.Webcam.OnGazeSide - so with no tracker no input can move a round.</para></summary>
+        /// fed by App.Webcam.OnGazeSide - so with no tracker no input can move a round.</para>
+        /// <para><b>NOT <c>CoreWebcam.IsAvailable</c>, though the two read the same today.</b> This
+        /// gate stands for "a gaze-SIDE stream reaches this window", which is strictly more than
+        /// "this head has a camera engine". Binding it to the capability flag would enable Start the
+        /// moment any head seeded one, on a game whose rounds still could not advance. Point it at
+        /// the stream when the stream exists.</para></summary>
         private static bool HasGazeTracker => false;
 
         /// <summary>Why Start is disabled on this head, stated once so the summary line, the
@@ -1526,7 +1531,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Lab.GazeMinigame
         // rather than the screen-projected OnGazeMove, because it already runs through the
         // calibrated left/right classifier with hysteresis and a 3-frame stability filter.
         // ponytail: needs WebcamTrackingService. It owns a camera, so it does not "move to
-        // Core" - it needs a seam, and there is none. Until then _currentSide is None forever,
+        // Core" - it needs a seam. CoreWebcam is now that seam, but it carries capability +
+        // consent-revoke only and NOT OnGazeSide, on purpose: this window's only input writer is
+        // that stream, so a capability flag would open Start onto a game nothing can play. Restore
+        // the gate and the stream in the same layer. Until then _currentSide is None forever,
         // which is why Start is gated (see the class header for what that silently produced).
         // OnFaceFound/OnFaceLost were the only writers of _faceLost; without the service the
         // face is simply never lost.

--- a/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs
@@ -178,7 +178,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             // ponytail: needs App.Webcam - ConditioningControlPanel/Services/Webcam/
             // WebcamTrackingService.cs - for the IsRunning gate and the OnRawIris / OnHeadPose /
             // OnTrackingStateChanged subscriptions. It is head-only by construction (its capture
-            // stack is Windows-side) and no Core seam names a tracker.
+            // stack is Windows-side). CoreWebcam carries capability + consent-revoke only and
+            // deliberately no per-frame feed, which is all this window consumes - see its class doc
+            // for why state without frames would be the worse half.
             // The WPF original bails to ShowError when tracking is not running; with no service to
             // ask, the intro is shown unconditionally so the view still has a first frame.
 

--- a/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs
@@ -31,8 +31,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
     /// <c>MainWindow.BtnWebcamDebugTrackerTest_Click</c> (MainWindow.LabTab.cs:1059) and only after
     /// two preconditions it can evaluate and this head cannot: the tracking service is RUNNING
     /// (starting it here if needed) and <c>svc.Calibration != null</c>. Neither exists on this head
-    /// — Services/Webcam/WebcamTrackingService.cs is the device, and CCP.Core/Services/Webcam holds
-    /// only WebcamConsent — so a button wired to this window would put up a full-screen "gaze
+    /// — Services/Webcam/WebcamTrackingService.cs is the device, and Core holds only WebcamConsent
+    /// plus CoreWebcam (capability + revoke, no feed) — so a button wired to this window would put
+    /// up a full-screen "gaze
     /// tracker" whose dot can never move, with the two checks that would have refused honestly
     /// silently dropped. That is the judgement already recorded for the Lab status pills
     /// (MainShellWindow.LabTab.cs) and it holds here. The window stays reachable only from
@@ -70,10 +71,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // ponytail: needs ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
             // (IsRunning / Calibration / OnGazeMove / OnTrackingStateChanged). It is head-only by
-            // construction and no Core seam names a tracker. With it back, this checks
-            // both preconditions, subscribes OnGazeMove and closes the window when the service
-            // stops. Without it there is no tracking to visualise, which is exactly the WPF
-            // original's first error path, so it takes that path verbatim.
+            // construction. CoreWebcam now exists but carries capability + consent-revoke ONLY,
+            // deliberately not IsRunning/Calibration - see its class doc. Gating on those two alone
+            // would be the worse half-port: the preconditions would pass and the dot would still
+            // never move, because OnGazeMove is what draws it. With the feed back, this checks both
+            // preconditions, subscribes OnGazeMove and closes the window when the service stops.
+            // Without it there is no tracking to visualise, which is exactly the WPF original's
+            // first error path, so it takes that path verbatim.
             ShowError("Webcam tracking is not running. Start tracking before opening the tracker test.");
         }
 

--- a/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs
@@ -80,8 +80,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
             // ponytail: needs ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
             // (IsRunning / Calibration / OnGazeMove / SetRuntimeOffset) plus
-            // ConditioningControlPanel/Services/CalibrationSoundService.cs. Neither is in Core and
-            // no Core seam names a tracker. With those back this shows the dot,
+            // ConditioningControlPanel/Services/CalibrationSoundService.cs. Neither is in Core.
+            // CoreWebcam carries capability + consent-revoke only, deliberately not the gaze feed
+            // (see its class doc): sampling is the whole of this window, so a capability flag alone
+            // unblocks nothing here. With those back this shows the dot,
             // samples for 2 s, takes the per-axis median after dropping the saccade onto the
             // dot, and writes (window centre - median) as the runtime offset. Without them
             // there is nothing to sample, so the window just parks in its opening state.

--- a/CCP.Core/CoreWebcam.cs
+++ b/CCP.Core/CoreWebcam.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The webcam seam: whether this head has an eye-tracking engine at all, and the one verb that
+    /// can be honoured without a live feed - revoking consent.
+    ///
+    /// <para><c>WebcamTrackingService</c> (ConditioningControlPanel/Services/Webcam/) owns a capture
+    /// device, three ONNX sessions and an OpenCvSharp frame loop, so it does not move to Core. Only
+    /// these two facts cross.</para>
+    ///
+    /// <para><b>What this seam deliberately does NOT carry, and why the next layer must not add it
+    /// casually.</b> There is no <c>Start</c>, <c>Stop</c>, <c>IsRunning</c>, <c>Calibration</c> and
+    /// no gaze / iris / head-pose event stream. Every blocked view that would consume those consumes
+    /// them TOGETHER with the per-frame feed: the tracker-test window plots <c>OnGazeMove</c>, quick
+    /// recal takes its median, the calibration window fits a polynomial to <c>OnRawIris</c> +
+    /// <c>OnHeadPose</c>, and the gaze minigame's only input writer is <c>OnGazeSide</c>. A seam
+    /// that answered "running" and "calibrated" but carried no frames would let all four pass their
+    /// preconditions and then sit there - a full-screen gaze tracker whose dot cannot move, a recal
+    /// that reports an offset it never sampled. Those are exactly the lies this port has been
+    /// refusing elsewhere. The feed and the state belong in one layer; carrying the state alone is
+    /// worse than carrying neither.
+    ///
+    /// <para>Add them the day a head can supply frames, and add them together.</para></para>
+    ///
+    /// <para>Unseeded means "this head has no webcam engine", answered honestly: not available, and
+    /// revoke is a silent no-op. It is never optimistic - it cannot report a camera as closed while
+    /// one is open, because it never claims to have closed one.</para>
+    /// </summary>
+    public static class CoreWebcam
+    {
+        public static volatile Func<bool>? IsAvailableProvider;
+        public static volatile Action? RevokeConsentAction;
+
+        /// <summary>
+        /// True when this head constructed a webcam tracking engine. Says nothing about consent
+        /// (that is <c>Services.Webcam.WebcamConsent.IsCurrent</c>), nothing about whether the
+        /// camera is open, and nothing about calibration - it is the capability question a view asks
+        /// before offering a webcam control at all. False means "offer nothing, and say why".
+        /// </summary>
+        public static bool IsAvailable
+        {
+            get { try { return IsAvailableProvider?.Invoke() ?? false; } catch { return false; } }
+        }
+
+        /// <summary>
+        /// Undoes everything the consent dialog promised: stops tracking, deletes the calibration,
+        /// clears the consent record and turns the webcam features off. All four or none - which is
+        /// why a view must call this rather than clearing <c>WebcamConsentGiven</c> itself and
+        /// leaving three of the four promises unkept.
+        ///
+        /// <para>A no-op when <see cref="IsAvailable"/> is false, safe in the direction that
+        /// matters: no engine means nothing to stop and no calibration to delete. Callers still gate
+        /// on <see cref="IsAvailable"/> before telling the user anything was revoked.</para>
+        /// </summary>
+        public static void RevokeConsent()
+        {
+            try { RevokeConsentAction?.Invoke(); } catch { /* revoking must never throw at a caller */ }
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -150,6 +150,19 @@ namespace ConditioningControlPanel.LinuxSmoke
                 Check("CoreSpeech.HasCaptureDevice is false with no speech service", !CoreSpeech.HasCaptureDevice);
                 Check("CoreSpeech.ModelStatus is NotProbed with no speech service", CoreSpeech.ModelStatus == CoreSpeechModelStatus.NotProbed);
                 Check("CoreSpeech.EnumerateInputDevices is empty with no speech service", CoreSpeech.EnumerateInputDevices().Count == 0);
+                // The webcam seam (wire/100). Unseeded must read as "this head has no camera
+                // engine": a view that believed "available" would draw an engine bar whose Start
+                // button opens nothing, and revoke must not claim it undid four things it did not.
+                Check("CoreWebcam.IsAvailable is false with no webcam service", !CoreWebcam.IsAvailable);
+                CoreWebcam.RevokeConsent();
+                Check("CoreWebcam.RevokeConsent is a silent no-op with no webcam service", true);
+                CoreWebcam.IsAvailableProvider = () => throw new InvalidOperationException("boom");
+                CoreWebcam.RevokeConsentAction = () => throw new InvalidOperationException("boom");
+                Check("CoreWebcam.IsAvailable is false when the provider throws", !CoreWebcam.IsAvailable);
+                CoreWebcam.RevokeConsent();
+                Check("CoreWebcam.RevokeConsent swallows a throwing action", true);
+                CoreWebcam.IsAvailableProvider = null;
+                CoreWebcam.RevokeConsentAction = null;
                 // The session and moderation-log seams (wire/36). Unseeded, "no engine is running"
                 // is the truth on a head that has none, and the log sink swallows the write.
                 Check("CoreSession.IsEngineRunning is false with no engine", !CoreSession.IsEngineRunning);

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -358,6 +358,13 @@ namespace ConditioningControlPanel
             // The app's one moderation log. Read lazily on every call because ModerationLog is
             // constructed in OnStartup, long after this ctor - and it is declared null! until then.
             CoreModerationLog.InstanceProvider = () => ModerationLog;
+            // Webcam capability + the consent revoke. The tracking engine stays here (capture
+            // device, ONNX sessions, OpenCvSharp loop); only "is there one" and "undo consent"
+            // cross. Read lazily: Webcam is constructed in OnStartup, long after this ctor, and is
+            // declared null! until then - so the provider must not capture it now.
+            CoreWebcam.IsAvailableProvider = () => Webcam != null;
+            CoreWebcam.RevokeConsentAction = () => Webcam?.RevokeConsent();
+
             // Speech capability, for the views that ask whether voice input is worth offering.
             // SpeechService itself stays here - it owns a capture device. Reading ModelStatus
             // lazily probes the model exactly as the WPF views already did.


### PR DESCRIPTION
WebcamTrackingService owns a capture device, three ONNX sessions and an OpenCvSharp
frame loop, so it does not move. CCP.Core/CoreWebcam.cs is its seam and carries
exactly two facts:

  IsAvailable   - did this head construct a webcam engine at all
  RevokeConsent - stop tracking, delete calibration, clear consent, disable the
                  webcam features; all four or none

Seeded from ConditioningControlPanel/App.xaml.cs next to the CoreSpeech block
(lazily - Webcam is null! until OnStartup). CCP.Avalonia seeds nothing: it has no
webcam service, which is the honest unseeded answer.

WHERE THE LINE IS DRAWN, and why it is not further out.

The seam deliberately carries no Start/Stop, no IsRunning, no Calibration and no
gaze/iris/head-pose stream. Every view that would read those reads them TOGETHER
with the per-frame feed: WebcamGazeTrackerWindow plots OnGazeMove, WebcamQuickRecal
takes its median, WebcamCalibrationWindow fits a polynomial to OnRawIris+OnHeadPose,
and GazeMinigameWindow's only input writer is OnGazeSide. A seam answering "running"
and "calibrated" with no frames behind it would let all four pass their preconditions
and then stall - a full-screen gaze tracker whose dot cannot move, a Quick Recal that
reports an offset it never sampled. That is a worse lie than the stub. State and feed
land in one layer or neither.

WHAT IS RESTORED.

DevicesSettingsSection: with no engine, the CAM/MON combos, refresh, Privacy info,
Calibrate, Quick Recal, Start tracking, Tracker Test, Revoke consent and the debug
cursor toggle are DISABLED and the reason is written to the debug log, rather than
enabled-and-inert. The three pure-settings checkboxes (blink-to-recalibrate, drift
correction, gaze restriction) stay live - they write a file both heads share and WPF
honours them; storing a preference is not promising a camera. The status pill stays
at rf_webcam_stopped: it needs OnTrackingStateChanged to stay true, and a pill read
once at construction lies the moment tracking starts.

BtnWebcamRevokeConsent is wired to the seam - MessageDialog.ConfirmAsync with
defaultToCancel, matching WPF's MessageBoxResult.Cancel default, awaited so the
revoke happens strictly after the answer, and gated on IsAvailable a second time so
it can never print "consent revoked" over a consent record still on disk. Clearing
WebcamConsentGiven here instead is the half-measure the old note refused: three of
the dialog's four promises unkept, all four claimed.

GazeMinigameWindow.HasGazeTracker stays false rather than becoming IsAvailable. The
two read the same today, but the gate means "a gaze-SIDE stream reaches this window",
which is strictly more than "this head has a camera engine"; binding it to the
capability flag would enable Start the day any head seeded one, on a game whose rounds
still could not advance.

Still blocked, and why:
  · CCP.Avalonia/Views/Windows/WebcamGazeTrackerWindow.axaml.cs - OnGazeMove /
    OnTrackingStateChanged. Unconditional error path stands.
  · CCP.Avalonia/Views/Windows/WebcamQuickRecalWindow.axaml.cs - OnGazeMove /
    SetRuntimeOffset + Services/CalibrationSoundService.cs. Window stays parked.
  · CCP.Avalonia/Views/Windows/WebcamCalibrationWindow.axaml.cs - OnRawIris /
    OnHeadPose / OnTrackingStateChanged + App.GazeCursor.
  · CCP.Avalonia/Views/Lab/GazeMinigame/GazeMinigameWindow.axaml.cs - OnGazeSide /
    OnFaceLost / OnFaceFound.
  · CCP.Avalonia/Views/Deeper/EnhancementPlayerWindow.axaml.cs BtnEyeTracking_Click -
    Start/Stop, not on the seam.
  · CCP.Avalonia/Views/Tabs/PlayTabView.axaml.cs ChkFocusGaze_Changed - also needs
    Services/Tracking/GazeFocusService.cs and Services/TierGate.cs.
  · CCP.Avalonia/Views/Tabs/BlinkTrainerTabView.axaml.cs - MainWindow's blink-trainer
    handlers, the overlay session and TierGate.
  · CCP.Avalonia/Views/Controls/AttentionCheckControl.axaml.cs - OnGazeMove plus a
    click-through topmost host window.
  · BtnCameraShortcutDevices / Behavior.CameraShortcutRequested - the combo drives
    MainWindow.SessionIO.cs:1485 ToggleWebcamFromHotkey; the seam carries no toggle.
  · Services/Webcam/WebcamTrackingService.cs itself and Services/Tracking/
    GazeDebugCursorService.cs stay in the WPF head.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU