### PR TITLE
feat(core): CoreBark, the seam the ported views ring for a companion reaction

### DIFF
--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -1399,11 +1399,18 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
         {
             var point = e.GetCurrentPoint(this);
             if (point.Properties.IsRightButtonPressed) return; // Avalonia opens the ContextMenu itself
-            // ponytail: needs ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Avatar.cs
-            // (BounceAvatar - the click squash, which on this head would be a hand-stepped tween on
-            // AvatarBounceHost's RenderTransform, not an Animation) and .Reactions.cs
-            // (ImgAvatar_MouseLeftButtonDown - the click bark, which needs BarkService). Neither
-            // partial is a Core move: both reach App.* services throughout.
+
+            // The reaction bark, the one line of WPF's ImgAvatar_MouseLeftButtonDown
+            // (AvatarTubeWindow.ChatInput.cs:75) that crosses. It feeds the rolling 60s click
+            // count behind the click-escalation eggs.
+            CoreBark.NotifyAvatarClicked();
+
+            // ponytail: the rest of that handler stays head-side and none of it is a Core move -
+            // the 4-click animation refresh, the 50-clicks-in-60s collapse trigger,
+            // App.Achievements.TrackAvatarClick, CirceClickEmote and the 1-in-25 pop sound all
+            // reach App.* or the animated-avatar pipeline. So does BounceAvatar (the click squash,
+            // AvatarTubeWindow.Avatar.cs), which here would be a hand-stepped tween on
+            // AvatarBounceHost's RenderTransform, not an Animation.
         }
 
         /// <summary>Send whatever is in the input box to the companion.</summary>

--- a/CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml.cs
@@ -82,8 +82,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
     /// <c>ChaosRanks</c>'s two members (shipped copy) and <c>ChaosWindowZ.BornTopmost</c>
     /// (<c>AppSettings.ChaosPinOnTop</c>). <c>ChaosArt</c>, <c>ChaosMeta</c>,
     /// <c>ChaosLessons</c>, <c>ChaosGlyphs</c>, <c>ChaosNarrator</c>,
-    /// <c>ChaosAnnouncerOverlay</c>, <c>ChaosModeService</c>, <c>RevealService</c> and
-    /// <c>App.Bark</c> still live in the WPF
+    /// <c>ChaosAnnouncerOverlay</c>, <c>ChaosModeService</c> and <c>RevealService</c>
+    /// still live in the WPF
     /// head - all under ConditioningControlPanel/Services/Chaos/ except <c>ChaosWindowZ</c> and
     /// <c>ChaosAnnouncerOverlay</c>, which are ConditioningControlPanel/Chaos/ - and this project
     /// may not reference it. They are stubbed in the Stubs region below,
@@ -512,7 +512,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             var revealed = _draftCards.FindAll(dc => dc.Pick.IsEnabled);
             var pool = revealed.Count > 0 ? revealed : _draftCards;
             var chosen = pool[Random.Shared.Next(pool.Count)];
-            try { App.Bark?.NotifyChaosDraftAutopick(); } catch { }
+            CoreBark.NotifyChaosDraftAutopick();
             SelectBoon(chosen);
         }
 
@@ -826,7 +826,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             _btnAdjust.IsVisible = _btnDollhouse.IsVisible;
 
             // Bark over the results (+ PB fields for the compulsion line).
-            App.Bark?.NotifyChaosResultsShown(score, ChaosMeta.State.BestScore, pbDelta, isPb,
+            CoreBark.NotifyChaosResultsShown(score, ChaosMeta.State.BestScore, pbDelta, isPb,
                 s.Defused, s.Detonated, s.BestCombo, s.Difficulty);
 
             // Rank spine: once the tally has settled, the quiet rank-up beat.
@@ -897,7 +897,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             // Stays bare and quiet by design — just a low velvet thump under the fade.
             ChaosSfx.Play("rank_settle", 0.6f);
 
-            try { App.Bark?.NotifyChaosRankUp(ChaosRanks.NameLower(rank)); } catch { }
+            CoreBark.NotifyChaosRankUp(ChaosRanks.NameLower(rank));
             ChaosMeta.State.LastRankSeen = (int)rank;
             ChaosMeta.Save();
             RevealService.Sync("rank_up");
@@ -1730,19 +1730,5 @@ namespace ConditioningControlPanel.Avalonia.Views.Chaos
             };
         }
 
-        /// <summary>The companion's reactive line. ponytail: needs App.Bark, wired when the bark
-        /// service moves to Core; null here so every call site keeps its `?.`.</summary>
-        private static class App
-        {
-            public static BarkStub? Bark => null;
-        }
-
-        private sealed class BarkStub
-        {
-            public void NotifyChaosDraftAutopick() { }
-            public void NotifyChaosResultsShown(double score, long best, double pbDelta, bool isPb,
-                                                int defused, int detonated, int bestCombo, string difficulty) { }
-            public void NotifyChaosRankUp(string rank) { }
-        }
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/CompanionPhraseEditorDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/CompanionPhraseEditorDialog.axaml.cs
@@ -206,9 +206,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
         /// <c>DisabledPhraseIds</c> mutes it, <c>PhraseAudioOverrides</c> re-points its audio. That
         /// order is what keeps a mod top-up from resurrecting a phrase the user deleted (#892).
         ///
-        /// ponytail: voice-line files (CompanionPhraseService.ResolveVoiceLineFolder) and bark lines
-        /// (BarkService.GetAllBarkLines) are still head-side, so those two row kinds are missing
-        /// here. Collapses into one GetAllPhrases() call when the service moves to Core.
+        /// The bark rows come through <see cref="CoreBark.AllLines"/>, which is the seam over
+        /// <c>BarkService.GetAllBarkLines()</c> - the engine itself cannot move (it subscribes to
+        /// some fifty head services), so only the enumeration crosses. Unseeded it answers an
+        /// empty list, so this head shows no bark rows, which is the truth on a head with no bark
+        /// engine rather than a lie about one.
+        ///
+        /// ponytail: voice-line files (CompanionPhraseService.ResolveVoiceLineFolder) are still
+        /// head-side, so that row kind is missing here. Collapses into one GetAllPhrases() call
+        /// when the service moves to Core.
         /// </summary>
         private static List<CompanionPhrase> LoadPhrases()
         {
@@ -248,6 +254,27 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
                     IsBuiltIn = false,
                     IsEnabled = custom.Enabled,
                     AudioFileName = custom.AudioFileName,
+                });
+            }
+
+            // Reactive "bark" voicelines for the active mod. Treated as built-in: the "Bark:" id
+            // prefix shares DisabledPhraseIds / RemovedPhraseIds, so toggling or hiding one routes
+            // through the same path the mod rows use and BarkService drops disabled lines at speak
+            // time. Mirrors CompanionPhraseService.GetAllPhrases (:276).
+            foreach (var b in CoreBark.AllLines)
+            {
+                if (removed.Contains(b.LineId)) continue;
+                result.Add(new CompanionPhrase
+                {
+                    Id = b.LineId,
+                    Text = b.Text,
+                    Category = "Bark",
+                    IsBark = true,
+                    GroupLabel = "Bark · " + b.Trigger,
+                    IsBuiltIn = true,
+                    IsEnabled = !disabled.Contains(b.LineId),
+                    AudioFileName = b.AudioFileName,
+                    AudioFolder = b.AudioFolder,
                 });
             }
 

--- a/CCP.Avalonia/Views/Tabs/AssetsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/AssetsTabView.axaml.cs
@@ -72,14 +72,15 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// App.EffectiveAssetsPath and hands the path to explorer.exe; CorePaths.EffectiveAssets is
         /// that path on this head and the Launcher is the portable shell open.
         ///
-        /// <para>ponytail: WPF also fires App.Bark.NotifyUiAction("open_assets") first. BarkService
-        /// has no Core seam, so the line is dropped rather than faked - a missing bark costs a
-        /// voiced reaction, never a file.</para>
+        /// <para>The "open_assets" bark fires first, exactly where WPF fires it, through
+        /// <see cref="CoreBark"/>. Unseeded on this head, so it is silent here and voiced on
+        /// Windows.</para>
         /// </summary>
         private async void BtnOpenAssetsFolder_Click(object? sender, RoutedEventArgs e)
         {
             try
             {
+                CoreBark.NotifyUiAction("open_assets");
                 var assets = CorePaths.EffectiveAssets;
                 Directory.CreateDirectory(Path.Combine(assets, "images"));
                 Directory.CreateDirectory(Path.Combine(assets, "videos"));

--- a/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/SettingsTabView.axaml.cs
@@ -301,22 +301,25 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         private void CardVault_Click(object? sender, RoutedEventArgs e) { }           // mw.CardVault_Click(...)
         private void CardJustDrop_Click(object? sender, RoutedEventArgs e) { }        // mw.CardJustDrop_Click(...)
         /// <summary>
-        /// WIRED (the easter egg half only). WPF's handler
+        /// WIRED (the bark and the easter egg). WPF's handler
         /// (MainWindow.UiUpdates.cs:1210) does four things: an achievement track, a bark
-        /// notify, the 100-clicks-in-60-seconds easter egg, and a click pulse. Only the egg
-        /// is portable today - App.Achievements and App.Bark are still head-side services -
-        /// and it needs nothing but a clock, so it runs here rather than waiting on them.
+        /// notify, the 100-clicks-in-60-seconds easter egg, and a click pulse. The bark now
+        /// crosses on <see cref="CoreBark"/> and fires FIRST, before the egg's early return,
+        /// which is where WPF fires it - the rolling 60s click count it feeds is what drives
+        /// the click-escalation eggs, so a click swallowed by the return would be a lost count.
         ///
         /// The counter lives on this view and not on the shell because this view owns the
         /// click: the shell's copy would be a second set of fields nothing increments.
         ///
-        /// ponytail: needs App.Achievements.TrackAvatarClick and App.Bark.NotifyAvatarClicked
-        /// (ConditioningControlPanel/Services/Progression/AchievementService.cs and
-        /// Services/Bark/BarkService.cs); neither is in Core. The click pulse is a
-        /// ScaleTransform animation on ImgLogo and is left out with them.
+        /// ponytail: still needs App.Achievements.TrackAvatarClick
+        /// (ConditioningControlPanel/Services/Progression/AchievementService.cs), which is not in
+        /// Core. The click pulse is a ScaleTransform animation on ImgLogo and is left out with it.
         /// </summary>
         private async void ImgLogo_MouseLeftButtonDown(object? sender, PointerPressedEventArgs e)
         {
+            // Bark hook: rolling 60s click count drives the click-escalation eggs.
+            CoreBark.NotifyAvatarClicked();
+
             if (_easterEggTriggered) return;
 
             var now = DateTime.Now;

--- a/CCP.Avalonia/Views/Tabs/StudioTabView.axaml.cs
+++ b/CCP.Avalonia/Views/Tabs/StudioTabView.axaml.cs
@@ -53,8 +53,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
     /// <para><b>What is stubbed, and why.</b> Everything the WPF code-behind reaches into the app
     /// head for: <c>MainWindow.ToggleWallFeature</c> (the eleven wall modules' quick-toggle, which
     /// owns the session-lock refusal and the per-feature service start/stop),
-    /// <c>BarkService.NotifyFeatureOpened</c>, <c>PerimeterCometAdorner</c> (the active tile's
-    /// comet) and the detail crossfade. Each is marked <c>ponytail:</c> at its site.</para>
+    /// <c>PerimeterCometAdorner</c> (the active tile's comet) and the detail crossfade. Each is
+    /// marked <c>ponytail:</c> at its site. The FeatureOpened bark is no longer among them - it
+    /// crosses on <see cref="CoreBark"/>.</para>
     ///
     /// <para><b>The art is real.</b> The rack's feature plates and the door medallion resolve
     /// through <see cref="ModArt.TryLoad"/> over <see cref="CoreModArt"/> against the
@@ -1165,13 +1166,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Tabs
         /// The FeatureOpened bark, on exactly the keys the FeaturePopupWindow path used. Losing
         /// this silently kills 14 voiced rules per built-in mod, which is why it lives on the one
         /// path every reveal goes through instead of on the click handler.
-        /// <para>ponytail: needs <c>App.Bark.NotifyFeatureOpened</c>, wired when BarkService moves
-        /// to Core. The KEYS are already correct and are the load-bearing half — deriving them from
-        /// a type name is what would fire into silence for Scheduler and Ramp.</para>
+        /// <para>The KEYS are the load-bearing half — deriving them from a type name is what
+        /// would fire into silence for Scheduler and Ramp. <see cref="CoreBark"/> swallows, so
+        /// there is no try/catch here; WPF's wraps the same single call.</para>
         /// </summary>
         private static void Announce(StudioRackEntry entry)
         {
             if (string.IsNullOrEmpty(entry.BarkFeature)) return;
+            CoreBark.NotifyFeatureOpened(entry.BarkFeature);
         }
 
         // =====================================================================================

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperTab.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.DeeperTab.cs
@@ -123,15 +123,17 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// project - the timeline, validation, save, the recent-files write - is already ported
         /// (Views/Deeper/DeeperEditorWindow.axaml.cs and its inlined file-ops region).
         ///
-        /// <para>Two things WPF also does are dropped and neither is a gate:
-        /// <c>App.Bark.NotifyUiAction("deeper_new")</c>, a UI-telemetry ping with no Core seam, and
-        /// the editor's <c>Closed</c> handler, which refreshed the hub list - still a stub in
-        /// MainShellWindow.DeeperHub.cs, so there is no list to refresh yet.</para>
+        /// <para>The "deeper_new" bark fires first, where WPF fires it, through
+        /// <see cref="CoreBark"/>. Still dropped: the editor's <c>Closed</c> handler, which
+        /// refreshed the hub list - still a stub in MainShellWindow.DeeperHub.cs, so there is no
+        /// list to refresh yet.</para>
         /// </summary>
         internal async void BtnDeeperNewEnhancement_Click(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
         {
             try
             {
+                CoreBark.NotifyUiAction("deeper_new");
+
                 // ShowDialog throws on an owner that is not VISIBLE, and a shell minimised to the
                 // tray is loaded but not visible.
                 if (!IsVisible) return;

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.TabNavigation.cs
@@ -25,7 +25,8 @@
 //         arriving at a tab cannot find a stale lock.
 //       * UpdateProfileSharingSummary() on "discord" - see the case itself for why it lands here
 //         and not in the FX partial WPF reaches it through.
-//   - Bark (App.Bark.NotifyTabNavigated) and EmiDesk (EmiTargets.NoteTabOpened) hooks.
+//   - EmiDesk (EmiTargets.NoteTabOpened). The Bark hook is REAL now, through CoreBark, and fires
+//     in the same place WPF fires it - see ShowTab.
 //   - The three keys that are WINDOWS, not tabs, and the one launcher door: "patreon" (opens
 //     Settings · Account via ShowAppInfoPopup), "fyp" (OpenFypFeed), "justdrop" (the shop host)
 //     and the "webapp" door. Each is a documented no-op below until its service exists here.
@@ -98,6 +99,18 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private static readonly HashSet<string> WindowKeys = new(StringComparer.Ordinal)
             { "patreon", "fyp", "justdrop", "webapp" };
 
+        /// <summary>
+        /// A live tab key mapped onto the BARK key it must keep announcing itself with. Copied from
+        /// WPF's <c>BarkTabAliases</c> (MainWindow.TabNavigation.cs:83) and it is head-side by
+        /// nature: Phase 6 retired the Lab page into the Play door, every built-in mod has a
+        /// `nav_lab` rule keyed `tab_eq: "lab"`, and every third-party .ccpmod on disk carries its
+        /// own copy we can never edit. Deriving the bark key from the live key would fire nothing.
+        /// <para>ShowTab("lab") still works as a permanent alias and fires "lab" directly, so it is
+        /// deliberately NOT an entry here.</para>
+        /// </summary>
+        private static readonly Dictionary<string, string> BarkTabAliases =
+            new(StringComparer.OrdinalIgnoreCase) { ["play"] = "lab" };
+
         /// <summary>The rail's doors: Tag on the door button, the tab it opens, the tabs it owns,
         /// and the entry panel that unfolds under it (null for the two doors that have none).
         /// Copied from WPF's NavDoorMap.</summary>
@@ -122,6 +135,14 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         {
             tab = (tab ?? string.Empty).ToLowerInvariant();
             if (WindowKeys.Contains(tab)) return;                 // a window, not a tab - see header
+
+            // Bark hook: announce navigation (gated/chanced in the rules so it isn't spammy).
+            // Routed through BarkTabAliases so renamed tabs keep answering to their old bark key.
+            // Placed exactly where WPF places it (MainWindow.TabNavigation.cs:158) - AFTER the
+            // window-key intercepts and BEFORE the panel lookup, so an unknown key announces
+            // itself here too, as it does there.
+            CoreBark.NotifyTabNavigated(BarkTabAliases.TryGetValue(tab, out var barkTab) ? barkTab : tab);
+
             if (!TabPanels.TryGetValue(tab, out var target)) return;
 
             foreach (var name in new HashSet<string>(TabPanels.Values))

--- a/CCP.Avalonia/Views/Windows/MainShellWindow.WindowChrome.cs
+++ b/CCP.Avalonia/Views/Windows/MainShellWindow.WindowChrome.cs
@@ -1,8 +1,9 @@
 // PORTED from ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs (478 lines).
 //
 // The four title-bar handlers are the ONLY members of this partial that touch nothing but the
-// window, so they are ported for real; everything else in the WPF file reaches App.Bark,
-// App.Lockdown, the avatar tube window or Win32 and is listed below rather than faked.
+// window, so they are ported for real; everything else in the WPF file reaches App.Lockdown, the
+// avatar tube window or Win32 and is listed below rather than faked. The two bark pings the
+// minimize and close buttons fire DO cross now, through CoreBark.
 //
 // Win32 -> Avalonia, per the port's mapping table:
 //   DragMove()                         -> BeginMoveDrag(PointerPressedEventArgs)
@@ -46,8 +47,9 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnMinimize_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: needs App.Bark (NotifyUiAction) and App.Lockdown (NotifyEscapeAttempt),
-            // plus HideAvatarTube; wired when those move to Core.
+            CoreBark.NotifyUiAction("minimize");
+            // ponytail: still needs App.Lockdown (NotifyEscapeAttempt - minimizing during a
+            // lockdown stays ALLOWED, it just gets noticed) and HideAvatarTube.
             WindowState = WindowState.Minimized;
         }
 
@@ -75,9 +77,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
 
         private void BtnClose_Click(object? sender, RoutedEventArgs e)
         {
-            // ponytail: the WPF handler runs EnsureSessionRestoredForExit and the tray/minimise-to-
-            // tray preference first. Both are services; this closes the window, which is what the
-            // button says it does.
+            CoreBark.NotifyUiAction("close");
+            // ponytail: the WPF handler also runs EnsureSessionRestoredForExit and the tray/
+            // minimise-to-tray preference. Both are services; this closes the window, which is
+            // what the button says it does.
             Close();
         }
     }

--- a/CCP.Core/CoreBark.cs
+++ b/CCP.Core/CoreBark.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using ConditioningControlPanel.Services.Bark;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The bark seam: the companion's reactive dialogue engine, told that something happened.
+    ///
+    /// <para><c>BarkService</c> itself does NOT move. It subscribes to some fifty head services
+    /// (<c>App.Webcam</c>, <c>App.GazeFocus</c>, <c>App.Video</c>, <c>App.Bubbles</c>,
+    /// <c>App.SkillTree</c>, the tray icon, the session engine…) and speaks through the avatar
+    /// window; a dry-run <c>git mv</c> into Core failed on <c>DescentBarkDecision</c>,
+    /// <c>LockCardCompletedEventArgs</c>, <c>BarkState</c>, <c>TrayIconService</c>,
+    /// <c>SessionEngine</c>, <c>ContextFrame</c> and <c>System.Windows.Threading</c> before Roslyn
+    /// even reached the method bodies. <c>CoreModsHooks.ReloadBarkRules</c> says the same thing
+    /// from the other side: the head owns rule loading. So the engine stays in the head and this
+    /// is the doorbell.</para>
+    ///
+    /// <para>Every member is fire-and-forget. Nothing here gates anything: a bark is a line the
+    /// companion may say, chanced and cooled down inside the rules, and losing one costs a voiced
+    /// reaction and never a file, a session or a consent. That is why an unseeded no-op is the
+    /// honest answer rather than a degraded one - and why the one member that returns data,
+    /// <see cref="AllLines"/>, returns an EMPTY list rather than null: a Phrase Manager on a head
+    /// with no bark engine has no bark rows, which is the truth.</para>
+    /// </summary>
+    public static class CoreBark
+    {
+        /// <summary>A UI action worth reacting to, by its bark key ("minimize", "open_assets"…).</summary>
+        public static volatile Action<string?>? UiAction;
+
+        /// <summary>The user navigated to a tab, by the tab's BARK key (see the head's alias map).</summary>
+        public static volatile Action<string?>? TabNavigated;
+
+        /// <summary>A studio feature was opened, by the feature's rule key ("SchedulerRamp"…).</summary>
+        public static volatile Action<string?>? FeatureOpened;
+
+        /// <summary>The avatar/logo was clicked - drives the rolling 60s click-escalation eggs.</summary>
+        public static volatile Action? AvatarClicked;
+
+        /// <summary>Chaos Mode: the draft timed out and picked for the player.</summary>
+        public static volatile Action? ChaosDraftAutopick;
+
+        /// <summary>Chaos Mode: the end-of-run recap is on screen. Signature copied verbatim.</summary>
+        public static volatile Action<double, double, double, bool, double, double, int, string>? ChaosResultsShown;
+
+        /// <summary>Chaos Mode: the run crossed into a new rank, by its lowercase name.</summary>
+        public static volatile Action<string>? ChaosRankUp;
+
+        /// <summary>Every inline bark line of the active mod's rule set, for the Phrase Manager.</summary>
+        public static volatile Func<IReadOnlyList<BarkLineInfo>>? AllLinesProvider;
+
+        public static void NotifyUiAction(string? action)
+        { try { UiAction?.Invoke(action); } catch { } }
+
+        public static void NotifyTabNavigated(string? tab)
+        { try { TabNavigated?.Invoke(tab); } catch { } }
+
+        public static void NotifyFeatureOpened(string? feature)
+        { try { FeatureOpened?.Invoke(feature); } catch { } }
+
+        public static void NotifyAvatarClicked()
+        { try { AvatarClicked?.Invoke(); } catch { } }
+
+        public static void NotifyChaosDraftAutopick()
+        { try { ChaosDraftAutopick?.Invoke(); } catch { } }
+
+        public static void NotifyChaosResultsShown(double score, double bestScore, double pbDelta, bool isPb,
+            double defused, double detonated, int bestCombo, string difficulty)
+        {
+            try { ChaosResultsShown?.Invoke(score, bestScore, pbDelta, isPb, defused, detonated, bestCombo, difficulty); }
+            catch { }
+        }
+
+        public static void NotifyChaosRankUp(string rank)
+        { try { ChaosRankUp?.Invoke(rank); } catch { } }
+
+        /// <summary>Never null: an unseeded seam, or a provider that throws, answers "no bark lines".</summary>
+        public static IReadOnlyList<BarkLineInfo> AllLines
+        {
+            get
+            {
+                try { return AllLinesProvider?.Invoke() ?? Array.Empty<BarkLineInfo>(); }
+                catch { return Array.Empty<BarkLineInfo>(); }
+            }
+        }
+    }
+}

--- a/CCP.Core/Services/Bark/BarkLineInfo.cs
+++ b/CCP.Core/Services/Bark/BarkLineInfo.cs
@@ -1,0 +1,11 @@
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// One enumerable bark line, surfaced to the Phrase Manager. Lifted out of
+    /// <c>BarkService</c> (where it was a nested type) so the Phrase Manager on a head without a
+    /// bark engine can still name the shape it reads through <see cref="CoreBark.AllLines"/>.
+    /// Nothing referenced it as <c>BarkService.BarkLineInfo</c>, so the lift is source-compatible.
+    /// </summary>
+    public readonly record struct BarkLineInfo(
+        string LineId, string RuleId, string Trigger, string Text, string? AudioFileName, string? AudioFolder);
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -166,6 +166,33 @@ namespace ConditioningControlPanel.LinuxSmoke
                 // The session and moderation-log seams (wire/36). Unseeded, "no engine is running"
                 // is the truth on a head that has none, and the log sink swallows the write.
                 Check("CoreSession.IsEngineRunning is false with no engine", !CoreSession.IsEngineRunning);
+                // The bark seam (wire/101). BarkService stays in the WPF head; only the doorbell
+                // crosses. Unseeded every ping is silent - a bark is a line the companion may say,
+                // never a gate - and the one member that returns data returns EMPTY, never null,
+                // so the Phrase Manager renders "no bark rows" rather than dereferencing nothing.
+                CoreBark.NotifyUiAction("minimize");
+                CoreBark.NotifyTabNavigated("lab");
+                CoreBark.NotifyFeatureOpened("SchedulerRamp");
+                CoreBark.NotifyAvatarClicked();
+                CoreBark.NotifyChaosDraftAutopick();
+                CoreBark.NotifyChaosResultsShown(1, 2, 3, true, 4, 5, 6, "hard");
+                CoreBark.NotifyChaosRankUp("claimed");
+                Check("CoreBark pings are silent no-ops with no bark engine", true);
+                Check("CoreBark.AllLines is empty and not null with no bark engine",
+                      CoreBark.AllLines is { Count: 0 });
+                var barkSeen = new System.Collections.Generic.List<string>();
+                CoreBark.UiAction = a => barkSeen.Add("ui:" + a);
+                CoreBark.TabNavigated = t => barkSeen.Add("tab:" + t);
+                CoreBark.NotifyUiAction("close");
+                CoreBark.NotifyTabNavigated("play");
+                Check("CoreBark forwards its key once seeded",
+                      barkSeen.Count == 2 && barkSeen[0] == "ui:close" && barkSeen[1] == "tab:play");
+                CoreBark.UiAction = _ => throw new InvalidOperationException("boom");
+                CoreBark.AllLinesProvider = () => throw new InvalidOperationException("boom");
+                CoreBark.NotifyUiAction("close");
+                Check("CoreBark swallows a throwing sink and still answers empty",
+                      CoreBark.AllLines is { Count: 0 });
+                CoreBark.UiAction = null; CoreBark.TabNavigated = null; CoreBark.AllLinesProvider = null;
                 CoreModerationLog.RecordEdit("smoke", 1, "linux_smoke");
                 CoreModerationLog.Record(ProhibitedCategory.Minor, "input", "smoke");
                 Check("CoreModerationLog records are silent no-ops with no log attached", true);

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -307,6 +307,21 @@ namespace ConditioningControlPanel
             CoreModsHooks.EventAccentHexProvider = () => LiveEvent?.AccentHex;
             CoreModsHooks.ActiveCompanionProvider = () => Companion?.ActiveCompanion;
             CoreModsHooks.SwitchCompanion = cid => Companion?.SwitchCompanion(cid);
+            // The bark seam (CCP.Core/CoreBark.cs). BarkService stays here - it subscribes to some
+            // fifty head services and speaks through the avatar window - so only the doorbell
+            // crosses. Every lambda reads the static LAZILY: Bark is constructed in OnStartup,
+            // long after this ctor, so a method group would bind null once and stay null.
+            CoreBark.UiAction = a => Bark?.NotifyUiAction(a);
+            CoreBark.TabNavigated = t => Bark?.NotifyTabNavigated(t);
+            CoreBark.FeatureOpened = f => Bark?.NotifyFeatureOpened(f);
+            CoreBark.AvatarClicked = () => Bark?.NotifyAvatarClicked();
+            CoreBark.ChaosDraftAutopick = () => Bark?.NotifyChaosDraftAutopick();
+            CoreBark.ChaosResultsShown = (score, best, pbDelta, isPb, defused, detonated, bestCombo, difficulty) =>
+                Bark?.NotifyChaosResultsShown(score, best, pbDelta, isPb, defused, detonated, bestCombo, difficulty);
+            CoreBark.ChaosRankUp = rank => Bark?.NotifyChaosRankUp(rank);
+            CoreBark.AllLinesProvider = () =>
+                (System.Collections.Generic.IReadOnlyList<Services.Bark.BarkLineInfo>?)Bark?.GetAllBarkLines()
+                ?? System.Array.Empty<Services.Bark.BarkLineInfo>();
             // The downloadable packs: the pack service seeds what the mod service reads.
             CoreReleaseContent.StampProvider = ReleaseContentService.GetStampFor;
             CoreReleaseContent.PackInfoProvider = id => ReleaseContent?.GetPackInfo(id);

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -1493,10 +1493,6 @@ namespace ConditioningControlPanel.Services
             return !s.DisabledPhraseIds.Contains(id) && !s.RemovedPhraseIds.Contains(id);
         }
 
-        /// <summary>One enumerable bark line, surfaced to the Phrase Manager.</summary>
-        public readonly record struct BarkLineInfo(
-            string LineId, string RuleId, string Trigger, string Text, string? AudioFileName, string? AudioFolder);
-
         /// <summary>
         /// All inline bark lines for the ACTIVE mod's loaded rule set, for display in the Phrase
         /// Manager. Skips <c>pool_ref</c> rules — those reuse existing phrase categories already shown


### PR DESCRIPTION
BarkService does NOT move, and the dry run is why. `git mv` into Core failed on
DescentBarkDecision, LockCardCompletedEventArgs, BarkState, TrayIconService,
SessionEngine, ContextFrame and System.Windows.Threading - and 26 errors
UNDERSTATES it: Roslyn stops at declaration binding, so the ~60 App.* body
references (Webcam, GazeFocus, Video, Bubbles, SkillTree, AttentionCheck, ...)
were never reached. CoreModsHooks.ReloadBarkRules already said the same thing
from the other side: the head owns rule loading. So the engine stays in the head
and only the doorbell crosses.

New: CCP.Core/CoreBark.cs - seven fire-and-forget pings (UiAction, TabNavigated,
FeatureOpened, AvatarClicked, the three Chaos ones) plus AllLines, the only
member that returns data. Unseeded, a ping is silence and AllLines is EMPTY,
never null. That is honest rather than degraded: a bark is a line the companion
MAY say, chanced and cooled down inside the rules, so a lost one costs a voiced
reaction and never a file, a session or a consent. Nothing here is a gate.

BarkLineInfo lifted out of BarkService (it was a nested type; nothing named it
as BarkService.BarkLineInfo, so the lift is source-compatible) into
CCP.Core/Services/Bark/, beside the BarkRule/BarkVariant/BarkRuleSet already
there.

Where the line is drawn: the selection logic did NOT turn out to be the portable
half. Rules, cooldowns, pools and weighting are inseparable from the ~50 event
subscriptions that feed them and from BarkState, so the split is at the CALL
SITE, not inside the engine.

WPF seeds every delegate lazily (`a => Bark?.NotifyUiAction(a)`) because Bark is
built in OnStartup, long after the App ctor - a method group would bind null once
and stay null. Avalonia seeds nothing: there is no bark engine on that head, so
CoreBark stays unseeded there and every member is the documented no-op.

Now wired on Avalonia (silent there until that head has a bark engine):
  - MainShellWindow.ShowTab announces navigation, through a copy of WPF's
    BarkTabAliases (["play"] = "lab"), placed exactly where WPF places it -
    after the window-key intercepts, before the panel lookup, so an unknown key
    announces itself here too. The alias map is head-side by nature: every
    built-in mod and every third-party .ccpmod on disk keys nav_lab to "lab".
  - BtnMinimize/BtnClose fire "minimize"/"close"; AssetsTab "open_assets";
    Deeper's new-enhancement door "deeper_new".
  - StudioTabView.Announce fires FeatureOpened on the reveal path, which is 14
    voiced rules per built-in mod that were silently dead.
  - The avatar/logo click fires NotifyAvatarClicked on both SettingsTabView and
    AvatarTubeWindow, BEFORE the easter-egg early return, because the rolling
    60s count it feeds is what drives the click-escalation eggs.
  - ChaosOverlayWindow's three calls drop their local App/BarkStub shim.
  - The Phrase Manager grows its Bark rows from CoreBark.AllLines, mirroring
    CompanionPhraseService.GetAllPhrases:276 - the "Bark:" id prefix shares
    DisabledPhraseIds/RemovedPhraseIds, so toggling one routes as before.

CCP.LinuxSmoke asserts the unseeded answers, the seeded forward, and that a
throwing sink still answers empty. Verified they can fail: breaking one on
purpose exits 1.

Still blocked:
  - App.Achievements.TrackAvatarClick (ConditioningControlPanel/Services/
    Progression/AchievementService.cs) - SettingsTabView + AvatarTubeWindow.
  - App.Lockdown.NotifyEscapeAttempt + HideAvatarTube -
    CCP.Avalonia/Views/Windows/MainShellWindow.WindowChrome.cs BtnMinimize.
  - EmiTargets.NoteTabOpened (ConditioningControlPanel/Services/EmiDesk/) -
    MainShellWindow.TabNavigation.cs.
  - CompanionPhraseService.ResolveVoiceLineFolder - the voice-line rows in
    CCP.Avalonia/Views/Dialogs/CompanionPhraseEditorDialog.axaml.cs.
  - BarkService.PickVoiceLine / ResolveModAudio - no view asks for them yet, so
    they are deliberately not on the seam.
  - The whole speak path (GigglePriority, self-echo mute, chat suppression) and
    the ~60 App.* subscriptions - ConditioningControlPanel/Services/Companion/
    BarkService.cs, and not a Core move at any point.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU