### PR TITLE
feat(core): the mod-art seam answers for sounds too, and the last private mod-art loader is gone

### DIFF
--- a/CCP.Avalonia/Helpers/ModArt.cs
+++ b/CCP.Avalonia/Helpers/ModArt.cs
@@ -20,30 +20,25 @@ namespace ConditioningControlPanel.Avalonia.Helpers
     /// caller must treat as the WPF null path (draw the glyph, collapse the plate) rather than as
     /// a failure.</para>
     ///
-    /// <para><b>Three private copies are still out there, and all three are BYTE-FOR-BYTE this
-    /// method</b> - same order, same catches, same log shape - so folding each one in is a delete
-    /// plus a call-site rename, not a port:</para>
-    /// <list type="bullet">
-    ///   <item><c>TubeFitDialog.TryLoadImage</c> (CCP.Avalonia/Views/Dialogs/TubeFitDialog.axaml.cs)</item>
-    ///   <item><c>AvatarTubeWindow.TryLoadImage</c> (CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs)</item>
-    ///   <item><c>ModCreatorWindow.TryLoadSlotHint</c> (CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs)</item>
-    /// </list>
-    /// <para>Six <c>Views/Features/*FeatureControl.axaml.cs</c> notes and
-    /// <c>EmiRingWindow.LoadThumb</c> still point a future wirer at
-    /// "TubeFitDialog.TryLoadImage is the decode pattern"; THIS is the answer they should name.
-    /// None of those files is reachable from Helpers/, so the layer that owns them makes the swap.</para>
+    /// <para>All three private copies of this two-step are folded in: <c>TubeFitDialog</c> and
+    /// <c>AvatarTubeWindow</c> call <see cref="TryLoad"/> directly, and
+    /// <c>ModCreatorWindow.TryLoadSlotHint</c> is gone. Exactly two notes still point a future
+    /// wirer at "TubeFitDialog.TryLoadImage is the decode pattern" - a method this file's fold
+    /// deleted - and THIS is the answer they should name:
+    /// <c>Views/Features/BubbleCountFeatureControl.axaml.cs</c> and
+    /// <c>Views/Features/PinkFilterFeatureControl.axaml.cs</c>. Neither is reachable from
+    /// Helpers/, so the layer that owns them makes the swap.</para>
     ///
-    /// <para>ponytail: no decode cache, and that is a decision rather than a gap. WPF's resolver
-    /// keys one on (event skin, mod id, path) because it serves per-frame art; every caller here
-    /// loads a handful of small PNGs once at build-time of a view. Add one the first time a caller
-    /// loads inside a render or a tick. <c>Controls/TierBadge</c> keeps its own three-bitmap cache
-    /// and does NOT come through here on purpose - tier livery is commerce chrome that a mod must
+    /// <para>ponytail: no decode cache, and that is now a measured decision rather than a guess.
+    /// All 42 call sites on this head were read: every one sits in a constructor, a one-shot
+    /// build (BubbleCountWindow.LoadBubbleImage, AvatarTubeWindow.LoadAvatarPoses), or a
+    /// user-driven repaint (SetTubeStyle, a ModChanged handler) that stores the Bitmap it gets.
+    /// Nothing decodes inside a render or a tick, so a cache would buy nothing and would need
+    /// invalidating on every mod switch. WPF's resolver keys one on (event skin, mod id, path)
+    /// because it also serves per-frame bubble sprites; this head does not. Add one the first
+    /// time a caller loads inside a render or a tick. <c>Controls/TierBadge</c> keeps its own
+    /// three-bitmap cache and does NOT come through here on purpose - tier livery is commerce chrome that a mod must
     /// not be able to restyle, which is why the WPF badge also reaches past ModResourceResolver.</para>
-    ///
-    /// <para>ponytail: the event-skin tier of the WPF chain is missing, and that half is Core's -
-    /// <see cref="CoreModArt"/> has no event-skin provider, so an event cannot outrank a mod on
-    /// this head. Needs a provider on CCP.Core/Services/CoreModArt.cs before anything here can
-    /// use it.</para>
     /// </summary>
     internal static class ModArt
     {

--- a/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
+++ b/CCP.Avalonia/Views/AvatarTube/AvatarTubeWindow.axaml.cs
@@ -932,7 +932,7 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             {
                 if (useAlternative && ModOverridesAttachedTubeOnly()) useAlternative = false;
                 var name = useAlternative ? "tube2.png" : "tube.png";
-                var art = TryLoadImage(name);
+                var art = ModArt.TryLoad(name);
                 if (art != null) _imgTubeFrame.Source = art;
                 Log.Information("Tube style changed to: {Style}", name);
             }
@@ -974,20 +974,11 @@ namespace ConditioningControlPanel.Avalonia.Views.AvatarTube
             string prefix = setNumber == 1 ? "avatar_pose" : $"avatar{setNumber}_pose";
             for (int i = 0; i < poses.Length; i++)
             {
-                poses[i] = TryLoadImage($"{prefix}{i + 1}.png");
-                if (poses[i] == null && setNumber > 1) poses[i] = TryLoadImage($"avatar_pose{i + 1}.png");
+                poses[i] = ModArt.TryLoad($"{prefix}{i + 1}.png");
+                if (poses[i] == null && setNumber > 1) poses[i] = ModArt.TryLoad($"avatar_pose{i + 1}.png");
             }
             return poses;
         }
-
-        /// <summary>
-        /// The mod's override first, then this head's own shipped copy under <c>avares://</c>, else
-        /// null - which every caller treats as "draw nothing here" rather than as a failure.
-        /// <para>This WAS a private copy of that two-step; <c>Helpers/ModArt.TryLoad</c> is the
-        /// head-wide one and is byte-for-byte the same chain, so the copy is deleted rather than
-        /// kept in sync. TubeFitDialog and ModCreatorWindow still carry theirs.</para>
-        /// </summary>
-        private static Bitmap? TryLoadImage(string resourceName) => ModArt.TryLoad(resourceName);
 
         /// <summary>
         /// Per-set framing: sets 2+ read 12% bigger and 10px right, and Locked's set 1 ("The Lure")

--- a/CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/ModCreatorWindow.axaml.cs
@@ -13,7 +13,6 @@ using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
 using ConditioningControlPanel.Avalonia.Views.Dialogs;
@@ -1796,14 +1795,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
             var borderHolder = new Grid { Width = width, Height = height };
 
             // Hint image (dimmed default). WPF called ModResourceResolver.ResolveImage, which
-            // cannot move to Core - it decodes to a WPF ImageSource. The portable half is
-            // CoreModArt.OverridePath plus this head's own avares:// copy.
+            // cannot move to Core - it decodes to a WPF ImageSource. Helpers.ModArt.TryLoad is
+            // this head's split of it: CoreModArt.OverridePath, then our own avares:// copy. Null
+            // is normal here - the head ships only a slice of achievements/ and skills/, so most
+            // badge slots legitimately have no hint.
             var hintImage = new Image
             {
                 Opacity = 0.2,
                 Stretch = Stretch.Uniform,
                 IsHitTestVisible = false,
-                Source = TryLoadSlotHint(resourceKey),
+                Source = Helpers.ModArt.TryLoad(resourceKey),
             };
             borderHolder.Children.Add(hintImage);
 
@@ -1924,40 +1925,6 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         /// border.Tag and pattern-matched it back out; a dictionary says the same thing without
         /// the cast, and Tag stays free.
         /// </summary>
-        /// <summary>
-        /// The mod's override first (<see cref="CoreModArt"/>), then this head's own shipped copy
-        /// under <c>avares://</c>. Null when neither exists, which is what an unhinted slot looked
-        /// like in the WPF head too - the head deliberately ships only a slice of achievements/
-        /// and skills/, so most badge slots legitimately have no hint here.
-        ///
-        /// ponytail: a byte-for-byte twin of TubeFitDialog.TryLoadImage, whose own note asks for a
-        /// head-wide helper once a second view wants the two-step. This is that second view, but
-        /// hoisting it means editing a file this layer does not own; do it in the layer that owns
-        /// both.
-        /// </summary>
-        private static Bitmap? TryLoadSlotHint(string resourceName)
-        {
-            var overridePath = CoreModArt.OverridePath(resourceName);
-            if (overridePath != null)
-            {
-                try { if (File.Exists(overridePath)) return new Bitmap(overridePath); }
-                catch (Exception ex) { Log.Warning(ex, "[ModCreator] mod override {Path} would not load", overridePath); }
-            }
-
-            try
-            {
-                var uri = new Uri($"avares://CCP.Avalonia/Resources/{resourceName}");
-                if (!AssetLoader.Exists(uri)) return null;
-                using var stream = AssetLoader.Open(uri);
-                return new Bitmap(stream);
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "[ModCreator] built-in {Name} would not load", resourceName);
-                return null;
-            }
-        }
-
         private readonly Dictionary<string, (Button Clear, TextBlock Plus, Image Hint)> _imageSlotParts = new();
 
         private void SetImageSlot(string key, string filePath, bool validate = true)

--- a/CCP.Core/CoreModArt.cs
+++ b/CCP.Core/CoreModArt.cs
@@ -4,8 +4,8 @@ using System.IO;
 namespace ConditioningControlPanel
 {
     /// <summary>
-    /// The mod-art seam: "does the active mod (or event skin) replace this picture, and where is
-    /// the replacement on disk". The WPF head answers it with
+    /// The mod-art seam: "does the active mod (or event skin) replace this picture - or this
+    /// sound - and where is the replacement on disk". The WPF head answers it with
     /// <c>Services.ModResourceResolver</c>, which cannot move here - it decodes to
     /// <c>System.Windows.Media.ImageSource</c> and falls back to <c>pack://</c> URIs, both head
     /// types. Only the RESOLUTION half is portable, so only the resolution half is here.
@@ -56,6 +56,38 @@ namespace ConditioningControlPanel
             if (path.Contains("..") || Path.IsPathRooted(path)) return null;
 
             var p = OverridePathProvider;
+            if (p is null) return null;
+            try { return p(path); } catch { return null; }
+        }
+
+        /// <summary>
+        /// The active mod's replacement for a sounds-relative logical name ("giggle5.mp3",
+        /// "bubbles/Pop.mp3", "chaos/heartbeat.mp3"), or null for "no mod cue - play your own".
+        ///
+        /// <para>Separate from <see cref="OverridePath"/> because the WPF chains genuinely
+        /// differ: the image chain probes <c>resources/&lt;path&gt;</c>, the audio chain probes
+        /// <c>resources/sounds/&lt;path&gt;</c> AND swaps .wav for .mp3 (and back) so a mod may
+        /// ship either format. One provider serving both would have to guess which rule to
+        /// apply.</para>
+        ///
+        /// <para>Override ONLY, same as the image half. Core must never learn where a head keeps
+        /// its shipped cues - the WPF head ends on <c>ContentLocator</c>, another head may not -
+        /// so a null here means "fall back the way you already do", never "silence".</para>
+        /// </summary>
+        public static volatile Func<string, string?>? AudioOverridePathProvider;
+
+        /// <summary>
+        /// The mod's replacement cue as an absolute path, or null for none. Traversal is rejected
+        /// HERE, before any head sees the string: a cue name can come out of mod-authored JSON.
+        /// </summary>
+        public static string? AudioOverridePath(string? soundRelativePath)
+        {
+            if (string.IsNullOrEmpty(soundRelativePath)) return null;
+
+            var path = soundRelativePath!.Replace('\\', '/');
+            if (path.Contains("..") || Path.IsPathRooted(path)) return null;
+
+            var p = AudioOverridePathProvider;
             if (p is null) return null;
             try { return p(path); } catch { return null; }
         }

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -272,6 +272,15 @@ namespace ConditioningControlPanel.LinuxSmoke
                 CoreModArt.OverridePathProvider = _ => throw new InvalidOperationException("boom");
                 Check("CoreModArt swallows a throwing provider", CoreModArt.OverridePath("tube.png") == null);
                 CoreModArt.OverridePathProvider = null;
+                // The audio half of the same seam. Unseeded is "no mod cue", which is what makes a
+                // head with no mod service fall back to its own shipped sound rather than to silence.
+                Check("CoreModArt.AudioOverridePath is null with no mod layer", CoreModArt.AudioOverridePath("chaos/heartbeat.mp3") == null);
+                CoreModArt.AudioOverridePathProvider = _ => "/hit.mp3";
+                Check("CoreModArt rejects traversal on the audio half too",
+                      CoreModArt.AudioOverridePath("../../etc/passwd") == null && CoreModArt.AudioOverridePath("bubbles/Pop.mp3") == "/hit.mp3");
+                CoreModArt.AudioOverridePathProvider = _ => throw new InvalidOperationException("boom");
+                Check("CoreModArt swallows a throwing audio provider", CoreModArt.AudioOverridePath("giggle5.mp3") == null);
+                CoreModArt.AudioOverridePathProvider = null;
                 Check("AwarenessIntensity.Current reads the ship default unseeded", Services.Awareness.AwarenessIntensityProfile.Current == Services.Awareness.AwarenessIntensity.Chatty);
                 // The subreddit rule moved from the online coordinator into Core with no test of its own.
                 Check("SubredditName strips r/", Services.Fyp.SubredditName.Sanitize("r/gonewild") == "gonewild");

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -298,6 +298,9 @@ namespace ConditioningControlPanel
                     : null;
             };
             CoreModArt.HasAvatarPortraitsProvider = Services.AvatarPortraitLoader.HasManifestForActiveMod;
+            // The AUDIO half of the same seam: the mod's replacement cue only, never our
+            // ContentLocator fallback - Core must not learn where a head keeps its shipped sounds.
+            CoreModArt.AudioOverridePathProvider = Services.ModResourceResolver.ModOverrideAudioPath;
             // The settings model now lives in Core; Core code reads the live instance through
             // this. Settings is created later in OnStartup; the delegate reads it lazily.
             CoreSettings.ServiceProvider = () => Settings;

--- a/ConditioningControlPanel/Services/ModResourceResolver.cs
+++ b/ConditioningControlPanel/Services/ModResourceResolver.cs
@@ -362,27 +362,41 @@ namespace ConditioningControlPanel.Services
 
             soundRelativePath = soundRelativePath.Replace('\\', '/');
 
-            var modPath = App.Mods?.ActiveMod?.InstalledPath;
-            if (modPath != null)
-            {
-                var modSoundsDir = Path.Combine(modPath, "resources", "sounds");
-                var overridePath = Path.Combine(modSoundsDir, soundRelativePath.Replace('/', Path.DirectorySeparatorChar));
-
-                // Check exact match first
-                if (File.Exists(overridePath))
-                    return overridePath;
-
-                // Check alternate extensions (.wav <-> .mp3) so mods can use either format
-                var altExt = Path.GetExtension(overridePath).ToLowerInvariant() == ".mp3" ? ".wav" : ".mp3";
-                var altPath = Path.ChangeExtension(overridePath, altExt);
-                if (File.Exists(altPath))
-                    return altPath;
-            }
-
             // Shared sounds: bundled install dir first, downloaded content pack second. A miss in both
             // comes back as the install-dir path so callers' "file missing" handling is unchanged.
-            return ContentLocator.Resolve(Path.Combine(
-                "Resources", "sounds", soundRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+            return ModOverrideAudioPath(soundRelativePath)
+                   ?? ContentLocator.Resolve(Path.Combine(
+                       "Resources", "sounds", soundRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        }
+
+        /// <summary>
+        /// The active mod's replacement cue for a sounds-relative path, or null when it ships
+        /// none. The override half of <see cref="ResolveAudioPath"/>, split out because that is
+        /// the only half Core can be told about: <c>CoreModArt.AudioOverridePathProvider</c> is
+        /// seeded from here, and each head keeps its own idea of where the SHIPPED cue lives
+        /// (<see cref="ContentLocator"/> on this one).
+        ///
+        /// <para>The .wav/.mp3 swap is part of the override rule, not of the fallback - a mod may
+        /// ship either format for a cue we bundle as the other - so it travels with the seam.</para>
+        /// </summary>
+        public static string? ModOverrideAudioPath(string soundRelativePath)
+        {
+            if (string.IsNullOrEmpty(soundRelativePath)) return null;
+            if (soundRelativePath.Contains("..") || Path.IsPathRooted(soundRelativePath)) return null;
+
+            var modPath = App.Mods?.ActiveMod?.InstalledPath;
+            if (modPath == null) return null;
+
+            var overridePath = Path.Combine(modPath, "resources", "sounds",
+                soundRelativePath.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar));
+
+            // Check exact match first
+            if (File.Exists(overridePath)) return overridePath;
+
+            // Check alternate extensions (.wav <-> .mp3) so mods can use either format
+            var altExt = Path.GetExtension(overridePath).ToLowerInvariant() == ".mp3" ? ".wav" : ".mp3";
+            var altPath = Path.ChangeExtension(overridePath, altExt);
+            return File.Exists(altPath) ? altPath : null;
         }
 
         /// <summary>


### PR DESCRIPTION
Job 1 - the private copies. The note in Helpers/ModArt.cs claimed three; two were
already folded in by an earlier layer and the note was stale about them.
TubeFitDialog calls Helpers.ModArt.TryLoad directly, and AvatarTubeWindow.TryLoadImage
was a one-line delegate - deleted, with its three call sites renamed, so the next
`grep TryLoadImage` does not read it as a copy again. The one real copy,
ModCreatorWindow.TryLoadSlotHint, is deleted and the slot hint now loads through
Helpers.ModArt.TryLoad.

Also deleted from ModArt.cs: the paragraph claiming the event-skin tier is missing.
It is wrong. The WPF head seeds CoreModArt.OverridePathProvider from
ModResourceResolver.ResolveUri, which already probes the event skin before the mod,
so an event DOES outrank a mod wherever the seam is seeded; and the file it told a
future wirer to edit (CCP.Core/Services/CoreModArt.cs) does not exist.

Job 2 - no decode cache, now on evidence rather than assertion. All 42 TryLoad call
sites on this head were read: every one is a constructor, a one-shot build
(BubbleCountWindow.LoadBubbleImage, AvatarTubeWindow.LoadAvatarPoses) or a
user-driven repaint (SetTubeStyle) that stores the Bitmap it gets. Nothing decodes
inside a render or a tick, so a cache would buy nothing and would need invalidating
on every mod switch. WPF caches because its resolver also serves per-frame bubble
sprites; this head's does not. The reason is written into ModArt.cs.

Job 3 - one real missing shape, the rest stale. CoreModArt gains
AudioOverridePathProvider / AudioOverridePath: the mod's replacement CUE only, with
the same traversal reject, the same swallowed faults and the same "null means draw
(play) your own" contract as the image half. Separate from OverridePath because the
two WPF chains genuinely differ - resources/<path> versus resources/sounds/<path>
plus a .wav/.mp3 swap - so one provider would have to guess which rule to apply.
No composite "override ?? bundled" in Core: each head keeps its own idea of where
shipped cues live (ContentLocator here), and Core must not learn it.

ModResourceResolver.ModOverrideAudioPath is that override half, extracted out of
ResolveAudioPath, which now reads `ModOverrideAudioPath(rel) ?? ContentLocator...`.
Behaviour is byte-identical for its ~15 WPF callers, so the helper is consumed today
rather than landing as seam-only code. App.xaml.cs seeds the provider beside the
image one. CCP.Avalonia/App.axaml.cs is untouched on purpose: this head has no mod
service, and unseeded already means "no mod cue, play your own".

Three LinuxSmoke assertions mirror the image half's: unseeded is null, traversal is
rejected before the head sees the string, a throwing provider degrades to "no
override".

Still blocked:
- CCP.Avalonia/Views/Chaos/ChaosOverlayWindow.axaml.cs:1505 (ChaosSfx) - the note is
  correct and now actionable: swap its resolve to CoreModArt.AudioOverridePath(rel)
  before its ContentLocator fallback. Not this layer's file. Nothing hears a mod's
  replacement cue on the Avalonia head until that swap AND that head grows a mod
  service, so the subject claims neither.
- ConditioningControlPanel/Services/ModResourceResolver.cs ResolveImageDecoded /
  ResolvePackPath stay head-only: both end on a pack:// URI and a WPF BitmapImage.

Stale ModResourceResolver notes, in files this layer does not own - the seam already
answers what each one names, so the next sweep can delete them in one pass:
  CCP.Avalonia/Views/Controls/EmiRingPicker.axaml.cs:23 (says so itself)
  CCP.Avalonia/Views/Dialogs/ModPickerDialog.axaml.cs:30
  CCP.Avalonia/Views/Tabs/DeeperTabView.axaml.cs:23,55
  CCP.Avalonia/Views/Tabs/HapticsTabView.axaml.cs:20 and HapticsTabView.axaml:41
  CCP.Avalonia/Views/Tabs/SheListeningTabView.axaml.cs:21
  CCP.Avalonia/Views/Windows/FirstRunWizard.axaml.cs:619
  CCP.Avalonia/Views/Features/SubliminalFeatureControl.axaml.cs:60
  CCP.Avalonia/Views/Windows/EmiDesk/EmiRingWindow.axaml.cs:95 (lists
    ModResourceResolver among "still in the WPF head"; it is seamed)
  CCP.Avalonia/Views/Features/BubbleCountFeatureControl.axaml.cs:53 and
    PinkFilterFeatureControl.axaml.cs:54 both point at
    "TubeFitDialog.TryLoadImage is the decode pattern", a method this commit deletes.
    Helpers.ModArt.TryLoad is the answer they should name.

Not stale, and NOT a seam gap - each note names a real non-seam blocker:
  CCP.Avalonia/Views/Windows/MainShellWindow.ProfileCard.cs:22 - this head ships no
    Resources/achievements/*.png to fall back to. An Assets Link= problem.
  CCP.Avalonia/Views/Windows/ProgramsIntroPopup.axaml.cs:92 - Assets/programs is not
    linked into CCP.Avalonia.csproj, plus a head-side ProgramDefinition.
  CCP.Avalonia/Controls/TierBadge.cs:44,823 - deliberate bypass. Tier livery is
    commerce chrome a mod must not restyle; the WPF badge also reaches past the
    resolver. Leave it.

No note anywhere asks for the mod-only (event-blind) HasActiveModOverride, so that
shape is not added.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU