### PR TITLE
feat(core): the account seam - the Settings tier card reads real entitlement

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -81,6 +81,15 @@ namespace ConditioningControlPanel.Avalonia
                 // is the truth here, and the safe direction on the only one that gates anything:
                 // HasPremium false refuses a premium enrolment rather than granting one.
 
+                // CoreAccount is deliberately left unseeded, and this one is a constraint rather
+                // than a gap. PatreonService owns an HttpListener OAuth callback and a
+                // SecureTokenStorage; this head seeds no CoreSecrets store, so by that seam's rule
+                // ("unseeded means NO store, never store in the clear") there is nowhere to keep a
+                // token even if the flow existed. Signed out and NOT entitled is therefore the
+                // literal truth here, not a placeholder - and it is the only safe unseeded answer,
+                // because an entitlement seam that failed open would hand every Linux user the
+                // paid tier.
+                //
                 // CoreSpeech is deliberately left unseeded: there is no speech engine on this head
                 // yet, and the seam's unseeded answers (no mic, empty device list, NotProbed) are
                 // exactly what that is. Seeding it with anything else would be a lie.

--- a/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml
@@ -9,9 +9,9 @@
        x:FieldModifier="internal"    ->  dropped; the MainWindow partials that poke these fields
                                          are not ported. x:Names are kept.
 
-     The tier card is painted by RefreshTierBadge() in the code-behind; on this head it is a stub
-     that leaves the signed-out markup defaults, because App.Patreon / App.IsLoggedIn live in the
-     WPF head. -->
+     The tier card is painted by RefreshTierBadge() in the code-behind, which reads the CoreAccount
+     seam. This head seeds no account provider, so the seam answers signed out and not entitled and
+     the card paints "sign in" - the truth for a head with no OAuth flow, not a placeholder. -->
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:loc="clr-namespace:ConditioningControlPanel.Avalonia.Localization"
@@ -36,12 +36,15 @@
                     </Grid.ColumnDefinitions>
 
                     <StackPanel VerticalAlignment="Center" Margin="0,0,14,0">
+                        <!-- No {loc:Str} on these two: RefreshTierBadge in the code-behind drives them (it has
+                             to - one of the three states shows the user's own name, which is not a loc key),
+                             and Avalonia keeps a binding alive under a local value, so a {loc:Str} here would
+                             quietly restore "sign in" over a signed-in name on the next language change.
+                             The code-behind re-runs on LanguageChanged instead. -->
                         <TextBlock x:Name="TxtAccountSectionName"
-                                   Text="{loc:Str account_chip_sign_in}"
                                    Foreground="{StaticResource SectionHueAccountBrush}"
                                    FontSize="15" FontWeight="Bold"/>
                         <TextBlock x:Name="TxtAccountSectionTier"
-                                   Text="{loc:Str label_login_to_unlock_exclusive_features}"
                                    Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12" Margin="0,2,0,0"
                                    TextWrapping="Wrap"/>
                     </StackPanel>

--- a/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml.cs
+++ b/CCP.Avalonia/Views/Controls/AppSettings/AccountSettingsSection.axaml.cs
@@ -1,43 +1,164 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using ConditioningControlPanel.Localization;
+using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Controls.AppSettings
 {
     /// <summary>
     /// SETTINGS · ACCOUNT, ported from the WPF head.
     ///
-    /// On WPF every Click is a one-line forward to the identically-named MainWindow handler and
-    /// <c>RefreshTierBadge</c> reads <c>App.IsLoggedIn</c> / <c>App.Patreon</c>. None of that is
-    /// reachable from this head, so the handlers are stubs and the tier card keeps its signed-out
-    /// markup defaults. The x:Names are preserved so wiring is mechanical once a host exists.
+    /// <para><see cref="RefreshTierBadge"/> is live: it reads <c>CoreAccount</c>, which is the
+    /// account seam (CCP.Core/CoreAccount.cs). It asks exactly the two properties the WPF original
+    /// asks, in the same order - <c>HasLabAccess</c> then <c>HasPremiumAccess</c> - so the badge can
+    /// never claim an entitlement the gates would refuse. On this head the seam is unseeded, which
+    /// means signed out and not entitled, so the card paints "sign in": that is the honest reading
+    /// of a head with no OAuth flow and no token store, not a placeholder.</para>
+    ///
+    /// <para>The two link buttons are live too - Avalonia's <c>Launcher</c> is the cross-platform
+    /// stand-in for WPF's <c>Process.Start(UseShellExecute)</c>, and the URLs are the same two
+    /// constants MainWindow carries.</para>
+    ///
+    /// <para>The login/link/backup/export buttons stay stubs: each needs a provider service (OAuth,
+    /// cloud backup) that this head does not have. See the notes on each.</para>
     /// </summary>
     public partial class AccountSettingsSection : UserControl
     {
+        // The same fixed brand values as the WPF original and the header chip: gold is the Tier-1
+        // lock everywhere in the app, violet the Tier-2 "Lab" flask. Not mod-owned.
+        private static readonly IBrush TierBadgeTier1Brush = new SolidColorBrush(Color.FromRgb(0xFF, 0xD7, 0x00));
+        private static readonly IBrush TierBadgeTier2Brush = new SolidColorBrush(Color.FromRgb(0xB4, 0x7B, 0xFF));
+        private static readonly IBrush TierBadgeNeutralBrush = new SolidColorBrush(Color.FromRgb(0x3D, 0x3D, 0x60));
+
+        private const string PatreonUrl = "https://www.patreon.com/CodeBambi";
+        private const string PrivacyPolicyUrl = "https://cclabs.app/privacy-policy.html";
+
+        // InitializeComponent, not AvaloniaXamlLoader.Load: only the generated one assigns the
+        // x:Name fields and wires the markup Click handlers (CLAUDE.md). The controls are still
+        // resolved by name here so this file never depends on which of the two ran.
+        private readonly Border _tierCard;
+        private readonly Border _tierBadge;
+        private readonly TextBlock _txtBadge;
+        private readonly TextBlock _txtName;
+        private readonly TextBlock _txtTier;
+
         public AccountSettingsSection()
         {
-            AvaloniaXamlLoader.Load(this);
+            InitializeComponent();
+
+            _tierCard = this.FindControl<Border>("AccountTierCard")!;
+            _tierBadge = this.FindControl<Border>("AccountTierBadge")!;
+            _txtBadge = this.FindControl<TextBlock>("TxtAccountTierBadge")!;
+            _txtName = this.FindControl<TextBlock>("TxtAccountSectionName")!;
+            _txtTier = this.FindControl<TextBlock>("TxtAccountSectionTier")!;
+
+            // WPF repaints on Loaded and on becoming visible; this head's sections are seeded from
+            // their own constructor (see GeneralSettingsSection), and Settings is a page you arrive
+            // at rather than sit on. The language hook is the one addition: the two TextBlocks are
+            // driven from code, so nothing else would re-render them after a language change.
+            RefreshTierBadge();
+            LocalizationManager.Instance.LanguageChanged += (_, _) => RefreshTierBadge();
         }
 
-        // ponytail: needs ConditioningControlPanel/Services/Account/PatreonService.cs (the tier and
-        // the entitlement) plus an App.IsLoggedIn twin. Neither is in Core and this head seeds no
-        // account seam at all, so the badge stays at its signed-out markup default - which is the
-        // honest reading of "we cannot tell whether you are signed in".
-        internal void RefreshTierBadge() { }
+        /// <summary>
+        /// Host seam: the Settings door repaints the tier card every time it opens, so a login that
+        /// happened behind another door is never shown stale.
+        /// </summary>
+        public void OnSectionShown() => RefreshTierBadge();
 
-        // ponytail: needs ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs and its
-        // SubscribeStar / CloudBackup siblings, all of which drive PatreonService and the WPF
-        // OAuth browser flow. CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs is this head's
-        // device-code prompt and is the surface to hang these on once a provider exists.
+        /// <summary>Repaints the account/tier card from the account seam. Never throws.</summary>
+        internal void RefreshTierBadge()
+        {
+            try
+            {
+                if (!CoreAccount.IsLoggedIn)
+                {
+                    _txtName.Text = Loc.Get("account_chip_sign_in");
+                    _txtTier.Text = Loc.Get("label_login_to_unlock_exclusive_features");
+                    _tierBadge.IsVisible = false;
+                    _tierCard.BorderBrush = TierBadgeNeutralBrush;
+                    return;
+                }
+
+                var name = CoreAccount.DisplayName;
+                _txtName.Text = string.IsNullOrWhiteSpace(name) ? Loc.Get("account_chip_signed_in") : name;
+
+                if (CoreAccount.HasLabAccess)
+                {
+                    _txtBadge.Text = "🧪";
+                    _tierBadge.IsVisible = true;
+                    _tierBadge.BorderBrush = TierBadgeTier2Brush;
+                    _tierCard.BorderBrush = TierBadgeTier2Brush;
+                    _txtTier.Text = CoreAccount.IsWhitelisted
+                        ? Loc.Get("label_patreon_tier_whitelisted")
+                        : Loc.Get("label_patreon_tier_level2");
+                }
+                else if (CoreAccount.HasPremiumAccess)
+                {
+                    _txtBadge.Text = "🔒";
+                    _tierBadge.IsVisible = true;
+                    _tierBadge.BorderBrush = TierBadgeTier1Brush;
+                    _tierCard.BorderBrush = TierBadgeTier1Brush;
+                    _txtTier.Text = Loc.Get("label_patreon_tier_level1");
+                }
+                else
+                {
+                    _tierBadge.IsVisible = false;
+                    _tierCard.BorderBrush = TierBadgeNeutralBrush;
+                    _txtTier.Text = Loc.Get("label_patreon_tier_connected");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("AccountSettingsSection.RefreshTierBadge failed: {E}", ex.Message);
+            }
+        }
+
+        private async void OpenUrl(string url)
+        {
+            try
+            {
+                var launcher = TopLevel.GetTopLevel(this)?.Launcher;
+                if (launcher == null) return;
+                await launcher.LaunchUriAsync(new Uri(url));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "AccountSettingsSection: failed to open {Url}", url);
+            }
+        }
+
+        // ponytail: the OAuth halves. Each needs a provider service this head does not have -
+        // PatreonService owns an HttpListener callback, and Discord/SubscribeStar the same shape.
+        // CoreAccount answers who is signed in; it deliberately carries no way to SIGN somebody in,
+        // because a login button that mints a session with no token store to keep it would leave
+        // the user logged in until they blink. CCP.Avalonia/Views/Dialogs/LoginDialog.axaml.cs is
+        // the surface to hang these on once a provider exists.
         private void BtnPatreonLogin_Click(object? sender, RoutedEventArgs e) { }
         private void BtnSubscribeStarLogin_Click(object? sender, RoutedEventArgs e) { }
         private void BtnDiscordLogin_Click(object? sender, RoutedEventArgs e) { }
         private void BtnLinkPatreon_Click(object? sender, RoutedEventArgs e) { }
         private void BtnLinkDiscord_Click(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: cloud settings backup - ProfileSyncService.BackupSettingsAsync /
+        // GetSettingsBackupInfoAsync / RestoreSettingsFromCloudAsync, all still in the WPF head and
+        // not in this layer's seam. CCP.Avalonia/Views/Windows/MainShellWindow.CloudBackup.cs holds
+        // the restore path's LOCAL-WINS field list and is where these belong.
         private void BtnBackupSettingsNow_Click(object? sender, RoutedEventArgs e) { }
         private void BtnRestoreSettings_Click(object? sender, RoutedEventArgs e) { }
+
+        // ponytail: GDPR export - ProfileSyncService.ExportDataAsync plus a save-file picker and a
+        // result message box. CoreAccount deliberately does not carry ExportDataAsync yet: it is
+        // one line to add, and adding it without the picker and the failure dialog would give the
+        // button a transport and no way to tell the user it failed.
         private void BtnExportData_Click(object? sender, RoutedEventArgs e) { }
-        private void BtnPrivacyPolicy_Click(object? sender, RoutedEventArgs e) { }
-        private void BtnVisitPatreon_Click(object? sender, RoutedEventArgs e) { }
+
+        // Live: WPF used Process.Start with UseShellExecute, Avalonia's Launcher is the
+        // cross-platform equivalent. Same two URLs MainWindow.CloudBackup.cs and
+        // MainWindow.Patreon.cs carry.
+        private void BtnPrivacyPolicy_Click(object? sender, RoutedEventArgs e) => OpenUrl(PrivacyPolicyUrl);
+        private void BtnVisitPatreon_Click(object? sender, RoutedEventArgs e) => OpenUrl(PatreonUrl);
     }
 }

--- a/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/DisplayNameDialog.axaml.cs
@@ -15,19 +15,22 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     ///    Enter ignored outside 2-20 characters), so it is a plain return here.
     /// The parameterless constructor is the real "welcome" mode and doubles as the render ctor.
     ///
-    /// <para>NO CALLER ON THIS HEAD, and not for want of one being written. All three WPF call
-    /// sites are blocked on code that is still Windows-only:</para>
+    /// <para>STILL NO CALLER ON THIS HEAD, but the reason has narrowed. The TRANSPORT now exists:
+    /// <c>CoreAccount.ChangeDisplayNameAsync</c> and <c>CoreAccount.DeleteAccountAsync</c>
+    /// (CCP.Core/CoreAccount.cs) carry both operations across, seeded from
+    /// <c>App.ProfileSync</c> on the WPF head. What is missing is the two callers:</para>
     /// <list type="bullet">
-    /// <item><c>MainWindow.Browser.cs:BtnChangeDisplayName_Click</c> and
-    /// <c>BtnDeleteProfile_Click</c> - both need <c>App.ProfileSync</c>
-    /// (ConditioningControlPanel/Services/Settings/ProfileSyncService.cs, no Core seam) for
-    /// <c>ChangeDisplayNameAsync</c> / <c>DeleteAccountAsync</c>, and both hang off DiscordTabView,
-    /// which is not converted. MainShellWindow.Browser.cs already lists them as blocked.</item>
+    /// <item><c>CCP.Avalonia/Views/Tabs/DiscordTabView.axaml.cs:155,163</c> -
+    /// <c>BtnChangeDisplayName_Click</c> and <c>BtnDeleteProfile_Click</c> are stubs there. That
+    /// file is not in this layer. Its delete path also ends in <c>MainWindow.Browser.cs</c>'s
+    /// <c>ClearProfileViewer</c> plus the local progression wipe, which is head-side.</item>
     /// <item><c>Services/Account/AccountService.cs:PromptForRegistrationAsync</c> - AccountService
-    /// is a static WPF-head class that has not been ported or moved to Core at all.</item>
+    /// is a static WPF-head class that takes a <c>System.Windows.Window</c> owner and drives
+    /// <c>App.Patreon</c>/<c>App.Discord</c>. It has no Avalonia twin and no seam, because there is
+    /// no OAuth flow on this head to register against.</item>
     /// </list>
-    /// <para>Wiring the dialog to anything else would open a name prompt whose answer nothing can
-    /// send, which is worse than a dialog nobody can reach.</para>
+    /// <para>Opening it from anywhere else would still be a name prompt whose answer nothing can
+    /// act on, which is worse than a dialog nobody can reach.</para>
     /// </summary>
     public partial class DisplayNameDialog : Window
     {

--- a/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
+++ b/CCP.Avalonia/Views/Dialogs/UsernamePickerDialog.axaml.cs
@@ -38,7 +38,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Dialogs
     /// class in the WPF head with no Avalonia twin and nothing in Core, and neither
     /// <c>V2AuthService</c> nor <c>App.Patreon</c> / <c>App.Discord</c> has a seam. There is no
     /// authentication flow on this head to hang the picker off; opening it from anywhere else
-    /// would collect a name with no registration behind it and no logout to undo it.</para>
+    /// would collect a name with no registration behind it and no logout to undo it.
+    /// <c>CoreAccount</c> does not change that: it reports an identity and can rename or delete
+    /// one, but it deliberately carries no way to CREATE one, so this dialog's blocker is
+    /// unchanged.</para>
     /// </summary>
     public partial class UsernamePickerDialog : Window
     {

--- a/CCP.Core/CoreAccount.cs
+++ b/CCP.Core/CoreAccount.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Threading.Tasks;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The account seam: who is signed in, which bar they clear, and the two destructive
+    /// self-service operations on that identity.
+    ///
+    /// <para>Three head-only services stand behind it and none of them can move.
+    /// <c>PatreonService</c> owns an <c>HttpListener</c> on port 47832 for the OAuth callback plus
+    /// a <c>SecureTokenStorage</c>; <c>AccountService</c> takes a <c>System.Windows.Window</c>
+    /// owner and drives <c>App.Patreon</c>/<c>App.Discord</c>; <c>ProfileSyncService</c> is a
+    /// 5,000-line HTTP client with a WPF <c>DispatcherTimer</c> heartbeat. A socket, a window and a
+    /// device-bound secret store are exactly the three things that stay in a head, so only the
+    /// ANSWERS cross here - never the transport.</para>
+    ///
+    /// <para><b>Unseeded means signed out and NOT ENTITLED, and that is not merely the safe answer
+    /// - it is the truth.</b> A head that seeds nothing here has no OAuth flow, and the Avalonia
+    /// head also seeds no <c>CoreSecrets</c> store, so there is no token, no session and no tier to
+    /// report. Every entitlement property therefore fails CLOSED, including when a seeded provider
+    /// throws: an exception means "I could not determine your tier", which must never be read as
+    /// "yes". Failing open here would hand every Linux user the paid tier.</para>
+    ///
+    /// <para>Deliberately NOT exposed, because no ported view asks for it and each is one line for
+    /// whoever needs it: <c>HasAiAccess</c>, the raw <c>PatreonTier</c>, <c>EntitlementResolved</c>,
+    /// <c>ExportDataAsync</c>. If <c>EntitlementResolved</c> is ever added, unseeded MUST answer
+    /// false - a true there beside a false <see cref="HasLabAccess"/> is #1048, the destructive
+    /// entitlement repair that cleared a saved setting on every single launch.</para>
+    /// </summary>
+    public static class CoreAccount
+    {
+        public static volatile Func<bool>? IsLoggedInProvider;
+        public static volatile Func<string?>? DisplayNameProvider;
+        public static volatile Func<bool>? IsWhitelistedProvider;
+        public static volatile Func<bool>? HasPremiumAccessProvider;
+        public static volatile Func<bool>? HasLabAccessProvider;
+
+        /// <summary>
+        /// Rename this account on the server. Answers with the name the SERVER settled on, which is
+        /// not always the one that was asked for.
+        /// </summary>
+        public static volatile Func<string, Task<(bool success, string? error, string? newName)>?>? ChangeDisplayNameProvider;
+
+        /// <summary>Delete this account and all its server-side data (GDPR). Irreversible.</summary>
+        public static volatile Func<Task<(bool success, string? error)>?>? DeleteAccountProvider;
+
+        /// <summary>Signed in with any provider, or holding a restored cloud identity.</summary>
+        public static bool IsLoggedIn => Ask(IsLoggedInProvider);
+
+        /// <summary>The name to show for this user, or null when there is none to show.</summary>
+        public static string? DisplayName
+        {
+            get { try { return DisplayNameProvider?.Invoke(); } catch { return null; } }
+        }
+
+        /// <summary>Server-side whitelist: full access regardless of subscription.</summary>
+        public static bool IsWhitelisted => Ask(IsWhitelistedProvider);
+
+        /// <summary>The canonical premium (tier 1) gate, offline grace and SubscribeStar folded in.</summary>
+        public static bool HasPremiumAccess => Ask(HasPremiumAccessProvider);
+
+        /// <summary>
+        /// The canonical Lab (tier 2) gate - the goon-game HOST bar. Advisory: the server refuses
+        /// on its own, and this exists so the UI can say so before the round-trip instead of after.
+        /// </summary>
+        public static bool HasLabAccess => Ask(HasLabAccessProvider);
+
+        /// <summary>
+        /// Rename the account. Unseeded - and on an absent or throwing provider - this is a refusal
+        /// carrying the head's own precondition message, never a silent success: the caller must
+        /// not go on to write the new name locally.
+        /// </summary>
+        public static async Task<(bool success, string? error, string? newName)> ChangeDisplayNameAsync(string newName)
+        {
+            var provider = ChangeDisplayNameProvider;
+            if (provider == null) return (false, NotSignedIn, null);
+            try
+            {
+                var task = provider(newName);
+                if (task == null) return (false, NotSignedIn, null);
+                return await task.ConfigureAwait(false);
+            }
+            catch { return (false, NotSignedIn, null); }
+        }
+
+        /// <summary>
+        /// Delete the account. Same refusal contract as <see cref="ChangeDisplayNameAsync"/>: an
+        /// unseeded head must report that nothing was deleted, so no caller clears local data on
+        /// the strength of a deletion that never happened.
+        /// </summary>
+        public static async Task<(bool success, string? error)> DeleteAccountAsync()
+        {
+            var provider = DeleteAccountProvider;
+            if (provider == null) return (false, NotSignedInDelete);
+            try
+            {
+                var task = provider();
+                if (task == null) return (false, NotSignedInDelete);
+                return await task.ConfigureAwait(false);
+            }
+            catch { return (false, NotSignedInDelete); }
+        }
+
+        // The WPF preconditions verbatim (ProfileSyncService.ChangeDisplayNameAsync /
+        // DeleteAccountAsync). Unseeded IS that precondition failing: IsLoggedIn is false.
+        private const string NotSignedIn = "You must be logged in to change your name";
+        private const string NotSignedInDelete = "You must be logged in to delete your account";
+
+        private static bool Ask(Func<bool>? provider)
+        {
+            try { return provider?.Invoke() ?? false; } catch { return false; }
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -226,6 +226,37 @@ namespace ConditioningControlPanel.LinuxSmoke
                 Check("CoreBark swallows a throwing sink and still answers empty",
                       CoreBark.AllLines is { Count: 0 });
                 CoreBark.UiAction = null; CoreBark.TabNavigated = null; CoreBark.AllLinesProvider = null;
+                // The account seam (wire/104). Unseeded must read as signed out and NOT ENTITLED.
+                // The entitlement half is the one that matters: failing open here would hand every
+                // Linux user the paid tier, so the throwing-provider checks below are the real
+                // assertions - a provider that blows up means "I could not determine your tier",
+                // which must never be read as "yes".
+                Check("CoreAccount.IsLoggedIn is false with no account service", !CoreAccount.IsLoggedIn);
+                Check("CoreAccount.DisplayName is null with no account service", CoreAccount.DisplayName == null);
+                Check("CoreAccount.HasPremiumAccess is false with no account service", !CoreAccount.HasPremiumAccess);
+                Check("CoreAccount.HasLabAccess is false with no account service", !CoreAccount.HasLabAccess);
+                Check("CoreAccount.IsWhitelisted is false with no account service", !CoreAccount.IsWhitelisted);
+                CoreAccount.HasPremiumAccessProvider = () => throw new InvalidOperationException("boom");
+                CoreAccount.HasLabAccessProvider = () => throw new InvalidOperationException("boom");
+                Check("a throwing entitlement provider fails CLOSED, never open",
+                      !CoreAccount.HasPremiumAccess && !CoreAccount.HasLabAccess);
+                CoreAccount.HasPremiumAccessProvider = () => true;
+                Check("CoreAccount.HasPremiumAccess forwards once seeded", CoreAccount.HasPremiumAccess);
+                CoreAccount.HasPremiumAccessProvider = null;
+                CoreAccount.HasLabAccessProvider = null;
+                // Rename and delete must REFUSE unseeded, never answer success: a caller that
+                // believed either would write a new name locally, or clear local data, on the
+                // strength of a server call that never happened.
+                var rename = CoreAccount.ChangeDisplayNameAsync("smoke").GetAwaiter().GetResult();
+                Check("CoreAccount.ChangeDisplayNameAsync refuses with no account service",
+                      !rename.success && rename.newName == null && rename.error != null, rename.error);
+                var deleted = CoreAccount.DeleteAccountAsync().GetAwaiter().GetResult();
+                Check("CoreAccount.DeleteAccountAsync refuses with no account service",
+                      !deleted.success && deleted.error != null, deleted.error);
+                CoreAccount.DeleteAccountProvider = () => throw new InvalidOperationException("boom");
+                Check("a throwing delete provider reports failure rather than propagating",
+                      !CoreAccount.DeleteAccountAsync().GetAwaiter().GetResult().success);
+                CoreAccount.DeleteAccountProvider = null;
                 CoreModerationLog.RecordEdit("smoke", 1, "linux_smoke");
                 CoreModerationLog.Record(ProhibitedCategory.Minor, "input", "smoke");
                 Check("CoreModerationLog records are silent no-ops with no log attached", true);

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -386,6 +386,18 @@ namespace ConditioningControlPanel
                 try { EmiDesk?.Fire("premiumTeaseSeen", new { target = verdict.Feature?.ToLowerInvariant() }); }
                 catch { }
             };
+            // The account seam. Every provider reads lazily, so the construction order of Patreon,
+            // Discord, SubscribeStar and ProfileSync (all built well after this ctor) does not
+            // matter. The entitlement trio is the same pair of properties, in the same order, that
+            // Services.TierGate and the header chip read, so the seam can never claim an
+            // entitlement the gates would refuse.
+            CoreAccount.IsLoggedInProvider = () => IsLoggedIn;
+            CoreAccount.DisplayNameProvider = () => UserDisplayName;
+            CoreAccount.IsWhitelistedProvider = () => Patreon?.IsWhitelisted == true;
+            CoreAccount.HasPremiumAccessProvider = () => Patreon?.HasPremiumAccess == true;
+            CoreAccount.HasLabAccessProvider = () => Patreon?.HasLabAccess == true;
+            CoreAccount.ChangeDisplayNameProvider = name => ProfileSync?.ChangeDisplayNameAsync(name);
+            CoreAccount.DeleteAccountProvider = () => ProfileSync?.DeleteAccountAsync();
             // The app's one moderation log. Read lazily on every call because ModerationLog is
             // constructed in OnStartup, long after this ctor - and it is declared null! until then.
             CoreModerationLog.InstanceProvider = () => ModerationLog;


### PR DESCRIPTION
Adds CCP.Core/CoreAccount.cs: who is signed in, which bar they clear, and the
two destructive operations on that identity (rename, delete). Seeded on the WPF
head from App.IsLoggedIn / App.UserDisplayName / App.Patreon / App.ProfileSync.

Nothing moved to Core, and after reading all three services in full that is the
right outcome, not a shortfall. PatreonService owns an HttpListener on port
47832 for the OAuth callback plus a SecureTokenStorage; AccountService takes a
System.Windows.Window owner and drives App.Patreon/App.Discord; ProfileSyncService
is 5,077 lines of HTTP client on a WPF DispatcherTimer heartbeat. A socket, a
window and a device-bound secret store are exactly the three things that stay in
a head, so only the answers cross.

Portable piece found and deliberately left where it is: the #865 XP-watermark
region, ProfileSyncService.cs:35-231 (MeaningfulProgressXp,
ServerProfileLooksUninitialized, ServerProfileTooEmptyToClampTo,
ServerProfileWouldCraterLocalLevel, ActiveXpWatermark, RecordAgreedServerXp,
ClearXpWatermark). It is App-free except for App.Logger and every type it touches
is already in Core, so it would move cleanly - but every call site is inside
SyncProfileAsync, which stays in the head, so moving it in this layer would be a
second concern with no consumer. There is no shared display-name validator to
extract: the 2-20 and 3-30 rules live in the two dialogs, not in the services.

Unseeded means signed out and NOT ENTITLED - the truth on a head with no OAuth
flow, and the only safe answer, since an entitlement seam that failed open would
hand every Linux user the paid tier. That includes a seeded provider that throws:
an exception is "I could not determine your tier", never "yes". Rename and delete
refuse unseeded with the WPF precondition string, so no caller writes a new name
locally or clears local data on the strength of a call that never happened.
The Avalonia head seeds nothing here on purpose - it seeds no CoreSecrets store
either, so by that seam's rule there is nowhere to keep a token even if the flow
existed. CoreAccount carries no way to SIGN somebody in for the same reason.

AccountSettingsSection: RefreshTierBadge is live and reads the seam, asking
HasLabAccess then HasPremiumAccess in that order exactly as WPF does, so the
badge can never claim an entitlement TierGate would refuse; the two link buttons
open through Avalonia's Launcher. The card's two TextBlocks lost their {loc:Str}
because code drives them (one state shows the user's own name) and Avalonia keeps
a binding alive under a local value - the code-behind re-runs on LanguageChanged
instead. Renders signed-out with real strings.

Still blocked:
- CCP.Avalonia/Views/Tabs/DiscordTabView.axaml.cs:155,163 - BtnChangeDisplayName_Click
  and BtnDeleteProfile_Click. The transport now exists; these callers are not in
  this layer, and the delete path also ends in MainWindow.Browser.cs ClearProfileViewer.
- DisplayNameDialog / UsernamePickerDialog stay caller-less. The picker's blocker
  is unchanged: AccountService.AuthenticateV2Async opens it and logs the provider
  OUT on cancel, and there is no registration flow on this head to reproduce.
- AccountSettingsSection BtnPatreonLogin/BtnSubscribeStarLogin/BtnDiscordLogin/
  BtnLinkPatreon/BtnLinkDiscord - need an OAuth provider service.
- AccountSettingsSection BtnBackupSettingsNow/BtnRestoreSettings - need
  ProfileSyncService.BackupSettingsAsync / GetSettingsBackupInfoAsync /
  RestoreSettingsFromCloudAsync.
- AccountSettingsSection BtnExportData - needs ProfileSyncService.ExportDataAsync
  plus a save picker and a failure dialog; the seam omits ExportDataAsync rather
  than give the button a transport with no way to report failure.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU