### PR TITLE
feat(avalonia): the Pink Filter card drives a per-monitor X11 tint overlay

### DIFF
--- a/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/PinkFilterFeatureControl.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Platform;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Avalonia.Views.Dialogs;
+using ConditioningControlPanel.Avalonia.Views.Overlays;
 using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services.UI;
 using Serilog;
@@ -122,9 +123,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             if (s.PinkFilterEnabled == want) return;   // an echo of the seed must not save
             s.PinkFilterEnabled = want;
             CoreSettings.Save();
-            // ponytail: WPF then calls App.Overlay.RefreshOverlays()
-            // (ConditioningControlPanel/Services/Notifications/OverlayService.cs), still in the WPF
-            // head - the tint windows are Win32 layered windows with no port yet.
+            PinkFilterOverlay.Refresh(this);
         }
 
         private void SliderOpacity_Changed(object? sender, RangeBaseValueChangedEventArgs e)
@@ -134,7 +133,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             TxtOpacity.Text = $"{v}%";
             CoreSettings.Current.PinkFilterOpacity = v;
             CoreSettings.Save();
-            // ponytail: WPF then calls App.Overlay.RefreshOverlays() - see ChkEnable_Changed.
+            PinkFilterOverlay.Refresh(this);
         }
 
         // ── Display monitor picker (#639) ─────────────────────────────────
@@ -186,7 +185,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
 
             s.PinkFilterTargetMonitor = target;
             CoreSettings.Save();
-            // ponytail: WPF then calls App.Overlay.RefreshOverlays() - see ChkEnable_Changed.
+            PinkFilterOverlay.Refresh(this);
         }
 
         /// <summary>
@@ -208,8 +207,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             CoreSettings.Current.PinkFilterColor = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
             CoreSettings.Save();
             UpdateSwatch();
-            // ponytail: WPF then calls App.Overlay.RefreshFilterColor() + RefreshOverlays() to push
-            // the colour into a tint already on screen - see ChkEnable_Changed.
+            PinkFilterOverlay.Refresh(this);   // WPF: RefreshFilterColor() + RefreshOverlays()
         }
 
         private void BtnResetColor_Click(object? sender, RoutedEventArgs e)
@@ -217,8 +215,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             CoreSettings.Current.PinkFilterColor = ""; // empty = default (mod / hot pink)
             CoreSettings.Save();
             UpdateSwatch();
-            // ponytail: WPF then calls App.Overlay.RefreshFilterColor() + RefreshOverlays() to push
-            // the colour into a tint already on screen - see ChkEnable_Changed.
+            PinkFilterOverlay.Refresh(this);   // WPF: RefreshFilterColor() + RefreshOverlays()
         }
 
         private void UpdateSwatch()
@@ -227,12 +224,8 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             ColorSwatch.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
         }
 
-        /// <summary>The colour the tint renders: the user's pick if set, else the active mod's
-        /// filter colour, which unseeded is the built-in default manifest's.</summary>
-        private static (byte R, byte G, byte B) EffectiveColor() =>
-            CoreMods.TryParseHexColor(CoreSettings.Current.PinkFilterColor, out var rgb)
-                ? rgb
-                : CoreMods.GetFilterColorRgb();
+        /// <summary>The colour the tint renders. One copy, on the host that paints it.</summary>
+        private static (byte R, byte G, byte B) EffectiveColor() => PinkFilterOverlay.EffectiveColor();
     }
 
     /// <summary>

--- a/CCP.Avalonia/Views/Overlays/PinkFilterOverlay.cs
+++ b/CCP.Avalonia/Views/Overlays/PinkFilterOverlay.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using ConditioningControlPanel.Avalonia.Platform;
+using ConditioningControlPanel.Avalonia.Views.Features;   // ScreenList
+using ConditioningControlPanel.Services.UI;               // MonitorTarget
+using Serilog;
+
+namespace ConditioningControlPanel.Avalonia.Views.Overlays
+{
+    /// <summary>
+    /// Owns the Pink Filter tint: one <see cref="TintOverlayWindow"/> per targeted monitor, kept
+    /// in step with <see cref="Models.AppSettings"/>. The Avalonia counterpart of
+    /// <c>OverlayService</c>'s Pink region (StartPinkFilter / StopPinkFilter /
+    /// UpdatePinkFilterOpacity / RefreshFilterColor), minus everything that belongs to the session
+    /// engine - the timed and sustained holds, the Deeper ramp override and the 500ms poll all
+    /// live in <c>OverlayService</c> and have nothing on this head to drive them.
+    ///
+    /// <para><b>Static, and not a service, deliberately.</b> There is exactly one desktop and one
+    /// tint on it; an instance would need an owner, and the only candidate owner is the shell
+    /// window this thing has to outlive between tab switches.</para>
+    ///
+    /// <para><b>Two refusals, and both matter more than showing the tint:</b> a full-screen
+    /// topmost window that is not click-through locks the user out of their own desktop, and a
+    /// window whose transparency request was denied paints an opaque screen-sized block instead of
+    /// a wash. Either one is caught in <see cref="Accept"/> and the window is closed rather than
+    /// left up. That is why this feature does NOT work through the Avalonia head on Windows or
+    /// under a native Wayland backend: <see cref="X11Overlay"/> is X11-only and answers false
+    /// there, so no tint is shown at all rather than an un-dismissable one.</para>
+    /// </summary>
+    internal static class PinkFilterOverlay
+    {
+        private static readonly List<TintOverlayWindow> Windows = new();
+        private static int[] _shownOn = Array.Empty<int>();
+        private static Window? _hookedOwner;
+
+        /// <summary>The colour the tint renders: the user's pick if set, else the active mod's
+        /// filter colour, which unseeded is the built-in default manifest's. Same order as
+        /// <c>OverlayService.GetFilterRgb</c>.</summary>
+        internal static (byte R, byte G, byte B) EffectiveColor() =>
+            CoreMods.TryParseHexColor(CoreSettings.Current.PinkFilterColor, out var rgb)
+                ? rgb
+                : CoreMods.GetFilterColorRgb();
+
+        /// <summary>
+        /// Bring the tint in line with the current settings: show it, hide it, move it or repaint
+        /// it as those say. Idempotent, so every card handler can just call this.
+        /// </summary>
+        /// <param name="host">Any attached visual - it is only used to reach <c>Screens</c> and
+        /// the owning window. A detached one enumerates no screens and hides the tint.</param>
+        public static void Refresh(Visual host)
+        {
+            var s = CoreSettings.Current;
+            if (!s.PinkFilterEnabled || !ShouldShow()) { CloseAll(); return; }
+
+            var screens = ScreenList.Enumerate(host);
+            var primary = -1;
+            for (var i = 0; i < screens.Count; i++) if (screens[i].IsPrimary) { primary = i; break; }
+
+            var want = ResolveScreenIndices(s.PinkFilterTargetMonitor, s.DualMonitorEnabled, screens.Count, primary);
+            var (r, g, b) = EffectiveColor();
+            var opacity = s.PinkFilterOpacity / 100.0;
+
+            // Same monitors as last time: repaint the brushes and leave the windows alone. This is
+            // the whole reason the slider does not tear down a full-screen window per tick.
+            if (Windows.Count > 0 && want.SequenceEqual(_shownOn))
+            {
+                foreach (var w in Windows) w.SetTint(r, g, b, opacity);
+                return;
+            }
+
+            CloseAll();
+
+            // Checked BEFORE anything is created, not only inside Accept: without this, a slider
+            // drag on a platform that cannot do click-through flashes a topmost full-screen window
+            // once per tick and logs a warning each time. Accept still runs - IsAvailable being
+            // true does not promise THIS window is an X11 one, nor that the compositor granted
+            // transparency.
+            if (!X11Overlay.IsAvailable)
+            {
+                Log.Debug("Pink filter: no X11 display, so no tint on this platform");
+                return;
+            }
+
+            HookOwner(TopLevel.GetTopLevel(host) as Window);
+
+            foreach (var i in want)
+            {
+                var w = new TintOverlayWindow();
+                w.PlaceOn(screens[i]);
+                w.SetTint(r, g, b, opacity);
+                w.Show();                       // Position -> Show -> click-through, the order
+                                                // BubbleCountWindow uses; there is no XID before Show
+                // A refusal is about the platform, not about this monitor, so drop the whole set
+                // rather than tinting some screens and not others.
+                if (!Accept(w)) { CloseAll(); return; }
+                Windows.Add(w);
+            }
+            _shownOn = want;
+            Log.Debug("Pink filter showing on {Count} screen(s) at {Opacity}%", Windows.Count, s.PinkFilterOpacity);
+        }
+
+        public static void CloseAll()
+        {
+            foreach (var w in Windows)
+            {
+                try { w.Close(); }
+                catch (Exception ex) { Log.Debug("Pink filter: failed to close a tint window: {E}", ex.Message); }
+            }
+            Windows.Clear();
+            _shownOn = Array.Empty<int>();
+            if (_hookedOwner is not null) { _hookedOwner.Closed -= OnOwnerClosed; _hookedOwner = null; }
+        }
+
+        /// <summary>
+        /// Which entries of the screen list an effect targets, ported case for case from
+        /// <c>App.ResolveScreens</c> (ConditioningControlPanel/App.ScreenResolver.cs). The sentinel
+        /// numbers are PERSISTED, so this has to agree with the WPF head exactly:
+        /// <see cref="MonitorTarget.All"/> is every monitor, <see cref="MonitorTarget.FollowGlobal"/>
+        /// is every monitor when <c>DualMonitorEnabled</c> and the primary otherwise, and 0..N is
+        /// that one index. An index that no longer exists (unplugged monitor) falls back to the
+        /// FollowGlobal behaviour WITHOUT rewriting the setting, so the target survives a reconnect.
+        /// </summary>
+        internal static int[] ResolveScreenIndices(int target, bool dualMonitorEnabled, int screenCount, int primaryIndex)
+        {
+            if (screenCount <= 0) return Array.Empty<int>();
+            if (primaryIndex < 0 || primaryIndex >= screenCount) primaryIndex = 0;
+
+            if (target == MonitorTarget.All) return Enumerable.Range(0, screenCount).ToArray();
+            if (target >= 0 && target < screenCount) return new[] { target };
+            return dualMonitorEnabled ? Enumerable.Range(0, screenCount).ToArray() : new[] { primaryIndex };
+        }
+
+        /// <summary>
+        /// WPF gates the persistent tint on the session engine: <c>RefreshOverlays</c> returns
+        /// early when <c>!_isRunning</c>, so the checkbox there arms the effect and
+        /// <c>OverlayService.Start()</c> is what puts it on screen.
+        ///
+        /// <para>That gate is mirrored here <b>except when there is no engine at all</b>, which is
+        /// this head today - <see cref="CoreSession"/> is unseeded, so the provider is null and
+        /// "not running" is a statement about the head rather than about the session. Mirroring it
+        /// literally would mean the checkbox could never draw anything on Linux, ever. With no
+        /// engine to own the tint's lifecycle, the card owns it; the moment a head seeds
+        /// <c>CoreSession</c> this falls back to the WPF rule on its own.</para>
+        /// </summary>
+        private static bool ShouldShow()
+            => CoreSession.IsEngineRunningProvider is null || CoreSession.IsEngineRunning;
+
+        // ponytail: nothing calls Refresh at startup, so a tint left enabled in settings does not
+        // come back until the user touches the card. Restoring it belongs to whatever owns the
+        // app's start-up sequence - OverlayService.Start() on the WPF side - and putting it in
+        // App.OnFrameworkInitializationCompleted here would show a full-screen overlay before the
+        // shell window the user needs in order to switch it off is even up.
+
+        /// <summary>The two safety refusals. False means the window has already been closed.</summary>
+        private static bool Accept(TintOverlayWindow w)
+        {
+            if (!X11Overlay.SetClickThrough(w, true))
+            {
+                Log.Warning("Pink filter: this platform cannot make the tint click-through, so it is not shown - a full-screen topmost window that swallows clicks would lock the desktop");
+                Close(w);
+                return false;
+            }
+
+            if (w.ActualTransparencyLevel == WindowTransparencyLevel.None)
+            {
+                Log.Warning("Pink filter: the window manager refused per-pixel transparency (no compositor), so the tint is not shown - it would paint an opaque block, not a wash");
+                Close(w);
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void Close(Window w)
+        {
+            try { w.Close(); } catch (Exception ex) { Log.Debug("Pink filter: close failed: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Avalonia's default <c>ShutdownMode</c> is <c>OnLastWindowClose</c>, and these windows
+        /// are windows. Without this, closing the shell while the tint is up leaves a live process
+        /// behind a pink sheet with no UI to turn it off.
+        /// </summary>
+        private static void HookOwner(Window? owner)
+        {
+            if (owner is null || ReferenceEquals(owner, _hookedOwner)) return;
+            if (_hookedOwner is not null) _hookedOwner.Closed -= OnOwnerClosed;
+            _hookedOwner = owner;
+            owner.Closed += OnOwnerClosed;
+        }
+
+        private static void OnOwnerClosed(object? sender, EventArgs e) => CloseAll();
+    }
+}

--- a/CCP.Avalonia/Views/Overlays/TintOverlayWindow.cs
+++ b/CCP.Avalonia/Views/Overlays/TintOverlayWindow.cs
@@ -1,0 +1,82 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Platform;
+
+namespace ConditioningControlPanel.Avalonia.Views.Overlays
+{
+    /// <summary>
+    /// One screen's worth of flat colour, drawn over everything and transparent to the mouse.
+    /// The Avalonia twin of the window <c>OverlayService.CreatePinkFilterForScreen</c> builds in
+    /// the WPF head (ConditioningControlPanel/Services/Notifications/OverlayService.cs:1363).
+    ///
+    /// <para><b>Code-only, no .axaml, on purpose.</b> The whole window is a <c>Border</c> whose
+    /// brush colour is the only thing that ever changes, so a XAML file would buy one more chance
+    /// to hit the <c>x:Name</c>-is-null trap and nothing else.</para>
+    ///
+    /// <para><b>The property mapping</b>, each one replacing a Win32 style the original ORs in
+    /// inside <c>SourceInitialized</c>:</para>
+    /// <list type="bullet">
+    ///   <item><c>WindowStyle=None</c> + <c>AllowsTransparency</c> -> <c>WindowDecorations.None</c>
+    ///         plus <c>TransparencyLevelHint = Transparent</c>. The hint is a REQUEST: X11 with no
+    ///         compositor answers <c>None</c>, and the host refuses to show the window in that
+    ///         case rather than painting a solid screen-sized block.</item>
+    ///   <item><c>WS_EX_TOOLWINDOW</c> -> <c>ShowInTaskbar = false</c>.</item>
+    ///   <item><c>WS_EX_NOACTIVATE</c> -> <c>ShowActivated = false</c>.</item>
+    ///   <item><c>WS_EX_TOPMOST</c> -> <c>Topmost</c>, which Avalonia maps to
+    ///         <c>_NET_WM_STATE_ABOVE</c> (see X11Overlay's header for why that is not wrapped).</item>
+    ///   <item><c>WS_EX_TRANSPARENT</c> -> <c>X11Overlay.SetClickThrough</c>, called by the host
+    ///         after <c>Show()</c> because the window has no XID before then.</item>
+    ///   <item><c>SetWindowPos</c> with physical pixels -> <see cref="PlaceOn"/>.
+    ///         <c>Window.Position</c> is ALREADY physical, so the DPI correction the WPF original
+    ///         needs has nothing to correct here; only Width/Height are DIPs and get divided.</item>
+    /// </list>
+    ///
+    /// <para>Opacity is linear, <c>percent / 100</c> straight into the alpha byte - the WPF path
+    /// says "Linear opacity (no exponential curve)" and this keeps it.</para>
+    /// </summary>
+    internal sealed class TintOverlayWindow : Window
+    {
+        private readonly SolidColorBrush _fill = new(Colors.Transparent);
+
+        public TintOverlayWindow()
+        {
+            SystemDecorations = WindowDecorations.None;
+            TransparencyLevelHint = new[] { WindowTransparencyLevel.Transparent };
+            Background = Brushes.Transparent;
+            Topmost = true;
+            ShowInTaskbar = false;
+            ShowActivated = false;
+            CanResize = false;
+            Focusable = false;
+            IsHitTestVisible = false;
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            Content = new Border { Background = _fill };
+
+            // The parameterless ctor is also what --render-all constructs, so it paints the tint
+            // the user's settings actually describe rather than an invented one. At the default
+            // 10% that PNG is a faint wash, which is the honest picture of the feature.
+            Width = 640;
+            Height = 400;
+            var (r, g, b) = PinkFilterOverlay.EffectiveColor();
+            SetTint(r, g, b, CoreSettings.Current.PinkFilterOpacity / 100.0);
+        }
+
+        /// <summary>Repaints in place, the way <c>UpdatePinkFilterOpacity</c> mutates the existing
+        /// brush rather than rebuilding the window - which is what keeps a slider drag from
+        /// creating and destroying a full-screen window on every tick.</summary>
+        public void SetTint(byte r, byte g, byte b, double opacity)
+            => _fill.Color = Color.FromArgb((byte)(Math.Clamp(opacity, 0, 1) * 255), r, g, b);
+
+        /// <summary>Fills exactly one monitor.</summary>
+        public void PlaceOn(Screen screen)
+        {
+            var b = screen.Bounds;
+            var scale = screen.Scaling > 0 ? screen.Scaling : 1.0;
+            Position = new PixelPoint(b.X, b.Y);
+            Width = b.Width / scale;
+            Height = b.Height / scale;
+        }
+    }
+}


### PR DESCRIPTION
First overlay feature on this head that draws. The card no longer only saves:
enable, opacity, colour and monitor target all push to a live surface.

What landed:

  Views/Overlays/TintOverlayWindow.cs   one screen of flat colour. Code-only, no
    .axaml - the whole window is a Border whose brush is the only thing that
    changes. Each Win32 style the WPF original ORs in inside SourceInitialized
    maps to a property: WindowStyle=None + AllowsTransparency ->
    WindowDecorations.None + TransparencyLevelHint, WS_EX_TOOLWINDOW ->
    ShowInTaskbar, WS_EX_NOACTIVATE -> ShowActivated, WS_EX_TOPMOST -> Topmost
    (_NET_WM_STATE_ABOVE), WS_EX_TRANSPARENT -> X11Overlay.SetClickThrough.
    SetWindowPos's physical-pixel correction has nothing to correct: Position is
    already physical, so only Width/Height divide by Screen.Scaling. Opacity
    stays linear, percent/100 into the alpha byte.

  Views/Overlays/PinkFilterOverlay.cs   the host: one window per targeted
    monitor. ResolveScreenIndices ports App.ResolveScreens case for case, so the
    persisted sentinels (-1 FollowGlobal, -2 All, 0..N index, out-of-range folds
    back to FollowGlobal without rewriting the setting) mean the same thing on
    both heads. A repaint reuses the windows and only mutates the brush, which is
    what keeps a slider drag from rebuilding a full-screen window per tick.

Where the line is, and why:

  Two refusals, both the "a half-port is worse than the stub" case, and both
  close the window rather than leave it up:
    - X11Overlay.SetClickThrough returning false. A full-screen topmost window
      that is NOT click-through locks the user out of their own desktop.
    - ActualTransparencyLevel == None (X11 with no compositor). That paints an
      opaque screen-sized block, not a wash.
  X11Overlay.IsAvailable is checked BEFORE any window is created too, so a
  slider drag on a platform that cannot do this creates nothing at all rather
  than flashing a full-screen window per tick. So the tint draws on X11 with a
  compositor and nowhere else: no tint through the Avalonia head on Windows or
  under a native Wayland backend, deliberately, rather than an un-dismissable one.

  WPF gates the tint on the session engine: OverlayService.RefreshOverlays()
  returns early when !_isRunning. That gate is mirrored, EXCEPT when there is no
  engine at all (CoreSession unseeded, which is this head). Mirroring it
  literally would mean the checkbox could never draw anything on Linux, ever;
  with no engine to own the tint's lifecycle, the card owns it. The moment a head
  seeds CoreSession, the WPF rule takes over on its own.

  The host hooks the owning window's Closed. Avalonia's default ShutdownMode is
  OnLastWindowClose and these are windows, so without it closing the shell leaves
  a live process behind a pink sheet with no UI to switch it off.

No Core seam was added: the card and the surface are both in this head, so
CoreOverlay would have been an indirection with one caller on each side.

Click-through itself was NOT observed this session - no X server was used, per
the nested-compositor rule. It rests on X11OverlayProbe's prior evidence plus the
refusal above, which is why the subject says the card drives the surface and not
that click-through works.

Still blocked:
  - Startup restore. Nothing calls PinkFilterOverlay.Refresh at launch, so a
    tint left enabled in settings returns only when the user touches the card.
    That belongs to whatever owns the start-up sequence
    (ConditioningControlPanel/Services/Notifications/OverlayService.cs Start()).
  - Everything the session engine owns in that same file: _timedPinkHolds,
    _sustainedPinkHeld, _rampPinkOpacity (Deeper), the 500ms UpdateOverlays poll
    and ShowPinkFilterAdHoc. All need a session engine on this head.
  - A DualMonitorEnabled change made elsewhere does not refresh the tint; WPF got
    that through OverlayService.RefreshOverlays, and this card does not hear it.
  - The compositor path (OverlayService.UseCompositor / GetPinkLayer) is
    Windows-only and not ported.
  - PinkFilterFeatureControl's mod-aware hero art still has no x:Name to paint.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU