### PR TITLE
feat(core): the lock-card schedule and phrase rotation are portable; Avalonia's Test button shows a real card

### DIFF
--- a/CCP.Avalonia/App.axaml.cs
+++ b/CCP.Avalonia/App.axaml.cs
@@ -47,6 +47,25 @@ namespace ConditioningControlPanel.Avalonia
                 Settings = new SettingsService();
                 CoreSettings.ServiceProvider = () => Settings;
 
+                // The lock-card surface seam. The schedule and the no-repeat phrase rotation are in
+                // Core now (LockCardScheduler); this is the half that draws, and on this head that
+                // is LockCardWindow.ShowOnAllMonitors - which already refuses to stack a second
+                // card and already falls a voice-mode card back to typing, honestly, because there
+                // is no recognition seam here yet.
+                //
+                // The hop is explicit because CoreDispatch is unseeded on this head, so the
+                // scheduler's tick arrives on a thread-pool thread. Everything after the hop -
+                // including the phrase draw - therefore runs on the UI thread, which is what keeps
+                // the scheduler's rotation state single-threaded.
+                CoreLockCard.ShowHandler = isTest => global::Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    var phrase = LockCardScheduler.Instance.PickPhrase(LockCardScheduler.EnabledPhrases());
+                    if (phrase is null) return;   // no enabled phrases: nothing to lock behind
+                    var s = CoreSettings.Current;
+                    Views.Windows.LockCardWindow.ShowOnAllMonitors(
+                        phrase, s.LockCardRepeats, s.LockCardStrict, isTest, s.LockCardVoiceMode);
+                });
+
                 // No CoreMods seeding here, deliberately. ModService is still in the WPF head, so
                 // this head has nothing to seed the mod seam with and leaves every provider null.
                 // Unseeded is the supported state: CoreMods answers from the built-in manifests,

--- a/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/LockCardFeatureControl.axaml.cs
@@ -1,12 +1,12 @@
 using System;
 using System.ComponentModel;
-using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
 using Serilog;
 
 namespace ConditioningControlPanel.Avalonia.Views.Features
@@ -21,10 +21,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
     /// warning, and voice mode still has to clear the mic consent flow before it is written. Both
     /// dialogs are awaited rather than blocking, and a decline reverts the box.</para>
     ///
-    /// <para>Still head-side: LockCardService (start/stop/test) and the mod-aware feature art. The
-    /// voice hint asks <see cref="CoreSpeech"/> for all four of its branches; with no speech
-    /// service seeded on this head it reports no capture device, so the "on" branch lands on
-    /// "No microphone detected", which is the honest answer here.</para>
+    /// <para>Start/stop/test are live now. The schedule is <see cref="LockCardScheduler"/> in Core;
+    /// showing a card goes through <see cref="CoreLockCard"/>, which this head seeds onto
+    /// <see cref="Windows.LockCardWindow.ShowOnAllMonitors"/>. The enable toggle keeps WPF's gate,
+    /// so with <see cref="CoreSession"/> unseeded here it never arms - Test is what puts a real card
+    /// on screen on this head.</para>
+    ///
+    /// <para>Still head-side: the mod-aware feature art. The voice hint asks
+    /// <see cref="CoreSpeech"/> for all four of its branches; with no speech service seeded on this
+    /// head it reports no capture device, so the "on" branch lands on "No microphone detected",
+    /// which is the honest answer here.</para>
     /// </summary>
     public partial class LockCardFeatureControl : UserControl
     {
@@ -113,10 +119,16 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             s.LockCardEnabled = on;
             CoreSettings.Save();
 
-            // ponytail: WPF live-applies here - App.LockCard.Start()/Stop(), gated on
-            // App.IsEngineRunning. Both are head-side: LockCardService
-            // (ConditioningControlPanel/Services/LockCard/LockCardService.cs) and
-            // App.IsEngineRunning (ConditioningControlPanel/App.xaml.cs:784).
+            // Live-apply, the same shape and the same gate as WPF: start or stop the schedule only
+            // while the engine is running. LockCardScheduler is in Core now, so this is a real call
+            // on both heads - but CoreSession is unseeded here (no session engine on this head yet),
+            // so IsEngineRunning is false and this branch never arms. That is the truth, not a stub:
+            // the Test button below is what shows a card on this head today.
+            if (CoreSession.IsEngineRunning)
+            {
+                if (on) LockCardScheduler.Instance.Start();
+                else LockCardScheduler.Instance.Stop();
+            }
         }
 
         private void SliderFreq_Changed(object? sender, RangeBaseValueChangedEventArgs e)
@@ -245,16 +257,10 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             Log.Information("Lock card phrases updated: {Count} items", editor.ResultData.Count);
         }
 
-        /// <summary>
-        /// The "no enabled phrases" guard is settings-backed, so it is real here; what it guards
-        /// is not, yet.
-        /// </summary>
+        /// <summary>Shows a real test card, through the same surface seam the scheduler uses.</summary>
         private async void BtnTest_Click(object? sender, RoutedEventArgs e)
         {
-            var s = CoreSettings.Current;
-
-            var enabledPhrases = s.LockCardPhrases.Where(p => p.Value).Select(p => p.Key).ToList();
-            if (enabledPhrases.Count == 0)
+            if (LockCardScheduler.EnabledPhrases().Count == 0)
             {
                 // WPF's MessageBox.Show(…, "No Phrases", OK, Warning), through this head's twin.
                 if (TopLevel.GetTopLevel(this) is Window owner)
@@ -262,8 +268,7 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
                         owner, "No Phrases", Loc.Get("msg_no_phrases_enabled_add_some_phrases_first"));
                 return;
             }
-            // ponytail: needs App.LockCard.TestLockCard() - LockCardService
-            // (ConditioningControlPanel/Services/LockCard/LockCardService.cs), still head-side.
+            CoreLockCard.Show(isTest: true);
         }
 
         private async void BtnColorSettings_Click(object? sender, RoutedEventArgs e)

--- a/CCP.Core/CoreLockCard.cs
+++ b/CCP.Core/CoreLockCard.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The lock-card <b>surface</b> seam: put a card on screen. The other half of the split -
+    /// when a card is due and which phrase it carries - is portable and lives in
+    /// <see cref="Services.LockCardScheduler"/>.
+    ///
+    /// <para>Showing one is not portable in any part. A lock card is an ownerless topmost cover on
+    /// every monitor with input synced across them; on the WPF head it must additionally clear the
+    /// interaction queue and a visible pop quiz, and its defer-and-replay policy is written against
+    /// <c>App.InteractionQueue</c>, <c>LockCardWindow</c> and <c>PopQuizWindow</c>. So this seam is
+    /// one delegate and the head supplies all of it - repeats, strict, voice and the phrase draw
+    /// included, because each head resolves those at the moment it actually shows the card.</para>
+    ///
+    /// <para><b>Unseeded is honest, not degraded.</b> A head with no lock-card window shows no lock
+    /// card; nothing is gated on this, nothing is unlocked by its absence, and the scheduler goes on
+    /// keeping correct time behind it. That is strictly the same outcome as the WPF original when
+    /// <c>App.LockCard</c> was null, which every call site there already writes as
+    /// <c>App.LockCard?.</c>.</para>
+    /// </summary>
+    public static class CoreLockCard
+    {
+        /// <summary>
+        /// Show a lock card now. <c>isTest</c> is the dashboard's Test button: the head's window
+        /// treats a test card as dismissible and awards nothing for it.
+        ///
+        /// <para>The head is expected to hop to its own UI thread, refuse to stack a second card,
+        /// draw the phrase through <see cref="Services.LockCardScheduler.PickPhrase"/> and read
+        /// repeats/strict/voice from <see cref="CoreSettings"/>.</para>
+        /// </summary>
+        public static volatile Action<bool>? ShowHandler;
+
+        /// <summary>Ask the head to show a card. Never throws; a head that is tearing down must not
+        /// take the scheduler with it.</summary>
+        public static void Show(bool isTest = false)
+        {
+            try { ShowHandler?.Invoke(isTest); } catch { }
+        }
+    }
+}

--- a/CCP.Core/Services/LockCard/LockCardScheduler.cs
+++ b/CCP.Core/Services/LockCard/LockCardScheduler.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Serilog;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// The portable half of the lock card: <b>when</b> the next card is due and <b>which</b> phrase
+    /// it carries. Both are arithmetic over <c>AppSettings</c> and a clock, so both live here.
+    ///
+    /// <para>Drawing is not. A lock card is an ownerless topmost cover over every monitor, and on
+    /// the WPF head it also has to negotiate with the interaction queue and a pop quiz before it
+    /// may appear. That whole decision stays in the head behind <see cref="CoreLockCard"/>, which
+    /// this class calls with nothing but "a card is due, and it is/isn't a test".</para>
+    ///
+    /// <para>One shared instance, because the rotation memory has to be shared: WPF's
+    /// <c>LockCardService</c> wraps this one, and every ad-hoc card (voice command, Deeper, the
+    /// dashboard Test button, remote trigger) draws its phrase from the same window of recently
+    /// shown ones the scheduled cards do.</para>
+    ///
+    /// <para>The WPF original ran on a <c>DispatcherTimer</c>, so its tick was on the UI thread. A
+    /// <see cref="Timer"/> ticks on the thread pool, so the body hops back through
+    /// <see cref="CoreDispatch"/> - which, unseeded, runs it in place. <see cref="PickPhrase"/> is
+    /// deliberately NOT called from the tick: the head calls it at show time, after its queue gate,
+    /// on its UI thread. Rotation state is therefore touched from one thread only, and a card that
+    /// is deferred or dropped never burns a rotation slot.</para>
+    /// </summary>
+    public sealed class LockCardScheduler : IDisposable
+    {
+        /// <summary>The app's one lock-card schedule. Both heads drive this instance.</summary>
+        public static LockCardScheduler Instance { get; } = new();
+
+        private Timer? _timer;
+        private volatile bool _isRunning;
+
+        // Per-session no-repeat rotation, in-memory only - lock-card rotation deliberately does NOT
+        // persist to disk. Avoids replaying any of the last few phrases so a pure random draw can't
+        // repeat the same phrase back-to-back.
+        private readonly Queue<string> _recentPhrases = new();
+        private readonly HashSet<string> _recentPhrasesSet = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>How many distinct just-shown phrases to avoid replaying.</summary>
+        private const int RecentPhrasesMemory = 3;
+
+        public bool IsRunning => _isRunning;
+
+        /// <param name="windowMinutes">
+        /// #736: how long the caller expects to keep the schedule running - a session's remaining
+        /// minutes. When supplied, the first card is guaranteed to land inside that window with
+        /// room to complete it. Null (dashboard use) means open-ended.
+        /// </param>
+        public void Start(double? windowMinutes = null)
+        {
+            if (_isRunning) return;
+
+            if (!CoreSettings.Current.LockCardEnabled)
+            {
+                Log.Information("LockCardScheduler: Disabled in settings");
+                return;
+            }
+
+            var perHour = Math.Max(1, CoreSettings.Current.LockCardFrequency);
+            var firstDelay = ComputeFirstCardDelayMinutes(perHour, windowMinutes, Random.Shared.NextDouble());
+
+            _isRunning = true;
+
+            // One-shot, re-armed inside the tick - which is all reassigning DispatcherTimer.Interval
+            // ever amounted to. The callback closes over its own timer so the tick can tell whether
+            // it is still the live one (see Tick).
+            Timer? created = null;
+            created = new Timer(_ => { var mine = created; CoreDispatch.Post(() => Tick(mine)); });
+            _timer = created;
+            created.Change(TimeSpan.FromMinutes(firstDelay), Timeout.InfiniteTimeSpan);
+
+            Log.Information(
+                "LockCardScheduler started - approximately {PerHour}/hour, first card in {First:F1}min (window {Window})",
+                perHour, firstDelay, windowMinutes is > 0 ? $"{windowMinutes.Value:F1}min" : "open-ended");
+        }
+
+        /// <summary>Stop the schedule. Scheduler only: a card already on screen is the head's to
+        /// drop, and most Stop() callers (pausing a session, un-ticking the feature, applying a
+        /// preset) must never walk through strict mode on a card the user is mid-way through
+        /// typing.</summary>
+        public void Stop()
+        {
+            if (!_isRunning) return;
+            _isRunning = false;
+
+            var timer = _timer;
+            _timer = null;
+            timer?.Dispose();
+
+            Log.Information("LockCardScheduler stopped");
+        }
+
+        /// <summary>A card is due: re-arm for the next one, then ask the head to show it.</summary>
+        /// <param name="firedBy">
+        /// The timer this tick belongs to. A <see cref="Timer"/> callback already in flight - plus
+        /// the <see cref="CoreDispatch"/> hop - can land AFTER <see cref="Stop"/>, where WPF's
+        /// <c>DispatcherTimer.Stop()</c> cancelled a pending tick outright. Without this check,
+        /// pausing a session could still pop a card.
+        /// </param>
+        private void Tick(Timer? firedBy)
+        {
+            if (!_isRunning || !ReferenceEquals(firedBy, _timer)) return;
+
+            var settings = CoreSettings.Current;
+            var next = ComputeNextIntervalMinutes(settings.LockCardFrequency, Random.Shared.NextDouble());
+            try { _timer?.Change(TimeSpan.FromMinutes(next), Timeout.InfiniteTimeSpan); }
+            catch (ObjectDisposedException) { return; }
+
+            if (!settings.LockCardEnabled) return;
+
+            CoreLockCard.Show(isTest: false);
+        }
+
+        /// <summary>#736: delay before the FIRST lock card of a run, in minutes. Pure so the
+        /// reachability guarantee is unit-testable without a dispatcher.
+        ///
+        /// The first card is an OFFSET into the opening interval, not a whole inter-arrival gap.
+        /// Scheduling it at 60/freq ±30% (as before) put the earliest possible card at 1/hour at
+        /// minute 42, so a 30-minute session could never produce one — which hard-blocked every
+        /// program day whose task required a lock card. Subsequent cards keep the ±30% spacing in
+        /// <see cref="ComputeNextIntervalMinutes"/>.
+        ///
+        /// When <paramref name="windowMinutes"/> is supplied the card is additionally clamped to
+        /// land inside it, leaving the tail free so the user can actually complete the card.
+        /// </summary>
+        /// <param name="perHour">Cards per hour; values below 1 are treated as 1.</param>
+        /// <param name="windowMinutes">Minutes the schedule will keep running, or null for open-ended.</param>
+        /// <param name="roll">A uniform random sample in [0,1).</param>
+        public static double ComputeFirstCardDelayMinutes(int perHour, double? windowMinutes, double roll)
+        {
+            var intervalMinutes = 60.0 / Math.Max(1, perHour);
+
+            var maxFirst = intervalMinutes;
+            if (windowMinutes is > 0)
+                maxFirst = Math.Min(maxFirst, windowMinutes.Value * 0.8);
+
+            return roll * maxFirst;
+        }
+
+        /// <summary>Gap to the card after that: the nominal 60/freq, jittered ±30% so the cards
+        /// don't land on a metronome. Extracted from the WPF tick body verbatim.</summary>
+        /// <param name="roll">A uniform random sample in [0,1).</param>
+        public static double ComputeNextIntervalMinutes(int perHour, double roll)
+        {
+            var intervalMinutes = 60.0 / Math.Max(1, perHour);
+            var min = intervalMinutes * 0.7;
+            var max = intervalMinutes * 1.3;
+            return roll * (max - min) + min;
+        }
+
+        /// <summary>
+        /// Pick a phrase at random while avoiding the last few shown, so the same phrase can't
+        /// repeat back-to-back. Filters the enabled pool against the recent set (rather than
+        /// re-rolling in a loop); if that empties the pool — or only one phrase is enabled — we
+        /// skip rotation and draw from the full list so we can never loop forever or go silent.
+        /// </summary>
+        /// <returns>The chosen phrase, or null when the pool is empty.</returns>
+        public string? PickPhrase(IReadOnlyList<string> enabledPhrases)
+        {
+            if (enabledPhrases is null || enabledPhrases.Count == 0) return null;
+
+            IReadOnlyList<string> candidates = enabledPhrases;
+            if (enabledPhrases.Count > 1)
+            {
+                var fresh = enabledPhrases.Where(p => !_recentPhrasesSet.Contains(p)).ToList();
+                if (fresh.Count > 0) candidates = fresh;
+            }
+
+            var phrase = candidates[Random.Shared.Next(candidates.Count)];
+
+            // Remember it, then trim the window to at most (pool - 1) so there's always at least one
+            // fresh candidate next time, capped at RecentPhrasesMemory. Skip tracking a lone phrase.
+            if (enabledPhrases.Count > 1 && _recentPhrasesSet.Add(phrase))
+            {
+                _recentPhrases.Enqueue(phrase);
+                int cap = Math.Min(enabledPhrases.Count - 1, RecentPhrasesMemory);
+                while (_recentPhrases.Count > cap)
+                    _recentPhrasesSet.Remove(_recentPhrases.Dequeue());
+            }
+
+            return phrase;
+        }
+
+        /// <summary>The enabled half of the phrase pool, in settings order. Both heads' "no phrases
+        /// enabled" guard and both heads' draw read the pool through here.</summary>
+        public static List<string> EnabledPhrases() =>
+            CoreSettings.Current.LockCardPhrases?.Where(p => p.Value).Select(p => p.Key).ToList()
+            ?? new List<string>();
+
+        public void Dispose() => Stop();
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -52,6 +52,7 @@ namespace ConditioningControlPanel.LinuxSmoke
             Arithmetic();
             ConsentAndReports();
             Roadmap();
+            LockCard();
 
             Console.WriteLine();
             if (_failures == 0)
@@ -582,6 +583,77 @@ namespace ConditioningControlPanel.LinuxSmoke
                   roadmap.GetFullPhotoPath("t1_step1_x.png").StartsWith(roadmap.DiaryFolderPath, StringComparison.Ordinal));
             Check("an empty photo path resolves to empty, not to the folder itself",
                   roadmap.GetFullPhotoPath("") == "");
+        }
+
+        /// <summary>
+        /// The lock-card split: the schedule and the phrase rotation are Core's, the card itself is
+        /// the head's. A headless render cannot exercise either, so this is where the scheduler is
+        /// actually run.
+        /// </summary>
+        private static void LockCard()
+        {
+            Console.WriteLine("\nLock card (schedule in Core, surface in the head)");
+
+            Check("CoreLockCard.Show is a no-op with no surface seeded",
+                  Safe(() => { CoreLockCard.Show(); CoreLockCard.Show(isTest: true); }));
+
+            // #736 - the regression that hard-blocked Kept Day 1: a 30-minute session, cards
+            // deferred to minute 12, 1/hour. The worst-case roll must still land inside the window.
+            Check("the first card lands inside an 18-minute window at 1/hour",
+                  LockCardScheduler.ComputeFirstCardDelayMinutes(1, 18, 0.999999) < 18);
+            Check("an open-ended first card stays inside one interval",
+                  LockCardScheduler.ComputeFirstCardDelayMinutes(4, null, 0.999999) < 15.0 &&
+                  LockCardScheduler.ComputeFirstCardDelayMinutes(1, null, 0.0) == 0.0);
+            Check("the spacing after the first card is 60/freq +/-30%",
+                  Math.Abs(LockCardScheduler.ComputeNextIntervalMinutes(1, 0.0) - 42.0) < 1e-9 &&
+                  Math.Abs(LockCardScheduler.ComputeNextIntervalMinutes(1, 1.0) - 78.0) < 1e-9);
+            Check("frequency 0 is treated as 1/hour rather than dividing by zero",
+                  LockCardScheduler.ComputeNextIntervalMinutes(0, 0.5) == LockCardScheduler.ComputeNextIntervalMinutes(1, 0.5));
+
+            var scheduler = new LockCardScheduler();
+            var pool = new List<string> { "a", "b", "c" };
+            var noRepeat = true;
+            var previous = scheduler.PickPhrase(pool);
+            for (var i = 0; i < 50; i++)
+            {
+                var next = scheduler.PickPhrase(pool);
+                if (next == previous) noRepeat = false;
+                previous = next;
+            }
+            Check("the phrase rotation never repeats back-to-back over 50 draws", noRepeat);
+            Check("a one-phrase pool still draws that phrase every time",
+                  scheduler.PickPhrase(new List<string> { "only" }) == "only" &&
+                  scheduler.PickPhrase(new List<string> { "only" }) == "only");
+            Check("an empty pool draws null rather than throwing",
+                  scheduler.PickPhrase(new List<string>()) is null);
+
+            // CoreSettings.Current is one shared default instance for the whole run, so put the
+            // flag back or every later check inherits it.
+            var settings = CoreSettings.Current;
+            var wasEnabled = settings.LockCardEnabled;
+            try
+            {
+                settings.LockCardEnabled = false;
+                scheduler.Start();
+                Check("Start() with the feature off leaves the schedule stopped", !scheduler.IsRunning);
+
+                settings.LockCardEnabled = true;
+                scheduler.Start();
+                Check("Start() with the feature on runs the schedule", scheduler.IsRunning);
+                scheduler.Stop();
+                Check("Stop() stops it", !scheduler.IsRunning);
+            }
+            finally { settings.LockCardEnabled = wasEnabled; }
+
+            Check("the enabled pool reads through Core, and is never null",
+                  LockCardScheduler.EnabledPhrases() is not null);
+        }
+
+        /// <summary>True when the action ran without throwing.</summary>
+        private static bool Safe(Action action)
+        {
+            try { action(); return true; }
+            catch { return false; }
         }
 
         /// <summary>Pure math must not drift with locale or floating-point defaults.</summary>

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -361,6 +361,11 @@ namespace ConditioningControlPanel
             // The engine-running flag, for the feature cards that only live-apply while a session
             // is up. The engine stays here; the flag is the whole seam.
             CoreSession.IsEngineRunningProvider = () => IsEngineRunning;
+            // The lock-card surface seam. The schedule moved to Core (LockCardScheduler); showing
+            // the card did not, because here it first has to clear the interaction queue and a
+            // visible pop quiz. Lazy, like the rest: LockCard is constructed in OnStartup, long
+            // after this ctor, and every existing caller already writes App.LockCard?.
+            CoreLockCard.ShowHandler = isTest => LockCard?.ShowLockCard(isTest: isTest);
             // The entitlement seam, for TierGate (now CCP.Core/Services/TierGate.cs). Deciding is
             // policy and moved; the two account bars, the daily-free wheel and the refusal toast
             // stay here. Every one is a lambda, not an eager read: Patreon, DailyFree and

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
-using System.Windows.Threading;
 using ConditioningControlPanel.Helpers;
 
 namespace ConditioningControlPanel.Services
@@ -15,25 +12,31 @@ namespace ConditioningControlPanel.Services
     }
 
     /// <summary>
-    /// Service that manages Lock Card popups
+    /// The Windows head's half of the lock card: putting one on screen, and negotiating with the
+    /// interaction queue and a visible pop quiz for the right to do so.
+    ///
+    /// <para>The schedule is no longer here. <see cref="LockCardScheduler"/> in Core owns the timer,
+    /// the first-card offset, the ±30% spacing and the no-repeat phrase rotation - all of it
+    /// arithmetic over <c>AppSettings</c> and a clock, so all of it portable. This class keeps its
+    /// public shape (<see cref="Start"/>, <see cref="Stop"/>, <see cref="IsRunning"/>,
+    /// <see cref="ShowLockCard"/>, <see cref="TestLockCard"/>) so no caller moved, and forwards the
+    /// scheduling half to the shared <see cref="LockCardScheduler.Instance"/> - shared because every
+    /// ad-hoc card here (voice command, Deeper, the dashboard Test button, remote trigger) must draw
+    /// from the same rotation window the scheduled cards do.</para>
+    ///
+    /// <para>What deliberately did NOT move: <see cref="ResolveBlockedCardAction"/> and
+    /// <see cref="BlockedCardAction"/>. They are pure, but they describe a race between two WPF
+    /// window classes and this head's interaction queue, and moving them would have edited two test
+    /// files this layer does not own for no behaviour gained.</para>
     /// </summary>
     public class LockCardService : IDisposable
     {
-        private DispatcherTimer? _timer;
-        private Random _random = new();
-        private bool _isRunning;
         private bool _isDisposed;
-        private DateTime _lastShown = DateTime.MinValue;
 
-        // Per-session no-repeat rotation (mirrors BarkService's _recentlySpoken idiom, but in-memory
-        // only — lock-card rotation deliberately does NOT persist to disk). Avoids replaying any of
-        // the last few phrases so a pure random draw can't repeat the same phrase back-to-back.
-        private readonly Queue<string> _recentPhrases = new();
-        private readonly HashSet<string> _recentPhrasesSet = new(StringComparer.OrdinalIgnoreCase);
-        /// <summary>How many distinct just-shown phrases to avoid replaying.</summary>
-        private const int RecentPhrasesMemory = 3;
+        /// <summary>The schedule, in Core. Shared, so ad-hoc cards share its phrase rotation.</summary>
+        private static LockCardScheduler Scheduler => LockCardScheduler.Instance;
 
-        public bool IsRunning => _isRunning;
+        public bool IsRunning => Scheduler.IsRunning;
 
         /// <summary>
         /// Fires when the user finishes typing all repeats of a real (non-test) lock card.
@@ -73,34 +76,7 @@ namespace ConditioningControlPanel.Services
         /// minutes. When supplied, the first card is guaranteed to land inside that window with
         /// room to complete it. Null (dashboard use) means open-ended.
         /// </param>
-        public void Start(double? windowMinutes = null)
-        {
-            if (_isRunning) return;
-
-            var settings = App.Settings.Current;
-
-            if (!settings.LockCardEnabled)
-            {
-                App.Logger?.Information("LockCardService: Disabled in settings");
-                return;
-            }
-
-            _isRunning = true;
-
-            var perHour = Math.Max(1, settings.LockCardFrequency);
-            var firstDelay = ComputeFirstCardDelayMinutes(perHour, windowMinutes, _random.NextDouble());
-
-            _timer = new DispatcherTimer
-            {
-                Interval = TimeSpan.FromMinutes(firstDelay)
-            };
-            _timer.Tick += Timer_Tick;
-            _timer.Start();
-
-            App.Logger?.Information(
-                "LockCardService started - approximately {PerHour}/hour, first card in {First:F1}min (window {Window})",
-                perHour, firstDelay, windowMinutes is > 0 ? $"{windowMinutes.Value:F1}min" : "open-ended");
-        }
+        public void Start(double? windowMinutes = null) => Scheduler.Start(windowMinutes);
 
         /// <summary>
         /// Stop the scheduler. <paramref name="dismissOpenCards"/> additionally tears down a card that
@@ -128,61 +104,14 @@ namespace ConditioningControlPanel.Services
                 try { LockCardWindow.ForceCloseAll(); } catch { }
             }
 
-            if (!_isRunning) return;
-            _isRunning = false;
-            
-            _timer?.Stop();
-            _timer = null;
-            
-            App.Logger?.Information("LockCardService stopped");
+            Scheduler.Stop();
         }
 
-        private void Timer_Tick(object? sender, EventArgs e)
-        {
-            // Recalculate next interval with randomness
-            var settings = App.Settings.Current;
-            var perHour = Math.Max(1, settings.LockCardFrequency);
-            var intervalMinutes = 60.0 / perHour;
-            var minInterval = intervalMinutes * 0.7;
-            var maxInterval = intervalMinutes * 1.3;
-            
-            if (_timer != null)
-            {
-                _timer.Interval = TimeSpan.FromMinutes(_random.NextDouble() * (maxInterval - minInterval) + minInterval);
-            }
-            
-            // Check if enabled
-            if (!settings.LockCardEnabled) return;
-            
-            // Show the lock card
-            ShowLockCard();
-        }
-
-        /// <summary>#736: delay before the FIRST lock card of a run, in minutes. Pure so the
-        /// reachability guarantee is unit-testable without a dispatcher.
-        ///
-        /// The first card is an OFFSET into the opening interval, not a whole inter-arrival gap.
-        /// Scheduling it at 60/freq ±30% (as before) put the earliest possible card at 1/hour at
-        /// minute 42, so a 30-minute session could never produce one — which hard-blocked every
-        /// program day whose task required a lock card. Subsequent cards keep the ±30% spacing in
-        /// <see cref="Timer_Tick"/>.
-        ///
-        /// When <paramref name="windowMinutes"/> is supplied the card is additionally clamped to
-        /// land inside it, leaving the tail free so the user can actually complete the card.
-        /// </summary>
-        /// <param name="perHour">Cards per hour; values below 1 are treated as 1.</param>
-        /// <param name="windowMinutes">Minutes the service will keep running, or null for open-ended.</param>
-        /// <param name="roll">A uniform random sample in [0,1).</param>
+        /// <summary>#736: delay before the FIRST lock card of a run, in minutes. The rule moved to
+        /// <see cref="LockCardScheduler.ComputeFirstCardDelayMinutes"/>; this forwards so
+        /// LockCardScheduleTests keeps testing the one implementation.</summary>
         internal static double ComputeFirstCardDelayMinutes(int perHour, double? windowMinutes, double roll)
-        {
-            var intervalMinutes = 60.0 / Math.Max(1, perHour);
-
-            var maxFirst = intervalMinutes;
-            if (windowMinutes is > 0)
-                maxFirst = Math.Min(maxFirst, windowMinutes.Value * 0.8);
-
-            return roll * maxFirst;
-        }
+            => LockCardScheduler.ComputeFirstCardDelayMinutes(perHour, windowMinutes, roll);
 
         /// <summary>Decision for what to do when <see cref="ShowLockCard"/> finds another fullscreen
         /// interaction already visible — a lock card (#676) or a pop quiz (#763). Pure so the
@@ -284,10 +213,7 @@ namespace ConditioningControlPanel.Services
                     var settings = App.Settings.Current;
 
                     // Get enabled phrases
-                    var enabledPhrases = settings.LockCardPhrases?
-                        .Where(p => p.Value)
-                        .Select(p => p.Key)
-                        .ToList() ?? new List<string>();
+                    List<string> enabledPhrases = LockCardScheduler.EnabledPhrases();
 
                     if (enabledPhrases.Count == 0)
                     {
@@ -306,16 +232,17 @@ namespace ConditioningControlPanel.Services
                     }
 
                     // Pick a random phrase (or use custom one if AI provided it). The custom (AI-supplied)
-                    // path bypasses rotation entirely — it isn't a draw from the enabled pool.
-                    var phrase = customPhrase ?? PickPhrase(enabledPhrases);
+                    // path bypasses rotation entirely — it isn't a draw from the enabled pool. The draw
+                    // happens HERE, past every gate above, so a deferred or dropped card never consumes a
+                    // rotation slot — and on the UI thread, which is what keeps the scheduler's rotation
+                    // state single-threaded.
+                    var phrase = customPhrase ?? Scheduler.PickPhrase(enabledPhrases)!;
                     var repeats = customRepeats >= 0 ? customRepeats : settings.LockCardRepeats;
                     var strict = customStrict || settings.LockCardStrict;
                     var voice = settings.LockCardVoiceMode;
 
                     // Show on all monitors with synced input
                     LockCardWindow.ShowOnAllMonitors(phrase, repeats, strict, isTest, voice);
-
-                    _lastShown = DateTime.Now;
 
                     App.Logger?.Information("Lock Card shown on all monitors - Phrase: {Phrase}", phrase);
                 }
@@ -330,36 +257,6 @@ namespace ConditioningControlPanel.Services
                     App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.LockCard);
                 }
             });
-        }
-
-        /// <summary>
-        /// Pick a phrase at random while avoiding the last few shown, so the same phrase can't
-        /// repeat back-to-back. Filters the enabled pool against the recent set (rather than
-        /// re-rolling in a loop); if that empties the pool — or only one phrase is enabled — we
-        /// skip rotation and draw from the full list so we can never loop forever or go silent.
-        /// </summary>
-        private string PickPhrase(List<string> enabledPhrases)
-        {
-            var candidates = enabledPhrases;
-            if (enabledPhrases.Count > 1)
-            {
-                var fresh = enabledPhrases.Where(p => !_recentPhrasesSet.Contains(p)).ToList();
-                if (fresh.Count > 0) candidates = fresh;
-            }
-
-            var phrase = candidates[_random.Next(candidates.Count)];
-
-            // Remember it, then trim the window to at most (pool - 1) so there's always at least one
-            // fresh candidate next time, capped at RecentPhrasesMemory. Skip tracking a lone phrase.
-            if (enabledPhrases.Count > 1 && _recentPhrasesSet.Add(phrase))
-            {
-                _recentPhrases.Enqueue(phrase);
-                int cap = Math.Min(enabledPhrases.Count - 1, RecentPhrasesMemory);
-                while (_recentPhrases.Count > cap)
-                    _recentPhrasesSet.Remove(_recentPhrases.Dequeue());
-            }
-
-            return phrase;
         }
 
         /// <summary>


### PR DESCRIPTION
Splits the smallest feature service along the deciding/drawing line.

Moved to Core (CCP.Core/Services/LockCard/LockCardScheduler.cs):
  - the timer, as a one-shot System.Threading.Timer re-armed in its own tick, whose
    body hops back through CoreDispatch.Post because the WPF DispatcherTimer ticked
    on the UI thread;
  - ComputeFirstCardDelayMinutes (#736, the first card is an offset INTO the opening
    interval, clamped to a session window) and ComputeNextIntervalMinutes (60/freq
    jittered +/-30%), the latter lifted out of the WPF tick body;
  - the per-session no-repeat phrase rotation, and EnabledPhrases() so both heads read
    the pool through one place.

New seam CCP.Core/CoreLockCard.cs: one delegate, Show(isTest). Showing a card is not
portable in any part - it is an ownerless topmost cover on every monitor, and on WPF it
must first clear the interaction queue and a visible pop quiz. Unseeded is honest rather
than degraded: a head with no lock-card window shows no lock card, nothing is gated on
this, and the schedule goes on keeping correct time behind it. That is exactly what
App.LockCard being null already meant, which every WPF call site writes as App.LockCard?.

Where the line fell, and why there:
  - The dry-run move died on App.Settings/Logger/EmiDesk/InteractionQueue,
    LockCardWindow, PopQuizWindow, DispatcherHelper and DispatcherTimer. Everything
    Roslyn named is orchestration around two WPF window classes; everything it did not
    name is arithmetic. The split follows the compiler.
  - The phrase is drawn at SHOW time, not at tick time - past the queue gate, on the
    head's UI thread. Drawing at tick time would have handed a deferred card a phrase
    chosen minutes earlier, burned a rotation slot on a card that was then dropped, and
    raced the Test button for the rotation state on a head where CoreDispatch is unseeded.
  - Tick() checks that its timer is still the live one. A Timer callback already in
    flight, plus the dispatch hop, can land after Stop(), where DispatcherTimer.Stop()
    cancelled a pending tick outright - without the check, pausing a session could still
    pop a card.
  - ResolveBlockedCardAction and BlockedCardAction stayed in the head. They are pure, but
    they describe a race between LockCardWindow, PopQuizWindow and this head's interaction
    queue, and moving them would have edited two test files this layer does not own for no
    behaviour gained. ComputeFirstCardDelayMinutes keeps a three-line forwarder on
    LockCardService for the same reason, so LockCardScheduleTests still tests the one
    implementation.

Avalonia: App.axaml.cs seeds CoreLockCard onto LockCardWindow.ShowOnAllMonitors, hopping
to the UI thread itself because CoreDispatch is unseeded on this head. The Lab card's
enable toggle now really starts and stops the schedule behind WPF's own
CoreSession.IsEngineRunning gate - which, with no session engine here, never arms; Test is
what puts a card on screen today. Voice mode is passed through unweakened: the window
already refuses it honestly and logs the fallback to typing, and the mic-consent gate on
the checkbox is untouched.

Twelve assertions added to CCP.LinuxSmoke, including the #736 Kept-Day-1 window, the
+/-30% spacing, a 50-draw no-repeat run and Start/Stop against the enabled flag (restored
in a finally, since CoreSettings.Current is one shared instance for the run). Verified
they can fail: setting RecentPhrasesMemory to 0 turns the rotation check red and exits 1.

Still blocked:
  - CoreSession.IsEngineRunningProvider unseeded on CCP.Avalonia (no session engine), so
    LockCardFeatureControl's enable toggle never arms the schedule there.
  - LockCardService.ShowLockCard stays in ConditioningControlPanel/Services/LockCard/ -
    App.InteractionQueue, InteractionQueueService, PopQuizWindow, DispatcherHelper.
  - NotifyCompleted / LockCardCompletedEventArgs stay head-side: App.EmiDesk, and
    BarkService is its only subscriber.
  - Voice solve on CCP.Avalonia needs a CoreSpeech recognition seam
    (RecognizePhraseAsync / LevelChanged / PartialTranscript); LockCardWindow.Configure
    forces _voiceMode false until then.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU