### PR TITLE
feat(core): corner-GIF placement, source order and stagger are portable; the window, admission and restore stay in the head

### DIFF
--- a/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
+++ b/CCP.Avalonia/Views/Features/SpiralFeatureControl.axaml.cs
@@ -137,9 +137,11 @@ namespace ConditioningControlPanel.Avalonia.Views.Features
             else if (e.PropertyName == nameof(AppSettings.SpiralPath))
             {
                 Dispatcher.UIThread.Post(UpdateSelectionHighlight);
-                // ponytail: WPF also re-renders the corner-GIF slots left on "built-in"
-                // (App.CornerGif.RefreshOverlays, ConditioningControlPanel/Services/CornerGifService.cs),
-                // still in the WPF head.
+                // A corner-GIF slot with no pick of its own plays the pool spiral
+                // (CornerGifPlanner.ResolveSourcePath), so a new pool selection changes what those
+                // slots draw. Ask the surface to rebuild them. Unseeded on this head until its
+                // overlay surface exists, so today this is a no-op rather than a wrong picture.
+                CoreCornerGif.Refresh();
             }
         }
 

--- a/CCP.Avalonia/Views/Windows/CornerGifWindow.axaml.cs
+++ b/CCP.Avalonia/Views/Windows/CornerGifWindow.axaml.cs
@@ -364,11 +364,13 @@ namespace ConditioningControlPanel.Avalonia.Views.Windows
         private void ApplyLive(int index = -1)
         {
             CoreSettings.Save();
-            // ponytail: needs CornerGifService.RefreshSlot(int) / RefreshOverlays()
-            // (ConditioningControlPanel/Services/CornerGifService.cs, reached as App.CornerGif),
-            // which is Win32-layered-window code still in the WPF head. The settings write above is
-            // live; only the re-realize of an already-showing overlay is missing.
-            _ = index;
+            // Where the overlay goes is CornerGifPlanner's answer now, and it is the same on every
+            // head. Raising the window is not: CoreCornerGif is the surface seam, seeded by the WPF
+            // head to App.CornerGif and UNSEEDED here until this head's overlay surface lands
+            // (CCP.Avalonia/Views/Overlays/), so this call is a deliberate no-op on Linux. The save
+            // above is the live part - the slot is correct on disk and shows the moment a surface
+            // exists.
+            CoreCornerGif.Refresh(index);
         }
     }
 }

--- a/CCP.Core/CoreCornerGif.cs
+++ b/CCP.Core/CoreCornerGif.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// The corner-GIF SURFACE seam: "the standalone corner-overlay settings changed - put the
+    /// picture where they now say".
+    ///
+    /// <para><see cref="Services.CornerGifPlanner"/> decides everything about a corner GIF except
+    /// the one thing a head must do: create a transparent, click-through, always-on-top window and
+    /// play an animation in it. This is that handback. The WPF head seeds it to
+    /// <c>App.CornerGif</c>; the Avalonia head does not seed it yet, because its overlay surface is
+    /// still being built.</para>
+    ///
+    /// <para>One entry point rather than three, matching what the config UI actually asks for: a
+    /// negative index means "rebuild every slot" (a corner pick or an enable toggle shifts the
+    /// same-corner nudge, so both slots move), and a non-negative index means "rebuild only this
+    /// slot" - the live size/opacity slider edit, which must leave the other slot's window and its
+    /// running animation untouched.</para>
+    ///
+    /// <para>Unseeded this is a NO-OP, and that is the honest answer rather than merely a safe one:
+    /// a head with no overlay surface has no window to rebuild. Settings are saved by the caller
+    /// either way, so the slot is correct on disk and appears the moment a surface exists. It never
+    /// throws - it rides on every slider tick and on the panic path's teardown.</para>
+    /// </summary>
+    public static class CoreCornerGif
+    {
+        /// <summary>Rebuild one slot's overlay (index >= 0) or all of them (index &lt; 0).</summary>
+        public static volatile Action<int>? RefreshHandler;
+
+        /// <summary>True when a head has actually seeded a surface, so a caller can say "saved,
+        /// not shown" instead of implying a picture appeared.</summary>
+        public static bool HasSurface => RefreshHandler != null;
+
+        /// <summary>
+        /// Re-realize the corner overlays from the current settings. <paramref name="index"/> below
+        /// zero rebuilds every slot. Safe to call from any thread and at any time; the seeded
+        /// handler owns its own thread marshalling.
+        /// </summary>
+        public static void Refresh(int index = -1)
+        {
+            try { RefreshHandler?.Invoke(index); } catch { /* a live-apply nudge must never throw */ }
+        }
+    }
+}

--- a/CCP.Core/Services/Media/CornerGifPlanner.cs
+++ b/CCP.Core/Services/Media/CornerGifPlanner.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// The portable half of the standalone corner-GIF overlays: everything the feature DECIDES.
+    /// Which file a slot plays, where on screen it lands, how big and how transparent it draws,
+    /// how far apart two slots realize. None of that needs a window, so none of it belongs in a
+    /// head.
+    ///
+    /// <para>What is deliberately NOT here: the layered / click-through window itself, the GIF
+    /// decode, the DPI read and the screen enumeration - all per-platform - and the ADMISSION rule
+    /// ("may a standalone slot realize at all?"), which stays beside the session-side rule it must
+    /// never disagree with, in the head's <c>CornerGifMedia</c>.</para>
+    ///
+    /// <para>Pure and static: no clock, no settings read, no I/O beyond a <c>File.Exists</c> probe
+    /// on paths the caller hands in. Every value it returns is finite, or null.</para>
+    /// </summary>
+    public static class CornerGifPlanner
+    {
+        /// <summary>Hard cap on simultaneous overlays, independent of what settings.json holds -
+        /// the config UI only ever writes two slots, but a hand-edited or migrated file must not be
+        /// able to spawn an unbounded number of topmost layered windows.</summary>
+        public const int MaxOverlays = 2;
+
+        /// <summary>Longest-edge target when a slot carries no size of its own.</summary>
+        public const int DefaultSize = 300;
+
+        /// <summary>Diagonal inset (logical px) applied per slot that lands in an already-claimed
+        /// corner. Two slots on identical pixels means two topmost animating windows fighting for
+        /// z-order, and one of them simply looks gone.</summary>
+        public const double SameCornerNudge = 40;
+
+        /// <summary>Real-time gap between two slots' realizations (#958). A dispatcher pass alone
+        /// was not enough: both slots still drained in the same pump, so the second layered surface
+        /// was created while the first GIF's animator was already driving the render thread.</summary>
+        public const int StaggerMs = 400;
+
+        /// <summary>Where one slot's overlay goes, in logical pixels, and how opaque it draws.
+        /// Opacity is 0..1, ready for a head's window property.</summary>
+        public readonly struct Placement
+        {
+            public Placement(double left, double top, double width, double height, double opacity)
+            {
+                Left = left; Top = top; Width = width; Height = height; Opacity = opacity;
+            }
+
+            public double Left { get; }
+            public double Top { get; }
+            public double Width { get; }
+            public double Height { get; }
+            public double Opacity { get; }
+        }
+
+        /// <summary>
+        /// Which file this slot should play, or null for "no file - draw your own default".
+        ///
+        /// <para>Resolution order, unchanged from the WPF original: the slot's explicit pick, then
+        /// the Spiral Library's active selection (<c>AppSettings.SpiralPath</c>, the "pool"), then
+        /// nothing. An enabled-but-unpicked slot therefore draws whatever spiral the app is already
+        /// using rather than a separate file.</para>
+        ///
+        /// <para>Null does NOT mean "no art": it means the head resolves its own default, which on
+        /// every head is the active mod's spiral (<see cref="CoreModArt.SpiralOverridePath"/>) and
+        /// otherwise its shipped pre-scaled corner asset. That last step stays head-side because
+        /// only a head knows where its own art lives, and on WPF it is a <c>pack://</c> URI that
+        /// Core is forbidden to name.</para>
+        /// </summary>
+        public static string? ResolveSourcePath(CornerGifOverlaySetting? setting, string? poolSpiralPath)
+        {
+            if (Playable(setting?.GifPath)) return setting!.GifPath;
+            if (Playable(poolSpiralPath)) return poolSpiralPath;
+            return null;
+        }
+
+        private static bool Playable(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            try { return File.Exists(path); }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// Scale the source to the slot's longest-edge size and pin it to the chosen corner of a
+        /// screen <paramref name="screenWidth"/> x <paramref name="screenHeight"/> logical pixels.
+        ///
+        /// <para>Returns null rather than a degenerate rectangle. Bug #625: a 0x0 source makes the
+        /// scale divide by zero, and handing WPF a NaN Width threw deep inside layout and took the
+        /// whole app down on the startup restore path. Every caller must treat null as "skip this
+        /// overlay and say why", never as "use a default size".</para>
+        ///
+        /// <para><paramref name="earlierSlotsInSameCorner"/> comes from
+        /// <see cref="CountEarlierSlotsInCorner"/>: counted from SETTINGS rather than from live
+        /// windows, so the offset is the same regardless of which slot realizes first.</para>
+        /// </summary>
+        public static Placement? Place(
+            CornerGifOverlaySetting? setting,
+            double sourceWidth, double sourceHeight,
+            double screenWidth, double screenHeight,
+            int earlierSlotsInSameCorner)
+        {
+            if (setting == null) return null;
+            if (!Finite(sourceWidth) || !Finite(sourceHeight) || sourceWidth <= 0 || sourceHeight <= 0) return null;
+            if (!Finite(screenWidth) || !Finite(screenHeight)) return null;
+
+            double target = setting.Size > 0 ? setting.Size : DefaultSize;
+            double scale = target / Math.Max(sourceWidth, sourceHeight);
+            double width = sourceWidth * scale;
+            double height = sourceHeight * scale;
+
+            if (!Finite(scale) || !Finite(width) || !Finite(height) || width <= 0 || height <= 0) return null;
+
+            double left = 0, top = 0;
+            switch (setting.Position)
+            {
+                case CornerPosition.TopLeft: left = 0; top = 0; break;
+                case CornerPosition.TopRight: left = screenWidth - width; top = 0; break;
+                case CornerPosition.BottomLeft: left = 0; top = screenHeight - height; break;
+                case CornerPosition.BottomRight: left = screenWidth - width; top = screenHeight - height; break;
+            }
+
+            if (earlierSlotsInSameCorner > 0)
+            {
+                double nudge = SameCornerNudge * earlierSlotsInSameCorner;
+                left += setting.Position is CornerPosition.TopLeft or CornerPosition.BottomLeft ? nudge : -nudge;
+                top += setting.Position is CornerPosition.TopLeft or CornerPosition.TopRight ? nudge : -nudge;
+            }
+
+            if (!Finite(left) || !Finite(top)) return null;
+
+            return new Placement(left, top, width, height, Math.Clamp(setting.Opacity, 1, 100) / 100.0);
+        }
+
+        private static bool Finite(double d) => !double.IsNaN(d) && !double.IsInfinity(d);
+
+        /// <summary>How many ENABLED slots before <paramref name="index"/> already claimed
+        /// <paramref name="position"/>. Feeds the same-corner nudge in <see cref="Place"/>.</summary>
+        public static int CountEarlierSlotsInCorner(
+            IList<CornerGifOverlaySetting>? overlays, int index, CornerPosition position)
+        {
+            if (overlays == null) return 0;
+            int count = 0;
+            for (int i = 0; i < index && i < overlays.Count; i++)
+            {
+                var o = overlays[i];
+                if (o != null && o.Enabled && o.Position == position) count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// How long this slot must wait before it realizes, so no two slots create a layered
+        /// surface back to back. <paramref name="cursor"/> is the caller's monotonic "earliest next
+        /// realization" tick and is advanced by <see cref="StaggerMs"/>; pass 0 for a fresh queue.
+        /// Answers 0 when the cursor is already in the past, which is the common single-slot case.
+        /// </summary>
+        public static long NextRealizeDelayMs(ref long cursor, long nowTick)
+        {
+            long at = Math.Max(nowTick, cursor);
+            cursor = at + StaggerMs;
+            return Math.Max(0, at - nowTick);
+        }
+    }
+}

--- a/CCP.LinuxSmoke/Program.cs
+++ b/CCP.LinuxSmoke/Program.cs
@@ -54,6 +54,7 @@ namespace ConditioningControlPanel.LinuxSmoke
             Roadmap();
             LockCard();
             MindWipe();
+            CornerGif();
 
             Console.WriteLine();
             if (_failures == 0)
@@ -725,6 +726,71 @@ namespace ConditioningControlPanel.LinuxSmoke
                   picked.Length == 1 && picked[0] == custom);
             Check("a custom path that does not exist falls back to the folders, not to nothing",
                   MindWipeSchedule.DiscoverClips(Path.Combine(CorePaths.UserData, "gone.wav")).Length == 1);
+        /// The corner-GIF split (wire/108). CornerGifPlanner decides where a corner overlay goes;
+        /// CoreCornerGif is the surface that draws it, and is UNSEEDED here - this head has no
+        /// overlay window yet. What is worth asserting off Windows is that the unseeded seam is a
+        /// silent no-op rather than a throw or a lie, that the placement arithmetic pins the corner
+        /// it was asked for, and above all that a degenerate source is answered NULL: bug #625 was
+        /// a 0x0 image producing NaN geometry that took the app down inside layout.
+        /// </summary>
+        private static void CornerGif()
+        {
+            Console.WriteLine("\nCorner GIF planner and surface seam");
+
+            Check("CoreCornerGif reports no surface with no head attached", !CoreCornerGif.HasSurface);
+            CoreCornerGif.Refresh();      // must not throw
+            CoreCornerGif.Refresh(1);
+            Check("an unseeded CoreCornerGif.Refresh is a silent no-op", true);
+
+            var slot = new Models.CornerGifOverlaySetting
+            {
+                Enabled = true, Size = 300, Opacity = 18,
+                Position = Models.CornerPosition.BottomRight
+            };
+
+            var placed = CornerGifPlanner.Place(slot, 600, 400, 1920, 1080, 0);
+            Check("a bottom-right slot is placed against both far edges",
+                  placed is { } p && Math.Abs(p.Left + p.Width - 1920) < 0.001
+                                  && Math.Abs(p.Top + p.Height - 1080) < 0.001,
+                  placed is { } q ? $"{q.Left}x{q.Top} {q.Width}x{q.Height}" : "null");
+
+            Check("the longest edge is scaled to the slot's size, aspect kept",
+                  placed is { } r && Math.Abs(r.Width - 300) < 0.001 && Math.Abs(r.Height - 200) < 0.001);
+
+            Check("opacity percent becomes a 0..1 fraction",
+                  placed is { } o && Math.Abs(o.Opacity - 0.18) < 0.0001);
+
+            Check("a second slot in the same corner is nudged diagonally inward",
+                  CornerGifPlanner.Place(slot, 600, 400, 1920, 1080, 1) is { } n
+                  && placed is { } b
+                  && Math.Abs(n.Left - (b.Left - CornerGifPlanner.SameCornerNudge)) < 0.001
+                  && Math.Abs(n.Top - (b.Top - CornerGifPlanner.SameCornerNudge)) < 0.001);
+
+            // #625. A degenerate source must never yield geometry a head can hand to a layout pass.
+            Check("a 0x0 source is answered null, not NaN geometry",
+                  CornerGifPlanner.Place(slot, 0, 0, 1920, 1080, 0) is null);
+            Check("a non-finite screen size is answered null",
+                  CornerGifPlanner.Place(slot, 600, 400, double.PositiveInfinity, 1080, 0) is null);
+
+            // The realization stagger: two slots must never create a layered surface back to back.
+            long cursor = 0;
+            long first = CornerGifPlanner.NextRealizeDelayMs(ref cursor, 1000);
+            long second = CornerGifPlanner.NextRealizeDelayMs(ref cursor, 1000);
+            Check("the first slot realizes immediately and the second waits out the stagger",
+                  first == 0 && second == CornerGifPlanner.StaggerMs, $"{first}/{second}");
+
+            // Source order: an unpicked slot falls through to the pool, and "no file" means the
+            // head draws its own default rather than nothing.
+            var poolFile = Path.Combine(CorePaths.UserData, "smoke_pool_spiral.gif");
+            Directory.CreateDirectory(CorePaths.UserData);
+            File.WriteAllText(poolFile, "not really a gif");
+            Check("an unpicked slot falls through to the pool spiral",
+                  CornerGifPlanner.ResolveSourcePath(slot, poolFile) == poolFile);
+            Check("a slot pick that is not on disk falls through too",
+                  CornerGifPlanner.ResolveSourcePath(
+                      new Models.CornerGifOverlaySetting { GifPath = poolFile + ".missing" }, poolFile) == poolFile);
+            Check("no pick and no pool means null - the head draws its own default",
+                  CornerGifPlanner.ResolveSourcePath(slot, null) is null);
         }
 
         /// <summary>Pure math must not drift with locale or floating-point defaults.</summary>

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -377,6 +377,19 @@ namespace ConditioningControlPanel
             // visible pop quiz. Lazy, like the rest: LockCard is constructed in OnStartup, long
             // after this ctor, and every existing caller already writes App.LockCard?.
             CoreLockCard.ShowHandler = isTest => LockCard?.ShowLockCard(isTest: isTest);
+
+            // The corner-GIF surface seam. CornerGifPlanner decides WHERE a corner GIF goes on
+            // every head; only the layered click-through window is ours, and this is the handback
+            // that raises it. A negative index rebuilds every slot (a corner pick or an enable
+            // toggle shifts the same-corner nudge, so both move); a non-negative one rebuilds only
+            // that slot, which is the live slider edit that must not restart the other's animation.
+            // Lazy on purpose: CornerGif is constructed later in OnStartup.
+            CoreCornerGif.RefreshHandler = index =>
+            {
+                if (index < 0) CornerGif?.RefreshOverlays();
+                else CornerGif?.RefreshSlot(index);
+            };
+
             // The entitlement seam, for TierGate (now CCP.Core/Services/TierGate.cs). Deciding is
             // policy and moved; the two account bars, the daily-free wheel and the refusal toast
             // stay here. Every one is a lambda, not an eager read: Patreon, DailyFree and

--- a/ConditioningControlPanel/Services/CornerGifService.cs
+++ b/ConditioningControlPanel/Services/CornerGifService.cs
@@ -15,20 +15,11 @@ namespace ConditioningControlPanel.Services
     /// </summary>
     public class CornerGifService
     {
-        /// <summary>Hard cap on simultaneous overlay windows, independent of what the settings file
-        /// contains - the config UI only ever writes CornerGifWindow.SlotCount entries, but a
-        /// hand-edited / migrated settings.json must not be able to spawn an unbounded number of
-        /// topmost layered windows.</summary>
-        private const int MaxOverlays = 2;
-
-        /// <summary>Diagonal inset (DIPs) applied per slot that lands in an already-claimed corner.</summary>
-        private const double SameCornerNudge = 40;
-
-        /// <summary>Real-time gap between two slots' realizations (#958). A dispatcher pass alone was
-        /// not enough: both slots still drained in the same pump, so the second layered surface was
-        /// created while the first GIF's animator had already started driving the render thread -
-        /// which is precisely the "enabled corner gif 2 and it froze" report.</summary>
-        private const int StaggerMs = 400;
+        /// <summary>Hard cap on simultaneous overlay windows, the same-corner nudge and the
+        /// realization stagger all live in <see cref="CornerGifPlanner"/> now - they are arithmetic
+        /// over settings, not window code, so every head gets one answer rather than a copy each.
+        /// This head keeps only what needs a Win32 surface.</summary>
+        private const int MaxOverlays = CornerGifPlanner.MaxOverlays;
 
         /// <summary>How many times a slot may be pushed back because a display change is in flight
         /// before it is realized anyway. 8 x <see cref="SpawnRetryMs"/> covers a monitor drag.</summary>
@@ -417,7 +408,7 @@ namespace ConditioningControlPanel.Services
         /// #709, and the "turned on corner gif 2 and it froze" hang in #958.
         ///
         /// <para>Background priority alone was not enough, because it only orders the work inside
-        /// one dispatcher drain. Each slot now also waits out a real <see cref="StaggerMs"/> gap
+        /// one dispatcher drain. Each slot now also waits out a real <see cref="CornerGifPlanner.StaggerMs"/> gap
         /// after the previous one, and no slot realizes while a display change is in flight
         /// (<see cref="Services.UI.DisplayChangeCoordinator.SpawnsSuppressed"/>) - #954 is a
         /// dual-monitor report, and layered-surface creation during a DPI/topology change is the
@@ -430,11 +421,9 @@ namespace ConditioningControlPanel.Services
             _pending.Add(index);
             SyncSentinel();
 
-            long now = Environment.TickCount64;
-            long at = Math.Max(now, _nextRealizeTick);
-            _nextRealizeTick = at + StaggerMs;
+            long delayMs = CornerGifPlanner.NextRealizeDelayMs(ref _nextRealizeTick, Environment.TickCount64);
 
-            ScheduleRealize(disp, index, setting, seq, Math.Max(0, at - now), 0);
+            ScheduleRealize(disp, index, setting, seq, delayMs, 0);
         }
 
         private void ScheduleRealize(Dispatcher disp, int index, CornerGifOverlaySetting setting,
@@ -514,17 +503,9 @@ namespace ConditioningControlPanel.Services
             // selection (App.Settings.SpiralPath, the "pool") -> built-in corner spiral.
             // So an enabled-but-unpicked slot draws whatever spiral the app is already using,
             // matching OverlayService.GetSpiralPath (the pool) rather than a separate file.
-            string filePath = "";
-            if (!string.IsNullOrEmpty(setting.GifPath) && System.IO.File.Exists(setting.GifPath))
-            {
-                filePath = setting.GifPath;
-            }
-            else
-            {
-                var poolPath = App.Settings?.Current?.SpiralPath;
-                if (!string.IsNullOrEmpty(poolPath) && System.IO.File.Exists(poolPath))
-                    filePath = poolPath;
-            }
+            // The first two steps are CornerGifPlanner's (they are the same on every head); only
+            // the built-in fallback below is this head's, because only it knows its pack:// art.
+            var filePath = CornerGifPlanner.ResolveSourcePath(setting, App.Settings?.Current?.SpiralPath);
 
             if (!string.IsNullOrEmpty(filePath))
             {
@@ -569,20 +550,6 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
-            // Scale to the user's longest-edge size (default 300).
-            var targetSize = setting.Size > 0 ? setting.Size : 300;
-            double scale = targetSize / Math.Max(gifWidth, gifHeight);
-            double windowWidth = gifWidth * scale;
-            double windowHeight = gifHeight * scale;
-
-            if (!double.IsFinite(scale) || !double.IsFinite(windowWidth) || !double.IsFinite(windowHeight)
-                || windowWidth <= 0 || windowHeight <= 0)
-            {
-                App.Logger?.Warning("CornerGifService: computed non-finite overlay geometry (scale={Scale}, {W}x{H}) - skipping overlay",
-                    scale, windowWidth, windowHeight);
-                return;
-            }
-
             var screen = System.Windows.Forms.Screen.PrimaryScreen;
             if (screen == null) return;
 
@@ -592,40 +559,31 @@ namespace ConditioningControlPanel.Services
                 dpiScale = g.DpiX / 96.0;
             }
 
-            double screenWidth = screen.Bounds.Width / dpiScale;
-            double screenHeight = screen.Bounds.Height / dpiScale;
+            // Everything from here to the window itself is CornerGifPlanner's, because none of it
+            // needs a window: the longest-edge scale (default 300), the corner the user picked, the
+            // same-corner nudge - two slots may legitimately pick ONE corner, and stacking them on
+            // identical pixels gives two topmost animating windows fighting for z-order, so one of
+            // them just looks "gone" - and the opacity clamp. Null means the numbers came out
+            // degenerate or non-finite; #625 is what happens when that is handed to WPF layout
+            // anyway, so bail out loudly instead. A zero DPI read lands here too.
+            var placement = CornerGifPlanner.Place(
+                setting, gifWidth, gifHeight,
+                screen.Bounds.Width / dpiScale, screen.Bounds.Height / dpiScale,
+                CornerGifPlanner.CountEarlierSlotsInCorner(
+                    App.Settings?.Current?.CornerGifOverlays, index, setting.Position));
 
-            double left = 0, top = 0;
-            switch (setting.Position)
+            if (placement is not { } place)
             {
-                case CornerPosition.TopLeft:
-                    left = 0; top = 0;
-                    break;
-                case CornerPosition.TopRight:
-                    left = screenWidth - windowWidth; top = 0;
-                    break;
-                case CornerPosition.BottomLeft:
-                    left = 0; top = screenHeight - windowHeight;
-                    break;
-                case CornerPosition.BottomRight:
-                    left = screenWidth - windowWidth; top = screenHeight - windowHeight;
-                    break;
+                App.Logger?.Warning("CornerGifService: computed non-finite overlay geometry for slot {Index} (source {W}x{H}, size {Size}, dpi {Dpi}) - skipping overlay",
+                    index, gifWidth, gifHeight, setting.Size, dpiScale);
+                return;
             }
 
-            // Two slots may legitimately pick the same corner; stacking them on identical pixels
-            // gives two topmost animating windows fighting for z-order (one of them looks "gone").
-            // Nudge each later slot diagonally inward instead of refusing the user's pick. Counted
-            // from settings rather than from live windows so the offset is the same regardless of
-            // which slot realizes first.
-            int stacked = CountEarlierSlotsInCorner(index, setting.Position);
-            if (stacked > 0)
-            {
-                double nudge = SameCornerNudge * stacked;
-                left += setting.Position is CornerPosition.TopLeft or CornerPosition.BottomLeft ? nudge : -nudge;
-                top += setting.Position is CornerPosition.TopLeft or CornerPosition.TopRight ? nudge : -nudge;
-            }
-
-            var opacity = Math.Clamp(setting.Opacity, 1, 100) / 100.0;
+            double windowWidth = place.Width;
+            double windowHeight = place.Height;
+            double left = place.Left;
+            double top = place.Top;
+            var opacity = place.Opacity;
 
             var window = new Window
             {
@@ -692,20 +650,6 @@ namespace ConditioningControlPanel.Services
 
             App.Logger?.Information("CornerGifService: overlay shown at {Position} ({Path}, {W}x{H}px, {Opacity}%)",
                 setting.Position, gifUri, (int)windowWidth, (int)windowHeight, setting.Opacity);
-        }
-
-        private static int CountEarlierSlotsInCorner(int index, CornerPosition position)
-        {
-            var overlays = App.Settings?.Current?.CornerGifOverlays;
-            if (overlays == null) return 0;
-
-            int count = 0;
-            for (int i = 0; i < index && i < overlays.Count; i++)
-            {
-                var o = overlays[i];
-                if (o != null && o.Enabled && o.Position == position) count++;
-            }
-            return count;
         }
 
         // Startup-restore flag file, same mechanism as EngineCrashSentinel (armed while the risky


### PR DESCRIPTION
The standalone corner-GIF overlays split along the decide/draw line.

Moved to CCP.Core/Services/Media/CornerGifPlanner.cs (pure, no clock, no settings read):
  - ResolveSourcePath: slot pick -> Spiral Library pool -> null. Null means "head draws
    its own default", not "no art" - the WPF fallback is a pack:// URI Core may not name.
  - Place: longest-edge scale, the four corners, the same-corner diagonal nudge, the
    opacity clamp. Returns null for a degenerate or non-finite result, which is #625:
    a 0x0 source made NaN geometry that took the app down inside WPF layout.
  - CountEarlierSlotsInCorner, NextRealizeDelayMs (the #958 realization stagger),
    MaxOverlays / SameCornerNudge / StaggerMs / DefaultSize.

New seam CCP.Core/CoreCornerGif.cs: one Refresh(index) - negative rebuilds every slot
(a corner pick or enable toggle shifts the nudge, so both move), non-negative rebuilds
one (the live slider edit, which must not restart the other slot's animation). Seeded by
the WPF head to App.CornerGif; unseeded on Avalonia, where it is a silent no-op.

ConditioningControlPanel/Services/CornerGifService.cs now calls the planner instead of
holding its own copy: -96 lines, same behaviour, plus a zero-DPI read that used to make
an infinite screen width and now lands on the null-geometry bail-out.

Where the line was drawn and why: the layered click-through window, the GIF decode, the
DPI read and Screen.PrimaryScreen stay in the head. So does the ADMISSION rule
(CornerGifMedia.AllowStandaloneCornerGif) - it must never disagree with the session-side
rule beside it, and three source-scanning tests lock both call sites to that one symbol.
So does the restore sentinel and ResolveRestoreAction: portable, but CornerGifRestoreTests
binds them by `using static ...CornerGifService`, and moving them buys a head with no
overlay to wedge exactly nothing.

Still blocked:
  - Nothing draws on Avalonia. CoreCornerGif.RefreshHandler is unseeded there and waits on
    the overlay surface being built in CCP.Avalonia/Views/Overlays/ this same wave.
  - ConditioningControlPanel/Services/CornerGifService.cs: RefreshOverlays, RefreshSlot,
    StopAll, ShowOne, MakeWindowClickThrough, QueueShow/ScheduleRealize, the
    _windows/_pending bookkeeping, RestoreOnStartup and the sentinel - all head-only.
  - ConditioningControlPanel/Services/Media/CornerGifMedia.cs: ResolveDefaultUriString,
    TryGetPixelSize, Attach/Detach, AllowStandaloneCornerGif, AllowSessionCornerGif.
  - Services.UI.DisplayChangeCoordinator.SpawnsSuppressed (the spawn-deferral gate).

The brief was wrong on two points, worth recording: there is no rotation and no show/hide
schedule in this service - a slot is always on while enabled, and the only timing anywhere
is the 400ms realization stagger. And the "slot policy" it named as portable is exactly the
one piece that must not move, for the reason above.

For the sibling overlay surface: a null from ResolveSourcePath means "call
CoreModArt.SpiralOverridePath(), then your own shipped corner asset" - skip that and a mod's
spiral branding is lost on Linux. And a corner GIF would be this head's FIRST caller that
loads on a repeated path (every debounced slider tick rebuilds the slot), so it must not go
through ModArt.TryLoad at native size per realize: decode once, off-thread, downscaled to
Placement.Width/Height, the way CornerGifMedia.Attach already does. That is the answer to
the decode-cache question in ModArt.cs for this feature - not a cache in ModArt.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUBy2doD7BCUKCDK8gH4XU